### PR TITLE
Add regression test for closure in array-length const generic

### DIFF
--- a/tests/ui/const-generics/generic_const_exprs/closure-in-array-len-ice-119316.rs
+++ b/tests/ui/const-generics/generic_const_exprs/closure-in-array-len-ice-119316.rs
@@ -1,0 +1,11 @@
+//@ edition: 2018
+// regression test for #119316
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+async fn foo<'a>() {
+    let _data = &mut [0u8; { N + (|| 42)() }];
+    //~^ ERROR cannot find value `N` in this scope
+}
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/closure-in-array-len-ice-119316.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/closure-in-array-len-ice-119316.stderr
@@ -1,0 +1,14 @@
+error[E0425]: cannot find value `N` in this scope
+  --> $DIR/closure-in-array-len-ice-119316.rs:7:30
+   |
+LL |     let _data = &mut [0u8; { N + (|| 42)() }];
+   |                              ^ not found in this scope
+   |
+help: you might be missing a const parameter
+   |
+LL | async fn foo<'a, const N: /* Type */>() {
+   |                +++++++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Adds a regression test for rust-lang/rust#119316 

The MCVE (a closure inside an array-length const in a generic async fn)
used to ICE with "expected type of closure to be a closure". It's since
been fixed and just emits ordinary errors now, so this adds a UI test to
lock that in.

Closes rust-lang/rust#119316 