### PR TITLE
added note/help about iterator invalidation when mutating a collection inside a for loop

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1880,6 +1880,14 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
                     issued_borrow.borrowed_place,
                     &issued_spans,
                 );
+                self.explain_iterator_invalidation_in_for_loop_if_applicable(
+                    &mut err,
+                    &issued_spans,
+                    place,
+                    issued_borrow.borrowed_place,
+                    issued_borrow.kind,
+                    span,
+                );
                 err
             }
 
@@ -1902,6 +1910,14 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
                     issued_borrow.borrowed_place,
                     span,
                     issued_span,
+                );
+                self.explain_iterator_invalidation_in_for_loop_if_applicable(
+                    &mut err,
+                    &issued_spans,
+                    place,
+                    issued_borrow.borrowed_place,
+                    issued_borrow.kind,
+                    span,
                 );
                 self.suggest_using_closure_argument_instead_of_capture(
                     &mut err,
@@ -2615,6 +2631,50 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
             } else {
                 err.help(msg);
             }
+        }
+    }
+
+    /// Explain iterator invalidation when mutating a collection in a for loop.
+    ///
+    /// For example:
+    /// ```compile_fail
+    /// let mut values = vec![1, 2, 3];
+    /// for value in &values {
+    ///     values.push(4);
+    /// }
+    /// ```
+    fn explain_iterator_invalidation_in_for_loop_if_applicable(
+        &self,
+        err: &mut Diag<'_>,
+        issued_spans: &UseSpans<'tcx>,
+        place: Place<'tcx>,
+        borrowed_place: Place<'tcx>,
+        borrow_kind: BorrowKind,
+        gen_span: Span,
+    ) {
+        let issue_span = issued_spans.args_or_use();
+        let tcx = self.infcx.tcx;
+
+        let Some(body_id) = tcx.hir_node(self.mir_hir_id()).body_id() else { return };
+
+        if let Some(for_span) = find_for_loop_span(tcx, body_id, issue_span)
+            && place.local == borrowed_place.local
+            && for_span.contains(gen_span)
+        {
+            let place_desc = self.describe_any_place(place.as_ref());
+            let borrow_kind_str =
+                if matches!(borrow_kind, BorrowKind::Mut { .. }) { "mutably" } else { "immutably" };
+            err.span_label(
+                for_span,
+                format!(
+                    "this for loop borrows {place_desc} {borrow_kind_str}, \
+                     preventing mutation within its body"
+                ),
+            );
+            err.help(
+                "consider using an index-based loop instead, or collecting \
+                 modifications into a separate collection",
+            );
         }
     }
 
@@ -4652,6 +4712,38 @@ enum AnnotatedBorrowFnSignature<'tcx> {
         argument_ty: Ty<'tcx>,
         argument_span: Span,
     },
