### PR TITLE
Detect when a macro without exclamation mark uses square brackets

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1380,12 +1380,22 @@ impl<'a> Parser<'a> {
 
     /// Parse an indexing expression `expr[...]`.
     fn parse_expr_index(&mut self, lo: Span, base: Box<Expr>) -> PResult<'a, Box<Expr>> {
-        let prev_span = self.prev_token.span;
+        let prev_token = self.prev_token;
         let open_delim_span = self.token.span;
         self.bump(); // `[`
         let index = self.parse_expr()?;
-        self.suggest_missing_semicolon_before_array(prev_span, open_delim_span)?;
-        self.expect(exp!(CloseBracket))?;
+        self.suggest_missing_semicolon_before_array(prev_token.span, open_delim_span)?;
+        self.expect(exp!(CloseBracket)).map_err(|mut e| {
+            if let TokenKind::Ident(_, _) = prev_token.kind {
+                e.span_suggestion_verbose(
+                    prev_token.span.shrink_to_hi(),
+                    "you might have meant to call a macro",
+                    "!".to_string(),
+                    Applicability::MaybeIncorrect,
+                );
+            }
+            e
+        })?;
         Ok(self.mk_expr(
             lo.to(self.prev_token.span),
             self.mk_index(base, index, open_delim_span.to(self.prev_token.span)),

--- a/tests/ui/parser/macro/do-not-suggest-semicolon-between-macro-without-exclamation-mark-and-array.stderr
+++ b/tests/ui/parser/macro/do-not-suggest-semicolon-between-macro-without-exclamation-mark-and-array.stderr
@@ -3,6 +3,11 @@ error: expected one of `.`, `?`, `]`, or an operator, found `,`
    |
 LL |     let _x = vec[1, 2, 3];
    |                   ^ expected one of `.`, `?`, `]`, or an operator
+   |
+help: you might have meant to call a macro
+   |
+LL |     let _x = vec![1, 2, 3];
+   |                 +
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
```
error: expected one of `.`, `?`, `]`, or an operator, found `,`
  --> $DIR/do-not-suggest-semicolon-between-macro-without-exclamation-mark-and-array.rs:2:19
   |
LL |     let _x = vec[1, 2, 3];
   |                   ^ expected one of `.`, `?`, `]`, or an operator
   |
help: you might have meant to call a macro
   |
LL |     let _x = vec![1, 2, 3];
   |                 +
```

Fix rust-lang/rust#101490.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
