### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/back/mod.rs
@@ -15,6 +15,8 @@ mod symbol_edit;
 pub mod symbol_export;
 pub mod write;
 
+pub use symbol_export::{exported_non_generic_symbols_helper, reachable_non_generics_helper};
+
 /// The target triple depends on the deployment target, and is required to
 /// enable features such as cross-language LTO, and for picking the right
 /// Mach-O commands.

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -54,6 +54,11 @@ fn reachable_non_generics_provider(tcx: TyCtxt<'_>, _: LocalCrate) -> DefIdMap<S
         return Default::default();
     }
 
+    reachable_non_generics_helper(tcx)
+}
+
+/// Exposed separately *without* the "should codegen" check so Miri can access it.
+pub fn reachable_non_generics_helper(tcx: TyCtxt<'_>) -> DefIdMap<SymbolExportInfo> {
     let is_compiler_builtins = tcx.is_compiler_builtins(LOCAL_CRATE);
 
     let mut reachable_non_generics: DefIdMap<_> = tcx
@@ -176,6 +181,13 @@ fn exported_non_generic_symbols_provider_local<'tcx>(
         return &[];
     }
 
+    exported_non_generic_symbols_helper(tcx)
+}
+
+/// Exposed separately *without* the "should codegen" check so Miri can access it.
+pub fn exported_non_generic_symbols_helper<'tcx>(
+    tcx: TyCtxt<'tcx>,
+) -> &'tcx [(ExportedSymbol<'tcx>, SymbolExportInfo)] {
     // FIXME: Sorting this is unnecessary since we are sorting later anyway.
     //        Can we skip the later sorting?
     let sorted = tcx.with_stable_hashing_context(|mut hcx| {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4769,7 +4769,7 @@ pub enum RestrictionKind<'hir> {
 /// explicitly to allow unsafe operations.
 #[derive(Copy, Clone, Debug, StableHash, PartialEq, Eq)]
 pub enum HeaderSafety {
-    /// A safe function annotated with `#[target_features]`.
+    /// A safe function annotated with `#[target_feature(..)]`.
     /// The type system treats this function as an unsafe function,
     /// but safety checking will check this enum to treat it as safe
     /// and allowing calling other safe target feature functions with

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -129,7 +129,8 @@ impl<'tcx> TypeError<'tcx> {
             }
             TypeError::IntrinsicCast => "cannot coerce intrinsics to function pointers".into(),
             TypeError::TargetFeatureCast(_) => {
-                "cannot coerce functions with `#[target_feature]` to safe function pointers".into()
+                "cannot coerce functions with `#[target_feature(..)]` to safe function pointers"
+                    .into()
             }
         }
     }

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -789,7 +789,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                     let mut sig =
                         self.tcx().fn_sig(def_id).instantiate(self.tcx(), args).skip_norm_wip();
                     if self.tcx().codegen_fn_attrs(def_id).safe_target_features {
-                        write!(self, "#[target_features] ")?;
+                        write!(self, "#[target_feature(..)] ")?;
                         sig = sig.map_bound(|mut sig| {
                             sig.fn_sig_kind = sig.fn_sig_kind.set_safety(hir::Safety::Safe);
                             sig

--- a/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
@@ -107,6 +107,7 @@ where
         response_no_constraints(cx, input, Certainty::overflow(true))
     }
 
+    const FIXPOINT_OVERFLOW_AMBIGUITY_KIND: Certainty = Certainty::overflow(false);
     fn fixpoint_overflow_result(
         cx: I,
         input: CanonicalInput<I>,
@@ -124,14 +125,6 @@ where
                 None
             }
         })
-    }
-
-    fn propagate_ambiguity(
-        cx: I,
-        for_input: CanonicalInput<I>,
-        certainty: Certainty,
-    ) -> (QueryResult<I>, AccessedOpaques<I>) {
-        response_no_constraints(cx, for_input, certainty)
     }
 
     fn compute_goal(

--- a/compiler/rustc_passes/src/reachable.rs
+++ b/compiler/rustc_passes/src/reachable.rs
@@ -444,6 +444,8 @@ fn has_custom_linkage(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
         // FIXME(nbdd0121): `#[used]` are marked as reachable here so it's picked up by
         // `linked_symbols` in cg_ssa. They won't be exported in binary or cdylib due to their
         // `SymbolExportLevel::Rust` export level but may end up being exported in dylibs.
+        // Also note that Miri is relying on this to be able to find private `link_section` statics
+        // across all crates.
         || codegen_attrs.flags.contains(CodegenFnAttrFlags::USED_COMPILER)
         || codegen_attrs.flags.contains(CodegenFnAttrFlags::USED_LINKER)
         // Right now, the only way to get "foreign item symbol aliases" is by being an EII-implementation.

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -1219,7 +1219,7 @@ impl Target {
     /// These features are checked against the target features reported by LLVM based on
     /// `-Ctarget-cpu` and `-Ctarget-features`. Constraint violations result in a warning.
     ///
-    /// We also check features enabled via `#[target_features]` (and here, constraint violations
+    /// We also check features enabled via `#[target_feature(..)]` (and here, constraint violations
     /// emit a hard error), including features enabled indirectly via implications -- but if LLVM
     /// considers more features to be implied than we do, that could bypass this check!
     pub fn abi_required_features(&self) -> FeatureConstraints {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -773,17 +773,17 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let (lt1, sig1) = get_lifetimes(sig1);
         let (lt2, sig2) = get_lifetimes(sig2);
 
-        // #[target_features] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
+        // #[target_feature(..)] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
         let mut values =
             (DiagStyledString::normal("".to_string()), DiagStyledString::normal("".to_string()));
 
-        // #[target_features] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
-        // ^^^^^^^^^^^^^^^^^^
+        // #[target_feature(..)] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
+        // ^^^^^^^^^^^^^^^^^^^^^
         let fn_item_prefix_and_safety = |fn_def, sig: ty::FnSig<'_>| match fn_def {
             None => ("", sig.safety().prefix_str()),
             Some((did, _)) => {
                 if self.tcx.codegen_fn_attrs(did).safe_target_features {
-                    ("#[target_features] ", "")
+                    ("#[target_feature(..)] ", "")
                 } else {
                     ("", sig.safety().prefix_str())
                 }
@@ -794,19 +794,19 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         values.0.push(prefix1, prefix1 != prefix2);
         values.1.push(prefix2, prefix1 != prefix2);
 
-        // #[target_features] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
-        //                    ^^^^^^^^
+        // #[target_feature(..)] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
+        //                       ^^^^^^^^
         let lifetime_diff = lt1 != lt2;
         values.0.push(lt1, lifetime_diff);
         values.1.push(lt2, lifetime_diff);
 
-        // #[target_features] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
-        //                            ^^^^^^
+        // #[target_feature(..)] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
+        //                               ^^^^^^
         values.0.push(safety1, safety1 != safety2);
         values.1.push(safety2, safety1 != safety2);
 
-        // #[target_features] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
-        //                                   ^^^^^^^^^^
+        // #[target_feature(..)] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
+        //                                      ^^^^^^^^^^
         if sig1.abi() != ExternAbi::Rust {
             values.0.push(format!("extern {} ", sig1.abi()), sig1.abi() != sig2.abi());
         }
@@ -814,13 +814,13 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             values.1.push(format!("extern {} ", sig2.abi()), sig1.abi() != sig2.abi());
         }
 
-        // #[target_features] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
-        //                                              ^^^
+        // #[target_feature(..)] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
+        //                                                 ^^^
         values.0.push_normal("fn(");
         values.1.push_normal("fn(");
 
-        // #[target_features] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
-        //                                                 ^^^^^
+        // #[target_feature(..)] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
+        //                                                    ^^^^^
         let len1 = sig1.inputs().len();
         let len2 = sig2.inputs().len();
         let splatted_arg_index1 = sig1.splatted().map(usize::from);
@@ -868,13 +868,13 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             values.1.push("...", !sig1.c_variadic());
         }
 
-        // #[target_features] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
-        //                                                      ^
+        // #[target_feature(..)] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
+        //                                                         ^
         values.0.push_normal(")");
         values.1.push_normal(")");
 
-        // #[target_features] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
-        //                                                        ^^^^^^^^
+        // #[target_feature(..)] for<'a> unsafe extern "C" fn(&'a T) -> &'a T
+        //                                                           ^^^^^^^^
         let output1 = sig1.output();
         let output2 = sig2.output();
         let (x1, x2) = self.cmp(output1, output2);

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
@@ -621,9 +621,9 @@ impl<T> Trait<T> for X {
             TypeError::TargetFeatureCast(def_id) => {
                 let target_spans = find_attr!(tcx, def_id, TargetFeature{attr_span: span, was_forced: false, ..} => *span);
                 diag.note(
-                    "functions with `#[target_feature]` can only be coerced to `unsafe` function pointers"
+                    "functions with `#[target_feature(..)]` can only be coerced to `unsafe` function pointers"
                 );
-                diag.span_labels(target_spans, "`#[target_feature]` added here");
+                diag.span_labels(target_spans, "`#[target_feature(..)]` added here");
             }
             _ => {}
         }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -555,7 +555,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         };
                         if is_fn_trait && is_target_feature_fn {
                             err.note(
-                                "`#[target_feature]` functions do not implement the `Fn` traits",
+                                "`#[target_feature(..)]` functions do not implement the `Fn` traits",
                             );
                             err.note(
                                 "try casting the function to a `fn` pointer or wrapping it in a closure",

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -680,7 +680,7 @@ impl<T, R, E> CollectAndApply<T, R> for Result<T, E> {
 impl<I: Interner> search_graph::Cx for I {
     type Input = CanonicalInput<I>;
     type Result = (QueryResult<I>, AccessedOpaques<I>);
-    type AmbiguityInfo = Certainty;
+    type AmbiguityKind = Certainty;
 
     type DepNodeIndex = I::DepNodeIndex;
     type Tracked<T: Debug + Clone> = I::Tracked<T>;

--- a/compiler/rustc_type_ir/src/search_graph/mod.rs
+++ b/compiler/rustc_type_ir/src/search_graph/mod.rs
@@ -40,7 +40,7 @@ pub use global_cache::GlobalCache;
 pub trait Cx: Copy {
     type Input: Debug + Eq + Hash + Copy;
     type Result: Debug + Eq + Hash + Copy;
-    type AmbiguityInfo: Debug + Eq + Hash + Copy;
+    type AmbiguityKind: Debug + Eq + Hash + Copy;
 
     type DepNodeIndex;
     type Tracked<T: Debug + Clone>: Debug;
@@ -92,6 +92,8 @@ pub trait Delegate: Sized {
         cx: Self::Cx,
         input: <Self::Cx as Cx>::Input,
     ) -> <Self::Cx as Cx>::Result;
+
+    const FIXPOINT_OVERFLOW_AMBIGUITY_KIND: <Self::Cx as Cx>::AmbiguityKind;
     fn fixpoint_overflow_result(
         cx: Self::Cx,
         input: <Self::Cx as Cx>::Input,
@@ -99,12 +101,7 @@ pub trait Delegate: Sized {
 
     fn is_ambiguous_result(
         result: <Self::Cx as Cx>::Result,
-    ) -> Option<<Self::Cx as Cx>::AmbiguityInfo>;
-    fn propagate_ambiguity(
-        cx: Self::Cx,
-        for_input: <Self::Cx as Cx>::Input,
-        ambiguity_info: <Self::Cx as Cx>::AmbiguityInfo,
-    ) -> <Self::Cx as Cx>::Result;
+    ) -> Option<<Self::Cx as Cx>::AmbiguityKind>;
 
     fn compute_goal(
         search_graph: &mut SearchGraph<Self>,
@@ -955,8 +952,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D> {
 #[derive_where(Debug; X: Cx)]
 enum RebaseReason<X: Cx> {
     NoCycleUsages,
-    Ambiguity(X::AmbiguityInfo),
-    Overflow,
+    Ambiguity(X::AmbiguityKind),
     /// We've actually reached a fixpoint.
     ///
     /// This either happens in the first evaluation step for the cycle head.
@@ -987,10 +983,9 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
     /// cache entries to also be ambiguous. This causes some undesirable ambiguity for nested
     /// goals whose result doesn't actually depend on this cycle head, but that's acceptable
     /// to me.
-    #[instrument(level = "trace", skip(self, cx))]
+    #[instrument(level = "trace", skip(self))]
     fn rebase_provisional_cache_entries(
         &mut self,
-        cx: X,
         stack_entry: &StackEntry<X>,
         rebase_reason: RebaseReason<X>,
     ) {
@@ -1065,18 +1060,22 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
                     }
 
                     // The provisional cache entry does depend on the provisional result
-                    // of the popped cycle head. We need to mutate the result of our
-                    // provisional cache entry in case we did not reach a fixpoint.
+                    // of the popped cycle head. In case we didn't actually reach a fixpoint,
+                    // we must not keep potentially incorrect provisional cache entries around.
                     match rebase_reason {
                         // If the cycle head does not actually depend on itself, then
                         // the provisional result used by the provisional cache entry
                         // is not actually equal to the final provisional result. We
                         // need to discard the provisional cache entry in this case.
                         RebaseReason::NoCycleUsages => return false,
-                        RebaseReason::Ambiguity(info) => {
-                            *result = D::propagate_ambiguity(cx, input, info);
+                        // If we avoid rerunning a goal due to ambiguity, we only keep provisional
+                        // results which depend on that cycle head if these are already ambiguous
+                        // themselves.
+                        RebaseReason::Ambiguity(kind) => {
+                            if !D::is_ambiguous_result(*result).is_some_and(|k| k == kind) {
+                                return false;
+                            }
                         }
-                        RebaseReason::Overflow => *result = D::fixpoint_overflow_result(cx, input),
                         RebaseReason::ReachedFixpoint(None) => {}
                         RebaseReason::ReachedFixpoint(Some(path_kind)) => {
                             if !popped_head.usages.is_single(path_kind) {
@@ -1380,17 +1379,12 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
             // final result is equal to the initial response for that case.
             if let Ok(fixpoint) = self.reached_fixpoint(&stack_entry, usages, result) {
                 self.rebase_provisional_cache_entries(
-                    cx,
                     &stack_entry,
                     RebaseReason::ReachedFixpoint(fixpoint),
                 );
                 return EvaluationResult::finalize(stack_entry, encountered_overflow, result);
             } else if usages.is_empty() {
-                self.rebase_provisional_cache_entries(
-                    cx,
-                    &stack_entry,
-                    RebaseReason::NoCycleUsages,
-                );
+                self.rebase_provisional_cache_entries(&stack_entry, RebaseReason::NoCycleUsages);
                 return EvaluationResult::finalize(stack_entry, encountered_overflow, result);
             }
 
@@ -1399,19 +1393,15 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
             // response in the next iteration in this case. These changes would
             // likely either be caused by incompleteness or can change the maybe
             // cause from ambiguity to overflow. Returning ambiguity always
-            // preserves soundness and completeness even if the goal is be known
-            // to succeed or fail.
+            // preserves soundness and completeness even if the goal could
+            // otherwise succeed or fail.
             //
             // This prevents exponential blowup affecting multiple major crates.
             // As we only get to this branch if we haven't yet reached a fixpoint,
             // we also taint all provisional cache entries which depend on the
             // current goal.
-            if let Some(info) = D::is_ambiguous_result(result) {
-                self.rebase_provisional_cache_entries(
-                    cx,
-                    &stack_entry,
-                    RebaseReason::Ambiguity(info),
-                );
+            if let Some(kind) = D::is_ambiguous_result(result) {
+                self.rebase_provisional_cache_entries(&stack_entry, RebaseReason::Ambiguity(kind));
                 return EvaluationResult::finalize(stack_entry, encountered_overflow, result);
             };
 
@@ -1421,7 +1411,10 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
             if i >= D::FIXPOINT_STEP_LIMIT {
                 debug!("canonical cycle overflow");
                 let result = D::fixpoint_overflow_result(cx, input);
-                self.rebase_provisional_cache_entries(cx, &stack_entry, RebaseReason::Overflow);
+                self.rebase_provisional_cache_entries(
+                    &stack_entry,
+                    RebaseReason::Ambiguity(D::FIXPOINT_OVERFLOW_AMBIGUITY_KIND),
+                );
                 return EvaluationResult::finalize(stack_entry, encountered_overflow, result);
             }
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -839,6 +839,10 @@ impl Step for CargoMiri {
             SourceType::Submodule,
             &[],
         );
+        // Run subcrate tests as well.
+        cargo.arg("--workspace");
+        // Some tests need isolation disabled.
+        cargo.env("MIRIFLAGS", "-Zmiri-disable-isolation");
 
         // If we are testing stage 2+ cargo miri, make sure that it works with the in-tree cargo.
         // We want to do this *somewhere* to ensure that Miri + nightly cargo actually works.

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -11,7 +11,6 @@
 extern crate rustc_codegen_ssa;
 extern crate rustc_data_structures;
 extern crate rustc_driver;
-extern crate rustc_hir;
 extern crate rustc_interface;
 extern crate rustc_log;
 extern crate rustc_middle;
@@ -48,14 +47,9 @@ use miri::{
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_data_structures::sync::{self, DynSync};
 use rustc_driver::Compilation;
-use rustc_hir::{self as hir, Node};
 use rustc_interface::interface::Config;
 use rustc_interface::util::DummyCodegenBackend;
 use rustc_log::tracing::debug;
-use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
-use rustc_middle::middle::exported_symbols::{
-    ExportedSymbol, SymbolExportInfo, SymbolExportKind, SymbolExportLevel,
-};
 use rustc_middle::query::LocalCrate;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::config::{CrateType, ErrorOutputType, OptLevel};
@@ -258,58 +252,14 @@ impl rustc_driver::Callbacks for MiriDepCompilerCalls {
         // Queries overridden here affect the data stored in `rmeta` files of dependencies,
         // which will be used later in non-`MIRI_BE_RUSTC` mode.
         config.override_queries = Some(|_, local_providers| {
-            // We need to add #[used] symbols to exported_symbols for `lookup_link_section`.
-            // FIXME handle this somehow in rustc itself to avoid this hack.
-            local_providers.queries.exported_non_generic_symbols = |tcx, LocalCrate| {
-                let reachable_set = tcx.with_stable_hashing_context(|mut hcx| {
-                    tcx.reachable_set(()).to_sorted(&mut hcx, true)
-                });
-                tcx.arena.alloc_from_iter(
-                    // This is based on:
-                    // https://github.com/rust-lang/rust/blob/2962e7c0089d5c136f4e9600b7abccfbbde4973d/compiler/rustc_codegen_ssa/src/back/symbol_export.rs#L62-L63
-                    // https://github.com/rust-lang/rust/blob/2962e7c0089d5c136f4e9600b7abccfbbde4973d/compiler/rustc_codegen_ssa/src/back/symbol_export.rs#L174
-                    reachable_set.into_iter().filter_map(|&local_def_id| {
-                        // Do the same filtering that rustc does:
-                        // https://github.com/rust-lang/rust/blob/2962e7c0089d5c136f4e9600b7abccfbbde4973d/compiler/rustc_codegen_ssa/src/back/symbol_export.rs#L84-L102
-                        // Otherwise it may cause unexpected behaviours and ICEs
-                        // (https://github.com/rust-lang/rust/issues/86261).
-                        let is_reachable_non_generic = matches!(
-                            tcx.hir_node_by_def_id(local_def_id),
-                            Node::Item(&hir::Item {
-                                kind: hir::ItemKind::Static(..) | hir::ItemKind::Fn{ .. },
-                                ..
-                            }) | Node::ImplItem(&hir::ImplItem {
-                                kind: hir::ImplItemKind::Fn(..),
-                                ..
-                            })
-                            if !tcx.generics_of(local_def_id).requires_monomorphization(tcx)
-                        );
-                        if !is_reachable_non_generic {
-                            return None;
-                        }
-                        let codegen_fn_attrs = tcx.codegen_fn_attrs(local_def_id);
-                        if codegen_fn_attrs.contains_extern_indicator()
-                            || codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::USED_COMPILER)
-                            || codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::USED_LINKER)
-                        {
-                            Some((
-                                ExportedSymbol::NonGeneric(local_def_id.to_def_id()),
-                                // Some dummy `SymbolExportInfo` here. We only use
-                                // `exported_symbols` in shims/foreign_items.rs and the export info
-                                // is ignored.
-                                SymbolExportInfo {
-                                    level: SymbolExportLevel::C,
-                                    kind: SymbolExportKind::Text,
-                                    used: false,
-                                    rustc_std_internal_symbol: false,
-                                },
-                            ))
-                        } else {
-                            None
-                        }
-                    }),
-                )
-            }
+            // `exported_non_generic_symbols` is usually empty because we don't codegen anything.
+            // However, we need it for `lookup_link_section`.
+            // So overwrite the query with a version that dooes something even without codegen.
+            local_providers.queries.exported_non_generic_symbols =
+                |tcx, LocalCrate| rustc_codegen_ssa::back::exported_non_generic_symbols_helper(tcx);
+            // `exported_non_generic_symbols_helper` calls `reachable_non_generics`.
+            local_providers.queries.reachable_non_generics =
+                |tcx, LocalCrate| rustc_codegen_ssa::back::reachable_non_generics_helper(tcx);
         });
 
         // Register our custom extra symbols.

--- a/src/tools/miri/src/helpers.rs
+++ b/src/tools/miri/src/helpers.rs
@@ -116,34 +116,36 @@ pub fn path_ty_layout<'tcx>(cx: &impl LayoutOf<'tcx>, path: &[&str]) -> TyAndLay
 /// Call `f` for each exported symbol.
 pub fn iter_exported_symbols<'tcx>(
     tcx: TyCtxt<'tcx>,
-    mut f: impl FnMut(CrateNum, DefId) -> InterpResult<'tcx>,
+    mut f: impl FnMut(CrateNum, DefId, /* used */ bool) -> InterpResult<'tcx>,
 ) -> InterpResult<'tcx> {
-    // First, the symbols in the local crate. We can't use `exported_symbols` here as that
-    // skips `#[used]` statics (since `reachable_set` skips them in binary crates).
-    // So we walk all HIR items ourselves instead.
+    // First, the symbols in the local crate. We can't use `exported_symbols` here as that skips
+    // `#[used]` statics (since `reachable_set` does not specifically include them in binary crates,
+    // only in library crates). So we walk all HIR items ourselves instead.
     let crate_items = tcx.hir_crate_items(());
     for def_id in crate_items.definitions() {
-        let exported = tcx.def_kind(def_id).has_codegen_attrs() && {
-            let codegen_attrs = tcx.codegen_fn_attrs(def_id);
-            codegen_attrs.contains_extern_indicator()
-                || codegen_attrs.flags.contains(CodegenFnAttrFlags::USED_COMPILER)
-                || codegen_attrs.flags.contains(CodegenFnAttrFlags::USED_LINKER)
-        };
+        if !tcx.def_kind(def_id).has_codegen_attrs() || tcx.is_foreign_item(def_id) {
+            continue;
+        }
+        let codegen_attrs = tcx.codegen_fn_attrs(def_id);
+        let used = codegen_attrs.flags.contains(CodegenFnAttrFlags::USED_COMPILER)
+            || codegen_attrs.flags.contains(CodegenFnAttrFlags::USED_LINKER);
+        if !(used || codegen_attrs.contains_extern_indicator()) {
+            continue;
+        }
         // FIXME: `#[no_mangle]` makes no sense on a generic item, but still causes it to be
         // considered "extern". Remove this once `no_mangle_generic_items` is a hard error.
-        let exported_mono = exported && {
+        let mono = {
             let generics = tcx.generics_of(def_id);
             !generics.requires_monomorphization(tcx)
         };
-        if exported_mono {
-            f(LOCAL_CRATE, def_id.into())?;
+        if mono {
+            f(LOCAL_CRATE, def_id.into(), used)?;
         }
     }
 
     // Next, all our dependencies.
-    // `dependency_formats` includes all the transitive information needed to link a crate,
-    // which is what we need here since we need to dig out `exported_symbols` from all transitive
-    // dependencies.
+    // `dependency_formats` includes all the transitive information needed to link a crate, which is
+    // what we need to dig out `exported_symbols` from all transitive dependencies.
     let dependency_formats = tcx.dependency_formats(());
     // Find the dependencies of the executable we are running.
     let dependency_format = dependency_formats
@@ -157,11 +159,12 @@ pub fn iter_exported_symbols<'tcx>(
             continue; // Already handled above
         }
 
-        // We can ignore `_export_info` here: we are a Rust crate, and everything is exported
-        // from a Rust crate.
-        for &(symbol, _export_info) in tcx.exported_non_generic_symbols(cnum) {
-            if let ExportedSymbol::NonGeneric(def_id) = symbol {
-                f(cnum, def_id)?;
+        for &(symbol, export_info) in tcx.exported_non_generic_symbols(cnum) {
+            if let ExportedSymbol::NonGeneric(def_id) = symbol
+                // Sometimes Rust has to re-export FFI imports; skip those.
+                && !tcx.is_foreign_item(def_id)
+            {
+                f(cnum, def_id, export_info.used)?;
             }
         }
     }
@@ -961,8 +964,13 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         let mut array = vec![];
 
-        iter_exported_symbols(tcx, |_cnum, def_id| {
+        iter_exported_symbols(tcx, |_cnum, def_id, used| {
             let attrs = tcx.codegen_fn_attrs(def_id);
+            if !used {
+                // We don't know if the symbol is actually going to be in the final binary,
+                // so we conservatively skip it.
+                return interp_ok(());
+            }
             let Some(link_section) = attrs.link_section else {
                 return interp_ok(());
             };

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -132,12 +132,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     is_weak: bool,
                 }
                 let mut symbol_target: Option<SymbolTarget<'tcx>> = None;
-                helpers::iter_exported_symbols(tcx, |cnum, def_id| {
+                helpers::iter_exported_symbols(tcx, |cnum, def_id, _used| {
                     let attrs = tcx.codegen_fn_attrs(def_id);
-                    // Skip over imports of items.
-                    if tcx.is_foreign_item(def_id) {
-                        return interp_ok(());
-                    }
                     // Skip over items without an explicitly defined symbol name.
                     if !(attrs.symbol_name.is_some()
                         || attrs.flags.contains(CodegenFnAttrFlags::NO_MANGLE)

--- a/src/tools/miri/test-cargo-miri/exported-symbol-dep/src/lib.rs
+++ b/src/tools/miri/test-cargo-miri/exported-symbol-dep/src/lib.rs
@@ -11,3 +11,49 @@ impl AssocFn {
         -123456
     }
 }
+
+// Also check static constructors in dependencies are run.
+
+#[rustfmt::skip]
+#[macro_export]
+macro_rules! ctor {
+    ($ident:ident = $ctor:ident) => {
+        #[cfg_attr(
+            all(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "haiku",
+                target_os = "illumos",
+                target_os = "netbsd",
+                target_os = "openbsd",
+                target_os = "solaris",
+                target_os = "none",
+                target_family = "wasm",
+            )),
+            link_section = ".init_array"
+        )]
+        #[cfg_attr(windows, link_section = ".CRT$XCU")]
+        #[cfg_attr(
+            any(target_os = "macos", target_os = "ios"),
+            // We do not set the `mod_init_funcs` flag here since ctor/inventory also do not do
+            // that. See <https://github.com/rust-lang/miri/pull/4459#discussion_r2200115629>.
+            link_section = "__DATA,__mod_init_func"
+        )]
+        #[used]
+        static $ident: unsafe extern "C" fn() = $ctor;
+    };
+}
+
+static mut INITIALIZED: bool = false;
+
+unsafe extern "C" fn ctor() {
+    unsafe { INITIALIZED = true };
+}
+
+pub fn check_initialized() {
+    assert!(unsafe { INITIALIZED });
+}
+
+ctor! { CTOR = ctor }

--- a/src/tools/miri/test-cargo-miri/exported-symbol/src/lib.rs
+++ b/src/tools/miri/test-cargo-miri/exported-symbol/src/lib.rs
@@ -1,1 +1,2 @@
 extern crate exported_symbol_dep;
+pub use exported_symbol_dep::check_initialized;

--- a/src/tools/miri/test-cargo-miri/src/main.rs
+++ b/src/tools/miri/test-cargo-miri/src/main.rs
@@ -67,6 +67,10 @@ fn main() {
 mod test {
     use byteorder_2::{BigEndian, ByteOrder};
 
+    extern crate cargo_miri_test;
+    extern crate exported_symbol;
+    extern crate issue_rust_86261;
+
     // Make sure in-crate tests with dev-dependencies work
     #[test]
     fn dev_dependency() {
@@ -75,9 +79,6 @@ mod test {
 
     #[test]
     fn exported_symbol() {
-        extern crate cargo_miri_test;
-        extern crate exported_symbol;
-        extern crate issue_rust_86261;
         // Test calling exported symbols in (transitive) dependencies.
         // Repeat calls to make sure the `Instance` cache is not broken.
         for _ in 0..3 {
@@ -94,5 +95,10 @@ mod test {
             unsafe { NoMangleStruct() }
             unsafe { no_mangle_generic() }
         }
+    }
+
+    #[test]
+    fn static_initializer_in_dep() {
+        exported_symbol::check_initialized();
     }
 }

--- a/tests/ui/async-await/async-closures/fn-exception-target-features.stderr
+++ b/tests/ui/async-await/async-closures/fn-exception-target-features.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `#[target_features] fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}: AsyncFn()` is not satisfied
+error[E0277]: the trait bound `#[target_feature(..)] fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}: AsyncFn()` is not satisfied
   --> $DIR/fn-exception-target-features.rs:15:10
    |
 LL |     test(target_feature);
@@ -6,7 +6,7 @@ LL |     test(target_feature);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `AsyncFn()` is not implemented for fn item `#[target_features] fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}`
+   = help: the trait `AsyncFn()` is not implemented for fn item `#[target_feature(..)] fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}`
 note: required by a bound in `test`
   --> $DIR/fn-exception-target-features.rs:12:17
    |

--- a/tests/ui/feature-gates/feature-gate-effective-target-features.default.stderr
+++ b/tests/ui/feature-gates/feature-gate-effective-target-features.default.stderr
@@ -29,7 +29,7 @@ note: type in trait
 LL |     fn foo(&self);
    |     ^^^^^^^^^^^^^^
    = note: expected signature `fn(&Bar2)`
-              found signature `#[target_features] fn(&Bar2)`
+              found signature `#[target_feature(..)] fn(&Bar2)`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-effective-target-features.feature.stderr
+++ b/tests/ui/feature-gates/feature-gate-effective-target-features.feature.stderr
@@ -32,7 +32,7 @@ note: type in trait
 LL |     fn foo(&self);
    |     ^^^^^^^^^^^^^^
    = note: expected signature `fn(&Bar2)`
-              found signature `#[target_features] fn(&Bar2)`
+              found signature `#[target_feature(..)] fn(&Bar2)`
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.stderr
@@ -2,31 +2,31 @@ error[E0308]: mismatched types
   --> $DIR/fn-ptr.rs:12:21
    |
 LL | #[target_feature(enable = "avx")]
-   | --------------------------------- `#[target_feature]` added here
+   | --------------------------------- `#[target_feature(..)]` added here
 ...
 LL |     let foo: fn() = foo_avx;
-   |              ----   ^^^^^^^ cannot coerce functions with `#[target_feature]` to safe function pointers
+   |              ----   ^^^^^^^ cannot coerce functions with `#[target_feature(..)]` to safe function pointers
    |              |
    |              expected due to this
    |
    = note: expected fn pointer `fn()`
-                 found fn item `#[target_features] fn() {foo_avx}`
-   = note: functions with `#[target_feature]` can only be coerced to `unsafe` function pointers
+                 found fn item `#[target_feature(..)] fn() {foo_avx}`
+   = note: functions with `#[target_feature(..)]` can only be coerced to `unsafe` function pointers
 
 error[E0308]: mismatched types
   --> $DIR/fn-ptr.rs:21:21
    |
 LL | #[target_feature(enable = "sse2")]
-   | ---------------------------------- `#[target_feature]` added here
+   | ---------------------------------- `#[target_feature(..)]` added here
 ...
 LL |     let foo: fn() = foo;
-   |              ----   ^^^ cannot coerce functions with `#[target_feature]` to safe function pointers
+   |              ----   ^^^ cannot coerce functions with `#[target_feature(..)]` to safe function pointers
    |              |
    |              expected due to this
    |
    = note: expected fn pointer `fn()`
-                 found fn item `#[target_features] fn() {foo}`
-   = note: functions with `#[target_feature]` can only be coerced to `unsafe` function pointers
+                 found fn item `#[target_feature(..)] fn() {foo}`
+   = note: functions with `#[target_feature(..)]` can only be coerced to `unsafe` function pointers
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
@@ -26,10 +26,10 @@ fn call_once_i32(f: impl FnOnce(i32)) {
 }
 
 fn main() {
-    call(foo); //~ ERROR expected an `Fn()` closure, found `#[target_features] fn() {foo}`
-    call_mut(foo); //~ ERROR expected an `FnMut()` closure, found `#[target_features] fn() {foo}`
-    call_once(foo); //~ ERROR expected an `FnOnce()` closure, found `#[target_features] fn() {foo}`
-    call_once_i32(bar); //~ ERROR expected an `FnOnce(i32)` closure, found `#[target_features] fn(i32) {bar}`
+    call(foo); //~ ERROR expected an `Fn()` closure, found `#[target_feature(..)] fn() {foo}`
+    call_mut(foo); //~ ERROR expected an `FnMut()` closure, found `#[target_feature(..)] fn() {foo}`
+    call_once(foo); //~ ERROR expected an `FnOnce()` closure, found `#[target_feature(..)] fn() {foo}`
+    call_once_i32(bar); //~ ERROR expected an `FnOnce(i32)` closure, found `#[target_feature(..)] fn(i32) {bar}`
 
     call(foo_unsafe);
     //~^ ERROR expected an `Fn()` closure, found `unsafe fn() {foo_unsafe}`

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
@@ -1,14 +1,14 @@
-error[E0277]: expected an `Fn()` closure, found `#[target_features] fn() {foo}`
+error[E0277]: expected an `Fn()` closure, found `#[target_feature(..)] fn() {foo}`
   --> $DIR/fn-traits.rs:29:10
    |
 LL |     call(foo);
-   |     ---- ^^^ expected an `Fn()` closure, found `#[target_features] fn() {foo}`
+   |     ---- ^^^ expected an `Fn()` closure, found `#[target_feature(..)] fn() {foo}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn()` is not implemented for fn item `#[target_features] fn() {foo}`
-   = note: wrap the `#[target_features] fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
-   = note: `#[target_feature]` functions do not implement the `Fn` traits
+   = help: the trait `Fn()` is not implemented for fn item `#[target_feature(..)] fn() {foo}`
+   = note: wrap the `#[target_feature(..)] fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
+   = note: `#[target_feature(..)]` functions do not implement the `Fn` traits
    = note: try casting the function to a `fn` pointer or wrapping it in a closure
 note: required by a bound in `call`
   --> $DIR/fn-traits.rs:12:17
@@ -16,17 +16,17 @@ note: required by a bound in `call`
 LL | fn call(f: impl Fn()) {
    |                 ^^^^ required by this bound in `call`
 
-error[E0277]: expected an `FnMut()` closure, found `#[target_features] fn() {foo}`
+error[E0277]: expected an `FnMut()` closure, found `#[target_feature(..)] fn() {foo}`
   --> $DIR/fn-traits.rs:30:14
    |
 LL |     call_mut(foo);
-   |     -------- ^^^ expected an `FnMut()` closure, found `#[target_features] fn() {foo}`
+   |     -------- ^^^ expected an `FnMut()` closure, found `#[target_feature(..)] fn() {foo}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnMut()` is not implemented for fn item `#[target_features] fn() {foo}`
-   = note: wrap the `#[target_features] fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
-   = note: `#[target_feature]` functions do not implement the `Fn` traits
+   = help: the trait `FnMut()` is not implemented for fn item `#[target_feature(..)] fn() {foo}`
+   = note: wrap the `#[target_feature(..)] fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
+   = note: `#[target_feature(..)]` functions do not implement the `Fn` traits
    = note: try casting the function to a `fn` pointer or wrapping it in a closure
 note: required by a bound in `call_mut`
   --> $DIR/fn-traits.rs:16:25
@@ -34,17 +34,17 @@ note: required by a bound in `call_mut`
 LL | fn call_mut(mut f: impl FnMut()) {
    |                         ^^^^^^^ required by this bound in `call_mut`
 
-error[E0277]: expected an `FnOnce()` closure, found `#[target_features] fn() {foo}`
+error[E0277]: expected an `FnOnce()` closure, found `#[target_feature(..)] fn() {foo}`
   --> $DIR/fn-traits.rs:31:15
    |
 LL |     call_once(foo);
-   |     --------- ^^^ expected an `FnOnce()` closure, found `#[target_features] fn() {foo}`
+   |     --------- ^^^ expected an `FnOnce()` closure, found `#[target_feature(..)] fn() {foo}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnOnce()` is not implemented for fn item `#[target_features] fn() {foo}`
-   = note: wrap the `#[target_features] fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
-   = note: `#[target_feature]` functions do not implement the `Fn` traits
+   = help: the trait `FnOnce()` is not implemented for fn item `#[target_feature(..)] fn() {foo}`
+   = note: wrap the `#[target_feature(..)] fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
+   = note: `#[target_feature(..)]` functions do not implement the `Fn` traits
    = note: try casting the function to a `fn` pointer or wrapping it in a closure
 note: required by a bound in `call_once`
   --> $DIR/fn-traits.rs:20:22
@@ -52,16 +52,16 @@ note: required by a bound in `call_once`
 LL | fn call_once(f: impl FnOnce()) {
    |                      ^^^^^^^^ required by this bound in `call_once`
 
-error[E0277]: expected an `FnOnce(i32)` closure, found `#[target_features] fn(i32) {bar}`
+error[E0277]: expected an `FnOnce(i32)` closure, found `#[target_feature(..)] fn(i32) {bar}`
   --> $DIR/fn-traits.rs:32:19
    |
 LL |     call_once_i32(bar);
-   |     ------------- ^^^ expected an `FnOnce(i32)` closure, found `#[target_features] fn(i32) {bar}`
+   |     ------------- ^^^ expected an `FnOnce(i32)` closure, found `#[target_feature(..)] fn(i32) {bar}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnOnce(i32)` is not implemented for fn item `#[target_features] fn(i32) {bar}`
-   = note: `#[target_feature]` functions do not implement the `Fn` traits
+   = help: the trait `FnOnce(i32)` is not implemented for fn item `#[target_feature(..)] fn(i32) {bar}`
+   = note: `#[target_feature(..)]` functions do not implement the `Fn` traits
    = note: try casting the function to a `fn` pointer or wrapping it in a closure
 note: required by a bound in `call_once_i32`
   --> $DIR/fn-traits.rs:24:26
@@ -80,7 +80,7 @@ LL |     call(foo_unsafe);
    = help: the trait `Fn()` is not implemented for fn item `unsafe fn() {foo_unsafe}`
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
    = note: unsafe function cannot be called generically without an unsafe block
-   = note: `#[target_feature]` functions do not implement the `Fn` traits
+   = note: `#[target_feature(..)]` functions do not implement the `Fn` traits
    = note: try casting the function to a `fn` pointer or wrapping it in a closure
 note: required by a bound in `call`
   --> $DIR/fn-traits.rs:12:17
@@ -99,7 +99,7 @@ LL |     call_mut(foo_unsafe);
    = help: the trait `FnMut()` is not implemented for fn item `unsafe fn() {foo_unsafe}`
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
    = note: unsafe function cannot be called generically without an unsafe block
-   = note: `#[target_feature]` functions do not implement the `Fn` traits
+   = note: `#[target_feature(..)]` functions do not implement the `Fn` traits
    = note: try casting the function to a `fn` pointer or wrapping it in a closure
 note: required by a bound in `call_mut`
   --> $DIR/fn-traits.rs:16:25
@@ -118,7 +118,7 @@ LL |     call_once(foo_unsafe);
    = help: the trait `FnOnce()` is not implemented for fn item `unsafe fn() {foo_unsafe}`
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
    = note: unsafe function cannot be called generically without an unsafe block
-   = note: `#[target_feature]` functions do not implement the `Fn` traits
+   = note: `#[target_feature(..)]` functions do not implement the `Fn` traits
    = note: try casting the function to a `fn` pointer or wrapping it in a closure
 note: required by a bound in `call_once`
   --> $DIR/fn-traits.rs:20:22

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/trait-impl.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/trait-impl.stderr
@@ -19,7 +19,7 @@ note: type in trait
 LL |     fn foo(&self);
    |     ^^^^^^^^^^^^^^
    = note: expected signature `fn(&Bar)`
-              found signature `#[target_features] fn(&Bar)`
+              found signature `#[target_feature(..)] fn(&Bar)`
 
 error: `#[target_feature(..)]` cannot be applied to safe trait method
   --> $DIR/trait-impl.rs:21:5

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -206,7 +206,7 @@ note: type in trait
 LL |     fn foo();
    |     ^^^^^^^^^
    = note: expected signature `fn()`
-              found signature `#[target_features] fn()`
+              found signature `#[target_feature(..)] fn()`
 
 error: the feature named `+sse2` is not valid for this target
   --> $DIR/invalid-attribute.rs:117:18

--- a/tests/ui/traits/next-solver/global-where-bound-normalization.rs
+++ b/tests/ui/traits/next-solver/global-where-bound-normalization.rs
@@ -1,0 +1,45 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+// Regression test for https://github.com/rust-lang/trait-system-refactor-initiative/issues/257.
+
+#![feature(rustc_attrs)]
+#![expect(internal_features)]
+#![rustc_no_implicit_bounds]
+
+pub trait Bound {}
+impl Bound for u8 {}
+
+pub trait Proj {
+    type Assoc;
+}
+impl<U: Bound> Proj for U {
+    type Assoc = U;
+}
+impl Proj for MyField {
+    type Assoc = u8;
+}
+
+// While wf-checking the global bounds of `fn foo`, elaborating this outlives predicate triggered a
+// cycle in the search graph along a particular probe path, which was not an actual solution.
+// That cycle then resulted in a forced false-positive ambiguity due to a performance hack in the
+// search graph and then ended up floundering the root goal evaluation.
+pub trait Field: Proj<Assoc: Bound + 'static> {}
+
+struct MyField;
+impl Field for MyField {}
+
+trait IdReqField {
+    type This;
+}
+impl<F: Field> IdReqField for F {
+    type This = F;
+}
+
+fn foo()
+where
+    <MyField as IdReqField>::This: Field,
+{
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#159740 (reuse regular exported_non_generic_symbols logic in Miri)
 - rust-lang/rust#155914 (when bailing on ambiguity, don't force other results to ambig)
 - rust-lang/rust#159809 (Avoid `#[target_features]`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=159740,155914,159809)
<!-- homu-ignore:end -->

