### PR TITLE
point at closure return expression in non-`FnOnce` E0271 errors

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1660,7 +1660,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             };
 
             let mut file = None;
-            let (msg, span, closure_span) = values
+            let (msg, mut span, mut closure_span) = values
                 .and_then(|(predicate, normalized_term, expected_term)| {
                     self.maybe_detailed_projection_msg(
                         obligation.cause.span,
@@ -1681,6 +1681,30 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         None,
                     )
                 });
+
+            // When the obligation comes from a closure arg and the projection isn't FnOnceOutput
+            // (which maybe_detailed_projection_msg handles via self_ty), point at the closure's
+            // return expression and label the closure declaration.
+            if closure_span.is_none()
+                && let ObligationCauseCode::FunctionArg { arg_hir_id, .. } = obligation.cause.code()
+                && let Node::Expr(arg_expr) = self.tcx.hir_node(*arg_hir_id)
+                && let hir::ExprKind::Closure(closure) = arg_expr.kind
+                && closure.kind == hir::ClosureKind::Closure
+            {
+                let body = self.tcx.hir_body(closure.body);
+                let ret_span = match body.value.kind {
+                    hir::ExprKind::Block(hir::Block { expr: Some(expr), .. }, _) => expr.span,
+                    hir::ExprKind::Block(hir::Block { expr: None, stmts: [.., last], .. }, _) => {
+                        last.span
+                    }
+                    _ => body.value.span,
+                };
+                if !closure.fn_decl_span.overlaps(ret_span) {
+                    closure_span = Some(closure.fn_decl_span);
+                    span = ret_span;
+                }
+            }
+
             let mut diag = struct_span_code_err!(self.dcx(), span, E0271, "{msg}");
             *diag.long_ty_path() = file;
             let mut mention_bounds = true;

--- a/tests/ui/closures/closure-arg-assoc-type-mismatch.rs
+++ b/tests/ui/closures/closure-arg-assoc-type-mismatch.rs
@@ -1,0 +1,30 @@
+// When a closure is passed as a function argument and the E0271 projection
+// mismatch is about an associated type of the closure's return type, the error
+// should point at the return expression inside the closure and label the
+// closure declaration — mirroring the FnOnce-output diagnostic.
+// https://github.com/rust-lang/rust/issues/42390
+
+trait MyTrait {
+    type Item;
+}
+
+struct S;
+impl MyTrait for S {
+    type Item = u32;
+}
+
+// Bound on the closure's output type's associated type.
+fn needs_unit_item<F: Fn() -> S>(_f: F)
+where
+    F::Output: MyTrait<Item = ()>,
+{
+}
+
+fn main() {
+    needs_unit_item(|| S); //~ ERROR type mismatch resolving `<S as MyTrait>::Item == ()`
+
+    needs_unit_item(|| { S }); //~ ERROR type mismatch resolving `<S as MyTrait>::Item == ()`
+
+    let x = S;
+    needs_unit_item(|| { let _ = 0; x }); //~ ERROR type mismatch resolving `<S as MyTrait>::Item == ()`
+}

