### PR TITLE
Show jobs where a given test was executed in `test-dashboard`

### DIFF
--- a/src/ci/citool/Cargo.lock
+++ b/src/ci/citool/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "askama"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e1676b346cadfec169374f949d7490fd80a24193d37d2afce0c047cf695e57"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
 dependencies = [
  "askama_macros",
  "itoa",
@@ -79,12 +79,13 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7661ff56517787343f376f75db037426facd7c8d3049cef8911f1e75016f3a37"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
 dependencies = [
  "askama_parser",
  "basic-toml",
+ "glob",
  "memchr",
  "proc-macro2",
  "quote",
@@ -96,18 +97,18 @@ dependencies = [
 
 [[package]]
 name = "askama_macros"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713ee4dbfd1eb719c2dab859465b01fa1d21cb566684614a713a6b7a99a4e47b"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
 dependencies = [
  "askama_derive",
 ]
 
 [[package]]
 name = "askama_parser"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d62d674238a526418b30c0def480d5beadb9d8964e7f38d635b03bf639c704c"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -379,6 +380,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "glob-match"
@@ -1105,9 +1112,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]

--- a/src/ci/citool/src/test_dashboard.rs
+++ b/src/ci/citool/src/test_dashboard.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::{Path, PathBuf};
@@ -17,12 +17,14 @@ pub fn generate_test_dashboard(
     output_dir: &Path,
 ) -> anyhow::Result<()> {
     let metrics = download_auto_job_metrics(&db, None, current)?;
-    let suites = gather_test_suites(&metrics);
+    let mut suites = gather_test_suites(&metrics);
 
     std::fs::create_dir_all(output_dir)?;
 
+    let jobsets = assign_jobsets(&mut suites);
+
     let test_count = suites.test_count();
-    write_page(output_dir, "index.html", &TestSuitesPage { suites, test_count })?;
+    write_page(output_dir, "index.html", &TestSuitesPage { suites, test_count, jobsets })?;
 
     Ok(())
 }
@@ -31,6 +33,45 @@ fn write_page<T: Template>(dir: &Path, name: &str, template: &T) -> anyhow::Resu
     let mut file = BufWriter::new(File::create(dir.join(name))?);
     Template::write_into(template, &mut file)?;
     Ok(())
+}
+
+struct JobSets {
+    sets: Vec<(u32, Vec<String>)>,
+}
+
+fn assign_jobsets(suites: &mut TestSuites) -> JobSets {
+    let mut jobsets: HashMap<Vec<String>, u32> = HashMap::new();
+
+    fn visit(jobsets: &mut HashMap<Vec<String>, u32>, group: &mut TestGroup) {
+        for (_, test) in &mut group.root_tests {
+            for (_, results) in &mut test.revisions {
+                let mut jobset: HashSet<String> = HashSet::new();
+                for test in &results.passed {
+                    jobset.insert(test.job.to_string());
+                }
+                let mut jobset: Vec<String> = jobset.into_iter().collect();
+                jobset.sort();
+
+                let jobset_count = jobsets.len() as u32;
+                let jobset_id = jobsets.entry(jobset).or_insert_with(|| jobset_count);
+                results.passed_jobset = Some(*jobset_id);
+            }
+        }
+        for (_, group) in &mut group.groups {
+            visit(jobsets, group);
+        }
+    }
+    for suite in &mut suites.suites {
+        visit(&mut jobsets, &mut suite.group);
+    }
+
+    let mut jobsets: Vec<(u32, Vec<String>)> = jobsets.into_iter().map(|(k, v)| (v, k)).collect();
+    jobsets.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    for (_, set) in &mut jobsets {
+        set.sort_unstable();
+    }
+
+    JobSets { sets: jobsets }
 }
 
 fn gather_test_suites(job_metrics: &HashMap<JobName, JobMetrics>) -> TestSuites<'_> {
@@ -68,10 +109,9 @@ fn gather_test_suites(job_metrics: &HashMap<JobName, JobMetrics>) -> TestSuites<
                     .tests
                     .entry(test_name.clone())
                     .or_insert_with(|| Test { revisions: Default::default() });
-                let variant_entry = test_entry
-                    .revisions
-                    .entry(variant_name)
-                    .or_insert_with(|| TestResults { passed: vec![], ignored: vec![] });
+                let variant_entry = test_entry.revisions.entry(variant_name).or_insert_with(|| {
+                    TestResults { passed: vec![], passed_jobset: None, ignored: vec![] }
+                });
 
                 match test.outcome {
                     TestOutcome::Passed => {
@@ -161,6 +201,8 @@ struct TestSuite<'a> {
 
 struct TestResults<'a> {
     passed: Vec<TestMetadata<'a>>,
+    /// An id representing a set of jobs on which this test has passed.
+    passed_jobset: Option<u32>,
     ignored: Vec<TestMetadata<'a>>,
 }
 
@@ -213,4 +255,5 @@ impl<'a> TestGroup<'a> {
 struct TestSuitesPage<'a> {
     suites: TestSuites<'a>,
     test_count: u64,
+    jobsets: JobSets,
 }

--- a/src/ci/citool/templates/test_group.askama
+++ b/src/ci/citool/templates/test_group.askama
@@ -1,5 +1,5 @@
-{% macro test_result(r) -%}
-passed: {{ r.passed.len() }}, ignored: {{ r.ignored.len() }}
+{% macro test_result(r, jobset) -%}
+<a href="#job-{{ jobset }}">passed: {{ r.passed.len() }}</a>, ignored: {{ r.ignored.len() }}
 {%- endmacro %}
 
 <li>
@@ -24,12 +24,12 @@ passed: {{ r.passed.len() }}, ignored: {{ r.ignored.len() }}
     {% for (name, test) in root_tests %}
         <li>
         {% if let Some(result) = test.single_test() %}
-            <b>{{ name }}</b> ({% call test_result(result) %}{% endcall %})
+            <b>{{ name }}</b> ({% call test_result(result, result.passed_jobset.as_ref().unwrap()) %}{% endcall %})
         {% else %}
             <b>{{ name }}</b> ({{ test.revisions.len() }} revision{{ test.revisions.len() | pluralize }})
             <ul>
             {% for (revision, result) in test.revisions %}
-                <li>#<i>{{ revision }}</i> ({% call test_result(result) %}{% endcall %})</li>
+                <li>#<i>{{ revision }}</i> ({% call test_result(result, result.passed_jobset.as_ref().unwrap()) %}{% endcall %})</li>
             {% endfor %}
             </ul>
         {% endif %}

--- a/src/ci/citool/templates/test_suites.askama
+++ b/src/ci/citool/templates/test_suites.askama
@@ -20,11 +20,26 @@ the count includes all combinations of "stage" x "target" x "CI job where the te
         </div>
     </div>
 
-    <ul>
+    <ul class="tests">
     {% for suite in suites.suites %}
         {{ suite.group|safe }}
     {% endfor %}
     </ul>
+    <div class="jobsets">
+        <h2>Job sets</h2>
+        <div>
+        {% for (id, jobs) in jobsets.sets %}
+            {% if !jobs.is_empty() %}
+            <div id="job-{{ id }}"><b>J{{ id }}</b></div>
+            <ul style="margin: 0">
+            {% for job in jobs %}
+                <li>{{ job }}</li>
+            {% endfor %}
+            </ul>
+            {% endif %}
+        {% endfor %}
+        </div>
+    </div>
 </div>
 {% endblock %}
 
@@ -33,6 +48,9 @@ h1 {
     text-align: center;
     color: #333333;
     margin-bottom: 30px;
+}
+a:visited {
+  color: blue;
 }
 
 .summary {
@@ -55,10 +73,14 @@ ul {
     padding-left: 0;
 }
 
-li {
+.tests li {
     list-style: none;
     padding-left: 20px;
 }
+.jobsets li {
+    margin-left: 30px;
+}
+
 summary {
     margin-bottom: 5px;
     padding: 6px;


### PR DESCRIPTION
This lets us see the specific set of jobs where a given test was executed on CI. This should be quite useful e.g. for debugging where we run debuginfo tests.

To test:
```bash
$ cargo run --release --manifest-path src/ci/citool/Cargo.toml -- test-dashboard 008fa22ce3f8d3c8dfaca2e6486043c2b21851eb --output-dir test-dashboard
```

r? @jieyouxu
