### PR TITLE
[beta] backports

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4560,7 +4560,7 @@ declare_lint! {
     Warn,
     "detects uses of ambiguously glob imported traits",
     @future_incompatible = FutureIncompatibleInfo {
-        reason: fcw!(FutureReleaseError #147992),
+        reason: fcw!(FutureReleaseError #152822),
         report_in_deps: false,
     };
 }

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -759,7 +759,7 @@ impl<'input> Parser<'input> {
             return spec;
         };
 
-        spec.ty = self.string(self.input_vec_index);
+        spec.ty = self.string(self.input_vec_index2pos(self.input_vec_index));
         spec.ty_span = {
             let end = self.input_vec_index2range(self.input_vec_index).start;
             Some(start..end)

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -818,17 +818,32 @@ impl<'ra> Module<'ra> {
         let mut traits = self.traits.borrow_mut(resolver.as_ref());
         if traits.is_none() {
             let mut collected_traits = Vec::new();
-            self.for_each_child(resolver, |r, ident, _, ns, binding| {
+            self.for_each_child(resolver, |r, ident, _, ns, mut decl| {
                 if ns != TypeNS {
                     return;
                 }
-                if let Res::Def(DefKind::Trait | DefKind::TraitAlias, def_id) = binding.res() {
-                    collected_traits.push((
-                        ident.name,
-                        binding,
-                        r.as_ref().get_module(def_id),
-                        binding.is_ambiguity_recursive(),
-                    ));
+
+                let ambiguous = decl.is_ambiguity_recursive();
+                let mut try_record_trait = |decl: Decl<'ra>| {
+                    if let Res::Def(DefKind::Trait | DefKind::TraitAlias, def_id) = decl.res() {
+                        collected_traits.push((
+                            ident.name,
+                            decl,
+                            r.as_ref().get_module(def_id),
+                            ambiguous,
+                        ));
+                        true
+                    } else {
+                        false
+                    }
+                };
+                // Try to record at least one trait if the decl is ambiguous, such that we can
+                // report the `ambiguous_glob_imported_traits` lint. Otherwise we would report an
+                // error that the trait is not found.
+                while !try_record_trait(decl)
+                    && let Some((_, ambig_decl)) = decl.descent_to_ambiguity()
+                {
+                    decl = ambig_decl;
                 }
             });
             *traits = Some(collected_traits.into_boxed_slice());

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -1317,6 +1317,10 @@ impl Step for UnstableBookGen {
         cmd.arg(rustc_path);
         cmd.arg(out);
 
+        // Running rustc requires the library path if rust.rpath = false
+        // or any other libraries are in a custom location.
+        builder.add_rustc_lib_path(self.build_compiler, &mut cmd);
+
         cmd.run(builder);
     }
 }

--- a/src/tools/unstable-book-gen/src/main.rs
+++ b/src/tools/unstable-book-gen/src/main.rs
@@ -128,6 +128,7 @@ fn collect_compiler_flags(rustc_path: impl AsRef<Path>) -> Features {
     rustc.env("RUSTC_BOOTSTRAP", "1");
     rustc.arg("-Zhelp");
     let output = t!(rustc.output());
+    assert!(output.status.success(), "`rustc -Zhelp` failed: {output:?}");
     let help_str = t!(String::from_utf8(output.stdout));
     let parts = help_str.split("\n    -Z").collect::<Vec<_>>();
     assert!(!parts[1..].is_empty(), "no -Z options were found");

--- a/tests/ui/diagnostic_namespace/unicode.rs
+++ b/tests/ui/diagnostic_namespace/unicode.rs
@@ -1,0 +1,10 @@
+#![crate_type = "lib"]
+#![deny(malformed_diagnostic_format_literals)]
+
+#[diagnostic::on_unimplemented(message = " \x00 \u{b123} \\\u{b123} {:?}")]
+//~^ERROR positional arguments are not permitted in diagnostic attributes [malformed_diagnostic_format_literals]
+//~|ERROR format specifiers are not permitted in diagnostic attributes [malformed_diagnostic_format_literals]
+#[diagnostic::on_unimplemented(note = "🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀{:?}")]
+//~^ERROR positional arguments are not permitted in diagnostic attributes [malformed_diagnostic_format_literals]
+//~|ERROR format specifiers are not permitted in diagnostic attributes [malformed_diagnostic_format_literals]
+pub trait ILoveUnicode {}

--- a/tests/ui/diagnostic_namespace/unicode.stderr
+++ b/tests/ui/diagnostic_namespace/unicode.stderr
@@ -1,0 +1,35 @@
+error: positional arguments are not permitted in diagnostic attributes
+  --> $DIR/unicode.rs:4:70
+   |
+LL | #[diagnostic::on_unimplemented(message = " \x00 \u{b123} \\u{b123} {:?}")]
+   |                                                                      ^ remove this format argument
+   |
+   = help: you can print empty braces by escaping them
+note: the lint level is defined here
+  --> $DIR/unicode.rs:2:9
+   |
+LL | #![deny(malformed_diagnostic_format_literals)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: format specifiers are not permitted in diagnostic attributes
+  --> $DIR/unicode.rs:4:70
+   |
+LL | #[diagnostic::on_unimplemented(message = " \x00 \u{b123} \\u{b123} {:?}")]
+   |                                                                      ^^ remove this format specifier
+
+error: positional arguments are not permitted in diagnostic attributes
+  --> $DIR/unicode.rs:7:53
+   |
+LL | #[diagnostic::on_unimplemented(note = "🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀{:?}")]
+   |                                                                 ^ remove this format argument
+   |
+   = help: you can print empty braces by escaping them
+
+error: format specifiers are not permitted in diagnostic attributes
+  --> $DIR/unicode.rs:7:53
+   |
+LL | #[diagnostic::on_unimplemented(note = "🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀{:?}")]
+   |                                                                 ^^ remove this format specifier
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/imports/ambiguous-trait-and-struct-in-scope.rs
+++ b/tests/ui/imports/ambiguous-trait-and-struct-in-scope.rs
@@ -1,0 +1,39 @@
+//@ check-pass
+//@ edition:2018
+//
+// Tests that when the primary declaration is not a trait but the ambiguous declaration is,
+// the ambiguous trait is still recorded among the module's traits. This is to make sure
+// that we can report the `ambiguously_glob_import_trait` lint.
+//
+// Test case is from #159476.
+
+mod module_1 {
+    mod nested_1 {
+        pub struct Foo;
+    }
+
+    pub use nested_1::Foo;
+}
+
+mod module_2 {
+    // same name as the struct
+    pub trait Foo: Sized {
+        fn method(self) {}
+    }
+    impl Foo for i32 {}
+}
+
+mod module_3 {
+    mod nested_3 {
+        use super::*;
+        use crate::module_2::*;
+        fn weird() {
+            1_i32.method(); //~ WARNING Use of ambiguously glob imported trait `Foo` [ambiguous_glob_imported_traits]
+                            //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+        }
+    }
+
+    use crate::module_1::*;
+}
+
+fn main() {}

--- a/tests/ui/imports/ambiguous-trait-and-struct-in-scope.stderr
+++ b/tests/ui/imports/ambiguous-trait-and-struct-in-scope.stderr
@@ -1,0 +1,16 @@
+warning: Use of ambiguously glob imported trait `Foo`
+  --> $DIR/ambiguous-trait-and-struct-in-scope.rs:31:19
+   |
+LL |         use crate::module_2::*;
+   |             --------------- `Foo` imported ambiguously here
+LL |         fn weird() {
+LL |             1_i32.method();
+   |                   ^^^^^^
+   |
+   = help: Import `Foo` explicitly
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
+   = note: `#[warn(ambiguous_glob_imported_traits)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/imports/ambiguous-trait-in-scope.stderr
+++ b/tests/ui/imports/ambiguous-trait-in-scope.stderr
@@ -9,7 +9,7 @@ LL |     0u8.method1();
    |
    = help: Import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147992 <https://github.com/rust-lang/rust/issues/147992>
+   = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
    = note: `#[warn(ambiguous_glob_imported_traits)]` (part of `#[warn(future_incompatible)]`) on by default
 
 error[E0599]: no method named `method2` found for type `u8` in the current scope
@@ -51,7 +51,7 @@ LL |     0u8.method2();
    |
    = help: Import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147992 <https://github.com/rust-lang/rust/issues/147992>
+   = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
 
 warning: Use of ambiguously glob imported trait `Trait`
   --> $DIR/ambiguous-trait-in-scope.rs:49:9
@@ -64,7 +64,7 @@ LL |     0u8.method1();
    |
    = help: Import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147992 <https://github.com/rust-lang/rust/issues/147992>
+   = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
 
 error[E0599]: no method named `method2` found for type `u8` in the current scope
   --> $DIR/ambiguous-trait-in-scope.rs:51:9
@@ -90,7 +90,7 @@ LL |     0u8.method1();
    |
    = help: Import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147992 <https://github.com/rust-lang/rust/issues/147992>
+   = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
 
 error[E0599]: no method named `method2` found for type `u8` in the current scope
   --> $DIR/ambiguous-trait-in-scope.rs:58:9
@@ -117,7 +117,7 @@ LL |     0u8.method1();
    |
    = help: Import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147992 <https://github.com/rust-lang/rust/issues/147992>
+   = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
 
 error[E0599]: no method named `method2` found for type `u8` in the current scope
   --> $DIR/ambiguous-trait-in-scope.rs:66:9
@@ -144,7 +144,7 @@ LL |     0u8.method1();
    |
    = help: Import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147992 <https://github.com/rust-lang/rust/issues/147992>
+   = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
 
 error[E0599]: no method named `method2` found for type `u8` in the current scope
   --> $DIR/ambiguous-trait-in-scope.rs:74:9
@@ -170,7 +170,7 @@ LL |     0u8.method1();
    |
    = help: Import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #147992 <https://github.com/rust-lang/rust/issues/147992>
+   = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
 
 error[E0599]: no method named `method2` found for type `u8` in the current scope
   --> $DIR/ambiguous-trait-in-scope.rs:81:9


### PR DESCRIPTION
- Fix string indexing in diagnostic format strings rust-lang/rust#159470
- Resolver: Record at least 1 ambiguous trait if main decl is not a trait. rust-lang/rust#159599
- Set the rustc lib path for unstable-book-gen rust-lang/rust#159613

r? me