+}
+
+/// Find the `Match` expression desugared from a for loop, whose
+/// `IntoIter::into_iter` argument contains `issue_span`.
+/// Returns the for-loop match expression span.
+fn find_for_loop_span<'hir>(
+    tcx: TyCtxt<'hir>,
+    body_id: hir::BodyId,
+    issue_span: Span,
+) -> Option<Span> {
+    struct ExprFinder<'hir> {
+        tcx: TyCtxt<'hir>,
+        issue_span: Span,
+        result: Option<Span>,
+    }
+    impl<'hir> Visitor<'hir> for ExprFinder<'hir> {
+        fn visit_expr(&mut self, ex: &'hir hir::Expr<'hir>) {
+            if let hir::ExprKind::Match(scrutinee, _, hir::MatchSource::ForLoopDesugar) = ex.kind
+                && let hir::ExprKind::Call(path, [arg]) = scrutinee.kind
+                && let hir::ExprKind::Path(qpath) = path.kind
+                && self.tcx.qpath_is_lang_item(qpath, LangItem::IntoIterIntoIter)
+                && arg.span.contains(self.issue_span)
+            {
+                self.result = Some(ex.span);
+                return;
+            }
+            hir::intravisit::walk_expr(self, ex);
+        }
+    }
+    let mut finder = ExprFinder { tcx, issue_span, result: None };
+    finder.visit_expr(tcx.hir_body(body_id).value);
+    finder.result
 }
 
 impl<'tcx> AnnotatedBorrowFnSignature<'tcx> {

--- a/tests/ui/array-slice-vec/vec-mut-iter-borrow.stderr
+++ b/tests/ui/array-slice-vec/vec-mut-iter-borrow.stderr
@@ -1,13 +1,18 @@
 error[E0499]: cannot borrow `xs` as mutable more than once at a time
   --> $DIR/vec-mut-iter-borrow.rs:5:9
    |
-LL |     for x in &mut xs {
-   |              -------
-   |              |
-   |              first mutable borrow occurs here
-   |              first borrow later used here
-LL |         xs.push(1)
-   |         ^^ second mutable borrow occurs here
+LL |       for x in &mut xs {
+   |       -        -------
+   |       |        |
+   |       |        first mutable borrow occurs here
+   |  _____|        first borrow later used here
+   | |
+LL | |         xs.push(1)
+   | |         ^^ second mutable borrow occurs here
+LL | |     }
+   | |_____- this for loop borrows `xs` mutably, preventing mutation within its body
+   |
+   = help: consider using an index-based loop instead, or collecting modifications into a separate collection
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-for-loop-head-linkage.stderr
+++ b/tests/ui/borrowck/borrowck-for-loop-head-linkage.stderr
@@ -1,26 +1,38 @@
 error[E0502]: cannot borrow `vector` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-for-loop-head-linkage.rs:7:9
    |
-LL |     for &x in &vector {
-   |               -------
-   |               |
-   |               immutable borrow occurs here
-   |               immutable borrow later used here
-LL |         let cap = vector.capacity();
-LL |         vector.extend(repeat(0));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
+LL |       for &x in &vector {
+   |       -         -------
+   |       |         |
+   |       |         immutable borrow occurs here
+   |  _____|         immutable borrow later used here
+   | |
+LL | |         let cap = vector.capacity();
+LL | |         vector.extend(repeat(0));
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
+LL | |         vector[1] = 5;
+LL | |     }
+   | |_____- this for loop borrows `vector` immutably, preventing mutation within its body
+   |
+   = help: consider using an index-based loop instead, or collecting modifications into a separate collection
 
 error[E0502]: cannot borrow `vector` as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-for-loop-head-linkage.rs:8:9
    |
-LL |     for &x in &vector {
-   |               -------
-   |               |
-   |               immutable borrow occurs here
-   |               immutable borrow later used here
-...
-LL |         vector[1] = 5;
-   |         ^^^^^^ mutable borrow occurs here
+LL |       for &x in &vector {
+   |       -         -------
+   |       |         |
+   |       |         immutable borrow occurs here
+   |  _____|         immutable borrow later used here
+   | |
+LL | |         let cap = vector.capacity();
+LL | |         vector.extend(repeat(0));
+LL | |         vector[1] = 5;
+   | |         ^^^^^^ mutable borrow occurs here
+LL | |     }
+   | |_____- this for loop borrows `vector` immutably, preventing mutation within its body
+   |
+   = help: consider using an index-based loop instead, or collecting modifications into a separate collection
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/issue-82462.stderr
+++ b/tests/ui/borrowck/issue-82462.stderr
@@ -1,17 +1,22 @@
 error[E0502]: cannot borrow `v` as mutable because it is also borrowed as immutable
   --> $DIR/issue-82462.rs:18:9
    |
-LL |     for x in DroppingSlice(&*v).iter() {
-   |              ------------------
-   |              |               |
-   |              |               immutable borrow occurs here
-   |              a temporary with access to the immutable borrow is created here ...
-LL |         v.push(*x);
-   |         ^^^^^^^^^^ mutable borrow occurs here
-LL |         break;
-LL |     }
-   |     - ... and the immutable borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `DroppingSlice`
+LL |       for x in DroppingSlice(&*v).iter() {
+   |       -        ------------------
+   |       |        |               |
+   |       |        |               immutable borrow occurs here
+   |  _____|        a temporary with access to the immutable borrow is created here ...
+   | |
+LL | |         v.push(*x);
+   | |         ^^^^^^^^^^ mutable borrow occurs here
+LL | |         break;
+LL | |     }
+   | |     -
+   | |     |
+   | |_____... and the immutable borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `DroppingSlice`
+   |       this for loop borrows `v` immutably, preventing mutation within its body
    |
+   = help: consider using an index-based loop instead, or collecting modifications into a separate collection
 help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
    |
 LL |     };

--- a/tests/ui/borrowck/mutate-vec-while-iterating.rs
+++ b/tests/ui/borrowck/mutate-vec-while-iterating.rs
@@ -1,0 +1,21 @@
+// Regression test for https://github.com/rust-lang/rust/issues/159489
+
+fn main() {
+    let mut values = vec![1, 2, 3];
+
+    for value in &values {
+        if *value == 2 {
+            values.push(4); //~ ERROR E0502
+        }
+    }
+}
+
+fn mutate_while_iterating_mut() {
+    let mut values = vec![1, 2, 3];
+
+    for value in &mut values {
+        if *value == 2 {
+            values.push(4); //~ ERROR E0499
+        }
+    }
+}

--- a/tests/ui/borrowck/mutate-vec-while-iterating.stderr
+++ b/tests/ui/borrowck/mutate-vec-while-iterating.stderr
@@ -1,0 +1,40 @@
+error[E0502]: cannot borrow `values` as mutable because it is also borrowed as immutable
+  --> $DIR/mutate-vec-while-iterating.rs:8:13
+   |
+LL |       for value in &values {
+   |       -            -------
+   |       |            |
+   |       |            immutable borrow occurs here
+   |  _____|            immutable borrow later used here
+   | |
+LL | |         if *value == 2 {
+LL | |             values.push(4);
+   | |             ^^^^^^^^^^^^^^ mutable borrow occurs here
+LL | |         }
+LL | |     }
+   | |_____- this for loop borrows `values` immutably, preventing mutation within its body
+   |
+   = help: consider using an index-based loop instead, or collecting modifications into a separate collection
+
+error[E0499]: cannot borrow `values` as mutable more than once at a time
+  --> $DIR/mutate-vec-while-iterating.rs:18:13
+   |
+LL |       for value in &mut values {
+   |       -            -----------
+   |       |            |
+   |       |            first mutable borrow occurs here
+   |  _____|            first borrow later used here
+   | |
+LL | |         if *value == 2 {
+LL | |             values.push(4);
+   | |             ^^^^^^ second mutable borrow occurs here
+LL | |         }
+LL | |     }
+   | |_____- this for loop borrows `values` mutably, preventing mutation within its body
+   |
+   = help: consider using an index-based loop instead, or collecting modifications into a separate collection
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0499, E0502.
+For more information about an error, try `rustc --explain E0499`.

--- a/tests/ui/nll/polonius/iterating-updating-cursor-issue-108704.nll.stderr
+++ b/tests/ui/nll/polonius/iterating-updating-cursor-issue-108704.nll.stderr
@@ -1,11 +1,20 @@
 error[E0499]: cannot borrow `*elements` as mutable more than once at a time
   --> $DIR/iterating-updating-cursor-issue-108704.rs:41:26
    |
-LL |         for (idx, el) in elements.iter_mut().enumerate() {
-   |                          ^^^^^^^^
-   |                          |
-   |                          `*elements` was mutably borrowed here in the previous iteration of the loop
-   |                          first borrow used here, in later iteration of loop
+LL |           for (idx, el) in elements.iter_mut().enumerate() {
+   |           -                ^^^^^^^^
+   |           |                |
+   |           |                `*elements` was mutably borrowed here in the previous iteration of the loop
+   |  _________|                first borrow used here, in later iteration of loop
+   | |
+LL | |             if el.name == *p {
+LL | |                 elements = &mut el.children;
+LL | |                 break;
+LL | |             }
+LL | |         }
+   | |_________- this for loop borrows `*elements` mutably, preventing mutation within its body
+   |
+   = help: consider using an index-based loop instead, or collecting modifications into a separate collection
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/polonius/iterating-updating-cursor-issue-108704.polonius.stderr
+++ b/tests/ui/nll/polonius/iterating-updating-cursor-issue-108704.polonius.stderr
@@ -1,11 +1,20 @@
 error[E0499]: cannot borrow `*elements` as mutable more than once at a time
   --> $DIR/iterating-updating-cursor-issue-108704.rs:41:26
    |
-LL |         for (idx, el) in elements.iter_mut().enumerate() {
-   |                          ^^^^^^^^
-   |                          |
-   |                          `*elements` was mutably borrowed here in the previous iteration of the loop
-   |                          first borrow used here, in later iteration of loop
+LL |           for (idx, el) in elements.iter_mut().enumerate() {
+   |           -                ^^^^^^^^
+   |           |                |
+   |           |                `*elements` was mutably borrowed here in the previous iteration of the loop
+   |  _________|                first borrow used here, in later iteration of loop
+   | |
+LL | |             if el.name == *p {
+LL | |                 elements = &mut el.children;
+LL | |                 break;
+LL | |             }
+LL | |         }
+   | |_________- this for loop borrows `*elements` mutably, preventing mutation within its body
+   |
+   = help: consider using an index-based loop instead, or collecting modifications into a separate collection
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/issue-102972.stderr
+++ b/tests/ui/suggestions/issue-102972.stderr
@@ -1,14 +1,18 @@
 error[E0499]: cannot borrow `chars` as mutable more than once at a time
   --> $DIR/issue-102972.rs:6:9
    |
-LL |     for _c in chars.by_ref() {
-   |               --------------
-   |               |
-   |               first mutable borrow occurs here
-   |               first borrow later used here
-LL |         chars.next();
-   |         ^^^^^ second mutable borrow occurs here
+LL |       for _c in chars.by_ref() {
+   |       -         --------------
+   |       |         |
+   |       |         first mutable borrow occurs here
+   |  _____|         first borrow later used here
+   | |
+LL | |         chars.next();
+   | |         ^^^^^ second mutable borrow occurs here
+LL | |     }
+   | |_____- this for loop borrows `chars` mutably, preventing mutation within its body
    |
+   = help: consider using an index-based loop instead, or collecting modifications into a separate collection
    = note: a for loop advances the iterator for you, the result is stored in `_c`
 help: if you want to call `next` on a iterator within the loop, consider using `while let`
    |
@@ -39,14 +43,18 @@ LL +     while let Some(_i) = iter.next() {
 error[E0499]: cannot borrow `i` as mutable more than once at a time
   --> $DIR/issue-102972.rs:22:9
    |
-LL |     for () in i.by_ref() {
-   |               ----------
-   |               |
-   |               first mutable borrow occurs here
-   |               first borrow later used here
-LL |         i.next();
-   |         ^ second mutable borrow occurs here
+LL |       for () in i.by_ref() {
+   |       -         ----------
+   |       |         |
+   |       |         first mutable borrow occurs here
+   |  _____|         first borrow later used here
+   | |
+LL | |         i.next();
+   | |         ^ second mutable borrow occurs here
+LL | |     }
+   | |_____- this for loop borrows `i` mutably, preventing mutation within its body
    |
+   = help: consider using an index-based loop instead, or collecting modifications into a separate collection
    = note: a for loop advances the iterator for you, the result is stored in its pattern
 help: if you want to call `next` on a iterator within the loop, consider using `while let`
    |


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159816)*
<!-- homu-ignore:end -->

closes: rust-lang/rust#159489 

when the borrow checker detects a mutable borrow of a collection that is also immutably borrowed by a for loop, 

this emits a note explaining that the for loop holds the borrow for its entire iteration, and a help
message suggesting alternatives like index-based loops.