### PR TITLE
rename abort_unwind → abort_on_unwind

### DIFF
--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -116,7 +116,7 @@ pub macro unreachable_2021 {
 /// convert unwinds to aborts, so using this function isn't necessary for FFI.
 #[unstable(feature = "abort_unwind", issue = "130338")]
 #[rustc_nounwind]
-pub fn abort_unwind<F: FnOnce() -> R, R>(f: F) -> R {
+pub fn abort_on_unwind<F: FnOnce() -> R, R>(f: F) -> R {
     f()
 }
 

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -285,7 +285,7 @@ where
 }
 
 #[unstable(feature = "abort_unwind", issue = "130338")]
-pub use core::panic::abort_unwind;
+pub use core::panic::abort_on_unwind;
 
 /// Invokes a closure, capturing the cause of an unwinding panic if one occurs.
 ///

--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -166,8 +166,8 @@ fn lang_start_internal(
     // prevent std from accidentally introducing a panic to these functions. Another is from
     // user code from `main` or, more nefariously, as described in e.g. issue #86030.
     //
-    // We use `catch_unwind` with `handle_rt_panic` instead of `abort_unwind` to make the error in
-    // case of a panic a bit nicer.
+    // We use `catch_unwind` with `handle_rt_panic` instead of `abort_on_unwind` to make the error
+    // in case of a panic a bit nicer.
     panic::catch_unwind(move || {
         // SAFETY: Only called once during runtime initialization.
         unsafe { init(argc, argv, sigpipe) };

--- a/src/tools/miri/src/shims/native_lib/trace/child.rs
+++ b/src/tools/miri/src/shims/native_lib/trace/child.rs
@@ -1,6 +1,10 @@
 use std::cell::RefCell;
 use std::ptr::NonNull;
 use std::rc::Rc;
+#[cfg(bootstrap)]
+use std::panic::abort_unwind as abort_on_unwind;
+#[cfg(not(bootstrap))]
+use std::panic::abort_on_unwind;
 
 use ipc_channel::{TryRecvError, ipc};
 use nix::sys::{mman, ptrace, signal};
@@ -89,7 +93,7 @@ impl Supervisor {
 
         // Unwinding might be messed up due to partly protected memory, so let's abort if something
         // breaks inside here.
-        let res = std::panic::abort_unwind(|| {
+        let res = abort_on_unwind(|| {
             // Send over the info.
             // NB: if we do not wait to receive a blank confirmation response, it is
             // possible that the supervisor is alerted of the SIGSTOP *before* it has

--- a/src/tools/miri/tests/fail/panic/abort_unwind.rs
+++ b/src/tools/miri/tests/fail/panic/abort_unwind.rs
@@ -5,5 +5,5 @@
 #![feature(abort_unwind)]
 
 fn main() {
-    std::panic::abort_unwind(|| panic!("PANIC!!!"));
+    std::panic::abort_on_unwind(|| panic!("PANIC!!!"));
 }

--- a/src/tools/miri/tests/genmc/pass/shims/mutex_simple.rs
+++ b/src/tools/miri/tests/genmc/pass/shims/mutex_simple.rs
@@ -27,7 +27,7 @@ static LOCK: Mutex<u64> = Mutex::new(0);
 
 #[unsafe(no_mangle)]
 fn miri_start(_argc: isize, _argv: *const *const u8) -> isize {
-    std::panic::abort_unwind(main_);
+    std::panic::abort_on_unwind(main_);
     0
 }
 


### PR DESCRIPTION
As suggested in the tracking issue (rust-lang/rust#130338).
r? @nia-e 
Cc @rust-lang/libs-api 