### PR TITLE
Align expect messages with guidance

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -146,7 +146,7 @@ mod prim_bool {}
 ///
 /// ```ignore (hypothetical-example)
 /// loop {
-///     let (client, request) = get_request().expect("disconnected");
+///     let (client, request) = get_request().expect("server should stay connected");
 ///     let response = request.process();
 ///     response.send(client);
 /// }

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -114,14 +114,15 @@
 //!
 //! You might instead, if you don't want to handle the error, simply
 //! assert success with [`expect`]. This will panic if the
-//! write fails, providing a marginally useful message indicating why:
+//! write fails, providing a message explaining why the write was expected
+//! to succeed:
 //!
 //! ```no_run
 //! use std::fs::File;
 //! use std::io::prelude::*;
 //!
 //! let mut file = File::create("valuable_data.txt").unwrap();
-//! file.write_all(b"important message").expect("failed to write message");
+//! file.write_all(b"important message").expect("writing to the file should succeed");
 //! ```
 //!
 //! You might also simply assert success:
@@ -978,7 +979,7 @@ impl<T, E> Result<T, E> {
     ///     .parse::<u8>()
     ///     .inspect(|x| println!("original: {x}"))
     ///     .map(|x| x.pow(3))
-    ///     .expect("failed to parse number");
+    ///     .expect("literal `4` should parse as a `u8`");
     /// ```
     #[inline]
     #[stable(feature = "result_option_inspect", since = "1.76.0")]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Issue: https://github.com/rust-lang/rust/issues/159751

- Changed 3 `expect` messages and some relevant comments in `library/core/src/result.rs` and `library/core/src/primitive_docs.rs`

- I intentionally left the below snippet unchanged in `library/core/src/result.rs`.
The example is quite minimal and focuses on showing the panic output format, so I thought it was better to keep the message short and simple.
```
    /// # Panics
    ///
    /// Panics if the value is an [`Err`], with a panic message including the
    /// passed message, and the content of the [`Err`].
    ///
    ///
    /// # Examples
    ///
    /// ```should_panic
    /// let x: Result<u32, &str> = Err("emergency failure");
    /// x.expect("Testing expect"); // panics with `Testing expect: emergency failure`
    /// ```
```

r? @fee1-dead 