### PR TITLE
Avoid stale closure recovery state across statements

### DIFF
--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -54,6 +54,8 @@ impl<'a> Parser<'a> {
         force_collect: ForceCollect,
         force_full_expr: bool,
     ) -> PResult<'a, Stmt> {
+        self.current_closure.take();
+
         let pre_attr_pos = self.collect_pos();
         let attrs = self.parse_outer_attributes()?;
         let lo = self.token.span;

--- a/tests/ui/expr/malformed_closure/missing-braces-before-close-brace.rs
+++ b/tests/ui/expr/malformed_closure/missing-braces-before-close-brace.rs
@@ -1,0 +1,11 @@
+// Regression test for https://github.com/rust-lang/rust/issues/159989
+
+fn main() {
+    for<> || -> () {};
+    //~^ ERROR `for<...>` binders for closures are experimental
+    for<'a> || -> () |_;
+    //~^ ERROR expected one of `,`, `:`, or `|`, found `;`
+    //~| ERROR expected one of `,`, `:`, or `|`, found `;`
+    //~| ERROR expected `{`, found `|`
+    //~| ERROR `for<...>` binders for closures are experimental
+}

--- a/tests/ui/expr/malformed_closure/missing-braces-before-close-brace.stderr
+++ b/tests/ui/expr/malformed_closure/missing-braces-before-close-brace.stderr
@@ -1,0 +1,45 @@
+error: expected one of `,`, `:`, or `|`, found `;`
+  --> $DIR/missing-braces-before-close-brace.rs:6:24
+   |
+LL |     for<'a> || -> () |_;
+   |                        ^ expected one of `,`, `:`, or `|`
+
+error: expected one of `,`, `:`, or `|`, found `;`
+  --> $DIR/missing-braces-before-close-brace.rs:6:24
+   |
+LL |     for<'a> || -> () |_;
+   |                        ^ expected one of `,`, `:`, or `|`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected `{`, found `|`
+  --> $DIR/missing-braces-before-close-brace.rs:6:22
+   |
+LL |     for<'a> || -> () |_;
+   |                      ^ expected `{`
+
+error[E0658]: `for<...>` binders for closures are experimental
+  --> $DIR/missing-braces-before-close-brace.rs:4:5
+   |
+LL |     for<> || -> () {};
+   |     ^^^^^
+   |
+   = note: see issue #97362 <https://github.com/rust-lang/rust/issues/97362> for more information
+   = help: add `#![feature(closure_lifetime_binder)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: consider removing `for<...>`
+
+error[E0658]: `for<...>` binders for closures are experimental
+  --> $DIR/missing-braces-before-close-brace.rs:6:5
+   |
+LL |     for<'a> || -> () |_;
+   |     ^^^^^^^
+   |
+   = note: see issue #97362 <https://github.com/rust-lang/rust/issues/97362> for more information
+   = help: add `#![feature(closure_lifetime_binder)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: consider removing `for<...>`
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#159989

`current_closure` was cleared when starting a new expression through `parse_expr`, but statement expressions call `parse_expr_res` directly. This allowed closure recovery state from one statement to remain active while parsing the next statement.

This pr clears `current_closure` when entering `parse_stmt_without_recovery`, matching the behavior of `parse_expr`.

https://github.com/rust-lang/rust/blob/da2697d1d842f4faf83083115aab396f82829a3a/compiler/rustc_parse/src/parser/expr.rs#L55-L56

https://github.com/rust-lang/rust/blob/da2697d1d842f4faf83083115aab396f82829a3a/compiler/rustc_parse/src/parser/expr.rs#L63-L64