### PR TITLE
miri: ensure validity of references and pointers we dereference and cast

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1605,8 +1605,8 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             ),
                         }
                     }
-                    CastKind::Subtype => {
-                        bug!("CastKind::Subtype shouldn't exist in borrowck")
+                    CastKind::Subtype | CastKind::BoxDerefTransmute => {
+                        bug!("CastKind::{cast_kind:?} shouldn't exist in borrowck")
                     }
                 }
             }

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -823,7 +823,11 @@ fn codegen_stmt<'tcx>(fx: &mut FunctionCx<'_, '_, 'tcx>, cur_block: Block, stmt:
                     let operand = codegen_operand(fx, operand);
                     crate::unsize::coerce_unsized_into(fx, operand, lval);
                 }
-                Rvalue::Cast(CastKind::Transmute | CastKind::Subtype, ref operand, _to_ty) => {
+                Rvalue::Cast(
+                    CastKind::Transmute | CastKind::BoxDerefTransmute | CastKind::Subtype,
+                    ref operand,
+                    _to_ty,
+                ) => {
                     let operand = codegen_operand(fx, operand);
                     lval.write_cvalue_transmute(fx, operand);
                 }

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -619,7 +619,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             bug!("Unsupported cast of {operand:?} to {cast:?}");
                         })
                     }
-                    mir::CastKind::Transmute | mir::CastKind::Subtype => {
+                    mir::CastKind::Transmute | mir::CastKind::BoxDerefTransmute | mir::CastKind::Subtype => {
                         self.codegen_transmute_operand(bx, operand, cast)
                     }
                 };

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -31,10 +31,66 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // possible.
         let cast_layout =
             if cast_ty == dest.layout.ty { dest.layout } else { self.layout_of(cast_ty)? };
-        // FIXME: In which cases should we trigger UB when the source is uninit?
+
+        // Check that the input is valid.
+        // Can be skipped for transmuts and unsizing as those do validation below.
+        if !matches!(
+            cast_kind,
+            CastKind::Transmute
+                | CastKind::Subtype
+                | CastKind::BoxDerefTransmute
+                | CastKind::PointerCoercion(PointerCoercion::Unsize, _)
+        ) && M::enforce_validity(self, src.layout)
+        {
+            match src.layout.ty.kind() {
+                ty::RawPtr { .. } => {
+                    // We only need to check anything for wide pointers.
+                    if matches!(src.layout.backend_repr, rustc_abi::BackendRepr::ScalarPair { .. })
+                    {
+                        self.deref_pointer(src)?;
+                    }
+                }
+                ty::FnPtr { .. } => {
+                    let ptr = self.read_pointer(src)?;
+                    self.get_ptr_fn(ptr)?;
+                }
+                ty::Closure(_closure, args) => {
+                    // Can only happen for non-capturing closures, which have nothing to validate.
+                    let args = args.as_closure();
+                    assert!(args.upvar_tys().is_empty());
+                }
+                // Types that have no requirements or whose requirements are checked by the actual
+                // cast operation.
+                ty::Int(..)
+                | ty::Uint(..)
+                | ty::Float(..)
+                | ty::Bool
+                | ty::Char
+                | ty::FnDef(..) => {}
+
+                _ => {
+                    span_bug!(
+                        self.cur_span(),
+                        "unexpected input type in non-transmute/unsize cast: {}",
+                        src.layout.ty
+                    )
+                }
+            }
+        }
+
         match cast_kind {
             CastKind::PointerCoercion(PointerCoercion::Unsize, _) => {
                 self.unsize_into(src, cast_layout, dest)?;
+                // Validate the entire thing and reset any padding in the output.
+                // It is enough to validate the output because we are only adding metadata,
+                // not discarding anything from the input that may have been invalid.
+                if M::enforce_validity(self, dest.layout()) {
+                    self.validate_place(
+                        dest,
+                        M::enforce_validity_recursively(self, dest.layout()),
+                        /*reset_provenance_and_padding*/ true,
+                    )?;
+                }
             }
 
             CastKind::PointerExposeProvenance => {
@@ -157,6 +213,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     self.deref_pointer(&ptr)?;
                 }
 
+                // This does validation at `src` and `dest` type.
                 self.copy_op_allow_transmute(src, dest)?;
             }
         }
@@ -276,6 +333,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // Let's make sure v is sign-extended *if* it has a signed type.
         let signed = src_layout.backend_repr.is_signed(); // Also asserts that abi is `Scalar`.
 
+        // We go through the actual type of `src` to ensure the value is valid.
         let v = match src_layout.ty.kind() {
             ty::Uint(_) | ty::RawPtr(..) | ty::FnPtr(..) => scalar.to_uint(src_layout.size)?,
             ty::Int(_) => scalar.to_int(src_layout.size)? as u128, // we will cast back to `i128` below if the sign matters
@@ -468,6 +526,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         }
     }
 
