### PR TITLE
Clarify that the expected runtime symbols signature is for the current target only

### DIFF
--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -840,7 +840,7 @@ pub(crate) enum RedefiningRuntimeSymbolsDiag<'tcx> {
         "invalid definition of the runtime `{$symbol_name}` symbol used by the standard library"
     )]
     #[note(
-        "expected `{$expected_fn_sig}`
+        "expected `{$expected_fn_sig}` (for the current target)
     found    `{$found_fn_sig}`"
     )]
     #[help(
@@ -851,7 +851,7 @@ pub(crate) enum RedefiningRuntimeSymbolsDiag<'tcx> {
         "suspicious definition of the runtime `{$symbol_name}` symbol used by the standard library"
     )]
     #[note(
-        "expected `{$expected_fn_sig}`
+        "expected `{$expected_fn_sig}` (for the current target)
     found    `{$found_fn_sig}`"
     )]
     #[help(

--- a/tests/ui/lint/runtime-symbols-unix.stderr
+++ b/tests/ui/lint/runtime-symbols-unix.stderr
@@ -4,7 +4,7 @@ error: invalid definition of the runtime `open` symbol used by the standard libr
 LL |     pub fn open() {}
    |     ^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*const U8, i32, ...) -> i32`
+   = note: expected `unsafe extern "C" fn(*const U8, i32, ...) -> i32` (for the current target)
            found    `fn()`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "open")]`, or `#[link_name = "open"]`
    = note: `#[deny(invalid_runtime_symbol_definitions)]` on by default
@@ -15,7 +15,7 @@ error: invalid definition of the runtime `read` symbol used by the standard libr
 LL |         pub fn read();
    |         ^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(i32, *mut c_void, usize) -> isize`
+   = note: expected `unsafe extern "C" fn(i32, *mut c_void, usize) -> isize` (for the current target)
            found    `unsafe extern "C" fn()`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "read")]`, or `#[link_name = "read"]`
 
@@ -25,7 +25,7 @@ error: invalid definition of the runtime `write` symbol used by the standard lib
 LL |         pub fn write();
    |         ^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(i32, *const c_void, usize) -> isize`
+   = note: expected `unsafe extern "C" fn(i32, *const c_void, usize) -> isize` (for the current target)
            found    `unsafe extern "C" fn()`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "write")]`, or `#[link_name = "write"]`
 
@@ -35,7 +35,7 @@ error: invalid definition of the runtime `close` symbol used by the standard lib
 LL |     pub static close: () = ();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(i32) -> i32`
+   = note: expected `unsafe extern "C" fn(i32) -> i32` (for the current target)
            found    `()`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "close")]`, or `#[link_name = "close"]`
 
@@ -45,7 +45,7 @@ error: invalid definition of the runtime `malloc` symbol used by the standard li
 LL |         pub fn malloc();
    |         ^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(usize) -> *mut c_void`
+   = note: expected `unsafe extern "C" fn(usize) -> *mut c_void` (for the current target)
            found    `unsafe extern "C" fn()`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "malloc")]`, or `#[link_name = "malloc"]`
 
@@ -55,7 +55,7 @@ error: invalid definition of the runtime `realloc` symbol used by the standard l
 LL |         pub fn realloc();
    |         ^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void`
+   = note: expected `unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void` (for the current target)
            found    `unsafe extern "C" fn()`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "realloc")]`, or `#[link_name = "realloc"]`
 
@@ -65,7 +65,7 @@ error: invalid definition of the runtime `free` symbol used by the standard libr
 LL |         pub fn free();
    |         ^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*mut c_void)`
+   = note: expected `unsafe extern "C" fn(*mut c_void)` (for the current target)
            found    `unsafe extern "C" fn()`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "free")]`, or `#[link_name = "free"]`
 
@@ -75,7 +75,7 @@ error: invalid definition of the runtime `exit` symbol used by the standard libr
 LL |         pub fn exit();
    |         ^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(i32) -> !`
+   = note: expected `unsafe extern "C" fn(i32) -> !` (for the current target)
            found    `unsafe extern "C" fn()`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
 
@@ -85,7 +85,7 @@ warning: suspicious definition of the runtime `open` symbol used by the standard
 LL |         pub fn open(path: *const U8, oflag: usize, ...) -> c_int;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*const U8, i32, ...) -> i32`
+   = note: expected `unsafe extern "C" fn(*const U8, i32, ...) -> i32` (for the current target)
            found    `unsafe extern "C" fn(*const U8, usize, ...) -> i32`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "open")]`, or `#[link_name = "open"]`
    = help: allow this lint if the signature is compatible
