### PR TITLE
Update expect messages in library/core/src/ptr/non_null.rs

### DIFF
--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -259,7 +259,7 @@ impl<T: PointeeSized> NonNull<T> {
     /// use std::ptr::NonNull;
     ///
     /// let mut x = 0u32;
-    /// let ptr = NonNull::<u32>::new(&mut x as *mut _).expect("ptr is null!");
+    /// let ptr = NonNull::<u32>::new(&mut x as *mut _).expect("pointer should not be null");
     ///
     /// if let Some(ptr) = NonNull::<u32>::new(std::ptr::null_mut()) {
     ///     unreachable!();
@@ -386,7 +386,7 @@ impl<T: PointeeSized> NonNull<T> {
     /// use std::ptr::NonNull;
     ///
     /// let mut x = 0u32;
-    /// let ptr = NonNull::new(&mut x).expect("ptr is null!");
+    /// let ptr = NonNull::new(&mut x).expect("pointer should not be null");
     ///
     /// let x_value = unsafe { *ptr.as_ptr() };
     /// assert_eq!(x_value, 0);
@@ -428,7 +428,7 @@ impl<T: PointeeSized> NonNull<T> {
     /// use std::ptr::NonNull;
     ///
     /// let mut x = 0u32;
-    /// let ptr = NonNull::new(&mut x as *mut _).expect("ptr is null!");
+    /// let ptr = NonNull::new(&mut x as *mut _).expect("pointer should not be null");
     ///
     /// let ref_x = unsafe { ptr.as_ref() };
     /// println!("{ref_x}");
@@ -464,7 +464,7 @@ impl<T: PointeeSized> NonNull<T> {
     /// use std::ptr::NonNull;
     ///
     /// let mut x = 0u32;
-    /// let mut ptr = NonNull::new(&mut x).expect("null pointer");
+    /// let mut ptr = NonNull::new(&mut x).expect("pointer should not be null");
     ///
     /// let x_ref = unsafe { ptr.as_mut() };
     /// assert_eq!(*x_ref, 0);
@@ -491,7 +491,7 @@ impl<T: PointeeSized> NonNull<T> {
     /// use std::ptr::NonNull;
     ///
     /// let mut x = 0u32;
-    /// let ptr = NonNull::new(&mut x as *mut _).expect("null pointer");
+    /// let ptr = NonNull::new(&mut x as *mut _).expect("pointer should not be null");
     ///
     /// let casted_ptr = ptr.cast::<i8>();
     /// let raw_ptr: *mut i8 = casted_ptr.as_ptr();


### PR DESCRIPTION
Related issue: rust-lang/rust#159751

Updates the expect messages in library/core/src/ptr/non_null.rs to follow the recommended style.