### PR TITLE
refactor(mir-transform): Merge `can_be_overridden`, `is_required` and `is_enabled` into one

### DIFF
--- a/compiler/rustc_mir_transform/src/abort_unwinding_calls.rs
+++ b/compiler/rustc_mir_transform/src/abort_unwinding_calls.rs
@@ -6,6 +6,8 @@ use rustc_middle::ty::{self, TyCtxt, layout};
 use rustc_span::sym;
 use rustc_target::spec::PanicStrategy;
 
+use crate::PassPolicy;
+
 /// A pass that runs which is targeted at ensuring that codegen guarantees about
 /// unwinding are upheld for compilations of panic=abort programs.
 ///
@@ -138,7 +140,7 @@ impl<'tcx> crate::MirPass<'tcx> for AbortUnwindingCalls {
         super::simplify::remove_dead_blocks(body);
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }

--- a/compiler/rustc_mir_transform/src/abort_unwinding_calls.rs
+++ b/compiler/rustc_mir_transform/src/abort_unwinding_calls.rs
@@ -141,6 +141,8 @@ impl<'tcx> crate::MirPass<'tcx> for AbortUnwindingCalls {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Implements part of MIR semantics, turning effectively implicit aborts into explicit
+        // ones.
+        PassPolicy::Required
     }
 }

--- a/compiler/rustc_mir_transform/src/add_call_guards.rs
+++ b/compiler/rustc_mir_transform/src/add_call_guards.rs
@@ -130,7 +130,9 @@ impl<'tcx> crate::MirPass<'tcx> for AddCallGuards {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Breaks critical edges so codegen can place edge-specific actions without affecting
+        // other control-flow edges.
+        PassPolicy::Required
     }
 }
 

--- a/compiler/rustc_mir_transform/src/add_call_guards.rs
+++ b/compiler/rustc_mir_transform/src/add_call_guards.rs
@@ -21,6 +21,8 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 use tracing::debug;
 
+use crate::PassPolicy;
+
 #[derive(PartialEq)]
 pub(super) enum AddCallGuards {
     AllCallEdges,
@@ -127,8 +129,8 @@ impl<'tcx> crate::MirPass<'tcx> for AddCallGuards {
         basic_blocks.extend(new_blocks);
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }
 

--- a/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
+++ b/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
@@ -4,7 +4,7 @@ use rustc_middle::ty::{self, TyCtxt};
 use tracing::debug;
 
 use crate::patch::MirPatch;
-use crate::util;
+use crate::{PassPolicy, util};
 
 /// This pass moves values being dropped that are within a packed
 /// struct to a separate local before dropping them, to ensure that
@@ -70,8 +70,8 @@ impl<'tcx> crate::MirPass<'tcx> for AddMovesForPackedDrops {
         patch.apply(body);
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }
 

--- a/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
+++ b/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
@@ -71,7 +71,8 @@ impl<'tcx> crate::MirPass<'tcx> for AddMovesForPackedDrops {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Implements part of MIR semantics by making implicit packed-drop handling explicit.
+        PassPolicy::Required
     }
 }
 

--- a/compiler/rustc_mir_transform/src/add_subtyping_projections.rs
+++ b/compiler/rustc_mir_transform/src/add_subtyping_projections.rs
@@ -67,6 +67,7 @@ impl<'tcx> crate::MirPass<'tcx> for Subtyper {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Later MIR phases expect all subtyping to be explicit.
+        PassPolicy::Required
     }
 }

--- a/compiler/rustc_mir_transform/src/add_subtyping_projections.rs
+++ b/compiler/rustc_mir_transform/src/add_subtyping_projections.rs
@@ -2,6 +2,7 @@ use rustc_middle::mir::visit::MutVisitor;
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 
+use crate::PassPolicy;
 use crate::patch::MirPatch;
 
 pub(super) struct Subtyper;
@@ -65,7 +66,7 @@ impl<'tcx> crate::MirPass<'tcx> for Subtyper {
         checker.patcher.apply(body);
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }

--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -14,6 +14,7 @@ pub(super) struct CheckAlignment;
 
 impl<'tcx> crate::MirPass<'tcx> for CheckAlignment {
     fn policy(&self, sess: &Session) -> PassPolicy {
+        // When UB checks are enabled this is part of their semantics, not an optimization.
         PassPolicy::optional_non_optimization(sess.ub_checks())
     }
 

--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -7,13 +7,14 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::{Ty, TyCtxt};
 use rustc_session::Session;
 
+use crate::PassPolicy;
 use crate::check_pointers::{BorrowedFieldProjectionMode, PointerCheck, check_pointers};
 
 pub(super) struct CheckAlignment;
 
 impl<'tcx> crate::MirPass<'tcx> for CheckAlignment {
-    fn is_enabled(&self, sess: &Session) -> bool {
-        sess.ub_checks()
+    fn policy(&self, sess: &Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(sess.ub_checks())
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -30,10 +31,6 @@ impl<'tcx> crate::MirPass<'tcx> for CheckAlignment {
             insert_alignment_check,
             BorrowedFieldProjectionMode::FollowProjections,
         );
-    }
-
-    fn is_required(&self) -> bool {
-        true
     }
 }
 

--- a/compiler/rustc_mir_transform/src/check_enums.rs
+++ b/compiler/rustc_mir_transform/src/check_enums.rs
@@ -19,6 +19,7 @@ pub(super) struct CheckEnums;
 
 impl<'tcx> crate::MirPass<'tcx> for CheckEnums {
     fn policy(&self, sess: &Session) -> PassPolicy {
+        // When UB checks are enabled this is part of their semantics, not an optimization.
         PassPolicy::optional_non_optimization(sess.ub_checks())
     }
 

--- a/compiler/rustc_mir_transform/src/check_enums.rs
+++ b/compiler/rustc_mir_transform/src/check_enums.rs
@@ -10,14 +10,16 @@ use rustc_middle::ty::{self, Ty, TyCtxt, TypingEnv};
 use rustc_session::Session;
 use tracing::debug;
 
+use crate::PassPolicy;
+
 /// This pass inserts checks for a valid enum discriminant where they are most
 /// likely to find UB, because checking everywhere like Miri would generate too
 /// much MIR.
 pub(super) struct CheckEnums;
 
 impl<'tcx> crate::MirPass<'tcx> for CheckEnums {
-    fn is_enabled(&self, sess: &Session) -> bool {
-        sess.ub_checks()
+    fn policy(&self, sess: &Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(sess.ub_checks())
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -108,10 +110,6 @@ impl<'tcx> crate::MirPass<'tcx> for CheckEnums {
                 }
             }
         }
-    }
-
-    fn is_required(&self) -> bool {
-        true
     }
 }
 

--- a/compiler/rustc_mir_transform/src/check_null.rs
+++ b/compiler/rustc_mir_transform/src/check_null.rs
@@ -12,6 +12,7 @@ pub(super) struct CheckNull;
 
 impl<'tcx> crate::MirPass<'tcx> for CheckNull {
     fn policy(&self, sess: &Session) -> PassPolicy {
+        // When UB checks are enabled this is part of their semantics, not an optimization.
         PassPolicy::optional_non_optimization(sess.ub_checks())
     }
 

--- a/compiler/rustc_mir_transform/src/check_null.rs
+++ b/compiler/rustc_mir_transform/src/check_null.rs
@@ -5,13 +5,14 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::{Ty, TyCtxt};
 use rustc_session::Session;
 
+use crate::PassPolicy;
 use crate::check_pointers::{BorrowedFieldProjectionMode, PointerCheck, check_pointers};
 
 pub(super) struct CheckNull;
 
 impl<'tcx> crate::MirPass<'tcx> for CheckNull {
-    fn is_enabled(&self, sess: &Session) -> bool {
-        sess.ub_checks()
+    fn policy(&self, sess: &Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(sess.ub_checks())
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -22,10 +23,6 @@ impl<'tcx> crate::MirPass<'tcx> for CheckNull {
             insert_null_check,
             BorrowedFieldProjectionMode::NoFollowProjections,
         );
-    }
-
-    fn is_required(&self) -> bool {
-        true
     }
 }
 

--- a/compiler/rustc_mir_transform/src/cleanup_post_borrowck.rs
+++ b/compiler/rustc_mir_transform/src/cleanup_post_borrowck.rs
@@ -88,6 +88,7 @@ impl<'tcx> crate::MirPass<'tcx> for CleanupPostBorrowck {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Removes administrative MIR instructions that later passes must never see.
+        PassPolicy::Required
     }
 }

--- a/compiler/rustc_mir_transform/src/cleanup_post_borrowck.rs
+++ b/compiler/rustc_mir_transform/src/cleanup_post_borrowck.rs
@@ -21,6 +21,8 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 use rustc_middle::ty::adjustment::PointerCoercion;
 
+use crate::PassPolicy;
+
 pub(super) struct CleanupPostBorrowck;
 
 impl<'tcx> crate::MirPass<'tcx> for CleanupPostBorrowck {
@@ -85,7 +87,7 @@ impl<'tcx> crate::MirPass<'tcx> for CleanupPostBorrowck {
         }
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }

--- a/compiler/rustc_mir_transform/src/copy_prop.rs
+++ b/compiler/rustc_mir_transform/src/copy_prop.rs
@@ -6,6 +6,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_mir_dataflow::{Analysis, ResultsCursor};
 use tracing::{debug, instrument};
 
+use crate::PassPolicy;
 use crate::ssa::{MaybeUninitializedLocals, SsaLocals};
 
 /// Unify locals that copy each other.
@@ -21,8 +22,8 @@ use crate::ssa::{MaybeUninitializedLocals, SsaLocals};
 pub(super) struct CopyProp;
 
 impl<'tcx> crate::MirPass<'tcx> for CopyProp {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() >= 1
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() >= 1)
     }
 
     #[instrument(level = "trace", skip(self, tcx, body))]
@@ -94,10 +95,6 @@ impl<'tcx> crate::MirPass<'tcx> for CopyProp {
             .visit_body_preserves_cfg(body);
 
         crate::simplify::remove_unused_definitions(body);
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/coroutine/mod.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/mod.rs
@@ -80,7 +80,7 @@ use tracing::{debug, instrument};
 
 use crate::deref_separator::deref_finder;
 use crate::patch::MirPatch;
-use crate::{abort_unwinding_calls, pass_manager as pm, simplify};
+use crate::{PassPolicy, abort_unwinding_calls, pass_manager as pm, simplify};
 
 pub(super) struct StateTransform;
 
@@ -1219,8 +1219,8 @@ impl<'tcx> crate::MirPass<'tcx> for StateTransform {
         create_coroutine_resume_function(tcx, transform, body, can_return, can_unwind);
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }
 

--- a/compiler/rustc_mir_transform/src/coroutine/mod.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/mod.rs
@@ -1220,7 +1220,8 @@ impl<'tcx> crate::MirPass<'tcx> for StateTransform {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Implements coroutine semantics by lowering the coroutine body to a state machine.
+        PassPolicy::Required
     }
 }
 

--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -3,6 +3,7 @@ use rustc_middle::mir::{self, BasicBlock, Statement, StatementKind, TerminatorKi
 use rustc_middle::ty::TyCtxt;
 use tracing::{debug, debug_span, trace};
 
+use crate::PassPolicy;
 use crate::coverage::counters::BcbCountersData;
 use crate::coverage::graph::CoverageGraph;
 use crate::coverage::mappings::ExtractedMappings;
@@ -24,8 +25,8 @@ mod tests;
 pub(super) struct InstrumentCoverage;
 
 impl<'tcx> crate::MirPass<'tcx> for InstrumentCoverage {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.instrument_coverage()
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(sess.instrument_coverage())
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, mir_body: &mut mir::Body<'tcx>) {
@@ -53,10 +54,6 @@ impl<'tcx> crate::MirPass<'tcx> for InstrumentCoverage {
         }
 
         instrument_function_for_coverage(tcx, mir_body);
-    }
-
-    fn is_required(&self) -> bool {
-        true
     }
 }
 

--- a/compiler/rustc_mir_transform/src/ctfe_limit.rs
+++ b/compiler/rustc_mir_transform/src/ctfe_limit.rs
@@ -8,6 +8,8 @@ use rustc_middle::mir::{
 use rustc_middle::ty::TyCtxt;
 use tracing::instrument;
 
+use crate::PassPolicy;
+
 pub(super) struct CtfeLimit;
 
 impl<'tcx> crate::MirPass<'tcx> for CtfeLimit {
@@ -37,8 +39,8 @@ impl<'tcx> crate::MirPass<'tcx> for CtfeLimit {
         }
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }
 

--- a/compiler/rustc_mir_transform/src/ctfe_limit.rs
+++ b/compiler/rustc_mir_transform/src/ctfe_limit.rs
@@ -40,6 +40,7 @@ impl<'tcx> crate::MirPass<'tcx> for CtfeLimit {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        // This is part of CTFE diagnostics rather than an optimization.
         PassPolicy::optional_non_optimization(true)
     }
 }

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -26,6 +26,8 @@ use rustc_mir_dataflow::{Analysis, ResultsVisitor, visit_reachable_results};
 use rustc_span::DUMMY_SP;
 use tracing::{debug, debug_span, instrument};
 
+use crate::PassPolicy;
+
 // These constants are somewhat random guesses and have not been optimized.
 // If `tcx.sess.mir_opt_level() >= 4`, we ignore the limits (this can become very expensive).
 const BLOCK_LIMIT: usize = 100;
@@ -34,8 +36,8 @@ const PLACE_LIMIT: usize = 100;
 pub(super) struct DataflowConstProp;
 
 impl<'tcx> crate::MirPass<'tcx> for DataflowConstProp {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() >= 3
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() >= 3)
     }
 
     #[instrument(skip_all level = "debug")]
@@ -73,10 +75,6 @@ impl<'tcx> crate::MirPass<'tcx> for DataflowConstProp {
         debug_span!("collect").in_scope(|| visit_reachable_results(body, &const_, &mut visitor));
         let mut patch = visitor.patch;
         debug_span!("patch").in_scope(|| patch.visit_body_preserves_cfg(body));
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/dead_store_elimination.rs
+++ b/compiler/rustc_mir_transform/src/dead_store_elimination.rs
@@ -22,6 +22,7 @@ use rustc_mir_dataflow::impls::{
     LivenessTransferFunction, MaybeTransitiveLiveLocals, borrowed_locals,
 };
 
+use crate::PassPolicy;
 use crate::simplify::UsedInStmtLocals;
 use crate::util::most_packed_projection;
 
@@ -140,8 +141,8 @@ impl<'tcx> crate::MirPass<'tcx> for DeadStoreElimination {
         }
     }
 
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() >= 2
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() >= 2)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -151,9 +152,5 @@ impl<'tcx> crate::MirPass<'tcx> for DeadStoreElimination {
                 data.strip_nops();
             }
         }
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }

--- a/compiler/rustc_mir_transform/src/deref_separator.rs
+++ b/compiler/rustc_mir_transform/src/deref_separator.rs
@@ -3,6 +3,7 @@ use rustc_middle::mir::visit::{MutVisitor, PlaceContext};
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 
+use crate::PassPolicy;
 use crate::patch::MirPatch;
 
 pub(super) struct Derefer;
