### PR TITLE
fuchsia: Add safestack as a supported sanitizer for x86_64 fuchsia

### DIFF
--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_fuchsia.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_fuchsia.rs
@@ -9,7 +9,9 @@ pub(crate) fn target() -> Target {
     base.features = "+cmpxchg16b,+lahfsahf,+popcnt,+sse3,+sse4.1,+sse4.2,+ssse3".into();
     base.max_atomic_width = Some(128);
     base.stack_probes = StackProbeType::Inline;
-    base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::LEAK;
+    base.supported_sanitizers =
+        SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::LEAK | SanitizerSet::SAFESTACK;
+    base.default_sanitizers = SanitizerSet::SAFESTACK;
     base.supports_xray = true;
 
     Target {

--- a/tests/assembly-llvm/stack-protector/stack-protector-target-support.rs
+++ b/tests/assembly-llvm/stack-protector/stack-protector-target-support.rs
@@ -177,13 +177,15 @@
 //@ compile-flags: -C opt-level=2
 
 #![crate_type = "lib"]
-#![feature(no_core, lang_items)]
+#![feature(no_core, lang_items, sanitize)]
 #![crate_type = "lib"]
 #![no_core]
 
 extern crate minicore;
 use minicore::*;
 
+// We only do this because we can't disable default sanitizers via compile-flags.
+#[sanitize(safestack = "off")]
 #[no_mangle]
 pub fn foo() {
     // CHECK: foo{{:|()}}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159873)*
<!-- homu-ignore:end -->

Make it also enabled by default just like it is for clang.