### PR TITLE
bootstrap: Remove obsolete option `build.compiletest-use-stage0-libtest`

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -533,8 +533,6 @@ impl Config {
             optimized_compiler_builtins: build_optimized_compiler_builtins,
             jobs: build_jobs,
             compiletest_diff_tool: build_compiletest_diff_tool,
-            // No longer has any effect; kept (for now) to avoid breaking people's configs.
-            compiletest_use_stage0_libtest: _,
             tidy_extra_checks: build_tidy_extra_checks,
             ccache: build_ccache,
             exclude: build_exclude,

--- a/src/bootstrap/src/core/config/toml/build.rs
+++ b/src/bootstrap/src/core/config/toml/build.rs
@@ -72,9 +72,6 @@ define_config! {
         jobs: Option<u32> = "jobs",
         compiletest_diff_tool: Option<String> = "compiletest-diff-tool",
         compiletest_allow_stage0: Option<bool> = "compiletest-allow-stage0",
-        /// No longer has any effect; kept (for now) to avoid breaking people's configs.
-        /// FIXME(#146929): Remove this in 2026.
-        compiletest_use_stage0_libtest: Option<bool> = "compiletest-use-stage0-libtest",
         tidy_extra_checks: Option<String> = "tidy-extra-checks",
         ccache: Option<StringOrBool> = "ccache",
         exclude: Option<Vec<PathBuf>> = "exclude",

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -656,4 +656,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "GDB and LLDB are no longer automatically discovered from the environment. If you want to use path discovery for them, you can opt in using `build.gdb = \"discover\"` or `build.lldb = \"discover\"`.",
     },
+    ChangeInfo {
+        change_id: 159878,
+        severity: ChangeSeverity::Warning,
+        summary: "Obsolete option `build.compiletest-use-stage0-libtest` has no effect and has been removed.",
+    },
 ];


### PR DESCRIPTION
During the bootstrap stage0 redesign, `compiletest-use-stage0-libtest` was needed as a workaround for big regressions in compiletest build times, due to compiletest's dependency on libtest or `#![feature(internal_output_capture)]`.

As of https://github.com/rust-lang/rust/pull/146929, compiletest has no dependency on libtest or any unstable features, and is always built with the stage0 compiler. Since then, `compiletest-use-stage0-libtest` has had no effect, and was retained only to avoid breaking people's builds if they had that option set.

Several months later, it should be fine to remove the option entirely.

r? jieyouxu (or bootstrap)