### PR TITLE
Fix cranelift asm const pointer handling

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/inline_asm.rs
+++ b/compiler/rustc_codegen_cranelift/src/inline_asm.rs
@@ -6,6 +6,7 @@ use cranelift_codegen::isa::CallConv;
 use rustc_abi::CanonAbi;
 use rustc_ast::ast::{InlineAsmOptions, InlineAsmTemplatePiece};
 use rustc_hir::LangItem;
+use rustc_middle::mir::interpret::{GlobalAlloc, PointerArithmetic, Scalar as ConstScalar};
 use rustc_middle::ty::layout::FnAbiOf;
 use rustc_span::sym;
 use rustc_target::asm::*;
@@ -104,13 +105,44 @@ pub(crate) fn codegen_inline_asm_terminator<'tcx>(
                     )
                 };
 
-                let value = rustc_codegen_ssa::common::asm_const_to_str(
-                    fx.tcx,
-                    span,
-                    scalar.assert_scalar_int(),
-                    fx.layout_of(ty),
-                );
-                CInlineAsmOperand::Const { value }
+                match scalar {
+                    ConstScalar::Int(int) => {
+                        let value = rustc_codegen_ssa::common::asm_const_to_str(
+                            fx.tcx,
+                            span,
+                            int,
+                            fx.layout_of(ty),
+                        );
+                        CInlineAsmOperand::Const { value }
+                    }
+                    ConstScalar::Ptr(ptr, _) => {
+                        let (prov, offset) = ptr.prov_and_relative_offset();
+
+                        let mut symbol = match fx.tcx.global_alloc(prov.alloc_id()) {
+                            GlobalAlloc::Function { instance, .. } => {
+                                fx.tcx.symbol_name(instance).name.to_owned()
+                            }
+                            GlobalAlloc::Static(def_id) => {
+                                fx.tcx.symbol_name(Instance::mono(fx.tcx, def_id)).name.to_owned()
+                            }
+                            GlobalAlloc::Memory(_)
+                            | GlobalAlloc::VTable(..)
+                            | GlobalAlloc::TypeId { .. } => {
+                                span_bug!(
+                                    span,
+                                    "unsupported allocation for inline asm const pointer"
+                                )
+                            }
+                        };
+
+                        if offset != Size::ZERO {
+                            let offset = fx.tcx.sign_extend_to_target_isize(offset.bytes());
+                            write!(symbol, "{offset:+}").unwrap();
+                        }
+
+                        CInlineAsmOperand::Symbol { symbol }
+                    }
+                }
             }
             InlineAsmOperand::SymFn { ref value } => {
                 if cfg!(not(feature = "inline_asm_sym")) {

--- a/tests/ui/asm/cranelift-asm-const-pointer.rs
+++ b/tests/ui/asm/cranelift-asm-const-pointer.rs
@@ -1,0 +1,20 @@
+//@ needs-asm-support
+//@ build-pass
+
+// Regression test for Cranelift handling of pointer-valued `asm!` `const` operands
+
+#![feature(asm_const_ptr)]
+#![crate_type = "lib"]
+
+use std::arch::asm;
+use std::ptr::addr_of;
+
+unsafe extern "C" {
+    static FOO: usize;
+}
+
+pub fn asm_const_pointer() {
+    unsafe {
+        asm!("/* {} */", const addr_of!(FOO));
+    }
+}


### PR DESCRIPTION
Cranelift assumed that every inline assembly `const` operand evaluated to an integer
Fixes rust-lang/rust#159979