### PR TITLE
Add CFI tests for return types and never type

### DIFF
--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-return-types.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-id-itanium-cxx-abi-return-types.rs
@@ -1,0 +1,52 @@
+// Verifies that type metadata identifiers for functions are emitted correctly
+// for return types.
+//
+//@ needs-sanitizer-cfi
+//@ compile-flags: -Clto -Cno-prepopulate-passes -Copt-level=0 -Zsanitizer=cfi -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitizer
+
+#![crate_type = "lib"]
+
+extern crate core;
+use core::ffi::*;
+
+pub unsafe extern "C" fn foo1() {}
+// CHECK: define{{.*}}foo1{{.*}}!type ![[TYPE1:[0-9]+]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
+
+// This should probably have the same CFI type as `foo1`, but it doesn't right now.
+pub unsafe extern "C" fn foo2() -> ! {
+    loop {}
+}
+// CHECK: define{{.*}}foo2{{.*}}!type ![[TYPE2:[0-9]+]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
+
+pub unsafe extern "C" fn foo3(arg: *mut c_void) -> *mut c_void {
+    arg
+}
+// CHECK: define{{.*}}foo3{{.*}}!type ![[TYPE3:[0-9]+]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
+
+pub unsafe extern "C" fn foo4(arg: *const c_void) -> *const c_void {
+    arg
+}
+// CHECK: define{{.*}}foo4{{.*}}!type ![[TYPE4:[0-9]+]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
+
+// `*mut ()` has the same CFI type (`_ZTSFPvS_E`) as `*mut c_void` (`foo3`), so it reuses `TYPE3`.
+pub unsafe extern "C" fn foo5(arg: *mut ()) -> *mut () {
+    arg
+}
+// CHECK: define{{.*}}foo5{{.*}}!type ![[TYPE3:[0-9]+]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
+
+pub unsafe extern "C" fn foo6(arg: *mut u8) -> *mut u8 {
+    arg
+}
+// CHECK: define{{.*}}foo6{{.*}}!type ![[TYPE6:[0-9]+]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
+
+pub unsafe extern "C" fn foo7(arg: *mut i8) -> *mut i8 {
+    arg
+}
+// CHECK: define{{.*}}foo7{{.*}}!type ![[TYPE7:[0-9]+]] !type !{{[0-9]+}} !type !{{[0-9]+}} !type !{{[0-9]+}}
+
+// CHECK: ![[TYPE1]] = !{i64 0, !"_ZTSFvvE"}
+// CHECK: ![[TYPE2]] = !{i64 0, !"_ZTSFu5nevervE"}
+// CHECK: ![[TYPE3]] = !{i64 0, !"_ZTSFPvS_E"}
+// CHECK: ![[TYPE4]] = !{i64 0, !"_ZTSFPKvS0_E"}
+// CHECK: ![[TYPE6]] = !{i64 0, !"_ZTSFPu2u8S0_E"}
+// CHECK: ![[TYPE7]] = !{i64 0, !"_ZTSFPu2i8S0_E"}


### PR DESCRIPTION
In a few different conversations, the CFI types of various functions has come up. First, the CFI type of returning `!` came up in https://github.com/rust-lang/rust/issues/159446#issuecomment-5011154213, where we found that it doesn't have the same CFI type as returning `()`, which it probably should.

Then in rust-lang/rust#159935, I wanted to make sure that this does not change the CFI type of functions when `*mut c_void` appears as an argument. Luckily it does not since it's a lang item, but there's no test for this case.

Thus, add tests for all of these cases and a few others.

AI assistance was involved with writing the test.