### PR TITLE
Fix opaque type ICE in late lints under the next-generation trait solver

### DIFF
--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -348,7 +348,7 @@ impl<'tcx> Drop for InferCtxt<'tcx> {
 
         // No need for the drop bomb when we're in `TypingMode::PostTypeckUntilBorrowck`, and the `InferCtxt`
         // doesn't consider regions. This is okay since after typeck, the only reason we care about opaques is
-        // in relation to regions. In some places *after* typeck that aren't borrowck, like in lints we use
+        // in relation to regions. In some places *after* typeck that aren't borrowck, we use
         // `TypingMode::PostTypeckUntilBorrowck` to prevent defining opaque types and we simply don't care about regions.
         match self.typing_mode_raw() {
             TypingMode::Coherence

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -645,7 +645,7 @@ impl<'tcx> LateContext<'tcx> {
             && self.tcx.use_typing_mode_post_typeck_until_borrowck()
         {
             let def_id = self.tcx.hir_enclosing_body_owner(body_id.hir_id);
-            TypingMode::borrowck(self.tcx, def_id)
+            TypingMode::post_borrowck_analysis(self.tcx, def_id)
         } else {
             TypingMode::non_body_analysis()
         }

--- a/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
+++ b/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
@@ -84,7 +84,7 @@ impl<'tcx> LateLintPass<'tcx> for OpaqueHiddenInferredBound {
         }
 
         let def_id = opaque.def_id.to_def_id();
-        let infcx = &cx.tcx.infer_ctxt().ignoring_regions().build(cx.typing_mode());
+        let infcx = &cx.tcx.infer_ctxt().build(cx.typing_mode());
         // For every projection predicate in the opaque type's explicit bounds,
         // check that the type that we're assigning actually satisfies the bounds
         // of the associated type.

--- a/src/tools/clippy/tests/ui/future_not_send.current.stderr
+++ b/src/tools/clippy/tests/ui/future_not_send.current.stderr
@@ -1,11 +1,11 @@
 error: future cannot be sent between threads safely
-  --> tests/ui/future_not_send.rs:8:62
+  --> tests/ui/future_not_send.rs:11:62
    |
 LL | async fn private_future(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
    |                                                              ^^^^ future returned by `private_future` is not `Send`
    |
 note: future is not `Send` as this value is used across an await
-  --> tests/ui/future_not_send.rs:11:20
+  --> tests/ui/future_not_send.rs:14:20
    |
 LL | async fn private_future(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
    |                         -- has type `std::rc::Rc<[u8]>` which is not `Send`
@@ -14,7 +14,7 @@ LL |     async { true }.await
    |                    ^^^^^ await occurs here, with `rc` maybe used later
    = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Send`
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
-  --> tests/ui/future_not_send.rs:8:39
+  --> tests/ui/future_not_send.rs:11:39
    |
 LL | async fn private_future(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
    |                                       ^^^^ has type `&std::cell::Cell<usize>` which is not `Send`, because `std::cell::Cell<usize>` is not `Sync`
@@ -23,13 +23,13 @@ LL | async fn private_future(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
    = help: to override `-D warnings` add `#[allow(clippy::future_not_send)]`
 
 error: future cannot be sent between threads safely
-  --> tests/ui/future_not_send.rs:14:41
+  --> tests/ui/future_not_send.rs:17:41
    |
 LL | pub async fn public_future(rc: Rc<[u8]>) {
    |                                         ^ future returned by `public_future` is not `Send`
    |
 note: future is not `Send` as this value is used across an await
-  --> tests/ui/future_not_send.rs:17:20
+  --> tests/ui/future_not_send.rs:20:20
    |
 LL | pub async fn public_future(rc: Rc<[u8]>) {
    |                            -- has type `std::rc::Rc<[u8]>` which is not `Send`
@@ -39,45 +39,45 @@ LL |     async { true }.await;
    = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Send`
 
 error: future cannot be sent between threads safely
-  --> tests/ui/future_not_send.rs:24:63
+  --> tests/ui/future_not_send.rs:27:63
    |
 LL | async fn private_future2(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
    |                                                               ^^^^ future returned by `private_future2` is not `Send`
    |
 note: captured value is not `Send`
-  --> tests/ui/future_not_send.rs:24:26
+  --> tests/ui/future_not_send.rs:27:26
    |
 LL | async fn private_future2(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
    |                          ^^ has type `std::rc::Rc<[u8]>` which is not `Send`
    = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Send`
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
-  --> tests/ui/future_not_send.rs:24:40
+  --> tests/ui/future_not_send.rs:27:40
    |
 LL | async fn private_future2(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
    |                                        ^^^^ has type `&std::cell::Cell<usize>` which is not `Send`, because `std::cell::Cell<usize>` is not `Sync`
    = note: `std::cell::Cell<usize>` doesn't implement `std::marker::Sync`
 
 error: future cannot be sent between threads safely
-  --> tests/ui/future_not_send.rs:30:42
+  --> tests/ui/future_not_send.rs:33:42
    |
 LL | pub async fn public_future2(rc: Rc<[u8]>) {}
    |                                          ^ future returned by `public_future2` is not `Send`
    |
 note: captured value is not `Send`
-  --> tests/ui/future_not_send.rs:30:29
+  --> tests/ui/future_not_send.rs:33:29
    |
 LL | pub async fn public_future2(rc: Rc<[u8]>) {}
    |                             ^^ has type `std::rc::Rc<[u8]>` which is not `Send`
    = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Send`
 
 error: future cannot be sent between threads safely
-  --> tests/ui/future_not_send.rs:42:39
+  --> tests/ui/future_not_send.rs:45:39
    |
 LL |     async fn private_future(&self) -> usize {
    |                                       ^^^^^ future returned by `private_future` is not `Send`
    |
 note: future is not `Send` as this value is used across an await
-  --> tests/ui/future_not_send.rs:45:24
+  --> tests/ui/future_not_send.rs:48:24
    |
 LL |     async fn private_future(&self) -> usize {
    |                             ----- has type `&Dummy` which is not `Send`
@@ -87,26 +87,26 @@ LL |         async { true }.await;
    = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Sync`
 
 error: future cannot be sent between threads safely
-  --> tests/ui/future_not_send.rs:49:38
+  --> tests/ui/future_not_send.rs:52:38
    |
 LL |     pub async fn public_future(&self) {
    |                                      ^ future returned by `public_future` is not `Send`
    |
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
-  --> tests/ui/future_not_send.rs:49:32
+  --> tests/ui/future_not_send.rs:52:32
    |
 LL |     pub async fn public_future(&self) {
    |                                ^^^^^ has type `&Dummy` which is not `Send`, because `Dummy` is not `Sync`
    = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Sync`
 
 error: future cannot be sent between threads safely
-  --> tests/ui/future_not_send.rs:61:37
+  --> tests/ui/future_not_send.rs:64:37
    |
 LL | async fn generic_future<T>(t: T) -> T
    |                                     ^ future returned by `generic_future` is not `Send`
    |
 note: future is not `Send` as this value is used across an await
-  --> tests/ui/future_not_send.rs:67:20
+  --> tests/ui/future_not_send.rs:70:20
    |
 LL |     let rt = &t;
    |         -- has type `&T` which is not `Send`
@@ -115,13 +115,13 @@ LL |     async { true }.await;
    = note: `T` doesn't implement `std::marker::Sync`
 
 error: future cannot be sent between threads safely
-  --> tests/ui/future_not_send.rs:83:51
+  --> tests/ui/future_not_send.rs:86:51
    |
 LL | async fn generic_future_always_unsend<T>(_: Rc<T>) {
    |                                                   ^ future returned by `generic_future_always_unsend` is not `Send`
    |
 note: future is not `Send` as this value is used across an await
-  --> tests/ui/future_not_send.rs:86:20
+  --> tests/ui/future_not_send.rs:89:20
    |
 LL | async fn generic_future_always_unsend<T>(_: Rc<T>) {
    |                                          - has type `std::rc::Rc<T>` which is not `Send`

--- a/src/tools/clippy/tests/ui/future_not_send.next.stderr
+++ b/src/tools/clippy/tests/ui/future_not_send.next.stderr
@@ -1,0 +1,75 @@
+error: future cannot be sent between threads safely
+  --> tests/ui/future_not_send.rs:11:62
+   |
+LL | async fn private_future(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
+   |                                                              ^^^^
+   |
+   = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Send`
+   = note: `-D clippy::future-not-send` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::future_not_send)]`
+
+error: future cannot be sent between threads safely
+  --> tests/ui/future_not_send.rs:17:41
+   |
+LL | pub async fn public_future(rc: Rc<[u8]>) {
+   |                                         ^
+   |
+   = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Send`
+
+error: future cannot be sent between threads safely
+  --> tests/ui/future_not_send.rs:27:63
+   |
+LL | async fn private_future2(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
+   |                                                               ^^^^
+   |
+   = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Send`
+
+error: future cannot be sent between threads safely
+  --> tests/ui/future_not_send.rs:33:42
+   |
+LL | pub async fn public_future2(rc: Rc<[u8]>) {}
+   |                                          ^
+   |
+   = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Send`
+
+error: future cannot be sent between threads safely
+  --> tests/ui/future_not_send.rs:45:39
+   |
+LL |     async fn private_future(&self) -> usize {
+   |                                       ^^^^^
+   |
+   = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Sync`
+
+error: future cannot be sent between threads safely
+  --> tests/ui/future_not_send.rs:52:38
+   |
+LL |     pub async fn public_future(&self) {
+   |                                      ^
+   |
+   = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Sync`
+
+error: future cannot be sent between threads safely
+  --> tests/ui/future_not_send.rs:64:37
+   |
+LL | async fn generic_future<T>(t: T) -> T
+   |                                     ^ future returned by `generic_future` is not `Send`
+   |
+note: future is not `Send` as this value is used across an await
+  --> tests/ui/future_not_send.rs:70:20
+   |
+LL |     let rt = &t;
+   |         -- has type `&T` which is not `Send`
+LL |     async { true }.await;
+   |                    ^^^^^ await occurs here, with `rt` maybe used later
+   = note: `T` doesn't implement `std::marker::Sync`
+
+error: future cannot be sent between threads safely
+  --> tests/ui/future_not_send.rs:86:51
+   |
+LL | async fn generic_future_always_unsend<T>(_: Rc<T>) {
+   |                                                   ^
+   |
+   = note: `std::rc::Rc<T>` doesn't implement `std::marker::Send`
+
+error: aborting due to 8 previous errors
+

--- a/src/tools/clippy/tests/ui/future_not_send.rs
+++ b/src/tools/clippy/tests/ui/future_not_send.rs
@@ -1,3 +1,6 @@
+//@revisions: current next
+//@[next] compile-flags: -Znext-solver=globally
+
 #![warn(clippy::future_not_send)]
 
 use std::cell::Cell;


### PR DESCRIPTION
fixes rust-lang/rust-clippy#17411

Under the next trait solver, late lints trigger an ICE due to having non-empty opaque storage when dropping `InferCtxt`.

Rather than forcing all current and future late lints to manually use `ignoring_regions`, use `PostBorrowck` in `LateContext`.

cc @adwinwhite 
