### PR TITLE
run intrinsic-test by default on x86_64-gnu

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -351,6 +351,10 @@
 # Set this to "discover" to automatically discover LLDB from the environment.
 #build.lldb = "lldb"
 
+# The path to (or name of) the Intel SDE executable, used to run the
+# intrinsic-test suite for x86 target features the host CPU may not support.
+#build.sde = "sde64"
+
 # The node.js executable to use. Note that this is only used for the emscripten
 # target when running tests, otherwise this can be omitted.
 #build.nodejs = "node"

--- a/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
@@ -34,6 +34,7 @@ ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
  --enable-sanitizers \
  --enable-profiler \
  --enable-compiler-docs \
- --set llvm.libzstd=true"
-ENV SCRIPT="python3 ../x.py --stage 2 test && \
-            python3 ../x.py --stage 2 test library/stdarch/crates/intrinsic-test"
+ --set llvm.libzstd=true \
+ --set build.sde=/intel-sde/sde64"
+ENV SCRIPT="python3 ../x.py --stage 2 test"
+           


### PR DESCRIPTION
This PR runs intrinsic-test by default on x86_64-gnu and set sde bootstrap config in `RUST_CONFIGURE_ARGS` .

r? @Kobzol
