### PR TITLE
core: implement float conversion methods

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -41,6 +41,8 @@ use crate::marker::PointeeSized;
 
 mod num;
 
+#[unstable(feature = "float_conversions", issue = "159913")]
+pub use num::FloatToFloat;
 #[unstable(feature = "convert_float_to_int", issue = "67057")]
 pub use num::FloatToInt;
 #[unstable(feature = "integer_casts", issue = "157388")]

--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -7,6 +7,14 @@ pub impl(self) trait FloatToInt<Int>: Sized {
     #[unstable(feature = "convert_float_to_int", issue = "67057")]
     #[doc(hidden)]
     unsafe fn to_int_unchecked(self) -> Int;
+
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[doc(hidden)]
+    fn to_int_saturating(self) -> Int;
+
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[doc(hidden)]
+    fn to_int_checked(self) -> Option<Int>;
 }
 
 macro_rules! impl_float_to_int {
@@ -19,6 +27,24 @@ macro_rules! impl_float_to_int {
                     // SAFETY: the safety contract must be upheld by the caller.
                     unsafe { crate::intrinsics::float_to_int_unchecked(self) }
                 }
+                #[inline]
+                fn to_int_saturating(self) -> $Int {
+                    // `as` already saturates and maps `NaN` to zero.
+                    self as $Int
+                }
+                #[inline]
+                fn to_int_checked(self) -> Option<$Int> {
+                    // `as` truncates toward zero and these bounds are exact for
+                    // that: `MAX + 1` rounds up to the first out-of-range value,
+                    // and the `- MIN` offset keeps the low comparison exact even
+                    // when `MIN - 1` is not representable. `NaN` and infinities
+                    // fail both comparisons.
+                    if self - (<$Int>::MIN as $Float) > -1.0 && self < <$Int>::MAX as $Float + 1.0 {
+                        Some(self as $Int)
+                    } else {
+                        None
+                    }
+                }
             }
         )+
     }
