### PR TITLE
fix: Do not stop `visible_parent_map` breadth-first search reaching children of `#[doc(hidden)]` modules

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -501,14 +501,14 @@ pub(in crate::rmeta) fn provide(providers: &mut Providers) {
                 }
 
                 if let Some(def_id) = child.res.opt_def_id() {
+                    let mut fallback = false;
+
                     if child.ident.name == kw::Underscore {
-                        fallback_map.push((def_id, parent));
-                        return;
+                        fallback = true;
                     }
 
                     if tcx.is_doc_hidden(parent) {
-                        fallback_map.push((def_id, parent));
-                        return;
+                        fallback = true;
                     }
 
                     // If the re-export itself is `#[doc(hidden)]`, deprioritize it.
@@ -519,20 +519,30 @@ pub(in crate::rmeta) fn provide(providers: &mut Providers) {
                         .and_then(|r| r.id())
                         .is_some_and(|id| tcx.is_doc_hidden(id))
                     {
-                        fallback_map.push((def_id, parent));
-                        return;
+                        fallback = true;
                     }
 
                     match visible_parent_map.entry(def_id) {
                         Entry::Occupied(mut entry) => {
-                            // If `child` is defined in crate `cnum`, ensure
-                            // that it is mapped to a parent in `cnum`.
-                            if def_id.is_local() && entry.get().is_local() {
-                                entry.insert(parent);
+                            if !fallback {
+                                // If `child` is defined in crate `cnum`, ensure
+                                // that it is mapped to a parent in `cnum`.
+                                if def_id.is_local() && entry.get().is_local() {
+                                    entry.insert(parent);
+                                }
                             }
                         }
                         Entry::Vacant(entry) => {
-                            entry.insert(parent);
+                            if fallback {
+                                // We do all of the same steps to fallback entries as to
+                                // preferred entries, except for recording them in a separate map.
+                                // It is important to not return early in the fallback cases to
+                                // ensure that we extend the BFS to the children of fallback items.
+                                fallback_map.push((def_id, parent));
+                            } else {
+                                entry.insert(parent);
+                            }
+
                             if child.res.module_like_def_id().is_some() {
                                 bfs_queue.push_back(def_id);
                             }

--- a/tests/ui/suggestions/suggest-path-through-direct-dep-crate/auxiliary/direct-dep-with-nesting.rs
+++ b/tests/ui/suggestions/suggest-path-through-direct-dep-crate/auxiliary/direct-dep-with-nesting.rs
@@ -1,0 +1,14 @@
+#![crate_type = "lib"]
+
+extern crate transitive_dep;
+
+mod private {
+    pub mod inner {
+        pub use crate::transitive_dep::Struct;
+    }
+}
+
+#[doc(hidden)]
+pub mod __private {
+    pub use crate::private::*;
+}

--- a/tests/ui/suggestions/suggest-path-through-direct-dep-crate/auxiliary/direct-dep.rs
+++ b/tests/ui/suggestions/suggest-path-through-direct-dep-crate/auxiliary/direct-dep.rs
@@ -1,0 +1,12 @@
+#![crate_type = "lib"]
+
+extern crate transitive_dep;
+
+mod private {
+    pub use crate::transitive_dep::Struct;
+}
+
+#[doc(hidden)]
+pub mod __private {
+    pub use crate::private::*;
+}

--- a/tests/ui/suggestions/suggest-path-through-direct-dep-crate/auxiliary/transitive-dep.rs
+++ b/tests/ui/suggestions/suggest-path-through-direct-dep-crate/auxiliary/transitive-dep.rs
@@ -1,0 +1,3 @@
+#![crate_type = "lib"]
+
+pub struct Struct;

--- a/tests/ui/suggestions/suggest-path-through-direct-dep-crate/hidden-reexport-of-nested-transitive-dep-item.rs
+++ b/tests/ui/suggestions/suggest-path-through-direct-dep-crate/hidden-reexport-of-nested-transitive-dep-item.rs
@@ -1,0 +1,16 @@
+//@ aux-build: transitive-dep.rs
+//@ aux-build: direct-dep-with-nesting.rs
+
+extern crate direct_dep_with_nesting as direct_dep;
+
+struct Struct;
+//~^ NOTE `Struct` is defined in the current crate
+
+fn main() {
+    let _: direct_dep::__private::inner::Struct = Struct;
+    //~^ ERROR mismatched types
+    //~| NOTE expected `direct_dep::__private::inner::Struct`, found `Struct`
+    //~| NOTE expected due to this
+    //~| NOTE `Struct` and `direct_dep::__private::inner::Struct` have similar names, but are actually distinct types
+    //~| NOTE `direct_dep::__private::inner::Struct` is defined in crate `transitive_dep`
+}

--- a/tests/ui/suggestions/suggest-path-through-direct-dep-crate/hidden-reexport-of-nested-transitive-dep-item.stderr
+++ b/tests/ui/suggestions/suggest-path-through-direct-dep-crate/hidden-reexport-of-nested-transitive-dep-item.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/hidden-reexport-of-nested-transitive-dep-item.rs:10:51
+   |
+LL |     let _: direct_dep::__private::inner::Struct = Struct;
+   |            ------------------------------------   ^^^^^^ expected `direct_dep::__private::inner::Struct`, found `Struct`
+   |            |
+   |            expected due to this
+   |
+   = note: `Struct` and `direct_dep::__private::inner::Struct` have similar names, but are actually distinct types
+note: `Struct` is defined in the current crate
+  --> $DIR/hidden-reexport-of-nested-transitive-dep-item.rs:6:1
+   |
+LL | struct Struct;
+   | ^^^^^^^^^^^^^
+note: `direct_dep::__private::inner::Struct` is defined in crate `transitive_dep`
+  --> $DIR/auxiliary/transitive-dep.rs:3:1
+   |
+LL | pub struct Struct;
+   | ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/suggestions/suggest-path-through-direct-dep-crate/hidden-reexport-of-transitive-dep-item.rs
+++ b/tests/ui/suggestions/suggest-path-through-direct-dep-crate/hidden-reexport-of-transitive-dep-item.rs
@@ -1,0 +1,16 @@
+//@ aux-build: transitive-dep.rs
+//@ aux-build: direct-dep.rs
+
+extern crate direct_dep;
+
+struct Struct;
+//~^ NOTE `Struct` is defined in the current crate
+
+fn main() {
+    let _: direct_dep::__private::Struct = Struct;
+    //~^ ERROR mismatched types
+    //~| NOTE expected `direct_dep::__private::Struct`, found `Struct`
+    //~| NOTE expected due to this
+    //~| NOTE `Struct` and `direct_dep::__private::Struct` have similar names, but are actually distinct types
+    //~| NOTE `direct_dep::__private::Struct` is defined in crate `transitive_dep`
+}

--- a/tests/ui/suggestions/suggest-path-through-direct-dep-crate/hidden-reexport-of-transitive-dep-item.stderr
+++ b/tests/ui/suggestions/suggest-path-through-direct-dep-crate/hidden-reexport-of-transitive-dep-item.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/hidden-reexport-of-transitive-dep-item.rs:10:44
+   |
+LL |     let _: direct_dep::__private::Struct = Struct;
+   |            -----------------------------   ^^^^^^ expected `direct_dep::__private::Struct`, found `Struct`
+   |            |
+   |            expected due to this
+   |
+   = note: `Struct` and `direct_dep::__private::Struct` have similar names, but are actually distinct types
+note: `Struct` is defined in the current crate
+  --> $DIR/hidden-reexport-of-transitive-dep-item.rs:6:1
+   |
+LL | struct Struct;
+   | ^^^^^^^^^^^^^
+note: `direct_dep::__private::Struct` is defined in crate `transitive_dep`
+  --> $DIR/auxiliary/transitive-dep.rs:3:1
+   |
+LL | pub struct Struct;
+   | ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
The `visible_parent_map` query misses putting the child items of `#[doc(hidden)]` modules into the queue, resulting in the breadth-first search missing them entirely. This results in inconsistent path printing behavior affecting diagnostics: namely that re-exports nested deeply within `#[doc(hidden)]` modules are not considered as a possible fallback path. See the linked issue (rust-lang/rust#159880) for more details and an example of how this manifests in diagnostics.

This PR makes sure that `#[doc(hidden)]` parents in the fallback map are still searched as part of the breadth-first search.

Fixes rust-lang/rust#159880.

The two tests for this change are based on the inconsistent diagnostics shown in the issue:
* `tests/ui/suggestions/suggest-path-through-direct-dep-crate/hidden-reexport-of-transitive-dep-item.rs` captures the current, expected behavior in the already working base case where the hidden module is still recorded in the fallback map;
* `tests/ui/suggestions/suggest-path-through-direct-dep-crate/hidden-reexport-of-nested-transitive-dep-item.rs` is a regression test for the breadth-first search covering nested children of `#[doc(hidden)]` modules to populate the fallback map by testing whether the diagnostic prefers the hidden but accessible path through the direct dependency crate.

Related PRs/issues:
* rust-lang/rust#87349
* rust-lang/rust#153477

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