@@ -101,7 +102,7 @@ impl<'tcx> crate::MirPass<'tcx> for Derefer {
         deref_finder(tcx, body, true);
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }

--- a/compiler/rustc_mir_transform/src/deref_separator.rs
+++ b/compiler/rustc_mir_transform/src/deref_separator.rs
@@ -103,6 +103,7 @@ impl<'tcx> crate::MirPass<'tcx> for Derefer {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Later MIR stages expect derefs to only appear as the first place projection.
+        PassPolicy::Required
     }
 }

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -149,11 +149,13 @@ use rustc_mir_dataflow::points::DenseLocationMap;
 use rustc_mir_dataflow::{Analysis, EntryStates, GenKill};
 use tracing::{debug, trace};
 
+use crate::PassPolicy;
+
 pub(super) struct DestinationPropagation;
 
 impl<'tcx> crate::MirPass<'tcx> for DestinationPropagation {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() >= 2
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() >= 2)
     }
 
     #[tracing::instrument(level = "trace", skip(self, tcx, body))]
@@ -231,10 +233,6 @@ impl<'tcx> crate::MirPass<'tcx> for DestinationPropagation {
         }
 
         apply_merges(body, tcx, relevant, merged_locals);
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -6,6 +6,7 @@ use rustc_middle::ty::{Ty, TyCtxt};
 use tracing::trace;
 
 use super::simplify::simplify_cfg;
+use crate::PassPolicy;
 use crate::patch::MirPatch;
 
 /// This pass optimizes something like
@@ -94,8 +95,8 @@ use crate::patch::MirPatch;
 pub(super) struct EarlyOtherwiseBranch;
 
 impl<'tcx> crate::MirPass<'tcx> for EarlyOtherwiseBranch {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() >= 2
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() >= 2)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -197,10 +198,6 @@ impl<'tcx> crate::MirPass<'tcx> for EarlyOtherwiseBranch {
         if should_cleanup {
             simplify_cfg(tcx, body);
         }
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/elaborate_box_derefs.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_box_derefs.rs
@@ -163,6 +163,7 @@ impl<'tcx> crate::MirPass<'tcx> for ElaborateBoxDerefs {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Implements Box dereference semantics so backends and Miri do not have to handle them.
+        PassPolicy::Required
     }
 }

--- a/compiler/rustc_mir_transform/src/elaborate_box_derefs.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_box_derefs.rs
@@ -8,6 +8,7 @@ use rustc_middle::mir::*;
 use rustc_middle::span_bug;
 use rustc_middle::ty::{self, PatternKind, Ty, TyCtxt};
 
+use crate::PassPolicy;
 use crate::patch::MirPatch;
 
 /// Constructs the types used when accessing a Box's pointer
@@ -161,7 +162,7 @@ impl<'tcx> crate::MirPass<'tcx> for ElaborateBoxDerefs {
         }
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }

--- a/compiler/rustc_mir_transform/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drops.rs
@@ -14,6 +14,7 @@ use rustc_mir_dataflow::{
 use rustc_span::Span;
 use tracing::{debug, instrument};
 
+use crate::PassPolicy;
 use crate::elaborate_drop::{DropElaborator, DropFlagMode, DropStyle, Unwind, elaborate_drop};
 use crate::patch::MirPatch;
 
@@ -87,8 +88,8 @@ impl<'tcx> crate::MirPass<'tcx> for ElaborateDrops {
         elaborate_patch.apply(body);
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }
 

--- a/compiler/rustc_mir_transform/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drops.rs
@@ -89,7 +89,8 @@ impl<'tcx> crate::MirPass<'tcx> for ElaborateDrops {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Implements MIR drop semantics.
+        PassPolicy::Required
     }
 }
 

--- a/compiler/rustc_mir_transform/src/erase_deref_temps.rs
+++ b/compiler/rustc_mir_transform/src/erase_deref_temps.rs
@@ -5,6 +5,8 @@ use rustc_middle::mir::visit::MutVisitor;
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 
+use crate::PassPolicy;
+
 struct EraseDerefTempsVisitor<'tcx> {
     tcx: TyCtxt<'tcx>,
 }
@@ -37,7 +39,7 @@ impl<'tcx> crate::MirPass<'tcx> for EraseDerefTemps {
         EraseDerefTempsVisitor { tcx }.visit_body_preserves_cfg(body);
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }

--- a/compiler/rustc_mir_transform/src/erase_deref_temps.rs
+++ b/compiler/rustc_mir_transform/src/erase_deref_temps.rs
@@ -40,6 +40,7 @@ impl<'tcx> crate::MirPass<'tcx> for EraseDerefTemps {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Later MIR stages assume that CopyForDeref is gone.
+        PassPolicy::Required
     }
 }

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -122,13 +122,14 @@ use rustc_span::DUMMY_SP;
 use smallvec::SmallVec;
 use tracing::{debug, instrument, trace};
 
+use crate::PassPolicy;
 use crate::ssa::{MaybeUninitializedLocals, SsaLocals};
 
 pub(super) struct GVN;
 
 impl<'tcx> crate::MirPass<'tcx> for GVN {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() >= 2
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() >= 2)
     }
 
     #[instrument(level = "trace", skip(self, tcx, body))]
@@ -184,10 +185,6 @@ impl<'tcx> crate::MirPass<'tcx> for GVN {
 
         StorageRemover { tcx, reused_locals: &state.reused_locals, storage_to_remove }
             .visit_body_preserves_cfg(body);
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/impossible_clauses.rs
+++ b/compiler/rustc_mir_transform/src/impossible_clauses.rs
@@ -115,6 +115,7 @@ impl<'tcx> MirPass<'tcx> for ImpossibleClauses {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        // This can only replace code proven unreachable with immediate UB, so it cannot remove UB.
         PassPolicy::optional_non_optimization(true)
     }
 }

--- a/compiler/rustc_mir_transform/src/impossible_clauses.rs
+++ b/compiler/rustc_mir_transform/src/impossible_clauses.rs
@@ -32,6 +32,7 @@ use rustc_span::def_id::DefId;
 use rustc_trait_selection::traits;
 use tracing::trace;
 
+use crate::PassPolicy;
 use crate::pass_manager::MirPass;
 
 fn is_structurally_unsized<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
