### PR TITLE
Expand docs for fs::metadata and fs::symlink_metadata

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2769,7 +2769,8 @@ pub fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// directory, etc.
 ///
 /// This function will traverse symbolic links to query information about the
-/// destination file.
+/// destination file. To query metadata about the path itself without following
+/// symbolic links, use [`symlink_metadata`].
 ///
 /// # Platform-specific behavior
 ///
@@ -2786,6 +2787,7 @@ pub fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
 ///
 /// * The user lacks permissions to perform `metadata` call on `path`.
 /// * `path` does not exist.
+/// * `path` is a symbolic link, but the destination file cannot be resolved.
 ///
 /// # Examples
 ///
@@ -2805,6 +2807,11 @@ pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
 }
 
 /// Queries the metadata about a file without following symlinks.
+///
+/// This function will return the [`Metadata`] of the exact path without
+/// traversing symbolic links to a resolved destination file. Using this function
+/// on a path that is a file or directory (not a symbolic link) will behave the
+/// same as [`metadata`].
 ///
 /// # Platform-specific behavior
 ///


### PR DESCRIPTION
Several changes:

## Link `symlink_metadata` from `metadata`

Someone reading `metadata` likely wants easy/quick access to `symlink_metadata` as well. Since this explicitly documents that it does follow symlinks, it made sense to leave a note stating how to perform the same action without that behavior.

## Add symbolic link note to errors

It's intuitive that you cannot return the `Metadata` of a resolved file if the file could not be resolved. But it's not always obvious. Since we're stating "the path does not exist" (also an obvious case). It will help to have this gentle reminder.

## Explicit behavior of directories and files in `symlink_metadata`

Reading the documentation, it was unclear whether `symlink_metadata` would also work on files and directories. I guessed it would, but it's nice to call it out. The wording also gave me an opportunity to cross-link to `metadata` so someone can easily jump back and forth between them.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
