### PR TITLE
Better account for `Self` that might be a typo of `self`

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -609,6 +609,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     call_expr_and_args.map_or(expr.span, |(e, _)| e.span),
                     expr.span,
                     expr.hir_id,
+                    call_expr_and_args.is_some(),
                 )
                 .0
             }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1004,6 +1004,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         span: Span,
         path_span: Span,
         hir_id: HirId,
+        has_args: bool,
     ) -> (Ty<'tcx>, Res) {
         let tcx = self.tcx;
 
@@ -1251,17 +1252,50 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         "the `Self` constructor can only be used with tuple or unit structs",
                     );
                     if let Some(adt_def) = ty.normalized.ty_adt_def() {
-                        match adt_def.adt_kind() {
-                            AdtKind::Enum => {
-                                err.help("did you mean to use one of the enum's variants?");
-                            }
-                            AdtKind::Struct | AdtKind::Union => {
-                                err.span_suggestion(
-                                    span,
-                                    "use curly brackets",
-                                    "Self { /* fields */ }",
-                                    Applicability::HasPlaceholders,
-                                );
+                        let def_id = self.body_def_id.to_def_id();
+                        if let Some(assoc) = tcx.opt_associated_item(def_id)
+                            && assoc.is_method()
+                            && !has_args
+                        {
+                            let self_ty =
+                                tcx.fn_sig(def_id).instantiate_identity().skip_binder().inputs()[0];
+                            let applicability = if let ty::Adt(..) = self_ty.kind() {
+                                // We're within a method that takes ownership of `Self`, likely a
+                                // builder, so this is most likely a typo.
+                                Applicability::MachineApplicable
+                            } else {
+                                // We still might have meant `self` instead of `Self`.
+                                Applicability::MaybeIncorrect
+                            };
+                            err.span_suggestion_verbose(
+                                span,
+                                format!(
+                                    "you might have meant to refer to the `self` binding of type \
+                                     `{self_ty}`",
+                                ),
+                                "self".to_string(),
+                                applicability,
+                            );
+                        } else {
+                            match adt_def.adt_kind() {
+                                AdtKind::Enum => {
+                                    err.span_help(
+                                        tcx.def_span(adt_def.did()),
+                                        if adt_def.variants().is_empty() {
+                                            "the enum is unconstructable because it has no variants"
+                                        } else {
+                                            "you might have meant to use one of the enum's variants"
+                                        },
+                                    );
+                                }
+                                AdtKind::Struct | AdtKind::Union => {
+                                    err.span_suggestion_verbose(
+                                        span,
+                                        "use curly brackets",
+                                        "Self { /* fields */ }",
+                                        Applicability::HasPlaceholders,
+                                    );
+                                }
                             }
                         }
                     }

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -915,7 +915,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             rustc_hir::PatExprKind::Path(qpath) => {
                 let (res, opt_ty, segments) =
                     self.resolve_ty_and_res_fully_qualified_call(qpath, lt.hir_id, lt.span);
-                self.instantiate_value_path(segments, opt_ty, res, lt.span, lt.span, lt.hir_id).0
+                self.instantiate_value_path(
+                    segments, opt_ty, res, lt.span, lt.span, lt.hir_id, false,
+                )
+                .0
             }
         };
         self.write_ty(lt.hir_id, ty);
@@ -1629,7 +1632,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Find the type of the path pattern, for later checking.
         let (pat_ty, pat_res) =
-            self.instantiate_value_path(segments, opt_ty, res, span, span, path_id);
+            self.instantiate_value_path(segments, opt_ty, res, span, span, path_id, false);
         Ok(ResolvedPat { ty: pat_ty, kind: ResolvedPatKind::Path { res, pat_res, segments } })
     }
 