@@ -113,7 +114,7 @@ impl<'tcx> MirPass<'tcx> for ImpossibleClauses {
         }
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -78,6 +78,7 @@ impl ForceInline {
 
 impl<'tcx> crate::MirPass<'tcx> for ForceInline {
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        // Forced inlining is part of MIR semantics.
         PassPolicy::Required
     }
 

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -24,7 +24,7 @@ use tracing::{debug, instrument, trace, trace_span};
 use crate::cost_checker::{CostChecker, is_call_like};
 use crate::simplify::{UsedInStmtLocals, simplify_cfg};
 use crate::validate::validate_types;
-use crate::{check_inline, util};
+use crate::{PassPolicy, check_inline, util};
 
 pub(crate) mod cycle;
 
@@ -44,19 +44,18 @@ struct CallSite<'tcx> {
 pub struct Inline;
 
 impl<'tcx> crate::MirPass<'tcx> for Inline {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        if let Some(enabled) = sess.opts.unstable_opts.inline_mir {
-            return enabled;
-        }
-
-        match sess.mir_opt_level() {
-            0 | 1 => false,
-            2 => {
-                (sess.opts.optimize == OptLevel::More || sess.opts.optimize == OptLevel::Aggressive)
-                    && sess.opts.incremental == None
-            }
-            _ => true,
-        }
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        let enabled_by_default =
+            sess.opts.unstable_opts.inline_mir.unwrap_or_else(|| match sess.mir_opt_level() {
+                0 | 1 => false,
+                2 => {
+                    (sess.opts.optimize == OptLevel::More
+                        || sess.opts.optimize == OptLevel::Aggressive)
+                        && sess.opts.incremental == None
+                }
+                _ => true,
+            });
+        PassPolicy::optimization(enabled_by_default)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -66,10 +65,6 @@ impl<'tcx> crate::MirPass<'tcx> for Inline {
             debug!("running simplify cfg on {:?}", body.source);
             simplify_cfg(tcx, body);
         }
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 
@@ -82,16 +77,8 @@ impl ForceInline {
 }
 
 impl<'tcx> crate::MirPass<'tcx> for ForceInline {
-    fn is_enabled(&self, _: &rustc_session::Session) -> bool {
-        true
-    }
-
-    fn can_be_overridden(&self) -> bool {
-        false
-    }
-
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::Required
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -10,6 +10,7 @@ use rustc_middle::ty::layout::{IntegerExt, ValidityRequirement};
 use rustc_middle::ty::{self, GenericArgsRef, Ty, TyCtxt, layout};
 use rustc_span::{Symbol, sym};
 
+use crate::PassPolicy;
 use crate::simplify::simplify_duplicate_switch_targets;
 
 pub(super) enum InstSimplify {
@@ -25,8 +26,8 @@ impl<'tcx> crate::MirPass<'tcx> for InstSimplify {
         }
     }
 
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() > 0
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() > 0)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -61,10 +62,6 @@ impl<'tcx> crate::MirPass<'tcx> for InstSimplify {
             ctx.simplify_nounwind_call(terminator);
             simplify_duplicate_switch_targets(terminator);
         }
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -68,6 +68,7 @@ use rustc_mir_dataflow::value_analysis::{
 use rustc_span::DUMMY_SP;
 use tracing::{debug, instrument, trace};
 
+use crate::PassPolicy;
 use crate::cost_checker::CostChecker;
 
 pub(super) struct JumpThreading;
@@ -75,16 +76,18 @@ pub(super) struct JumpThreading;
 const MAX_COST: u8 = 100;
 
 impl<'tcx> crate::MirPass<'tcx> for JumpThreading {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        if sess.target.is_like_gpu {
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        let enabled_by_default = if sess.target.is_like_gpu {
             // Jump threading can duplicate calls in control-flow.
             // This leads to incorrect code when done for so called "convergent" operations on GPU
             // targets, similar to how inline assembly cannot be duplicated on all targets.
             // Conservatively prevent this by disabling the pass.
             // See also issue #137086.
-            return false;
-        }
-        sess.mir_opt_level() >= 2
+            false
+        } else {
+            sess.mir_opt_level() >= 2
+        };
+        PassPolicy::optimization(enabled_by_default)
     }
 
     #[instrument(skip_all level = "debug")]
@@ -147,10 +150,6 @@ impl<'tcx> crate::MirPass<'tcx> for JumpThreading {
         if let Some(opportunities) = OpportunitySet::new(body, entry_states) {
             opportunities.apply();
         }
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/large_enums.rs
+++ b/compiler/rustc_mir_transform/src/large_enums.rs
@@ -7,6 +7,7 @@ use rustc_middle::ty::util::IntTypeExt;
 use rustc_middle::ty::{self, AdtDef, Ty, TyCtxt};
 use rustc_session::Session;
 
+use crate::PassPolicy;
 use crate::patch::MirPatch;
 
 /// A pass that seeks to optimize unnecessary moves of large enum types, if there is a large
@@ -31,11 +32,13 @@ pub(super) struct EnumSizeOpt {
 }
 
 impl<'tcx> crate::MirPass<'tcx> for EnumSizeOpt {
-    fn is_enabled(&self, sess: &Session) -> bool {
+    fn policy(&self, sess: &Session) -> PassPolicy {
         // There are some differences in behavior on wasm and ARM that are not properly
         // understood, so we conservatively treat this optimization as unsound:
         // https://github.com/rust-lang/rust/issues/154413
-        sess.opts.unstable_opts.unsound_mir_opts && sess.mir_opt_level() >= 3
+        PassPolicy::optimization(
+            sess.opts.unstable_opts.unsound_mir_opts && sess.mir_opt_level() >= 3,
+        )
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -164,10 +167,6 @@ impl<'tcx> crate::MirPass<'tcx> for EnumSizeOpt {
         }
 
         patch.apply(body);
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -35,7 +35,7 @@ mod pass_manager;
 
 use std::sync::LazyLock;
 
-use pass_manager::{self as pm, Lint, MirLint, MirPass, WithMinOptLevel};
+use pass_manager::{self as pm, Lint, MirLint, MirPass, PassPolicy, WithMinOptLevel};
 
 mod check_pointers;
 mod cost_checker;

--- a/compiler/rustc_mir_transform/src/lint_and_remove_uninhabited.rs
+++ b/compiler/rustc_mir_transform/src/lint_and_remove_uninhabited.rs
@@ -84,7 +84,9 @@ impl<'tcx> crate::MirPass<'tcx> for LintAndRemoveUninhabited {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Removing visibly uninhabited return edges determines the control flow seen by MIR checks.
+        // Cannot remove UB: removing the return edge would *introduce* UB if the call actually returned.
+        PassPolicy::Required
     }
 }
 

--- a/compiler/rustc_mir_transform/src/lint_and_remove_uninhabited.rs
+++ b/compiler/rustc_mir_transform/src/lint_and_remove_uninhabited.rs
@@ -3,6 +3,7 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::lint::builtin::UNREACHABLE_CODE;
 
+use crate::PassPolicy;
 use crate::diagnostics::UnreachableDueToUninhabited;
 
 /// Lint unreachable code due to uninhabited values from function calls,
@@ -82,8 +83,8 @@ impl<'tcx> crate::MirPass<'tcx> for LintAndRemoveUninhabited {
         }
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }
 

--- a/compiler/rustc_mir_transform/src/lower_intrinsics.rs
+++ b/compiler/rustc_mir_transform/src/lower_intrinsics.rs
@@ -340,6 +340,7 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Implements intrinsic semantics by lowering intrinsic calls to ordinary MIR operations.
+        PassPolicy::Required
     }
 }

--- a/compiler/rustc_mir_transform/src/lower_intrinsics.rs
+++ b/compiler/rustc_mir_transform/src/lower_intrinsics.rs
@@ -5,7 +5,7 @@ use rustc_middle::ty::{self, TyCtxt};
 use rustc_middle::{bug, span_bug};
 use rustc_span::sym;
 
-use crate::take_array;
+use crate::{PassPolicy, take_array};
 
 pub(super) struct LowerIntrinsics;
 
@@ -339,7 +339,7 @@ impl<'tcx> crate::MirPass<'tcx> for LowerIntrinsics {
         }
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }

--- a/compiler/rustc_mir_transform/src/lower_slice_len.rs
+++ b/compiler/rustc_mir_transform/src/lower_slice_len.rs
@@ -5,11 +5,13 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 
+use crate::PassPolicy;
+
 pub(super) struct LowerSliceLenCalls;
 
 impl<'tcx> crate::MirPass<'tcx> for LowerSliceLenCalls {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() > 0
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() > 0)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -25,10 +27,6 @@ impl<'tcx> crate::MirPass<'tcx> for LowerSliceLenCalls {
             // lower `<[_]>::len` calls
             lower_slice_len_call(block, slice_len_fn_item_def_id);
         }
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/match_branches.rs
+++ b/compiler/rustc_mir_transform/src/match_branches.rs
@@ -6,6 +6,7 @@ use rustc_middle::ty::util::Discr;
 use rustc_middle::ty::{self, ScalarInt, Ty, TyCtxt};
 
 use super::simplify::simplify_cfg;
+use crate::PassPolicy;
 use crate::patch::MirPatch;
 use crate::unreachable_prop::remove_successors_from_switch;
 
@@ -13,9 +14,9 @@ use crate::unreachable_prop::remove_successors_from_switch;
 pub(super) struct MatchBranchSimplification;
 
 impl<'tcx> crate::MirPass<'tcx> for MatchBranchSimplification {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
         // Enable only under -Zmir-opt-level=2 as this can make programs less debuggable.
-        sess.mir_opt_level() >= 2
+        PassPolicy::optimization(sess.mir_opt_level() >= 2)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -31,10 +32,6 @@ impl<'tcx> crate::MirPass<'tcx> for MatchBranchSimplification {
         if changed {
             simplify_cfg(tcx, body);
         }
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/mentioned_items.rs
+++ b/compiler/rustc_mir_transform/src/mentioned_items.rs
@@ -5,6 +5,8 @@ use rustc_middle::ty::{self, TyCtxt};
 use rustc_session::Session;
 use rustc_span::Spanned;
 
+use crate::PassPolicy;
+
 pub(super) struct MentionedItems;
 
 struct MentionedItemsVisitor<'a, 'tcx> {
@@ -14,22 +16,18 @@ struct MentionedItemsVisitor<'a, 'tcx> {
 }
 
 impl<'tcx> crate::MirPass<'tcx> for MentionedItems {
-    fn is_enabled(&self, _sess: &Session) -> bool {
+    fn policy(&self, _sess: &Session) -> PassPolicy {
         // If this pass is skipped the collector assume that nothing got mentioned! We could
         // potentially skip it in opt-level 0 if we are sure that opt-level will never *remove* uses
         // of anything, but that still seems fragile. Furthermore, even debug builds use level 1, so
         // special-casing level 0 is just not worth it.
-        true
+        PassPolicy::optional_non_optimization(true)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut mir::Body<'tcx>) {
         let mut visitor = MentionedItemsVisitor { tcx, body, mentioned_items: Vec::new() };
         visitor.visit_body(body);
         body.set_mentioned_items(visitor.mentioned_items);
-    }
-
-    fn is_required(&self) -> bool {
-        true
     }
 }
 

--- a/compiler/rustc_mir_transform/src/mentioned_items.rs
+++ b/compiler/rustc_mir_transform/src/mentioned_items.rs
@@ -21,7 +21,7 @@ impl<'tcx> crate::MirPass<'tcx> for MentionedItems {
         // potentially skip it in opt-level 0 if we are sure that opt-level will never *remove* uses
         // of anything, but that still seems fragile. Furthermore, even debug builds use level 1, so
         // special-casing level 0 is just not worth it.
-        PassPolicy::optional_non_optimization(true)
+        PassPolicy::Required
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut mir::Body<'tcx>) {

--- a/compiler/rustc_mir_transform/src/multiple_return_terminators.rs
+++ b/compiler/rustc_mir_transform/src/multiple_return_terminators.rs
@@ -5,13 +5,13 @@ use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 
-use crate::simplify;
+use crate::{PassPolicy, simplify};
 
 pub(super) struct MultipleReturnTerminators;
 
 impl<'tcx> crate::MirPass<'tcx> for MultipleReturnTerminators {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() >= 4
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() >= 4)
     }
 
     fn run_pass(&self, _: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -33,9 +33,5 @@ impl<'tcx> crate::MirPass<'tcx> for MultipleReturnTerminators {
         }
 
         simplify::remove_dead_blocks(body)
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }

--- a/compiler/rustc_mir_transform/src/pass_manager.rs
+++ b/compiler/rustc_mir_transform/src/pass_manager.rs
@@ -79,6 +79,52 @@ const fn simplify_pass_type_name(name: &'static str) -> &'static str {
     }
 }
 
+/// Rules outlining when this pass may be overridden or suppressed.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PassPolicy {
+    /// This pass implements a mandatory lowering step, either to implement parts of the MIR semantics
+    /// or to bring MIR into a shape that is easier to deal with for later passes/codegen.
+    /// Passes using this cannot be disabled via any means. They must not remove any UB, as they will
+    /// run in Miri. They must also come with a comment justifying why they must always run.
+    Required,
+    /// An optional pass that may be configured by `-Zmir-enable-passes`.
+    Optional {
+        /// Whether this pass should be enabled by default in this session in the absence of
+        /// an explicit `-Zmir-enable-passes` or `#[optimize(none)]`.
+        generally_enabled: bool,
+        /// Whether this is an optimization pass. `#[optimize(none)]` only disables optimization
+        /// passes.
+        /// A pass may be optional without being an optimization pass,
+        /// e.g. if it just adds extra debug checks that one can turn off.
+        optimization: bool,
+    },
+}
+
+impl PassPolicy {
+    fn and_enabled(self, enabled: bool) -> Self {
+        match self {
+            PassPolicy::Required => PassPolicy::Required,
+            PassPolicy::Optional { generally_enabled: enabled_by_default, optimization } => {
+                PassPolicy::Optional {
+                    generally_enabled: enabled_by_default && enabled,
+                    optimization,
+                }
+            }
+        }
+    }
+
+    /// Create a [`PassPolicy::Optional`] that is not an optimization,
+    /// enabled by default under the given condition.
+    pub(crate) fn optional_non_optimization(condition: bool) -> Self {
+        Self::Optional { generally_enabled: condition, optimization: false }
+    }
+
+    /// Create a [`PassPolicy::Optional`] optimization, enabled by default under the given condition.
+    pub(crate) fn optimization(condition: bool) -> Self {
+        Self::Optional { generally_enabled: condition, optimization: true }
+    }
+}
+
 /// A streamlined trait that you can implement to create a pass; the
 /// pass will be named after the type, and it will consist of a main
 /// loop that goes over each available MIR and applies `run_pass`.
@@ -91,27 +137,14 @@ pub(super) trait MirPass<'tcx> {
         to_profiler_name(self.name())
     }
 
-    /// Returns `true` if this pass is enabled with the current combination of compiler flags.
-    fn is_enabled(&self, _sess: &Session) -> bool {
-        true
-    }
-
-    /// Returns `true` if this pass can be overridden by `-Zenable-mir-passes`. This should be
-    /// true for basically every pass other than those that are necessary for correctness.
-    fn can_be_overridden(&self) -> bool {
-        true
-    }
+    /// Describes how this pass is enabled and which mechanisms may disable it.
+    fn policy(&self, sess: &Session) -> PassPolicy;
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>);
 
     fn is_mir_dump_enabled(&self) -> bool {
         true
     }
-
-    /// Returns `true` if this pass must be run (i.e. it is required for soundness).
-    /// For passes which are strictly optimizations, this should return `false`.
-    /// If this is `false`, `#[optimize(none)]` will disable the pass.
-    fn is_required(&self) -> bool;
 }
 
 /// Just like `MirPass`, except it cannot mutate `Body`, and MIR dumping is
@@ -119,10 +152,6 @@ pub(super) trait MirPass<'tcx> {
 pub(super) trait MirLint<'tcx> {
     fn name(&self) -> &'static str {
         const { simplify_pass_type_name(std::any::type_name::<Self>()) }
-    }
-
-    fn is_enabled(&self, _sess: &Session) -> bool {
-        true
     }
 
     fn run_lint(&self, tcx: TyCtxt<'tcx>, body: &Body<'tcx>);
@@ -140,10 +169,6 @@ where
         self.0.name()
     }
 
