### PR TITLE
Use real ThinVec in StmtDebugInfos

### DIFF
--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -3,6 +3,7 @@
 use std::ops;
 
 use rustc_data_structures::outline;
+use thin_vec::ThinVec;
 use tracing::{debug, instrument};
 
 use super::interpret::GlobalAlloc;
@@ -1038,17 +1039,15 @@ impl RawPtrKind {
     }
 }
 
-// FIXME(panstromek)
-//  I'd like to use real ThinVec here, but it fails to borrow check,
-//  probably because ThinVec doesn't have #[may_dangle] on Drop impl?
-type ThinVec<T> = Option<Box<Vec<T>>>;
-
 // This collection is almost always empty, so we
 // use thin representation and optimize all methods
 // for that by inlining the empty check
-// and outlining the rest.
+// and outlining the rest. Note that Option is
+// technically not needed, because empty ThinVec
+// points to a static singleton, this version performed
+// better in our benchmarks
 #[derive(Default, Debug, Clone, TyEncodable, TyDecodable, StableHash, TypeFoldable, TypeVisitable)]
-pub struct StmtDebugInfos<'tcx>(ThinVec<StmtDebugInfo<'tcx>>);
+pub struct StmtDebugInfos<'tcx>(Option<ThinVec<StmtDebugInfo<'tcx>>>);
 
 impl<'tcx> StmtDebugInfos<'tcx> {
     pub fn push(&mut self, debuginfo: StmtDebugInfo<'tcx>) {
@@ -1084,9 +1083,7 @@ impl<'tcx> StmtDebugInfos<'tcx> {
         if debuginfos.is_empty() {
             return;
         };
-        outline(move || {
-            self.0.get_or_insert_default().append(debuginfos.0.as_mut().unwrap().as_mut())
-        });
+        outline(move || self.0.get_or_insert_default().append(debuginfos.0.as_mut().unwrap()));
     }
     #[inline]
     pub fn extend(&mut self, debuginfos: &Self) {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/159975)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This is now possible, because thin vec has may_dangle Drop impl. Depends on https://github.com/rust-lang/rust/pull/159974