### PR TITLE
compiletest: forward disable-minification from bootstrap

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2563,6 +2563,9 @@ Please disable assertions with `rust.debug-assertions = false`.
         if builder.config.rust_optimize_tests {
             cmd.arg("--optimize-tests");
         }
+        if !builder.config.docs_minification {
+            cmd.arg("--disable-minification");
+        }
         if builder.config.rust_randomize_layout {
             cmd.arg("--rust-randomized-layout");
         }

--- a/src/tools/compiletest/src/cli.rs
+++ b/src/tools/compiletest/src/cli.rs
@@ -257,6 +257,9 @@ struct Args {
     /// Run tests with optimizations enabled.
     #[arg(long)]
     optimize_tests: bool,
+    /// Pass `--disable-minification` to rustdoc when generating docs for tests.
+    #[arg(long)]
+    disable_minification: bool,
     /// Run tests verbosely, showing all output.
     #[arg(long)]
     verbose: bool,
@@ -441,6 +444,7 @@ pub(crate) fn parse_config(args: Vec<String>) -> Config {
         cxxflags: args.cxxflags,
         default_codegen_backend,
         diff_command: args.compiletest_diff_tool,
+        disable_minification: args.disable_minification,
 
         edition: args.edition,
 

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -553,6 +553,11 @@ pub(crate) struct Config {
     /// *only* applied to the [`PassFailMode::RunPass`] test crate and not its auxiliaries.
     pub(crate) optimize_tests: bool,
 
+    /// Whether rustdoc should disable CSS/JS minification when generating docs for tests.
+    ///
+    /// Forwarded from bootstrap's `build.docs-minification = false`.
+    pub(crate) disable_minification: bool,
+
     /// Target platform tuple.
     pub(crate) target: String,
 

--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -122,6 +122,7 @@ struct ConfigBuilder {
     rustc_debug_assertions: bool,
     std_debug_assertions: bool,
     std_remap_debuginfo: bool,
+    disable_minification: bool,
 }
 
 impl ConfigBuilder {
@@ -200,6 +201,11 @@ impl ConfigBuilder {
         self
     }
 
+    fn disable_minification(&mut self, is_enabled: bool) -> &mut Self {
+        self.disable_minification = is_enabled;
+        self
+    }
+
     fn build(&mut self) -> Config {
         let args = &[
             "compiletest",
@@ -266,6 +272,9 @@ impl ConfigBuilder {
         if self.std_remap_debuginfo {
             args.push("--with-std-remap-debuginfo".to_owned());
         }
+        if self.disable_minification {
+            args.push("--disable-minification".to_owned());
+        }
 
         args.push("--rustc-path".to_string());
         args.push(std::env::var("TEST_RUSTC").expect("must be configured by bootstrap"));
@@ -307,6 +316,15 @@ fn should_fail() {
     assert_eq!(d.should_fail, ShouldFail::No);
     let d = make_test_description(&config, tn, p, p, "//@ should-fail", None, None);
     assert_eq!(d.should_fail, ShouldFail::Yes);
+}
+
+#[test]
+fn disable_minification_flag() {
+    let config: Config = cfg().build();
+    assert!(!config.disable_minification);
+
+    let config: Config = cfg().disable_minification(true).build();
+    assert!(config.disable_minification);
 }
 
 #[test]

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1049,8 +1049,16 @@ impl<'test> TestCx<'test> {
         match kind {
             DocKind::Html => {}
             DocKind::Json => {
-                rustdoc.arg("--output-format").arg("json").arg("-Zunstable-options");
+                rustdoc.arg("--output-format").arg("json");
             }
+        }
+
+        // Both JSON output and `--disable-minification` are unstable rustdoc options.
+        if matches!(kind, DocKind::Json) || self.config.disable_minification {
+            rustdoc.arg("-Zunstable-options");
+        }
+        if self.config.disable_minification {
+            rustdoc.arg("--disable-minification");
         }
 
         if let Some(ref linker) = self.config.target_linker {
@@ -1609,6 +1617,15 @@ impl<'test> TestCx<'test> {
         // Enable wasm proc macros.
         if self.config.wasm_proc_macros {
             compiler.arg("-Zwasm-proc-macros");
+        }
+
+        // `--disable-minification` is an unstable rustdoc option. Rustdoc UI tests intentionally
+        // exercise diagnostics for unstable options, so don't enable them for that suite.
+        if compiler_kind == CompilerKind::Rustdoc
+            && self.config.disable_minification
+            && self.config.mode != TestMode::Ui
+        {
+            compiler.arg("-Zunstable-options").arg("--disable-minification");
         }
 
         // Hide libstd sources from ui tests to make sure we generate the stderr

--- a/src/tools/compiletest/src/rustdoc_gui_test.rs
+++ b/src/tools/compiletest/src/rustdoc_gui_test.rs
@@ -96,6 +96,7 @@ fn incomplete_config_for_rustdoc_gui_test() -> Config {
         target_rustcflags: Default::default(),
         rust_randomized_layout: Default::default(),
         optimize_tests: Default::default(),
+        disable_minification: Default::default(),
         target: Default::default(),
         host: Default::default(),
         cdb: Default::default(),


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

`build.docs-minification = false` was already honored when building docs through bootstrap's doc steps, but compiletest-driven rustdoc suites always generated minified CSS/JS.

Bootstrap now forwards `--disable-minification` to compiletest when docs minification is disabled, and compiletest passes `-Zunstable-options --disable-minification` to rustdoc for HTML/JS/JSON/UI doc generation.

Fixes rust-lang/rust#142737.