### PR TITLE
Report "capacity overflow" for oversized Rc<[T]>/Arc<[T]>

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -294,7 +294,11 @@ fn rc_inner_layout_for_value_layout(layout: Layout) -> Layout {
     // Previously, layout was calculated on the expression
     // `&*(ptr as *const RcInner<T>)`, but this created a misaligned
     // reference (see #54908).
-    Layout::new::<RcInner<()>>().extend(layout).unwrap().0.pad_to_align()
+    Layout::new::<RcInner<()>>()
+        .extend(layout)
+        .unwrap_or_else(|_| panic!("capacity overflow"))
+        .0
+        .pad_to_align()
 }
 
 /// A single-threaded reference-counting pointer. 'Rc' stands for 'Reference

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -406,7 +406,11 @@ fn arcinner_layout_for_value_layout(layout: Layout) -> Layout {
     // Previously, layout was calculated on the expression
     // `&*(ptr as *const ArcInner<T>)`, but this created a misaligned
     // reference (see #54908).
-    Layout::new::<ArcInner<()>>().extend(layout).unwrap().0.pad_to_align()
+    Layout::new::<ArcInner<()>>()
+        .extend(layout)
+        .unwrap_or_else(|_| panic!("capacity overflow"))
+        .0
+        .pad_to_align()
 }
 
 unsafe impl<T: ?Sized + Sync + Send> Send for ArcInner<T> {}

--- a/library/alloctests/tests/arc.rs
+++ b/library/alloctests/tests/arc.rs
@@ -390,3 +390,9 @@ fn issue_155746_make_mut_panic_safety() {
     assert_eq!(*arc, [[1]]);
     assert_eq!(Arc::strong_count(&arc), 1); // if this is 0, we have a UAF!
 }
+
+#[test]
+#[should_panic = "capacity overflow"]
+fn new_uninit_slice_capacity_overflow() {
+    let _ = Arc::<[u8]>::new_uninit_slice(isize::MAX as usize);
+}

--- a/library/alloctests/tests/rc.rs
+++ b/library/alloctests/tests/rc.rs
@@ -967,3 +967,11 @@ fn issue_158875_make_mut_dont_leak_allocator() {
 
     assert_eq!(Rc::strong_count(&alloc), 1); // if this is >1, we have a memory leak!
 }
+
+#[test]
+#[should_panic = "capacity overflow"]
+fn new_uninit_slice_capacity_overflow() {
+    // header + payload layout exceeds isize::MAX -> "capacity overflow", not
+    // an unwrapped LayoutError. Regression test for #136797.
+    let _ = Rc::<[u8]>::new_uninit_slice(isize::MAX as usize);
+}


### PR DESCRIPTION
Fixes rust-lang/rust#136797.

Building an Rc<[T]>/Arc<[T]> whose header + payload layout exceeds
isize::MAX unwrapped a LayoutError and panicked with "called
Result::unwrap() on an Err value: LayoutError". Vec and Box report
"capacity overflow" here; this makes Rc/Arc do the same.

Used an inline panic!("capacity overflow") rather than raw_vec's
capacity_overflow(), since that helper is cfg'd out under
no_global_oom_handling while these two layout fns still compile there.