### PR TITLE
Apply str debugger visualizer to `*const str`, `*mut str` and `Box<str>`

### DIFF
--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -175,14 +175,28 @@ def register_providers_compatibility():
     register(
         StdSliceSyntheticProvider,
         StdStrSummaryProvider,
-        r"^&(mut )?str$",
+        r"^((&(mut )?)|(\*(const|mut) ))str$",
+    )
+
+    # Box<str> GNU
+    register(
+        StdSliceSyntheticProvider,
+        StdStrSummaryProvider,
+        r"^(alloc::([a-z_]+::)+)Box<str,.*>$",
     )
 
     # str MSVC
     register(
         MSVCStrSyntheticProvider,
         StdStrSummaryProvider,
-        r"^ref(_mut)?\$<str\$>$",
+        r"^((ref(_mut)?)|(ptr_(const|mut)))\$<str\$>$",
+    )
+
+    # Box<str> MSVC
+    register(
+        MSVCStrSyntheticProvider,
+        StdStrSummaryProvider,
+        r"^(alloc::([a-z_]+::)+)Box<str\$,.*>$",
     )
 
     # slice GNU

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -1,31 +1,31 @@
 from __future__ import annotations
+
 import sys
-from typing import Generator, Dict, List, TYPE_CHECKING, Optional
 from enum import Flag, auto
+from typing import TYPE_CHECKING, Dict, Generator, List, Optional
 
 from lldb import (
     SBData,
     SBError,
-    eBasicTypeLong,
-    eBasicTypeUnsignedLong,
-    eBasicTypeUnsignedChar,
-    eBasicTypeUnsignedShort,
-    eBasicTypeUnsignedLongLong,
-    eBasicTypeSignedChar,
-    eBasicTypeShort,
-    eBasicTypeLongLong,
-    eBasicTypeFloat,
-    eBasicTypeDouble,
-    eBasicTypeHalf,
     eBasicTypeChar32,
+    eBasicTypeDouble,
+    eBasicTypeFloat,
+    eBasicTypeHalf,
+    eBasicTypeLong,
+    eBasicTypeLongLong,
+    eBasicTypeShort,
+    eBasicTypeSignedChar,
+    eBasicTypeUnsignedChar,
+    eBasicTypeUnsignedLong,
+    eBasicTypeUnsignedLongLong,
+    eBasicTypeUnsignedShort,
     eFormatChar,
     eTypeIsInteger,
 )
-
 from rust_types import is_tuple_fields
 
 if TYPE_CHECKING:
-    from lldb import SBValue, SBType, SBTypeStaticField, SBTarget, SBProcess
+    from lldb import SBProcess, SBTarget, SBType, SBTypeStaticField, SBValue
 
 # from lldb.formatters import Logger
 
@@ -564,7 +564,13 @@ class StdStringSyntheticProvider:
 
 
 class MSVCStrSyntheticProvider:
-    __slots__ = ["valobj", "data_ptr", "length"]
+    _name_map: Dict[str, str] = {
+        "ref$<str$>": "&str",
+        "ref_mut$<str$>": "&mut str",
+        "ptr_const$<str$>": "*const str",
+        "ptr_mut$<str$>": "*mut str",
+    }
+    __slots__ = ["data_ptr", "length", "valobj"]
 
     def __init__(self, valobj: SBValue, _dict: LLDBOpaque):
         self.valobj = valobj
@@ -598,10 +604,14 @@ class MSVCStrSyntheticProvider:
         return element
 
     def get_type_name(self):
-        if self.valobj.GetTypeName().startswith("ref_mut"):
-            return "&mut str"
+        name = self.valobj.GetTypeName()
+
+        if (type_name := self._name_map.get(name)) is not None:
+            return type_name
+        elif name.startswith("alloc::boxed::Box<str$"):
+            return "Box<str>"
         else:
-            return "&str"
+            return name
 
 
 def _getVariantName(variant: SBValue) -> str:

--- a/tests/debuginfo/strings-and-strs.rs
+++ b/tests/debuginfo/strings-and-strs.rs
@@ -1,6 +1,5 @@
 //@ min-gdb-version: 15.1
 // LLDB 1800+ tests were not tested in CI, broke, and now are disabled
-//@ ignore-lldb
 
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
@@ -38,16 +37,16 @@
 //@ lldb-check:(&str) plain_str = "Hello" { [0] = 'H' [1] = 'e' [2] = 'l' [3] = 'l' [4] = 'o' }
 
 //@ lldb-command:v str_in_struct
-//@ lldb-check:(strings_and_strs::Foo) str_in_struct = { inner = "Hello" { [0] = 'H' [1] = 'e' [2] = 'l' [3] = 'l' [4] = 'o' } }
+//@ lldb-check:(strings_and_strs::Foo) str_in_struct = {inner:"Hello"}
 
 //@ lldb-command:v str_in_tuple
-//@ lldb-check:((&str, &str)) str_in_tuple = ("Hello", "World") { 0 = "Hello" { [0] = 'H' [1] = 'e' [2] = 'l' [3] = 'l' [4] = 'o' } 1 = "World" { [0] = 'W' [1] = 'o' [2] = 'r' [3] = 'l' [4] = 'd' } }
+//@ lldb-check:((&str, &str)) str_in_tuple = ("Hello", "World")
 
 //@ lldb-command:v str_in_rc
 //@ lldb-check:(alloc::rc::Rc<&str, alloc::alloc::Global>) str_in_rc = strong=1, weak=0 { value = "Hello" { [0] = 'H' [1] = 'e' [2] = 'l' [3] = 'l' [4] = 'o' } }
 
 //@ lldb-command:v box_str
-//@ lldb-check:(alloc::boxed::Box<unsigned char[], alloc::alloc::Global>) box_str = { __0 = { pointer = { pointer = { data_ptr = 0x[...] "World" length = 5 } } _marker = } __1 = }
+//@ lldb-check:(alloc::boxed::Box<str, alloc::alloc::Global>) box_str = "World" { [0] = 'W' [1] = 'o' [2] = 'r' [3] = 'l' [4] = 'd' }
 
 //@ lldb-command:v rc_str
 //@ lldb-check:(alloc::rc::Rc<unsigned char[], alloc::alloc::Global>) rc_str = strong=1, weak=0 { value = "World" }


### PR DESCRIPTION
Fairly straightforward. Note that the MSVC changes very likely aren't exercised by CI. My GSoC project is actively working on fixing that, but in the meantime i can personally verify that it works (note that the `ref$<str$> *` type name confirms this is MSVC):

<img width="318" height="138" alt="image" src="https://github.com/user-attachments/assets/fd868f16-d9a5-438a-a155-a429771bf525" />
