### PR TITLE
Fix invalidation of stdlib in bootstrap when using non-LLVM codegen backends

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1798,10 +1798,7 @@ fn write_codegen_backend_stamp(
         return stamp;
     }
 
-    let mut files = files.into_iter().filter(|f| {
-        let filename = f.file_name().unwrap().to_str().unwrap();
-        is_dylib(f) && filename.contains("rustc_codegen_")
-    });
+    let mut files = files.into_iter().filter(|f| looks_like_codegen_backend(Path::new(f)));
     let codegen_backend = match files.next() {
         Some(f) => f,
         None => panic!("no dylibs built for codegen backend?"),
@@ -1814,6 +1811,11 @@ fn write_codegen_backend_stamp(
     stamp = stamp.add_stamp(codegen_backend);
     t!(stamp.write());
     stamp
+}
+
+pub fn looks_like_codegen_backend(path: &Path) -> bool {
+    is_dylib(path)
+        && path.file_name().and_then(|p| p.to_str()).is_some_and(|n| n.contains("rustc_codegen_"))
 }
 
 /// Creates the `codegen-backends` folder for a compiler that's about to be

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -15,7 +15,7 @@ use tracing::instrument;
 
 pub use self::cargo::{Cargo, apply_pgo, cargo_profile_var};
 pub use crate::Compiler;
-use crate::core::build_steps::compile::{Std, StdLink};
+use crate::core::build_steps::compile::{Std, StdLink, looks_like_codegen_backend};
 use crate::core::build_steps::tool::RustcPrivateCompilers;
 use crate::core::build_steps::{
     check, clean, clippy, compile, dist, doc, gcc, install, llvm, run, setup, test, tool, vendor,
@@ -1466,6 +1466,7 @@ Alternatively, you can set `build.local-rebuild=true` and use a stage0 compiler 
             .into_iter()
             .flatten()
             .filter_map(Result::ok)
+            .filter(|path| looks_like_codegen_backend(&path.path()))
             .map(|entry| entry.path())
     }
 


### PR DESCRIPTION
This was quite the detective hunt. Antoyo reached out to me that when using the GCC codegen backend by default (`--set rust.codegen-backends=["gcc"]`), the stdlib is invalidated after every rebuild.

I did some digging, and found out this:
- The `Builder::cargo` step manually invalidates the target directory if any of the used codegen backends is dirty, because apparently the used codegen backend is not tracked by `-Zbinary-dep-depinfo` yet.
- It does so by getting all paths from `<sysroot>/lib/rustlib/<target>/codegen-backends` via the `Builder::codegen_backends` function, and if any such path is newer than the output directory, the output directory is deleted.
- The intention was for this function to return codegen backends, i.e. `.so/.dll` files. However, since the GCC codegen backend has additional dependencies (libgccjit), the `codegen-backends` contains a `lib` subdirectory. And bootstrap was checking the mtime of this *directory*, which was always considered dirty.

So I changed the function to only return the actual codegen backends, which fixes the issue. In theory, we should also be checking all the nested contents of the `lib` directory, i.e. the libgccjit dylibs, but I think that if they change, the GCC codegen backend itself should also change, in the vast majority of cases, so I consider this to be a worthy fix in the meantime.

CC @antoyo @bjorn3
