### PR TITLE
Suggest mutable method when iterating over binding

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -1086,62 +1086,76 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
                 }
             }
         }
-        if let Some(body) = tcx.hir_maybe_body_owned_by(self.mir_def_id())
-            && let Block(block, _) = body.value.kind
+        let Some(body) = tcx.hir_maybe_body_owned_by(self.mir_def_id()) else { return };
+        let Block(block, _) = body.value.kind else { return };
+        // `span` corresponds to the expression being iterated, find the `for`-loop desugared
+        // expression with that span in order to identify potential fixes when encountering a
+        // read-only iterator that should be mutable.
+        let mut expr = if let ControlFlow::Break(expr) = (Finder { span }).visit_block(block)
+            && let Call(_, [expr]) = expr.kind
         {
-            // `span` corresponds to the expression being iterated, find the `for`-loop desugared
-            // expression with that span in order to identify potential fixes when encountering a
-            // read-only iterator that should be mutable.
-            if let ControlFlow::Break(expr) = (Finder { span }).visit_block(block)
-                && let Call(_, [expr]) = expr.kind
-            {
-                match expr.kind {
-                    MethodCall(path_segment, _, _, span) => {
-                        // We have `for _ in iter.read_only_iter()`, try to
-                        // suggest `for _ in iter.mutable_iter()` instead.
-                        let opt_suggestions = tcx
-                            .typeck(path_segment.hir_id.owner.def_id)
-                            .type_dependent_def_id(expr.hir_id)
-                            .and_then(|def_id| tcx.impl_of_assoc(def_id))
-                            .map(|def_id| tcx.associated_items(def_id))
-                            .map(|assoc_items| {
-                                assoc_items
-                                    .in_definition_order()
-                                    .map(|assoc_item_def| assoc_item_def.ident(tcx))
-                                    .filter(|&ident| {
-                                        let original_method_ident = path_segment.ident;
-                                        original_method_ident != ident
-                                            && ident.as_str().starts_with(
-                                                &original_method_ident.name.to_string(),
-                                            )
-                                    })
-                                    .map(|ident| format!("{ident}()"))
-                                    .peekable()
-                            });
+            expr
+        } else {
+            return;
+        };
+        loop {
+            match expr.kind {
+                MethodCall(path_segment, _, _, span) => {
+                    // We have `for _ in iter.read_only_iter()`, try to
+                    // suggest `for _ in iter.mutable_iter()` instead.
+                    let opt_suggestions = tcx
+                        .typeck(path_segment.hir_id.owner.def_id)
+                        .type_dependent_def_id(expr.hir_id)
+                        .and_then(|def_id| tcx.impl_of_assoc(def_id))
+                        .map(|def_id| tcx.associated_items(def_id))
+                        .map(|assoc_items| {
+                            assoc_items
+                                .in_definition_order()
+                                .map(|assoc_item_def| assoc_item_def.ident(tcx))
+                                .filter(|&ident| {
+                                    let original_method_ident = path_segment.ident;
+                                    original_method_ident != ident
+                                        && ident
+                                            .as_str()
+                                            .starts_with(&original_method_ident.name.to_string())
+                                })
+                                .map(|ident| format!("{ident}()"))
+                                .peekable()
+                        });
 
-                        if let Some(mut suggestions) = opt_suggestions
-                            && suggestions.peek().is_some()
-                        {
-                            err.span_suggestions(
-                                span,
-                                "use mutable method",
-                                suggestions,
-                                Applicability::MaybeIncorrect,
-                            );
-                        }
-                    }
-                    AddrOf(BorrowKind::Ref, Mutability::Not, expr) => {
-                        // We have `for _ in &i`, suggest `for _ in &mut i`.
-                        err.span_suggestion_verbose(
-                            expr.span.shrink_to_lo(),
-                            "use a mutable iterator instead",
-                            "mut ",
-                            Applicability::MachineApplicable,
+                    if let Some(mut suggestions) = opt_suggestions
+                        && suggestions.peek().is_some()
+                    {
+                        err.span_suggestions(
+                            span,
+                            "use mutable method",
+                            suggestions,
+                            Applicability::MaybeIncorrect,
                         );
                     }
-                    _ => {}
                 }
+                AddrOf(BorrowKind::Ref, Mutability::Not, expr) => {
+                    // We have `for _ in &i`, suggest `for _ in &mut i`.
+                    err.span_suggestion_verbose(
+                        expr.span.shrink_to_lo(),
+                        "use a mutable iterator instead",
+                        "mut ",
+                        Applicability::MachineApplicable,
+                    );
+                }
+                ExprKind::Path(hir::QPath::Resolved(None, path))
+                    if let hir::def::Res::Local(hir_id) = path.res
+                        && let hir::Node::LetStmt(stmt) =
+                            self.infcx.tcx.parent_hir_node(hir_id)
+                        && let Some(init) = stmt.init =>
+                {
+                    // We're iterating over a binding, try to suggest changing the binding's expr.
+                    expr = init;
+                    continue;
+                }
+                _ => {}
             }
+            break;
         }
     }
 

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
@@ -1,5 +1,5 @@
 //@ run-rustfix
-// https://github.com/rust-lang/rust/issues/82081
+// https://github.com/rust-lang/rust/issues/82081 & https://github.com/rust-lang/rust/issues/49839
 
 use std::collections::HashMap;
 
@@ -7,7 +7,7 @@ struct Test {
     v: u32,
 }
 
-fn main() {
+fn a() {
     let mut map = HashMap::new();
     map.insert("a", Test { v: 0 });
 
@@ -18,4 +18,23 @@ fn main() {
         //~^ ERROR cannot assign to `v.v`
         //~| NOTE `v` is a `&` reference
     }
+}
+
+fn b() {
+    let mut map = HashMap::new();
+    map.insert("a", Test { v: 0 });
+
+    let x = map.iter_mut();
+    //~^ HELP use mutable method
+    for (_k, v) in x {
+        //~^ NOTE this iterator yields `&` references
+        v.v += 1;
+        //~^ ERROR cannot assign to `v.v`
+        //~| NOTE `v` is a `&` reference
+    }
+}
+
+fn main() {
+    a();
+    b();
 }

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
@@ -1,5 +1,5 @@
 //@ run-rustfix
-// https://github.com/rust-lang/rust/issues/82081
+// https://github.com/rust-lang/rust/issues/82081 & https://github.com/rust-lang/rust/issues/49839
 
 use std::collections::HashMap;
 
@@ -7,7 +7,7 @@ struct Test {
     v: u32,
 }
 
-fn main() {
+fn a() {
     let mut map = HashMap::new();
     map.insert("a", Test { v: 0 });
 
@@ -18,4 +18,23 @@ fn main() {
         //~^ ERROR cannot assign to `v.v`
         //~| NOTE `v` is a `&` reference
     }
+}
+
+fn b() {
+    let mut map = HashMap::new();
+    map.insert("a", Test { v: 0 });
+
+    let x = map.iter();
+    //~^ HELP use mutable method
+    for (_k, v) in x {
+        //~^ NOTE this iterator yields `&` references
+        v.v += 1;
+        //~^ ERROR cannot assign to `v.v`
+        //~| NOTE `v` is a `&` reference
+    }
+}
+
+fn main() {
+    a();
+    b();
 }

--- a/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
+++ b/tests/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
@@ -12,6 +12,20 @@ help: use mutable method
 LL |     for (_k, v) in map.iter_mut() {
    |                            ++++
 
-error: aborting due to 1 previous error
+error[E0594]: cannot assign to `v.v`, which is behind a `&` reference
+  --> $DIR/suggest-mut-method-for-loop-hashmap.rs:31:9
+   |
+LL |     for (_k, v) in x {
+   |                    - this iterator yields `&` references
+LL |
+LL |         v.v += 1;
+   |         ^^^^^^^^ `v` is a `&` reference, so it cannot be written to
+   |
+help: use mutable method
+   |
+LL |     let x = map.iter_mut();
+   |                     ++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0594`.


### PR DESCRIPTION
When encountering a for loop that requires a mutable iterator item, we previously suggested changing the method on the iterated expression, but ignored bindings. We now go to the binding's definition and suggest changing the method there too.

```
error[E0594]: cannot assign to `v.v`, which is behind a `&` reference
  --> $DIR/suggest-mut-method-for-loop-hashmap.rs:31:9
   |
LL |     for (_k, v) in x {
   |                    - this iterator yields `&` references
...
LL |         v.v += 1;
   |         ^^^^^^^^ `v` is a `&` reference, so it cannot be written to
   |
help: use mutable method
   |
LL |     let mut x = map.iter_mut();
   |                         ++++
```

Fix rust-lang/rust#49839.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
