### PR TITLE
Add regression test for #132767

### DIFF
--- a/tests/ui/associated-types/fn-ptr-coercion-normalize-ice-132767.rs
+++ b/tests/ui/associated-types/fn-ptr-coercion-normalize-ice-132767.rs
@@ -1,0 +1,45 @@
+// Regression test for #132767. Coercing the fn item `bar` to a fn pointer while
+// `Foo::value` holds the associated-type projection `<<T as Func>::Ret as Id>::Assoc`
+// used to ICE during normalization ("maybe try to call `try_normalize_erasing_regions`
+// instead"). It should now report the ordinary `u32: Id` trait error instead of crashing.
+
+use std::hint::black_box;
+
+trait Func {
+    type Ret: Id;
+}
+
+trait Id {
+    type Assoc;
+}
+
+impl Id for i32 {
+    type Assoc = i32;
+}
+
+impl<F: FnOnce() -> R, R: Id> Func for F {
+    type Ret = R;
+}
+
+fn bar() -> impl Copy + Id {
+    //~^ ERROR the trait bound `u32: Id` is not satisfied
+    0u32
+}
+
+struct Foo<T: Func> {
+    _func: T,
+    value: Option<<<T as Func>::Ret as Id>::Assoc>,
+}
+
+fn main() {
+    let mut fn_def = black_box(Foo {
+        _func: bar,
+        value: None,
+    });
+    let fn_ptr = black_box(Foo {
+        _func: bar as fn() -> _,
+        value: None,
+    });
+    fn_def.value = fn_ptr.value;
+    black_box(fn_def);
+}

--- a/tests/ui/associated-types/fn-ptr-coercion-normalize-ice-132767.stderr
+++ b/tests/ui/associated-types/fn-ptr-coercion-normalize-ice-132767.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `u32: Id` is not satisfied
+  --> $DIR/fn-ptr-coercion-normalize-ice-132767.rs:24:13
+   |
+LL | fn bar() -> impl Copy + Id {
+   |             ^^^^^^^^^^^^^^ the trait `Id` is not implemented for `u32`
+LL |
+LL |     0u32
+   |     ---- return type was inferred to be `u32` here
+   |
+help: the trait `Id` is implemented for `i32`
+  --> $DIR/fn-ptr-coercion-normalize-ice-132767.rs:16:1
+   |
+LL | impl Id for i32 {
+   | ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Closes rust-lang/rust#132767. Coercing a fn item to a fn pointer with an associated type projection used to ICE during normalization. now errors with E0277.