### PR TITLE
Remove the leading `.` (CurrentDir) prefix while normalizing

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3436,10 +3436,14 @@ impl Path {
         // `components` splits it into two: (Prefix, RootDir).
         let root = match iter.peek() {
             Some(Component::ParentDir) => return Err(NormalizeError),
-            Some(p @ Component::RootDir) | Some(p @ Component::CurDir) => {
+            Some(p @ Component::RootDir) => {
                 lexical.push(p);
                 iter.next();
                 lexical.as_os_str().len()
+            }
+            Some(Component::CurDir) => {
+                iter.next();
+                0
             }
             Some(Component::Prefix(prefix)) => {
                 lexical.push(prefix.as_os_str());
@@ -3470,6 +3474,11 @@ impl Path {
                 Component::Normal(path) => lexical.push(path),
             }
         }
+
+        if lexical.is_empty() {
+            lexical.push(Component::CurDir);
+        }
+
         Ok(lexical)
     }
 

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -2511,20 +2511,27 @@ fn normalize_lexically() {
     }
 
     // Relative paths
+    check_ok("", "");
     check_ok("a", "a");
-    check_ok("./a", "./a");
+    check_ok("./a", "a");
+    check_ok(".", ".");
+    check_ok("./", ".");
     check_ok("a/b/c", "a/b/c");
     check_ok("a/././b/./c/.", "a/b/c");
     check_ok("a/../c", "c");
-    check_ok("./a/b", "./a/b");
+    check_ok("./a/b", "a/b");
+    check_ok("./a/..", ".");
+    check_ok("a/..", ".");
     check_ok("a/../b/c/..", "b");
 
     check_err("..");
+    check_err("./..");
     check_err("../..");
     check_err("a/../..");
     check_err("a/../../b");
     check_err("a/../../b/c");
     check_err("a/../b/../..");
+    check_err("./a/../..");
 
     // Check we don't escape the root or prefix
     #[cfg(unix)]


### PR DESCRIPTION
Today, if you pass `./a/b` and `a/b` through normalize equality will tell you they are different. That was surprising to me.

Here is how other languages behave with the current Rust behavior for comparison:


| Implementation                    | `a` | `./a` | `a/` | `(empty)` | `.`       |
| --------------------------------- | --- | ----- | ---- | --------- | --------- |
| Go `path.Clean`                   | `a` | `a`   | `a`  | `.`       | `.`       |
| Java `Path.normalize`             | `a` | `a`   | `a`  | `(empty)` | `(empty)` |
| Node `path.posix.normalize`       | `a` | `a`   | `a/` | `.`       | `.`       |
| C++ `lexically_normal`            | `a` | `a`   | `a/` | `(empty)` | `.`       |
| Ruby `Pathname#cleanpath`         | `a` | `a`   | `a`  | `.`       | `.`       |
| Python `os.path.normpath`         | `a` | `a`   | `a`  | `.`       | `.`       |
| Rust `normalize_lexically` (main) | `a` | `./a` | `a`  | `(empty)` | `.`       |


Rust is the only one that keeps the leading `.`. This PR strips it so `./a` normalizes to `a` (a lone `.` is still preserved):

| Implementation                        | `a` | `./a` | `a/` | `(empty)` | `.` |
|---------------------------------------|-----|-------|------|-----------|-----|
| Rust `normalize_lexically` (proposed) | `a` | `a`   | `a`  | `(empty)` | `.` |

This aligns the leading `.` case with other languages.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Related tracking issue for `normalize_lexically` unstable feature https://github.com/rust-lang/rust/issues/134694.