### PR TITLE
Fix mono reachability with no-op landing pads

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -301,6 +301,8 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             }
 
             let block = &mir.basic_blocks[next];
+            let successors = block.mono_successors(tcx, instance);
+
             if let Some(mir::UnwindAction::Cleanup(target)) = block.terminator().unwind()
                 && fx.nop_landing_pads.contains(*target)
             {
@@ -309,9 +311,9 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
                 // It's guaranteed that the cleanup block (`target`) occurs only in
                 // UnwindAction::Cleanup(...) -- i.e., we can't incorrectly filter too much here --
                 // because cleanup transitions must happen via UnwindAction::Cleanup.
-                to_visit.extend(block.terminator().successors().filter(|s| s != target));
+                to_visit.extend(successors.filter(|s| s != target));
             } else {
-                to_visit.extend(block.terminator().successors());
+                to_visit.extend(successors);
             }
         }
 

--- a/tests/ui/impl-trait/method/resume-without-personality-issue-159980.rs
+++ b/tests/ui/impl-trait/method/resume-without-personality-issue-159980.rs
@@ -1,0 +1,23 @@
+//@ needs-unwind
+//@ compile-flags: -Zmir-opt-level=0 -Zverify-llvm-ir=yes
+//@ check-pass
+
+use std::ops::Deref;
+
+trait Foo {
+    fn method(&self) {}
+}
+
+impl Foo for u32 {}
+
+fn via_deref_nested() -> Box<impl Deref<Target = impl Foo>> {
+    if false {
+        via_deref_nested().method();
+    }
+
+    Box::new(Box::new(1u32))
+}
+
+fn main() {
+    via_deref_nested();
+}


### PR DESCRIPTION
the landing pad filtering used regular MIR successors when the initial traversal used monomorphized one
fixes rust-lang/rust#159980