@@ -28,6 +54,34 @@ impl_float_to_int!(f16 => u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i12
 impl_float_to_int!(f32 => u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
 impl_float_to_int!(f64 => u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
 impl_float_to_int!(f128 => u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
+
+/// Supporting trait for the inherent `cast` method converting between float types.
+/// Typically doesn’t need to be used directly.
+#[unstable(feature = "float_conversions", issue = "159913")]
+pub impl(self) trait FloatToFloat<Flt>: Sized {
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[doc(hidden)]
+    fn cast(self) -> Flt;
+}
+
+macro_rules! impl_float_to_float {
+    ($Float:ty => $($Flt:ty),+) => {
+        $(
+            #[unstable(feature = "float_conversions", issue = "159913")]
+            impl FloatToFloat<$Flt> for $Float {
+                #[inline]
+                fn cast(self) -> $Flt {
+                    self as $Flt
+                }
+            }
+        )+
+    }
+}
+
+impl_float_to_float!(f16 => f16, f32, f64, f128);
+impl_float_to_float!(f32 => f16, f32, f64, f128);
+impl_float_to_float!(f64 => f16, f32, f64, f128);
+impl_float_to_float!(f128 => f16, f32, f64, f128);
 
 /// Implement `From<bool>` for integers
 macro_rules! impl_from_bool {

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -11,7 +11,7 @@
 
 #![unstable(feature = "f128", issue = "116909")]
 
-use crate::convert::FloatToInt;
+use crate::convert::{FloatToFloat, FloatToInt};
 use crate::num::FpCategory;
 use crate::panic::const_assert;
 use crate::{intrinsics, mem};
@@ -1026,6 +1026,100 @@ impl f128 {
         // SAFETY: the caller must uphold the safety contract for
         // `FloatToInt::to_int_unchecked`.
         unsafe { FloatToInt::<Int>::to_int_unchecked(self) }
+    }
+
+    /// Converts to the target float type, rounding as defined in IEEE 754.
+    ///
+    /// This is equivalent to `self as Flt`. Narrowing to a smaller type can
+    /// produce an infinity.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f128)]
+    /// # #[cfg(target_has_reliable_f128)] {
+    ///
+    /// let x = 1.5_f128;
+    /// assert_eq!(x.cast::<f64>(), 1.5_f64);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn cast<Flt>(self) -> Flt
+    where
+        Self: FloatToFloat<Flt>,
+    {
+        FloatToFloat::<Flt>::cast(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, saturating
+    /// at the type's boundaries and mapping `NaN` to zero.
+    ///
+    /// This is equivalent to `self as Int`.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f128)]
+    /// # #[cfg(target_has_reliable_f128)] {
+    ///
+    /// assert_eq!(4.6_f128.to_int_saturating::<u8>(), 4);
+    /// assert_eq!(f128::NAN.to_int_saturating::<u8>(), 0);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_saturating<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_saturating(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, returning
+    /// `None` if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f128)]
+    /// # #[cfg(target_has_reliable_f128)] {
+    ///
+    /// assert_eq!(4.6_f128.to_int_checked::<u8>(), Some(4));
+    /// assert_eq!(f128::NAN.to_int_checked::<u8>(), None);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_checked<Int>(self) -> Option<Int>
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_checked(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type.
+    ///
+    /// This is equivalent to `self.to_int_checked().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f128)]
+    /// # #[cfg(target_has_reliable_f128)] {
+    ///
+    /// assert_eq!(4.6_f128.to_int_strict::<u8>(), 4);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    #[track_caller]
+    pub fn to_int_strict<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        self.to_int_checked::<Int>()
+            .expect("the value cannot be represented in the target integer type")
     }
 
     /// Raw transmutation to `u128`.

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -11,7 +11,7 @@
 
 #![unstable(feature = "f16", issue = "116909")]
 
-use crate::convert::FloatToInt;
+use crate::convert::{FloatToFloat, FloatToInt};
 use crate::num::FpCategory;
 #[cfg(not(test))]
 use crate::num::imp::libm;
@@ -1022,6 +1022,100 @@ impl f16 {
         // SAFETY: the caller must uphold the safety contract for
         // `FloatToInt::to_int_unchecked`.
         unsafe { FloatToInt::<Int>::to_int_unchecked(self) }
+    }
+
+    /// Converts to the target float type, rounding as defined in IEEE 754.
+    ///
+    /// This is equivalent to `self as Flt`. Narrowing to a smaller type can
+    /// produce an infinity.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f16)]
+    /// # #[cfg(target_has_reliable_f16)] {
+    ///
+    /// let x = 1.5_f16;
+    /// assert_eq!(x.cast::<f32>(), 1.5_f32);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn cast<Flt>(self) -> Flt
+    where
+        Self: FloatToFloat<Flt>,
+    {
+        FloatToFloat::<Flt>::cast(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, saturating
+    /// at the type's boundaries and mapping `NaN` to zero.
+    ///
+    /// This is equivalent to `self as Int`.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f16)]
+    /// # #[cfg(target_has_reliable_f16)] {
+    ///
+    /// assert_eq!(4.6_f16.to_int_saturating::<u8>(), 4);
+    /// assert_eq!(f16::NAN.to_int_saturating::<u8>(), 0);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_saturating<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_saturating(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, returning
+    /// `None` if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f16)]
+    /// # #[cfg(target_has_reliable_f16)] {
+    ///
+    /// assert_eq!(4.6_f16.to_int_checked::<u8>(), Some(4));
+    /// assert_eq!(f16::NAN.to_int_checked::<u8>(), None);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_checked<Int>(self) -> Option<Int>
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_checked(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type.
+    ///
+    /// This is equivalent to `self.to_int_checked().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f16)]
+    /// # #[cfg(target_has_reliable_f16)] {
+    ///
+    /// assert_eq!(4.6_f16.to_int_strict::<u8>(), 4);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    #[track_caller]
+    pub fn to_int_strict<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        self.to_int_checked::<Int>()
+            .expect("the value cannot be represented in the target integer type")
     }
 
     /// Raw transmutation to `u16`.

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -11,7 +11,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use crate::convert::FloatToInt;
+use crate::convert::{FloatToFloat, FloatToInt};
 use crate::num::FpCategory;
 use crate::panic::const_assert;
 use crate::{cfg_select, intrinsics, mem};
@@ -1219,6 +1219,99 @@ impl f32 {
         // SAFETY: the caller must uphold the safety contract for
         // `FloatToInt::to_int_unchecked`.
         unsafe { FloatToInt::<Int>::to_int_unchecked(self) }
+    }
+
+    /// Converts to the target float type, rounding as defined in IEEE 754.
+    ///
+    /// This is equivalent to `self as Flt`. Narrowing to a smaller type can
+    /// produce an infinity.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// let x = 1.5_f32;
+    /// assert_eq!(x.cast::<f64>(), 1.5_f64);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[inline]
+    pub fn cast<Flt>(self) -> Flt
+    where
+        Self: FloatToFloat<Flt>,
+    {
+        FloatToFloat::<Flt>::cast(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, saturating
+    /// at the type's boundaries and mapping `NaN` to zero.
+    ///
+    /// This is equivalent to `self as Int`.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f32.to_int_saturating::<u8>(), 255);
+    /// assert_eq!(300.0_f32.to_int_saturating::<u8>(), 255);
+    /// assert_eq!((-1.0_f32).to_int_saturating::<u8>(), 0);
+    /// assert_eq!(f32::NAN.to_int_saturating::<u8>(), 0);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[inline]
+    pub fn to_int_saturating<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_saturating(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, returning
+    /// `None` if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f32.to_int_checked::<u8>(), Some(255));
+    /// assert_eq!(256.0_f32.to_int_checked::<u8>(), None);
+    /// assert_eq!(f32::NAN.to_int_checked::<u8>(), None);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[inline]
+    pub fn to_int_checked<Int>(self) -> Option<Int>
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_checked(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type.
+    ///
+    /// This is equivalent to `self.to_int_checked().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f32.to_int_strict::<u8>(), 255);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[inline]
+    #[track_caller]
+    pub fn to_int_strict<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        self.to_int_checked::<Int>()
+            .expect("the value cannot be represented in the target integer type")
     }
 
     /// Raw transmutation to `u32`.

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -11,7 +11,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use crate::convert::FloatToInt;
+use crate::convert::{FloatToFloat, FloatToInt};
 use crate::num::FpCategory;
 use crate::panic::const_assert;
 use crate::{cfg_select, intrinsics, mem};
@@ -1215,6 +1215,99 @@ impl f32 {
         // SAFETY: the caller must uphold the safety contract for
         // `FloatToInt::to_int_unchecked`.
         unsafe { FloatToInt::<Int>::to_int_unchecked(self) }
+    }
+
+    /// Converts to the target float type, rounding as defined in IEEE 754.
+    ///
+    /// This is equivalent to `self as Flt`. Narrowing to a smaller type can
+    /// produce an infinity.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// let x = 1.5_f32;
+    /// assert_eq!(x.cast::<f64>(), 1.5_f64);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[inline]
+    pub fn cast<Flt>(self) -> Flt
+    where
+        Self: FloatToFloat<Flt>,
+    {
+        FloatToFloat::<Flt>::cast(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, saturating
+    /// at the type's boundaries and mapping `NaN` to zero.
+    ///
+    /// This is equivalent to `self as Int`.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f32.to_int_saturating::<u8>(), 255);
+    /// assert_eq!(300.0_f32.to_int_saturating::<u8>(), 255);
+    /// assert_eq!((-1.0_f32).to_int_saturating::<u8>(), 0);
+    /// assert_eq!(f32::NAN.to_int_saturating::<u8>(), 0);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[inline]
+    pub fn to_int_saturating<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_saturating(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, returning
+    /// `None` if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f32.to_int_checked::<u8>(), Some(255));
+    /// assert_eq!(256.0_f32.to_int_checked::<u8>(), None);
+    /// assert_eq!(f32::NAN.to_int_checked::<u8>(), None);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[inline]
+    pub fn to_int_checked<Int>(self) -> Option<Int>
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_checked(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type.
+    ///
+    /// This is equivalent to `self.to_int_checked().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f32.to_int_strict::<u8>(), 255);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[inline]
+    #[track_caller]
+    pub fn to_int_strict<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        self.to_int_checked::<Int>()
+            .expect("the value cannot be represented in the target integer type")
     }
 
     /// Raw transmutation to `u32`.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -11,7 +11,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use crate::convert::FloatToInt;
+use crate::convert::{FloatToFloat, FloatToInt};
 use crate::num::FpCategory;
 use crate::panic::const_assert;
 use crate::{intrinsics, mem};
@@ -1202,6 +1202,95 @@ impl f64 {
         // SAFETY: the caller must uphold the safety contract for
         // `FloatToInt::to_int_unchecked`.
         unsafe { FloatToInt::<Int>::to_int_unchecked(self) }
+    }
+
+    /// Converts to the target float type, rounding as defined in IEEE 754.
+    ///
+    /// This is equivalent to `self as Flt`. Narrowing to a smaller type can
+    /// produce an infinity.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// let x = 1.5_f64;
+    /// assert_eq!(x.cast::<f32>(), 1.5_f32);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn cast<Flt>(self) -> Flt
+    where
+        Self: FloatToFloat<Flt>,
+    {
+        FloatToFloat::<Flt>::cast(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, saturating
+    /// at the type's boundaries and mapping `NaN` to zero.
+    ///
+    /// This is equivalent to `self as Int`.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f64.to_int_saturating::<u8>(), 255);
+    /// assert_eq!(300.0_f64.to_int_saturating::<u8>(), 255);
+    /// assert_eq!((-1.0_f64).to_int_saturating::<u8>(), 0);
+    /// assert_eq!(f64::NAN.to_int_saturating::<u8>(), 0);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_saturating<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_saturating(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, returning
+    /// `None` if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f64.to_int_checked::<u8>(), Some(255));
+    /// assert_eq!(256.0_f64.to_int_checked::<u8>(), None);
+    /// assert_eq!(f64::NAN.to_int_checked::<u8>(), None);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_checked<Int>(self) -> Option<Int>
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_checked(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type.
+    ///
+    /// This is equivalent to `self.to_int_checked().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f64.to_int_strict::<u8>(), 255);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    #[track_caller]
+    pub fn to_int_strict<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        self.to_int_checked::<Int>()
+            .expect("the value cannot be represented in the target integer type")
     }
 
     /// Raw transmutation to `u64`.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -11,7 +11,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use crate::convert::FloatToInt;
+use crate::convert::{FloatToFloat, FloatToInt};
 use crate::num::FpCategory;
 use crate::panic::const_assert;
 use crate::{intrinsics, mem};
@@ -1196,6 +1196,95 @@ impl f64 {
         // SAFETY: the caller must uphold the safety contract for
         // `FloatToInt::to_int_unchecked`.
         unsafe { FloatToInt::<Int>::to_int_unchecked(self) }
+    }
+
+    /// Converts to the target float type, rounding as defined in IEEE 754.
+    ///
+    /// This is equivalent to `self as Flt`. Narrowing to a smaller type can
+    /// produce an infinity.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// let x = 1.5_f64;
+    /// assert_eq!(x.cast::<f32>(), 1.5_f32);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn cast<Flt>(self) -> Flt
+    where
+        Self: FloatToFloat<Flt>,
+    {
+        FloatToFloat::<Flt>::cast(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, saturating
+    /// at the type's boundaries and mapping `NaN` to zero.
+    ///
+    /// This is equivalent to `self as Int`.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f64.to_int_saturating::<u8>(), 255);
+    /// assert_eq!(300.0_f64.to_int_saturating::<u8>(), 255);
+    /// assert_eq!((-1.0_f64).to_int_saturating::<u8>(), 0);
+    /// assert_eq!(f64::NAN.to_int_saturating::<u8>(), 0);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_saturating<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_saturating(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, returning
+    /// `None` if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f64.to_int_checked::<u8>(), Some(255));
+    /// assert_eq!(256.0_f64.to_int_checked::<u8>(), None);
+    /// assert_eq!(f64::NAN.to_int_checked::<u8>(), None);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_checked<Int>(self) -> Option<Int>
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_checked(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type.
+    ///
+    /// This is equivalent to `self.to_int_checked().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f64.to_int_strict::<u8>(), 255);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    #[track_caller]
+    pub fn to_int_strict<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        self.to_int_checked::<Int>()
+            .expect("the value cannot be represented in the target integer type")
     }
 
     /// Raw transmutation to `u64`.

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -54,6 +54,7 @@
 #![feature(extern_types)]
 #![feature(f16)]
 #![feature(f128)]
+#![feature(float_conversions)]
 #![feature(float_exact_integer_constants)]
 #![feature(float_gamma)]
 #![feature(float_minimum_maximum)]

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -53,6 +53,7 @@
 #![feature(extern_types)]
 #![feature(f16)]
 #![feature(f128)]
+#![feature(float_conversions)]
 #![feature(float_exact_integer_constants)]
 #![feature(float_gamma)]
 #![feature(float_minimum_maximum)]

--- a/library/coretests/tests/num/float_conversions.rs
+++ b/library/coretests/tests/num/float_conversions.rs
@@ -1,0 +1,117 @@
+// Tests for the `float_conversions` methods (ACP rust-lang/libs-team#810):
+// `cast`, `to_int_saturating`, `to_int_checked`, and `to_int_strict`.
+
+#[test]
+fn cast_widen_narrow() {
+    assert_eq!(1.5_f32.cast::<f64>(), 1.5_f64);
+    assert_eq!(0.5_f64.cast::<f32>(), 0.5_f32);
+    // Narrowing a value out of the target range produces an infinity.
+    assert_eq!(1e300_f64.cast::<f32>(), f32::INFINITY);
+    assert_eq!((-1e300_f64).cast::<f32>(), f32::NEG_INFINITY);
+    // Same-type cast is the identity.
+    assert_eq!(3.25_f64.cast::<f64>(), 3.25_f64);
+    // Narrowing rounds to the nearest representable value.
+    assert_eq!(0.1_f64.cast::<f32>(), 0.1_f32);
+}
+
+#[test]
+fn saturating_basics() {
+    assert_eq!(255.9_f32.to_int_saturating::<u8>(), 255);
+    assert_eq!(300.0_f32.to_int_saturating::<u8>(), 255);
+    assert_eq!((-1.0_f32).to_int_saturating::<u8>(), 0);
+    assert_eq!(f32::NAN.to_int_saturating::<u8>(), 0);
+    assert_eq!(f32::INFINITY.to_int_saturating::<u8>(), 255);
+    assert_eq!(f32::NEG_INFINITY.to_int_saturating::<i8>(), i8::MIN);
+    assert_eq!(f64::NAN.to_int_saturating::<i32>(), 0);
+    // Large finite values saturate at the target boundary.
+    assert_eq!(1e18_f64.to_int_saturating::<i32>(), i32::MAX);
+    assert_eq!((-1e18_f64).to_int_saturating::<i32>(), i32::MIN);
+}
+
+#[test]
+fn checked_truncates_then_bounds() {
+    // Truncation toward zero happens before the bounds check.
+    assert_eq!(255.5_f64.to_int_checked::<u8>(), Some(255));
+    assert_eq!(255.9_f64.to_int_checked::<u8>(), Some(255));
+    assert_eq!(256.0_f64.to_int_checked::<u8>(), None);
+    // A negative fraction truncates toward zero and fits.
+    assert_eq!((-0.5_f64).to_int_checked::<u8>(), Some(0));
+    assert_eq!((-1.0_f64).to_int_checked::<u8>(), None);
+    // Non-finite is always None.
+    assert_eq!(f64::NAN.to_int_checked::<u8>(), None);
+    assert_eq!(f64::INFINITY.to_int_checked::<u8>(), None);
+    assert_eq!(f64::NEG_INFINITY.to_int_checked::<i32>(), None);
+}
+
+#[test]
+fn checked_signed_boundaries() {
+    assert_eq!((-128.0_f64).to_int_checked::<i8>(), Some(-128));
+    assert_eq!((-128.9_f64).to_int_checked::<i8>(), Some(-128));
+    assert_eq!((-129.0_f64).to_int_checked::<i8>(), None);
+    assert_eq!(127.0_f64.to_int_checked::<i8>(), Some(127));
+    assert_eq!(127.9_f64.to_int_checked::<i8>(), Some(127));
+    assert_eq!(128.0_f64.to_int_checked::<i8>(), None);
+}
+
+#[test]
+fn checked_exact_power_of_two_bounds() {
+    // i32::MIN is exactly representable and must be accepted.
+    assert_eq!((i32::MIN as f64).to_int_checked::<i32>(), Some(i32::MIN));
+    // 2^31 as f32 is exact and one past i32::MAX, so it is rejected...
+    assert_eq!((2147483648.0_f32).to_int_checked::<i32>(), None);
+    // ...while the largest f32 below 2^31 is accepted.
+    assert_eq!((2147483520.0_f32).to_int_checked::<i32>(), Some(2147483520));
+}
+
+#[test]
+fn strict_matches_checked() {
+    assert_eq!(255.5_f64.to_int_strict::<u8>(), 255);
+    assert_eq!((-128.0_f64).to_int_strict::<i8>(), -128);
+}
+
+#[test]
+#[should_panic]
+fn strict_panics_on_nan() {
+    let _ = f64::NAN.to_int_strict::<u8>();
+}
+
+#[test]
+#[should_panic]
+fn strict_panics_on_overflow() {
+    let _ = 256.0_f64.to_int_strict::<u8>();
+}
+
+#[cfg(target_has_reliable_f16)]
+#[test]
+fn f16_into_wide_int_accepts_all_finite() {
+    // Every finite f16 fits in i128, so the bounds are +/-inf and accept all
+    // finite values; only non-finite is rejected.
+    assert_eq!(f16::MAX.to_int_checked::<i128>(), Some(f16::MAX as i128));
+    assert_eq!((-f16::MAX).to_int_checked::<i128>(), Some(-f16::MAX as i128));
+    assert_eq!(f16::INFINITY.to_int_checked::<u128>(), None);
+    assert_eq!(f16::NAN.to_int_checked::<u128>(), None);
+    assert_eq!(4.6_f16.to_int_saturating::<u8>(), 4);
+    assert_eq!(1.5_f16.cast::<f32>(), 1.5_f32);
+}
+
+// Truncation-then-check must not depend on a libm `trunc`, which is unreliable
+// for f16/f128 on some targets. These exercise the fractional checked path.
+#[cfg(target_has_reliable_f16)]
+#[test]
+fn f16_checked_fractional() {
+    assert_eq!(4.6_f16.to_int_checked::<u8>(), Some(4));
+    assert_eq!(255.5_f16.to_int_checked::<u8>(), Some(255));
+    assert_eq!(256.0_f16.to_int_checked::<u8>(), None);
+    assert_eq!((-0.5_f16).to_int_checked::<u8>(), Some(0));
+    assert_eq!(4.6_f16.to_int_strict::<u8>(), 4);
+}
+
+#[cfg(target_has_reliable_f128)]
+#[test]
+fn f128_checked_fractional() {
+    assert_eq!(4.6_f128.to_int_checked::<u8>(), Some(4));
+    assert_eq!(255.5_f128.to_int_checked::<u8>(), Some(255));
+    assert_eq!(256.0_f128.to_int_checked::<u8>(), None);
+    assert_eq!((-0.5_f128).to_int_checked::<u8>(), Some(0));
+    assert_eq!(4.6_f128.to_int_strict::<u8>(), 4);
+}

--- a/library/coretests/tests/num/mod.rs
+++ b/library/coretests/tests/num/mod.rs
@@ -26,6 +26,7 @@ mod carryless_mul;
 mod cast;
 mod const_from;
 mod dec2flt;
+mod float_conversions;
 mod float_ieee754_flt2dec_dec2flt;
 mod float_iter_sum_identity;
 mod floats;


### PR DESCRIPTION
Implements the accepted ACP rust-lang/libs-team#810, adding float conversion methods on `f16`, `f32`, `f64`, and `f128`:

- `cast` converts to the target float type (`self as Flt`, IEEE rounding).
- `to_int_saturating` converts to an integer with `as` semantics: saturating, and `NaN` to 0.
- `to_int_checked` truncates toward zero and returns `None` on `NaN`, infinity, or out of range.
- `to_int_strict` is `to_int_checked().unwrap()`.

Per the libs-api meetings on the ACP, `to_float` is named `cast` and `to_int_saturating` maps `NaN` to 0 rather than panicking (which the team noted makes rust-lang/libs-team#831 redundant).

The integer-to-float `cast` from the ACP is left out: it shares the `cast` method name on integer types with the integer-to-integer `cast` in rust-lang/libs-team#811 (being unified with the other integer cast methods in rust-lang/libs-team#833), so it needs a decision on how those fit together. Happy to follow up once that settles.

Tracking issue: rust-lang/rust#159913

r? libs

