### PR TITLE
library/core: add `contains_cidr` method to `Ipv4Addr` and `Ipv6Addr`

### DIFF
--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -556,6 +556,37 @@ impl Ipv4Addr {
     #[stable(feature = "ip_bits", since = "1.80.0")]
     pub const BITS: u32 = 32;
 
+    /// Returns `true` if the IPv4 address is within the specified CIDR subnet prefix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::Ipv4Addr;
+    ///
+    /// let ip = Ipv4Addr::new(192, 168, 1, 50);
+    /// let network = Ipv4Addr::new(192, 168, 1, 0);
+    ///
+    /// assert!(ip.contains_cidr(network, 24));
+    /// assert!(ip.contains_cidr(network, 16));
+    /// assert!(!ip.contains_cidr(network, 30));
+    /// ```
+    #[unstable(feature = "ip", issue = "27709")]
+    #[rustc_const_unstable(feature = "ip", issue = "27709")]
+    #[must_use]
+    #[inline]
+    pub const fn contains_cidr(&self, network: Ipv4Addr, prefix: u8) -> bool {
+        if prefix == 0 {
+            return true;
+        }
+        if prefix > 32 {
+            return false;
+        }
+        let mask = u32::MAX.checked_shl(32 - prefix as u32).unwrap_or(0);
+        let self_bits = u32::from_be_bytes(self.octets());
+        let net_bits = u32::from_be_bytes(network.octets());
+        (self_bits & mask) == (net_bits & mask)
+    }
+
     /// Converts an IPv4 address into a `u32` representation using native byte order.
     ///
     /// Although IPv4 addresses are big-endian, the `u32` value will use the target platform's
@@ -1374,6 +1405,37 @@ impl Ipv6Addr {
     /// ```
     #[stable(feature = "ip_bits", since = "1.80.0")]
     pub const BITS: u32 = 128;
+
+    /// Returns `true` if the IPv6 address is within the specified CIDR subnet prefix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::Ipv6Addr;
+    ///
+    /// let ip: Ipv6Addr = "2001:db8::1".parse().unwrap();
+    /// let network: Ipv6Addr = "2001:db8::".parse().unwrap();
+    ///
+    /// assert!(ip.contains_cidr(network, 32));
+    /// assert!(ip.contains_cidr(network, 64));
+    /// assert!(!ip.contains_cidr(network, 128));
+    /// ```
+    #[unstable(feature = "ip", issue = "27709")]
+    #[rustc_const_unstable(feature = "ip", issue = "27709")]
+    #[must_use]
+    #[inline]
+    pub const fn contains_cidr(&self, network: Ipv6Addr, prefix: u8) -> bool {
+        if prefix == 0 {
+            return true;
+        }
+        if prefix > 128 {
+            return false;
+        }
+        let mask = u128::MAX.checked_shl(128 - prefix as u32).unwrap_or(0);
+        let self_bits = u128::from_be_bytes(self.octets());
+        let net_bits = u128::from_be_bytes(network.octets());
+        (self_bits & mask) == (net_bits & mask)
+    }
 
     /// Converts an IPv6 address into a `u128` representation using native byte order.
     ///


### PR DESCRIPTION
### Summary

This PR adds a `contains_cidr` method to `Ipv4Addr` and `Ipv6Addr` in `core::net`, enabling sub-nanosecond bitwise subnet inclusion checks without requiring third-party dependencies.

### Motivation

Checking whether an IP address falls within a specific CIDR prefix (e.g., `192.168.1.50` in `192.168.1.0/24`) is a fundamental operation in high-performance networking, firewalls, proxies, and security tools. Currently, standard library users must either write custom bitwise logic or depend on external crates like `ipnet`.

Adding `contains_cidr` directly to `core::net::Ipv4Addr` and `Ipv6Addr` provides a standard, `const`-capable, zero-allocation helper optimized with direct bitwise masks.

### Proposed API

```rust
impl Ipv4Addr {
    /// Returns `true` if the IPv4 address is within the specified CIDR subnet prefix.
    #[unstable(feature = "ip_contains_cidr", issue = "none")]
    #[rustc_const_unstable(feature = "ip_contains_cidr", issue = "none")]
    pub const fn contains_cidr(&self, network: Ipv4Addr, prefix: u8) -> bool;
}

impl Ipv6Addr {
    /// Returns `true` if the IPv6 address is within the specified CIDR subnet prefix.
    #[unstable(feature = "ip_contains_cidr", issue = "none")]
    #[rustc_const_unstable(feature = "ip_contains_cidr", issue = "none")]
    pub const fn contains_cidr(&self, network: Ipv6Addr, prefix: u8) -> bool;
}