### PR TITLE
[experiment] try to enable TrustedLen for (old) thin vec

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -194,6 +194,7 @@ where
                     .map(|obligation| NextSolverError::Overflow(obligation)),
             )
             .map(|e| E::from_solver_error(infcx, e))
+            .skip(0)
             .collect()
     }
 

--- a/compiler/rustc_type_ir/Cargo.toml
+++ b/compiler/rustc_type_ir/Cargo.toml
@@ -41,5 +41,6 @@ nightly = [
     "rustc_type_ir_macros/nightly",
     "smallvec/may_dangle",
     "smallvec/union",
+    "thin-vec/unstable"
 ]
 # tidy-alphabetical-end


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This looks like it causes a regression, I want to test this out.