### PR TITLE
Fix `find_attr` hygiene and `rustc_hir` cleanups

### DIFF
--- a/compiler/rustc_hir/src/arena.rs
+++ b/compiler/rustc_hir/src/arena.rs
@@ -6,10 +6,10 @@ macro_rules! arena_types {
         $macro!([
             // HIR types
             [] asm_template: rustc_ast::InlineAsmTemplatePiece,
-            [] attribute: rustc_hir::Attribute,
-            [] owner_info: rustc_hir::OwnerInfo<'tcx>,
+            [] attribute: crate::Attribute,
+            [] owner_info: crate::OwnerInfo<'tcx>,
             [] macro_def: rustc_ast::MacroDef,
-            [] delegation_info: rustc_hir::DelegationInfo,
+            [] delegation_info: crate::DelegationInfo,
         ]);
     )
 }

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -12,7 +12,6 @@ use rustc_ast::{AttrStyle, Path, ast};
 use rustc_data_structures::Limit;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_error_messages::{DiagArgValue, IntoDiagArg};
-use rustc_hir::LangItem;
 use rustc_macros::{Decodable, Encodable, PrintAttribute, StableHash};
 use rustc_span::def_id::DefId;
 use rustc_span::hygiene::Transparency;
@@ -22,7 +21,7 @@ use thin_vec::ThinVec;
 
 use crate::attrs::diagnostic::*;
 use crate::attrs::pretty_printing::PrintAttribute;