-    fn is_enabled(&self, sess: &Session) -> bool {
-        self.0.is_enabled(sess)
-    }
-
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         self.0.run_lint(tcx, body)
     }
@@ -152,8 +177,8 @@ where
         false
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }
 
@@ -167,22 +192,18 @@ where
         self.1.name()
     }
 
-    fn is_enabled(&self, sess: &Session) -> bool {
-        sess.mir_opt_level() >= self.0 as usize
-    }
-
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         self.1.run_pass(tcx, body)
     }
 
-    fn is_required(&self) -> bool {
-        self.1.is_required()
+    fn policy(&self, sess: &Session) -> PassPolicy {
+        self.1.policy(sess).and_enabled(sess.mir_opt_level() >= self.0 as usize)
     }
 }
 
-/// Whether to allow non-[required] optimizations
+/// Whether to allow [optimization passes].
 ///
-/// [required]: MirPass::is_required
+/// [optimization passes]: PassPolicy::Optional::optimization
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Optimizations {
     /// The current function has `#[optimize(none)]`.
@@ -221,23 +242,34 @@ where
     P: MirPass<'tcx> + ?Sized,
 {
     let name = pass.name();
+    let pass_override = || {
+        tcx.sess
+            .opts
+            .unstable_opts
+            .mir_enable_passes
+            .iter()
+            .rev()
+            .find_map(|(name_, polarity)| if name == name_ { Some(*polarity) } else { None })
+    };
 
-    if !pass.can_be_overridden() {
-        return pass.is_enabled(tcx.sess);
+    match pass.policy(tcx.sess) {
+        PassPolicy::Required => true,
+        PassPolicy::Optional { generally_enabled: enabled_by_default, optimization } => {
+            if let Some(o) = pass_override() {
+                trace!(
+                    pass = %name,
+                    "{} as requested by flag",
+                    if o { "Running" } else { "Not running" }
+                );
+                o
+            } else if optimization && optimizations == Optimizations::Suppressed {
+                trace!(pass = %name, "Not running as requested by `#[optimize(none)]`");
+                false
+            } else {
+                enabled_by_default
+            }
+        }
     }
-
-    let overridden_passes = &tcx.sess.opts.unstable_opts.mir_enable_passes;
-    let overridden =
-        overridden_passes.iter().rev().find(|(s, _)| s == &*name).map(|(_name, polarity)| {
-            trace!(
-                pass = %name,
-                "{} as requested by flag",
-                if *polarity { "Running" } else { "Not running" },
-            );
-            *polarity
-        });
-    let suppressed = !pass.is_required() && matches!(optimizations, Optimizations::Suppressed);
-    overridden.unwrap_or_else(|| !suppressed && pass.is_enabled(tcx.sess))
 }
 
 fn run_passes_inner<'tcx>(

--- a/compiler/rustc_mir_transform/src/post_analysis_normalize.rs
+++ b/compiler/rustc_mir_transform/src/post_analysis_normalize.rs
@@ -6,6 +6,8 @@ use rustc_middle::mir::visit::*;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 
+use crate::PassPolicy;
+
 pub(super) struct PostAnalysisNormalize;
 
 impl<'tcx> crate::MirPass<'tcx> for PostAnalysisNormalize {
@@ -16,8 +18,8 @@ impl<'tcx> crate::MirPass<'tcx> for PostAnalysisNormalize {
         PostAnalysisNormalizeVisitor { tcx, typing_env }.visit_body_preserves_cfg(body);
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }
 

--- a/compiler/rustc_mir_transform/src/post_analysis_normalize.rs
+++ b/compiler/rustc_mir_transform/src/post_analysis_normalize.rs
@@ -19,7 +19,8 @@ impl<'tcx> crate::MirPass<'tcx> for PostAnalysisNormalize {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Reveals opaque types and normalizes MIR while transitioning to the runtime dialect.
+        PassPolicy::Required
     }
 }
 

--- a/compiler/rustc_mir_transform/src/prettify.rs
+++ b/compiler/rustc_mir_transform/src/prettify.rs
@@ -21,7 +21,7 @@ pub(super) struct ReorderBasicBlocks;
 
 impl<'tcx> crate::MirPass<'tcx> for ReorderBasicBlocks {
     fn policy(&self, _session: &Session) -> PassPolicy {
-        PassPolicy::optimization(false)
+        PassPolicy::optional_non_optimization(false)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -49,7 +49,7 @@ pub(super) struct ReorderLocals;
 
 impl<'tcx> crate::MirPass<'tcx> for ReorderLocals {
     fn policy(&self, _session: &Session) -> PassPolicy {
-        PassPolicy::optimization(false)
+        PassPolicy::optional_non_optimization(false)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {

--- a/compiler/rustc_mir_transform/src/prettify.rs
+++ b/compiler/rustc_mir_transform/src/prettify.rs
@@ -11,6 +11,8 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 
+use crate::PassPolicy;
+
 /// Rearranges the basic blocks into a *reverse post-order*.
 ///
 /// Thus after this pass, all the successors of a block are later than it in the
@@ -18,8 +20,8 @@ use rustc_session::Session;
 pub(super) struct ReorderBasicBlocks;
 
 impl<'tcx> crate::MirPass<'tcx> for ReorderBasicBlocks {
-    fn is_enabled(&self, _session: &Session) -> bool {
-        false
+    fn policy(&self, _session: &Session) -> PassPolicy {
+        PassPolicy::optimization(false)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -35,10 +37,6 @@ impl<'tcx> crate::MirPass<'tcx> for ReorderBasicBlocks {
 
         permute(body.basic_blocks.as_mut(), &updater.map);
     }
-
-    fn is_required(&self) -> bool {
-        false
-    }
 }
 
 /// Rearranges the locals into *use* order.
@@ -50,8 +48,8 @@ impl<'tcx> crate::MirPass<'tcx> for ReorderBasicBlocks {
 pub(super) struct ReorderLocals;
 
 impl<'tcx> crate::MirPass<'tcx> for ReorderLocals {
-    fn is_enabled(&self, _session: &Session) -> bool {
-        false
+    fn policy(&self, _session: &Session) -> PassPolicy {
+        PassPolicy::optimization(false)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -88,10 +86,6 @@ impl<'tcx> crate::MirPass<'tcx> for ReorderLocals {
         updater.visit_body_preserves_cfg(body);
 
         permute(&mut body.local_decls, &updater.map);
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -27,6 +27,8 @@ use rustc_middle::{bug, mir, span_bug};
 use rustc_span::{Span, Spanned};
 use tracing::{debug, instrument};
 
+use crate::PassPolicy;
+
 /// A `MirPass` for promotion.
 ///
 /// Promotion is the extraction of promotable temps into separate MIR bodies so they can have
@@ -62,8 +64,8 @@ impl<'tcx> crate::MirPass<'tcx> for PromoteTemps<'tcx> {
         self.promoted_fragments.set(promoted);
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }
 

--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -65,7 +65,8 @@ impl<'tcx> crate::MirPass<'tcx> for PromoteTemps<'tcx> {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Implements promotion by extracting eligible values into separate constant MIR bodies.
+        PassPolicy::Required
     }
 }
 

--- a/compiler/rustc_mir_transform/src/ref_prop.rs
+++ b/compiler/rustc_mir_transform/src/ref_prop.rs
@@ -11,6 +11,7 @@ use rustc_mir_dataflow::Analysis;
 use rustc_mir_dataflow::impls::{MaybeStorageDead, always_storage_live_locals};
 use tracing::{debug, instrument};
 
+use crate::PassPolicy;
 use crate::ssa::{SsaLocals, StorageLiveLocals};
 
 /// Propagate references using SSA analysis.
@@ -72,8 +73,8 @@ use crate::ssa::{SsaLocals, StorageLiveLocals};
 pub(super) struct ReferencePropagation;
 
 impl<'tcx> crate::MirPass<'tcx> for ReferencePropagation {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() >= 2
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() >= 2)
     }
 
     #[instrument(level = "trace", skip(self, tcx, body))]
@@ -81,10 +82,6 @@ impl<'tcx> crate::MirPass<'tcx> for ReferencePropagation {
         debug!(def_id = ?body.source.def_id());
         move_to_copy_pointers(tcx, body);
         while propagate_ssa(tcx, body) {}
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
+++ b/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
@@ -3,6 +3,7 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::{self, Instance, TyCtxt};
 use tracing::{debug, instrument};
 
+use crate::PassPolicy;
 use crate::patch::MirPatch;
 
 /// A pass that removes noop landing pads and replaces jumps to them with
@@ -11,8 +12,8 @@ use crate::patch::MirPatch;
 pub(super) struct RemoveNoopLandingPads;
 
 impl<'tcx> crate::MirPass<'tcx> for RemoveNoopLandingPads {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.panic_strategy().unwinds()
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(sess.panic_strategy().unwinds())
     }
 
     #[instrument(level = "debug", skip(self, _tcx, body))]
@@ -65,10 +66,6 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveNoopLandingPads {
                 }
             });
         }
-    }
-
-    fn is_required(&self) -> bool {
-        true
     }
 }
 

--- a/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
+++ b/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
@@ -13,6 +13,8 @@ pub(super) struct RemoveNoopLandingPads;
 
 impl<'tcx> crate::MirPass<'tcx> for RemoveNoopLandingPads {
     fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        // FIXME: isn't this an optimization? Or is the LLVM code so terrible we want this even with
+        // "no" optimizations?
         PassPolicy::optional_non_optimization(sess.panic_strategy().unwinds())
     }
 

--- a/compiler/rustc_mir_transform/src/remove_place_mention.rs
+++ b/compiler/rustc_mir_transform/src/remove_place_mention.rs
@@ -4,11 +4,13 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 use tracing::trace;
 
+use crate::PassPolicy;
+
 pub(super) struct RemovePlaceMention;
 
 impl<'tcx> crate::MirPass<'tcx> for RemovePlaceMention {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        !sess.opts.unstable_opts.mir_preserve_ub
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(!sess.opts.unstable_opts.mir_preserve_ub)
     }
 
     fn run_pass(&self, _: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -19,9 +21,5 @@ impl<'tcx> crate::MirPass<'tcx> for RemovePlaceMention {
                 _ => true,
             })
         }
-    }
-
-    fn is_required(&self) -> bool {
-        true
     }
 }

--- a/compiler/rustc_mir_transform/src/remove_storage_markers.rs
+++ b/compiler/rustc_mir_transform/src/remove_storage_markers.rs
@@ -4,11 +4,15 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 use tracing::trace;
 
+use crate::PassPolicy;
+
 pub(super) struct RemoveStorageMarkers;
 
 impl<'tcx> crate::MirPass<'tcx> for RemoveStorageMarkers {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() > 0 && !sess.emit_lifetime_markers()
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(
+            sess.mir_opt_level() > 0 && !sess.emit_lifetime_markers(),
+        )
     }
 
     fn run_pass(&self, _tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -21,9 +25,5 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveStorageMarkers {
                 _ => true,
             })
         }
-    }
-
-    fn is_required(&self) -> bool {
-        true
     }
 }

