### PR TITLE
Normalize absolute paths to root, add docs

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3426,10 +3426,62 @@ impl Path {
     ///
     /// [`path::absolute`](absolute) is an alternative that preserves `..`.
     /// Or [`Path::canonicalize`] can be used to resolve any `..` by querying the filesystem.
+    ///
+    /// # Errors
+    ///
+    /// This method will return an error in the following situations:
+    ///
+    /// - `path` where [`Path::has_root`] is `false` and a parent reference `..` points outside
+    ///    of the base directory.
+    ///
+    /// On Unix, a path that is absolute ([`Path::is_absolute`]) is equivalent to
+    /// [`Path::has_root`] and will never fail. On Windows, a root-relative path such
+    /// as `\..` is not considered absolute, but it has a root, so its `..` is pinned
+    /// to that root and it will not fail.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(normalize_lexically)]
+    /// use std::path::Path;
+    ///
+    /// let path = Path::new("relative/path/unnormalized/../.");
+    /// let normalized = path.normalize_lexically().unwrap();
+    /// assert_eq!(Path::new("relative/path"), normalized);
+    ///
+    /// let path = Path::new("/absolute/path/un/../normalized/.");
+    /// let normalized = path.normalize_lexically().unwrap();
+    /// assert_eq!(Path::new("/absolute/path/normalized"), normalized);
+    /// ```
+    ///
+    /// A path without a root cannot normalize beyond its current base, attempting to do so will
+    /// cause an error. Paths with a root will pin `..` to the root.
+    ///
+    /// ```
+    /// #![feature(normalize_lexically)]
+    /// use std::path::Path;
+    ///
+    /// let path = Path::new("../relative");
+    /// assert!(path.normalize_lexically().is_err());
+    ///
+    /// let path = Path::new("relative/../..");
+    /// assert!(path.normalize_lexically().is_err());
+    ///
+    /// let path = Path::new("/../has_root");
+    /// assert_eq!(Path::new("/has_root"), path.normalize_lexically().unwrap());
+    /// ```
+    ///
+    /// This root pinning behavior for absolute paths is common in many operating systems but is
+    /// [not guaranteed by POSIX](https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/basedefs/V1_chap04.html#tag_04_16).
+    ///
+    /// > As a special case, in the root directory, dot-dot may refer to the root directory itself.
+    ///
+    /// If your operating system behavior diverges you can use [`Component`] directly.
     #[unstable(feature = "normalize_lexically", issue = "134694")]
     pub fn normalize_lexically(&self) -> Result<PathBuf, NormalizeError> {
         let mut lexical = PathBuf::new();
         let mut iter = self.components().peekable();
+        let base_dir_not_root = !self.has_root();
 
         // Find the root, if any, and add it to the lexical path.
         // Here we treat the Windows path "C:\" as a single "root" even though
@@ -3460,9 +3512,11 @@ impl Path {
                 Component::Prefix(_) => return Err(NormalizeError),
                 Component::CurDir => continue,
                 Component::ParentDir => {
-                    // It's an error if ParentDir causes us to go above the "root".
+                    // This ParentDir would take us above the "root".
                     if lexical.as_os_str().len() == root {
-                        return Err(NormalizeError);
+                        if base_dir_not_root {
+                            return Err(NormalizeError);
+                        }
                     } else {
                         lexical.pop();
                     }

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -2526,28 +2526,37 @@ fn normalize_lexically() {
     check_err("a/../../b/c");
     check_err("a/../b/../..");
 
-    // Check we don't escape the root or prefix
+    // Absolute paths pin `..` at the root rather than escaping it.
     #[cfg(unix)]
     {
-        check_err("/..");
-        check_err("/a/../..");
+        check_ok("/..", "/");
+        check_ok("/a/../..", "/");
+        check_ok("/../a", "/a");
+        // Pinning composes with later components: `..` stops at root, then `c` is appended.
+        check_ok("/a/b/../../../c", "/c");
     }
     #[cfg(windows)]
     {
-        check_err(r"C:\..");
-        check_err(r"C:\a\..\..");
+        check_ok(r"C:\..", r"C:\");
+        check_ok(r"C:\a\..\..", r"C:\");
 
+        check_ok(r"\\server\share\..", r"\\server\share\");
+        check_ok(r"\\server\share\a\..\..", r"\\server\share\");
+
+        check_ok(r"\..", r"\");
+        check_ok(r"\a\..\..", r"\");
+
+        check_ok(r"\\?\UNC\server\share\..", r"\\?\UNC\server\share\");
+        check_ok(r"\\?\UNC\server\share\a\..\..", r"\\?\UNC\server\share\");
+
+        // Verbatim disk prefix: `..` pins to the verbatim root.
+        check_ok(r"\\?\C:\..", r"\\?\C:\");
+        check_ok(r"\\?\C:\a\..\..", r"\\?\C:\");
+
+        // Drive-relative paths (no `RootDir`) are not absolute, so `..` above
+        // the prefix still escapes the base directory and is an error.
         check_err(r"C:..");
         check_err(r"C:a\..\..");
-
-        check_err(r"\\server\share\..");
-        check_err(r"\\server\share\a\..\..");
-
-        check_err(r"\..");
-        check_err(r"\a\..\..");
-
-        check_err(r"\\?\UNC\server\share\..");
-        check_err(r"\\?\UNC\server\share\a\..\..");
     }
 }
 


### PR DESCRIPTION
It is common to pin a path normalization to root for many languages:

```ruby
# Ruby
File.expand_path("/tmp/../../lol")
=> "/lol"
```

The error on `normalize_lexically` makes sense for a relative path because Rust CANNOT know how to construct the parent path without performing a call to get CWD. However, for absolute path, I am proposing that we stabilize this behavior to pin at the root for absolute paths. There are links to the POSIX spec and documentation in the commit.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Related tracking issue for `normalize_lexically` unstable feature https://github.com/rust-lang/rust/issues/134694.