### PR TITLE
Do not run tests in `dist` jobs

### DIFF
--- a/src/ci/docker/host-x86_64/dist-i586-gnu-i586-i686-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-i586-gnu-i586-i686-musl/Dockerfile
@@ -75,5 +75,4 @@ ENV CFLAGS_i586_unknown_linux_musl=-Wa,-mrelax-relocations=no
 
 ENV TARGETS=i586-unknown-linux-gnu,i686-unknown-linux-musl
 
-ENV SCRIPT="python3 ../x.py --stage 2 test --host= --target $TARGETS && \
-      python3 ../x.py dist --host= --target $TARGETS,i586-unknown-linux-musl"
+ENV SCRIPT="python3 ../x.py dist --host= --target $TARGETS,i586-unknown-linux-musl"

--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -175,8 +175,7 @@ ENV RUST_CONFIGURE_ARGS="--musl-root-armv5te=/musl-armv5te \
       --musl-root-armv7hf=/musl-armv7hf \
       --disable-docs"
 
-ENV SCRIPT="python3 ../x.py --stage 2 test --host= --target $RUN_MAKE_TARGETS tests/run-make tests/run-make-cargo && \
-      python3 ../x.py dist --host= --target $TARGETS"
+ENV SCRIPT="python3 ../x.py dist --host= --target $TARGETS"
 
 # sccache
 COPY scripts/sccache.sh /scripts/


### PR DESCRIPTION
We found out in https://github.com/rust-lang/rust/pull/159455 that some dist jobs run tests, but this seems as a historical artifact (going way back to <2020).

These targets are tier 2 or tier 3 anyway, and shouldn't run tests, much less so in `dist` jobs.

r? @jieyouxu