-use crate::{DefaultBodyStability, PartialConstStability, RustcVersion, Stability};
+use crate::{DefaultBodyStability, LangItem, PartialConstStability, RustcVersion, Stability};
 
 #[derive(Copy, Clone, Debug, StableHash, Encodable, Decodable, PrintAttribute)]
 pub enum EiiImplResolution {

--- a/compiler/rustc_hir/src/attrs/mod.rs
+++ b/compiler/rustc_hir/src/attrs/mod.rs
@@ -85,13 +85,13 @@ macro_rules! find_attr {
         'done: {
             for i in $attributes_list {
                 #[allow(unused_imports)]
-                use rustc_hir::attrs::AttributeKind::*;
-                let i: &rustc_hir::Attribute = i;
+                use $crate::attrs::AttributeKind::*;
+                let i: &$crate::Attribute = i;
                 match i {
-                    rustc_hir::Attribute::Parsed($pattern) $(if $guard)? => {
+                    $crate::Attribute::Parsed($pattern) $(if $guard)? => {
                         break 'done Some($e);
                     }
-                    rustc_hir::Attribute::Unparsed(..) => {}
+                    $crate::Attribute::Unparsed(..) => {}
                     // In lint emitting, there's a specific exception for this warning.
                     // It's not usually emitted from inside macros from other crates
                     // (see https://github.com/rust-lang/rust/issues/110613)

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -136,48 +136,42 @@ impl<'hir> HirTyCtxt<'hir> for ! {
     }
 }
 
-pub mod nested_filter {
-    use super::HirTyCtxt;
+/// Specifies what nested things a visitor wants to visit. By "nested
+/// things", we are referring to bits of HIR that are not directly embedded
+/// within one another but rather indirectly, through a table in the crate.
+/// This is done to control dependencies during incremental compilation: the
+/// non-inline bits of HIR can be tracked and hashed separately.
+///
+/// The most common choice is `OnlyBodies`, which will cause the visitor to
+/// visit fn bodies for fns that it encounters, and closure bodies, but
+/// skip over nested item-like things.
+///
+/// See the [module level documentation](self) for more details on the overall
+/// visit strategy.
+pub trait NestedFilter<'hir> {
+    type MaybeTyCtxt: HirTyCtxt<'hir>;
 
-    /// Specifies what nested things a visitor wants to visit. By "nested
-    /// things", we are referring to bits of HIR that are not directly embedded
-    /// within one another but rather indirectly, through a table in the crate.
-    /// This is done to control dependencies during incremental compilation: the
-    /// non-inline bits of HIR can be tracked and hashed separately.
-    ///
-    /// The most common choice is `OnlyBodies`, which will cause the visitor to
-    /// visit fn bodies for fns that it encounters, and closure bodies, but
-    /// skip over nested item-like things.
-    ///
-    /// See the comments at [`rustc_hir::intravisit`] for more details on the overall
-    /// visit strategy.
-    pub trait NestedFilter<'hir> {
-        type MaybeTyCtxt: HirTyCtxt<'hir>;
-
-        /// Whether the visitor visits nested "item-like" things.
-        /// E.g., item, impl-item.
-        const INTER: bool;
-        /// Whether the visitor visits "intra item-like" things.
-        /// E.g., function body, closure, `AnonConst`
-        const INTRA: bool;
-    }
-
-    /// Do not visit any nested things. When you add a new
-    /// "non-nested" thing, you will want to audit such uses to see if
-    /// they remain valid.
-    ///
-    /// Use this if you are only walking some particular kind of tree
-    /// (i.e., a type, or fn signature) and you don't want to thread a
-    /// `tcx` around.
-    pub struct None(());
-    impl NestedFilter<'_> for None {
-        type MaybeTyCtxt = !;
-        const INTER: bool = false;
-        const INTRA: bool = false;
-    }
+    /// Whether the visitor visits nested "item-like" things.
+    /// E.g., item, impl-item.
+    const INTER: bool;
+    /// Whether the visitor visits "intra item-like" things.
+    /// E.g., function body, closure, `AnonConst`
+    const INTRA: bool;
 }
 
-use nested_filter::NestedFilter;
+/// Do not visit any nested things. When you add a new
+/// "non-nested" thing, you will want to audit such uses to see if
+/// they remain valid.
+///
+/// Use this if you are only walking some particular kind of tree
+/// (i.e., a type, or fn signature) and you don't want to thread a
+/// `tcx` around.
+pub struct IgnoreNested(());
+impl NestedFilter<'_> for IgnoreNested {
+    type MaybeTyCtxt = !;
+    const INTER: bool = false;
+    const INTRA: bool = false;
+}
 
 /// Each method of the Visitor trait is a hook to be potentially
 /// overridden. Each method's default implementation recursively visits
@@ -215,7 +209,7 @@ pub trait Visitor<'v>: Sized {
     /// `visit_nested_XXX` methods. If a new `visit_nested_XXX` variant is
     /// added in the future, it will cause a panic which can be detected
     /// and fixed appropriately.
-    type NestedFilter: NestedFilter<'v> = nested_filter::None;
+    type NestedFilter: NestedFilter<'v> = IgnoreNested;
 
     /// The result type of the `visit_*` methods. Can be either `()`,
     /// or `ControlFlow<T>`.
@@ -226,16 +220,16 @@ pub trait Visitor<'v>: Sized {
     fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
         panic!(
             "maybe_tcx must be implemented or consider using \
-            `type NestedFilter = nested_filter::None` (the default)"
+            `type NestedFilter = Skip` (the default)"
         );
     }
 
     /// Invoked when a nested item is encountered. By default, when
-    /// `Self::NestedFilter` is `nested_filter::None`, this method does
+    /// `Self::NestedFilter` is `Skip`, this method does
     /// nothing. **You probably don't want to override this method** --
     /// instead, override [`Self::NestedFilter`] or use the "shallow" or
     /// "deep" visit patterns described at
-    /// [`rustc_hir::intravisit`]. The only reason to override
+    /// [`intravisit`](self). The only reason to override
     /// this method is if you want a nested pattern but cannot supply a
     /// `TyCtxt`; see `maybe_tcx` for advice.
     fn visit_nested_item(&mut self, id: ItemId) -> Self::Result {

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -114,25 +114,25 @@ pub trait HirTyCtxt<'hir> {
     fn hir_foreign_item(&self, id: ForeignItemId) -> &'hir ForeignItem<'hir>;
 }
 
