### PR TITLE
compiletest: do not talk about JSON when the user never sees any

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -818,7 +818,7 @@ impl<'test> TestCx<'test> {
             if !unexpected.is_empty() {
                 writeln!(
                     self.stdout,
-                    "\n{prefix}: {n} diagnostics reported in JSON output but not expected in test file",
+                    "\n{prefix}: {n} diagnostics reported in rustc output but not expected in test file",
                     prefix = self.error_prefix(),
                     n = unexpected.len(),
                 );
@@ -853,7 +853,7 @@ impl<'test> TestCx<'test> {
             if !not_found.is_empty() {
                 writeln!(
                     self.stdout,
-                    "\n{prefix}: {n} diagnostics expected in test file but not reported in JSON output",
+                    "\n{prefix}: {n} diagnostics expected in test file but not reported in rustc output",
                     prefix = self.error_prefix(),
                     n = not_found.len(),
                 );


### PR DESCRIPTION
The user is not reading or writing any JSON here so it's quite confusing to talk about the "JSON output". JSON is just how rustc emits the errors so compiletest can parse them, but that's an implementation detail that we should not leak.

r? @petrochenkov 