### PR TITLE
Avoid duplicate type check errors for constrained struct 

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1815,7 +1815,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         base_expr: &'tcx hir::StructTailExpr<'tcx>,
     ) -> Ty<'tcx> {
         // Find the relevant variant
-        let (variant, adt_ty) = match self.check_struct_path(qpath, expr.hir_id) {
+        let expected_ty = expected.only_has_type(self);
+        let (variant, adt_ty) = match self.check_struct_path(qpath, expr.hir_id, expected_ty) {
             Ok(data) => data,
             Err(guar) => {
                 self.check_struct_fields_on_error(fields, base_expr);

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1039,6 +1039,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         qpath: &QPath<'tcx>,
         hir_id: HirId,
+        expected_ty: Option<Ty<'tcx>>,
     ) -> Result<(&'tcx ty::VariantDef, Ty<'tcx>), ErrorGuaranteed> {
         let path_span = qpath.span();
         let (def, ty) = self.finish_resolving_struct_path(qpath, path_span, hir_id);
@@ -1072,8 +1073,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Register type annotation.
             self.write_user_type_annotation_from_args(hir_id, did, args, user_self_ty);
 
-            // Check bounds on type arguments used in the path.
-            self.add_required_obligations_for_hir(path_span, did, args, hir_id);
+            let expected_ty_provides_bounds = expected_ty.is_some_and(|expected_ty| {
+                !expected_ty.has_non_region_infer()
+                    && self.can_eq(self.param_env, expected_ty, ty.normalized)
+            });
+
+            // Avoid duplicating bounds already checked by an equivalent concrete expected type.
+            if !expected_ty_provides_bounds {
+                self.add_required_obligations_for_hir(path_span, did, args, hir_id);
+            }
 
             Ok((variant, ty.normalized))
         } else {

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -1504,7 +1504,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         qpath: &hir::QPath<'tcx>,
     ) -> Result<ResolvedPat<'tcx>, ErrorGuaranteed> {
         // Resolve the path and check the definition for errors.
-        let (variant, pat_ty) = self.check_struct_path(qpath, pat.hir_id)?;
+        let (variant, pat_ty) = self.check_struct_path(qpath, pat.hir_id, None)?;
         Ok(ResolvedPat { ty: pat_ty, kind: ResolvedPatKind::Struct { variant } })
     }
 

--- a/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.rs
+++ b/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.rs
@@ -5,7 +5,6 @@ struct X<F> where F: FnOnce() + 'static + Send {
 fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
     //~^ ERROR `F` cannot be sent between threads safely
     return X { field: blk };
-    //~^ ERROR `F` cannot be sent between threads safely
 }
 
 fn main() {

--- a/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -14,22 +14,6 @@ help: consider further restricting type parameter `F` with trait `Send`
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + std::marker::Send {
    |                                                       +++++++++++++++++++
 
-error[E0277]: `F` cannot be sent between threads safely
-  --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:7:23
-   |
-LL |     return X { field: blk };
-   |                       ^^^ `F` cannot be sent between threads safely
-   |
-note: required by a bound in `X`
-  --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:1:43
-   |
-LL | struct X<F> where F: FnOnce() + 'static + Send {
-   |                                           ^^^^ required by this bound in `X`
-help: consider further restricting type parameter `F` with trait `Send`
-   |
-LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + std::marker::Send {
-   |                                                       +++++++++++++++++++
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.full.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.full.stderr
@@ -14,22 +14,6 @@ LL | struct Arr<const N: usize>
 LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                                       ^^^^^^ required by this bound in `Arr`
 
-error[E0308]: mismatched types
-  --> $DIR/issue-72819-generic-in-const-eval.rs:20:32
-   |
-LL |     let x: Arr<{usize::MAX}> = Arr {};
-   |                                ^^^ expected `false`, found `true`
-   |
-   = note: expected constant `false`
-              found constant `true`
-note: required by a bound in `Arr`
-  --> $DIR/issue-72819-generic-in-const-eval.rs:8:39
-   |
-LL | struct Arr<const N: usize>
-   |        --- required by a bound in this struct
-LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
-   |                                       ^^^^^^ required by this bound in `Arr`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.rs
@@ -19,5 +19,4 @@ impl IsTrue for Assert<true> {}
 fn main() {
     let x: Arr<{usize::MAX}> = Arr {};
     //[full]~^ ERROR mismatched types
-    //[full]~| ERROR mismatched types
 }

--- a/tests/ui/const-generics/issues/issue-73260.rs
+++ b/tests/ui/const-generics/issues/issue-73260.rs
@@ -14,5 +14,4 @@ impl IsTrue for Assert<true> {}
 fn main() {
     let x: Arr<{usize::MAX}> = Arr {};
     //~^ ERROR mismatched types
-    //~| ERROR mismatched types
 }

--- a/tests/ui/const-generics/issues/issue-73260.stderr
+++ b/tests/ui/const-generics/issues/issue-73260.stderr
@@ -15,23 +15,6 @@ LL | where
 LL |     Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                                     ^^^^^^ required by this bound in `Arr`
 
-error[E0308]: mismatched types
-  --> $DIR/issue-73260.rs:15:32
-   |
-LL |     let x: Arr<{usize::MAX}> = Arr {};
-   |                                ^^^ expected `false`, found `true`
-   |
-   = note: expected constant `false`
-              found constant `true`
-note: required by a bound in `Arr`
-  --> $DIR/issue-73260.rs:5:37
-   |
-LL | struct Arr<const N: usize>
-   |        --- required by a bound in this struct
-LL | where
-LL |     Assert::<{N < usize::MAX / 2}>: IsTrue,
-   |                                     ^^^^^^ required by this bound in `Arr`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/suggestions/trait-impl-bound-suggestions.fixed
+++ b/tests/ui/suggestions/trait-impl-bound-suggestions.fixed
@@ -14,7 +14,6 @@ trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized, X: std::marker::
     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
         //~^ ERROR the trait bound `X: Copy` is not satisfied
         ConstrainedStruct { x }
-        //~^ ERROR the trait bound `X: Copy` is not satisfied
     }
 }
 
@@ -24,7 +23,6 @@ trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized, X:
     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
         //~^ ERROR the trait bound `X: Copy` is not satisfied
         ConstrainedStruct { x }
-        //~^ ERROR the trait bound `X: Copy` is not satisfied
     }
 }
 

