### PR TITLE
Rename splat to avoid stable name collisions

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3071,7 +3071,7 @@ impl FnDecl {
             } else {
                 arg.attrs
                     .iter()
-                    .any(|attr| attr.has_name(sym::splat))
+                    .any(|attr| attr.has_name(sym::rustc_splat))
                     .then_some(u8::try_from(index).unwrap())
             }
         })

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -454,7 +454,7 @@ impl<'a> AstValidator<'a> {
                 let splat_arg_spans: Vec<Span> = arg
                     .attrs
                     .iter()
-                    .filter_map(|attr| attr.has_name(sym::splat).then_some(attr.span))
+                    .filter_map(|attr| attr.has_name(sym::rustc_splat).then_some(attr.span))
                     .collect();
                 if splat_arg_spans.is_empty() {
                     None
@@ -522,7 +522,7 @@ impl<'a> AstValidator<'a> {
             .filter(|attr| match &attr.kind {
                 AttrKind::Normal(normal) => {
                     let arr =
-                        [sym::allow, sym::deny, sym::expect, sym::forbid, sym::splat, sym::warn];
+                        [sym::allow, sym::deny, sym::expect, sym::forbid, sym::rustc_splat, sym::warn];
                     !attr.has_any_name(&arr) && rustc_attr_parsing::is_builtin_attr(&normal.item)
                 }
                 AttrKind::Synthetic(CfgTrace(_) | CfgAttrTrace(_)) => false,

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -46,7 +46,7 @@ enum SelfSemantic {
     No,
 }
 
-/// Is `#[splat]` allowed semantically in a function or closure?
+/// Is `#[rustc_splat]` allowed semantically in a function or closure?
 /// Only applies to the function kind and header, the parameters are checked elsewhere.
 enum SplatSemantic {
     Yes,
@@ -439,7 +439,7 @@ impl<'a> AstValidator<'a> {
 
     /// Emits an error if a function declaration has more than one splatted argument, with a
     /// C-variadic parameter, or a splat at an unsupported index (for performance).
-    /// Example: `fn foo(#[splat] x: (), #[splat] y: ())` will emit an error.
+    /// Example: `fn foo(#[rustc_splat] x: (), #[rustc_splat] y: ())` will emit an error.
     fn check_decl_splatting(
         &self,
         fn_decl: &FnDecl,

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -521,8 +521,14 @@ impl<'a> AstValidator<'a> {
             .flat_map(|i| i.attrs.as_ref())
             .filter(|attr| match &attr.kind {
                 AttrKind::Normal(normal) => {
-                    let arr =
-                        [sym::allow, sym::deny, sym::expect, sym::forbid, sym::rustc_splat, sym::warn];
+                    let arr = [
+                        sym::allow,
+                        sym::deny,
+                        sym::expect,
+                        sym::forbid,
+                        sym::rustc_splat,
+                        sym::warn,
+                    ];
                     !attr.has_any_name(&arr) && rustc_attr_parsing::is_builtin_attr(&normal.item)
                 }
                 AttrKind::Synthetic(CfgTrace(_) | CfgAttrTrace(_)) => false,

--- a/compiler/rustc_ast_passes/src/diagnostics.rs
+++ b/compiler/rustc_ast_passes/src/diagnostics.rs
@@ -127,7 +127,9 @@ pub(crate) struct FnParamCVarArgsNotLast {
 #[diag(
     "`#[rustc_splat]` is only supported on argument index {$max_valid_splatted_arg_index} or less, this `#[rustc_splat]` is on index {$first_invalid_splatted_arg_index}"
 )]
-#[help("remove `#[rustc_splat]`, or use it on an argument closer to the start of the argument list")]
+#[help(
+    "remove `#[rustc_splat]`, or use it on an argument closer to the start of the argument list"
+)]
 pub(crate) struct InvalidSplattedArgs {
     pub max_valid_splatted_arg_index: u16,
 

--- a/compiler/rustc_ast_passes/src/diagnostics.rs
+++ b/compiler/rustc_ast_passes/src/diagnostics.rs
@@ -125,46 +125,46 @@ pub(crate) struct FnParamCVarArgsNotLast {
 
 #[derive(Diagnostic)]
 #[diag(
-    "`#[splat]` is only supported on argument index {$max_valid_splatted_arg_index} or less, this `#[splat]` is on index {$first_invalid_splatted_arg_index}"
+    "`#[rustc_splat]` is only supported on argument index {$max_valid_splatted_arg_index} or less, this `#[rustc_splat]` is on index {$first_invalid_splatted_arg_index}"
 )]
-#[help("remove `#[splat]`, or use it on an argument closer to the start of the argument list")]
+#[help("remove `#[rustc_splat]`, or use it on an argument closer to the start of the argument list")]
 pub(crate) struct InvalidSplattedArgs {
     pub max_valid_splatted_arg_index: u16,
 
     pub first_invalid_splatted_arg_index: u16,
 
     #[primary_span]
-    #[label("`#[splat]` is not supported here")]
+    #[label("`#[rustc_splat]` is not supported here")]
     pub spans: Vec<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag("multiple `#[splat]`s are not allowed in the same function argument list")]
-#[help("remove `#[splat]` from all but one argument")]
+#[diag("multiple `#[rustc_splat]`s are not allowed in the same function argument list")]
+#[help("remove `#[rustc_splat]` from all but one argument")]
 pub(crate) struct DuplicateSplattedArgs {
     #[primary_span]
     pub spans: Vec<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag("`...` and `#[splat]` are not allowed in the same function argument list")]
-#[help("remove `#[splat]` or remove `...`")]
+#[diag("`...` and `#[rustc_splat]` are not allowed in the same function argument list")]
+#[help("remove `#[rustc_splat]` or remove `...`")]
 pub(crate) struct CVarArgsAndSplat {
     #[primary_span]
     pub spans: Vec<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag("`#[splat]` is not allowed on closure arguments")]
-#[help("remove `#[splat]` or turn the closure into a function")]
+#[diag("`#[rustc_splat]` is not allowed on closure arguments")]
+#[help("remove `#[rustc_splat]` or turn the closure into a function")]
 pub(crate) struct SplatNotAllowedOnClosures {
     #[primary_span]
     pub spans: Vec<Span>,
 }
 
 #[derive(Diagnostic)]
-#[diag("`#[splat]` is not allowed in the arguments of functions with the `{$abi}` ABI")]
-#[help("remove `#[splat]` or change the ABI")]
+#[diag("`#[rustc_splat]` is not allowed in the arguments of functions with the `{$abi}` ABI")]
+#[help("remove `#[rustc_splat]` or change the ABI")]
 pub(crate) struct SplatNotAllowedOnAbiCall {
     #[primary_span]
     pub spans: Vec<Span>,

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -483,7 +483,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
     gate_all!(pin_ergonomics, "pinned reference syntax is experimental");
     gate_all!(postfix_match, "postfix match is experimental");
     gate_all!(return_type_notation, "return type notation is experimental");
-    gate_all!(splat, "`fn(#[splat] (a, ...))` is incomplete", "call as func((a, ...)) instead");
+    gate_all!(splat, "`fn(#[rustc_splat] (a, ...))` is incomplete", "call as func((a, ...)) instead");
     gate_all!(super_let, "`super let` is experimental");
     gate_all!(try_blocks_heterogeneous, "`try bikeshed` expression is experimental");
     gate_all!(unnamed_enum_variants, "unnamed enum variants are experimental");

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -483,7 +483,11 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
     gate_all!(pin_ergonomics, "pinned reference syntax is experimental");
     gate_all!(postfix_match, "postfix match is experimental");
     gate_all!(return_type_notation, "return type notation is experimental");
-    gate_all!(splat, "`fn(#[rustc_splat] (a, ...))` is incomplete", "call as func((a, ...)) instead");
+    gate_all!(
+        splat,
+        "`fn(#[rustc_splat] (a, ...))` is incomplete",
+        "call as func((a, ...)) instead"
+    );
     gate_all!(super_let, "`super let` is experimental");
     gate_all!(try_blocks_heterogeneous, "`try bikeshed` expression is experimental");
     gate_all!(unnamed_enum_variants, "unnamed enum variants are experimental");

--- a/compiler/rustc_attr_parsing/src/attributes/splat.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/splat.rs
@@ -10,6 +10,7 @@ pub(crate) struct SplatParser;
 impl NoArgsAttributeParser for SplatParser {
     const PATH: &[Symbol] = &[sym::rustc_splat];
     const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Param)]);
-    const STABILITY: AttributeStability = unstable!(splat, "the `rustc_splat` attribute is experimental");
+    const STABILITY: AttributeStability =
+        unstable!(splat, "the `rustc_splat` attribute is experimental");
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::Splat;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/splat.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/splat.rs
@@ -1,4 +1,4 @@
-//! Attribute parsing for the `#[splat]` function argument overloading attribute.
+//! Attribute parsing for the `#[rustc_splat]` function argument overloading attribute.
 //! This attribute modifies typecheck to support overload resolution, then modifies codegen for performance.
 
 use rustc_feature::AttributeStability;
@@ -8,8 +8,8 @@ use super::prelude::*;
 pub(crate) struct SplatParser;
 
 impl NoArgsAttributeParser for SplatParser {
-    const PATH: &[Symbol] = &[sym::splat];
+    const PATH: &[Symbol] = &[sym::rustc_splat];
     const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Param)]);
-    const STABILITY: AttributeStability = unstable!(splat, "the `splat` attribute is experimental");
+    const STABILITY: AttributeStability = unstable!(splat, "the `rustc_splat` attribute is experimental");
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::Splat;
 }

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -211,11 +211,11 @@ pub static BUILTIN_ATTRIBUTES: &[Symbol] = &[
     // - https://github.com/rust-lang/rust/issues/130494
     sym::pin_v2,
 
-    // The `#[splat]` attribute is part of the `splat` experiment
+    // The `#[rustc_splat]` attribute is part of the `splat` experiment
     // that improves the ergonomics of function overloading, tracked in:
     //
     // - https://github.com/rust-lang/rust/issues/153629
-    sym::splat,
+    sym::rustc_splat,
 
     // The `#[unroll]` attribute.
     //

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -736,7 +736,7 @@ declare_features! (
     /// Allows specialization of implementations (RFC 1210).
     (incomplete, specialization, "1.7.0", Some(31844)),
     /// Experimental "splatting" of function call arguments at the call site.
-    /// e.g. `foo(a, b, c)` calls `#[splat] fn foo((a: A, b: B, c: C))`.
+    /// e.g. `foo(a, b, c)` calls `#[rustc_splat] fn foo((a: A, b: B, c: C))`.
     (incomplete, splat, "1.98.0", Some(153629)),
     /// Allows using `#[rustc_align_static(...)]` on static items.
     (unstable, static_align, "1.91.0", Some(146177)),

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1674,7 +1674,7 @@ pub enum AttributeKind {
         reason: Option<Symbol>,
     },
 
-    /// Represents `#[splat]`
+    /// Represents `#[rustc_splat]`
     Splat(Span),
 
     /// Represents `#[stable]`, `#[unstable]` and `#[rustc_allowed_through_unstable_modules]`.

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -451,7 +451,7 @@ fn fn_sig_suggestion<'tcx>(
         .iter()
         .enumerate()
         .map(|(i, ty)| {
-            let splat = if splatted_arg_index == Some(i) { "#[splat] " } else { "" };
+            let splat = if splatted_arg_index == Some(i) { "#[rustc_splat] " } else { "" };
             let arg_ty = match ty.kind() {
                 ty::Param(_) if assoc.is_method() && i == 0 => "self".to_string(),
                 ty::Ref(reg, ref_ty, mutability) if i == 0 => {

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -2278,7 +2278,7 @@ impl<'a> State<'a> {
         let mut i = 0;
         let mut print_arg = |s: &mut Self, ty: Option<&hir::Ty<'_>>| {
             if Some(i) == decl.splatted().map(usize::from) {
-                s.word("#[splat]");
+                s.word("#[rustc_splat]");
             }
             if i == 0 && decl.implicit_self().has_implicit_self() {
                 s.print_implicit_self(&decl.implicit_self());

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -50,7 +50,7 @@ rustc_index::newtype_index! {
     pub(crate) struct GenericIdx {}
 }
 
-/// Outcome of checking arguments that are tupled by "rust-call" or `#[splat]`.
+/// Outcome of checking arguments that are tupled by "rust-call" or `#[rustc_splat]`.
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct TupledArgCheckOutcome<'tcx> {
     /// The error code to emit if the arguments are not compatible.
@@ -559,7 +559,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    /// Check arguments that are tupled by "rust-call" or `#[splat]`.
+    /// Check arguments that are tupled by "rust-call" or `#[rustc_splat]`.
     fn check_tupled_arguments(
         &self,
         // Span enclosing the call site
@@ -593,10 +593,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // The argument difference can range from -1 to u16::MAX - 1, so we count the number
         // of tupled arguments instead.
         // (An empty argument list becomes a unit tuple in the callee.)
-        // 0: f() -> f(#[splat] _: ())
-        // 1: f(a) -> f(#[splat] _: (A,))
-        // 2: f(a, b) -> f(#[splat] _: (A, B))
-        // The Fn* traits ensure this by construction, and `#[splat]` can only be applied to
+        // 0: f() -> f(#[rustc_splat] _: ())
+        // 1: f(a) -> f(#[rustc_splat] _: (A,))
+        // 2: f(a, b) -> f(#[rustc_splat] _: (A, B))
+        // The Fn* traits ensure this by construction, and `#[rustc_splat]` can only be applied to
         // an actual argument.
         let tupled_args_count = (1 + provided_args.len()).checked_sub(formal_input_tys.len());
         debug!(

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1505,7 +1505,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         let mut input_iter = inputs.iter().copied();
         if let Some(index) = splatted_arg_index {
             self.comma_sep((&mut input_iter).take(usize::from(index)))?;
-            write!(self, ", #[splat]")?;
+            write!(self, ", #[rustc_splat]")?;
             self.comma_sep(input_iter)?;
         } else {
             self.comma_sep(input_iter)?;

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -374,7 +374,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
             hir::ExprKind::MethodCall(segment, receiver, args, fn_span) => {
                 if self.typeck_results.is_splatted_call(expr) {
                     // The callee has a splatted tuple argument.
-                    // rewrite `receiver.f(a, u, v)` into `receiver.f(a, #[splat] (u, v))`
+                    // rewrite `receiver.f(a, u, v)` into `receiver.f(a, #[rustc_splat] (u, v))`
                     self.convert_splatted_callee(expr, fn_span, args, Some(receiver))
                 } else {
                     // Rewrite a.b(c) into UFCS form like Trait::b(a, c)
@@ -424,7 +424,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     }
                 } else if self.typeck_results.is_splatted_call(expr) {
                     // The callee has a splatted tuple argument.
-                    // rewrite `f(a, u, v)` into `f(a, #[splat] (u, v))`
+                    // rewrite `f(a, u, v)` into `f(a, #[rustc_splat] (u, v))`
                     self.convert_splatted_callee(expr, fun.span, args, None)
                 } else {
                     // Tuple-like ADTs are represented as ExprKind::Call. We convert them here.
@@ -1282,7 +1282,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
     }
 
     /// The callee has a splatted tuple argument.
-    /// Rewrite a splatted call `receiver.f(a, u, v)` into `receiver.f(a, #[splat] (u, v))`.
+    /// Rewrite a splatted call `receiver.f(a, u, v)` into `receiver.f(a, #[rustc_splat] (u, v))`.
     /// The receiver is optional.
     fn convert_splatted_callee(
         &mut self,
@@ -1298,7 +1298,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
         let tupled_arg_index = usize::from(tupled_arg_index);
         let tupled_args_count = usize::from(tupled_args_count);
 
-        // Splatting an empty tuple is permitted: `a.f() -> Trait::f(a, #[splat] ())`.
+        // Splatting an empty tuple is permitted: `a.f() -> Trait::f(a, #[rustc_splat] ())`.
         // In that case, the tupled arg index is one past the end of the args.
         if tupled_arg_index + tupled_args_count > args.len() {
             span_bug!(

--- a/compiler/rustc_public/src/unstable/convert/internal.rs
+++ b/compiler/rustc_public/src/unstable/convert/internal.rs
@@ -313,7 +313,7 @@ impl RustcInternal for FnSig {
         tables: &mut Tables<'_, BridgeTys>,
         tcx: impl InternalCx<'tcx>,
     ) -> Self::T<'tcx> {
-        // FIXME(splat): When `#[splat]` is complete (or stable), add splatted to the public FnSig
+        // FIXME(splat): When `#[rustc_splat]` is complete (or stable), add splatted to the public FnSig
         let fn_sig_kind = rustc_ty::FnSigKind::default()
             .set_abi(self.abi.internal(tables, tcx))
             .set_safety(self.safety.internal(tables, tcx))

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1861,6 +1861,7 @@ symbols! {
         rustc_simd_monomorphize_lane_limit,
         rustc_skip_during_method_dispatch,
         rustc_specialization_trait,
+        rustc_splat,
         rustc_std_internal_symbol,
         rustc_strict_coherence,
         rustc_test_entrypoint_marker,

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -829,11 +829,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             for (i, (l, r)) in iter::zip(sig1.inputs(), sig2.inputs()).enumerate() {
                 self.push_comma(&mut values.0, &mut values.1, i);
                 if Some(i) == splatted_arg_index1 {
-                    values.0.push("#[splat]", splatted_arg_index1 != splatted_arg_index2);
+                    values.0.push("#[rustc_splat]", splatted_arg_index1 != splatted_arg_index2);
                     values.0.push_normal(" ");
                 }
                 if Some(i) == splatted_arg_index2 {
-                    values.1.push("#[splat]", splatted_arg_index1 != splatted_arg_index2);
+                    values.1.push("#[rustc_splat]", splatted_arg_index1 != splatted_arg_index2);
                     values.1.push_normal(" ");
                 }
                 let (x1, x2) = self.cmp(*l, *r);

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -1241,7 +1241,7 @@ impl<I: Interner> fmt::Debug for FnSig<I> {
                 write!(f, ", ")?;
             }
             if Some(i) == fn_sig_kind.splatted().map(usize::from) {
-                write!(f, "#[splat] ")?;
+                write!(f, "#[rustc_splat] ")?;
             }
             write!(f, "{ty:?}")?;
         }

--- a/library/core/src/mem/type_info.rs
+++ b/library/core/src/mem/type_info.rs
@@ -349,7 +349,7 @@ pub struct FnPtr {
     pub is_splatted: bool,
 
     /// The index of the splatted function argument in `inputs`, only valid if `is_splatted` is true.
-    /// e.g. in `fn overload(a: u8, #[splat] b: (f32, usize))` the index is 1, and it can be called
+    /// e.g. in `fn overload(a: u8, #[rustc_splat] b: (f32, usize))` the index is 1, and it can be called
     /// as `overload(a, 1.0, 2)`.
     pub splatted_index: u8,
 }

--- a/library/coretests/tests/mem/fn_ptr.rs
+++ b/library/coretests/tests/mem/fn_ptr.rs
@@ -192,7 +192,7 @@ fn test_variadic() {
 #[test]
 fn test_splat() {
     #[rustfmt::skip]
-    let TypeKind::FnPtr(fn_ptr_ty) = &(const { Type::of::<fn(#[splat] (String, u8))>().kind }) else {
+    let TypeKind::FnPtr(fn_ptr_ty) = &(const { Type::of::<fn(#[rustc_splat] (String, u8))>().kind }) else {
         panic!();
     };
     let FnPtr {

--- a/src/doc/rustc/src/symbol-mangling/v0.md
+++ b/src/doc/rustc/src/symbol-mangling/v0.md
@@ -778,7 +778,7 @@ Remaining primitives are encoded as a crate production, e.g. `C4f128`.
 
   Note that a zero-length tuple (unit) is encoded with the `u` *[basic-type]*.
 
-* `w` — A [splatted type][tracking-splat] `#[splat] T`.
+* `w` — A [splatted type][tracking-splat] `#[rustc_splat] T`.
 
   > <span id="splatted-type">splatted-type</span> → `w` {*[type]*}
 

--- a/tests/ui/feature-gates/feature-gate-splat.rs
+++ b/tests/ui/feature-gates/feature-gate-splat.rs
@@ -1,6 +1,6 @@
 #[rustfmt::skip]
 fn tuple_args(
-    #[splat] //~ ERROR the `splat` attribute is an experimental feature
+    #[rustc_splat] //~ ERROR the `rustc_splat` attribute is an experimental feature
     (a, b, c): (u32, i8, char),
 ) {
 }

--- a/tests/ui/feature-gates/feature-gate-splat.stderr
+++ b/tests/ui/feature-gates/feature-gate-splat.stderr
@@ -1,13 +1,13 @@
-error[E0658]: the `splat` attribute is an experimental feature
+error[E0658]: the `rustc_splat` attribute is an experimental feature
   --> $DIR/feature-gate-splat.rs:3:7
    |
-LL |     #[splat]
-   |       ^^^^^
+LL |     #[rustc_splat]
+   |       ^^^^^^^^^^^
    |
    = note: see issue #153629 <https://github.com/rust-lang/rust/issues/153629> for more information
    = help: add `#![feature(splat)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: the `splat` attribute is experimental
+   = note: the `rustc_splat` attribute is experimental
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/splat/arg-count-ice-issue-158482.rs
+++ b/tests/ui/splat/arg-count-ice-issue-158482.rs
@@ -3,10 +3,10 @@
 #![feature(splat)]
 struct Foo {}
 trait BarTrait {
-    fn trait_assoc<W>(w: W, #[splat] _s: (u32, u8));
+    fn trait_assoc<W>(w: W, #[rustc_splat] _s: (u32, u8));
 }
 impl BarTrait for Foo {
-    fn trait_assoc<W>(_w: W, #[splat] _s: (u32, u8)) {}
+    fn trait_assoc<W>(_w: W, #[rustc_splat] _s: (u32, u8)) {}
 }
 fn main() {
     Foo::trait_assoc()

--- a/tests/ui/splat/reject-closure-issue-158605.rs
+++ b/tests/ui/splat/reject-closure-issue-158605.rs
@@ -7,20 +7,20 @@
 use std::marker::Tuple;
 
 trait Trait: Tuple + Sized {
-    extern "rust-call" fn method(#[splat] self: Self);
-    //~^ ERROR: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+    extern "rust-call" fn method(#[rustc_splat] self: Self);
+    //~^ ERROR: `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
 }
 
 impl Trait for (i32, i64) {
-    extern "rust-call" fn method(#[splat] self: Self) {
-        //~^ ERROR: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+    extern "rust-call" fn method(#[rustc_splat] self: Self) {
+        //~^ ERROR: `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
         println!("{self:?}");
     }
 }
 
 fn main() {
-    (|#[splat] x: i32| {
-        //~^ ERROR `#[splat]` is not allowed on closure arguments
+    (|#[rustc_splat] x: i32| {
+        //~^ ERROR `#[rustc_splat]` is not allowed on closure arguments
         println!("{x}");
     })(1);
 

--- a/tests/ui/splat/reject-closure-issue-158605.stderr
+++ b/tests/ui/splat/reject-closure-issue-158605.stderr
@@ -1,30 +1,30 @@
-error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+error: `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
   --> $DIR/reject-closure-issue-158605.rs:10:5
    |
-LL |     extern "rust-call" fn method(#[splat] self: Self);
-   |     ^^^^^^^^^^^^^^^^^^           ^^^^^^^^
+LL |     extern "rust-call" fn method(#[rustc_splat] self: Self);
+   |     ^^^^^^^^^^^^^^^^^^           ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or change the ABI
+   = help: remove `#[rustc_splat]` or change the ABI
 
-error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+error: `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
   --> $DIR/reject-closure-issue-158605.rs:15:5
    |
-LL |     extern "rust-call" fn method(#[splat] self: Self) {
-   |     ^^^^^^^^^^^^^^^^^^           ^^^^^^^^
+LL |     extern "rust-call" fn method(#[rustc_splat] self: Self) {
+   |     ^^^^^^^^^^^^^^^^^^           ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or change the ABI
+   = help: remove `#[rustc_splat]` or change the ABI
 
-error: `#[splat]` is not allowed on closure arguments
+error: `#[rustc_splat]` is not allowed on closure arguments
   --> $DIR/reject-closure-issue-158605.rs:22:7
    |
-LL |       (|#[splat] x: i32| {
-   |  _______^^^^^^^^_________^
+LL |       (|#[rustc_splat] x: i32| {
+   |  _______^^^^^^^^^^^^^^_________^
 LL | |
 LL | |         println!("{x}");
 LL | |     })(1);
    | |_____^
    |
-   = help: remove `#[splat]` or turn the closure into a function
+   = help: remove `#[rustc_splat]` or turn the closure into a function
 
 error: functions with the "rust-call" ABI must take a single non-self tuple argument
   --> $DIR/reject-closure-issue-158605.rs:28:26

--- a/tests/ui/splat/run-splat.rs
+++ b/tests/ui/splat/run-splat.rs
@@ -12,7 +12,7 @@ trait MethodArgs: Tuple {
 }
 
 impl Foo {
-    fn method(&self, #[splat] args: impl MethodArgs) -> String {
+    fn method(&self, #[rustc_splat] args: impl MethodArgs) -> String {
         args.call_method(self)
     }
 }

--- a/tests/ui/splat/splat-255-limit-fail.rs
+++ b/tests/ui/splat/splat-255-limit-fail.rs
@@ -1,5 +1,5 @@
 // ignore-tidy-file-linelength
-//! Test `#[splat]` fails over the 255th argument index (or higher).
+//! Test `#[rustc_splat]` fails over the 255th argument index (or higher).
 //! FIXME(splat): The 255 argument limit is a temporary performance hack.
 
 #![allow(incomplete_features)]
@@ -47,7 +47,7 @@ fn s_255_terminal(
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
-    #[splat] (_a, _b): (u32, i8), //~ ERROR `#[splat]` is only supported on argument index 254 or less, this `#[splat]` is on index 255
+    #[rustc_splat] (_a, _b): (u32, i8), //~ ERROR `#[rustc_splat]` is only supported on argument index 254 or less, this `#[rustc_splat]` is on index 255
 ) {}
 
 #[rustfmt::skip]
@@ -68,7 +68,7 @@ fn s_256_terminal(
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A,
-    #[splat] (_a, _b): (u32, i8), //~ ERROR `#[splat]` is only supported on argument index 254 or less, this `#[splat]` is on index 256
+    #[rustc_splat] (_a, _b): (u32, i8), //~ ERROR `#[rustc_splat]` is only supported on argument index 254 or less, this `#[rustc_splat]` is on index 256
 ) {}
 
 #[rustfmt::skip]
@@ -88,7 +88,7 @@ fn s_255_non_terminal(
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
-    #[splat] (_a, _b): (u32, i8), //~ ERROR `#[splat]` is only supported on argument index 254 or less, this `#[splat]` is on index 255
+    #[rustc_splat] (_a, _b): (u32, i8), //~ ERROR `#[rustc_splat]` is only supported on argument index 254 or less, this `#[rustc_splat]` is on index 255
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
 ) {}
 
@@ -110,12 +110,12 @@ fn s_256_non_terminal(
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A,
-    #[splat] (_a, _b): (u32, i8), //~ ERROR `#[splat]` is only supported on argument index 254 or less, this `#[splat]` is on index 256
+    #[rustc_splat] (_a, _b): (u32, i8), //~ ERROR `#[rustc_splat]` is only supported on argument index 254 or less, this `#[rustc_splat]` is on index 256
     _: A,
 ) {}
 
 // It's only the splatted index that's constrained to 255, not the argument count of the caller or callee.
-fn more_than_255_splatted_args(#[splat] _t: Tuple256) {}
+fn more_than_255_splatted_args(#[rustc_splat] _t: Tuple256) {}
 
 fn main() {
     let a = ();

--- a/tests/ui/splat/splat-255-limit-fail.stderr
+++ b/tests/ui/splat/splat-255-limit-fail.stderr
@@ -1,34 +1,34 @@
-error: `#[splat]` is only supported on argument index 254 or less, this `#[splat]` is on index 255
+error: `#[rustc_splat]` is only supported on argument index 254 or less, this `#[rustc_splat]` is on index 255
   --> $DIR/splat-255-limit-fail.rs:50:5
    |
-LL |     #[splat] (_a, _b): (u32, i8),
-   |     ^^^^^^^^ `#[splat]` is not supported here
+LL |     #[rustc_splat] (_a, _b): (u32, i8),
+   |     ^^^^^^^^^^^^^^ `#[rustc_splat]` is not supported here
    |
-   = help: remove `#[splat]`, or use it on an argument closer to the start of the argument list
+   = help: remove `#[rustc_splat]`, or use it on an argument closer to the start of the argument list
 
-error: `#[splat]` is only supported on argument index 254 or less, this `#[splat]` is on index 256
+error: `#[rustc_splat]` is only supported on argument index 254 or less, this `#[rustc_splat]` is on index 256
   --> $DIR/splat-255-limit-fail.rs:71:5
    |
-LL |     #[splat] (_a, _b): (u32, i8),
-   |     ^^^^^^^^ `#[splat]` is not supported here
+LL |     #[rustc_splat] (_a, _b): (u32, i8),
+   |     ^^^^^^^^^^^^^^ `#[rustc_splat]` is not supported here
    |
-   = help: remove `#[splat]`, or use it on an argument closer to the start of the argument list
+   = help: remove `#[rustc_splat]`, or use it on an argument closer to the start of the argument list
 
-error: `#[splat]` is only supported on argument index 254 or less, this `#[splat]` is on index 255
+error: `#[rustc_splat]` is only supported on argument index 254 or less, this `#[rustc_splat]` is on index 255
   --> $DIR/splat-255-limit-fail.rs:91:5
    |
-LL |     #[splat] (_a, _b): (u32, i8),
-   |     ^^^^^^^^ `#[splat]` is not supported here
+LL |     #[rustc_splat] (_a, _b): (u32, i8),
+   |     ^^^^^^^^^^^^^^ `#[rustc_splat]` is not supported here
    |
-   = help: remove `#[splat]`, or use it on an argument closer to the start of the argument list
+   = help: remove `#[rustc_splat]`, or use it on an argument closer to the start of the argument list
 
-error: `#[splat]` is only supported on argument index 254 or less, this `#[splat]` is on index 256
+error: `#[rustc_splat]` is only supported on argument index 254 or less, this `#[rustc_splat]` is on index 256
   --> $DIR/splat-255-limit-fail.rs:113:5
    |
-LL |     #[splat] (_a, _b): (u32, i8),
-   |     ^^^^^^^^ `#[splat]` is not supported here
+LL |     #[rustc_splat] (_a, _b): (u32, i8),
+   |     ^^^^^^^^^^^^^^ `#[rustc_splat]` is not supported here
    |
-   = help: remove `#[splat]`, or use it on an argument closer to the start of the argument list
+   = help: remove `#[rustc_splat]`, or use it on an argument closer to the start of the argument list
 
 error[E0057]: this splatted function takes 256 arguments, but 255 were provided
   --> $DIR/splat-255-limit-fail.rs:124:5

--- a/tests/ui/splat/splat-255-limit-pass.rs
+++ b/tests/ui/splat/splat-255-limit-pass.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 // ignore-tidy-file-linelength
-//! Test `#[splat]` on the 255th argument index (or lower).
+//! Test `#[rustc_splat]` on the 255th argument index (or lower).
 //! FIXME(splat): The 255 argument limit is a temporary performance hack.
 
 #![allow(incomplete_features)]
@@ -48,7 +48,7 @@ fn s_253_terminal(
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
-    #[splat] (_a, _b): (u32, i8),
+    #[rustc_splat] (_a, _b): (u32, i8),
 ) {}
 
 #[rustfmt::skip]
@@ -68,7 +68,7 @@ fn s_254_terminal(
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
-    #[splat] (_a, _b): (u32, i8),
+    #[rustc_splat] (_a, _b): (u32, i8),
 ) {}
 
 #[rustfmt::skip]
@@ -88,13 +88,13 @@ fn s_254_non_terminal_272_args(
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
-    #[splat] (_a, _b): (u32, i8),
+    #[rustc_splat] (_a, _b): (u32, i8),
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
 ) {}
 
 #[rustfmt::skip]
 fn s_0_initial_253_args(
-    #[splat] (_a, _b): (u32, i8),
+    #[rustc_splat] (_a, _b): (u32, i8),
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
@@ -114,7 +114,7 @@ fn s_0_initial_253_args(
 
 #[rustfmt::skip]
 fn s_0_initial_254_args(
-    #[splat] (_a, _b): (u32, i8),
+    #[rustc_splat] (_a, _b): (u32, i8),
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
@@ -134,7 +134,7 @@ fn s_0_initial_254_args(
 
 #[rustfmt::skip]
 fn s_0_initial_255_args(
-    #[splat] (_a, _b): (u32, i8),
+    #[rustc_splat] (_a, _b): (u32, i8),
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
@@ -155,7 +155,7 @@ fn s_0_initial_255_args(
 // It's only the splatted index that's constrained to 255, not the argument count of the caller or callee.
 #[rustfmt::skip]
 fn s_0_initial_256_args(
-    #[splat] (_a, _b): (u32, i8),
+    #[rustc_splat] (_a, _b): (u32, i8),
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
     _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A, _: A,
@@ -174,7 +174,7 @@ fn s_0_initial_256_args(
     _: A,
 ) {}
 
-fn more_than_255_splatted_args(#[splat] _t: Tuple256) {}
+fn more_than_255_splatted_args(#[rustc_splat] _t: Tuple256) {}
 
 fn main() {
     let a = ();

--- a/tests/ui/splat/splat-assoc-fn-tuple-simple.rs
+++ b/tests/ui/splat/splat-assoc-fn-tuple-simple.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//! Test using `#[splat]` on associated function tuple arguments (no receivers).
+//! Test using `#[rustc_splat]` on associated function tuple arguments (no receivers).
 
 #![allow(incomplete_features)]
 #![feature(splat)]
@@ -7,9 +7,9 @@
 struct Foo;
 
 impl Foo {
-    fn tuple_1(#[splat] (_a,): (u32,)) {}
+    fn tuple_1(#[rustc_splat] (_a,): (u32,)) {}
 
-    fn tuple_3(#[splat] (_a, _b, _c): (u32, i32, i8)) {}
+    fn tuple_3(#[rustc_splat] (_a, _b, _c): (u32, i32, i8)) {}
 }
 
 fn main() {

--- a/tests/ui/splat/splat-async-fn-tuple-fail.rs
+++ b/tests/ui/splat/splat-async-fn-tuple-fail.rs
@@ -7,8 +7,11 @@
 async fn async_wrong_type(#[rustc_splat] _x: u32) {}
 //~^ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32
 
-async fn async_multi_splat(#[rustc_splat] (_a, _b): (u32, i8), #[rustc_splat] (_c, _d): (u32, i8)) {}
-//~^ ERROR multiple `#[rustc_splat]`s are not allowed in the same function argument list
+async fn async_multi_splat(
+    #[rustc_splat] (_a, _b): (u32, i8),
+    //~^ ERROR multiple `#[rustc_splat]`s are not allowed in the same function argument list
+    #[rustc_splat] (_c, _d): (u32, i8),
+) {}
 
 fn main() {
     async_wrong_type(1u32);

--- a/tests/ui/splat/splat-async-fn-tuple-fail.rs
+++ b/tests/ui/splat/splat-async-fn-tuple-fail.rs
@@ -1,14 +1,14 @@
 //@ edition:2024
-//! Test that using `#[splat]` incorrectly on async functions gives errors.
+//! Test that using `#[rustc_splat]` incorrectly on async functions gives errors.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 
-async fn async_wrong_type(#[splat] _x: u32) {}
+async fn async_wrong_type(#[rustc_splat] _x: u32) {}
 //~^ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32
 
-async fn async_multi_splat(#[splat] (_a, _b): (u32, i8), #[splat] (_c, _d): (u32, i8)) {}
-//~^ ERROR multiple `#[splat]`s are not allowed in the same function argument list
+async fn async_multi_splat(#[rustc_splat] (_a, _b): (u32, i8), #[rustc_splat] (_c, _d): (u32, i8)) {}
+//~^ ERROR multiple `#[rustc_splat]`s are not allowed in the same function argument list
 
 fn main() {
     async_wrong_type(1u32);

--- a/tests/ui/splat/splat-async-fn-tuple-fail.stderr
+++ b/tests/ui/splat/splat-async-fn-tuple-fail.stderr
@@ -1,16 +1,16 @@
-error: multiple `#[splat]`s are not allowed in the same function argument list
+error: multiple `#[rustc_splat]`s are not allowed in the same function argument list
   --> $DIR/splat-async-fn-tuple-fail.rs:10:28
    |
-LL | async fn async_multi_splat(#[splat] (_a, _b): (u32, i8), #[splat] (_c, _d): (u32, i8)) {}
-   |                            ^^^^^^^^                      ^^^^^^^^
+LL | async fn async_multi_splat(#[rustc_splat] (_a, _b): (u32, i8), #[rustc_splat] (_c, _d): (u32, i8)) {}
+   |                            ^^^^^^^^^^^^^^                      ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` from all but one argument
+   = help: remove `#[rustc_splat]` from all but one argument
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32 (u32)
-  --> $DIR/splat-async-fn-tuple-fail.rs:7:40
+  --> $DIR/splat-async-fn-tuple-fail.rs:7:46
    |
-LL | async fn async_wrong_type(#[splat] _x: u32) {}
-   |                                        ^^^
+LL | async fn async_wrong_type(#[rustc_splat] _x: u32) {}
+   |                                              ^^^
 ...
 LL |     async_wrong_type(1u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-async-fn-tuple-fail.stderr
+++ b/tests/ui/splat/splat-async-fn-tuple-fail.stderr
@@ -1,8 +1,11 @@
 error: multiple `#[rustc_splat]`s are not allowed in the same function argument list
-  --> $DIR/splat-async-fn-tuple-fail.rs:10:28
+  --> $DIR/splat-async-fn-tuple-fail.rs:11:5
    |
-LL | async fn async_multi_splat(#[rustc_splat] (_a, _b): (u32, i8), #[rustc_splat] (_c, _d): (u32, i8)) {}
-   |                            ^^^^^^^^^^^^^^                      ^^^^^^^^^^^^^^
+LL |     #[rustc_splat] (_a, _b): (u32, i8),
+   |     ^^^^^^^^^^^^^^
+LL |
+LL |     #[rustc_splat] (_c, _d): (u32, i8),
+   |     ^^^^^^^^^^^^^^
    |
    = help: remove `#[rustc_splat]` from all but one argument
 
@@ -16,7 +19,7 @@ LL |     async_wrong_type(1u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0057]: this splatted function takes 3 arguments, but 4 were provided
-  --> $DIR/splat-async-fn-tuple-fail.rs:15:5
+  --> $DIR/splat-async-fn-tuple-fail.rs:18:5
    |
 LL |     async_multi_splat(1u32, 2i8, 3u32, 4i8);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-async-fn-tuple.rs
+++ b/tests/ui/splat/splat-async-fn-tuple.rs
@@ -1,13 +1,13 @@
 //@ run-pass
 //@ edition:2024
-//! Test using `#[splat]` on tuple arguments of async functions.
+//! Test using `#[rustc_splat]` on tuple arguments of async functions.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 
-async fn async_tuple_args(#[splat] (_a, _b): (u32, i8)) {}
+async fn async_tuple_args(#[rustc_splat] (_a, _b): (u32, i8)) {}
 
-async fn async_splat_non_terminal_arg(#[splat] (_a, _b): (u32, i8), _c: f64) {}
+async fn async_splat_non_terminal_arg(#[rustc_splat] (_a, _b): (u32, i8), _c: f64) {}
 
 fn main() {
     let _ = async_tuple_args(1u32, 2i8);

--- a/tests/ui/splat/splat-cannot-resolve.rs
+++ b/tests/ui/splat/splat-cannot-resolve.rs
@@ -1,16 +1,16 @@
-//! Test that using `#[splat]` on un-resolvable types is an error.
+//! Test that using `#[rustc_splat]` on un-resolvable types is an error.
 
 #![allow(incomplete_features)]
 #![allow(unconditional_recursion)]
 #![feature(splat)]
 #![feature(tuple_trait)]
 
-fn tuple(#[splat] t: impl Sized) -> impl Sized {
+fn tuple(#[rustc_splat] t: impl Sized) -> impl Sized {
     //~^ ERROR cannot resolve opaque type
     tuple(tuple((t, ())))
 }
 
-fn tuple_trait(#[splat] t: impl std::marker::Tuple) -> impl std::marker::Tuple {
+fn tuple_trait(#[rustc_splat] t: impl std::marker::Tuple) -> impl std::marker::Tuple {
     //~^ ERROR cannot resolve opaque type
     tuple_trait(tuple_trait((t, ())))
 }
@@ -20,12 +20,12 @@ trait Trait {
     type Tup: std::marker::Tuple;
 }
 
-fn ambig(#[splat] t: Trait::MaybeTup) {}
+fn ambig(#[rustc_splat] t: Trait::MaybeTup) {}
 //~^ ERROR ambiguous associated type
 //~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
 //~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
 //~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
-fn ambig_tup(#[splat] t: Trait::Tup) {}
+fn ambig_tup(#[rustc_splat] t: Trait::Tup) {}
 //~^ ERROR ambiguous associated type
 //~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
 //~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a

--- a/tests/ui/splat/splat-cannot-resolve.stderr
+++ b/tests/ui/splat/splat-cannot-resolve.stderr
@@ -1,89 +1,89 @@
 error[E0223]: ambiguous associated type
-  --> $DIR/splat-cannot-resolve.rs:23:22
+  --> $DIR/splat-cannot-resolve.rs:23:28
    |
-LL | fn ambig(#[splat] t: Trait::MaybeTup) {}
-   |                      ^^^^^^^^^^^^^^^
+LL | fn ambig(#[rustc_splat] t: Trait::MaybeTup) {}
+   |                            ^^^^^^^^^^^^^^^
    |
 help: if there were a type named `Example` that implemented `Trait`, you could use the fully-qualified path
    |
-LL - fn ambig(#[splat] t: Trait::MaybeTup) {}
-LL + fn ambig(#[splat] t: <Example as Trait>::MaybeTup) {}
+LL - fn ambig(#[rustc_splat] t: Trait::MaybeTup) {}
+LL + fn ambig(#[rustc_splat] t: <Example as Trait>::MaybeTup) {}
    |
 
 error[E0223]: ambiguous associated type
-  --> $DIR/splat-cannot-resolve.rs:28:26
+  --> $DIR/splat-cannot-resolve.rs:28:32
    |
-LL | fn ambig_tup(#[splat] t: Trait::Tup) {}
-   |                          ^^^^^^^^^^
+LL | fn ambig_tup(#[rustc_splat] t: Trait::Tup) {}
+   |                                ^^^^^^^^^^
    |
 help: if there were a type named `Example` that implemented `Trait`, you could use the fully-qualified path
    |
-LL - fn ambig_tup(#[splat] t: Trait::Tup) {}
-LL + fn ambig_tup(#[splat] t: <Example as Trait>::Tup) {}
+LL - fn ambig_tup(#[rustc_splat] t: Trait::Tup) {}
+LL + fn ambig_tup(#[rustc_splat] t: <Example as Trait>::Tup) {}
    |
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/splat-cannot-resolve.rs:8:37
+  --> $DIR/splat-cannot-resolve.rs:8:43
    |
-LL | fn tuple(#[splat] t: impl Sized) -> impl Sized {
-   |                                     ^^^^^^^^^^
+LL | fn tuple(#[rustc_splat] t: impl Sized) -> impl Sized {
+   |                                           ^^^^^^^^^^
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/splat-cannot-resolve.rs:13:56
+  --> $DIR/splat-cannot-resolve.rs:13:62
    |
-LL | fn tuple_trait(#[splat] t: impl std::marker::Tuple) -> impl std::marker::Tuple {
-   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn tuple_trait(#[rustc_splat] t: impl std::marker::Tuple) -> impl std::marker::Tuple {
+   |                                                              ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
-  --> $DIR/splat-cannot-resolve.rs:23:22
+  --> $DIR/splat-cannot-resolve.rs:23:28
    |
-LL | fn ambig(#[splat] t: Trait::MaybeTup) {}
-   |                      ^^^^^^^^^^^^^^^
+LL | fn ambig(#[rustc_splat] t: Trait::MaybeTup) {}
+   |                            ^^^^^^^^^^^^^^^
 ...
 LL |     ambig();
    |     ^^^^^^^
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
-  --> $DIR/splat-cannot-resolve.rs:28:26
+  --> $DIR/splat-cannot-resolve.rs:28:32
    |
-LL | fn ambig_tup(#[splat] t: Trait::Tup) {}
-   |                          ^^^^^^^^^^
+LL | fn ambig_tup(#[rustc_splat] t: Trait::Tup) {}
+   |                                ^^^^^^^^^^
 ...
 LL |     ambig_tup();
    |     ^^^^^^^^^^^
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
-  --> $DIR/splat-cannot-resolve.rs:23:22
+  --> $DIR/splat-cannot-resolve.rs:23:28
    |
-LL | fn ambig(#[splat] t: Trait::MaybeTup) {}
-   |                      ^^^^^^^^^^^^^^^
+LL | fn ambig(#[rustc_splat] t: Trait::MaybeTup) {}
+   |                            ^^^^^^^^^^^^^^^
 ...
 LL |     ambig(1);
    |     ^^^^^^^^
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
-  --> $DIR/splat-cannot-resolve.rs:28:26
+  --> $DIR/splat-cannot-resolve.rs:28:32
    |
-LL | fn ambig_tup(#[splat] t: Trait::Tup) {}
-   |                          ^^^^^^^^^^
+LL | fn ambig_tup(#[rustc_splat] t: Trait::Tup) {}
+   |                                ^^^^^^^^^^
 ...
 LL |     ambig_tup(1);
    |     ^^^^^^^^^^^^
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
-  --> $DIR/splat-cannot-resolve.rs:23:22
+  --> $DIR/splat-cannot-resolve.rs:23:28
    |
-LL | fn ambig(#[splat] t: Trait::MaybeTup) {}
-   |                      ^^^^^^^^^^^^^^^
+LL | fn ambig(#[rustc_splat] t: Trait::MaybeTup) {}
+   |                            ^^^^^^^^^^^^^^^
 ...
 LL |     ambig(1, 2.0);
    |     ^^^^^^^^^^^^^
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
-  --> $DIR/splat-cannot-resolve.rs:28:26
+  --> $DIR/splat-cannot-resolve.rs:28:32
    |
-LL | fn ambig_tup(#[splat] t: Trait::Tup) {}
-   |                          ^^^^^^^^^^
+LL | fn ambig_tup(#[rustc_splat] t: Trait::Tup) {}
+   |                                ^^^^^^^^^^
 ...
 LL |     ambig_tup(1, 2.0);
    |     ^^^^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-const-fn-tuple-generic.rs
+++ b/tests/ui/splat/splat-const-fn-tuple-generic.rs
@@ -1,20 +1,20 @@
 //@ run-pass
-//! Test using `#[splat]` on tuple arguments of const functions with generics.
+//! Test using `#[rustc_splat]` on tuple arguments of const functions with generics.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 
 // Generic type in first position
-const fn const_generic_first<T: Copy>(#[splat] _: (T, u32)) {}
+const fn const_generic_first<T: Copy>(#[rustc_splat] _: (T, u32)) {}
 
 // Generic type in second position
-const fn const_generic_second<T: Copy>(#[splat] _: (u32, T)) {}
+const fn const_generic_second<T: Copy>(#[rustc_splat] _: (u32, T)) {}
 
 // Multiple generic types
-const fn const_generic_both<T: Copy, U: Copy>(#[splat] _: (T, U)) {}
+const fn const_generic_both<T: Copy, U: Copy>(#[rustc_splat] _: (T, U)) {}
 
 // Generic with extra non-splatted arg
-const fn const_generic_extra<T: Copy>(#[splat] _: (T, u32), _extra: i32) {}
+const fn const_generic_extra<T: Copy>(#[rustc_splat] _: (T, u32), _extra: i32) {}
 
 fn main() {
     const_generic_first(1i8, 2u32);

--- a/tests/ui/splat/splat-const-fn-tuple.rs
+++ b/tests/ui/splat/splat-const-fn-tuple.rs
@@ -1,10 +1,10 @@
 //@ run-pass
-//! Test using `#[splat]` on tuple arguments of const functions.
+//! Test using `#[rustc_splat]` on tuple arguments of const functions.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 
-const fn sum(#[splat] (a, b): (u32, u32)) -> u32 {
+const fn sum(#[rustc_splat] (a, b): (u32, u32)) -> u32 {
     a + b
 }
 

--- a/tests/ui/splat/splat-dyn-asref-tuple-fail.rs
+++ b/tests/ui/splat/splat-dyn-asref-tuple-fail.rs
@@ -1,4 +1,4 @@
-//! Test that `#[splat]` on `&dyn AsRef<T>` where `T: Tuple` is an error.
+//! Test that `#[rustc_splat]` on `&dyn AsRef<T>` where `T: Tuple` is an error.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
@@ -9,7 +9,7 @@
 
 // FIXME(splat): Some errors are reported on the callee, but they would be more ergonomic on the
 // caller as well
-fn dyn_asref_splat<T>(#[splat] _t: &dyn AsRef<T>)
+fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)
 //~^ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
 //~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
 //~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a

--- a/tests/ui/splat/splat-dyn-asref-tuple-fail.stderr
+++ b/tests/ui/splat/splat-dyn-asref-tuple-fail.stderr
@@ -1,8 +1,8 @@
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Trait(std::convert::AsRef<std::string::String>)
-  --> $DIR/splat-dyn-asref-tuple-fail.rs:12:36
+  --> $DIR/splat-dyn-asref-tuple-fail.rs:12:42
    |
-LL | fn dyn_asref_splat<T>(#[splat] _t: &dyn AsRef<T>)
-   |                                    ^^^^^^^^^^^^^
+LL | fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)
+   |                                          ^^^^^^^^^^^^^
 ...
 LL |     dyn_asref_splat::<String>(&s);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,35 +16,35 @@ LL |     dyn_asref_splat::<String>(&s);
 note: required by a bound in `dyn_asref_splat`
   --> $DIR/splat-dyn-asref-tuple-fail.rs:18:8
    |
-LL | fn dyn_asref_splat<T>(#[splat] _t: &dyn AsRef<T>)
+LL | fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)
    |    --------------- required by a bound in this function
 ...
 LL |     T: std::marker::Tuple,
    |        ^^^^^^^^^^^^^^^^^^ required by this bound in `dyn_asref_splat`
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Trait(std::convert::AsRef<_>)
-  --> $DIR/splat-dyn-asref-tuple-fail.rs:12:36
+  --> $DIR/splat-dyn-asref-tuple-fail.rs:12:42
    |
-LL | fn dyn_asref_splat<T>(#[splat] _t: &dyn AsRef<T>)
-   |                                    ^^^^^^^^^^^^^
+LL | fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)
+   |                                          ^^^^^^^^^^^^^
 ...
 LL |     dyn_asref_splat(&s);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Trait(std::convert::AsRef<(u8, f32)>)
-  --> $DIR/splat-dyn-asref-tuple-fail.rs:12:36
+  --> $DIR/splat-dyn-asref-tuple-fail.rs:12:42
    |
-LL | fn dyn_asref_splat<T>(#[splat] _t: &dyn AsRef<T>)
-   |                                    ^^^^^^^^^^^^^
+LL | fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)
+   |                                          ^^^^^^^^^^^^^
 ...
 LL |     dyn_asref_splat::<(u8, f32)>(&t);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Trait(std::convert::AsRef<_>)
-  --> $DIR/splat-dyn-asref-tuple-fail.rs:12:36
+  --> $DIR/splat-dyn-asref-tuple-fail.rs:12:42
    |
-LL | fn dyn_asref_splat<T>(#[splat] _t: &dyn AsRef<T>)
-   |                                    ^^^^^^^^^^^^^
+LL | fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)
+   |                                          ^^^^^^^^^^^^^
 ...
 LL |     dyn_asref_splat(&t);
    |     ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-fn-ptr-cast-fail.rs
+++ b/tests/ui/splat/splat-fn-ptr-cast-fail.rs
@@ -5,11 +5,11 @@
 
 use std::marker::Tuple;
 
-fn tuple_args(#[splat] (_a, _b): (u32, i8)) {}
+fn tuple_args(#[rustc_splat] (_a, _b): (u32, i8)) {}
 
-fn splat_non_terminal_arg(#[splat] (_a, _b): (u32, i8), _c: f64) {}
+fn splat_non_terminal_arg(#[rustc_splat] (_a, _b): (u32, i8), _c: f64) {}
 
-fn f<Args: Tuple>(#[splat] args: Args) {}
+fn f<Args: Tuple>(#[rustc_splat] args: Args) {}
 
 fn main() {
     // Function pointers

--- a/tests/ui/splat/splat-fn-ptr-cast-fail.stderr
+++ b/tests/ui/splat/splat-fn-ptr-cast-fail.stderr
@@ -7,7 +7,7 @@ LL |     let _fn_ptr: fn((u32, i8)) = tuple_args;
    |                  expected due to this
    |
    = note: expected fn pointer `fn((_, _))`
-                 found fn item `fn(#[splat] (_, _)) {tuple_args}`
+                 found fn item `fn(#[rustc_splat] (_, _)) {tuple_args}`
 
 error[E0308]: mismatched types
   --> $DIR/splat-fn-ptr-cast-fail.rs:17:39
@@ -18,15 +18,15 @@ LL |     let _fn_ptr: fn((u32, i8), f64) = splat_non_terminal_arg;
    |                  expected due to this
    |
    = note: expected fn pointer `fn((_, _), _)`
-                 found fn item `fn(#[splat] (_, _), _) {splat_non_terminal_arg}`
+                 found fn item `fn(#[rustc_splat] (_, _), _) {splat_non_terminal_arg}`
 
-error[E0605]: non-primitive cast: `fn(, #[splat](u32, i8)) {tuple_args}` as `fn((u32, i8))`
+error[E0605]: non-primitive cast: `fn(, #[rustc_splat](u32, i8)) {tuple_args}` as `fn((u32, i8))`
   --> $DIR/splat-fn-ptr-cast-fail.rs:19:34
    |
 LL |     let _fn_ptr: fn((u32, i8)) = tuple_args as fn((u32, i8));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid cast
 
-error[E0605]: non-primitive cast: `fn(, #[splat](u32, i8), f64) {splat_non_terminal_arg}` as `fn((u32, i8), f64)`
+error[E0605]: non-primitive cast: `fn(, #[rustc_splat](u32, i8), f64) {splat_non_terminal_arg}` as `fn((u32, i8), f64)`
   --> $DIR/splat-fn-ptr-cast-fail.rs:20:39
    |
 LL |     let _fn_ptr: fn((u32, i8), f64) = splat_non_terminal_arg as fn((u32, i8), f64);
@@ -41,7 +41,7 @@ LL |     const _F2: fn((u8, u32)) = f::<(u8, u32)>;
    |                expected because of the type of the constant
    |
    = note: expected fn pointer `fn((_, _))`
-                 found fn item `fn(#[splat] (_, _)) {f::<(u8, u32)>}`
+                 found fn item `fn(#[rustc_splat] (_, _)) {f::<(u8, u32)>}`
 
 error[E0308]: mismatched types
   --> $DIR/splat-fn-ptr-cast-fail.rs:24:35
@@ -52,7 +52,7 @@ LL |     const _F1: fn(((u8, u32),)) = f::<((u8, u32),)>;
    |                expected because of the type of the constant
    |
    = note: expected fn pointer `fn(((_, _),))`
-                 found fn item `fn(#[splat] ((_, _),)) {f::<((u8, u32),)>}`
+                 found fn item `fn(#[rustc_splat] ((_, _),)) {f::<((u8, u32),)>}`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/splat/splat-fn-ptr-cast.rs
+++ b/tests/ui/splat/splat-fn-ptr-cast.rs
@@ -8,7 +8,7 @@
 fn main() {
     // Bug #158603 regression test variants
     #[rustfmt::skip]
-    let _x: fn(#[splat] (f32,)) = None.unwrap();
+    let _x: fn(#[rustc_splat] (f32,)) = None.unwrap();
     // FIXME(splat): causes an ICE until #158603 is fixed
     //x(1.0);
 

--- a/tests/ui/splat/splat-fn-ptr-ptr-tuple.rs
+++ b/tests/ui/splat/splat-fn-ptr-ptr-tuple.rs
@@ -25,7 +25,8 @@ fn main() {
     // MIR lowering
     // FIXME(rustfmt): the attribute gets deleted by rustfmt
     #[rustfmt::skip]
-    let fn_pp: *const fn(#[rustc_splat] (u32, i8)) = tuple_args as *const fn(#[rustc_splat] (u32, i8));
+    let fn_pp: *const fn(#[rustc_splat] (u32, i8))
+        = tuple_args as *const fn(#[rustc_splat] (u32, i8));
     unsafe {
         (*fn_pp)(1, 2); //~ ERROR splatted FnPtr side-tables are not yet implemented
         // The ICE means that code after this line is not fully checked

--- a/tests/ui/splat/splat-fn-ptr-ptr-tuple.rs
+++ b/tests/ui/splat/splat-fn-ptr-ptr-tuple.rs
@@ -1,4 +1,4 @@
-//! Test using `#[splat]` on tuple arguments of pointers to pointers to simple functions.
+//! Test using `#[rustc_splat]` on tuple arguments of pointers to pointers to simple functions.
 //! Currently ICEs, but if we fix it, we'll want to know and update this test to pass.
 
 //@ failure-status: 101
@@ -16,16 +16,16 @@
 #![allow(incomplete_features)]
 #![feature(splat)]
 
-fn tuple_args(#[splat] (_a, _b): (u32, i8)) {}
+fn tuple_args(#[rustc_splat] (_a, _b): (u32, i8)) {}
 
-fn splat_non_terminal_arg(#[splat] (_a, _b): (u32, i8), _c: f64) {}
+fn splat_non_terminal_arg(#[rustc_splat] (_a, _b): (u32, i8), _c: f64) {}
 
 fn main() {
     // FIXME(splat): not currently supported, can be supported when we no longer require a DefId in
     // MIR lowering
     // FIXME(rustfmt): the attribute gets deleted by rustfmt
     #[rustfmt::skip]
-    let fn_pp: *const fn(#[splat] (u32, i8)) = tuple_args as *const fn(#[splat] (u32, i8));
+    let fn_pp: *const fn(#[rustc_splat] (u32, i8)) = tuple_args as *const fn(#[rustc_splat] (u32, i8));
     unsafe {
         (*fn_pp)(1, 2); //~ ERROR splatted FnPtr side-tables are not yet implemented
         // The ICE means that code after this line is not fully checked
@@ -33,8 +33,8 @@ fn main() {
     }
 
     #[rustfmt::skip]
-    let fn_pp: *const fn(#[splat] (u32, i8), f64) =
-        splat_non_terminal_arg as *const fn(#[splat] (u32, i8), f64);
+    let fn_pp: *const fn(#[rustc_splat] (u32, i8), f64) =
+        splat_non_terminal_arg as *const fn(#[rustc_splat] (u32, i8), f64);
     unsafe {
         (*fn_pp)(1, 2, 3.5);
         (*fn_pp)(1u32, 2i8, 3.5f64);

--- a/tests/ui/splat/splat-fn-ptr-ptr-tuple.stderr
+++ b/tests/ui/splat/splat-fn-ptr-ptr-tuple.stderr
@@ -1,5 +1,5 @@
 error: compiler/rustc_mir_build/src/thir/cx/expr.rs:LL:CC: splatted FnPtr side-tables are not yet implemented
-  --> $DIR/splat-fn-ptr-ptr-tuple.rs:30:9
+  --> $DIR/splat-fn-ptr-ptr-tuple.rs:31:9
    |
 LL |         (*fn_pp)(1, 2);
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-fn-ptr-rust-call.rs
+++ b/tests/ui/splat/splat-fn-ptr-rust-call.rs
@@ -1,18 +1,18 @@
-//! Test using `#[splat]` on tuple arguments of pointers to "rust-call" functions.
+//! Test using `#[rustc_splat]` on tuple arguments of pointers to "rust-call" functions.
 //! Currently ICEs at a later stage, but AST validation should catch it earlier.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 #![feature(unboxed_closures)]
 
-extern "rust-call" fn f(#[splat] _: ()) {} //~ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+extern "rust-call" fn f(#[rustc_splat] _: ()) {} //~ ERROR `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
 
 fn main() {
     // FIXME(rustfmt): the attribute gets deleted by rustfmt
     #[rustfmt::skip]
-    let f2: extern "rust-call" fn(#[splat] ()) = f; //~ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+    let f2: extern "rust-call" fn(#[rustc_splat] ()) = f; //~ ERROR `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
     // These errors could be confusing, but they're useful if the user meant to use "rust-call"
-    // instead of #[splat]
+    // instead of #[rustc_splat]
     f(); //~ ERROR functions with the "rust-call" ABI must take a single non-self tuple argument
     f2(); //~ ERROR functions with the "rust-call" ABI must take a single non-self tuple argument
 }

--- a/tests/ui/splat/splat-fn-ptr-rust-call.stderr
+++ b/tests/ui/splat/splat-fn-ptr-rust-call.stderr
@@ -1,18 +1,18 @@
-error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+error: `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
   --> $DIR/splat-fn-ptr-rust-call.rs:8:1
    |
-LL | extern "rust-call" fn f(#[splat] _: ()) {}
-   | ^^^^^^^^^^^^^^^^^^      ^^^^^^^^
+LL | extern "rust-call" fn f(#[rustc_splat] _: ()) {}
+   | ^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or change the ABI
+   = help: remove `#[rustc_splat]` or change the ABI
 
-error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+error: `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
   --> $DIR/splat-fn-ptr-rust-call.rs:13:13
    |
-LL |     let f2: extern "rust-call" fn(#[splat] ()) = f;
-   |             ^^^^^^^^^^^^^^^^^^    ^^^^^^^^
+LL |     let f2: extern "rust-call" fn(#[rustc_splat] ()) = f;
+   |             ^^^^^^^^^^^^^^^^^^    ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or change the ABI
+   = help: remove `#[rustc_splat]` or change the ABI
 
 error: functions with the "rust-call" ABI must take a single non-self tuple argument
   --> $DIR/splat-fn-ptr-rust-call.rs:16:5

--- a/tests/ui/splat/splat-fn-ptr-tuple-const.rs
+++ b/tests/ui/splat/splat-fn-ptr-tuple-const.rs
@@ -1,4 +1,4 @@
-//! Test using `#[splat]` on tuple arguments of generic function constants.
+//! Test using `#[rustc_splat]` on tuple arguments of generic function constants.
 //! Currently ICEs (#158603), but if we fix it, we'll want to know and update this test to pass.
 
 //@ failure-status: 101
@@ -18,17 +18,17 @@
 
 use std::marker::Tuple;
 
-fn f<Args: Tuple>(#[splat] args: Args) {}
+fn f<Args: Tuple>(#[rustc_splat] args: Args) {}
 
 fn main() {
     // FIXME(splat): not currently supported, can be supported when we no longer require a DefId in
     // MIR lowering
     // FIXME(rustfmt): the attribute gets deleted by rustfmt
     #[rustfmt::skip]
-    const F2: fn(#[splat] (u8, u32)) = f::<(u8, u32)>;
+    const F2: fn(#[rustc_splat] (u8, u32)) = f::<(u8, u32)>;
     const R2: () = F2(1, 2); //~ ERROR splatted FnPtr side-tables are not yet implemented
 
     #[rustfmt::skip]
-    const F1: fn(#[splat] ((u8, u32),)) = f::<((u8, u32),)>;
+    const F1: fn(#[rustc_splat] ((u8, u32),)) = f::<((u8, u32),)>;
     const R1: () = F1((1, 2)); //~ ERROR splatted FnPtr side-tables are not yet implemented
 }

--- a/tests/ui/splat/splat-fn-ptr-tuple.rs
+++ b/tests/ui/splat/splat-fn-ptr-tuple.rs
@@ -1,4 +1,4 @@
-//! Test using `#[splat]` on tuple arguments of pointers to simple functions.
+//! Test using `#[rustc_splat]` on tuple arguments of pointers to simple functions.
 //! Currently ICEs, but if we fix it, we'll want to know and update this test to pass.
 
 //@ failure-status: 101
@@ -16,16 +16,16 @@
 #![allow(incomplete_features)]
 #![feature(splat)]
 
-fn tuple_args(#[splat] (_a, _b): (u32, i8)) {}
+fn tuple_args(#[rustc_splat] (_a, _b): (u32, i8)) {}
 
-fn splat_non_terminal_arg(#[splat] (_a, _b): (u32, i8), _c: f64) {}
+fn splat_non_terminal_arg(#[rustc_splat] (_a, _b): (u32, i8), _c: f64) {}
 
 fn main() {
     // FIXME(splat): not currently supported, can be supported when we no longer require a DefId in
     // MIR lowering
     // FIXME(rustfmt): the attribute gets deleted by rustfmt
     #[rustfmt::skip]
-    let fn_ptr: fn(#[splat] (u32, i8)) = tuple_args;
+    let fn_ptr: fn(#[rustc_splat] (u32, i8)) = tuple_args;
     fn_ptr(1, 2); //~ ERROR splatted FnPtr side-tables are not yet implemented
     // The ICE means that code after this line is not fully checked
     fn_ptr(1u32, 2i8);
@@ -35,12 +35,12 @@ fn main() {
     //fn_ptr((1, 2)); // ERROR this splatted function takes 2 arguments, but 1 was provided
 
     #[rustfmt::skip]
-    let fn_ptr: fn(#[splat] (u32, i8), f64) = splat_non_terminal_arg;
+    let fn_ptr: fn(#[rustc_splat] (u32, i8), f64) = splat_non_terminal_arg;
     fn_ptr(1, 2, 3.5);
     fn_ptr(1u32, 2i8, 3.5f64);
 
     // Bug #158603 regression test
     #[rustfmt::skip]
-    let x: fn(#[splat] (i32,)) = None.unwrap();
+    let x: fn(#[rustc_splat] (i32,)) = None.unwrap();
     x(1);
 }

--- a/tests/ui/splat/splat-fn-tuple-generic-fail.rs
+++ b/tests/ui/splat/splat-fn-tuple-generic-fail.rs
@@ -1,4 +1,4 @@
-//! Test failing use of `#[splat]` on tuple trait arguments of generic functions.
+//! Test failing use of `#[rustc_splat]` on tuple trait arguments of generic functions.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
@@ -6,9 +6,9 @@
 
 use std::marker::Tuple;
 
-fn splat_generic_tuple<T: Tuple>(#[splat] _t: T) {}
+fn splat_generic_tuple<T: Tuple>(#[rustc_splat] _t: T) {}
 
-fn f<Args: Tuple>(#[splat] args: Args) {}
+fn f<Args: Tuple>(#[rustc_splat] args: Args) {}
 
 fn main() {
     // Calling with un-splatted arguments might look like it works, but the actual generic type is

--- a/tests/ui/splat/splat-fn-tuple-generic-fail.stderr
+++ b/tests/ui/splat/splat-fn-tuple-generic-fail.stderr
@@ -43,7 +43,7 @@ LL |     const F1: fn((u8, u32)) = f::<(u8, u32)>;
    |               expected because of the type of the constant
    |
    = note: expected fn pointer `fn((_, _))`
-                 found fn item `fn(#[splat] (_, _)) {f::<(u8, u32)>}`
+                 found fn item `fn(#[rustc_splat] (_, _)) {f::<(u8, u32)>}`
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/splat/splat-fn-tuple-generic.rs
+++ b/tests/ui/splat/splat-fn-tuple-generic.rs
@@ -1,11 +1,11 @@
 //@ run-pass
-//! Test using `#[splat]` on tuple trait arguments of generic functions.
+//! Test using `#[rustc_splat]` on tuple trait arguments of generic functions.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 #![feature(tuple_trait)]
 
-fn splat_generic_tuple<T: std::marker::Tuple>(#[splat] _t: T) {}
+fn splat_generic_tuple<T: std::marker::Tuple>(#[rustc_splat] _t: T) {}
 
 fn main() {
     // Calling with un-splatted arguments might look like it works, but the actual generic type is

--- a/tests/ui/splat/splat-fn-tuple-simple.rs
+++ b/tests/ui/splat/splat-fn-tuple-simple.rs
@@ -1,12 +1,12 @@
 //@ run-pass
-//! Test using `#[splat]` on tuple arguments of simple functions.
+//! Test using `#[rustc_splat]` on tuple arguments of simple functions.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 
-fn tuple_args(#[splat] (_a, _b): (u32, i8)) {}
+fn tuple_args(#[rustc_splat] (_a, _b): (u32, i8)) {}
 
-fn splat_non_terminal_arg(#[splat] (_a, _b): (u32, i8), _c: f64) {}
+fn splat_non_terminal_arg(#[rustc_splat] (_a, _b): (u32, i8), _c: f64) {}
 
 fn main() {
     tuple_args(1, 2);

--- a/tests/ui/splat/splat-generics-complex-types.rs
+++ b/tests/ui/splat/splat-generics-complex-types.rs
@@ -1,17 +1,17 @@
 //@ run-pass
-//! Test using `#[splat]` on tuples with complex generic types inside the splatted tuple.
+//! Test using `#[rustc_splat]` on tuples with complex generic types inside the splatted tuple.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 
 // Vec<T> and Option<U> inside splatted tuple
-fn nested_generic<T, U>(#[splat] _: (Vec<T>, Option<U>)) {}
+fn nested_generic<T, U>(#[rustc_splat] _: (Vec<T>, Option<U>)) {}
 
 // Box<T> inside splatted tuple
-fn box_generic<T>(#[splat] _: (Box<T>, u32)) {}
+fn box_generic<T>(#[rustc_splat] _: (Box<T>, u32)) {}
 
 // Multiple complex generics
-fn multi_generic<T, U, V>(#[splat] _: (Vec<T>, Option<U>, Box<V>)) {}
+fn multi_generic<T, U, V>(#[rustc_splat] _: (Vec<T>, Option<U>, Box<V>)) {}
 
 fn main() {
     nested_generic(vec![1u32, 2u32], Some(2i8));

--- a/tests/ui/splat/splat-generics-everywhere.rs
+++ b/tests/ui/splat/splat-generics-everywhere.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//! Test using `#[splat]` on tuples with generics in various positions.
+//! Test using `#[rustc_splat]` on tuples with generics in various positions.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
@@ -12,45 +12,45 @@ impl<T> Foo<T> {
         Self(t)
     }
 
-    fn assoc<U>(_u: U, #[splat] _s: ()) {}
+    fn assoc<U>(_u: U, #[rustc_splat] _s: ()) {}
 
-    fn method<V>(&self, _v: V, #[splat] _s: (u32, f64)) {}
+    fn method<V>(&self, _v: V, #[rustc_splat] _s: (u32, f64)) {}
 
-    fn lifetime<'a>(&self, #[splat] _s: (u32, f64, &'a str)) {}
+    fn lifetime<'a>(&self, #[rustc_splat] _s: (u32, f64, &'a str)) {}
 
-    fn const_generic<const N: usize>(&self, #[splat] _s: (u32, f64, [u8; N])) {}
+    fn const_generic<const N: usize>(&self, #[rustc_splat] _s: (u32, f64, [u8; N])) {}
 
-    fn generic_in_tuple<U>(&self, #[splat] _s: (U, u32)) {}
+    fn generic_in_tuple<U>(&self, #[rustc_splat] _s: (U, u32)) {}
 
-    fn generic_tuple_assoc<U: std::marker::Tuple>(_u: U, #[splat] _s: ()) {}
+    fn generic_tuple_assoc<U: std::marker::Tuple>(_u: U, #[rustc_splat] _s: ()) {}
 }
 
 trait BarTrait<T> {
-    fn trait_assoc<W>(w: W, #[splat] _s: ());
+    fn trait_assoc<W>(w: W, #[rustc_splat] _s: ());
 
-    fn trait_method<X>(&self, x: X, #[splat] _s: (u32, f64));
+    fn trait_method<X>(&self, x: X, #[rustc_splat] _s: (u32, f64));
 
-    fn trait_lifetime<'a>(&self, #[splat] _s: (u32, f64, &'a str)) {}
+    fn trait_lifetime<'a>(&self, #[rustc_splat] _s: (u32, f64, &'a str)) {}
 
-    fn trait_const_generic<const N: usize>(&self, #[splat] _s: (u32, f64, [u8; N])) {}
+    fn trait_const_generic<const N: usize>(&self, #[rustc_splat] _s: (u32, f64, [u8; N])) {}
 
-    fn trait_generic_in_tuple<U>(&self, #[splat] _s: (T, U)) {}
+    fn trait_generic_in_tuple<U>(&self, #[rustc_splat] _s: (T, U)) {}
 
-    fn trait_generic_tuple<U: std::marker::Tuple>(&self, #[splat] _s: U) {}
+    fn trait_generic_tuple<U: std::marker::Tuple>(&self, #[rustc_splat] _s: U) {}
 }
 
 impl<T> BarTrait<T> for Foo<T> {
-    fn trait_assoc<W>(_w: W, #[splat] _s: ()) {}
+    fn trait_assoc<W>(_w: W, #[rustc_splat] _s: ()) {}
 
-    fn trait_method<X>(&self, _x: X, #[splat] _s: (u32, f64)) {}
+    fn trait_method<X>(&self, _x: X, #[rustc_splat] _s: (u32, f64)) {}
 
-    fn trait_lifetime<'a>(&self, #[splat] _s: (u32, f64, &'a str)) {}
+    fn trait_lifetime<'a>(&self, #[rustc_splat] _s: (u32, f64, &'a str)) {}
 
-    fn trait_const_generic<const N: usize>(&self, #[splat] _s: (u32, f64, [u8; N])) {}
+    fn trait_const_generic<const N: usize>(&self, #[rustc_splat] _s: (u32, f64, [u8; N])) {}
 
-    fn trait_generic_in_tuple<U>(&self, #[splat] _s: (T, U)) {}
+    fn trait_generic_in_tuple<U>(&self, #[rustc_splat] _s: (T, U)) {}
 
-    fn trait_generic_tuple<U: std::marker::Tuple>(&self, #[splat] _s: U) {}
+    fn trait_generic_tuple<U: std::marker::Tuple>(&self, #[rustc_splat] _s: U) {}
 }
 
 fn main() {

--- a/tests/ui/splat/splat-generics-inside-tuple.rs
+++ b/tests/ui/splat/splat-generics-inside-tuple.rs
@@ -1,15 +1,15 @@
 //@ run-pass
-//! Test using `#[splat]` on tuples with generics inside the splatted tuple.
+//! Test using `#[rustc_splat]` on tuples with generics inside the splatted tuple.
 #![allow(incomplete_features)]
 #![feature(splat)]
 
-fn generic_second<T>(#[splat] _s: (u32, T)) {}
+fn generic_second<T>(#[rustc_splat] _s: (u32, T)) {}
 
-fn generic_first<T>(#[splat] _s: (T, u32)) {}
+fn generic_first<T>(#[rustc_splat] _s: (T, u32)) {}
 
-fn generic_both<T, U>(#[splat] _s: (T, U)) {}
+fn generic_both<T, U>(#[rustc_splat] _s: (T, U)) {}
 
-fn generic_triple<T, U, V>(#[splat] _s: (T, U, V)) {}
+fn generic_triple<T, U, V>(#[rustc_splat] _s: (T, U, V)) {}
 
 fn main() {
     generic_second(1u32, 2i8);

--- a/tests/ui/splat/splat-invalid-trait-impl.rs
+++ b/tests/ui/splat/splat-invalid-trait-impl.rs
@@ -1,9 +1,9 @@
-//! Test that `#[splat]` trait impls with mismatched tuple element types are rejected.
+//! Test that `#[rustc_splat]` trait impls with mismatched tuple element types are rejected.
 #![allow(incomplete_features)]
 #![feature(splat)]
 
 trait FooTrait {
-    fn method(#[splat] _: (u32, i8));
+    fn method(#[rustc_splat] _: (u32, i8));
 }
 
 struct Foo;
@@ -11,17 +11,17 @@ struct Foo1;
 struct Foo2;
 
 impl FooTrait for Foo {
-    fn method(#[splat] _: (u32, f32)) {}
+    fn method(#[rustc_splat] _: (u32, f32)) {}
     //~^ ERROR method `method` has an incompatible type for trait
 }
 
 impl FooTrait for Foo1 {
-    fn method(#[splat] _: (f32, i8)) {}
+    fn method(#[rustc_splat] _: (f32, i8)) {}
     //~^ ERROR method `method` has an incompatible type for trait
 }
 
 impl FooTrait for Foo2 {
-    fn method(#[splat] _: (f32, f64)) {}
+    fn method(#[rustc_splat] _: (f32, f64)) {}
     //~^ ERROR method `method` has an incompatible type for trait
 }
 fn main() {}

--- a/tests/ui/splat/splat-invalid-trait-impl.stderr
+++ b/tests/ui/splat/splat-invalid-trait-impl.stderr
@@ -1,58 +1,58 @@
 error[E0053]: method `method` has an incompatible type for trait
-  --> $DIR/splat-invalid-trait-impl.rs:14:27
+  --> $DIR/splat-invalid-trait-impl.rs:14:33
    |
-LL |     fn method(#[splat] _: (u32, f32)) {}
-   |                           ^^^^^^^^^^ expected `i8`, found `f32`
+LL |     fn method(#[rustc_splat] _: (u32, f32)) {}
+   |                                 ^^^^^^^^^^ expected `i8`, found `f32`
    |
 note: type in trait
-  --> $DIR/splat-invalid-trait-impl.rs:6:27
+  --> $DIR/splat-invalid-trait-impl.rs:6:33
    |
-LL |     fn method(#[splat] _: (u32, i8));
-   |                           ^^^^^^^^^
-   = note: expected signature `fn(#[splat] (_, i8))`
-              found signature `fn(#[splat] (_, f32))`
+LL |     fn method(#[rustc_splat] _: (u32, i8));
+   |                                 ^^^^^^^^^
+   = note: expected signature `fn(#[rustc_splat] (_, i8))`
+              found signature `fn(#[rustc_splat] (_, f32))`
 help: change the parameter type to match the trait
    |
-LL -     fn method(#[splat] _: (u32, f32)) {}
-LL +     fn method(#[splat] _: (u32, i8)) {}
+LL -     fn method(#[rustc_splat] _: (u32, f32)) {}
+LL +     fn method(#[rustc_splat] _: (u32, i8)) {}
    |
 
 error[E0053]: method `method` has an incompatible type for trait
-  --> $DIR/splat-invalid-trait-impl.rs:19:27
+  --> $DIR/splat-invalid-trait-impl.rs:19:33
    |
-LL |     fn method(#[splat] _: (f32, i8)) {}
-   |                           ^^^^^^^^^ expected `u32`, found `f32`
+LL |     fn method(#[rustc_splat] _: (f32, i8)) {}
+   |                                 ^^^^^^^^^ expected `u32`, found `f32`
    |
 note: type in trait
-  --> $DIR/splat-invalid-trait-impl.rs:6:27
+  --> $DIR/splat-invalid-trait-impl.rs:6:33
    |
-LL |     fn method(#[splat] _: (u32, i8));
-   |                           ^^^^^^^^^
-   = note: expected signature `fn(#[splat] (u32, _))`
-              found signature `fn(#[splat] (f32, _))`
+LL |     fn method(#[rustc_splat] _: (u32, i8));
+   |                                 ^^^^^^^^^
+   = note: expected signature `fn(#[rustc_splat] (u32, _))`
+              found signature `fn(#[rustc_splat] (f32, _))`
 help: change the parameter type to match the trait
    |
-LL -     fn method(#[splat] _: (f32, i8)) {}
-LL +     fn method(#[splat] _: (u32, i8)) {}
+LL -     fn method(#[rustc_splat] _: (f32, i8)) {}
+LL +     fn method(#[rustc_splat] _: (u32, i8)) {}
    |
 
 error[E0053]: method `method` has an incompatible type for trait
-  --> $DIR/splat-invalid-trait-impl.rs:24:27
+  --> $DIR/splat-invalid-trait-impl.rs:24:33
    |
-LL |     fn method(#[splat] _: (f32, f64)) {}
-   |                           ^^^^^^^^^^ expected `u32`, found `f32`
+LL |     fn method(#[rustc_splat] _: (f32, f64)) {}
+   |                                 ^^^^^^^^^^ expected `u32`, found `f32`
    |
 note: type in trait
-  --> $DIR/splat-invalid-trait-impl.rs:6:27
+  --> $DIR/splat-invalid-trait-impl.rs:6:33
    |
-LL |     fn method(#[splat] _: (u32, i8));
-   |                           ^^^^^^^^^
-   = note: expected signature `fn(#[splat] (u32, i8))`
-              found signature `fn(#[splat] (f32, f64))`
+LL |     fn method(#[rustc_splat] _: (u32, i8));
+   |                                 ^^^^^^^^^
+   = note: expected signature `fn(#[rustc_splat] (u32, i8))`
+              found signature `fn(#[rustc_splat] (f32, f64))`
 help: change the parameter type to match the trait
    |
-LL -     fn method(#[splat] _: (f32, f64)) {}
-LL +     fn method(#[splat] _: (u32, i8)) {}
+LL -     fn method(#[rustc_splat] _: (f32, f64)) {}
+LL +     fn method(#[rustc_splat] _: (u32, i8)) {}
    |
 
 error: aborting due to 3 previous errors

--- a/tests/ui/splat/splat-invalid.rs
+++ b/tests/ui/splat/splat-invalid.rs
@@ -1,54 +1,54 @@
-//! Test using `#[splat]` incorrectly, in ways not covered by other tests.
+//! Test using `#[rustc_splat]` incorrectly, in ways not covered by other tests.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 
-fn multisplat_fn_bad(#[splat] (_a, _b): (u32, i8), #[splat] (_c, _d): (u32, i8)) {}
-//~^ ERROR multiple `#[splat]`s are not allowed in the same function argument list
+fn multisplat_fn_bad(#[rustc_splat] (_a, _b): (u32, i8), #[rustc_splat] (_c, _d): (u32, i8)) {}
+//~^ ERROR multiple `#[rustc_splat]`s are not allowed in the same function argument list
 
 fn multisplat_arg_bad(
-    #[splat]
-    #[splat]
-    //~^ ERROR  multiple `splat` attributes
+    #[rustc_splat]
+    #[rustc_splat]
+    //~^ ERROR  multiple `rustc_splat` attributes
     (_a, _b): (u32, i8),
 ) {
 }
 
 fn multisplat_arg_fn_bad(
-    #[splat]
-    //~^ ERROR multiple `#[splat]`s are not allowed in the same function argument list
-    #[splat]
-    //~^ ERROR  multiple `splat` attributes
+    #[rustc_splat]
+    //~^ ERROR multiple `#[rustc_splat]`s are not allowed in the same function argument list
+    #[rustc_splat]
+    //~^ ERROR  multiple `rustc_splat` attributes
     (_a, _b): (u32, i8),
-    #[splat] (_c, _d): (u32, i8),
+    #[rustc_splat] (_c, _d): (u32, i8),
 ) {
 }
 
-unsafe extern "C" fn splat_variadic(#[splat] (_a, _b): (u32, i8), varargs: ...) {}
-//~^ ERROR `...` and `#[splat]` are not allowed in the same function argument list
+unsafe extern "C" fn splat_variadic(#[rustc_splat] (_a, _b): (u32, i8), varargs: ...) {}
+//~^ ERROR `...` and `#[rustc_splat]` are not allowed in the same function argument list
 
-unsafe extern "C" fn splat_variadic2(varargs: ..., #[splat] (_a, _b): (u32, i8)) {}
-//~^ ERROR `...` and `#[splat]` are not allowed in the same function argument list
+unsafe extern "C" fn splat_variadic2(varargs: ..., #[rustc_splat] (_a, _b): (u32, i8)) {}
+//~^ ERROR `...` and `#[rustc_splat]` are not allowed in the same function argument list
 //~| ERROR `...` must be the last argument of a C-variadic function
 
 extern "C" {
-    fn splat_variadic3(#[splat] (_a, _b): (u32, i8), ...) {}
+    fn splat_variadic3(#[rustc_splat] (_a, _b): (u32, i8), ...) {}
     //~^ ERROR incorrect function inside `extern` block
-    //~| ERROR `...` and `#[splat]` are not allowed in the same function
+    //~| ERROR `...` and `#[rustc_splat]` are not allowed in the same function
 
-    fn splat_variadic4(..., #[splat] (_a, _b): (u32, i8)) {}
+    fn splat_variadic4(..., #[rustc_splat] (_a, _b): (u32, i8)) {}
     //~^ ERROR incorrect function inside `extern` block
-    //~| ERROR `...` and `#[splat]` are not allowed in the same function
+    //~| ERROR `...` and `#[rustc_splat]` are not allowed in the same function
     //~| ERROR `...` must be the last argument of a C-variadic function
 
     // FIXME(splat): tuple layouts are unspecified. Should this error in addition to
     // the existing `improper_ctypes` lint?
     #[expect(improper_ctypes)]
-    fn bar_2(#[splat] _: (u32, i8));
+    fn bar_2(#[rustc_splat] _: (u32, i8));
 }
 
 trait FooTrait {
-    fn has_splat(#[splat] _: ());
+    fn has_splat(#[rustc_splat] _: ());
 
     fn no_splat(_: (u32, f64));
 }
@@ -58,7 +58,7 @@ struct Foo;
 impl FooTrait for Foo {
     fn has_splat(_: ()) {} //~ ERROR method `has_splat` has an incompatible type for trait
 
-    fn no_splat(#[splat] _: (u32, f64)) {} //~ ERROR method `no_splat` has an incompatible type for trait
+    fn no_splat(#[rustc_splat] _: (u32, f64)) {} //~ ERROR method `no_splat` has an incompatible type for trait
 }
 
 fn main() {}

--- a/tests/ui/splat/splat-invalid.stderr
+++ b/tests/ui/splat/splat-invalid.stderr
@@ -1,65 +1,65 @@
-error: multiple `#[splat]`s are not allowed in the same function argument list
+error: multiple `#[rustc_splat]`s are not allowed in the same function argument list
   --> $DIR/splat-invalid.rs:6:22
    |
-LL | fn multisplat_fn_bad(#[splat] (_a, _b): (u32, i8), #[splat] (_c, _d): (u32, i8)) {}
-   |                      ^^^^^^^^                      ^^^^^^^^
+LL | fn multisplat_fn_bad(#[rustc_splat] (_a, _b): (u32, i8), #[rustc_splat] (_c, _d): (u32, i8)) {}
+   |                      ^^^^^^^^^^^^^^                      ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` from all but one argument
+   = help: remove `#[rustc_splat]` from all but one argument
 
-error: multiple `#[splat]`s are not allowed in the same function argument list
+error: multiple `#[rustc_splat]`s are not allowed in the same function argument list
   --> $DIR/splat-invalid.rs:18:5
    |
-LL |     #[splat]
-   |     ^^^^^^^^
+LL |     #[rustc_splat]
+   |     ^^^^^^^^^^^^^^
 LL |
-LL |     #[splat]
-   |     ^^^^^^^^
+LL |     #[rustc_splat]
+   |     ^^^^^^^^^^^^^^
 ...
-LL |     #[splat] (_c, _d): (u32, i8),
-   |     ^^^^^^^^
+LL |     #[rustc_splat] (_c, _d): (u32, i8),
+   |     ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` from all but one argument
+   = help: remove `#[rustc_splat]` from all but one argument
 
-error: `...` and `#[splat]` are not allowed in the same function argument list
+error: `...` and `#[rustc_splat]` are not allowed in the same function argument list
   --> $DIR/splat-invalid.rs:27:37
    |
-LL | unsafe extern "C" fn splat_variadic(#[splat] (_a, _b): (u32, i8), varargs: ...) {}
-   |                                     ^^^^^^^^                      ^^^^^^^^^^^^
+LL | unsafe extern "C" fn splat_variadic(#[rustc_splat] (_a, _b): (u32, i8), varargs: ...) {}
+   |                                     ^^^^^^^^^^^^^^                      ^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or remove `...`
+   = help: remove `#[rustc_splat]` or remove `...`
 
 error: `...` must be the last argument of a C-variadic function
   --> $DIR/splat-invalid.rs:30:38
    |
-LL | unsafe extern "C" fn splat_variadic2(varargs: ..., #[splat] (_a, _b): (u32, i8)) {}
+LL | unsafe extern "C" fn splat_variadic2(varargs: ..., #[rustc_splat] (_a, _b): (u32, i8)) {}
    |                                      ^^^^^^^^^^^^
 
-error: `...` and `#[splat]` are not allowed in the same function argument list
+error: `...` and `#[rustc_splat]` are not allowed in the same function argument list
   --> $DIR/splat-invalid.rs:30:38
    |
-LL | unsafe extern "C" fn splat_variadic2(varargs: ..., #[splat] (_a, _b): (u32, i8)) {}
-   |                                      ^^^^^^^^^^^^  ^^^^^^^^
+LL | unsafe extern "C" fn splat_variadic2(varargs: ..., #[rustc_splat] (_a, _b): (u32, i8)) {}
+   |                                      ^^^^^^^^^^^^  ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or remove `...`
+   = help: remove `#[rustc_splat]` or remove `...`
 
 error: incorrect function inside `extern` block
   --> $DIR/splat-invalid.rs:35:8
    |
 LL | extern "C" {
    | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
-LL |     fn splat_variadic3(#[splat] (_a, _b): (u32, i8), ...) {}
-   |        ^^^^^^^^^^^^^^^ cannot have a body                 -- help: remove the invalid body: `;`
+LL |     fn splat_variadic3(#[rustc_splat] (_a, _b): (u32, i8), ...) {}
+   |        ^^^^^^^^^^^^^^^ cannot have a body                       -- help: remove the invalid body: `;`
    |
    = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
 
-error: `...` and `#[splat]` are not allowed in the same function argument list
+error: `...` and `#[rustc_splat]` are not allowed in the same function argument list
   --> $DIR/splat-invalid.rs:35:24
    |
-LL |     fn splat_variadic3(#[splat] (_a, _b): (u32, i8), ...) {}
-   |                        ^^^^^^^^                      ^^^
+LL |     fn splat_variadic3(#[rustc_splat] (_a, _b): (u32, i8), ...) {}
+   |                        ^^^^^^^^^^^^^^                      ^^^
    |
-   = help: remove `#[splat]` or remove `...`
+   = help: remove `#[rustc_splat]` or remove `...`
 
 error: incorrect function inside `extern` block
   --> $DIR/splat-invalid.rs:39:8
@@ -67,8 +67,8 @@ error: incorrect function inside `extern` block
 LL | extern "C" {
    | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
 ...
-LL |     fn splat_variadic4(..., #[splat] (_a, _b): (u32, i8)) {}
-   |        ^^^^^^^^^^^^^^^ cannot have a body                 -- help: remove the invalid body: `;`
+LL |     fn splat_variadic4(..., #[rustc_splat] (_a, _b): (u32, i8)) {}
+   |        ^^^^^^^^^^^^^^^ cannot have a body                       -- help: remove the invalid body: `;`
    |
    = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
@@ -76,40 +76,40 @@ LL |     fn splat_variadic4(..., #[splat] (_a, _b): (u32, i8)) {}
 error: `...` must be the last argument of a C-variadic function
   --> $DIR/splat-invalid.rs:39:24
    |
-LL |     fn splat_variadic4(..., #[splat] (_a, _b): (u32, i8)) {}
+LL |     fn splat_variadic4(..., #[rustc_splat] (_a, _b): (u32, i8)) {}
    |                        ^^^
 
-error: `...` and `#[splat]` are not allowed in the same function argument list
+error: `...` and `#[rustc_splat]` are not allowed in the same function argument list
   --> $DIR/splat-invalid.rs:39:24
    |
-LL |     fn splat_variadic4(..., #[splat] (_a, _b): (u32, i8)) {}
-   |                        ^^^  ^^^^^^^^
+LL |     fn splat_variadic4(..., #[rustc_splat] (_a, _b): (u32, i8)) {}
+   |                        ^^^  ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or remove `...`
+   = help: remove `#[rustc_splat]` or remove `...`
 
-error: multiple `splat` attributes
+error: multiple `rustc_splat` attributes
   --> $DIR/splat-invalid.rs:11:5
    |
-LL |     #[splat]
-   |     ^^^^^^^^ help: remove this attribute
+LL |     #[rustc_splat]
+   |     ^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
   --> $DIR/splat-invalid.rs:10:5
    |
-LL |     #[splat]
-   |     ^^^^^^^^
+LL |     #[rustc_splat]
+   |     ^^^^^^^^^^^^^^
 
-error: multiple `splat` attributes
+error: multiple `rustc_splat` attributes
   --> $DIR/splat-invalid.rs:20:5
    |
-LL |     #[splat]
-   |     ^^^^^^^^ help: remove this attribute
+LL |     #[rustc_splat]
+   |     ^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
   --> $DIR/splat-invalid.rs:18:5
    |
-LL |     #[splat]
-   |     ^^^^^^^^
+LL |     #[rustc_splat]
+   |     ^^^^^^^^^^^^^^
 
 error[E0053]: method `has_splat` has an incompatible type for trait
   --> $DIR/splat-invalid.rs:59:5
@@ -120,16 +120,16 @@ LL |     fn has_splat(_: ()) {}
 note: type in trait
   --> $DIR/splat-invalid.rs:51:5
    |
-LL |     fn has_splat(#[splat] _: ());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: expected signature `fn(#[splat] ())`
+LL |     fn has_splat(#[rustc_splat] _: ());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected signature `fn(#[rustc_splat] ())`
               found signature `fn(())`
 
 error[E0053]: method `no_splat` has an incompatible type for trait
   --> $DIR/splat-invalid.rs:61:5
    |
-LL |     fn no_splat(#[splat] _: (u32, f64)) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected fn with no splatted arg, found fn with arg 0 splatted
+LL |     fn no_splat(#[rustc_splat] _: (u32, f64)) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected fn with no splatted arg, found fn with arg 0 splatted
    |
 note: type in trait
   --> $DIR/splat-invalid.rs:53:5
@@ -137,7 +137,7 @@ note: type in trait
 LL |     fn no_splat(_: (u32, f64));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected signature `fn((_, _))`
-              found signature `fn(#[splat] (_, _))`
+              found signature `fn(#[rustc_splat] (_, _))`
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/splat/splat-mangling-issue-158644.rs
+++ b/tests/ui/splat/splat-mangling-issue-158644.rs
@@ -11,7 +11,7 @@
 
 fn main() {
     #[rustfmt::skip]
-    let _x: fn(#[splat] (i32,)) = None.unwrap();
+    let _x: fn(#[rustc_splat] (i32,)) = None.unwrap();
 
     let x: fn((i32,)) = None.unwrap();
     x((1,));

--- a/tests/ui/splat/splat-mangling.legacy.stderr
+++ b/tests/ui/splat/splat-mangling.legacy.stderr
@@ -1,16 +1,16 @@
-error: symbol-name(_ZN14splat_mangling4main66Type$LT$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$u8$C$u32$RP$$RP$$GT$17hCRATE_HASHE)
+error: symbol-name(_ZN14splat_mangling4main72Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u8$C$u32$RP$$RP$$GT$17hCRATE_HASHE)
   --> $DIR/splat-mangling.rs:22:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(splat_mangling::main::Type<fn(, #[splat](u8,u32))>::hCRATE_HASH)
+error: demangling(splat_mangling::main::Type<fn(, #[rustc_splat](u8,u32))>::hCRATE_HASH)
   --> $DIR/splat-mangling.rs:22:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(splat_mangling::main::Type<fn(, #[splat](u8,u32))>)
+error: demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat](u8,u32))>)
   --> $DIR/splat-mangling.rs:22:5
    |
 LL |     #[rustc_dump_symbol_name]
@@ -34,19 +34,19 @@ error: demangling-alt(splat_mangling::main::Type<fn((u8,u32))>)
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN14splat_mangling4main77Type$LT$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT$17hCRATE_HASHE)
+error: symbol-name(_ZN14splat_mangling4main83Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT$17hCRATE_HASHE)
   --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(splat_mangling::main::Type<fn(, #[splat]((u8,u32),))>::hCRATE_HASH)
+error: demangling(splat_mangling::main::Type<fn(, #[rustc_splat]((u8,u32),))>::hCRATE_HASH)
   --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(splat_mangling::main::Type<fn(, #[splat]((u8,u32),))>)
+error: demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat]((u8,u32),))>)
   --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
@@ -70,19 +70,19 @@ error: demangling-alt(splat_mangling::main::Type<fn(((u8,u32),))>)
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN14splat_mangling4main80Type$LT$$BP$const$u20$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$u32$C$i8$RP$$RP$$GT$17hCRATE_HASHE)
+error: symbol-name(_ZN14splat_mangling4main86Type$LT$$BP$const$u20$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u32$C$i8$RP$$RP$$GT$17hCRATE_HASHE)
   --> $DIR/splat-mangling.rs:62:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(splat_mangling::main::Type<*const fn(, #[splat](u32,i8))>::hCRATE_HASH)
+error: demangling(splat_mangling::main::Type<*const fn(, #[rustc_splat](u32,i8))>::hCRATE_HASH)
   --> $DIR/splat-mangling.rs:62:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(splat_mangling::main::Type<*const fn(, #[splat](u32,i8))>)
+error: demangling-alt(splat_mangling::main::Type<*const fn(, #[rustc_splat](u32,i8))>)
   --> $DIR/splat-mangling.rs:62:5
    |
 LL |     #[rustc_dump_symbol_name]
@@ -106,19 +106,19 @@ error: demangling-alt(splat_mangling::main::Type<*const fn((u32,i8))>)
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN14splat_mangling4main72Type$LT$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$u32$C$i8$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
+error: symbol-name(_ZN14splat_mangling4main78Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u32$C$i8$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
   --> $DIR/splat-mangling.rs:82:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(splat_mangling::main::Type<fn(, #[splat](u32,i8),f64)>::hCRATE_HASH)
+error: demangling(splat_mangling::main::Type<fn(, #[rustc_splat](u32,i8),f64)>::hCRATE_HASH)
   --> $DIR/splat-mangling.rs:82:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(splat_mangling::main::Type<fn(, #[splat](u32,i8),f64)>)
+error: demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat](u32,i8),f64)>)
   --> $DIR/splat-mangling.rs:82:5
    |
 LL |     #[rustc_dump_symbol_name]

--- a/tests/ui/splat/splat-mangling.rs
+++ b/tests/ui/splat/splat-mangling.rs
@@ -20,7 +20,7 @@ fn main() {
     #[rustfmt::skip]
     // FIXME(splat, legacy mangling): the first comma is in the wrong place
     #[rustc_dump_symbol_name]
-           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main66Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u8$C$u32$RP$$RP$$GT
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main72Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u8$C$u32$RP$$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[rustc_splat](u8,u32))>::
            //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat](u8,u32))>)
     //[v0,default]~^^^^ ERROR symbol-name(_RMNvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwThmEEuE)
@@ -40,7 +40,7 @@ fn main() {
 
     #[rustfmt::skip]
     #[rustc_dump_symbol_name]
-           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main77Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main83Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[rustc_splat]((u8,u32),))>::
            //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat]((u8,u32),))>)
     //[v0,default]~^^^^ ERROR symbol-name(_RMs0_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTThmEEEuE)
@@ -60,7 +60,7 @@ fn main() {
 
     #[rustfmt::skip]
     #[rustc_dump_symbol_name]
-           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main80Type$LT$$BP$const$u20$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u32$C$i8$RP$$RP$$GT
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main86Type$LT$$BP$const$u20$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u32$C$i8$RP$$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<*const fn(, #[rustc_splat](u32,i8))>::
            //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<*const fn(, #[rustc_splat](u32,i8))>)
     //[v0,default]~^^^^ ERROR symbol-name(_RMs2_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFwTmaEEuE)
@@ -80,7 +80,7 @@ fn main() {
 
     #[rustfmt::skip]
     #[rustc_dump_symbol_name]
-           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main72Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u32$C$i8$RP$$C$f64$RP$$GT
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main78Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u32$C$i8$RP$$C$f64$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[rustc_splat](u32,i8),f64)>::
            //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat](u32,i8),f64)>)
     //[v0,default]~^^^^ ERROR symbol-name(_RMs4_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTmaEdEuE)

--- a/tests/ui/splat/splat-mangling.rs
+++ b/tests/ui/splat/splat-mangling.rs
@@ -20,13 +20,13 @@ fn main() {
     #[rustfmt::skip]
     // FIXME(splat, legacy mangling): the first comma is in the wrong place
     #[rustc_dump_symbol_name]
-           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main66Type$LT$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$u8$C$u32$RP$$RP$$GT
-           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[splat](u8,u32))>::
-           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[splat](u8,u32))>)
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main66Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u8$C$u32$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[rustc_splat](u8,u32))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat](u8,u32))>)
     //[v0,default]~^^^^ ERROR symbol-name(_RMNvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwThmEEuE)
        //[v0,default]~| ERROR demangling(<splat_mangling[
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u8, u32))>>)
-    impl Type<fn(#[splat] (u8, u32))> {}
+    impl Type<fn(#[rustc_splat] (u8, u32))> {}
 
     #[rustfmt::skip]
     #[rustc_dump_symbol_name]
@@ -40,13 +40,13 @@ fn main() {
 
     #[rustfmt::skip]
     #[rustc_dump_symbol_name]
-           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main77Type$LT$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT
-           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[splat]((u8,u32),))>::
-           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[splat]((u8,u32),))>)
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main77Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[rustc_splat]((u8,u32),))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat]((u8,u32),))>)
     //[v0,default]~^^^^ ERROR symbol-name(_RMs0_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTThmEEEuE)
        //[v0,default]~| ERROR demangling(<splat_mangling[
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(#[splat] ((u8, u32),))>>)
-    impl Type<fn(#[splat] ((u8, u32),))> {}
+    impl Type<fn(#[rustc_splat] ((u8, u32),))> {}
 
     #[rustfmt::skip]
     #[rustc_dump_symbol_name]
@@ -60,13 +60,13 @@ fn main() {
 
     #[rustfmt::skip]
     #[rustc_dump_symbol_name]
-           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main80Type$LT$$BP$const$u20$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$u32$C$i8$RP$$RP$$GT
-           //[legacy]~| ERROR demangling(splat_mangling::main::Type<*const fn(, #[splat](u32,i8))>::
-           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<*const fn(, #[splat](u32,i8))>)
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main80Type$LT$$BP$const$u20$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u32$C$i8$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<*const fn(, #[rustc_splat](u32,i8))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<*const fn(, #[rustc_splat](u32,i8))>)
     //[v0,default]~^^^^ ERROR symbol-name(_RMs2_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFwTmaEEuE)
        //[v0,default]~| ERROR demangling(<splat_mangling[
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<*const fn(#[splat] (u32, i8))>>)
-    impl Type<*const fn(#[splat] (u32, i8))> {}
+    impl Type<*const fn(#[rustc_splat] (u32, i8))> {}
 
     #[rustfmt::skip]
     #[rustc_dump_symbol_name]
@@ -80,13 +80,13 @@ fn main() {
 
     #[rustfmt::skip]
     #[rustc_dump_symbol_name]
-           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main72Type$LT$fn$LP$$C$$u20$$u23$$u5b$splat$u5d$$LP$u32$C$i8$RP$$C$f64$RP$$GT
-           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[splat](u32,i8),f64)>::
-           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[splat](u32,i8),f64)>)
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main72Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u32$C$i8$RP$$C$f64$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[rustc_splat](u32,i8),f64)>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat](u32,i8),f64)>)
     //[v0,default]~^^^^ ERROR symbol-name(_RMs4_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTmaEdEuE)
        //[v0,default]~| ERROR demangling(<splat_mangling[
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u32, i8), f64)>>)
-    impl Type<fn(#[splat] (u32, i8), f64)> {}
+    impl Type<fn(#[rustc_splat] (u32, i8), f64)> {}
 
     #[rustfmt::skip]
     #[rustc_dump_symbol_name]

--- a/tests/ui/splat/splat-maybe-tuple.rs
+++ b/tests/ui/splat/splat-maybe-tuple.rs
@@ -1,11 +1,11 @@
-//! Test that using `#[splat]` on maybe-tuple generic function arguments is an error,
+//! Test that using `#[rustc_splat]` on maybe-tuple generic function arguments is an error,
 //! but only when the generics aren't tuples.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 #![expect(unused)]
 
-fn unbound_generic_arg<T>(#[splat] t: T) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32
+fn unbound_generic_arg<T>(#[rustc_splat] t: T) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32
 
 fn main() {
     unbound_generic_arg();

--- a/tests/ui/splat/splat-maybe-tuple.stderr
+++ b/tests/ui/splat/splat-maybe-tuple.stderr
@@ -1,8 +1,8 @@
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32 (u32)
-  --> $DIR/splat-maybe-tuple.rs:8:39
+  --> $DIR/splat-maybe-tuple.rs:8:45
    |
-LL | fn unbound_generic_arg<T>(#[splat] t: T) {}
-   |                                       ^
+LL | fn unbound_generic_arg<T>(#[rustc_splat] t: T) {}
+   |                                             ^
 ...
 LL |     unbound_generic_arg::<u32>(1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-method-tuple-simple.rs
+++ b/tests/ui/splat/splat-method-tuple-simple.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//! Test using `#[splat]` on method tuple arguments (with receivers).
+//! Test using `#[rustc_splat]` on method tuple arguments (with receivers).
 
 #![allow(incomplete_features)]
 #![feature(splat)]
@@ -7,11 +7,11 @@
 struct Foo;
 
 impl Foo {
-    fn tuple_2(&self, #[splat] (a, _b): (u32, i8)) -> u32 {
+    fn tuple_2(&self, #[rustc_splat] (a, _b): (u32, i8)) -> u32 {
         a
     }
 
-    fn tuple_4(&self, #[splat] (a, _b, _c, _d): (u32, i8, (), f32)) -> u32 {
+    fn tuple_4(&self, #[rustc_splat] (a, _b, _c, _d): (u32, i8, (), f32)) -> u32 {
         a
     }
 }
@@ -20,7 +20,7 @@ impl Foo {
 struct TupleStruct(u32, i8);
 
 impl TupleStruct {
-    fn tuple_2(&self, #[splat] (a, _b): (u32, i8)) -> u32 {
+    fn tuple_2(&self, #[rustc_splat] (a, _b): (u32, i8)) -> u32 {
         a
     }
 }

--- a/tests/ui/splat/splat-non-fn-arg.rs
+++ b/tests/ui/splat/splat-non-fn-arg.rs
@@ -1,12 +1,12 @@
-//! Test that using `#[splat]` on non-function-arguments is an error.
+//! Test that using `#[rustc_splat]` on non-function-arguments is an error.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 
-#[splat] //~ ERROR the `splat` attribute cannot be used on functions
+#[rustc_splat] //~ ERROR the `rustc_splat` attribute cannot be used on functions
 fn tuple_args_bad((a, b): (u32, i8)) {}
 
-#[splat] //~ ERROR the `splat` attribute cannot be used on traits
+#[rustc_splat] //~ ERROR the `rustc_splat` attribute cannot be used on traits
 trait FooTraitBad {
     fn tuple_1(_: (u32,));
 
@@ -15,45 +15,45 @@ trait FooTraitBad {
 
 struct Foo;
 
-#[splat] //~ ERROR the `splat` attribute cannot be used on inherent impl blocks
+#[rustc_splat] //~ ERROR the `rustc_splat` attribute cannot be used on inherent impl blocks
 impl Foo {
     fn tuple_1_bad((a,): (u32,)) {}
 }
 
 impl Foo {
-    #[splat] //~ ERROR the `splat` attribute cannot be used on inherent methods
+    #[rustc_splat] //~ ERROR the `rustc_splat` attribute cannot be used on inherent methods
     fn tuple_3_bad((a, b, c): (u32, i32, i8)) {}
 
-    #[splat] //~ ERROR the `splat` attribute cannot be used on inherent methods
+    #[rustc_splat] //~ ERROR the `rustc_splat` attribute cannot be used on inherent methods
     fn tuple_2_bad(self, (a, b): (u32, i8)) -> u32 {
         a
     }
 }
 
-#[splat] //~ ERROR the `splat` attribute cannot be used on trait impl blocks
+#[rustc_splat] //~ ERROR the `rustc_splat` attribute cannot be used on trait impl blocks
 impl FooTraitBad for Foo {
     fn tuple_1(_: (u32,)) {}
 
     fn tuple_4(self, _: (u32, i8, (), f32)) {}
 }
 
-#[splat] //~ ERROR the `splat` attribute cannot be used on foreign modules
+#[rustc_splat] //~ ERROR the `rustc_splat` attribute cannot be used on foreign modules
 extern "C" {
     fn foo_2(_: (u32, i8));
 }
 
 extern "C" {
-    #[splat] //~ ERROR the `splat` attribute cannot be used on foreign functions
+    #[rustc_splat] //~ ERROR the `rustc_splat` attribute cannot be used on foreign functions
     fn bar_2_bad(_: (u32, i8));
 }
 
-#[splat] //~ ERROR the `splat` attribute cannot be used on modules
+#[rustc_splat] //~ ERROR the `rustc_splat` attribute cannot be used on modules
 mod foo_mod {}
 
-#[splat] //~ ERROR the `splat` attribute cannot be used on use statements
+#[rustc_splat] //~ ERROR the `rustc_splat` attribute cannot be used on use statements
 use std::mem;
 
-#[splat] //~ ERROR the `splat` attribute cannot be used on structs
+#[rustc_splat] //~ ERROR the `rustc_splat` attribute cannot be used on structs
 struct FooStruct;
 
 fn main() {}

--- a/tests/ui/splat/splat-non-fn-arg.stderr
+++ b/tests/ui/splat/splat-non-fn-arg.stderr
@@ -1,90 +1,90 @@
-error: the `splat` attribute cannot be used on functions
+error: the `rustc_splat` attribute cannot be used on functions
   --> $DIR/splat-non-fn-arg.rs:6:3
    |
-LL | #[splat]
-   |   ^^^^^
+LL | #[rustc_splat]
+   |   ^^^^^^^^^^^
    |
-   = help: the `splat` attribute can only be applied to function params
+   = help: the `rustc_splat` attribute can only be applied to function params
 
-error: the `splat` attribute cannot be used on traits
+error: the `rustc_splat` attribute cannot be used on traits
   --> $DIR/splat-non-fn-arg.rs:9:3
    |
-LL | #[splat]
-   |   ^^^^^
+LL | #[rustc_splat]
+   |   ^^^^^^^^^^^
    |
-   = help: the `splat` attribute can only be applied to function params
+   = help: the `rustc_splat` attribute can only be applied to function params
 
-error: the `splat` attribute cannot be used on inherent impl blocks
+error: the `rustc_splat` attribute cannot be used on inherent impl blocks
   --> $DIR/splat-non-fn-arg.rs:18:3
    |
-LL | #[splat]
-   |   ^^^^^
+LL | #[rustc_splat]
+   |   ^^^^^^^^^^^
    |
-   = help: the `splat` attribute can only be applied to function params
+   = help: the `rustc_splat` attribute can only be applied to function params
 
-error: the `splat` attribute cannot be used on inherent methods
+error: the `rustc_splat` attribute cannot be used on inherent methods
   --> $DIR/splat-non-fn-arg.rs:24:7
    |
-LL |     #[splat]
-   |       ^^^^^
+LL |     #[rustc_splat]
+   |       ^^^^^^^^^^^
    |
-   = help: the `splat` attribute can only be applied to function params
+   = help: the `rustc_splat` attribute can only be applied to function params
 
-error: the `splat` attribute cannot be used on inherent methods
+error: the `rustc_splat` attribute cannot be used on inherent methods
   --> $DIR/splat-non-fn-arg.rs:27:7
    |
-LL |     #[splat]
-   |       ^^^^^
+LL |     #[rustc_splat]
+   |       ^^^^^^^^^^^
    |
-   = help: the `splat` attribute can only be applied to function params
+   = help: the `rustc_splat` attribute can only be applied to function params
 
-error: the `splat` attribute cannot be used on trait impl blocks
+error: the `rustc_splat` attribute cannot be used on trait impl blocks
   --> $DIR/splat-non-fn-arg.rs:33:3
    |
-LL | #[splat]
-   |   ^^^^^
+LL | #[rustc_splat]
+   |   ^^^^^^^^^^^
    |
-   = help: the `splat` attribute can only be applied to function params
+   = help: the `rustc_splat` attribute can only be applied to function params
 
-error: the `splat` attribute cannot be used on foreign modules
+error: the `rustc_splat` attribute cannot be used on foreign modules
   --> $DIR/splat-non-fn-arg.rs:40:3
    |
-LL | #[splat]
-   |   ^^^^^
+LL | #[rustc_splat]
+   |   ^^^^^^^^^^^
    |
-   = help: the `splat` attribute can only be applied to function params
+   = help: the `rustc_splat` attribute can only be applied to function params
 
-error: the `splat` attribute cannot be used on foreign functions
+error: the `rustc_splat` attribute cannot be used on foreign functions
   --> $DIR/splat-non-fn-arg.rs:46:7
    |
-LL |     #[splat]
-   |       ^^^^^
+LL |     #[rustc_splat]
+   |       ^^^^^^^^^^^
    |
-   = help: the `splat` attribute can only be applied to function params
+   = help: the `rustc_splat` attribute can only be applied to function params
 
-error: the `splat` attribute cannot be used on modules
+error: the `rustc_splat` attribute cannot be used on modules
   --> $DIR/splat-non-fn-arg.rs:50:3
    |
-LL | #[splat]
-   |   ^^^^^
+LL | #[rustc_splat]
+   |   ^^^^^^^^^^^
    |
-   = help: the `splat` attribute can only be applied to function params
+   = help: the `rustc_splat` attribute can only be applied to function params
 
-error: the `splat` attribute cannot be used on use statements
+error: the `rustc_splat` attribute cannot be used on use statements
   --> $DIR/splat-non-fn-arg.rs:53:3
    |
-LL | #[splat]
-   |   ^^^^^
+LL | #[rustc_splat]
+   |   ^^^^^^^^^^^
    |
-   = help: the `splat` attribute can only be applied to function params
+   = help: the `rustc_splat` attribute can only be applied to function params
 
-error: the `splat` attribute cannot be used on structs
+error: the `rustc_splat` attribute cannot be used on structs
   --> $DIR/splat-non-fn-arg.rs:56:3
    |
-LL | #[splat]
-   |   ^^^^^
+LL | #[rustc_splat]
+   |   ^^^^^^^^^^^
    |
-   = help: the `splat` attribute can only be applied to function params
+   = help: the `rustc_splat` attribute can only be applied to function params
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/splat/splat-non-tuple.rs
+++ b/tests/ui/splat/splat-non-tuple.rs
@@ -1,33 +1,33 @@
-//! Test that using `#[splat]` on non-tuple function arguments is an error.
+//! Test that using `#[rustc_splat]` on non-tuple function arguments is an error.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 #![expect(unused)]
 
-fn primitive_arg(#[splat] x: u32) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32
+fn primitive_arg(#[rustc_splat] x: u32) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32
 
 enum NotATuple {
     A(u32),
     B(i8),
 }
 
-fn enum_arg(#[splat] y: NotATuple) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a NotATuple
+fn enum_arg(#[rustc_splat] y: NotATuple) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a NotATuple
 
 trait FooTrait {
-    fn tuple_1(#[splat] _: (u32,)); //~ NOTE type in trait
+    fn tuple_1(#[rustc_splat] _: (u32,)); //~ NOTE type in trait
 
     // Ambiguous case, self could be a tuple or a non-tuple
-    fn tuple_4(#[splat] self, _: (u32, i8, (), f32));
+    fn tuple_4(#[rustc_splat] self, _: (u32, i8, (), f32));
 }
 
 struct Foo;
 
-fn struct_arg(#[splat] z: Foo) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Foo
+fn struct_arg(#[rustc_splat] z: Foo) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Foo
 
 impl Foo {
     fn tuple_2_self(
         // FIXME(splat): ERROR cannot use splat attribute; the splatted argument type must be a...
-        #[splat] self,
+        #[rustc_splat] self,
         (a, b): (u32, i8),
     ) -> u32 {
         a
@@ -38,12 +38,12 @@ impl FooTrait for Foo {
     fn tuple_1(_: (u32,)) {}
     //~^ ERROR method `tuple_1` has an incompatible type for trait
     //~| NOTE expected fn with arg 0 splatted, found fn with no splatted arg
-    //~| NOTE expected signature `fn(#[splat] (_,))`
+    //~| NOTE expected signature `fn(#[rustc_splat] (_,))`
     //~| NOTE found signature `fn((_,))`
 
     fn tuple_4(
         // FIXME(splat): ERROR cannot use splat attribute; the splatted argument type must be a...
-        #[splat] self,
+        #[rustc_splat] self,
         _: (u32, i8, (), f32),
     ) {
     }
@@ -51,11 +51,11 @@ impl FooTrait for Foo {
 
 struct TupleStruct(u32, i8);
 
-fn tuple_struct_arg(#[splat] z: TupleStruct) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a TupleStruct
+fn tuple_struct_arg(#[rustc_splat] z: TupleStruct) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a TupleStruct
 
 impl TupleStruct {
     fn tuple_2(
-        #[splat] self, // FIXME(splat): ERROR `#[splat]` attribute must be used on a tuple
+        #[rustc_splat] self, // FIXME(splat): ERROR `#[rustc_splat]` attribute must be used on a tuple
         (a, b): (f32, f64),
     ) -> f32 {
         a
@@ -63,10 +63,10 @@ impl TupleStruct {
 }
 
 impl FooTrait for TupleStruct {
-    fn tuple_1(#[splat] _: (u32,)) {}
+    fn tuple_1(#[rustc_splat] _: (u32,)) {}
 
     fn tuple_4(
-        #[splat] self, // FIXME(splat): ERROR `#[splat]` attribute must be used on a tuple
+        #[rustc_splat] self, // FIXME(splat): ERROR `#[rustc_splat]` attribute must be used on a tuple
         _: (u32, i8, (), f32),
     ) {
     }

--- a/tests/ui/splat/splat-non-tuple.rs
+++ b/tests/ui/splat/splat-non-tuple.rs
@@ -25,8 +25,8 @@ struct Foo;
 fn struct_arg(#[rustc_splat] z: Foo) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Foo
 
 impl Foo {
+    // FIXME(splat): ERROR cannot use splat attribute; the splatted argument type must be a tuple
     fn tuple_2_self(
-        // FIXME(splat): ERROR cannot use splat attribute; the splatted argument type must be a...
         #[rustc_splat] self,
         (a, b): (u32, i8),
     ) -> u32 {
@@ -41,8 +41,8 @@ impl FooTrait for Foo {
     //~| NOTE expected signature `fn(#[rustc_splat] (_,))`
     //~| NOTE found signature `fn((_,))`
 
+    // FIXME(splat): ERROR cannot use splat attribute; the splatted argument type must be a tuple
     fn tuple_4(
-        // FIXME(splat): ERROR cannot use splat attribute; the splatted argument type must be a...
         #[rustc_splat] self,
         _: (u32, i8, (), f32),
     ) {
@@ -54,8 +54,9 @@ struct TupleStruct(u32, i8);
 fn tuple_struct_arg(#[rustc_splat] z: TupleStruct) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a TupleStruct
 
 impl TupleStruct {
+    // FIXME(splat): ERROR cannot use splat attribute; the splatted argument type must be a tuple
     fn tuple_2(
-        #[rustc_splat] self, // FIXME(splat): ERROR `#[rustc_splat]` attribute must be used on a tuple
+        #[rustc_splat] self,
         (a, b): (f32, f64),
     ) -> f32 {
         a
@@ -65,8 +66,9 @@ impl TupleStruct {
 impl FooTrait for TupleStruct {
     fn tuple_1(#[rustc_splat] _: (u32,)) {}
 
+    // FIXME(splat): ERROR cannot use splat attribute; the splatted argument type must be a tuple
     fn tuple_4(
-        #[rustc_splat] self, // FIXME(splat): ERROR `#[rustc_splat]` attribute must be used on a tuple
+        #[rustc_splat] self,
         _: (u32, i8, (), f32),
     ) {
     }

--- a/tests/ui/splat/splat-non-tuple.stderr
+++ b/tests/ui/splat/splat-non-tuple.stderr
@@ -7,43 +7,43 @@ LL |     fn tuple_1(_: (u32,)) {}
 note: type in trait
   --> $DIR/splat-non-tuple.rs:17:5
    |
-LL |     fn tuple_1(#[splat] _: (u32,));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: expected signature `fn(#[splat] (_,))`
+LL |     fn tuple_1(#[rustc_splat] _: (u32,));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected signature `fn(#[rustc_splat] (_,))`
               found signature `fn((_,))`
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32 (u32)
-  --> $DIR/splat-non-tuple.rs:7:30
+  --> $DIR/splat-non-tuple.rs:7:36
    |
-LL | fn primitive_arg(#[splat] x: u32) {}
-   |                              ^^^
+LL | fn primitive_arg(#[rustc_splat] x: u32) {}
+   |                                    ^^^
 ...
 LL |     primitive_arg(1u32);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a NotATuple (NotATuple)
-  --> $DIR/splat-non-tuple.rs:14:25
+  --> $DIR/splat-non-tuple.rs:14:31
    |
-LL | fn enum_arg(#[splat] y: NotATuple) {}
-   |                         ^^^^^^^^^
+LL | fn enum_arg(#[rustc_splat] y: NotATuple) {}
+   |                               ^^^^^^^^^
 ...
 LL |     enum_arg(NotATuple::A(1u32));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Foo (Foo)
-  --> $DIR/splat-non-tuple.rs:25:27
+  --> $DIR/splat-non-tuple.rs:25:33
    |
-LL | fn struct_arg(#[splat] z: Foo) {}
-   |                           ^^^
+LL | fn struct_arg(#[rustc_splat] z: Foo) {}
+   |                                 ^^^
 ...
 LL |     struct_arg(foo);
    |     ^^^^^^^^^^^^^^^
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a TupleStruct (TupleStruct)
-  --> $DIR/splat-non-tuple.rs:54:33
+  --> $DIR/splat-non-tuple.rs:54:39
    |
-LL | fn tuple_struct_arg(#[splat] z: TupleStruct) {}
-   |                                 ^^^^^^^^^^^
+LL | fn tuple_struct_arg(#[rustc_splat] z: TupleStruct) {}
+   |                                       ^^^^^^^^^^^
 ...
 LL |     tuple_struct_arg(tuple_struct);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-overload-at-home-fail.rs
+++ b/tests/ui/splat/splat-overload-at-home-fail.rs
@@ -1,4 +1,4 @@
-//! Test error cases for `#[splat]` "overloading at home" example code.
+//! Test error cases for `#[rustc_splat]` "overloading at home" example code.
 //! Splatted calls that don't match any registered MethodArgs impl should fail.
 #![allow(incomplete_features)]
 #![feature(splat)]
@@ -23,7 +23,7 @@ impl MethodArgs for (i32, String) {
 }
 
 impl Foo {
-    fn method<T: MethodArgs>(&self, #[splat] args: T) {
+    fn method<T: MethodArgs>(&self, #[rustc_splat] args: T) {
         args.call_method(self)
     }
 }

--- a/tests/ui/splat/splat-overload-at-home-fail.stderr
+++ b/tests/ui/splat/splat-overload-at-home-fail.stderr
@@ -9,8 +9,8 @@ LL |     foo.method(42f32);
 note: method defined here
   --> $DIR/splat-overload-at-home-fail.rs:26:8
    |
-LL |     fn method<T: MethodArgs>(&self, #[splat] args: T) {
-   |        ^^^^^^                       ----------------
+LL |     fn method<T: MethodArgs>(&self, #[rustc_splat] args: T) {
+   |        ^^^^^^                       ----------------------
 help: change the type of the numeric literal from `f32` to `i32`
    |
 LL -     foo.method(42f32);
@@ -28,7 +28,7 @@ LL |     foo.method(42i32, 42i32);
 note: method defined here
   --> $DIR/splat-overload-at-home-fail.rs:26:8
    |
-LL |     fn method<T: MethodArgs>(&self, #[splat] args: T) {
+LL |     fn method<T: MethodArgs>(&self, #[rustc_splat] args: T) {
    |        ^^^^^^
 help: try using a conversion method
    |

--- a/tests/ui/splat/splat-overload-at-home.rs
+++ b/tests/ui/splat/splat-overload-at-home.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 // ignore-tidy-file-linelength
-//! Test using `#[splat]` on some "overloading at home" example code.
+//! Test using `#[rustc_splat]` on some "overloading at home" example code.
 //! <https://internals.rust-lang.org/t/pre-pre-rfc-splatting-for-named-arguments-and-function-overloading/24012>
 
 #![allow(incomplete_features)]
@@ -23,7 +23,7 @@ impl MethodArgs for (i32, String) {
 }
 
 impl Foo {
-    fn method<T: MethodArgs>(&self, #[splat] args: T) {
+    fn method<T: MethodArgs>(&self, #[rustc_splat] args: T) {
         args.call_method(self)
     }
 }

--- a/tests/ui/splat/splat-rust-call-fn-trait-issue-158800.rs
+++ b/tests/ui/splat/splat-rust-call-fn-trait-issue-158800.rs
@@ -1,4 +1,4 @@
-//! Regression test for `#[splat] ()` in a rust-call Fn* trait method not ICEing in WF
+//! Regression test for `#[rustc_splat] ()` in a rust-call Fn* trait method not ICEing in WF
 //! checking.
 
 #![feature(splat)]
@@ -7,8 +7,8 @@
 
 impl<T> dyn FnOnce(T) -> () {
     //~^ ERROR cannot define inherent `impl` for a type outside of the crate
-    extern "rust-call" fn call_once(#[splat] _: ()) {}
-    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+    extern "rust-call" fn call_once(#[rustc_splat] _: ()) {}
+    //~^ ERROR `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
 }
 
 fn main() {}

--- a/tests/ui/splat/splat-rust-call-fn-trait-issue-158800.stderr
+++ b/tests/ui/splat/splat-rust-call-fn-trait-issue-158800.stderr
@@ -1,10 +1,10 @@
-error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+error: `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
   --> $DIR/splat-rust-call-fn-trait-issue-158800.rs:10:5
    |
-LL |     extern "rust-call" fn call_once(#[splat] _: ()) {}
-   |     ^^^^^^^^^^^^^^^^^^              ^^^^^^^^
+LL |     extern "rust-call" fn call_once(#[rustc_splat] _: ()) {}
+   |     ^^^^^^^^^^^^^^^^^^              ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or change the ABI
+   = help: remove `#[rustc_splat]` or change the ABI
 
 error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
   --> $DIR/splat-rust-call-fn-trait-issue-158800.rs:8:1

--- a/tests/ui/splat/splat-rust-call-fn-trait-self-issue-158800.rs
+++ b/tests/ui/splat/splat-rust-call-fn-trait-self-issue-158800.rs
@@ -1,4 +1,4 @@
-//! Regression test for `#[splat] self` in a rust-call Fn* trait method not ICEing in WF
+//! Regression test for `#[rustc_splat] self` in a rust-call Fn* trait method not ICEing in WF
 //! checking.
 
 #![feature(splat)]
@@ -7,8 +7,8 @@
 
 impl<T> dyn FnOnce(T) -> () {
     //~^ ERROR cannot define inherent `impl` for a type outside of the crate
-    extern "rust-call" fn call_once(#[splat] self) {}
-    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+    extern "rust-call" fn call_once(#[rustc_splat] self) {}
+    //~^ ERROR `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
     //~| ERROR functions with the "rust-call" ABI must take a single non-self tuple argument
     //~| ERROR the size for values of type `(dyn FnOnce(T) + 'static)` cannot be known
 }

--- a/tests/ui/splat/splat-rust-call-fn-trait-self-issue-158800.stderr
+++ b/tests/ui/splat/splat-rust-call-fn-trait-self-issue-158800.stderr
@@ -1,16 +1,16 @@
-error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+error: `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
   --> $DIR/splat-rust-call-fn-trait-self-issue-158800.rs:10:5
    |
-LL |     extern "rust-call" fn call_once(#[splat] self) {}
-   |     ^^^^^^^^^^^^^^^^^^              ^^^^^^^^
+LL |     extern "rust-call" fn call_once(#[rustc_splat] self) {}
+   |     ^^^^^^^^^^^^^^^^^^              ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or change the ABI
+   = help: remove `#[rustc_splat]` or change the ABI
 
 error: functions with the "rust-call" ABI must take a single non-self tuple argument
-  --> $DIR/splat-rust-call-fn-trait-self-issue-158800.rs:10:46
+  --> $DIR/splat-rust-call-fn-trait-self-issue-158800.rs:10:52
    |
-LL |     extern "rust-call" fn call_once(#[splat] self) {}
-   |                                              ^^^^
+LL |     extern "rust-call" fn call_once(#[rustc_splat] self) {}
+   |                                                    ^^^^
 
 error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
   --> $DIR/splat-rust-call-fn-trait-self-issue-158800.rs:8:1
@@ -22,17 +22,17 @@ LL | impl<T> dyn FnOnce(T) -> () {
    = note: for more details about the orphan rules, see <https://doc.rust-lang.org/reference/items/implementations.html?highlight=orphan#orphan-rules>
 
 error[E0277]: the size for values of type `(dyn FnOnce(T) + 'static)` cannot be known at compilation time
-  --> $DIR/splat-rust-call-fn-trait-self-issue-158800.rs:10:46
+  --> $DIR/splat-rust-call-fn-trait-self-issue-158800.rs:10:52
    |
-LL |     extern "rust-call" fn call_once(#[splat] self) {}
-   |                                              ^^^^ doesn't have a size known at compile-time
+LL |     extern "rust-call" fn call_once(#[rustc_splat] self) {}
+   |                                                    ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn FnOnce(T) + 'static)`
    = help: unsized fn params are gated as an unstable feature
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
-LL |     extern "rust-call" fn call_once(#[splat] &self) {}
-   |                                              +
+LL |     extern "rust-call" fn call_once(#[rustc_splat] &self) {}
+   |                                                    +
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/splat/splat-rust-call-trait-issue-158800.rs
+++ b/tests/ui/splat/splat-rust-call-trait-issue-158800.rs
@@ -1,4 +1,4 @@
-//! Regression test for `#[splat] ()` in a rust-call trait method not ICEing in WF
+//! Regression test for `#[rustc_splat] ()` in a rust-call trait method not ICEing in WF
 //! checking.
 
 #![feature(splat)]
@@ -6,13 +6,13 @@
 #![expect(incomplete_features)]
 
 trait Trait {
-    extern "rust-call" fn f(#[splat] _: ()) where Self: Sized;
-    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+    extern "rust-call" fn f(#[rustc_splat] _: ()) where Self: Sized;
+    //~^ ERROR `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
 }
 
 impl dyn Trait {
-    extern "rust-call" fn f(#[splat] _: ()) where Self: Sized {}
-    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+    extern "rust-call" fn f(#[rustc_splat] _: ()) where Self: Sized {}
+    //~^ ERROR `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
     //~| ERROR the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
 }
 

--- a/tests/ui/splat/splat-rust-call-trait-issue-158800.stderr
+++ b/tests/ui/splat/splat-rust-call-trait-issue-158800.stderr
@@ -1,24 +1,24 @@
-error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+error: `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
   --> $DIR/splat-rust-call-trait-issue-158800.rs:9:5
    |
-LL |     extern "rust-call" fn f(#[splat] _: ()) where Self: Sized;
-   |     ^^^^^^^^^^^^^^^^^^      ^^^^^^^^
+LL |     extern "rust-call" fn f(#[rustc_splat] _: ()) where Self: Sized;
+   |     ^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or change the ABI
+   = help: remove `#[rustc_splat]` or change the ABI
 
-error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+error: `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
   --> $DIR/splat-rust-call-trait-issue-158800.rs:14:5
    |
-LL |     extern "rust-call" fn f(#[splat] _: ()) where Self: Sized {}
-   |     ^^^^^^^^^^^^^^^^^^      ^^^^^^^^
+LL |     extern "rust-call" fn f(#[rustc_splat] _: ()) where Self: Sized {}
+   |     ^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or change the ABI
+   = help: remove `#[rustc_splat]` or change the ABI
 
 error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
-  --> $DIR/splat-rust-call-trait-issue-158800.rs:14:51
+  --> $DIR/splat-rust-call-trait-issue-158800.rs:14:57
    |
-LL |     extern "rust-call" fn f(#[splat] _: ()) where Self: Sized {}
-   |                                                   ^^^^^^^^^^^ doesn't have a size known at compile-time
+LL |     extern "rust-call" fn f(#[rustc_splat] _: ()) where Self: Sized {}
+   |                                                         ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Trait + 'static)`
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/tests/ui/splat/splat-rust-call-type-issue-158800.rs
+++ b/tests/ui/splat/splat-rust-call-type-issue-158800.rs
@@ -1,4 +1,4 @@
-//! Regression test for `#[splat] ())` in a rust-call type method not ICEing in WF
+//! Regression test for `#[rustc_splat] ())` in a rust-call type method not ICEing in WF
 //! checking.
 
 #![feature(splat)]
@@ -8,18 +8,18 @@
 struct Type;
 
 trait Trait {
-    extern "rust-call" fn f(#[splat] _: ());
-    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+    extern "rust-call" fn f(#[rustc_splat] _: ());
+    //~^ ERROR `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
 }
 
 impl Type {
-    extern "rust-call" fn f2(#[splat] _: ()) {}
-    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+    extern "rust-call" fn f2(#[rustc_splat] _: ()) {}
+    //~^ ERROR `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
 }
 
 impl Trait for Type {
-    extern "rust-call" fn f(#[splat] _: ()) {}
-    //~^ ERROR `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+    extern "rust-call" fn f(#[rustc_splat] _: ()) {}
+    //~^ ERROR `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
 }
 
 fn main() {}

--- a/tests/ui/splat/splat-rust-call-type-issue-158800.stderr
+++ b/tests/ui/splat/splat-rust-call-type-issue-158800.stderr
@@ -1,26 +1,26 @@
-error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+error: `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
   --> $DIR/splat-rust-call-type-issue-158800.rs:11:5
    |
-LL |     extern "rust-call" fn f(#[splat] _: ());
-   |     ^^^^^^^^^^^^^^^^^^      ^^^^^^^^
+LL |     extern "rust-call" fn f(#[rustc_splat] _: ());
+   |     ^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or change the ABI
+   = help: remove `#[rustc_splat]` or change the ABI
 
-error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+error: `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
   --> $DIR/splat-rust-call-type-issue-158800.rs:16:5
    |
-LL |     extern "rust-call" fn f2(#[splat] _: ()) {}
-   |     ^^^^^^^^^^^^^^^^^^       ^^^^^^^^
+LL |     extern "rust-call" fn f2(#[rustc_splat] _: ()) {}
+   |     ^^^^^^^^^^^^^^^^^^       ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or change the ABI
+   = help: remove `#[rustc_splat]` or change the ABI
 
-error: `#[splat]` is not allowed in the arguments of functions with the `rust-call` ABI
+error: `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
   --> $DIR/splat-rust-call-type-issue-158800.rs:21:5
    |
-LL |     extern "rust-call" fn f(#[splat] _: ()) {}
-   |     ^^^^^^^^^^^^^^^^^^      ^^^^^^^^
+LL |     extern "rust-call" fn f(#[rustc_splat] _: ()) {}
+   |     ^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` or change the ABI
+   = help: remove `#[rustc_splat]` or change the ABI
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/splat/splat-self.rs
+++ b/tests/ui/splat/splat-self.rs
@@ -1,16 +1,16 @@
 //@ run-pass
 //@ check-run-results
-//! Test using `#[splat]` on self arguments of trait methods.
+//! Test using `#[rustc_splat]` on self arguments of trait methods.
 
 #![feature(splat)]
 #![expect(incomplete_features)]
 
 trait Trait {
-    fn method(#[splat] self: Self);
+    fn method(#[rustc_splat] self: Self);
 }
 
 impl Trait for (i32, i64) {
-    fn method(#[splat] self: Self) {
+    fn method(#[rustc_splat] self: Self) {
         println!("{self:?}");
     }
 }

--- a/tests/ui/splat/splat-trait-tuple.rs
+++ b/tests/ui/splat/splat-trait-tuple.rs
@@ -1,31 +1,31 @@
 //@ run-pass
-//! Test using `#[splat]` on trait assoc function/method tuple arguments.
+//! Test using `#[rustc_splat]` on trait assoc function/method tuple arguments.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 
 trait FooTrait {
-    fn tuple_1_trait(#[splat] _: (u32,));
+    fn tuple_1_trait(#[rustc_splat] _: (u32,));
 
-    fn tuple_2_trait(&self, #[splat] _: (u32, f32));
+    fn tuple_2_trait(&self, #[rustc_splat] _: (u32, f32));
 }
 
 struct Foo;
 
 impl FooTrait for Foo {
     // Currently, splat attributes on impls must match traits. This provides better UX.
-    fn tuple_1_trait(#[splat] _: (u32,)) {}
+    fn tuple_1_trait(#[rustc_splat] _: (u32,)) {}
 
-    fn tuple_2_trait(&self, #[splat] _: (u32, f32)) {}
+    fn tuple_2_trait(&self, #[rustc_splat] _: (u32, f32)) {}
 }
 
 #[expect(dead_code)]
 struct TupleStruct(u32, i8);
 
 impl FooTrait for TupleStruct {
-    fn tuple_1_trait(#[splat] _: (u32,)) {}
+    fn tuple_1_trait(#[rustc_splat] _: (u32,)) {}
 
-    fn tuple_2_trait(&self, #[splat] _: (u32, f32)) {}
+    fn tuple_2_trait(&self, #[rustc_splat] _: (u32, f32)) {}
 }
 
 fn main() {

--- a/tests/ui/splat/splat-unsafe-fn-tuple-fail.rs
+++ b/tests/ui/splat/splat-unsafe-fn-tuple-fail.rs
@@ -1,13 +1,13 @@
-//! Test that using `#[splat]` incorrectly on unsafe functions gives errors.
+//! Test that using `#[rustc_splat]` incorrectly on unsafe functions gives errors.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 
-unsafe fn unsafe_wrong_type(#[splat] _x: u32) {}
+unsafe fn unsafe_wrong_type(#[rustc_splat] _x: u32) {}
 //~^ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32
 
-unsafe fn unsafe_multi_splat(#[splat] (_a, _b): (u32, i8), #[splat] (_c, _d): (u32, i8)) {}
-//~^ ERROR multiple `#[splat]`s are not allowed in the same function argument list
+unsafe fn unsafe_multi_splat(#[rustc_splat] (_a, _b): (u32, i8), #[rustc_splat] (_c, _d): (u32, i8)) {}
+//~^ ERROR multiple `#[rustc_splat]`s are not allowed in the same function argument list
 
 fn main() {
     unsafe {

--- a/tests/ui/splat/splat-unsafe-fn-tuple-fail.rs
+++ b/tests/ui/splat/splat-unsafe-fn-tuple-fail.rs
@@ -6,8 +6,11 @@
 unsafe fn unsafe_wrong_type(#[rustc_splat] _x: u32) {}
 //~^ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32
 
-unsafe fn unsafe_multi_splat(#[rustc_splat] (_a, _b): (u32, i8), #[rustc_splat] (_c, _d): (u32, i8)) {}
-//~^ ERROR multiple `#[rustc_splat]`s are not allowed in the same function argument list
+unsafe fn unsafe_multi_splat(
+    #[rustc_splat] (_a, _b): (u32, i8),
+    //~^ ERROR multiple `#[rustc_splat]`s are not allowed in the same function argument list
+    #[rustc_splat] (_c, _d): (u32, i8),
+) {}
 
 fn main() {
     unsafe {

--- a/tests/ui/splat/splat-unsafe-fn-tuple-fail.stderr
+++ b/tests/ui/splat/splat-unsafe-fn-tuple-fail.stderr
@@ -1,16 +1,16 @@
-error: multiple `#[splat]`s are not allowed in the same function argument list
+error: multiple `#[rustc_splat]`s are not allowed in the same function argument list
   --> $DIR/splat-unsafe-fn-tuple-fail.rs:9:30
    |
-LL | unsafe fn unsafe_multi_splat(#[splat] (_a, _b): (u32, i8), #[splat] (_c, _d): (u32, i8)) {}
-   |                              ^^^^^^^^                      ^^^^^^^^
+LL | unsafe fn unsafe_multi_splat(#[rustc_splat] (_a, _b): (u32, i8), #[rustc_splat] (_c, _d): (u32, i8)) {}
+   |                              ^^^^^^^^^^^^^^                      ^^^^^^^^^^^^^^
    |
-   = help: remove `#[splat]` from all but one argument
+   = help: remove `#[rustc_splat]` from all but one argument
 
 error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32 (u32)
-  --> $DIR/splat-unsafe-fn-tuple-fail.rs:6:42
+  --> $DIR/splat-unsafe-fn-tuple-fail.rs:6:48
    |
-LL | unsafe fn unsafe_wrong_type(#[splat] _x: u32) {}
-   |                                          ^^^
+LL | unsafe fn unsafe_wrong_type(#[rustc_splat] _x: u32) {}
+   |                                                ^^^
 ...
 LL |         unsafe_wrong_type(1u32);
    |         ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-unsafe-fn-tuple-fail.stderr
+++ b/tests/ui/splat/splat-unsafe-fn-tuple-fail.stderr
@@ -1,8 +1,11 @@
 error: multiple `#[rustc_splat]`s are not allowed in the same function argument list
-  --> $DIR/splat-unsafe-fn-tuple-fail.rs:9:30
+  --> $DIR/splat-unsafe-fn-tuple-fail.rs:10:5
    |
-LL | unsafe fn unsafe_multi_splat(#[rustc_splat] (_a, _b): (u32, i8), #[rustc_splat] (_c, _d): (u32, i8)) {}
-   |                              ^^^^^^^^^^^^^^                      ^^^^^^^^^^^^^^
+LL |     #[rustc_splat] (_a, _b): (u32, i8),
+   |     ^^^^^^^^^^^^^^
+LL |
+LL |     #[rustc_splat] (_c, _d): (u32, i8),
+   |     ^^^^^^^^^^^^^^
    |
    = help: remove `#[rustc_splat]` from all but one argument
 

--- a/tests/ui/splat/splat-unsafe-fn-tuple.rs
+++ b/tests/ui/splat/splat-unsafe-fn-tuple.rs
@@ -1,12 +1,12 @@
 //@ run-pass
-//! Test using `#[splat]` on tuple arguments of unsafe functions.
+//! Test using `#[rustc_splat]` on tuple arguments of unsafe functions.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 
-unsafe fn unsafe_tuple_args(#[splat] (_a, _b): (u32, i8)) {}
+unsafe fn unsafe_tuple_args(#[rustc_splat] (_a, _b): (u32, i8)) {}
 
-unsafe fn unsafe_splat_non_terminal_arg(#[splat] (_a, _b): (u32, i8), _c: f64) {}
+unsafe fn unsafe_splat_non_terminal_arg(#[rustc_splat] (_a, _b): (u32, i8), _c: f64) {}
 
 fn main() {
     unsafe {

--- a/tests/ui/splat/splat-where-clause.rs
+++ b/tests/ui/splat/splat-where-clause.rs
@@ -1,17 +1,17 @@
 //@ run-pass
-//! Test using `#[splat]` on tuple arguments with where clause bounds.
+//! Test using `#[rustc_splat]` on tuple arguments with where clause bounds.
 
 #![allow(incomplete_features)]
 #![feature(splat)]
 #![feature(tuple_trait)]
 
-fn where_splat<T>(#[splat] _t: T) where T: std::marker::Tuple {}
+fn where_splat<T>(#[rustc_splat] _t: T) where T: std::marker::Tuple {}
 
-fn where_splat_with_extra<T>(#[splat] _t: T, _extra: u32) where T: std::marker::Tuple {}
+fn where_splat_with_extra<T>(#[rustc_splat] _t: T, _extra: u32) where T: std::marker::Tuple {}
 
-fn impl_tuple_splat(#[splat] _t: impl std::marker::Tuple) {}
+fn impl_tuple_splat(#[rustc_splat] _t: impl std::marker::Tuple) {}
 
-fn impl_tuple_splat_with_extra(#[splat] _t: impl std::marker::Tuple, _extra: u32) {}
+fn impl_tuple_splat_with_extra(#[rustc_splat] _t: impl std::marker::Tuple, _extra: u32) {}
 
 fn main() {
     // empty tuple


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159817)*
<!-- homu-ignore:end -->

Tracking issue: rust-lang/rust#153629

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR renames `#[splat]` to `#[rustc_splat]`, in a mostly automated way (using `fastmod`).

The rename commands I used were:
```sh
fastmod --fixed-strings '#[splat]' '#[rustc_splat]'
fastmod --fixed-strings '`splat` attribute' '`rustc_splat` attribute'
# I'm pretty sure the symbol demangling commands are no-ops on beta
# Legacy symbol demangling
fastmod --fixed-strings '$splat$' '$rustc_splat$'
# Revert some changes that aren't in rustc_demangle yet
fastmod 'v0(.*)#\[rustc_splat\]' 'v0${1}#[splat]' tests/ui/splat/splat-mangling.rs
```

Part of rust-lang/rust#159428

#### Backport Advice

Cherry-pick the first commit to the beta branch, then run the fastmod commands above.
I've tested this locally (with a slightly different name), and it works, see my [`splat-rename-beta` branch](https://github.com/teor2345/rust/tree/splat-rename-beta).

#### Remaining Work

rustc_demangle needs an update to the attribute name, a release, and then a version bump in rust-lang/rust. I'll do that separately. It doesn't need to be backported, because the last version bump was after beta branched.

There's also some external code that needs updates, the full list is in the ticket: https://github.com/rust-lang/rust/issues/159428#issuecomment-5040163201

@rustbot label +beta-nominated +A-attributes +A-macros +A-resolve +C-bug +F-splat +P-high +T-compiler