### PR TITLE
tests/ui: Ignore one query cycle test in parallel frontend mode

### DIFF
--- a/tests/ui/specialization/min_specialization/next-solver-region-resolution.rs
+++ b/tests/ui/specialization/min_specialization/next-solver-region-resolution.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: -Znext-solver=globally
+//@ ignore-parallel-frontend query cycle
 // ICE regression test for https://github.com/rust-lang/rust/issues/151327
 
 #![feature(min_specialization)]

--- a/tests/ui/specialization/min_specialization/next-solver-region-resolution.stderr
+++ b/tests/ui/specialization/min_specialization/next-solver-region-resolution.stderr
@@ -1,27 +1,27 @@
 error[E0391]: cycle detected when coherence checking all impls of trait `Foo`
-  --> $DIR/next-solver-region-resolution.rs:6:1
+  --> $DIR/next-solver-region-resolution.rs:7:1
    |
 LL | trait Foo {
    | ^^^^^^^^^
    |
    = note: ...which requires building specialization graph of trait `Foo`...
 note: ...which requires computing whether impls specialize one another...
-  --> $DIR/next-solver-region-resolution.rs:12:1
+  --> $DIR/next-solver-region-resolution.rs:13:1
    |
 LL | / impl<'a, T> Foo for &'a T
 LL | | where
 LL | |     Self::Item: 'a,
    | |___________________^
-note: ...which requires computing normalized predicates of `<impl at $DIR/next-solver-region-resolution.rs:18:1: 20:21>`...
-  --> $DIR/next-solver-region-resolution.rs:18:1
+note: ...which requires computing normalized predicates of `<impl at $DIR/next-solver-region-resolution.rs:19:1: 21:21>`...
+  --> $DIR/next-solver-region-resolution.rs:19:1
    |
 LL | / impl<'a, T> Foo for &T
 LL | | where
 LL | |     Self::Item: Baz,
    | |____________________^
    = note: ...which again requires coherence checking all impls of trait `Foo`, completing the cycle
-note: cycle used when checking that `<impl at $DIR/next-solver-region-resolution.rs:12:1: 14:20>` is well-formed
-  --> $DIR/next-solver-region-resolution.rs:12:1
+note: cycle used when checking that `<impl at $DIR/next-solver-region-resolution.rs:13:1: 15:20>` is well-formed
+  --> $DIR/next-solver-region-resolution.rs:13:1
    |
 LL | / impl<'a, T> Foo for &'a T
 LL | | where


### PR DESCRIPTION
Failed in https://github.com/rust-lang/rust/pull/158298#issuecomment-5084088857.

This is one of known issues, diagnostics with parallel frontend may be unstable in presence of query cycles, cc https://github.com/rust-lang/rust/issues/154314.