### PR TITLE
On many bindings with move error, limit the number of `Span`s

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -1243,6 +1243,9 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
                 }
             } else if j == 0 {
                 err.span_label(binding_span, "data moved here");
+            } else if j == 5 && binds_to.len() > 6 && !self.infcx.tcx.sess.opts.verbose {
+                err.note(format!("...and {} other places", binds_to.len() - 5));
+                break;
             } else {
                 err.span_label(binding_span, "...and here");
             }

--- a/tests/ui/borrowck/borrowck-move-error-many-places.rs
+++ b/tests/ui/borrowck/borrowck-move-error-many-places.rs
@@ -1,0 +1,28 @@
+#![allow(unused)]
+enum Foo {
+    Foo1(Box<u32>, Box<u32>),
+    Foo2(Box<u32>),
+    Foo3(Box<u32>),
+    Foo4(Box<u32>),
+    Foo5(Box<u32>),
+    Foo6(Box<u32>),
+    Foo7(Box<u32>),
+    Foo8(Box<u32>),
+}
+
+fn blah() {
+    let f = &Foo::Foo1(Box::new(1), Box::new(2));
+    match *f { //~ ERROR cannot move out of
+        Foo::Foo1(num1,
+                  num2) => (),
+        Foo::Foo2(num) => (),
+        Foo::Foo3(num) => (),
+        Foo::Foo4(num) => (),
+        Foo::Foo5(num) => (),
+        Foo::Foo6(num) => (),
+        Foo::Foo7(num) => (),
+        Foo::Foo8(num) => (),
+    }
+}
+
+fn main() {}

--- a/tests/ui/borrowck/borrowck-move-error-many-places.stderr
+++ b/tests/ui/borrowck/borrowck-move-error-many-places.stderr
@@ -1,0 +1,27 @@
+error[E0507]: cannot move out of `f` as enum variant `Foo1` which is behind a shared reference
+  --> $DIR/borrowck-move-error-many-places.rs:15:11
+   |
+LL |     match *f {
+   |           ^^
+LL |         Foo::Foo1(num1,
+   |                   ---- data moved here
+LL |                   num2) => (),
+   |                   ---- ...and here
+LL |         Foo::Foo2(num) => (),
+   |                   --- ...and here
+LL |         Foo::Foo3(num) => (),
+   |                   --- ...and here
+LL |         Foo::Foo4(num) => (),
+   |                   --- ...and here
+   |
+   = note: ...and 4 other places
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the dereference here
+   |
+LL -     match *f {
+LL +     match f {
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0507`.


### PR DESCRIPTION
When a "can't move out of" error would point at too many places, limit the number of spans so that we don't spam the terminal.

```
error[E0507]: cannot move out of `f` as enum variant `Foo1` which is behind a shared reference
  --> $DIR/borrowck-move-error-many-places.rs:15:11
   |
LL |     match *f {
   |           ^^
LL |         Foo::Foo1(num1,
   |                   ---- data moved here
LL |                   num2) => (),
   |                   ---- ...and here
LL |         Foo::Foo2(num) => (),
   |                   --- ...and here
LL |         Foo::Foo3(num) => (),
   |                   --- ...and here
LL |         Foo::Foo4(num) => (),
   |                   --- ...and here
   |
   = note: ...and 4 other places
   = note: move occurs because these variables have types that don't implement the `Copy` trait
help: consider removing the dereference here
   |
LL -     match *f {
LL +     match f {
   |
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