+    /// Perform an unsizing coercion. The caller is responsible for checking validity afterwards!
     pub fn unsize_into(
         &mut self,
         src: &OpTy<'tcx, M::Provenance>,
@@ -499,7 +558,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     if src_field.layout.is_1zst() && cast_ty_field.is_1zst() {
                         // Skip 1-ZST fields.
                     } else if src_field.layout.ty == cast_ty_field.ty {
-                        self.copy_op(&src_field, &dst_field)?;
+                        // The caller performs validation.
+                        self.copy_op_no_validate(
+                            &src_field, &dst_field, /* allow_transmute */ false,
+                        )?;
                     } else {
                         if found_cast_field {
                             span_bug!(self.cur_span(), "unsize_into: more than one field to cast");

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -17,7 +17,7 @@ use super::{
     throw_ub_format,
 };
 use crate::enter_trace_span;
-use crate::interpret::Writeable;
+use crate::interpret::{Projectable, Writeable};
 
 impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     pub fn cast(
@@ -133,7 +133,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 }
             }
 
-            CastKind::Transmute | CastKind::Subtype => {
+            CastKind::Transmute | CastKind::Subtype | CastKind::BoxDerefTransmute => {
                 assert!(src.layout.is_sized());
                 assert!(dest.layout.is_sized());
                 assert_eq!(cast_ty, dest.layout.ty); // we otherwise ignore `cast_ty` enirely...
@@ -145,6 +145,16 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                         src = src.layout.ty,
                         dest = dest.layout.ty,
                     );
+                }
+
+                if matches!(cast_kind, CastKind::BoxDerefTransmute) {
+                    // Do the extra UB checking by making the input an actual `Box<T>` pointer
+                    // and dereferencing it.
+                    let ptr = self.read_immediate(src)?;
+                    let pointee_ty = cast_ty.builtin_deref(true).unwrap();
+                    let box_ty = Ty::new_box(*self.tcx, pointee_ty);
+                    let ptr = ptr.transmute(self.layout_of(box_ty)?, self)?;
+                    self.deref_pointer(&ptr)?;
                 }
 
                 self.copy_op_allow_transmute(src, dest)?;

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -472,7 +472,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
                 // Check that the memory between them is dereferenceable at all, starting from the
                 // origin pointer: `dist` is `a - b`, so it is based on `b`.
-                self.check_ptr_access_signed(b, dist, CheckInAllocMsg::Dereferenceable)
+                self.check_ptr_access_signed(b, dist, CheckInAllocMsg::Dereferenceable("pointer"))
                     .map_err_kind(|_| {
                         // This could mean they point to different allocations, or they point to the same allocation
                         // but not the entire range between the pointers is in-bounds.
@@ -494,7 +494,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 self.check_ptr_access_signed(
                     a,
                     dist.checked_neg().unwrap(), // i64::MIN is impossible as no allocation can be that large
-                    CheckInAllocMsg::Dereferenceable,
+                    CheckInAllocMsg::Dereferenceable("pointer"),
                 )
                 .map_err_kind(|_| {
                     // Make the error more specific.

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -1071,14 +1071,17 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         expected_trait: Option<&'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>>,
     ) -> InterpResult<'tcx, Ty<'tcx>> {
         trace!("get_ptr_vtable({:?})", ptr);
-        let (alloc_id, offset, _tag) = self.ptr_get_alloc_id(ptr, 0)?;
+        let (alloc_id, offset, _tag) = self.ptr_get_alloc_id(ptr, 0).map_err_kind(|err| {
+            let err_ub!(DanglingIntPointer { addr, .. }) = err else { bug!() };
+            err_ub!(InvalidVTablePointer(Pointer::without_provenance(addr)))
+        })?;
         if offset.bytes() != 0 {
-            throw_ub!(InvalidVTablePointer(Pointer::new(alloc_id, offset)))
+            throw_ub!(InvalidVTablePointer(Pointer::new(alloc_id, offset).into()))
         }
         let Some(GlobalAlloc::VTable(ty, vtable_dyn_type)) =
             self.tcx.try_get_global_alloc(alloc_id)
         else {
-            throw_ub!(InvalidVTablePointer(Pointer::new(alloc_id, offset)))
+            throw_ub!(InvalidVTablePointer(Pointer::new(alloc_id, offset).into()))
         };
         if let Some(expected_dyn_type) = expected_trait {
             self.check_vtable_for_type(vtable_dyn_type, expected_dyn_type)?;
@@ -1720,11 +1723,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         size: i64,
     ) -> InterpResult<'tcx, (AllocId, Size, M::ProvenanceExtra)> {
         self.ptr_try_get_alloc_id(ptr, size)
-            .map_err(|offset| {
+            .map_err(|addr| {
                 err_ub!(DanglingIntPointer {
-                    addr: offset,
+                    addr,
                     inbounds_size: size,
-                    msg: CheckInAllocMsg::Dereferenceable
+                    msg: CheckInAllocMsg::Dereferenceable("pointer")
                 })
             })
             .into()

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -640,7 +640,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     /// Try returning an immediate for the operand. If the layout does not permit loading this as an
     /// immediate, return where in memory we can find the data.
     /// Note that for a given layout, this operation will either always return Left or Right!
-    /// succeed!  Whether it returns Left depends on whether the layout can be represented
+    /// Whether it returns Left depends on whether the layout can be represented
     /// in an `Immediate`, not on which data is stored there currently.
     ///
     /// This is an internal function that should not usually be used; call `read_immediate` instead.

--- a/compiler/rustc_const_eval/src/interpret/operator.rs
+++ b/compiler/rustc_const_eval/src/interpret/operator.rs
@@ -428,8 +428,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         }
     }
 
-    /// Returns the result of the specified operation, whether it overflowed, and
-    /// the result type.
+    /// Returns the result of the specified operation.
     pub fn unary_op(
         &self,
         un_op: mir::UnOp,
@@ -486,6 +485,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             }
             ty::RawPtr(..) | ty::Ref(..) => {
                 assert_eq!(un_op, PtrMetadata);
+                self.deref_pointer(val)?; // validity check
                 let (_, meta) = val.to_scalar_and_meta();
                 interp_ok(match meta {
                     MemPlaceMeta::Meta(scalar) => {

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -13,9 +13,10 @@ use tracing::field::Empty;
 use tracing::{instrument, trace};
 
 use super::{
-    AllocInit, AllocRef, AllocRefMut, CheckAlignMsg, CtfeProvenance, ImmTy, Immediate, InterpCx,
-    InterpResult, Machine, MemoryKind, Misalignment, OffsetMode, OpTy, Operand, Pointer,
-    Projectable, Provenance, Scalar, alloc_range, interp_ok, mir_assign_valid_types,
+    AllocInit, AllocRef, AllocRefMut, CheckAlignMsg, CheckInAllocMsg, CtfeProvenance, ImmTy,
+    Immediate, InterpCx, InterpResult, Machine, MemoryKind, Misalignment, OffsetMode, OpTy,
+    Operand, Pointer, Projectable, Provenance, Scalar, alloc_range, err_ub, err_ub_format,
+    interp_ok, mir_assign_valid_types, throw_ub_format,
 };
 use crate::enter_trace_span;
 
@@ -462,22 +463,79 @@ where
 
     /// Take an operand, representing a pointer, and dereference it to a place.
     /// Corresponds to the `*` operator in Rust.
+    /// Unlike `imm_ptr_to_mplace`, this checks that the pointer is valid for its type.
     #[instrument(skip(self), level = "trace")]
     pub fn deref_pointer(
         &self,
         src: &impl Projectable<'tcx, M::Provenance>,
     ) -> InterpResult<'tcx, MPlaceTy<'tcx, M::Provenance>> {
-        if src.layout().ty.is_box() {
-            // Derefer should have removed all Box derefs.
-            // Some `Box` are not immediates (if they have a custom allocator)
-            // so the code below would fail.
-            bug!("dereferencing {}", src.layout().ty);
+        let src_ty = src.layout().ty;
+        // Obtain the actual pointer we are deref'ing.
+        let val = if src_ty.is_box() {
+            // Project to where we have an actual pointer.
+            let (raw_ptr, _alloc) = self.project_to_ptr_in_box(src)?;
+            self.read_immediate(&raw_ptr)?
+        } else {
+            self.read_immediate(src)?
+        };
+        // Construct a place for that pointer.
+        trace!("deref to {} on {:?}", val.layout.ty, *val);
+        let mplace = self.imm_ptr_to_mplace(&val)?;
+
+        // This is conceptually a typed load from `src` to get the pointer. Most of the time when
+        // we do typed loads for primitive operations, all relevant invariants are checked
+        // implicitly, e.g. when we call `to_bool()` on a Boolean.
+        // But here, we do need to specifically check for metadata validity, null, alignment, and
+        // dereferenceability, or they will not be checked anywhere at all.
+        // (We do *not* currently check the allocator, if there is any. Basically we are saying that
+        // `Box<T, A>` is a library type where the pointer field is a language-primitive `box T`.)
+        // This duplicates some of the logic in the validity check, but so far we found no
+        // good way to share that logic.
+        if src_ty.is_ref() || src_ty.is_box() {
+            let kind = if src_ty.is_ref() { "reference" } else { "box" };
+
+            // Null check.
+            let scalar_ptr = Scalar::from_maybe_pointer(mplace.ptr(), self);
+            if self.scalar_may_be_null(scalar_ptr)? {
+                let maybe = !M::Provenance::OFFSET_IS_ADDR && matches!(scalar_ptr, Scalar::Ptr(..));
+                throw_ub_format!(
+                    "dereferencing a {maybe}null {kind}",
+                    maybe = if maybe { "maybe-" } else { "" }
+                );
+            }
+
+            // Dereferencability and alignment check. This also implicitly checks metadata validity.
+            let (size, align) = self
+                .size_and_align_of_val(&mplace)?
+                .unwrap_or_else(|| (mplace.layout.size, mplace.layout.align.abi));
+            self.check_ptr_access(mplace.ptr(), size, CheckInAllocMsg::Dereferenceable(kind))?;
+            self.check_ptr_align(mplace.ptr(), align).map_err_kind(|err| {
+                let err_ub!(AlignmentCheckFailed(Misalignment { required, has }, _msg)) = err else { bug!() };
+                err_ub_format!(
+                    "encountered an unaligned {kind} (required {required_bytes} byte alignment but found {found_bytes})",
+                    required_bytes = required.bytes(),
+                    found_bytes = has.bytes()
+                )
+            })?;
+        } else {
+            assert!(src_ty.is_raw_ptr());
+            // For raw pointers, the validity invariant is pretty weak, but we do require the vtable
+            // to make sense, so we do have to check that if there is one.
+            if mplace.layout.is_unsized() {
+                let tail = self.tcx.struct_tail_for_codegen(mplace.layout.ty, self.typing_env);
+                match tail.kind() {
+                    ty::Dynamic(data, _) => {
+                        let vtable = mplace.meta().unwrap_meta().to_pointer(self)?;
+                        self.get_ptr_vtable_ty(vtable, Some(data))?;
+                    }
+                    ty::Slice(..) | ty::Str | ty::Foreign(..) => {
+                        // Nothing to check (`read_immediate` already ensured initialization).
+                    }
+                    _ => bug!("Unexpected unsized type tail: {:?}", tail),
+                }
+            }
         }
 
-        let val = self.read_immediate(src)?;
-        trace!("deref to {} on {:?}", val.layout.ty, *val);
-
-        let mplace = self.imm_ptr_to_mplace(&val)?;
         interp_ok(mplace)
     }
 

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -469,15 +469,12 @@ where
         &self,
         src: &impl Projectable<'tcx, M::Provenance>,
     ) -> InterpResult<'tcx, MPlaceTy<'tcx, M::Provenance>> {
-        let src_ty = src.layout().ty;
-        // Obtain the actual pointer we are deref'ing.
-        let val = if src_ty.is_box() {
-            // Project to where we have an actual pointer.
-            let (raw_ptr, _alloc) = self.project_to_ptr_in_box(src)?;
-            self.read_immediate(&raw_ptr)?
-        } else {
-            self.read_immediate(src)?
-        };
+        let ptr_ty = src.layout().ty;
+        if !(ptr_ty.is_ref() || ptr_ty.is_raw_ptr() || ptr_ty.is_box_global(*self.tcx)) {
+            bug!("dereferencing {}", src.layout().ty);
+        }
+
+        let val = self.read_immediate(src)?;
         // Construct a place for that pointer.
         trace!("deref to {} on {:?}", val.layout.ty, *val);
         let mplace = self.imm_ptr_to_mplace(&val)?;
@@ -487,12 +484,10 @@ where
         // implicitly, e.g. when we call `to_bool()` on a Boolean.
         // But here, we do need to specifically check for metadata validity, null, alignment, and
         // dereferenceability, or they will not be checked anywhere at all.
-        // (We do *not* currently check the allocator, if there is any. Basically we are saying that
-        // `Box<T, A>` is a library type where the pointer field is a language-primitive `box T`.)
         // This duplicates some of the logic in the validity check, but so far we found no
         // good way to share that logic.
-        if src_ty.is_ref() || src_ty.is_box() {
-            let kind = if src_ty.is_ref() { "reference" } else { "box" };
+        if ptr_ty.is_ref() || ptr_ty.is_box() {
+            let kind = if ptr_ty.is_ref() { "reference" } else { "box" };
 
             // Null check.
             let scalar_ptr = Scalar::from_maybe_pointer(mplace.ptr(), self);
@@ -518,7 +513,7 @@ where
                 )
             })?;
         } else {
-            assert!(src_ty.is_raw_ptr());
+            assert!(ptr_ty.is_raw_ptr());
             // For raw pointers, the validity invariant is pretty weak, but we do require the vtable
             // to make sense, so we do have to check that if there is one.
             if mplace.layout.is_unsized() {
@@ -889,8 +884,13 @@ where
         self.copy_op_inner(src, dest, /* allow_transmute */ false)
     }
 
-    /// Copies the data from an operand to a place.
-    /// `allow_transmute` indicates whether the layouts may disagree.
+    /// Perform a typed copy of the data from an operand to a place.
+    ///
+    /// `allow_transmute` indicates whether the layouts may disagree. In that case there are
+    /// technically *two* typed copies: `src` is a not-yet-loaded value, so we're doing a typed copy
+    /// at `src` type from there to some intermediate storage. And then we're doing a second typed
+    /// copy at `dest` type from that intermediate storage to `dest`. As an optimization, we only
+    /// make a single direct copy here, but we still have to ensure the data is valid at both types.
     #[inline(always)]
     #[instrument(skip(self), level = "trace")]
     fn copy_op_inner(
@@ -899,11 +899,6 @@ where
         dest: &impl Writeable<'tcx, M::Provenance>,
         allow_transmute: bool,
     ) -> InterpResult<'tcx> {
-        // These are technically *two* typed copies: `src` is a not-yet-loaded value,
-        // so we're doing a typed copy at `src` type from there to some intermediate storage.
-        // And then we're doing a second typed copy at `dest` type from that intermediate storage to
-        // `dest`. But as an optimization, we only make a single direct copy here.
-
         // Do the actual copy.
         self.copy_op_no_validate(src, dest, allow_transmute)?;
 
@@ -932,10 +927,10 @@ where
         interp_ok(())
     }
 
-    /// Copies the data from an operand to a place.
+    /// Perform an untyped copy of the data from an operand to a place.
+    /// You are responsible for validating that things get copied at the right type.
+    ///
     /// `allow_transmute` indicates whether the layouts may disagree.
-    /// Also, if you use this you are responsible for validating that things get copied at the
-    /// right type.
     #[instrument(skip(self), level = "trace")]
     pub(super) fn copy_op_no_validate(
         &mut self,

--- a/compiler/rustc_const_eval/src/interpret/projection.rs
+++ b/compiler/rustc_const_eval/src/interpret/projection.rs
@@ -427,4 +427,22 @@ where
             Subslice { from, to, from_end } => self.project_subslice(base, from, to, from_end)?,
         })
     }
+
+    /// Given a value of type `Box`, returns the inner value of raw pointer type, as well as
+    /// the allocator.
+    pub(super) fn project_to_ptr_in_box<P: Projectable<'tcx, M::Provenance>>(
+        &self,
+        box_: &P,
+    ) -> InterpResult<'tcx, (P, P)> {
+        // `Box` has two fields: the pointer we care about, and the allocator.
+        assert_eq!(box_.layout().fields.count(), 2, "`Box` must have exactly 2 fields");
+        let [ptr, alloc] = self.project_fields(box_, [FieldIdx::ZERO, FieldIdx::ONE])?;
+
+        // We simply transmute the pointer we care about to the underlying raw pointer.
+        // (We could project a bit but that would end up at a pattern type that needs a transmute.)
+        let pointee_ty = box_.layout().ty.boxed_ty().unwrap();
+        let raw_ptr_ty = Ty::new_ptr(*self.tcx, pointee_ty, ty::Mutability::Mut);
+        let raw_ptr = ptr.transmute(self.layout_of(raw_ptr_ty)?, self)?; // The actual raw pointer
+        interp_ok((raw_ptr, alloc))
+    }
 }

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -565,6 +565,8 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
         ty: Ty<'tcx>,
         ptr_kind: PtrKind,
     ) -> InterpResult<'tcx> {
+        // Note that some of those checks (those that encode the basic validity invariant of
+        // pointers) are duplicated in `place_deref`, so changes here might need updates there.
         let ptr = self.read_immediate(value, ptr_kind.into())?;
         if self.reset_provenance_and_padding {
             // There's no padding in a pointer.
@@ -604,7 +606,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
                 self.ecx.check_ptr_access(
                     place.ptr(),
                     size,
-                    CheckInAllocMsg::Dereferenceable, // will anyway be replaced by validity message
+                    CheckInAllocMsg::Dereferenceable("pointer"), // will anyway be replaced by validity message
                 ),
                 self.path,
                 Ub(DanglingIntPointer { addr: 0, .. }) =>

--- a/compiler/rustc_const_eval/src/interpret/visitor.rs
+++ b/compiler/rustc_const_eval/src/interpret/visitor.rs
@@ -12,6 +12,9 @@ use super::{InterpCx, MPlaceTy, Machine, Projectable, interp_ok, throw_inval};
 
 /// How to traverse a value and what to do when we are at the leaves.
 pub trait ValueVisitor<'tcx, M: Machine<'tcx>>: Sized {
+    // The `From<MPlaceTy>` rules out `ImmTy`... we could use a `TryFrom` instead since the only
+    // case we need this is visiting something unsized which cannot happen when visiting an `ImmTy`.
+    // But so far this was just not needed.
     type V: Projectable<'tcx, M::Provenance> + From<MPlaceTy<'tcx, M::Provenance>>;
 
     /// The visitor must have an `InterpCx` in it.

--- a/compiler/rustc_const_eval/src/interpret/visitor.rs
+++ b/compiler/rustc_const_eval/src/interpret/visitor.rs
@@ -3,7 +3,7 @@
 
 use std::num::NonZero;
 
-use rustc_abi::{FieldIdx, FieldsShape, VariantIdx, Variants};
+use rustc_abi::{FieldsShape, VariantIdx, Variants};
 use rustc_middle::mir::interpret::InterpResult;
 use rustc_middle::ty::{self, Ty};
 use tracing::trace;
@@ -111,33 +111,9 @@ pub trait ValueVisitor<'tcx, M: Machine<'tcx>>: Sized {
                 // allocator field. We also assert tons of things to ensure we do not miss
                 // any other fields.
 
-                // `Box` has two fields: the pointer we care about, and the allocator.
-                assert_eq!(v.layout().fields.count(), 2, "`Box` must have exactly 2 fields");
-                let [unique_ptr, alloc] =
-                    self.ecx().project_fields(v, [FieldIdx::ZERO, FieldIdx::ONE])?;
+                let (raw_ptr, alloc) = self.ecx().project_to_ptr_in_box(v)?;
 
-                // Unfortunately there is some type junk in the way here: `unique_ptr` is a `Unique`...
-                // (which means another 2 fields, the second of which is a `PhantomData`)
-                assert_eq!(unique_ptr.layout().fields.count(), 2);
-                let [nonnull_ptr, phantom] =
-                    self.ecx().project_fields(&unique_ptr, [FieldIdx::ZERO, FieldIdx::ONE])?;
-                assert!(
-                    phantom.layout().ty.ty_adt_def().is_some_and(|adt| adt.is_phantom_data()),
-                    "2nd field of `Unique` should be PhantomData but is {:?}",
-                    phantom.layout().ty,
-                );
-
-                // ... that contains a `NonNull` whose only field finally is a raw ptr we can
-                // dereference.
-                assert_eq!(nonnull_ptr.layout().fields.count(), 1);
-                let pat_ptr = self.ecx().project_field(&nonnull_ptr, FieldIdx::ZERO)?; // `*mut T is !null`
-                let base = match *pat_ptr.layout().ty.kind() {
-                    ty::Pat(base, _) => self.ecx().layout_of(base)?,
-                    _ => unreachable!(),
-                };
-                let raw_ptr = pat_ptr.transmute(base, self.ecx())?; // The actual raw pointer
-
-                // Hand this actual pointer to the visitor.
+                // Hand the actual pointer to the visitor.
                 self.visit_box(ty, &raw_ptr)?;
 
                 // The second `Box` field is the allocator, which we recursively check for validity

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -251,7 +251,8 @@ pub enum CheckInAllocMsg {
     /// We are doing pointer arithmetic.
     InboundsPointerArithmetic,
     /// None of the above -- generic/unspecific inbounds test.
-    Dereferenceable,
+    /// The string is the subject of the test, e.g. "pointer".
+    Dereferenceable(&'static str),
 }
 
 impl fmt::Display for CheckInAllocMsg {
@@ -260,7 +261,7 @@ impl fmt::Display for CheckInAllocMsg {
         match self {
             MemoryAccess => write!(f, "memory access failed"),
             InboundsPointerArithmetic => write!(f, "in-bounds pointer arithmetic failed"),
-            Dereferenceable => write!(f, "pointer not dereferenceable"),
+            Dereferenceable(what) => write!(f, "{what} not dereferenceable"),
         }
     }
 }
@@ -391,7 +392,7 @@ pub enum UndefinedBehaviorInfo<'tcx> {
     /// Using a pointer-not-to-a-va-list as variable argument list pointer.
     InvalidVaListPointer(Pointer<AllocId>),
     /// Using a pointer-not-to-a-vtable as vtable pointer.
-    InvalidVTablePointer(Pointer<AllocId>),
+    InvalidVTablePointer(Pointer<Option<AllocId>>),
     /// Using a vtable for the wrong trait.
     InvalidVTableTrait {
         /// The vtable that was actually referenced by the wide pointer metadata.
@@ -452,11 +453,11 @@ impl<'tcx> fmt::Display for UndefinedBehaviorInfo<'tcx> {
                 CheckInAllocMsg::InboundsPointerArithmetic => {
                     write!(f, "attempting to offset pointer by {inbounds_size_fmt}")
                 }
-                CheckInAllocMsg::Dereferenceable if inbounds_size == 0 => {
-                    write!(f, "pointer must point to some allocation")
+                CheckInAllocMsg::Dereferenceable(what) if inbounds_size == 0 => {
+                    write!(f, "{what} must point to some allocation")
                 }
-                CheckInAllocMsg::Dereferenceable => {
-                    write!(f, "pointer must be dereferenceable for {inbounds_size_fmt}")
+                CheckInAllocMsg::Dereferenceable(what) => {
+                    write!(f, "{what} must be dereferenceable for {inbounds_size_fmt}")
                 }
             }
         }

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -792,6 +792,7 @@ impl<'tcx> Rvalue<'tcx> {
                 | CastKind::PointerCoercion(_, _)
                 | CastKind::PointerWithExposedProvenance
                 | CastKind::Transmute
+                | CastKind::BoxDerefTransmute
                 | CastKind::Subtype,
                 _,
                 _,

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -1496,6 +1496,14 @@ pub enum CastKind {
     /// MIR is well-formed if the input and output types have different sizes,
     /// but running a transmute between differently-sized types is UB.
     Transmute,
+    /// A special transmute used by elaborated `box` deref's to turn the inner pointer into a raw
+    /// pointer. This is almost equivalent to a regular transmute except that if the input would not
+    /// be valid as `Box<T>`, the cast is UB. Backends that do not care about UB detection can treat
+    /// this like a regular transmute.
+    ///
+    /// Well-formedness: The input type must be a pointer type or a newtype around one (e.g.
+    /// `NonNull`). The output type must be a raw pointer.
+    BoxDerefTransmute,
 
     /// A `Subtype` cast is applied to any [`StatementKind::Assign`] where
     /// type of lvalue doesn't match the type of rvalue, the primary goal is making subtyping

--- a/compiler/rustc_mir_transform/src/elaborate_box_derefs.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_box_derefs.rs
@@ -72,7 +72,7 @@ impl<'a, 'tcx> MutVisitor<'tcx> for ElaborateBoxDerefVisitor<'a, 'tcx> {
                 location,
                 Place::from(ptr_local),
                 Rvalue::Cast(
-                    CastKind::Transmute,
+                    CastKind::BoxDerefTransmute,
                     Operand::Copy(
                         Place::from(place.local)
                             .project_deeper(&build_projection(unique_ty, nonnull_ty), tcx),

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -653,15 +653,8 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
         location: Location,
     ) {
         match elem {
-            ProjectionElem::Deref
-                if self.body.phase >= MirPhase::Runtime(RuntimePhase::Initial) =>
-            {
-                let base_ty = place_ref.ty(&self.body.local_decls, self.tcx).ty;
-
-                if base_ty.is_box() {
-                    self.fail(location, format!("{base_ty} dereferenced after ElaborateBoxDerefs"))
-                }
-            }
+            // Miri needs `Deref` on `Box` to stay intact for proper UB checking,
+            // so we cannot reject it here even though codegen does not support such `Deref`.
             ProjectionElem::Field(f, ty) => {
                 let parent_ty = place_ref.ty(&self.body.local_decls, self.tcx);
                 let fail_out_of_bounds = |this: &mut Self, location| {

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -653,8 +653,15 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
         location: Location,
     ) {
         match elem {
-            // Miri needs `Deref` on `Box` to stay intact for proper UB checking,
-            // so we cannot reject it here even though codegen does not support such `Deref`.
+            ProjectionElem::Deref
+                if self.body.phase >= MirPhase::Runtime(RuntimePhase::Initial) =>
+            {
+                let base_ty = place_ref.ty(&self.body.local_decls, self.tcx).ty;
+
+                if base_ty.is_box() {
+                    self.fail(location, format!("{base_ty} dereferenced after ElaborateBoxDerefs"))
+                }
+            }
             ProjectionElem::Field(f, ty) => {
                 let parent_ty = place_ref.ty(&self.body.local_decls, self.tcx);
                 let fail_out_of_bounds = |this: &mut Self, location| {
@@ -1379,7 +1386,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             );
                         }
                     }
-                    CastKind::Transmute => {
+                    CastKind::Transmute | CastKind::BoxDerefTransmute => {
                         // Unlike `mem::transmute`, a MIR `Transmute` is well-formed
                         // for any two `Sized` types, just potentially UB to run.
 
@@ -1408,6 +1415,17 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                                 location,
                                 format!("Cannot transmute to non-`Sized` type {target_type:?}"),
                             );
+                        }
+
+                        if matches!(kind, CastKind::BoxDerefTransmute) {
+                            if !target_type.is_raw_ptr() {
+                                self.fail(
+                                    location,
+                                    format!(
+                                        "Cannot BoxDerefTransmute to non-pointer type {target_type}"
+                                    ),
+                                );
+                            }
                         }
                     }
                     CastKind::Subtype => {

--- a/compiler/rustc_public/src/mir/body.rs
+++ b/compiler/rustc_public/src/mir/body.rs
@@ -1087,6 +1087,7 @@ pub enum CastKind {
     PtrToPtr,
     FnPtrToPtr,
     Transmute,
+    BoxDerefTransmute,
     Subtype,
 }
 

--- a/compiler/rustc_public/src/unstable/convert/stable/mir.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/mir.rs
@@ -365,6 +365,7 @@ impl<'tcx> Stable<'tcx> for mir::CastKind {
             PtrToPtr => crate::mir::CastKind::PtrToPtr,
             FnPtrToPtr => crate::mir::CastKind::FnPtrToPtr,
             Transmute => crate::mir::CastKind::Transmute,
+            BoxDerefTransmute => crate::mir::CastKind::BoxDerefTransmute,
             Subtype => crate::mir::CastKind::Subtype,
         }
     }

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -189,7 +189,7 @@ fn check_rvalue<'tcx>(
         Rvalue::Cast(CastKind::PointerExposeProvenance, _, _) => {
             Err((span, "casting pointers to ints is unstable in const fn".into()))
         },
-        Rvalue::Cast(CastKind::Transmute, _, _) => Err((
+        Rvalue::Cast(CastKind::Transmute | CastKind::BoxDerefTransmute, _, _) => Err((
             span,
             "transmute can attempt to turn pointers into integers, so is unstable in const fn".into(),
         )),

--- a/src/tools/miri/src/borrow_tracker/stacked_borrows/mod.rs
+++ b/src/tools/miri/src/borrow_tracker/stacked_borrows/mod.rs
@@ -601,7 +601,7 @@ trait EvalContextPrivExt<'tcx, 'ecx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, Option<Provenance>> {
         let this = self.eval_context_mut();
         // Ensure we bail out if the pointer goes out-of-bounds (see miri#1050).
-        this.check_ptr_access(place.ptr(), size, CheckInAllocMsg::Dereferenceable)?;
+        this.check_ptr_access(place.ptr(), size, CheckInAllocMsg::Dereferenceable("pointer"))?;
 
         // It is crucial that this gets called on all code paths, to ensure we track tag creation.
         let log_creation = |this: &MiriInterpCx<'tcx>,

--- a/src/tools/miri/src/borrow_tracker/tree_borrows/mod.rs
+++ b/src/tools/miri/src/borrow_tracker/tree_borrows/mod.rs
@@ -244,7 +244,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, Option<Provenance>> {
         let this = self.eval_context_mut();
         // Ensure we bail out if the pointer goes out-of-bounds (see miri#1050).
-        this.check_ptr_access(place.ptr(), ptr_size, CheckInAllocMsg::Dereferenceable)?;
+        this.check_ptr_access(place.ptr(), ptr_size, CheckInAllocMsg::Dereferenceable("pointer"))?;
 
         // It is crucial that this gets called on all code paths, to ensure we track tag creation.
         let log_creation = |this: &MiriInterpCx<'tcx>,

--- a/src/tools/miri/src/concurrency/sync.rs
+++ b/src/tools/miri/src/concurrency/sync.rs
@@ -339,7 +339,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     {
         assert!(init_val != uninit_val);
         let this = self.eval_context_mut();
-        this.check_ptr_access(obj.ptr(), obj.layout.size, CheckInAllocMsg::Dereferenceable)?;
+        this.check_ptr_access(obj.ptr(), obj.layout.size, CheckInAllocMsg::Dereferenceable("pointer"))?;
         assert!(init_offset < obj.layout.size); // ensure our 1-byte flag fits
         let init_field = obj.offset(init_offset, this.machine.layouts.u8, this)?;
 
@@ -391,7 +391,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         'tcx: 'a,
     {
         let this = self.eval_context_mut();
-        this.check_ptr_access(obj.ptr(), obj.layout.size, CheckInAllocMsg::Dereferenceable)?;
+        this.check_ptr_access(obj.ptr(), obj.layout.size, CheckInAllocMsg::Dereferenceable("pointer"))?;
         assert!(init_offset < obj.layout.size); // ensure our 1-byte flag fits
         let init_field = obj.offset(init_offset, this.machine.layouts.u8, this)?;
 

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -191,8 +191,6 @@ pub const MIRI_DEFAULT_ARGS: &[&str] = &[
     // Disable passes that add checks for language UB -- we get better diagnostics if
     // we let Miri do these checks.
     "-Zmir-enable-passes=-CheckAlignment,-CheckNull,-CheckEnums",
-    // Disable `ElaborateBoxDerefs` as that hides UB from dereferencing invalid `Box`es.
-    "-Zmir-enable-passes=-ElaborateBoxDerefs",
     // FIXME: Disable some passes to make higher opt levels also work.
     // - ReferencePropagation is incompatible with SB's ref-to-raw castb behavior.
     //   The fix here is to ditch SB and use TB instead but we're not yet ready for that.

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -191,6 +191,8 @@ pub const MIRI_DEFAULT_ARGS: &[&str] = &[
     // Disable passes that add checks for language UB -- we get better diagnostics if
     // we let Miri do these checks.
     "-Zmir-enable-passes=-CheckAlignment,-CheckNull,-CheckEnums",
+    // Disable `ElaborateBoxDerefs` as that hides UB from dereferencing invalid `Box`es.
+    "-Zmir-enable-passes=-ElaborateBoxDerefs",
     // FIXME: Disable some passes to make higher opt levels also work.
     // - ReferencePropagation is incompatible with SB's ref-to-raw castb behavior.
     //   The fix here is to ditch SB and use TB instead but we're not yet ready for that.

--- a/src/tools/miri/tests/fail/both_borrows/box-custom-alloc-aliasing.stack.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/box-custom-alloc-aliasing.stack.stderr
@@ -6,7 +6,7 @@ LL |         let thread_id = ptr::read(ptr::addr_of!((*their_bin).thread_id));
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-help: <TAG> was created by a Unique retag at offsets [RANGE]
+help: <TAG> was created by a SharedReadWrite retag at offsets [RANGE]
   --> tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
    |
 LL |     (Box::new_in([t], a) as Box<[T], A>).into_vec()

--- a/src/tools/miri/tests/fail/both_borrows/box-custom-alloc-aliasing.stack.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/box-custom-alloc-aliasing.stack.stderr
@@ -6,7 +6,7 @@ LL |         let thread_id = ptr::read(ptr::addr_of!((*their_bin).thread_id));
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-help: <TAG> was created by a SharedReadWrite retag at offsets [RANGE]
+help: <TAG> was created by a Unique retag at offsets [RANGE]
   --> tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
    |
 LL |     (Box::new_in([t], a) as Box<[T], A>).into_vec()

--- a/src/tools/miri/tests/fail/coroutine-pinned-moved.stderr
+++ b/src/tools/miri/tests/fail/coroutine-pinned-moved.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: memory access failed: ALLOC has been freed, so this pointer is dangling
+error: Undefined Behavior: reference not dereferenceable: ALLOC has been freed, so this pointer is dangling
   --> tests/fail/coroutine-pinned-moved.rs:LL:CC
    |
 LL |         *num += 1;

--- a/src/tools/miri/tests/fail/dangling_pointers/stack_temporary.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/stack_temporary.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: memory access failed: ALLOC has been freed, so this pointer is dangling
+error: Undefined Behavior: reference not dereferenceable: ALLOC has been freed, so this pointer is dangling
   --> tests/fail/dangling_pointers/stack_temporary.rs:LL:CC
    |
 LL |         let val = *x;

--- a/src/tools/miri/tests/fail/dangling_pointers/storage_dead_dangling.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/storage_dead_dangling.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: memory access failed: attempting to access 4 bytes, but got $HEX[noalloc] which is a dangling pointer (it has no provenance)
+error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got $HEX[noalloc] which is a dangling pointer (it has no provenance)
   --> tests/fail/dangling_pointers/storage_dead_dangling.rs:LL:CC
    |
 LL |     let _x = unsafe { *&mut *(LEAK as *mut i32) };

--- a/src/tools/miri/tests/fail/provenance/pointer_partial_overwrite.stderr
+++ b/src/tools/miri/tests/fail/provenance/pointer_partial_overwrite.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: memory access failed: attempting to access 4 bytes, but got $HEX[noalloc] which is a dangling pointer (it has no provenance)
+error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got $HEX[noalloc] which is a dangling pointer (it has no provenance)
   --> tests/fail/provenance/pointer_partial_overwrite.rs:LL:CC
    |
 LL |     let x = *p;

--- a/src/tools/miri/tests/fail/rc_as_ptr.stderr
+++ b/src/tools/miri/tests/fail/rc_as_ptr.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: memory access failed: ALLOC has been freed, so this pointer is dangling
+error: Undefined Behavior: box not dereferenceable: ALLOC has been freed, so this pointer is dangling
   --> tests/fail/rc_as_ptr.rs:LL:CC
    |
 LL |     assert_eq!(42, **unsafe { &*Weak::as_ptr(&weak) });

--- a/src/tools/miri/tests/fail/unaligned_pointers/dyn_alignment.rs
+++ b/src/tools/miri/tests/fail/unaligned_pointers/dyn_alignment.rs
@@ -19,7 +19,7 @@ fn main() {
         unsafe {
             (&mut ptr as *mut _ as *mut *const u8).write(&buf as *const _ as *const u8);
         }
-        // Re-borrow that. This should be UB.
-        let _ptr = &*ptr; //~ERROR: required 256 byte alignment
+        // Dereference that. This should be UB.
+        let _ptr = &raw const *ptr; //~ERROR: required 256 byte alignment
     }
 }

--- a/src/tools/miri/tests/fail/unaligned_pointers/dyn_alignment.stderr
+++ b/src/tools/miri/tests/fail/unaligned_pointers/dyn_alignment.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: constructing invalid value of type &dyn std::fmt::Debug: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
+error: Undefined Behavior: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
   --> tests/fail/unaligned_pointers/dyn_alignment.rs:LL:CC
    |
-LL |         let _ptr = &*ptr;
-   |                    ^^^^^ Undefined Behavior occurred here
+LL |         let _ptr = &raw const *ptr;
+   |                    ^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/call_null_ref_fn_def.rs
+++ b/src/tools/miri/tests/fail/validity/call_null_ref_fn_def.rs
@@ -1,0 +1,7 @@
+fn foo() {}
+
+fn main() {
+    let mut f = &foo;
+    unsafe { (&raw mut f).cast::<usize>().write(0) };
+    f(); //~ERROR: null reference
+}

--- a/src/tools/miri/tests/fail/validity/call_null_ref_fn_def.stderr
+++ b/src/tools/miri/tests/fail/validity/call_null_ref_fn_def.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
-  --> tests/fail/dangling_pointers/deref-invalid-ptr.rs:LL:CC
+error: Undefined Behavior: dereferencing a null reference
+  --> tests/fail/validity/call_null_ref_fn_def.rs:LL:CC
    |
-LL |     let _y = unsafe { *(&*x as *const u32) };
-   |                         ^^^ Undefined Behavior occurred here
+LL |     f();
+   |     ^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/cast_dangling_ref.rs
+++ b/src/tools/miri/tests/fail/validity/cast_dangling_ref.rs
@@ -1,0 +1,11 @@
+#[repr(C)]
+struct S {
+    a: (),
+    b: i8,
+}
+
+fn main() {
+    let mut x = &S { a: (), b: 0 };
+    unsafe { (&raw mut x).cast::<usize>().write(16) };
+    let _val = x as *const _; //~ERROR: must be dereferenceable for 1 byte, but got 0x10[noalloc] which is a dangling pointer
+}

--- a/src/tools/miri/tests/fail/validity/cast_dangling_ref.stderr
+++ b/src/tools/miri/tests/fail/validity/cast_dangling_ref.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
-  --> tests/fail/dangling_pointers/deref-invalid-ptr.rs:LL:CC
+error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 1 byte, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
+  --> tests/fail/validity/cast_dangling_ref.rs:LL:CC
    |
-LL |     let _y = unsafe { *(&*x as *const u32) };
-   |                         ^^^ Undefined Behavior occurred here
+LL |     let _val = x as *const _;
+   |                ^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid.rs
+++ b/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid.rs
@@ -1,0 +1,36 @@
+//! Even just *casting* a function pointer, withot ever calling it, requires validity.
+#![feature(core_intrinsics, custom_mir)]
+#![allow(internal_features)]
+#![allow(unused_assignments)]
+
+use core::intrinsics::mir::*;
+
+// Overwrites `ptr` by invoking the callback, then casts `ptr` to `*mut u8`.
+// Needs to use custom MIR to avoid copies that perform their own validation.
+#[custom_mir(dialect = "runtime", phase = "optimized")]
+fn test(ptr: fn(), overwrite: fn(&mut fn())) {
+    mir! {
+        let ptrptr;
+        let ptr2 : *mut u8;
+        let _unused;
+
+        {
+            ptrptr = &mut ptr;
+            Call(_unused = overwrite(ptrptr), ReturnTo(ret), UnwindContinue())
+        }
+        
+        ret = {
+            ptr2 = ptr as *mut u8; //~ERROR: does not point to a function
+            Return()
+        }
+    }
+}
+
+fn f() {}
+
+fn main() {
+    test(f, |ptrptr| unsafe {
+        let ptrptr = std::ptr::from_mut(ptrptr);
+        ptrptr.cast::<*const ()>().write(&())
+    });
+}

--- a/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid.stderr
+++ b/src/tools/miri/tests/fail/validity/cast_fn_ptr_invalid.stderr
@@ -1,0 +1,18 @@
+error: Undefined Behavior: using ALLOC as function pointer but it does not point to a function
+  --> tests/fail/validity/cast_fn_ptr_invalid.rs:LL:CC
+   |
+LL |             ptr2 = ptr as *mut u8;
+   |             ^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: stack backtrace:
+           0: test
+               at tests/fail/validity/cast_fn_ptr_invalid.rs:LL:CC
+           1: main
+               at tests/fail/validity/cast_fn_ptr_invalid.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/src/tools/miri/tests/fail/validity/cast_null_ref.rs
+++ b/src/tools/miri/tests/fail/validity/cast_null_ref.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let mut x = &();
+    unsafe { (&raw mut x).cast::<usize>().write(0) };
+    let _val = x as *const _; //~ERROR: null reference
+}

--- a/src/tools/miri/tests/fail/validity/cast_null_ref.stderr
+++ b/src/tools/miri/tests/fail/validity/cast_null_ref.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
-  --> tests/fail/dangling_pointers/deref-invalid-ptr.rs:LL:CC
+error: Undefined Behavior: dereferencing a null reference
+  --> tests/fail/validity/cast_null_ref.rs:LL:CC
    |
-LL |     let _y = unsafe { *(&*x as *const u32) };
-   |                         ^^^ Undefined Behavior occurred here
+LL |     let _val = x as *const _;
+   |                ^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/cast_raw_ptr_invalid_vtable.rs
+++ b/src/tools/miri/tests/fail/validity/cast_raw_ptr_invalid_vtable.rs
@@ -1,0 +1,47 @@
+#![feature(core_intrinsics, custom_mir)]
+#![allow(internal_features)]
+#![allow(unused_assignments)]
+
+use core::intrinsics::mir::*;
+
+// Overwrites `ptr` by invoking the callback, then casts `ptr` to `*mut u8`.
+// Needs to use custom MIR to avoid copies that perform their own validation.
+#[custom_mir(dialect = "runtime", phase = "optimized")]
+fn test<T: ?Sized, U>(ptr: *const T, data: U, overwrite: fn(&mut *const T, U)) {
+    mir! {
+        let ptrptr;
+        let ptr2 : *mut u8; // cast drops metadata!
+        let _unused;
+
+        {
+            ptrptr = &mut ptr;
+            Call(_unused = overwrite(ptrptr, data), ReturnTo(ret), UnwindContinue())
+        }
+        
+        ret = {
+            ptr2 = CastPtrToPtr(ptr); //~ERROR: vtable for `std::fmt::Debug` but `std::fmt::Display` was expected
+            Return()
+        }
+    }
+}
+
+#[allow(unused)]
+struct S<Tail: ?Sized> {
+    f: i32,
+    g: Tail,
+}
+
+fn main() {
+    let x = S { f: 0, g: 0 };
+    let ptr1: *const S<dyn std::fmt::Debug> = &x;
+    let ptr2: *const S<dyn std::fmt::Display> = &x;
+    test::<S<dyn std::fmt::Display>, _>(
+        ptr2,
+        ptr1,
+        |ptrptr2, ptr1| unsafe {
+            // Give ptr2 the vtable from ptr1.
+            let ptrptr2 = std::ptr::from_mut(ptrptr2);
+            ptrptr2.copy_from(&raw const ptr1 as *const _, 1) ;
+        }
+    );
+}

--- a/src/tools/miri/tests/fail/validity/cast_raw_ptr_invalid_vtable.stderr
+++ b/src/tools/miri/tests/fail/validity/cast_raw_ptr_invalid_vtable.stderr
@@ -1,0 +1,18 @@
+error: Undefined Behavior: using vtable for `std::fmt::Debug` but `std::fmt::Display` was expected
+  --> tests/fail/validity/cast_raw_ptr_invalid_vtable.rs:LL:CC
+   |
+LL |             ptr2 = CastPtrToPtr(ptr);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: stack backtrace:
+           0: test::<S<dyn std::fmt::Display>, *const S<dyn std::fmt::Debug>>
+               at tests/fail/validity/cast_raw_ptr_invalid_vtable.rs:LL:CC
+           1: main
+               at tests/fail/validity/cast_raw_ptr_invalid_vtable.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/src/tools/miri/tests/fail/validity/cast_unaligned_ref.rs
+++ b/src/tools/miri/tests/fail/validity/cast_unaligned_ref.rs
@@ -1,0 +1,8 @@
+#[repr(align(8))]
+struct S {}
+
+fn main() {
+    let mut x = &S {};
+    unsafe { (&raw mut x).cast::<usize>().write(1) };
+    let _val = x as *const _; //~ERROR: unaligned reference
+}

--- a/src/tools/miri/tests/fail/validity/cast_unaligned_ref.stderr
+++ b/src/tools/miri/tests/fail/validity/cast_unaligned_ref.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
-  --> tests/fail/dangling_pointers/deref-invalid-ptr.rs:LL:CC
+error: Undefined Behavior: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
+  --> tests/fail/validity/cast_unaligned_ref.rs:LL:CC
    |
-LL |     let _y = unsafe { *(&*x as *const u32) };
-   |                         ^^^ Undefined Behavior occurred here
+LL |     let _val = x as *const _;
+   |                ^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/deref_dangling_box.rs
+++ b/src/tools/miri/tests/fail/validity/deref_dangling_box.rs
@@ -1,0 +1,11 @@
+#[repr(C)]
+struct S {
+    a: (),
+    b: i8,
+}
+
+fn main() {
+    let mut x = Box::new(S { a: (), b: 0 });
+    unsafe { (&raw mut x).cast::<usize>().write(16) };
+    let _ = x.a; //~ERROR: must be dereferenceable for 1 byte, but got 0x10[noalloc] which is a dangling pointer
+}

--- a/src/tools/miri/tests/fail/validity/deref_dangling_box.stderr
+++ b/src/tools/miri/tests/fail/validity/deref_dangling_box.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
-  --> tests/fail/dangling_pointers/deref-invalid-ptr.rs:LL:CC
+error: Undefined Behavior: box not dereferenceable: box must be dereferenceable for 1 byte, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
+  --> tests/fail/validity/deref_dangling_box.rs:LL:CC
    |
-LL |     let _y = unsafe { *(&*x as *const u32) };
-   |                         ^^^ Undefined Behavior occurred here
+LL |     let _ = x.a;
+   |             ^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/deref_dangling_ref.rs
+++ b/src/tools/miri/tests/fail/validity/deref_dangling_ref.rs
@@ -1,0 +1,11 @@
+#[repr(C)]
+struct S {
+    a: (),
+    b: i8,
+}
+
+fn main() {
+    let mut x = &S { a: (), b: 0 };
+    unsafe { (&raw mut x).cast::<usize>().write(16) };
+    let _ = x.a; //~ERROR: must be dereferenceable for 1 byte, but got 0x10[noalloc] which is a dangling pointer
+}

--- a/src/tools/miri/tests/fail/validity/deref_dangling_ref.stderr
+++ b/src/tools/miri/tests/fail/validity/deref_dangling_ref.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
-  --> tests/fail/dangling_pointers/deref-invalid-ptr.rs:LL:CC
+error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 1 byte, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
+  --> tests/fail/validity/deref_dangling_ref.rs:LL:CC
    |
-LL |     let _y = unsafe { *(&*x as *const u32) };
-   |                         ^^^ Undefined Behavior occurred here
+LL |     let _ = x.a;
+   |             ^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/deref_null_box.rs
+++ b/src/tools/miri/tests/fail/validity/deref_null_box.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let mut x = Box::new(());
+    unsafe { (&raw mut x).cast::<usize>().write(0) };
+    let _ = *x; //~ERROR: null box
+}

--- a/src/tools/miri/tests/fail/validity/deref_null_box.stderr
+++ b/src/tools/miri/tests/fail/validity/deref_null_box.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
-  --> tests/fail/dangling_pointers/deref-invalid-ptr.rs:LL:CC
+error: Undefined Behavior: dereferencing a null box
+  --> tests/fail/validity/deref_null_box.rs:LL:CC
    |
-LL |     let _y = unsafe { *(&*x as *const u32) };
-   |                         ^^^ Undefined Behavior occurred here
+LL |     let _ = *x;
+   |             ^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/deref_null_ref.rs
+++ b/src/tools/miri/tests/fail/validity/deref_null_ref.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let mut x = &();
+    unsafe { (&raw mut x).cast::<usize>().write(0) };
+    let _ = *x; //~ERROR: null reference
+}

--- a/src/tools/miri/tests/fail/validity/deref_null_ref.stderr
+++ b/src/tools/miri/tests/fail/validity/deref_null_ref.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
-  --> tests/fail/dangling_pointers/deref-invalid-ptr.rs:LL:CC
+error: Undefined Behavior: dereferencing a null reference
+  --> tests/fail/validity/deref_null_ref.rs:LL:CC
    |
-LL |     let _y = unsafe { *(&*x as *const u32) };
-   |                         ^^^ Undefined Behavior occurred here
+LL |     let _ = *x;
+   |             ^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/deref_raw_ptr_no_vtable.rs
+++ b/src/tools/miri/tests/fail/validity/deref_raw_ptr_no_vtable.rs
@@ -1,0 +1,12 @@
+struct S<Tail: ?Sized> {
+    f: i32,
+    #[allow(unused)]
+    g: Tail,
+}
+
+fn main() {
+    let x = S { f: 0, g: 0 };
+    let mut ptr: *const S<dyn std::fmt::Debug> = &x;
+    unsafe { (&raw mut ptr).cast::<usize>().add(1).write(0) };
+    let _val = unsafe { &(*ptr).f }; //~ERROR: vtable
+}

--- a/src/tools/miri/tests/fail/validity/deref_raw_ptr_no_vtable.stderr
+++ b/src/tools/miri/tests/fail/validity/deref_raw_ptr_no_vtable.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
-  --> tests/fail/dangling_pointers/deref-invalid-ptr.rs:LL:CC
+error: Undefined Behavior: using null pointer as vtable pointer but it does not point to a vtable
+  --> tests/fail/validity/deref_raw_ptr_no_vtable.rs:LL:CC
    |
-LL |     let _y = unsafe { *(&*x as *const u32) };
-   |                         ^^^ Undefined Behavior occurred here
+LL |     let _val = unsafe { &(*ptr).f };
+   |                         ^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/deref_raw_ptr_wrong_vtable.rs
+++ b/src/tools/miri/tests/fail/validity/deref_raw_ptr_wrong_vtable.rs
@@ -1,0 +1,14 @@
+struct S<Tail: ?Sized> {
+    f: i32,
+    #[allow(unused)]
+    g: Tail,
+}
+
+fn main() {
+    let x = S { f: 0, g: 0 };
+    let ptr1: *const S<dyn std::fmt::Debug> = &x;
+    let mut ptr2: *const S<dyn std::fmt::Display> = &x;
+    // Give ptr2 the vtable from ptr1.
+    unsafe { (&raw mut ptr2).copy_from(&raw const ptr1 as *const _, 1) };
+    let _val = unsafe { &(*ptr2).f }; //~ERROR: vtable
+}

--- a/src/tools/miri/tests/fail/validity/deref_raw_ptr_wrong_vtable.stderr
+++ b/src/tools/miri/tests/fail/validity/deref_raw_ptr_wrong_vtable.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
-  --> tests/fail/dangling_pointers/deref-invalid-ptr.rs:LL:CC
+error: Undefined Behavior: using vtable for `std::fmt::Debug` but `std::fmt::Display` was expected
+  --> tests/fail/validity/deref_raw_ptr_wrong_vtable.rs:LL:CC
    |
-LL |     let _y = unsafe { *(&*x as *const u32) };
-   |                         ^^^ Undefined Behavior occurred here
+LL |     let _val = unsafe { &(*ptr2).f };
+   |                         ^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/deref_unaligned_box.rs
+++ b/src/tools/miri/tests/fail/validity/deref_unaligned_box.rs
@@ -1,0 +1,10 @@
+#[repr(align(8))]
+struct S {
+    f: (),
+}
+
+fn main() {
+    let mut x = Box::new(S { f: () });
+    unsafe { (&raw mut x).cast::<usize>().write(1) };
+    let _ = &x.f; //~ERROR: unaligned box
+}

--- a/src/tools/miri/tests/fail/validity/deref_unaligned_box.stderr
+++ b/src/tools/miri/tests/fail/validity/deref_unaligned_box.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
-  --> tests/fail/dangling_pointers/deref-invalid-ptr.rs:LL:CC
+error: Undefined Behavior: encountered an unaligned box (required ALIGN byte alignment but found ALIGN)
+  --> tests/fail/validity/deref_unaligned_box.rs:LL:CC
    |
-LL |     let _y = unsafe { *(&*x as *const u32) };
-   |                         ^^^ Undefined Behavior occurred here
+LL |     let _ = &x.f;
+   |             ^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/deref_unaligned_ref.rs
+++ b/src/tools/miri/tests/fail/validity/deref_unaligned_ref.rs
@@ -1,0 +1,10 @@
+#[repr(align(8))]
+struct S {
+    f: (),
+}
+
+fn main() {
+    let mut x = &S { f: () };
+    unsafe { (&raw mut x).cast::<usize>().write(1) };
+    let _ = &x.f; //~ERROR: unaligned reference
+}

--- a/src/tools/miri/tests/fail/validity/deref_unaligned_ref.stderr
+++ b/src/tools/miri/tests/fail/validity/deref_unaligned_ref.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
-  --> tests/fail/dangling_pointers/deref-invalid-ptr.rs:LL:CC
+error: Undefined Behavior: encountered an unaligned reference (required ALIGN byte alignment but found ALIGN)
+  --> tests/fail/validity/deref_unaligned_ref.rs:LL:CC
    |
-LL |     let _y = unsafe { *(&*x as *const u32) };
-   |                         ^^^ Undefined Behavior occurred here
+LL |     let _ = &x.f;
+   |             ^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/validity/ptr_metadata_invalid_vtable.rs
+++ b/src/tools/miri/tests/fail/validity/ptr_metadata_invalid_vtable.rs
@@ -1,0 +1,36 @@
+#![feature(core_intrinsics, custom_mir)]
+#![allow(internal_features)]
+#![allow(unused_assignments)]
+
+use core::intrinsics::mir::*;
+
+fn main() {
+    test8345(&1, |ptrptr| unsafe {
+        let ptrptr = std::ptr::from_mut(ptrptr);
+        ptrptr.cast::<(usize, usize)>().write((0, 1))
+    });
+}
+
+trait A {}
+impl<T> A for T {}
+
+#[custom_mir(dialect = "runtime", phase = "optimized")]
+fn test8345(mut ptr: &dyn A, overwrite: fn(&mut &dyn A)) {
+    mir! {
+        let ptrptr;
+        let _unused;
+        let idk;
+
+        {
+            ptrptr = &mut ptr;
+            // Overwrite `ptr` to make it invalid.
+            Call(_unused = overwrite(ptrptr), ReturnTo(ret), UnwindContinue())
+        }
+
+        ret = {
+            // Do something with `ptr`.
+            idk = PtrMetadata(ptr); //~ERROR: null reference
+            Return()
+        }
+    }
+}

--- a/src/tools/miri/tests/fail/validity/ptr_metadata_invalid_vtable.stderr
+++ b/src/tools/miri/tests/fail/validity/ptr_metadata_invalid_vtable.stderr
@@ -1,0 +1,18 @@
+error: Undefined Behavior: dereferencing a null reference
+  --> tests/fail/validity/ptr_metadata_invalid_vtable.rs:LL:CC
+   |
+LL |             idk = PtrMetadata(ptr);
+   |             ^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: stack backtrace:
+           0: test8345
+               at tests/fail/validity/ptr_metadata_invalid_vtable.rs:LL:CC
+           1: main
+               at tests/fail/validity/ptr_metadata_invalid_vtable.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/mir-opt/const_prop/transmute.unreachable_box.GVN.32bit.diff
+++ b/tests/mir-opt/const_prop/transmute.unreachable_box.GVN.32bit.diff
@@ -12,9 +12,9 @@
       bb0: {
           StorageLive(_1);
 -         _1 = const 1_usize as std::boxed::Box<Never> (Transmute);
--         _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (Transmute);
+-         _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (BoxDerefTransmute);
 +         _1 = const Box::<Never>(std::ptr::Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
-+         _2 = const std::ptr::NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }} as *const Never (Transmute);
++         _2 = const std::ptr::NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }} as *const Never (BoxDerefTransmute);
           unreachable;
       }
   }

--- a/tests/mir-opt/const_prop/transmute.unreachable_box.GVN.64bit.diff
+++ b/tests/mir-opt/const_prop/transmute.unreachable_box.GVN.64bit.diff
@@ -12,9 +12,9 @@
       bb0: {
           StorageLive(_1);
 -         _1 = const 1_usize as std::boxed::Box<Never> (Transmute);
--         _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (Transmute);
+-         _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (BoxDerefTransmute);
 +         _1 = const Box::<Never>(std::ptr::Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
-+         _2 = const std::ptr::NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }} as *const Never (Transmute);
++         _2 = const std::ptr::NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }} as *const Never (BoxDerefTransmute);
           unreachable;
       }
   }

--- a/tests/mir-opt/dataflow-const-prop/transmute.unreachable_box.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/transmute.unreachable_box.DataflowConstProp.32bit.diff
@@ -13,7 +13,7 @@
           StorageLive(_1);
 -         _1 = const 1_usize as std::boxed::Box<Never> (Transmute);
 +         _1 = const Box::<Never>(std::ptr::Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
-          _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (Transmute);
+          _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (BoxDerefTransmute);
           unreachable;
       }
   }

--- a/tests/mir-opt/dataflow-const-prop/transmute.unreachable_box.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/transmute.unreachable_box.DataflowConstProp.64bit.diff
@@ -13,7 +13,7 @@
           StorageLive(_1);
 -         _1 = const 1_usize as std::boxed::Box<Never> (Transmute);
 +         _1 = const Box::<Never>(std::ptr::Unique::<Never> {{ pointer: NonNull::<Never> {{ pointer: {0x1 as *const Never} is !null }}, _marker: PhantomData::<Never> }}, std::alloc::Global);
-          _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (Transmute);
+          _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (BoxDerefTransmute);
           unreachable;
       }
   }

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
@@ -73,7 +73,7 @@
           StorageDead(_2);
           StorageLive(_5);
           _10 = no_retag copy (*_1);
-          _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (Transmute);
+          _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (BoxDerefTransmute);
           _5 = &raw const (*_11);
           StorageLive(_6);
           StorageLive(_7);

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-unwind.diff
@@ -53,7 +53,7 @@
           StorageDead(_2);
           StorageLive(_5);
           _10 = no_retag copy (*_1);
-          _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (Transmute);
+          _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (BoxDerefTransmute);
           _5 = &raw const (*_11);
           StorageLive(_6);
           StorageLive(_7);

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
@@ -73,7 +73,7 @@
           StorageDead(_2);
           StorageLive(_5);
           _10 = no_retag copy (*_1);
-          _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (Transmute);
+          _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (BoxDerefTransmute);
           _5 = &raw const (*_11);
           StorageLive(_6);
           StorageLive(_7);

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-unwind.diff
@@ -53,7 +53,7 @@
           StorageDead(_2);
           StorageLive(_5);
           _10 = no_retag copy (*_1);
-          _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (Transmute);
+          _11 = copy ((_10.0: std::ptr::Unique<()>).0: std::ptr::NonNull<()>) as *const () (BoxDerefTransmute);
           _5 = &raw const (*_11);
           StorageLive(_6);
           StorageLive(_7);

--- a/tests/mir-opt/inline/dont_ice_on_generic_rust_call.call.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/dont_ice_on_generic_rust_call.call.Inline.panic-abort.diff
@@ -23,7 +23,7 @@
 +         StorageLive(_7);
 +         StorageLive(_5);
 +         _7 = no_retag copy (((*_3).0: std::ptr::Unique<dyn std::ops::FnMut<I, Output = ()>>).0: std::ptr::NonNull<dyn std::ops::FnMut<I, Output = ()>>);
-+         _6 = copy _7 as *const dyn std::ops::FnMut<I, Output = ()> (Transmute);
++         _6 = copy _7 as *const dyn std::ops::FnMut<I, Output = ()> (BoxDerefTransmute);
 +         _5 = &mut (*_6);
 +         _0 = <dyn FnMut<I, Output = ()> as FnMut<I>>::call_mut(move _5, move _4) -> [return: bb2, unwind unreachable];
       }

--- a/tests/mir-opt/inline/dont_ice_on_generic_rust_call.call.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/dont_ice_on_generic_rust_call.call.Inline.panic-unwind.diff
@@ -23,7 +23,7 @@
 +         StorageLive(_7);
 +         StorageLive(_5);
 +         _7 = no_retag copy (((*_3).0: std::ptr::Unique<dyn std::ops::FnMut<I, Output = ()>>).0: std::ptr::NonNull<dyn std::ops::FnMut<I, Output = ()>>);
-+         _6 = copy _7 as *const dyn std::ops::FnMut<I, Output = ()> (Transmute);
++         _6 = copy _7 as *const dyn std::ops::FnMut<I, Output = ()> (BoxDerefTransmute);
 +         _5 = &mut (*_6);
 +         _0 = <dyn FnMut<I, Output = ()> as FnMut<I>>::call_mut(move _5, move _4) -> [return: bb4, unwind: bb2];
       }

--- a/tests/mir-opt/inline/inline_box_fn.call.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_box_fn.call.Inline.panic-abort.diff
@@ -24,7 +24,7 @@
 +         StorageLive(_7);
 +         StorageLive(_5);
 +         _7 = no_retag copy (((*_3).0: std::ptr::Unique<dyn std::ops::Fn(i32)>).0: std::ptr::NonNull<dyn std::ops::Fn(i32)>);
-+         _6 = copy _7 as *const dyn std::ops::Fn(i32) (Transmute);
++         _6 = copy _7 as *const dyn std::ops::Fn(i32) (BoxDerefTransmute);
 +         _5 = &(*_6);
 +         _2 = <dyn Fn(i32) as Fn<(i32,)>>::call(move _5, move _4) -> [return: bb2, unwind unreachable];
       }

--- a/tests/mir-opt/inline/inline_box_fn.call.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_box_fn.call.Inline.panic-unwind.diff
@@ -24,7 +24,7 @@
 +         StorageLive(_7);
 +         StorageLive(_5);
 +         _7 = no_retag copy (((*_3).0: std::ptr::Unique<dyn std::ops::Fn(i32)>).0: std::ptr::NonNull<dyn std::ops::Fn(i32)>);
-+         _6 = copy _7 as *const dyn std::ops::Fn(i32) (Transmute);
++         _6 = copy _7 as *const dyn std::ops::Fn(i32) (BoxDerefTransmute);
 +         _5 = &(*_6);
 +         _2 = <dyn Fn(i32) as Fn<(i32,)>>::call(move _5, move _4) -> [return: bb4, unwind: bb2];
       }

--- a/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
+++ b/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
@@ -20,7 +20,7 @@ fn b(_1: &mut Box<T>) -> &mut T {
         StorageLive(_5);
         StorageLive(_6);
         _6 = no_retag copy (((*_4).0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>);
-        _5 = copy _6 as *const T (Transmute);
+        _5 = copy _6 as *const T (BoxDerefTransmute);
         _3 = &mut (*_5);
         StorageDead(_6);
         StorageDead(_5);

--- a/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
+++ b/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
@@ -18,7 +18,7 @@ fn d(_1: &Box<T>) -> &T {
         StorageLive(_4);
         StorageLive(_5);
         _5 = no_retag copy (((*_3).0: std::ptr::Unique<T>).0: std::ptr::NonNull<T>);
-        _4 = copy _5 as *const T (Transmute);
+        _4 = copy _5 as *const T (BoxDerefTransmute);
         _2 = &(*_4);
         StorageDead(_5);
         StorageDead(_4);

--- a/tests/mir-opt/inline/unsized_argument.caller.Inline.diff
+++ b/tests/mir-opt/inline/unsized_argument.caller.Inline.diff
@@ -12,7 +12,7 @@
           StorageLive(_2);
           StorageLive(_3);
           _3 = move _1;
-          _4 = copy ((_3.0: std::ptr::Unique<[i32]>).0: std::ptr::NonNull<[i32]>) as *const [i32] (Transmute);
+          _4 = copy ((_3.0: std::ptr::Unique<[i32]>).0: std::ptr::NonNull<[i32]>) as *const [i32] (BoxDerefTransmute);
           _2 = callee(move (*_4)) -> [return: bb1, unwind: bb3];
       }
   

--- a/tests/mir-opt/lower_intrinsics.transmute_to_box_uninhabited.LowerIntrinsics.panic-abort.diff
+++ b/tests/mir-opt/lower_intrinsics.transmute_to_box_uninhabited.LowerIntrinsics.panic-abort.diff
@@ -17,7 +17,7 @@
       }
   
       bb1: {
-          _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (Transmute);
+          _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (BoxDerefTransmute);
           PlaceMention((*_2));
           unreachable;
       }

--- a/tests/mir-opt/lower_intrinsics.transmute_to_box_uninhabited.LowerIntrinsics.panic-unwind.diff
+++ b/tests/mir-opt/lower_intrinsics.transmute_to_box_uninhabited.LowerIntrinsics.panic-unwind.diff
@@ -17,7 +17,7 @@
       }
   
       bb1: {
-          _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (Transmute);
+          _2 = copy ((_1.0: std::ptr::Unique<Never>).0: std::ptr::NonNull<Never>) as *const Never (BoxDerefTransmute);
           PlaceMention((*_2));
           unreachable;
       }

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.runtime-optimized.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.runtime-optimized.after.panic-abort.mir
@@ -65,7 +65,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                                     }
                                 }
                             }
-                            scope 37 (inlined without_provenance_mut::<T>) {
+                            scope 37 (inlined std::ptr::without_provenance_mut::<T>) {
                             }
                         }
                         scope 32 (inlined std::ptr::const_ptr::<impl *const T>::addr) {
@@ -109,7 +109,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                     scope 7 {
                     }
                     scope 11 (inlined std::ptr::without_provenance::<T>) {
-                        scope 12 (inlined without_provenance_mut::<T>) {
+                        scope 12 (inlined std::ptr::without_provenance_mut::<T>) {
                         }
                     }
                     scope 13 (inlined NonNull::<T>::as_ptr) {

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.runtime-optimized.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.runtime-optimized.after.panic-abort.mir
@@ -34,7 +34,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                                 }
                             }
                         }
-                        scope 25 (inlined without_provenance_mut::<T>) {
+                        scope 25 (inlined std::ptr::without_provenance_mut::<T>) {
                         }
                     }
                     scope 20 (inlined std::ptr::const_ptr::<impl *const T>::addr) {
@@ -77,7 +77,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                     scope 7 {
                     }
                     scope 11 (inlined std::ptr::without_provenance::<T>) {
-                        scope 12 (inlined without_provenance_mut::<T>) {
+                        scope 12 (inlined std::ptr::without_provenance_mut::<T>) {
                         }
                     }
                     scope 13 (inlined NonNull::<T>::as_ptr) {

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.runtime-optimized.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.runtime-optimized.after.panic-abort.mir
@@ -103,7 +103,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                     scope 7 {
                     }
                     scope 11 (inlined std::ptr::without_provenance::<T>) {
-                        scope 12 (inlined without_provenance_mut::<T>) {
+                        scope 12 (inlined std::ptr::without_provenance_mut::<T>) {
                         }
                     }
                     scope 13 (inlined NonNull::<T>::as_ptr) {

--- a/tests/mir-opt/pre-codegen/slice_iter.slice_iter_next.runtime-optimized.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.slice_iter_next.runtime-optimized.after.panic-abort.mir
@@ -21,7 +21,7 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
                             }
                         }
                     }
-                    scope 10 (inlined without_provenance_mut::<T>) {
+                    scope 10 (inlined std::ptr::without_provenance_mut::<T>) {
                     }
                 }
                 scope 5 (inlined std::ptr::const_ptr::<impl *const T>::addr) {

--- a/tests/ui/const-ptr/forbidden_slices.rs
+++ b/tests/ui/const-ptr/forbidden_slices.rs
@@ -20,7 +20,7 @@ pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
 
 // Out of bounds
 pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
-//~^ ERROR: dangling reference (going beyond the bounds of its allocation)
+//~^ ERROR: reference must be dereferenceable for 8 bytes
 
 // Reading uninitialized  data
 pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }; //~ ERROR: uninitialized memory
@@ -39,14 +39,14 @@ pub static S7: &[u16] = unsafe {
 
 // Unaligned read
 pub static S8: &[u64] = unsafe {
-    //~^ ERROR: dangling reference (going beyond the bounds of its allocation)
     let ptr = (&D4 as *const [u32; 2] as *const u32).byte_add(1).cast::<u64>();
 
     from_raw_parts(ptr, 1)
+    //~^ ERROR: reference must be dereferenceable for 8 bytes
 };
 
 pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-//~^ ERROR encountered a null reference
+//~^ ERROR: null reference
 pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) }; // errors inside libcore
 //~^ ERROR 0 < pointee_size && pointee_size <= isize::MAX as usize
 pub static R2: &[u32] = unsafe {
@@ -70,9 +70,9 @@ pub static R6: &[bool] = unsafe {
     from_ptr_range(ptr..ptr.add(4))
 };
 pub static R7: &[u16] = unsafe {
-    //~^ ERROR: unaligned reference (required 2 byte alignment but found 1)
     let ptr = (&D2 as *const Struct as *const u16).byte_add(1);
     from_ptr_range(ptr..ptr.add(4))
+    //~^ ERROR: unaligned reference (required 2 byte alignment but found 1)
 };
 pub static R8: &[u64] = unsafe {
     let ptr = (&D4 as *const [u32; 2] as *const u32).byte_add(1).cast::<u64>();

--- a/tests/ui/const-ptr/forbidden_slices.stderr
+++ b/tests/ui/const-ptr/forbidden_slices.stderr
@@ -1,35 +1,20 @@
-error[E0080]: constructing invalid value of type &[u32]: encountered a null reference
-  --> $DIR/forbidden_slices.rs:16:1
+error[E0080]: dereferencing a null reference
+  --> $DIR/forbidden_slices.rs:16:34
    |
 LL | pub static S0: &[u32] = unsafe { from_raw_parts(ptr::null(), 0) };
-   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `S0` failed here
 
-error[E0080]: constructing invalid value of type &[()]: encountered a null reference
-  --> $DIR/forbidden_slices.rs:18:1
+error[E0080]: dereferencing a null reference
+  --> $DIR/forbidden_slices.rs:18:33
    |
 LL | pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
-   | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `S1` failed here
 
-error[E0080]: constructing invalid value of type &[u32]: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/forbidden_slices.rs:22:1
+error[E0080]: reference not dereferenceable: reference must be dereferenceable for 8 bytes, but got ALLOC$ID which is only 4 bytes from the end of the allocation
+  --> $DIR/forbidden_slices.rs:22:34
    |
 LL | pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
-   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ HEX_DUMP
-           }
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `S2` failed here
 
 error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered uninitialized memory, but expected an integer
   --> $DIR/forbidden_slices.rs:26:1
@@ -77,27 +62,17 @@ LL | pub static S7: &[u16] = unsafe {
                ╾ALLOC$ID╼ HEX_DUMP
            }
 
-error[E0080]: constructing invalid value of type &[u64]: encountered a dangling reference (going beyond the bounds of its allocation)
-  --> $DIR/forbidden_slices.rs:41:1
+error[E0080]: reference not dereferenceable: reference must be dereferenceable for 8 bytes, but got ALLOC$ID+0x1 which is only 7 bytes from the end of the allocation
+  --> $DIR/forbidden_slices.rs:44:5
    |
-LL | pub static S8: &[u64] = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ HEX_DUMP
-           }
+LL |     from_raw_parts(ptr, 1)
+   |     ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `S8` failed here
 
-error[E0080]: constructing invalid value of type &[u32]: encountered a null reference
-  --> $DIR/forbidden_slices.rs:48:1
+error[E0080]: dereferencing a null reference
+  --> $DIR/forbidden_slices.rs:48:34
    |
 LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `R0` failed here
 
 error[E0080]: evaluation panicked: assertion failed: 0 < pointee_size && pointee_size <= isize::MAX as usize
   --> $DIR/forbidden_slices.rs:50:33
@@ -146,16 +121,11 @@ LL | pub static R6: &[bool] = unsafe {
                ╾ALLOC$ID╼ HEX_DUMP
            }
 
-error[E0080]: constructing invalid value of type &[u16]: encountered an unaligned reference (required 2 byte alignment but found 1)
-  --> $DIR/forbidden_slices.rs:72:1
+error[E0080]: encountered an unaligned reference (required 2 byte alignment but found 1)
+  --> $DIR/forbidden_slices.rs:74:5
    |
-LL | pub static R7: &[u16] = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ HEX_DUMP
-           }
+LL |     from_ptr_range(ptr..ptr.add(4))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `R7` failed here
 
 error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 8 bytes, but got ALLOC$ID+0x1 which is only 7 bytes from the end of the allocation
   --> $DIR/forbidden_slices.rs:79:25

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.rs
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.rs
@@ -10,10 +10,10 @@
 use std::intrinsics;
 
 const _X: &'static u8 = unsafe {
-    //~^ ERROR: dangling reference (use-after-free)
     let ptr = intrinsics::const_allocate(4, 4);
     intrinsics::const_deallocate(ptr, 4, 4);
     &*ptr
+    //~^ ERROR: this pointer is dangling
 };
 
 const _Y: u8 = unsafe {

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.stderr
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.stderr
@@ -1,15 +1,10 @@
-error[E0080]: constructing invalid value of type &u8: encountered a dangling reference (use-after-free)
-  --> $DIR/dealloc_intrinsic_dangling.rs:12:1
+error[E0080]: reference not dereferenceable: ALLOC$ID has been freed, so this pointer is dangling
+  --> $DIR/dealloc_intrinsic_dangling.rs:15:5
    |
-LL | const _X: &'static u8 = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ │ ╾─╼
-           }
+LL |     &*ptr
+   |     ^^^^^ evaluation of `_X` failed here
 