--- a/compiler/rustc_mir_transform/src/remove_uninit_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_uninit_drops.rs
@@ -6,6 +6,8 @@ use rustc_mir_dataflow::impls::MaybeInitializedPlaces;
 use rustc_mir_dataflow::move_paths::{LookupResult, MoveData, MovePathIndex};
 use rustc_mir_dataflow::{Analysis, MaybeReachable, move_path_children_matching};
 
+use crate::PassPolicy;
+
 /// Removes `Drop` terminators whose target is known to be uninitialized at
 /// that point.
 ///
@@ -64,8 +66,8 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveUninitDrops {
         }
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }
 

--- a/compiler/rustc_mir_transform/src/remove_uninit_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_uninit_drops.rs
@@ -67,7 +67,8 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveUninitDrops {
     }
 
     fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
-        PassPolicy::optional_non_optimization(true)
+        // Const checking relies on uninitialized drops being removed before drop elaboration.
+        PassPolicy::Required
     }
 }
 

--- a/compiler/rustc_mir_transform/src/remove_unneeded_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_unneeded_drops.rs
@@ -10,6 +10,7 @@ use rustc_middle::ty::TyCtxt;
 use tracing::{debug, trace};
 
 use super::simplify::simplify_cfg;
+use crate::PassPolicy;
 
 pub(super) struct RemoveUnneededDrops;
 
