### PR TITLE
std: retry waitid on EINTR in the pidfd wait path

### DIFF
--- a/library/std/src/sys/process/unix/pidfd.rs
+++ b/library/std/src/sys/process/unix/pidfd.rs
@@ -2,7 +2,7 @@ use super::ExitStatus;
 use crate::io;
 use crate::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use crate::sys::fd::FileDesc;
-use crate::sys::{AsInner, FromInner, IntoInner, cvt};
+use crate::sys::{AsInner, FromInner, IntoInner, cvt, cvt_r};
 
 #[cfg(test)]
 mod tests;
@@ -61,7 +61,7 @@ impl PidFd {
 
     fn waitid(&self, options: libc::c_int) -> io::Result<Option<ExitStatus>> {
         let mut siginfo: libc::siginfo_t = unsafe { crate::mem::zeroed() };
-        let r = cvt(unsafe {
+        let r = cvt_r(|| unsafe {
             libc::waitid(libc::P_PIDFD, self.0.as_raw_fd() as u32, &mut siginfo, options)
         });
         match r {


### PR DESCRIPTION
The pidfd-backed `Child::wait()` and `try_wait()` share a `waitid` helper that calls `waitid` through plain `cvt`, so an `EINTR` reaches the caller as `ErrorKind::Interrupted`. The legacy `waitpid` path that the pidfd path stands in for retries instead: `wait()` there uses `cvt_r`. So a child spawned with a pidfd can see `Interrupted` from `wait()` where the same call without one wouldn't.

Both callers go through the one helper, so this wraps the `waitid` call in `cvt_r` to match the legacy `wait()`:

```rust
let r = cvt_r(|| unsafe {
    libc::waitid(libc::P_PIDFD, self.0.as_raw_fd() as u32, &mut siginfo, options)
});
```

For the blocking `wait()` that's the fix. `try_wait()` passes `WNOHANG`, and `waitid` only returns `EINTR` when it isn't set, from
[`wait(2)`](https://www.man7.org/linux/man-pages/man2/wait.2.html#ERRORS):
> EINTR  WNOHANG was not set and an unblocked signal or a SIGCHLD was caught; see signal(7).

I didn't add a test, since landing an `EINTR` in the wait window needs a signal to arrive at the right moment and isn't practical to reproduce.

r? libs