@@ -97,7 +97,7 @@ warning: suspicious definition of the runtime `free` symbol used by the standard
 LL |         pub fn free(ptr: *const U8);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*mut c_void)`
+   = note: expected `unsafe extern "C" fn(*mut c_void)` (for the current target)
            found    `unsafe extern "C" fn(*const U8)`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "free")]`, or `#[link_name = "free"]`
    = help: allow this lint if the signature is compatible
@@ -108,7 +108,7 @@ warning: suspicious definition of the runtime `exit` symbol used by the standard
 LL |         pub fn exit(code: f32) -> !;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(i32) -> !`
+   = note: expected `unsafe extern "C" fn(i32) -> !` (for the current target)
            found    `unsafe extern "C" fn(f32) -> !`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
    = help: allow this lint if the signature is compatible
@@ -119,7 +119,7 @@ warning: suspicious definition of the runtime `exit` symbol used by the standard
 LL |         pub static exit2: Option<unsafe extern "C" fn(f32) -> !>;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(i32) -> !`
+   = note: expected `unsafe extern "C" fn(i32) -> !` (for the current target)
            found    `unsafe extern "C" fn(f32) -> !`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
    = help: allow this lint if the signature is compatible
@@ -130,7 +130,7 @@ warning: suspicious definition of the runtime `exit` symbol used by the standard
 LL |         pub fn exit3(code: i32) -> i32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(i32) -> !`
+   = note: expected `unsafe extern "C" fn(i32) -> !` (for the current target)
            found    `unsafe extern "C" fn(i32) -> i32`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
    = help: allow this lint if the signature is compatible
@@ -141,7 +141,7 @@ warning: suspicious definition of the runtime `exit` symbol used by the standard
 LL |         pub fn exit4(code: i32);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(i32) -> !`
+   = note: expected `unsafe extern "C" fn(i32) -> !` (for the current target)
            found    `unsafe extern "C" fn(i32)`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "exit")]`, or `#[link_name = "exit"]`
    = help: allow this lint if the signature is compatible

--- a/tests/ui/lint/runtime-symbols.stderr
+++ b/tests/ui/lint/runtime-symbols.stderr
@@ -4,7 +4,7 @@ error: invalid definition of the runtime `memmove` symbol used by the standard l
 LL |     pub fn memmove() {}
    |     ^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*mut c_void, *const c_void, usize) -> *mut c_void`
+   = note: expected `unsafe extern "C" fn(*mut c_void, *const c_void, usize) -> *mut c_void` (for the current target)
            found    `fn()`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "memmove")]`, or `#[link_name = "memmove"]`
    = note: `#[deny(invalid_runtime_symbol_definitions)]` on by default
@@ -15,7 +15,7 @@ error: invalid definition of the runtime `memset` symbol used by the standard li
 LL |         pub fn memset();
    |         ^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*mut c_void, i32, usize) -> *mut c_void`
+   = note: expected `unsafe extern "C" fn(*mut c_void, i32, usize) -> *mut c_void` (for the current target)
            found    `unsafe extern "C" fn()`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "memset")]`, or `#[link_name = "memset"]`
 
@@ -25,7 +25,7 @@ error: invalid definition of the runtime `memcmp` symbol used by the standard li
 LL |         pub fn memcmp();
    |         ^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*const c_void, *const c_void, usize) -> i32`
+   = note: expected `unsafe extern "C" fn(*const c_void, *const c_void, usize) -> i32` (for the current target)
            found    `unsafe extern "C" fn()`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "memcmp")]`, or `#[link_name = "memcmp"]`
 
@@ -35,7 +35,7 @@ error: invalid definition of the runtime `strlen` symbol used by the standard li
 LL |     pub static strlen: () = ();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*const U8) -> usize`
+   = note: expected `unsafe extern "C" fn(*const U8) -> usize` (for the current target)
            found    `()`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "strlen")]`, or `#[link_name = "strlen"]`
 
@@ -45,7 +45,7 @@ error: invalid definition of the runtime `strlen` symbol used by the standard li
 LL |         static strlen2: Option<unsafe extern "C" fn(s: *const c_char)>;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*const U8) -> usize`
+   = note: expected `unsafe extern "C" fn(*const U8) -> usize` (for the current target)
            found    `unsafe extern "C" fn(*const U8)`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "strlen")]`, or `#[link_name = "strlen"]`
 
@@ -55,7 +55,7 @@ error: invalid definition of the runtime `memcpy` symbol used by the standard li
 LL |     pub fn memcpy(dest: *mut c_void, src: *const c_void, n: usize) -> *mut c_void {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*mut c_void, *const c_void, usize) -> *mut c_void`
+   = note: expected `unsafe extern "C" fn(*mut c_void, *const c_void, usize) -> *mut c_void` (for the current target)
            found    `fn(*mut c_void, *const c_void, usize) -> *mut c_void`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "memcpy")]`, or `#[link_name = "memcpy"]`
 