@@ -1791,8 +1794,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         // Type-check the path.
-        let (pat_ty, res) =
-            self.instantiate_value_path(segments, opt_ty, res, pat.span, pat.span, pat.hir_id);
+        let (pat_ty, res) = self
+            .instantiate_value_path(segments, opt_ty, res, pat.span, pat.span, pat.hir_id, false);
         if !pat_ty.is_fn() {
             return report_unexpected_res(res);
         }

--- a/tests/ui/structs/invalid-self-constructor-56835.stderr
+++ b/tests/ui/structs/invalid-self-constructor-56835.stderr
@@ -2,7 +2,13 @@ error: the `Self` constructor can only be used with tuple or unit structs
   --> $DIR/invalid-self-constructor-56835.rs:5:12
    |
 LL |     fn bar(Self(foo): Self) {}
-   |            ^^^^^^^^^ help: use curly brackets: `Self { /* fields */ }`
+   |            ^^^^^^^^^
+   |
+help: use curly brackets
+   |
+LL -     fn bar(Self(foo): Self) {}
+LL +     fn bar(Self { /* fields */ }: Self) {}
+   |
 
 error[E0164]: expected tuple struct or tuple variant, found self constructor `Self`
   --> $DIR/invalid-self-constructor-56835.rs:5:12

--- a/tests/ui/typeck/self-constructor-type-error-56199.rs
+++ b/tests/ui/typeck/self-constructor-type-error-56199.rs
@@ -1,9 +1,18 @@
 // https://github.com/rust-lang/rust/issues/56199
 enum Foo {}
