### PR TITLE
std: make send_process_group_signal unsupported on VxWorks

### DIFF
--- a/library/std/src/sys/process/unix/vxworks.rs
+++ b/library/std/src/sys/process/unix/vxworks.rs
@@ -171,12 +171,9 @@ impl Process {
         }
     }
 
-    pub fn send_process_group_signal(&self, signal: i32) -> io::Result<()> {
-        // See note in `send_signal` regarding recycled PIDs.
-        if self.status.is_some() {
-            return Ok(());
-        }
-        cvt(unsafe { libc::killpg(self.pid, signal) }).map(drop)
+    pub fn send_process_group_signal(&self, _signal: i32) -> io::Result<()> {
+        // VxWorks doesn't have process groups
+        unimplemented!()
     }
 
     pub fn wait(&mut self) -> io::Result<ExitStatus> {


### PR DESCRIPTION
`x86_64-wrs-vxworks` doesn't build std: `cargo new` plus `-Zbuild-std` stops
with E0425 on `libc::killpg`, which rust-lang/rust#156539 introduced.

libc has never declared `killpg` for vxworks, and declaring it wouldn't help.
On wrsdk-vxworks7-qemu-1.17.0 there's no `killpg` in the headers, the sysroot
archives or the prebuilt kernel, and `getpgrp`/`setpgid` are no-ops in libunix:
`getpgrp` returns a constant 0, `setpgid` stores nothing. That rules out
`kill(-pgrp, sig)` too. `Command::process_group` is already ignored on this
target, since `get_pgroup` is only read by the fork/posix_spawn path while
vxworks spawns through `rtpSpawn`.

Closes rust-lang/rust#159969.