### PR TITLE
Fallback F_DUPFD_CLOEXEC to non-atomic ops on AIX on EINVAL

### DIFF
--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -125,8 +125,24 @@ impl BorrowedFd<'_> {
         let cmd = libc::F_DUPFD;
 
         // Avoid using file descriptors below 3 as they are used for stdio
-        let fd = cvt(unsafe { libc::fcntl(self.as_raw_fd(), cmd, 3) })?;
-        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+        let fd = cvt(unsafe { libc::fcntl(self.as_raw_fd(), cmd, 3) });
+
+        // Some older AIX 7.2 versions don't implement F_DUPFD_CLOEXEC and return EINVAL.
+        // Try to fallback to a non-atomic F_DUPFD + FD_CLOEXEC.
+        #[cfg(target_os = "aix")]
+        let fd = match fd {
+            Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {
+                let fd = cvt(unsafe { libc::fcntl(self.as_raw_fd(), libc::F_DUPFD, 3) })?;
+                if let Err(e) = cvt(unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) }) {
+                    unsafe { libc::close(fd) };
+                    return Err(e);
+                }
+                Ok(fd)
+            }
+            fd => fd,
+        };
+
+        Ok(unsafe { OwnedFd::from_raw_fd(fd?) })
     }
 
     /// Creates a new `OwnedFd` instance that shares the same underlying file


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

AIX 7.2 TL2 (and older) doesn't support `F_DUPFD_CLOEXEC`, and `fcntl` returns `EINVAL` in that case, similarly to older Linux kernels.

This makes `tokio` fail to initialize on those versions: `Failed building the Runtime: Os { code: 22, EINVAL }`.

This PR implements a fallback to non-atomically do `F_DUPFD` then set `FD_CLOEXEC` when `EINVAL` is returned on AIX.

A similar mechanism used to exist for Linux (removed by https://github.com/rust-lang/rust/pull/74606).