### PR TITLE
Use dylib build in distcheck

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-distcheck/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-distcheck/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-# Make distcheck builds faster
-ENV DISTCHECK_CONFIGURE_ARGS="--enable-sccache"
+# Make distcheck builds faster and use less disk space
+ENV DISTCHECK_CONFIGURE_ARGS="--enable-sccache --set llvm.link-shared=true"
 
 ENV SCRIPT="python3 ../x.py test distcheck"


### PR DESCRIPTION
This reduces disk usage, and thus avoids the distcheck job running out of disk space.