### PR TITLE
Remove redundant `#[rustc_paren_sugar]` feature gate

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/traits.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/traits.rs
@@ -53,7 +53,7 @@ pub(crate) struct RustcParenSugarParser;
 impl NoArgsAttributeParser for RustcParenSugarParser {
     const PATH: &[Symbol] = &[sym::rustc_paren_sugar];
     const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
-    const STABILITY: AttributeStability = unstable!(rustc_attrs);
+    const STABILITY: AttributeStability = unstable!(unboxed_closures);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcParenSugar;
 }
 

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -947,9 +947,6 @@ fn trait_def(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::TraitDef {
     let attrs = tcx.get_all_attrs(def_id);
 
     let paren_sugar = find_attr!(attrs, RustcParenSugar);
-    if paren_sugar && !tcx.features().unboxed_closures() {
-        tcx.dcx().emit_err(diagnostics::ParenSugarAttribute { span: item.span });
-    }
 
     // Only regular traits can be marker.
     let is_marker = !is_alias && find_attr!(attrs, Marker);

--- a/compiler/rustc_hir_analysis/src/diagnostics.rs
+++ b/compiler/rustc_hir_analysis/src/diagnostics.rs
@@ -863,16 +863,6 @@ pub(crate) struct EnumDiscriminantOverflowed {
 }
 
 #[derive(Diagnostic)]
-#[diag(
-    "the `#[rustc_paren_sugar]` attribute is a temporary means of controlling which traits can use parenthetical notation"
-)]
-#[help("add `#![feature(unboxed_closures)]` to the crate attributes to use it")]
-pub(crate) struct ParenSugarAttribute {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag("use of SIMD type{$snip} in FFI is highly experimental and may result in invalid code")]
 #[help("add `#![feature(simd_ffi)]` to the crate attributes to enable")]
 pub(crate) struct SIMDFFIHighlyExperimental {

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures.rs
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures.rs
@@ -2,6 +2,10 @@
 
 struct Test;
 
+
+#[rustc_paren_sugar]
+//~^ ERROR the `rustc_paren_sugar` attribute is an experimental feature
+pub trait Fn<Args> {}
 impl FnOnce<(u32, u32)> for Test {
 //~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
 //~| ERROR manual implementations of `FnOnce` are experimental

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures.stderr
@@ -1,5 +1,15 @@
+error[E0658]: the `rustc_paren_sugar` attribute is an experimental feature
+  --> $DIR/feature-gate-unboxed-closures.rs:6:3
+   |
+LL | #[rustc_paren_sugar]
+   |   ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: the extern "rust-call" ABI is experimental and subject to change
-  --> $DIR/feature-gate-unboxed-closures.rs:10:12
+  --> $DIR/feature-gate-unboxed-closures.rs:14:12
    |
 LL |     extern "rust-call" fn call_once(self, (a, b): (u32, u32)) -> u32 {
    |            ^^^^^^^^^^^
@@ -9,7 +19,7 @@ LL |     extern "rust-call" fn call_once(self, (a, b): (u32, u32)) -> u32 {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/feature-gate-unboxed-closures.rs:5:6
+  --> $DIR/feature-gate-unboxed-closures.rs:9:6
    |
 LL | impl FnOnce<(u32, u32)> for Test {
    |      ^^^^^^^^^^^^^^^^^^
@@ -19,14 +29,14 @@ LL | impl FnOnce<(u32, u32)> for Test {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0183]: manual implementations of `FnOnce` are experimental
-  --> $DIR/feature-gate-unboxed-closures.rs:5:6
+  --> $DIR/feature-gate-unboxed-closures.rs:9:6
    |
 LL | impl FnOnce<(u32, u32)> for Test {
    |      ^^^^^^^^^^^^^^^^^^ manual implementations of `FnOnce` are experimental
    |
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0183, E0658.
 For more information about an error, try `rustc --explain E0183`.


### PR DESCRIPTION
It is already gated on `rustc_attrs`.

Alternatively we could update attribute parsing to optionally require multiple features, but that seems unnecessary.

r? @JonathanBrouwer 