### PR TITLE
std::sync::poison: disable auto_cfg on PoisonError::new

### DIFF
--- a/library/std/src/sync/poison.rs
+++ b/library/std/src/sync/poison.rs
@@ -263,6 +263,7 @@ impl<T> PoisonError<T> {
     /// or [`RwLock::read`](crate::sync::RwLock::read).
     ///
     /// This method may panic if std was built with `panic="abort"`.
+    #[doc(auto_cfg = false)]
     #[cfg(panic = "unwind")]
     #[stable(feature = "sync_poison", since = "1.2.0")]
     pub fn new(data: T) -> PoisonError<T> {
@@ -275,6 +276,7 @@ impl<T> PoisonError<T> {
     /// or [`RwLock::read`](crate::sync::RwLock::read).
     ///
     /// This method may panic if std was built with `panic="abort"`.
+    #[doc(auto_cfg = false)]
     #[cfg(not(panic = "unwind"))]
     #[stable(feature = "sync_poison", since = "1.2.0")]
     #[track_caller]

--- a/tests/rustdoc-html/doc-cfg/mutually-exclusive-cfg-item.rs
+++ b/tests/rustdoc-html/doc-cfg/mutually-exclusive-cfg-item.rs
@@ -1,0 +1,24 @@
+// An item split into mutually-exclusive `#[cfg(..)]` variants that together cover
+// every configuration must not get a portability note when `auto_cfg` is disabled.
+// Regression test for <https://github.com/rust-lang/rust/issues/149786>.
+
+#![feature(doc_cfg)]
+#![crate_name = "foo"]
+
+pub struct S;
+
+impl S {
+    //@ has 'foo/struct.S.html'
+    //@ count - '//*[@id="method.new"]/..//*[@class="stab portability"]' 0
+    #[doc(auto_cfg = false)]
+    #[cfg(panic = "unwind")]
+    pub fn new() -> S {
+        S
+    }
+
+    #[doc(auto_cfg = false)]
+    #[cfg(not(panic = "unwind"))]
+    pub fn new() -> S {
+        S
+    }
+}


### PR DESCRIPTION
`PoisonError::new` is defined twice, once for `#[cfg(panic = "unwind")]` and once for its negation. While exactly one definition survives expansion in any given build, the method itself is actually present in every configuration. 

Currently, rustdoc's `auto_cfg` only looks at whichever `cfg` survived expansion and tags the method accordingly, generating a misleading "Available on panic=unwind only" portability badge in the docs.

This is the same `auto_cfg` limitation previously addressed in rust-lang/rust#153964, rust-lang/rust#154311, and rust-lang/rust#156426: when an item is split into mutually-exclusive `cfg` variants that collectively cover all builds, rustdoc incorrectly marks it as conditionally available. Issue rust-lang/rust#149786 pointed out `PoisonError::new` as another case of this pattern, but it hadn't been touched yet.

This PR applies the same fix as rust-lang/rust#156426 (adding `#[doc(auto_cfg = false)]` to both variants) and adds a regression test to cover this pattern going forward.

r? @GuillaumeGomez