### PR TITLE
codegen: handle OperandValue::Uninit in codegen_return_terminator

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -580,10 +580,10 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
             PassMode::Direct(_) | PassMode::Pair(..) => {
                 let op = self.codegen_consume(bx, mir::Place::return_place().as_ref());
-                if let Ref(place_val) = op.val {
-                    bx.load_from_place(bx.backend_type(op.layout), place_val)
-                } else {
-                    op.immediate_or_packed_pair(bx)
+                match op.val {
+                    Ref(place_val) => bx.load_from_place(bx.backend_type(op.layout), place_val),
+                    Uninit => bx.cx().const_undef(bx.cx().immediate_backend_type(op.layout)),
+                    _ => op.immediate_or_packed_pair(bx),
                 }
             }
 

--- a/tests/codegen-llvm/uninit-return-value.rs
+++ b/tests/codegen-llvm/uninit-return-value.rs
@@ -1,0 +1,13 @@
+// Regression test for https://github.com/rust-lang/rust/issues/159815
+
+#![crate_type = "lib"]
+
+use std::mem::MaybeUninit;
+
+// CHECK-LABEL: @f
+#[no_mangle]
+pub fn f() -> MaybeUninit<*const ()> {
+    // CHECK: start:
+    // CHECK-NEXT: ret ptr undef
+    const { MaybeUninit::uninit() }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159825)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#159815.

rust-lang/rust#157797 added `OperandValue::Uninit` to skip stores for entirely-uninit constants, but missed the `PassMode::Direct | PassMode::Pair` branch of `codegen_return_terminator`, which called `immediate_or_packed_pair` unconditionally. A function directly returning an all-uninit value (e.g. `MaybeUninit::uninit()`) would hit that branch and ICE in `OperandRef::immediate`, as reported against tokio and reduced by tmiasko.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? oli-obk
-->
<!-- homu-ignore:end -->
