### PR TITLE
Use RUNNER_TEMP in `distcheck` when running on CI

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3731,7 +3731,12 @@ impl Step for Distcheck {
     fn run(self, builder: &Builder<'_>) {
         // Use a temporary directory completely outside the current checkout, to avoid reusing any
         // local source code, built artifacts or configuration by accident
-        let root_dir = std::env::temp_dir().join("distcheck");
+        let root_dir = if builder.config.ci_env.is_running_in_ci() {
+            std::env::var("RUNNER_TEMP").map(PathBuf::from).unwrap_or_else(|_| std::env::temp_dir())
+        } else {
+            std::env::temp_dir()
+        };
+        let root_dir = root_dir.join("distcheck");
 
         distcheck_plain_source_tarball(builder, &root_dir.join("distcheck-rustc-src"));
         distcheck_rust_src(builder, &root_dir.join("distcheck-rust-src"));

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -347,6 +347,7 @@ docker \
   --env TOOLSTATE_REPO_ACCESS_TOKEN \
   --env TOOLSTATE_REPO \
   --env TOOLSTATE_PUBLISH \
+  --env RUNNER_TEMP \
   --env RUST_CI_OVERRIDE_RELEASE_CHANNEL \
   --env CI_JOB_NAME="${CI_JOB_NAME-$image}" \
   --env CI_JOB_DOC_URL="${CI_JOB_DOC_URL}" \


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
