### PR TITLE
Redefine `c_void`

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -272,7 +272,7 @@ language_item_table! {
     OrderingEnum,            sym::Ordering,            ordering_enum,              Target::Enum,           GenericRequirement::Exact(0);
     PartialEq,               sym::eq,                  eq_trait,                   Target::Trait,          GenericRequirement::Exact(1);
     PartialOrd,              sym::partial_ord,         partial_ord_trait,          Target::Trait,          GenericRequirement::Exact(1);
-    CVoid,                   sym::c_void,              c_void,                     Target::Enum,           GenericRequirement::None;
+    CVoid,                   sym::c_void,              c_void,                     Target::Struct,         GenericRequirement::None;
 
     Type,                    sym::type_info,           type_struct,                Target::Struct,         GenericRequirement::None;
     TypeId,                  sym::type_id,             type_id,                    Target::Struct,         GenericRequirement::None;

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -55,6 +55,9 @@ pub struct c_void {
     _inner: u8,
     #[cfg(miri)]
     _uninhabited: !,
+    // Ensure no `Freeze`, for consistency with `not(miri)`
+    #[cfg(miri)]
+    _nonfreeze: crate::cell::SyncUnsafeCell<()>,
 }
 
 // for backward compatibility.

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -45,19 +45,13 @@ pub struct c_void {
     // while minimizing UB if a user incorrectly tries
     // to dereference a pointer to `c_void`,
     // or reborrow it as a reference.
-    #[cfg(not(miri))]
     _inner: crate::pin::UnsafePinned<crate::mem::MaybeUninit<u8>>,
 
     // However, if running in Miri,
     // we want to maximize detection of UB,
     // so we make `c_void` uninhabited.
     #[cfg(miri)]
-    _inner: u8,
-    #[cfg(miri)]
     _uninhabited: !,
-    // Ensure no `Freeze`, for consistency with `not(miri)`
-    #[cfg(miri)]
-    _nonfreeze: crate::cell::SyncUnsafeCell<()>,
 }
 
 // for backward compatibility.

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -9,6 +9,10 @@
 #![stable(feature = "core_ffi", since = "1.30.0")]
 #![allow(non_camel_case_types)]
 
+use crate::fmt;
+use crate::panic::RefUnwindSafe;
+#[stable(feature = "c_str_module", since = "1.88.0")]
+pub mod c_str;
 #[doc(inline)]
 #[stable(feature = "core_c_str", since = "1.64.0")]
 pub use self::c_str::CStr;
@@ -18,14 +22,6 @@ pub use self::c_str::FromBytesUntilNulError;
 #[doc(inline)]
 #[stable(feature = "core_c_str", since = "1.64.0")]
 pub use self::c_str::FromBytesWithNulError;
-use crate::fmt;
-
-#[stable(feature = "c_str_module", since = "1.88.0")]
-pub mod c_str;
-
-mod va_list;
-#[stable(feature = "c_variadic", since = "CURRENT_RUSTC_VERSION")]
-pub use self::va_list::{VaArgSafe, VaList};
 
 mod primitives;
 #[stable(feature = "core_ffi_c", since = "1.64.0")]
@@ -36,34 +32,34 @@ pub use self::primitives::{
 #[unstable(feature = "c_size_t", issue = "88345")]
 pub use self::primitives::{c_ptrdiff_t, c_size_t, c_ssize_t};
 
-// N.B., for LLVM to recognize the void pointer type and by extension
-//     functions like malloc(), we need to have it represented as i8* in
-//     LLVM bitcode. The enum used here ensures this and prevents misuse
-//     of the "raw" type by only having private variants. We need two
-//     variants, because the compiler complains about the repr attribute
-//     otherwise and we need at least one variant as otherwise the enum
-//     would be uninhabited and at least dereferencing such pointers would
-//     be UB.
+mod va_list;
+#[stable(feature = "c_variadic", since = "CURRENT_RUSTC_VERSION")]
+pub use self::va_list::{VaArgSafe, VaList};
+
 #[doc = include_str!("c_void.md")]
 #[lang = "c_void"]
-#[repr(u8)]
+#[repr(transparent)]
 #[stable(feature = "core_c_void", since = "1.30.0")]
-pub enum c_void {
-    #[unstable(
-        feature = "c_void_variant",
-        reason = "temporary implementation detail",
-        issue = "none"
-    )]
-    #[doc(hidden)]
-    __variant1,
-    #[unstable(
-        feature = "c_void_variant",
-        reason = "temporary implementation detail",
-        issue = "none"
-    )]
-    #[doc(hidden)]
-    __variant2,
+pub struct c_void {
+    // Using this weird type ensures a size of 1,
+    // while minimizing UB if a user incorrectly tries
+    // to dereference a pointer to `c_void`,
+    // or reborrow it as a reference.
+    #[cfg(not(miri))]
+    _inner: crate::pin::UnsafePinned<crate::mem::MaybeUninit<u8>>,
+
+    // However, if running in Miri,
+    // we want to maximize detection of UB,
+    // so we make `c_void` uninhabited.
+    #[cfg(miri)]
+    _inner: u8,
+    #[cfg(miri)]
+    _uninhabited: !,
 }
