### PR TITLE
Add regression test for #159890

### DIFF
--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -162,7 +162,8 @@ where
     let prev_universe = delegate.universe();
     let universes_created_in_query = response.max_universe.index();
     for _ in 0..universes_created_in_query {
-        delegate.create_next_universe();
+        let universe = delegate.create_next_universe();
+        delegate.insert_placeholder_assumptions(universe, None);
     }
 
     let var_values = response.value.var_values();

--- a/tests/ui/assumptions_on_binders/missing-placeholder-assumptions-issue-159890.rs
+++ b/tests/ui/assumptions_on_binders/missing-placeholder-assumptions-issue-159890.rs
@@ -1,0 +1,34 @@
+//@ edition: 2024
+//@ compile-flags: -Znext-solver=globally -Zassumptions-on-binders
+//@ check-fail
+
+trait FutureIterator: 'static {
+    type Future<'s, 'cx>: Future + Send + 'cx;
+}
+
+trait IterCaller: 'static {
+    type Future2<'cx>: Future + 'cx;
+
+    fn call_2() {}
+}
+
+struct UseIter<FI1, FI2> {
+    fi_1: FI1,
+    fi_2: FI2,
+}
+
+impl<FI1, FI2: 'static> IterCaller for UseIter<FI1, FI2>
+//~^ ERROR not all trait items implemented
+where
+    FI1: FutureIterator + 'static + Send,
+    for<'s, 'cx> FI1::Future<'s, 'cx>: Send,
+{
+    fn call_2<'s, 'cx>() -> Self::Future2<'cx>
+    //~^ ERROR lifetime parameters or bounds on associated function `call_2` do not match
+    where
+        's: 'cx,
+    {
+    }
+}
+
+fn main() {}

--- a/tests/ui/assumptions_on_binders/missing-placeholder-assumptions-issue-159890.stderr
+++ b/tests/ui/assumptions_on_binders/missing-placeholder-assumptions-issue-159890.stderr
@@ -1,0 +1,30 @@
+error[E0195]: lifetime parameters or bounds on associated function `call_2` do not match the trait declaration
+  --> $DIR/missing-placeholder-assumptions-issue-159890.rs:26:14
+   |
+LL |       fn call_2() {}
+   |                - lifetimes in impl do not match this associated function in trait
+...
+LL |       fn call_2<'s, 'cx>() -> Self::Future2<'cx>
+   |                ^^^^^^^^^ lifetimes do not match associated function in trait
+LL |
+LL | /     where
+LL | |         's: 'cx,
+   | |________________- this `where` clause might not match the one in the trait
+
+error[E0046]: not all trait items implemented, missing: `Future2`
+  --> $DIR/missing-placeholder-assumptions-issue-159890.rs:20:1
+   |
+LL |       type Future2<'cx>: Future + 'cx;
+   |       ------------------------------- `Future2` from trait
+...
+LL | / impl<FI1, FI2: 'static> IterCaller for UseIter<FI1, FI2>
+LL | |
+LL | | where
+LL | |     FI1: FutureIterator + 'static + Send,
+LL | |     for<'s, 'cx> FI1::Future<'s, 'cx>: Send,
+   | |____________________________________________^ missing `Future2` in implementation
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0046, E0195.
+For more information about an error, try `rustc --explain E0046`.


### PR DESCRIPTION
Adds regression coverage for rust-lang/rust#159890

The ICE no longer reproduces after the canonical response universe assumptions fix landed. this keeps the original reproducer as a UI test and checks that it reports the expected E0195 and E0046 diagnostics instead of panicking

Closes rust-lang/rust#159890