--- a/tests/ui/suggestions/trait-impl-bound-suggestions.rs
+++ b/tests/ui/suggestions/trait-impl-bound-suggestions.rs
@@ -14,7 +14,6 @@ trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized {
     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
         //~^ ERROR the trait bound `X: Copy` is not satisfied
         ConstrainedStruct { x }
-        //~^ ERROR the trait bound `X: Copy` is not satisfied
     }
 }
 
@@ -24,7 +23,6 @@ trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized {
     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
         //~^ ERROR the trait bound `X: Copy` is not satisfied
         ConstrainedStruct { x }
-        //~^ ERROR the trait bound `X: Copy` is not satisfied
     }
 }
 

--- a/tests/ui/suggestions/trait-impl-bound-suggestions.stderr
+++ b/tests/ui/suggestions/trait-impl-bound-suggestions.stderr
@@ -15,7 +15,7 @@ LL | trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized, X: std::mar
    |                                                               ++++++++++++++++++++++
 
 error[E0277]: the trait bound `X: Copy` is not satisfied
-  --> $DIR/trait-impl-bound-suggestions.rs:24:52
+  --> $DIR/trait-impl-bound-suggestions.rs:23:52
    |
 LL |     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
    |                                                    ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `X`
@@ -30,38 +30,6 @@ help: consider further restricting type parameter `X` with trait `Copy`
 LL | trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized, X: std::marker::Copy {
    |                                                                             ++++++++++++++++++++++
 
-error[E0277]: the trait bound `X: Copy` is not satisfied
-  --> $DIR/trait-impl-bound-suggestions.rs:16:29
-   |
-LL |         ConstrainedStruct { x }
-   |                             ^ the trait `Copy` is not implemented for `X`
-   |
-note: required by a bound in `ConstrainedStruct`
-  --> $DIR/trait-impl-bound-suggestions.rs:8:29
-   |
-LL | struct ConstrainedStruct<X: Copy> {
-   |                             ^^^^ required by this bound in `ConstrainedStruct`
-help: consider further restricting type parameter `X` with trait `Copy`
-   |
-LL | trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized, X: std::marker::Copy {
-   |                                                               ++++++++++++++++++++++
-
-error[E0277]: the trait bound `X: Copy` is not satisfied
-  --> $DIR/trait-impl-bound-suggestions.rs:26:29
-   |
-LL |         ConstrainedStruct { x }
-   |                             ^ the trait `Copy` is not implemented for `X`
-   |
-note: required by a bound in `ConstrainedStruct`
-  --> $DIR/trait-impl-bound-suggestions.rs:8:29
-   |
-LL | struct ConstrainedStruct<X: Copy> {
-   |                             ^^^^ required by this bound in `ConstrainedStruct`
-help: consider further restricting type parameter `X` with trait `Copy`
-   |
-LL | trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized, X: std::marker::Copy {
-   |                                                                             ++++++++++++++++++++++
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/bound/on-structs-and-enums-static.rs
+++ b/tests/ui/traits/bound/on-structs-and-enums-static.rs
@@ -7,7 +7,7 @@ struct Foo<T:Trait> {
 }
 
 static X: Foo<usize> = Foo { //~ ERROR E0277
-    x: 1, //~ ERROR: E0277
+    x: 1,
 };
 
 fn main() {

--- a/tests/ui/traits/bound/on-structs-and-enums-static.stderr
+++ b/tests/ui/traits/bound/on-structs-and-enums-static.stderr
@@ -15,23 +15,6 @@ note: required by a bound in `Foo`
 LL | struct Foo<T:Trait> {
    |              ^^^^^ required by this bound in `Foo`
 
-error[E0277]: the trait bound `{integer}: Trait` is not satisfied
-  --> $DIR/on-structs-and-enums-static.rs:10:8
-   |
-LL |     x: 1,
-   |        ^ the trait `Trait` is not implemented for `{integer}`
-   |
-help: this trait has no implementations, consider adding one
-  --> $DIR/on-structs-and-enums-static.rs:1:1
-   |
-LL | trait Trait {
-   | ^^^^^^^^^^^
-note: required by a bound in `Foo`
-  --> $DIR/on-structs-and-enums-static.rs:5:14
-   |
-LL | struct Foo<T:Trait> {
-   |              ^^^^^ required by this bound in `Foo`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/type-inference/constrained-struct-duplicate-errors-issue-104637.rs
+++ b/tests/ui/type-inference/constrained-struct-duplicate-errors-issue-104637.rs
@@ -1,0 +1,20 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/104637>.
+//! A failed bound on an explicitly typed struct should not cause duplicate type errors.
+
+trait Trait {}
+
+struct Struct<T>
+where
+    Struct<T>: Trait,
+{
+    field: T,
+}
+
+impl Trait for Struct<bool> {}
+
+fn main() {
+    let _: Struct<u8> = Struct { field: 0 };
+    //~^ ERROR the trait bound `Struct<u8>: Trait` is not satisfied
+    //~| ERROR mismatched types
+    //~| ERROR mismatched types
+}

--- a/tests/ui/type-inference/constrained-struct-duplicate-errors-issue-104637.rs
+++ b/tests/ui/type-inference/constrained-struct-duplicate-errors-issue-104637.rs
@@ -15,6 +15,10 @@ impl Trait for Struct<bool> {}
 fn main() {
     let _: Struct<u8> = Struct { field: 0 };
     //~^ ERROR the trait bound `Struct<u8>: Trait` is not satisfied
-    //~| ERROR mismatched types
+
+    let _: Struct<_> = Struct { field: false };
+
+    let _: Struct<bool> = Struct::<u8> { field: 0 };
+    //~^ ERROR the trait bound `Struct<u8>: Trait` is not satisfied
     //~| ERROR mismatched types
 }

--- a/tests/ui/type-inference/constrained-struct-duplicate-errors-issue-104637.stderr
+++ b/tests/ui/type-inference/constrained-struct-duplicate-errors-issue-104637.stderr
@@ -1,0 +1,46 @@
+error[E0277]: the trait bound `Struct<u8>: Trait` is not satisfied
+  --> $DIR/constrained-struct-duplicate-errors-issue-104637.rs:16:12
+   |
+LL |     let _: Struct<u8> = Struct { field: 0 };
+   |            ^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `Trait` is not implemented for `Struct<u8>`
+  --> $DIR/constrained-struct-duplicate-errors-issue-104637.rs:6:1
+   |
+LL | struct Struct<T>
+   | ^^^^^^^^^^^^^^^^
+help: the trait `Trait` is implemented for `Struct<bool>`
+  --> $DIR/constrained-struct-duplicate-errors-issue-104637.rs:13:1
+   |
+LL | impl Trait for Struct<bool> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `Struct`
+  --> $DIR/constrained-struct-duplicate-errors-issue-104637.rs:8:16
+   |
+LL | struct Struct<T>
+   |        ------ required by a bound in this struct
+LL | where
+LL |     Struct<T>: Trait,
+   |                ^^^^^ required by this bound in `Struct`
+
+error[E0308]: mismatched types
+  --> $DIR/constrained-struct-duplicate-errors-issue-104637.rs:16:41
+   |
+LL |     let _: Struct<u8> = Struct { field: 0 };
+   |                                         ^ expected `bool`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/constrained-struct-duplicate-errors-issue-104637.rs:16:25
+   |
+LL |     let _: Struct<u8> = Struct { field: 0 };
+   |            ----------   ^^^^^^^^^^^^^^^^^^^ expected `Struct<u8>`, found `Struct<bool>`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `Struct<u8>`
+              found struct `Struct<bool>`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/type-inference/constrained-struct-duplicate-errors-issue-104637.stderr
+++ b/tests/ui/type-inference/constrained-struct-duplicate-errors-issue-104637.stderr
@@ -24,21 +24,40 @@ LL |     Struct<T>: Trait,
    |                ^^^^^ required by this bound in `Struct`
 
 error[E0308]: mismatched types
-  --> $DIR/constrained-struct-duplicate-errors-issue-104637.rs:16:41
+  --> $DIR/constrained-struct-duplicate-errors-issue-104637.rs:21:27
    |
-LL |     let _: Struct<u8> = Struct { field: 0 };
-   |                                         ^ expected `bool`, found integer
-
-error[E0308]: mismatched types
-  --> $DIR/constrained-struct-duplicate-errors-issue-104637.rs:16:25
-   |
-LL |     let _: Struct<u8> = Struct { field: 0 };
-   |            ----------   ^^^^^^^^^^^^^^^^^^^ expected `Struct<u8>`, found `Struct<bool>`
+LL |     let _: Struct<bool> = Struct::<u8> { field: 0 };
+   |            ------------   ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Struct<bool>`, found `Struct<u8>`
    |            |
    |            expected due to this
    |
-   = note: expected struct `Struct<u8>`
-              found struct `Struct<bool>`
+   = note: expected struct `Struct<bool>`
+              found struct `Struct<u8>`
+
+error[E0277]: the trait bound `Struct<u8>: Trait` is not satisfied
+  --> $DIR/constrained-struct-duplicate-errors-issue-104637.rs:21:49
+   |
+LL |     let _: Struct<bool> = Struct::<u8> { field: 0 };
+   |                                                 ^ unsatisfied trait bound
+   |
+help: the trait `Trait` is not implemented for `Struct<u8>`
+  --> $DIR/constrained-struct-duplicate-errors-issue-104637.rs:6:1
+   |
+LL | struct Struct<T>
+   | ^^^^^^^^^^^^^^^^
+help: the trait `Trait` is implemented for `Struct<bool>`
+  --> $DIR/constrained-struct-duplicate-errors-issue-104637.rs:13:1
+   |
+LL | impl Trait for Struct<bool> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `Struct`
+  --> $DIR/constrained-struct-duplicate-errors-issue-104637.rs:8:16
+   |
+LL | struct Struct<T>
+   |        ------ required by a bound in this struct
+LL | where
+LL |     Struct<T>: Trait,
+   |                ^^^^^ required by this bound in `Struct`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/wf/wf-const-type.rs
+++ b/tests/ui/wf/wf-const-type.rs
@@ -10,7 +10,6 @@ struct NotCopy;
 const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
 //~^ ERROR E0277
 //~| ERROR E0277
-//~| ERROR E0277
 
 
 fn main() { }

--- a/tests/ui/wf/wf-const-type.stderr
+++ b/tests/ui/wf/wf-const-type.stderr
@@ -35,24 +35,6 @@ LL + #[derive(Copy)]
 LL | struct NotCopy;
    |
 
-error[E0277]: the trait bound `NotCopy: Copy` is not satisfied
-  --> $DIR/wf-const-type.rs:10:50
-   |
-LL | const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
-   |                                                  ^^^^ the trait `Copy` is not implemented for `NotCopy`
-   |
-   = note: required for `Option<NotCopy>` to implement `Copy`
-note: required by a bound in `IsCopy`
-  --> $DIR/wf-const-type.rs:7:17
-   |
-LL | struct IsCopy<T:Copy> { t: T }
-   |                 ^^^^ required by this bound in `IsCopy`
-help: consider annotating `NotCopy` with `#[derive(Copy)]`
-   |
-LL + #[derive(Copy)]
-LL | struct NotCopy;
-   |
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes rust-lang/rust#104637

When a struct literal has an equivalent concrete expected type, avoid registering the same struct bounds again, remove some noise.