+
+// for backward compatibility.
+#[stable(feature = "core_c_void", since = "1.30.0")]
+impl RefUnwindSafe for c_void {}
 
 #[stable(feature = "std_debug", since = "1.16.0")]
 impl fmt::Debug for c_void {

--- a/src/doc/unstable-book/src/library-features/c-void-variant.md
+++ b/src/doc/unstable-book/src/library-features/c-void-variant.md
@@ -1,5 +1,0 @@
-# `c_void_variant`
-
-This feature is internal to the Rust compiler and is not intended for general use.
-
-------------------------

--- a/src/tools/miri/src/shims/native_lib/mod.rs
+++ b/src/tools/miri/src/shims/native_lib/mod.rs
@@ -492,7 +492,7 @@ pub fn build_libffi_closure<'tcx, 'this>(
 /// As future improvement we might continue execution in the interpreter here.
 unsafe extern "C" fn libffi_closure_callback<'tcx>(
     _cif: &libffi::low::ffi_cif,
-    _result: &mut c_void,
+    _result: &mut (),
     _args: *const *const c_void,
     data: &LibffiClosureData<'tcx>,
 ) {

--- a/src/tools/miri/tests/fail/validity/c-void-validity.rs
+++ b/src/tools/miri/tests/fail/validity/c-void-validity.rs
@@ -1,0 +1,7 @@
+use core::ffi::c_void;
+
+fn main() {
+    let mut b: u8 = 0;
+    let p: *const c_void = (&raw mut b).cast_const().cast();
+    let _r: &c_void = unsafe { &*p }; //~ERROR: constructing invalid value
+}

--- a/src/tools/miri/tests/fail/validity/c-void-validity.stderr
+++ b/src/tools/miri/tests/fail/validity/c-void-validity.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: constructing invalid value of type &std::ffi::c_void: encountered a reference pointing to uninhabited type `std::ffi::c_void`
+  --> tests/fail/validity/c-void-validity.rs:LL:CC
+   |
+LL |     let _r: &c_void = unsafe { &*p };
+   |                                ^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/src/tools/rust-analyzer/crates/ide-db/src/generated/lints.rs
+++ b/src/tools/rust-analyzer/crates/ide-db/src/generated/lints.rs
@@ -4363,18 +4363,6 @@ The tracking issue for this feature is: [#148767]
         deny_since: None,
     },
     Lint {
-        label: "c_void_variant",
-        description: r##"# `c_void_variant`
-
-This feature is internal to the Rust compiler and is not intended for general use.
-
-------------------------
-"##,
-        default_severity: Severity::Allow,
-        warn_since: None,
-        deny_since: None,
-    },
-    Lint {
         label: "can_vector",
         description: r##"# `can_vector`
 

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -25,6 +25,7 @@
     auto_traits,
     freeze_impls,
     negative_impls,
+    never_type,
     pattern_types,
     rustc_attrs,
     decl_macro,
@@ -392,10 +393,10 @@ pub mod hint {
 }
 
 #[lang = "c_void"]
-#[repr(u8)]
-pub enum c_void {
-    __variant1,
-    __variant2,
+#[repr(transparent)]
+pub struct c_void {
+    _inner: u8,
+    _uninhabited: !,
 }
 
 #[rustc_builtin_macro(pattern_type)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159935)*
<!-- homu-ignore:end -->

The current definition is based on legacy cruft which no longer matter. Let's make it somewhat saner:

- **Outside Miri**: be maximally accepting, use `UnsafePinned` and `MaybeUninit` to make it as difficult as possible to cause UB with the type.
- **Inside Miri**: make `c_void`  uninhabited. That way, any attempt to construct a value of `c_void`, or a reference to it, gets flagged. (Such code is essentially guaranteed to be wrong, as `c_void` should only be used behind a raw pointer. However, people [love to do it anyway](https://github.com/search?q=+lang%3ARust+%2F%26%28%27%5Ba-z_%5D%2B+%29%3F%28mut+%29%3F%28%5Ba-z%3A%5D*%29%3Fc_void%2F&type=code). We should add a lint at some point…)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

@rustbot label A-FFI A-miri