@@ -65,7 +65,7 @@ error: invalid definition of the runtime `bcmp` symbol used by the standard libr
 LL |     pub unsafe extern "C" fn bcmp(s1: *const c_void, s2: *const c_void, n: usize, _: ...) -> c_int {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*const c_void, *const c_void, usize) -> i32`
+   = note: expected `unsafe extern "C" fn(*const c_void, *const c_void, usize) -> i32` (for the current target)
            found    `unsafe extern "C" fn(*const c_void, *const c_void, usize, ...) -> i32`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "bcmp")]`, or `#[link_name = "bcmp"]`
 
@@ -75,7 +75,7 @@ error: invalid definition of the runtime `bcmp` symbol used by the standard libr
 LL |     pub extern "C" fn bcmp_(s1: *const c_void, s2: *const c_void, n: usize) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*const c_void, *const c_void, usize) -> i32`
+   = note: expected `unsafe extern "C" fn(*const c_void, *const c_void, usize) -> i32` (for the current target)
            found    `extern "C" fn(*const c_void, *const c_void, usize)`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "bcmp")]`, or `#[link_name = "bcmp"]`
 
@@ -85,7 +85,7 @@ warning: suspicious definition of the runtime `memcpy` symbol used by the standa
 LL |     pub extern "C" fn memcpy(dest: *mut c_void, src: *const c_void, n: i64) -> *mut c_void {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*mut c_void, *const c_void, usize) -> *mut c_void`
+   = note: expected `unsafe extern "C" fn(*mut c_void, *const c_void, usize) -> *mut c_void` (for the current target)
            found    `extern "C" fn(*mut c_void, *const c_void, i64) -> *mut c_void`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "memcpy")]`, or `#[link_name = "memcpy"]`
    = help: allow this lint if the signature is compatible
@@ -97,7 +97,7 @@ warning: suspicious definition of the runtime `memmove` symbol used by the stand
 LL |     pub extern "C" fn memmove(dest: *mut c_void, src: *const c_void, n: i64) -> *mut c_void {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*mut c_void, *const c_void, usize) -> *mut c_void`
+   = note: expected `unsafe extern "C" fn(*mut c_void, *const c_void, usize) -> *mut c_void` (for the current target)
            found    `extern "C" fn(*mut c_void, *const c_void, i64) -> *mut c_void`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "memmove")]`, or `#[link_name = "memmove"]`
    = help: allow this lint if the signature is compatible
@@ -108,7 +108,7 @@ warning: suspicious definition of the runtime `memset` symbol used by the standa
 LL |         fn memset(s: *mut c_void, c: c_int, n: usize) -> f64;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*mut c_void, i32, usize) -> *mut c_void`
+   = note: expected `unsafe extern "C" fn(*mut c_void, i32, usize) -> *mut c_void` (for the current target)
            found    `unsafe extern "C" fn(*mut c_void, i32, usize) -> f64`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "memset")]`, or `#[link_name = "memset"]`
    = help: allow this lint if the signature is compatible
@@ -119,7 +119,7 @@ warning: suspicious definition of the runtime `bcmp` symbol used by the standard
 LL |     pub extern "C" fn bcmp_(s1: *const U8, s2: *const U8, n: usize) -> c_int {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*const c_void, *const c_void, usize) -> i32`
+   = note: expected `unsafe extern "C" fn(*const c_void, *const c_void, usize) -> i32` (for the current target)
            found    `extern "C" fn(*const U8, *const U8, usize) -> i32`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "bcmp")]`, or `#[link_name = "bcmp"]`
    = help: allow this lint if the signature is compatible
@@ -130,7 +130,7 @@ warning: suspicious definition of the runtime `strlen` symbol used by the standa
 LL |     pub extern "C" fn strlen(s: *const u64) -> usize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `unsafe extern "C" fn(*const U8) -> usize`
+   = note: expected `unsafe extern "C" fn(*const U8) -> usize` (for the current target)
            found    `extern "C" fn(*const u64) -> usize`
    = help: either fix the signature or remove any attributes like `#[unsafe(no_mangle)]`, `#[unsafe(export_name = "strlen")]`, or `#[link_name = "strlen"]`
    = help: allow this lint if the signature is compatible


### PR DESCRIPTION
Some of the signatures expected by our runtime symbols are slightly different from one target to the other one (`i8` vs `u8`), and while the original definition uses type alias, they are not recorded and displayed in the diagnostic.

So, to avoid any ambiguity let's add a small note that the displayed signature is only for the current target.

r? @GuillaumeGomez