--- a/tests/ui/closures/closure-arg-assoc-type-mismatch.stderr
+++ b/tests/ui/closures/closure-arg-assoc-type-mismatch.stderr
@@ -1,0 +1,72 @@
+error[E0271]: type mismatch resolving `<S as MyTrait>::Item == ()`
+  --> $DIR/closure-arg-assoc-type-mismatch.rs:24:24
+   |
+LL |     needs_unit_item(|| S);
+   |     --------------- -- ^ type mismatch resolving `<S as MyTrait>::Item == ()`
+   |     |               |
+   |     |               this closure
+   |     required by a bound introduced by this call
+   |
+note: expected this to be `()`
+  --> $DIR/closure-arg-assoc-type-mismatch.rs:13:17
+   |
+LL |     type Item = u32;
+   |                 ^^^
+note: required by a bound in `needs_unit_item`
+  --> $DIR/closure-arg-assoc-type-mismatch.rs:19:24
+   |
+LL | fn needs_unit_item<F: Fn() -> S>(_f: F)
+   |    --------------- required by a bound in this function
+LL | where
+LL |     F::Output: MyTrait<Item = ()>,
+   |                        ^^^^^^^^^ required by this bound in `needs_unit_item`
+
+error[E0271]: type mismatch resolving `<S as MyTrait>::Item == ()`
+  --> $DIR/closure-arg-assoc-type-mismatch.rs:26:26
+   |
+LL |     needs_unit_item(|| { S });
+   |     --------------- --   ^ type mismatch resolving `<S as MyTrait>::Item == ()`
+   |     |               |
+   |     |               this closure
+   |     required by a bound introduced by this call
+   |
+note: expected this to be `()`
+  --> $DIR/closure-arg-assoc-type-mismatch.rs:13:17
+   |
+LL |     type Item = u32;
+   |                 ^^^
+note: required by a bound in `needs_unit_item`
+  --> $DIR/closure-arg-assoc-type-mismatch.rs:19:24
+   |
+LL | fn needs_unit_item<F: Fn() -> S>(_f: F)
+   |    --------------- required by a bound in this function
+LL | where
+LL |     F::Output: MyTrait<Item = ()>,
+   |                        ^^^^^^^^^ required by this bound in `needs_unit_item`
+
+error[E0271]: type mismatch resolving `<S as MyTrait>::Item == ()`
+  --> $DIR/closure-arg-assoc-type-mismatch.rs:29:37
+   |
+LL |     needs_unit_item(|| { let _ = 0; x });
+   |     --------------- --              ^ type mismatch resolving `<S as MyTrait>::Item == ()`
+   |     |               |
+   |     |               this closure
+   |     required by a bound introduced by this call
+   |
+note: expected this to be `()`
+  --> $DIR/closure-arg-assoc-type-mismatch.rs:13:17
+   |
+LL |     type Item = u32;
+   |                 ^^^
+note: required by a bound in `needs_unit_item`
+  --> $DIR/closure-arg-assoc-type-mismatch.rs:19:24
+   |
+LL | fn needs_unit_item<F: Fn() -> S>(_f: F)
+   |    --------------- required by a bound in this function
+LL | where
+LL |     F::Output: MyTrait<Item = ()>,
+   |                        ^^^^^^^^^ required by this bound in `needs_unit_item`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0271`.

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.next.stderr
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.next.stderr
@@ -13,11 +13,12 @@ note: required by a bound in `find`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
 error[E0271]: type mismatch resolving `<{closure@closure-arg-type-mismatch-issue-45727.rs:6:29} as FnOnce<(&{integer},)>>::Output == bool`
-  --> $DIR/closure-arg-type-mismatch-issue-45727.rs:6:29
+  --> $DIR/closure-arg-type-mismatch-issue-45727.rs:6:38
    |
 LL |     let _ = (-10..=10).find(|x: i32| x.signum() == 0);
-   |                        ---- ^^^^^^^^^^^^^^^^^^^^^^^^ types differ
-   |                        |
+   |                        ---- -------- ^^^^^^^^^^^^^^^ types differ
+   |                        |    |
+   |                        |    this closure
    |                        required by a bound introduced by this call
    |
 note: required by a bound in `find`
@@ -38,11 +39,12 @@ note: required by a bound in `find`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
 error[E0271]: type mismatch resolving `<{closure@closure-arg-type-mismatch-issue-45727.rs:10:29} as FnOnce<(&{integer},)>>::Output == bool`
-  --> $DIR/closure-arg-type-mismatch-issue-45727.rs:10:29
+  --> $DIR/closure-arg-type-mismatch-issue-45727.rs:10:41
    |
 LL |     let _ = (-10..=10).find(|x: &&&i32| x.signum() == 0);
-   |                        ---- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ types differ
-   |                        |
+   |                        ---- ----------- ^^^^^^^^^^^^^^^ types differ
+   |                        |    |
+   |                        |    this closure
    |                        required by a bound introduced by this call
    |
 note: required by a bound in `find`


### PR DESCRIPTION
when a closure literal is passed as a function argument and E0271 fires for a projection that isnt `FnOnceOutput`. the error now points at the closures return expression and labels the closure declaration with "this closure". mirroring the existing FnOnce handling in `maybe_detailed_projection_msg`. which cant recover the closure from `self_ty` alone.

fixes https://github.com/rust-lang/rust/issues/42390

r? @estebank