-error[E0080]: memory access failed: ALLOC$ID has been freed, so this pointer is dangling
+error[E0080]: reference not dereferenceable: ALLOC$ID has been freed, so this pointer is dangling
   --> $DIR/dealloc_intrinsic_dangling.rs:23:5
    |
 LL |     *reference

--- a/tests/ui/consts/const-eval/issue-49296.stderr
+++ b/tests/ui/consts/const-eval/issue-49296.stderr
@@ -1,4 +1,4 @@
-error[E0080]: memory access failed: ALLOC$ID has been freed, so this pointer is dangling
+error[E0080]: reference not dereferenceable: ALLOC$ID has been freed, so this pointer is dangling
   --> $DIR/issue-49296.rs:9:16
    |
 LL | const X: u64 = *wat(42);

--- a/tests/ui/consts/const-eval/nonnull_as_ref_ub.stderr
+++ b/tests/ui/consts/const-eval/nonnull_as_ref_ub.stderr
@@ -1,8 +1,11 @@
-error[E0080]: memory access failed: attempting to access 1 byte, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
-  --> $DIR/nonnull_as_ref_ub.rs:4:29
+error[E0080]: reference not dereferenceable: reference must be dereferenceable for 1 byte, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
+  --> $DIR/nonnull_as_ref_ub.rs:4:39
    |
 LL | const _: () = assert!(42 == *unsafe { NON_NULL.as_ref() });
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
+   |                                       ^^^^^^^^^^^^^^^^^ evaluation of `_` failed inside this call
+   |
+note: inside `NonNull::<u8>::as_ref::<'_>`
+  --> $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
@@ -1,24 +1,14 @@
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:18:1
+error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
+  --> $DIR/ub-incorrect-vtable.rs:19:14
    |
-LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_ALIGNMENT` failed here
 
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:22:1
+error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
+  --> $DIR/ub-incorrect-vtable.rs:23:14
    |
-LL | const INVALID_VTABLE_SIZE: &dyn Trait =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_SIZE` failed here
 
 error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:31:1

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
@@ -1,24 +1,14 @@
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:18:1
+error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
+  --> $DIR/ub-incorrect-vtable.rs:19:14
    |
-LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_ALIGNMENT` failed here
 
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-incorrect-vtable.rs:22:1
+error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
+  --> $DIR/ub-incorrect-vtable.rs:23:14
    |
-LL | const INVALID_VTABLE_SIZE: &dyn Trait =
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_SIZE` failed here
 
 error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:31:1

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.rs
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.rs
@@ -17,11 +17,11 @@ trait Trait {}
 
 const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
-//~^^ ERROR vtable
+//~^ ERROR vtable
 
 const INVALID_VTABLE_SIZE: &dyn Trait =
     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
-//~^^ ERROR vtable
+//~^ ERROR vtable
 
 #[repr(transparent)]
 struct W<T>(T);

--- a/tests/ui/consts/const-eval/ub-nonnull.rs
+++ b/tests/ui/consts/const-eval/ub-nonnull.rs
@@ -19,9 +19,9 @@ const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
 //~^ ERROR invalid value
 
 const OUT_OF_BOUNDS_PTR: NonNull<u8> = { unsafe {
-    let ptr: &[u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
+    let ptr: *const [u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
     // Use address-of-element for pointer arithmetic. This could wrap around to null!
-    let out_of_bounds_ptr = &ptr[255]; //~ ERROR in-bounds pointer arithmetic failed
+    let out_of_bounds_ptr = &(*ptr)[255]; //~ ERROR in-bounds pointer arithmetic failed
     mem::transmute(out_of_bounds_ptr)
 } };
 

--- a/tests/ui/consts/const-eval/ub-nonnull.stderr
+++ b/tests/ui/consts/const-eval/ub-nonnull.stderr
@@ -12,8 +12,8 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
 error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 255 bytes, but got ALLOC$ID which is only 1 byte from the end of the allocation
   --> $DIR/ub-nonnull.rs:24:29
    |
-LL |     let out_of_bounds_ptr = &ptr[255];
-   |                             ^^^^^^^^^ evaluation of `OUT_OF_BOUNDS_PTR` failed here
+LL |     let out_of_bounds_ptr = &(*ptr)[255];
+   |                             ^^^^^^^^^^^^ evaluation of `OUT_OF_BOUNDS_PTR` failed here
 
 error[E0080]: constructing invalid value of type NonZero<u8>: at .0.0, encountered 0, but expected something greater or equal to 1
   --> $DIR/ub-nonnull.rs:28:1

--- a/tests/ui/consts/const-eval/ub-wide-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.rs
@@ -140,11 +140,11 @@ const DYN_METADATA: ptr::DynMetadata<dyn Send> = ptr::metadata::<dyn Send>(ptr::
 
 static mut RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF: *const dyn Trait = unsafe {
     mem::transmute::<_, &dyn Trait>((&92u8, 0usize))
-    //~^^ ERROR null pointer
+    //~^ ERROR null pointer
 };
 static mut RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF: *const dyn Trait = unsafe {
     mem::transmute::<_, &dyn Trait>((&92u8, &3u64))
-    //~^^ ERROR vtable
+    //~^ ERROR vtable
 };
 
 fn main() {}

--- a/tests/ui/consts/const-eval/ub-wide-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.stderr
@@ -226,38 +226,23 @@ LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u
                ╾ALLOC$ID╼ HEX_DUMP
            }
 
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:119:1
+error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
+  --> $DIR/ub-wide-ptr.rs:119:57
    |
 LL | const TRAIT_OBJ_UNALIGNED_VTABLE: &dyn Trait = unsafe { mem::transmute((&92u8, &[0u8; 128])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
-           }
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_UNALIGNED_VTABLE` failed here
 
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:121:1
+error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
+  --> $DIR/ub-wide-ptr.rs:121:57
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NULL: &dyn Trait = unsafe { mem::transmute((&92u8, &[0usize; 8])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
-           }
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_BAD_DROP_FN_NULL` failed here
 
-error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:123:1
+error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
+  --> $DIR/ub-wide-ptr.rs:123:56
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_INT: &dyn Trait = unsafe { mem::transmute((&92u8, &[1usize; 8])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
-           }
+   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_BAD_DROP_FN_INT` failed here
 
 error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:125:1
@@ -303,27 +288,17 @@ LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transm
                ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
            }
 
-error[E0080]: constructing invalid value of type *const dyn Trait: encountered null pointer, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:141:1
+error[E0080]: using null pointer as vtable pointer but it does not point to a vtable
+  --> $DIR/ub-wide-ptr.rs:142:5
    |
-LL | static mut RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF: *const dyn Trait = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ HEX_DUMP
-           }
+LL |     mem::transmute::<_, &dyn Trait>((&92u8, 0usize))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF` failed here
 
-error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
-  --> $DIR/ub-wide-ptr.rs:145:1
+error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
+  --> $DIR/ub-wide-ptr.rs:146:5
    |
-LL | static mut RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF: *const dyn Trait = unsafe {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
-   |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
-           }
+LL |     mem::transmute::<_, &dyn Trait>((&92u8, &3u64))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF` failed here
 
 error: aborting due to 29 previous errors
 

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.rs
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.rs
@@ -84,8 +84,8 @@ fn dangling() {
         // Undefined behaviour (integer as pointer), who doesn't love tests like this.
         Some(&mut *(42 as *mut i32))
     } }
-    const INT2PTR: Option<&mut i32> = helper_int2ptr(); //~ ERROR encountered a dangling reference
-    static INT2PTR_STATIC: Option<&mut i32> = helper_int2ptr(); //~ ERROR encountered a dangling reference
+    const INT2PTR: Option<&mut i32> = helper_int2ptr(); //~ ERROR reference not dereferenceable
+    static INT2PTR_STATIC: Option<&mut i32> = helper_int2ptr(); //~ ERROR reference not dereferenceable
 
     const fn helper_dangling() -> Option<&'static mut i32> { unsafe {
         // Undefined behaviour (dangling pointer), who doesn't love tests like this.

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
@@ -120,27 +120,29 @@ LL | const RAW_MUT_COERCE_C: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
    = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
-error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (0x2a[noalloc] has no provenance)
-  --> $DIR/mut_ref_in_final.rs:87:5
+error[E0080]: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x2a[noalloc] which is a dangling pointer (it has no provenance)
+  --> $DIR/mut_ref_in_final.rs:87:39
    |
 LL |     const INT2PTR: Option<&mut i32> = helper_int2ptr();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |                                       ^^^^^^^^^^^^^^^^ evaluation of `dangling::INT2PTR` failed inside this call
    |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+note: inside `helper_int2ptr`
+  --> $DIR/mut_ref_in_final.rs:85:14
+   |
+LL |         Some(&mut *(42 as *mut i32))
+   |              ^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
-error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (0x2a[noalloc] has no provenance)
-  --> $DIR/mut_ref_in_final.rs:88:5
+error[E0080]: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x2a[noalloc] which is a dangling pointer (it has no provenance)
+  --> $DIR/mut_ref_in_final.rs:88:47
    |
 LL |     static INT2PTR_STATIC: Option<&mut i32> = helper_int2ptr();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |                                               ^^^^^^^^^^^^^^^^ evaluation of `dangling::INT2PTR_STATIC` failed inside this call
    |
-   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
-               HEX_DUMP
-           }
+note: inside `helper_int2ptr`
+  --> $DIR/mut_ref_in_final.rs:85:14
+   |
+LL |         Some(&mut *(42 as *mut i32))
+   |              ^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (use-after-free)
   --> $DIR/mut_ref_in_final.rs:94:5

--- a/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.stderr
+++ b/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.stderr
@@ -17,11 +17,11 @@ LL |     std::intrinsics::raw_eq(&(&0), &(&1))
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: accessing memory with alignment 1, but alignment 4 is required
-  --> $DIR/intrinsic-raw_eq-const-bad.rs:17:5
+error[E0080]: encountered an unaligned reference (required 4 byte alignment but found 1)
+  --> $DIR/intrinsic-raw_eq-const-bad.rs:17:29
    |
 LL |     std::intrinsics::raw_eq(aref, aref)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_EQ_NOT_ALIGNED` failed here
+   |                             ^^^^ evaluation of `RAW_EQ_NOT_ALIGNED` failed here
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160012)*
<!-- homu-ignore:end -->

Conceptually, when we evaluate the place expression `*place`, there are two steps that happen:
- perform a (typed) load from `place`, which yields a value of pointer/ref type
- construct a new place from that value

Since this is a typed load, we have to ensure that the value satisfies the validity invariant. We forgot to do that, which led to Miri missing a bunch of UB. This PR fixes that by adding the missing checks.

Triggering this UB is a bit non-trivial: you cannot just store an invalid value into `place` using regular assignment (that would already be caught as part of the assignment). However, you can take a raw pointer to `place` and then use that to mutate the contents of `place` in a way that its validity invariant no longer holds. For example:
```rust
fn main() {
    let mut x = &();
    // Overwrite `x` with null.
    unsafe { (&raw mut x).cast::<usize>().write(0) };
    let _val = *x; //~ERROR: null reference
}
```
This program clearly (IMO) should have UB, and has UB in MiniRust, but Miri accepted that program before this PR. The same applies to references that are invalid because they are unaligned (even if we end up only accessing a 1-aligned field, i.e. the rest of the place expression evaluates just fine), and to references that are invalid because they are not dereferenceable (even if we end up projecting to a zero-sized field, i.e., the rest of the place expression evaluates just fine).

Even raw pointers have this problem: a raw pointer can be invalid if its vtable pointer is wrong, and we did not check that.

And finally, this also affects `Box`, and this is where things get tricky. `Box` derefs are not even present any more in the MIR Miri sees; they have been replaced by derefs of the underlying raw pointer. But that means we have no way to know that we should check all those things. So to fix that I adjusted the ElaborateBoxDerefs to emit a new special kind of cast that's almost a transmute but also checks `Box` validity.

Fixes https://github.com/rust-lang/miri/issues/5226
Fixes https://github.com/rust-lang/unsafe-code-guidelines/issues/617
Cc @rust-lang/opsem 