### PR TITLE
Make BorrowSet methods public again

### DIFF
--- a/compiler/rustc_borrowck/src/borrow_set.rs
+++ b/compiler/rustc_borrowck/src/borrow_set.rs
@@ -80,34 +80,38 @@ impl<'tcx> BorrowSet<'tcx> {
         }
     }
 
-    // Public method to support Aquascope.
+    // Public method to support Aquascope and Creusot.
     /// Iterate through all BorrowData in the BorrowSet.
     pub fn iter(&self) -> impl Iterator<Item = &BorrowData<'tcx>> {
         self.borrows.iter()
     }
 
-    // The following functions are not depended upon by outside consumers.
-    pub(crate) fn locals_state_at_exit(&self) -> &LocalsStateAtExit {
+    // Public method to support Creusot.
+    pub fn locals_state_at_exit(&self) -> &LocalsStateAtExit {
         &self.locals_state_at_exit
     }
 
-    pub(crate) fn len(&self) -> usize {
+    // Public method to support Creusot.
+    pub fn len(&self) -> usize {
         self.borrows.len()
     }
 
-    pub(crate) fn iter_enumerated(&self) -> impl Iterator<Item = (BorrowIndex, &BorrowData<'tcx>)> {
+    pub fn iter_enumerated(&self) -> impl Iterator<Item = (BorrowIndex, &BorrowData<'tcx>)> {
         self.borrows.iter_enumerated()
     }
 
-    pub(crate) fn activations_at_location(&self, location: &Location) -> &[BorrowIndex] {
+    // Public method to support Creusot.
+    pub fn activations_at_location(&self, location: &Location) -> &[BorrowIndex] {
         self.activation_map.get(&location).map_or(&[], |activations| &activations[..])
     }
 
-    pub(crate) fn borrows_at_location(&self, location: &Location) -> Option<&[BorrowIndex]> {
+    // Public method to support Creusot.
+    pub fn borrows_at_location(&self, location: &Location) -> Option<&[BorrowIndex]> {
         self.location_map.get(location).map(|v| v.as_slice())
     }
 
-    pub(crate) fn borrows_on_local(&self, local: Local) -> Option<&IndexSet<BorrowIndex>> {
+    // Public method to support Creusot.
+    pub fn borrows_on_local(&self, local: Local) -> Option<&IndexSet<BorrowIndex>> {
         self.local_map.get(&local)
     }
 }


### PR DESCRIPTION
BorrowSet's methods were made private in rust-lang/rust#159449 except for a couple used by Aquascope. I'd like to make these methods public again for Creusot, which indeed makes more extensive use of BorrowSet. Technically only `locals_state_at_exit` exposes information that is not already available in the current API (and Creusot does make use of it to call `Place::ignore_borrow`). The other fields can be reconstructed via `iter`, but it seems unnecessary to restrict the efficient access provided by the other methods to rustc's own analyses as opposed to third-party consumers.