+enum Lab {
+    Qux,
+}
 struct Bar {}
 
 impl Foo {
     fn foo() {
+        let _ = Self;
+        //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
+        let _ = Self();
+        //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
+    }
+    fn foo_method(self) {
         let _ = Self;
         //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
         let _ = Self();
@@ -18,6 +27,28 @@ impl Bar {
         let _ = Self();
         //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
     }
+    fn bar_method(self) {
+        let _ = Self;
+        //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
+        let _ = Self();
+        //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
+    }
 }
+
+impl Lab {
+    fn lab() {
+        let _ = Self;
+        //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
+        let _ = Self();
+        //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
+    }
+    fn lab_method(self) {
+        let _ = Self;
+        //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
+        let _ = Self();
+        //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
+    }
+}
+
 
 fn main() {}

--- a/tests/ui/typeck/self-constructor-type-error-56199.stderr
+++ b/tests/ui/typeck/self-constructor-type-error-56199.stderr
@@ -1,30 +1,145 @@
 error: the `Self` constructor can only be used with tuple or unit structs
-  --> $DIR/self-constructor-type-error-56199.rs:7:17
+  --> $DIR/self-constructor-type-error-56199.rs:10:17
    |
 LL |         let _ = Self;
    |                 ^^^^
    |
-   = help: did you mean to use one of the enum's variants?
+help: the enum is unconstructable because it has no variants
+  --> $DIR/self-constructor-type-error-56199.rs:2:1
+   |
+LL | enum Foo {}
+   | ^^^^^^^^
 
 error: the `Self` constructor can only be used with tuple or unit structs
-  --> $DIR/self-constructor-type-error-56199.rs:9:17
+  --> $DIR/self-constructor-type-error-56199.rs:12:17
    |
 LL |         let _ = Self();
    |                 ^^^^^^
    |
-   = help: did you mean to use one of the enum's variants?
+help: the enum is unconstructable because it has no variants
+  --> $DIR/self-constructor-type-error-56199.rs:2:1
+   |
+LL | enum Foo {}
+   | ^^^^^^^^
 
 error: the `Self` constructor can only be used with tuple or unit structs
   --> $DIR/self-constructor-type-error-56199.rs:16:17
    |
 LL |         let _ = Self;
-   |                 ^^^^ help: use curly brackets: `Self { /* fields */ }`
+   |                 ^^^^
+   |
+help: you might have meant to refer to the `self` binding of type `Foo` (notice the capitalization)
+   |
+LL -         let _ = Self;
+LL +         let _ = self;
+   |
 
 error: the `Self` constructor can only be used with tuple or unit structs
   --> $DIR/self-constructor-type-error-56199.rs:18:17
    |
 LL |         let _ = Self();
-   |                 ^^^^^^ help: use curly brackets: `Self { /* fields */ }`
+   |                 ^^^^^^
+   |
+help: the enum is unconstructable because it has no variants
+  --> $DIR/self-constructor-type-error-56199.rs:2:1
+   |
+LL | enum Foo {}
+   | ^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: the `Self` constructor can only be used with tuple or unit structs
+  --> $DIR/self-constructor-type-error-56199.rs:25:17
+   |
+LL |         let _ = Self;
+   |                 ^^^^
+   |
+help: use curly brackets
+   |
+LL |         let _ = Self { /* fields */ };
+   |                      ++++++++++++++++
+
+error: the `Self` constructor can only be used with tuple or unit structs
+  --> $DIR/self-constructor-type-error-56199.rs:27:17
+   |
+LL |         let _ = Self();
+   |                 ^^^^^^
+   |
+help: use curly brackets
+   |
+LL -         let _ = Self();
+LL +         let _ = Self { /* fields */ };
+   |
+
+error: the `Self` constructor can only be used with tuple or unit structs
+  --> $DIR/self-constructor-type-error-56199.rs:31:17
+   |
+LL |         let _ = Self;
+   |                 ^^^^
+   |
+help: you might have meant to refer to the `self` binding of type `Bar` (notice the capitalization)
+   |
+LL -         let _ = Self;
+LL +         let _ = self;
+   |
+
+error: the `Self` constructor can only be used with tuple or unit structs
+  --> $DIR/self-constructor-type-error-56199.rs:33:17
+   |
+LL |         let _ = Self();
+   |                 ^^^^^^
+   |
+help: use curly brackets
+   |
+LL -         let _ = Self();
+LL +         let _ = Self { /* fields */ };
+   |
+
+error: the `Self` constructor can only be used with tuple or unit structs
+  --> $DIR/self-constructor-type-error-56199.rs:40:17
+   |
+LL |         let _ = Self;
+   |                 ^^^^
+   |
+help: you might have meant to use one of the enum's variants
+  --> $DIR/self-constructor-type-error-56199.rs:3:1
+   |
+LL | enum Lab {
+   | ^^^^^^^^
+
+error: the `Self` constructor can only be used with tuple or unit structs
+  --> $DIR/self-constructor-type-error-56199.rs:42:17
+   |
+LL |         let _ = Self();
+   |                 ^^^^^^
+   |
+help: you might have meant to use one of the enum's variants
+  --> $DIR/self-constructor-type-error-56199.rs:3:1
+   |
+LL | enum Lab {
+   | ^^^^^^^^
+
+error: the `Self` constructor can only be used with tuple or unit structs
+  --> $DIR/self-constructor-type-error-56199.rs:46:17
+   |
+LL |         let _ = Self;
+   |                 ^^^^
+   |
+help: you might have meant to refer to the `self` binding of type `Lab` (notice the capitalization)
+   |
+LL -         let _ = Self;
+LL +         let _ = self;
+   |
+
+error: the `Self` constructor can only be used with tuple or unit structs
+  --> $DIR/self-constructor-type-error-56199.rs:48:17
+   |
+LL |         let _ = Self();
+   |                 ^^^^^^
+   |
+help: you might have meant to use one of the enum's variants
+  --> $DIR/self-constructor-type-error-56199.rs:3:1
+   |
+LL | enum Lab {
+   | ^^^^^^^^
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
When in a method trying to access `Self` on its own, suggest `self`. When in any assoc fn trying to access `Self()`, suggest `Self { fields }` or using an enum variant. When enum has no variants, mention it.

Fix rust-lang/rust#91525.
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