-// Used when no tcx is actually available, forcing manual implementation of nested visitors.
+/// Used when no tcx is actually available, forcing manual implementation of nested visitors.
 impl<'hir> HirTyCtxt<'hir> for ! {
     fn hir_node(&self, _: HirId) -> Node<'hir> {
-        unreachable!();
+        *self
     }
     fn hir_body(&self, _: BodyId) -> &'hir Body<'hir> {
-        unreachable!();
+        *self
     }
     fn hir_item(&self, _: ItemId) -> &'hir Item<'hir> {
-        unreachable!();
+        *self
     }
     fn hir_trait_item(&self, _: TraitItemId) -> &'hir TraitItem<'hir> {
-        unreachable!();
+        *self
     }
     fn hir_impl_item(&self, _: ImplItemId) -> &'hir ImplItem<'hir> {
-        unreachable!();
+        *self
     }
     fn hir_foreign_item(&self, _: ForeignItemId) -> &'hir ForeignItem<'hir> {
-        unreachable!();
+        *self
     }
 }
 

--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -15,8 +15,6 @@
 #![recursion_limit = "256"]
 // tidy-alphabetical-end
 
-extern crate self as rustc_hir;
-
 mod arena;
 pub mod attrs;
 pub mod canonical_symbols;

--- a/compiler/rustc_middle/src/hir/nested_filter.rs
+++ b/compiler/rustc_middle/src/hir/nested_filter.rs
@@ -1,4 +1,4 @@
-use rustc_hir::intravisit::nested_filter::NestedFilter;
+use rustc_hir::intravisit::NestedFilter;
 
 use crate::ty::TyCtxt;
 

--- a/src/tools/clippy/clippy_lints/src/lifetimes.rs
+++ b/src/tools/clippy/clippy_lints/src/lifetimes.rs
@@ -7,7 +7,7 @@ use rustc_ast::visit::{try_visit, walk_list};
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_errors::Applicability;
 use rustc_hir::FnRetTy::Return;
-use rustc_hir::intravisit::nested_filter::{self as hir_nested_filter, NestedFilter};
+use rustc_hir::intravisit::{IgnoreNested, NestedFilter};
 use rustc_hir::intravisit::{
     Visitor, VisitorExt, walk_fn_decl, walk_generic_args, walk_generic_param, walk_generics, walk_impl_item_ref,
     walk_param_bound, walk_poly_trait_ref, walk_trait_ref, walk_ty, walk_unambig_ty, walk_where_predicate,
@@ -714,7 +714,7 @@ fn report_extra_trait_object_lifetimes<'tcx>(
     generic_params: &'tcx [GenericParam<'_>],
     trait_ref: &'tcx TraitRef<'tcx>,
 ) {
-    let mut checker = LifetimeChecker::<hir_nested_filter::None>::new(cx, generic_params);
+    let mut checker = LifetimeChecker::<IgnoreNested>::new(cx, generic_params);
 
     for param in generic_params {
         walk_generic_param(&mut checker, param);
@@ -738,7 +738,7 @@ fn report_extra_trait_object_lifetimes<'tcx>(
 }
 
 fn report_extra_lifetimes<'tcx>(cx: &LateContext<'tcx>, func: &'tcx FnDecl<'_>, generics: &'tcx Generics<'_>) {
-    let mut checker = LifetimeChecker::<hir_nested_filter::None>::new(cx, generics.params);
+    let mut checker = LifetimeChecker::<IgnoreNested>::new(cx, generics.params);
 
     walk_generics(&mut checker, generics);
     walk_fn_decl(&mut checker, func);

--- a/src/tools/clippy/clippy_lints/src/unnecessary_literal_bound.rs
+++ b/src/tools/clippy/clippy_lints/src/unnecessary_literal_bound.rs
@@ -81,7 +81,7 @@ struct FindNonLiteralReturn;
 
 impl<'hir> Visitor<'hir> for FindNonLiteralReturn {
     type Result = std::ops::ControlFlow<()>;
-    type NestedFilter = intravisit::nested_filter::None;
+    type NestedFilter = intravisit::IgnoreNested;
 
     fn visit_expr(&mut self, expr: &'hir Expr<'hir>) -> Self::Result {
         if let ExprKind::Ret(Some(ret_val_expr)) = expr.kind


### PR DESCRIPTION
In particular, `extern crate self as rustc_hir;` leads to very noisy import suggestions if you get an import wrong. Also flatten the `nested_filter` module which seemed to exist just to avoid `None` / `Option:None` nameres conflicts