@@ -39,7 +40,7 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveUnneededDrops {
         }
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }

--- a/compiler/rustc_mir_transform/src/remove_zsts.rs
+++ b/compiler/rustc_mir_transform/src/remove_zsts.rs
@@ -4,11 +4,13 @@ use rustc_middle::mir::visit::*;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 
+use crate::PassPolicy;
+
 pub(super) struct RemoveZsts;
 
 impl<'tcx> crate::MirPass<'tcx> for RemoveZsts {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() > 0
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(sess.mir_opt_level() > 0)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -26,10 +28,6 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveZsts {
         for (bb, data) in body.basic_blocks.as_mut_preserves_cfg().iter_enumerated_mut() {
             replacer.visit_basic_block_data(bb, data);
         }
-    }
-
-    fn is_required(&self) -> bool {
-        true
     }
 }
 

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -45,6 +45,8 @@ use rustc_span::DUMMY_SP;
 use smallvec::SmallVec;
 use tracing::{debug, trace};
 
+use crate::PassPolicy;
+
 pub(super) enum SimplifyCfg {
     Initial,
     PromoteConsts,
@@ -93,13 +95,13 @@ impl<'tcx> crate::MirPass<'tcx> for SimplifyCfg {
         self.name()
     }
 
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(true)
+    }
+
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         debug!("SimplifyCfg({:?}) - simplifying {:?}", self.name(), body.source);
         simplify_cfg(tcx, body);
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 
@@ -427,8 +429,8 @@ impl<'tcx> crate::MirPass<'tcx> for SimplifyLocals {
         }
     }
 
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() > 0
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() > 0)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -456,10 +458,6 @@ impl<'tcx> crate::MirPass<'tcx> for SimplifyLocals {
 
             body.local_decls.shrink_to_fit();
         }
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/simplify_branches.rs
+++ b/compiler/rustc_mir_transform/src/simplify_branches.rs
@@ -2,6 +2,7 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 use tracing::trace;
 
+use crate::PassPolicy;
 use crate::patch::MirPatch;
 
 pub(super) enum SimplifyConstCondition {
@@ -20,6 +21,10 @@ impl<'tcx> crate::MirPass<'tcx> for SimplifyConstCondition {
             SimplifyConstCondition::AfterConstProp => "SimplifyConstCondition-after-const-prop",
             SimplifyConstCondition::Final => "SimplifyConstCondition-final",
         }
+    }
+
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(true)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -90,9 +95,5 @@ impl<'tcx> crate::MirPass<'tcx> for SimplifyConstCondition {
             patch.patch_terminator(bb, terminator);
         }
         patch.apply(body);
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }

--- a/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
+++ b/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
@@ -8,6 +8,7 @@ use rustc_middle::mir::{
 use rustc_middle::ty::{Ty, TyCtxt};
 use tracing::trace;
 
+use crate::PassPolicy;
 use crate::ssa::SsaLocals;
 
 /// Pass to convert `if` conditions on integrals into switches on the integral.
@@ -26,8 +27,8 @@ use crate::ssa::SsaLocals;
 pub(super) struct SimplifyComparisonIntegral;
 
 impl<'tcx> crate::MirPass<'tcx> for SimplifyComparisonIntegral {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() > 1
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() > 1)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -103,10 +104,6 @@ impl<'tcx> crate::MirPass<'tcx> for SimplifyComparisonIntegral {
             terminator.kind =
                 TerminatorKind::SwitchInt { discr: Operand::Copy(opt.to_switch_on), targets };
         }
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/single_use_consts.rs
+++ b/compiler/rustc_mir_transform/src/single_use_consts.rs
@@ -5,6 +5,7 @@ use rustc_middle::mir::visit::{MutVisitor, PlaceContext, Visitor};
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 
+use crate::PassPolicy;
 use crate::strip_debuginfo::drop_invalid_debuginfos;
 
 /// Various parts of MIR building introduce temporaries that are commonly not needed.
@@ -24,8 +25,8 @@ use crate::strip_debuginfo::drop_invalid_debuginfos;
 pub(super) struct SingleUseConsts;
 
 impl<'tcx> crate::MirPass<'tcx> for SingleUseConsts {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() > 0
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() > 0)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -86,10 +87,6 @@ impl<'tcx> crate::MirPass<'tcx> for SingleUseConsts {
         }
 
         drop_invalid_debuginfos(body);
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -10,13 +10,14 @@ use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_mir_dataflow::value_analysis::{excluded_locals, iter_fields};
 use tracing::{debug, instrument};
 
+use crate::PassPolicy;
 use crate::patch::MirPatch;
 
 pub(super) struct ScalarReplacementOfAggregates;
 
 impl<'tcx> crate::MirPass<'tcx> for ScalarReplacementOfAggregates {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() >= 2
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() >= 2)
     }
 
     #[instrument(level = "debug", skip(self, tcx, body))]
@@ -48,10 +49,6 @@ impl<'tcx> crate::MirPass<'tcx> for ScalarReplacementOfAggregates {
                 break;
             }
         }
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/ssa_range_prop.rs
+++ b/compiler/rustc_mir_transform/src/ssa_range_prop.rs
@@ -19,13 +19,14 @@ use rustc_middle::mir::{BasicBlock, Body, Location, Operand, Place, TerminatorKi
 use rustc_middle::ty::{TyCtxt, TypingEnv};
 use rustc_span::DUMMY_SP;
 
+use crate::PassPolicy;
 use crate::ssa::SsaLocals;
 
 pub(super) struct SsaRangePropagation;
 
 impl<'tcx> crate::MirPass<'tcx> for SsaRangePropagation {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() > 1
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() > 1)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -41,10 +42,6 @@ impl<'tcx> crate::MirPass<'tcx> for SsaRangePropagation {
             let data = &mut body.basic_blocks.as_mut_preserves_cfg()[bb];
             range_set.visit_basic_block_data(bb, data);
         }
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/strip_debuginfo.rs
+++ b/compiler/rustc_mir_transform/src/strip_debuginfo.rs
@@ -3,6 +3,8 @@ use rustc_middle::ty::TyCtxt;
 use rustc_mir_dataflow::debuginfo::debuginfo_locals;
 use rustc_session::config::MirStripDebugInfo;
 
+use crate::PassPolicy;
+
 /// Conditionally remove some of the VarDebugInfo in MIR.
 ///
 /// In particular, stripping non-parameter debug info for tiny, primitive-like
@@ -10,8 +12,10 @@ use rustc_session::config::MirStripDebugInfo;
 pub(super) struct StripDebugInfo;
 
 impl<'tcx> crate::MirPass<'tcx> for StripDebugInfo {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.opts.unstable_opts.mir_strip_debuginfo != MirStripDebugInfo::None
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(
+            sess.opts.unstable_opts.mir_strip_debuginfo != MirStripDebugInfo::None,
+        )
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -33,10 +37,6 @@ impl<'tcx> crate::MirPass<'tcx> for StripDebugInfo {
         });
 
         drop_invalid_debuginfos(body);
-    }
-
-    fn is_required(&self) -> bool {
-        true
     }
 }
 

--- a/compiler/rustc_mir_transform/src/unreachable_enum_branching.rs
+++ b/compiler/rustc_mir_transform/src/unreachable_enum_branching.rs
@@ -10,6 +10,7 @@ use rustc_middle::ty::layout::TyAndLayout;
 use rustc_middle::ty::{Ty, TyCtxt};
 use tracing::trace;
 
+use crate::PassPolicy;
 use crate::patch::MirPatch;
 
 pub(super) struct UnreachableEnumBranching;
@@ -77,8 +78,8 @@ fn variant_discriminants<'tcx>(
 }
 
 impl<'tcx> crate::MirPass<'tcx> for UnreachableEnumBranching {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() > 0
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optimization(sess.mir_opt_level() > 0)
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -168,9 +169,5 @@ impl<'tcx> crate::MirPass<'tcx> for UnreachableEnumBranching {
         }
 
         patch.apply(body);
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }

--- a/compiler/rustc_mir_transform/src/unreachable_prop.rs
+++ b/compiler/rustc_mir_transform/src/unreachable_prop.rs
@@ -9,14 +9,15 @@ use rustc_middle::mir::interpret::Scalar;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, TyCtxt};
 
+use crate::PassPolicy;
 use crate::patch::MirPatch;
 
 pub(super) struct UnreachablePropagation;
 
 impl crate::MirPass<'_> for UnreachablePropagation {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
+    fn policy(&self, sess: &rustc_session::Session) -> PassPolicy {
         // Enable only under -Zmir-opt-level=2 as this can make programs less debuggable.
-        sess.mir_opt_level() >= 2
+        PassPolicy::optimization(sess.mir_opt_level() >= 2)
     }
 
     fn run_pass<'tcx>(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -54,10 +55,6 @@ impl crate::MirPass<'_> for UnreachablePropagation {
         for bb in unreachable_blocks {
             body.basic_blocks_mut()[bb].statements.clear();
         }
-    }
-
-    fn is_required(&self) -> bool {
-        false
     }
 }
 

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -20,6 +20,7 @@ use rustc_middle::{bug, span_bug};
 use rustc_mir_dataflow::debuginfo::debuginfo_locals;
 use rustc_trait_selection::traits::ObligationCtxt;
 
+use crate::PassPolicy;
 use crate::util::{self, most_packed_projection};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -97,8 +98,8 @@ impl<'tcx> crate::MirPass<'tcx> for Validator {
         }
     }
 
-    fn is_required(&self) -> bool {
-        true
+    fn policy(&self, _sess: &rustc_session::Session) -> PassPolicy {
+        PassPolicy::optional_non_optimization(true)
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160015)*
<!-- homu-ignore:end -->

https://github.com/rust-lang/rust/pull/128657 and https://github.com/rust-lang/rust/pull/134082 both merged at similar times, and added two similar flags to the `MirPass` trait
- `can_be_overridden`: Controls if `-Zmir-enable-passes` can enable/disable a pass; only set to `false` for `ForceInline`
- `is_required`: Controls if `#[optimize(none)]` should suppress a pass; set to explicitly `true`/`false` across all passes based on which appeared to be unconditionally enabled at the time

<del>
This adds some redundancy, so this PR merges both into `can_be_overridden`:
- removes cases of `is_required(&self) -> bool { true }`
- replaces `is_required(&self) -> bool { false }` with `can_be_overridden(&self) -> bool { true }`

Also, previously, `-Zmir-enable-passes` took precedence, but now `#[optimize(none)]` does, as the latter is more local.
</del>

This merges both functions as well as `is_enabled` into a single `PassPolicy` enum

r? @RalfJung 