### PR TITLE
core: implement FusedIterator for StepBy

### DIFF
--- a/library/core/src/iter/adapters/step_by.rs
+++ b/library/core/src/iter/adapters/step_by.rs
@@ -1,5 +1,5 @@
 use crate::intrinsics;
-use crate::iter::{TrustedLen, TrustedRandomAccess, from_fn};
+use crate::iter::{FusedIterator, TrustedLen, TrustedRandomAccess, from_fn};
 use crate::num::NonZero;
 use crate::ops::{Range, Try};
 use crate::range::RangeIter;
@@ -135,6 +135,11 @@ where
 // StepBy can only make the iterator shorter, so the len will still fit.
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
 impl<I> ExactSizeIterator for StepBy<I> where I: ExactSizeIterator {}
+
+// StepBy stops yielding items once the underlying iterator does, so it is fused
+// whenever the underlying iterator is fused.
+#[stable(feature = "step_by_fused", since = "CURRENT_RUSTC_VERSION")]
+impl<I> FusedIterator for StepBy<I> where I: FusedIterator {}
 
 // SAFETY: This adapter is shortening. TrustedLen requires the upper bound to be calculated correctly.
 // These requirements can only be satisfied when the upper bound of the inner iterator's upper

--- a/library/coretests/tests/iter/adapters/step_by.rs
+++ b/library/coretests/tests/iter/adapters/step_by.rs
@@ -418,3 +418,16 @@ fn test_step_by_nth_non_fused_on_non_first_take() {
     // so we should expect `StepBy::nth` to return `None`
     assert_eq!(iter.nth(usize::MAX), None)
 }
+
+#[test]
+fn test_step_by_fused() {
+    // `StepBy` is fused whenever the underlying iterator is fused.
+    fn assert_fused<I: FusedIterator>(_: I) {}
+    assert_fused((0..10).step_by(3));
+
+    // Once the underlying fused iterator is exhausted, `StepBy` keeps yielding `None`.
+    let mut it = (0..3).step_by(5);
+    assert_eq!(it.next(), Some(0));
+    assert_eq!(it.next(), None);
+    assert_eq!(it.next(), None);
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159963)*
<!-- homu-ignore:end -->

Implements the accepted ACP rust-lang/libs-team#757.

`StepBy` yields no more items once its underlying iterator is exhausted, so it is fused whenever the underlying iterator is fused. `StepBy` was added in 1.28.0, just after the batch of `FusedIterator` impls stabilized in 1.26.0 (`Map`, `Skip`, `Take`, `Enumerate`, ...), so it was left out.

```rust
impl<I: FusedIterator> FusedIterator for StepBy<I> {}
```

This is insta-stable, matching the sibling adapter impls, so it needs a libs-api FCP.

Motivation from the ACP: crates with traits refined on top of `FusedIterator` (e.g. `range-set-blaze`'s `SortedStarts`) cannot cover `StepBy` today, even though it would always be valid.

A `test_step_by_fused` regression test is added.
