### PR TITLE
Fix an edge case with `StepBy::nth` on non-fused iterators

### DIFF
--- a/library/core/src/iter/adapters/step_by.rs
+++ b/library/core/src/iter/adapters/step_by.rs
@@ -254,9 +254,9 @@ unsafe impl<I: Iterator> StepByImpl<I> for StepBy<I> {
     default fn spec_nth(&mut self, mut n: usize) -> Option<I::Item> {
         if self.first_take {
             self.first_take = false;
-            let first = self.iter.next();
+            let first = self.iter.next()?;
             if n == 0 {
-                return first;
+                return Some(first);
             }
             n -= 1;
         }
@@ -266,7 +266,7 @@ unsafe impl<I: Iterator> StepByImpl<I> for StepBy<I> {
         // n + 1 could overflow
         // thus, if n is usize::MAX, instead of adding one, we call .nth(step)
         if n == usize::MAX {
-            self.iter.nth(step - 1);
+            self.iter.nth(step - 1)?;
         } else {
             n += 1;
         }
@@ -290,7 +290,8 @@ unsafe impl<I: Iterator> StepByImpl<I> for StepBy<I> {
                 n -= div_step;
                 nth_step
             };
-            self.iter.nth(nth - 1);
+
+            self.iter.nth(nth - 1)?;
         }
     }
 

--- a/library/coretests/tests/iter/adapters/step_by.rs
+++ b/library/coretests/tests/iter/adapters/step_by.rs
@@ -94,6 +94,46 @@ fn test_iterator_step_by_nth_overflow() {
 }
 
 #[test]
+#[allow(non_local_definitions)]
+fn test_iterator_step_by_nth_overflow_on_none() {
+    #[cfg(target_pointer_width = "16")]
+    type Bigger = u32;
+    #[cfg(target_pointer_width = "32")]
+    type Bigger = u64;
+    #[cfg(target_pointer_width = "64")]
+    type Bigger = u128;
+
+    #[derive(Clone)]
+    struct Test(Bigger);
+    impl Iterator for &mut Test {
+        type Item = i32;
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+        fn nth(&mut self, n: usize) -> Option<Self::Item> {
+            self.0 += n as Bigger + 1;
+            None
+        }
+    }
+
+    // usize::MAX * usize::MAX overflow
+    let mut it = Test(0);
+    let mut step_by = (&mut it).step_by(usize::MAX);
+    // first next() call sets StepBy's first_take to false
+    assert_eq!(step_by.next(), None);
+    assert_eq!(step_by.nth(usize::MAX), None);
+    assert_eq!(it.0, usize::MAX as Bigger + 1);
+
+    // usize::MAX * (usize::MAX - 1) overflow
+    let mut it = Test(0);
+    let mut step_by = (&mut it).step_by(usize::MAX);
+    // first next() call sets StepBy's first_take to false
+    assert_eq!(step_by.next(), None);
+    assert_eq!(step_by.nth(usize::MAX - 1), None);
+    assert_eq!(it.0, usize::MAX as Bigger + 1);
+}
+
+#[test]
 fn test_iterator_step_by_nth_try_fold() {
     let mut it = (0..).step_by(10);
     assert_eq!(it.try_fold(0, i8::checked_add), None);
@@ -336,4 +376,45 @@ fn test_step_by_new_range_iter() {
     assert_eq!(it.next(), Some(5));
     assert_eq!(it.next_back(), Some(10));
     assert_eq!(it.next(), None);
+}
+
+#[test]
+fn test_step_by_nth_non_fused() {
+    struct StepByNthOne {
+        exhausted: bool,
+    }
+    impl Iterator for StepByNthOne {
+        type Item = i32;
+        fn next(&mut self) -> Option<i32> {
+            if self.exhausted {
+                Some(0)
+            } else {
+                self.exhausted = true;
+                None
+            }
+        }
+    }
+
+    let mut iter = StepByNthOne { exhausted: false }.step_by(1);
+    assert_eq!(iter.nth(1), None)
+}
+
+#[test]
+fn test_step_by_nth_non_fused_on_non_first_take() {
+    struct StepByOneNthMax(i32);
+    impl Iterator for StepByOneNthMax {
+        type Item = i32;
+        fn next(&mut self) -> Option<i32> {
+            let prev = self.0;
+            self.0 += 1;
+            if prev == 1 { None } else { Some(prev) }
+        }
+    }
+
+    let mut iter = StepByOneNthMax(0).step_by(1);
+    // sets StepBy iterator first_take field to false
+    assert_eq!(iter.next(), Some(0));
+    // Our underlying iterator should be pointing at a `None` item
+    // so we should expect `StepBy::nth` to return `None`
+    assert_eq!(iter.nth(usize::MAX), None)
 }


### PR DESCRIPTION
Fixes rust-lang/rust#159965.

From the `nth` documentation as pointed out by theemathas:

> `nth()` will return `None` if `n` is greater than or equal to the length of the iterator.

Currently, there is an edge case for non-fused iterator where it's able to return `Some` through `StepBy::nth` iterator even though the first item from the non-fused iterator returns `None` (it is logically an empty iterator). 

The issue came from how in the first take block it advances the underlying iterator forward using `.next()` and does not check if what it returns is a `None` value or not. This wouldn't be a problem for fused iterators because all the values that it would return after reaching the `None` point will also be `None`. However since non-fused iterators do not have to abide by continuously yielding `None` after reaching a `None`, it allows for a case, where after falling down from `first_take` block it can return `Some(_)` from a `self.iter.nth()` call in there.

In the `first_take` block we should definitely check if the first item we got from `self.iter.next()` is `None` item, and return `None` if it is so.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
