### PR TITLE
rustdoc-json: Make `Stability` compatible with non-self-describing serde formats

### DIFF
--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -114,8 +114,8 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 // will instead cause conflicts. See #94591 for more. (This paragraph and the "Latest feature" line
 // are deliberately not in a doc comment, because they need not be in public docs.)
 //
-// Latest feature: Add default-body stability metadata.
-pub const FORMAT_VERSION: u32 = 60;
+// Latest feature: Make `Stability` work with non-self-describing formats
+pub const FORMAT_VERSION: u32 = 61;
 
 /// The root of the emitted JSON blob.
 ///
@@ -354,14 +354,13 @@ pub struct Stability {
     /// For stable items, this is the historical label recorded when the item was stabilized.
     pub feature: String,
 
-    #[serde(flatten)]
     pub level: StabilityLevel,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "rkyv_0_8", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
 #[cfg_attr(feature = "rkyv_0_8", rkyv(derive(Debug)))]
-#[serde(tag = "level", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum StabilityLevel {
     Stable {
         /// The Rust version in which this item became stable, if available.

--- a/src/rustdoc-json-types/tests.rs
+++ b/src/rustdoc-json-types/tests.rs
@@ -1,4 +1,22 @@
+use std::fmt::Debug;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
 use super::*;
+
+fn check_roundtrips<T: Serialize + DeserializeOwned + PartialEq + Debug>(t: T) {
+    let ser_json = serde_json::to_string(&t).expect("should be able to serialize to json");
+    let de_json: T =
+        serde_json::from_str(&ser_json).expect("should be able to deserialize from json");
+    assert_eq!(t, de_json, "value should be the same after json roundtrip");
+
+    let ser_postcard =
+        ::postcard::to_allocvec(&t).expect("should be able to serialize to postcard");
+    let de_postcard: T =
+        ::postcard::from_bytes(&ser_postcard).expect("should be able to deserialze from postcard");
+    assert_eq!(t, de_postcard, "value should be the same after postcard rountrip");
+}
 
 #[test]
 fn test_struct_info_roundtrip() {
@@ -8,15 +26,7 @@ fn test_struct_info_roundtrip() {
         impls: vec![],
     });
 
-    // JSON
-    let struct_json = serde_json::to_string(&s).unwrap();
-    let de_s = serde_json::from_str(&struct_json).unwrap();
-    assert_eq!(s, de_s);
-
-    // Postcard
-    let encoded: Vec<u8> = postcard::to_allocvec(&s).unwrap();
-    let decoded: ItemEnum = postcard::from_bytes(&encoded).unwrap();
-    assert_eq!(s, decoded);
+    check_roundtrips(s);
 }
 
 #[test]
@@ -28,15 +38,19 @@ fn test_union_info_roundtrip() {
         impls: vec![],
     });
 
-    // JSON
-    let union_json = serde_json::to_string(&u).unwrap();
-    let de_u = serde_json::from_str(&union_json).unwrap();
-    assert_eq!(u, de_u);
+    check_roundtrips(u);
+}
 
-    // Postcard
-    let encoded: Vec<u8> = postcard::to_allocvec(&u).unwrap();
-    let decoded: ItemEnum = postcard::from_bytes(&encoded).unwrap();
-    assert_eq!(u, decoded);
+#[test]
+fn test_stability() {
+    check_roundtrips(Stability {
+        feature: "guam_dotcom".to_owned(),
+        level: StabilityLevel::Stable { since: None },
+    });
+    check_roundtrips(Stability {
+        feature: "bing_mexico".to_owned(),
+        level: StabilityLevel::Unstable,
+    });
 }
 
 #[cfg(feature = "rkyv_0_8")]

--- a/tests/rustdoc-json/attrs/stability/associated_items.rs
+++ b/tests/rustdoc-json/attrs/stability/associated_items.rs
@@ -3,64 +3,54 @@
 // Trait-associated item declarations only. Items defined inside impl blocks are tested in
 // `impls.rs` because they have different parent-item behavior.
 
-//@ is "$.index[?(@.name=='StableTraitWithAssociatedItems')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='StableTraitWithAssociatedItems')].stability.feature" '"stable_trait_with_associated_items"'
-//@ is "$.index[?(@.name=='StableTraitWithAssociatedItems')].stability.since" '"1.0.0"'
+//@ is "$.index[?(@.name=='StableTraitWithAssociatedItems')].stability.level.stable.since" '"1.0.0"'
 #[stable(feature = "stable_trait_with_associated_items", since = "1.0.0")]
 pub trait StableTraitWithAssociatedItems {
     // Stable trait-associated items need their own stability attributes in staged API crates.
-    //@ is "$.index[?(@.name=='StableAssocType')].stability.level" '"stable"'
     //@ is "$.index[?(@.name=='StableAssocType')].stability.feature" '"stable_assoc_type_feature"'
-    //@ is "$.index[?(@.name=='StableAssocType')].stability.since" '"1.1.0"'
+    //@ is "$.index[?(@.name=='StableAssocType')].stability.level.stable.since" '"1.1.0"'
     //@ is "$.index[?(@.name=='StableAssocType')].attrs" []
     #[stable(feature = "stable_assoc_type_feature", since = "1.1.0")]
     type StableAssocType;
 
     //@ is "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_STABLE_TRAIT')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_STABLE_TRAIT')].stability.feature" '"unstable_assoc_const_in_stable_trait"'
-    //@ !has "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_STABLE_TRAIT')].stability.since"
     #[unstable(feature = "unstable_assoc_const_in_stable_trait", issue = "none")]
     const UNSTABLE_ASSOC_CONST_IN_STABLE_TRAIT: usize = 0;
 
     //@ is "$.index[?(@.name=='unstable_provided_method')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='unstable_provided_method')].stability.feature" '"unstable_provided_method_feature"'
-    //@ !has "$.index[?(@.name=='unstable_provided_method')].stability.since"
     #[unstable(feature = "unstable_provided_method_feature", issue = "none")]
     fn unstable_provided_method(&self) {}
 }
 
 //@ is "$.index[?(@.name=='UnstableTraitWithUnannotatedAssociatedItems')].stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='UnstableTraitWithUnannotatedAssociatedItems')].stability.feature" '"unstable_trait_with_unannotated_associated_items"'
-//@ !has "$.index[?(@.name=='UnstableTraitWithUnannotatedAssociatedItems')].stability.since"
 #[unstable(feature = "unstable_trait_with_unannotated_associated_items", issue = "none")]
 pub trait UnstableTraitWithUnannotatedAssociatedItems {
     // Unannotated associated items in unstable traits inherit the trait's unstable stability.
     //@ is "$.index[?(@.name=='UnannotatedAssocTypeInUnstableTrait')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='UnannotatedAssocTypeInUnstableTrait')].stability.feature" '"unstable_trait_with_unannotated_associated_items"'
-    //@ !has "$.index[?(@.name=='UnannotatedAssocTypeInUnstableTrait')].stability.since"
     type UnannotatedAssocTypeInUnstableTrait;
 
     //@ is "$.index[?(@.name=='UNANNOTATED_ASSOC_CONST_IN_UNSTABLE_TRAIT')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='UNANNOTATED_ASSOC_CONST_IN_UNSTABLE_TRAIT')].stability.feature" '"unstable_trait_with_unannotated_associated_items"'
-    //@ !has "$.index[?(@.name=='UNANNOTATED_ASSOC_CONST_IN_UNSTABLE_TRAIT')].stability.since"
     const UNANNOTATED_ASSOC_CONST_IN_UNSTABLE_TRAIT: usize;
 
     //@ is "$.index[?(@.name=='unannotated_required_method_in_unstable_trait')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='unannotated_required_method_in_unstable_trait')].stability.feature" '"unstable_trait_with_unannotated_associated_items"'
-    //@ !has "$.index[?(@.name=='unannotated_required_method_in_unstable_trait')].stability.since"
     fn unannotated_required_method_in_unstable_trait(&self);
 }
 
 //@ is "$.index[?(@.name=='UnstableTraitWithExplicitAssociatedItem')].stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='UnstableTraitWithExplicitAssociatedItem')].stability.feature" '"unstable_trait_with_explicit_associated_item"'
-//@ !has "$.index[?(@.name=='UnstableTraitWithExplicitAssociatedItem')].stability.since"
 #[unstable(feature = "unstable_trait_with_explicit_associated_item", issue = "none")]
 pub trait UnstableTraitWithExplicitAssociatedItem {
     // It's possble to override the parent's instability with another `#[unstable]` attribute,
     // for example to specify a different feature gate for that item.
     //@ is "$.index[?(@.name=='UnstableAssocTypeInUnstableTrait')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='UnstableAssocTypeInUnstableTrait')].stability.feature" '"unstable_assoc_type_in_unstable_trait"'
-    //@ !has "$.index[?(@.name=='UnstableAssocTypeInUnstableTrait')].stability.since"
     #[unstable(feature = "unstable_assoc_type_in_unstable_trait", issue = "none")]
     type UnstableAssocTypeInUnstableTrait;
 }

--- a/tests/rustdoc-json/attrs/stability/const.rs
+++ b/tests/rustdoc-json/attrs/stability/const.rs
@@ -5,23 +5,19 @@
 pub fn non_const_function() {}
 
 //@ set stable_const_fn = "$.index[?(@.name=='stable_const_fn')].id"
-//@ is "$.index[?(@.name=='stable_const_fn')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='stable_const_fn')].stability.feature" '"stable_const_fn_feature"'
-//@ is "$.index[?(@.name=='stable_const_fn')].stability.since" '"1.0.0"'
-//@ is "$.index[?(@.name=='stable_const_fn')].const_stability.level" '"stable"'
+//@ is "$.index[?(@.name=='stable_const_fn')].stability.level.stable.since" '"1.0.0"'
 //@ is "$.index[?(@.name=='stable_const_fn')].const_stability.feature" '"stable_const_fn_const_feature"'
-//@ is "$.index[?(@.name=='stable_const_fn')].const_stability.since" '"1.1.0"'
+//@ is "$.index[?(@.name=='stable_const_fn')].const_stability.level.stable.since" '"1.1.0"'
 //@ is "$.index[?(@.name=='stable_const_fn')].attrs" []
 #[stable(feature = "stable_const_fn_feature", since = "1.0.0")]
 #[rustc_const_stable(feature = "stable_const_fn_const_feature", since = "1.1.0")]
 pub const fn stable_const_fn() {}
 
-//@ is "$.index[?(@.name=='const_unstable_fn')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='const_unstable_fn')].stability.feature" '"const_unstable_fn_feature"'
-//@ is "$.index[?(@.name=='const_unstable_fn')].stability.since" '"2.0.0"'
+//@ is "$.index[?(@.name=='const_unstable_fn')].stability.level.stable.since" '"2.0.0"'
 //@ is "$.index[?(@.name=='const_unstable_fn')].const_stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='const_unstable_fn')].const_stability.feature" '"const_unstable_fn_const_feature"'
-//@ !has "$.index[?(@.name=='const_unstable_fn')].const_stability.since"
 //@ is "$.index[?(@.name=='const_unstable_fn')].attrs" []
 #[stable(feature = "const_unstable_fn_feature", since = "2.0.0")]
 #[rustc_const_unstable(feature = "const_unstable_fn_const_feature", issue = "none")]
@@ -35,7 +31,6 @@ pub const fn const_unstable_fn() {}
 //@ !has "$.index[?(@.name=='unstable_fn_with_explicit_const_gate')].stability.since"
 //@ is "$.index[?(@.name=='unstable_fn_with_explicit_const_gate')].const_stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='unstable_fn_with_explicit_const_gate')].const_stability.feature" '"explicit_const_gate_on_unstable_fn"'
-//@ !has "$.index[?(@.name=='unstable_fn_with_explicit_const_gate')].const_stability.since"
 //@ is "$.index[?(@.name=='unstable_fn_with_explicit_const_gate')].attrs" []
 #[unstable(feature = "unstable_fn_with_explicit_const_gate_feature", issue = "none")]
 #[rustc_const_unstable(feature = "explicit_const_gate_on_unstable_fn", issue = "none")]

--- a/tests/rustdoc-json/attrs/stability/const_traits.rs
+++ b/tests/rustdoc-json/attrs/stability/const_traits.rs
@@ -20,12 +20,10 @@ impl InherentConstMethodTarget {
     pub const fn unstable_inherent_const_method_without_const_gate(&self) {}
 }
 
-//@ is "$.index[?(@.name=='ConstTrait')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='ConstTrait')].stability.feature" '"const_trait_feature"'
-//@ is "$.index[?(@.name=='ConstTrait')].stability.since" '"2.0.0"'
+//@ is "$.index[?(@.name=='ConstTrait')].stability.level.stable.since" '"2.0.0"'
 //@ is "$.index[?(@.name=='ConstTrait')].const_stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='ConstTrait')].const_stability.feature" '"const_trait_const_feature"'
-//@ !has "$.index[?(@.name=='ConstTrait')].const_stability.since"
 //@ is "$.index[?(@.name=='ConstTrait')].attrs" []
 #[stable(feature = "const_trait_feature", since = "2.0.0")]
 #[rustc_const_unstable(feature = "const_trait_const_feature", issue = "none")]
@@ -33,7 +31,6 @@ pub const trait ConstTrait {
     // This item is *not* usable in a const context, because its parent is const-unstable.
     //@ is "$.index[?(@.docs=='assoc type inside const trait')].const_stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='assoc type inside const trait')].const_stability.feature" '"const_trait_const_feature"'
-    //@ !has "$.index[?(@.docs=='assoc type inside const trait')].const_stability.since"
     /// assoc type inside const trait
     #[stable(feature = "trait_assoc_type_feature", since = "2.1.0")]
     type TraitAssocType;
@@ -41,7 +38,6 @@ pub const trait ConstTrait {
     // This item is also *not* usable in a const context, because its parent is const-unstable.
     //@ is "$.index[?(@.docs=='method inside const trait')].const_stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='method inside const trait')].const_stability.feature" '"const_trait_const_feature"'
-    //@ !has "$.index[?(@.docs=='method inside const trait')].const_stability.since"
     /// method inside const trait
     #[stable(feature = "trait_method_feature", since = "2.2.0")]
     fn trait_method(&self);
@@ -55,7 +51,7 @@ pub const trait ConstTrait {
     const TRAIT_ASSOC_CONST: usize;
 }
 
-//@ is "$.index[?(@.name=='ConstTraitWithUnstableMethod')].stability.level" '"stable"'
+//@ is "$.index[?(@.name=='ConstTraitWithUnstableMethod')].stability.level.stable.since" '"2.4.0"'
 //@ is "$.index[?(@.name=='ConstTraitWithUnstableMethod')].const_stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='ConstTraitWithUnstableMethod')].const_stability.feature" '"const_trait_with_unstable_method_const_feature"'
 #[stable(feature = "const_trait_with_unstable_method_feature", since = "2.4.0")]
@@ -72,12 +68,10 @@ pub const trait ConstTraitWithUnstableMethod {
     fn unstable_method_without_const_gate(&self);
 }
 
-//@ is "$.index[?(@.docs=='const trait impl')].stability.level" '"stable"'
 //@ is "$.index[?(@.docs=='const trait impl')].stability.feature" '"const_trait_impl_feature"'
-//@ is "$.index[?(@.docs=='const trait impl')].stability.since" '"3.0.0"'
+//@ is "$.index[?(@.docs=='const trait impl')].stability.level.stable.since" '"3.0.0"'
 //@ is "$.index[?(@.docs=='const trait impl')].const_stability.level" '"unstable"'
 //@ is "$.index[?(@.docs=='const trait impl')].const_stability.feature" '"const_trait_impl_const_feature"'
-//@ !has "$.index[?(@.docs=='const trait impl')].const_stability.since"
 /// const trait impl
 #[stable(feature = "const_trait_impl_feature", since = "3.0.0")]
 #[rustc_const_unstable(feature = "const_trait_impl_const_feature", issue = "none")]
@@ -85,14 +79,12 @@ const impl ConstTrait for ConstTraitTarget {
     // This item is *not* usable in a const context, because its parent is const-unstable.
     //@ is "$.index[?(@.docs=='assoc type inside const trait impl')].const_stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='assoc type inside const trait impl')].const_stability.feature" '"const_trait_impl_const_feature"'
-    //@ !has "$.index[?(@.docs=='assoc type inside const trait impl')].const_stability.since"
     /// assoc type inside const trait impl
     type TraitAssocType = usize;
 
     // This item is also *not* usable in a const context, because its parent is const-unstable.
     //@ is "$.index[?(@.docs=='method inside const trait impl')].const_stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='method inside const trait impl')].const_stability.feature" '"const_trait_impl_const_feature"'
-    //@ !has "$.index[?(@.docs=='method inside const trait impl')].const_stability.since"
     /// method inside const trait impl
     fn trait_method(&self) {}
 
@@ -107,12 +99,10 @@ const impl ConstTrait for ConstTraitTarget {
 // The `const trait` is const-stable. We indicate that *once* on the trait, but since
 // there are no special cases here (unlike in the const-unstable case with associated consts)
 // we do not duplicate the const-stability to all the associated items so as not to bloat the JSON.
-//@ is "$.index[?(@.name=='ConstStableTrait')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='ConstStableTrait')].stability.feature" '"const_stable_trait_feature"'
-//@ is "$.index[?(@.name=='ConstStableTrait')].stability.since" '"4.0.0"'
-//@ is "$.index[?(@.name=='ConstStableTrait')].const_stability.level" '"stable"'
-//@ is "$.index[?(@.name=='ConstStableTrait')].const_stability.since" '"4.0.0"'
+//@ is "$.index[?(@.name=='ConstStableTrait')].stability.level.stable.since" '"4.0.0"'
 //@ is "$.index[?(@.name=='ConstStableTrait')].const_stability.feature" '"const_stable_trait_const_feature"'
+//@ is "$.index[?(@.name=='ConstStableTrait')].const_stability.level.stable.since" '"4.0.0"'
 #[stable(feature = "const_stable_trait_feature", since = "4.0.0")]
 #[rustc_const_stable(feature = "const_stable_trait_const_feature", since = "4.0.0")]
 pub const trait ConstStableTrait {
@@ -135,12 +125,10 @@ pub const trait ConstStableTrait {
 // The `const impl` is const-stable. We indicate that *once* on the impl itself, but since
 // there are no special cases here (unlike in the const-unstable case with associated consts)
 // we do not duplicate the const-stability to all the associated items so as not to bloat the JSON.
-//@ is "$.index[?(@.docs=='const-stable trait impl')].stability.level" '"stable"'
 //@ is "$.index[?(@.docs=='const-stable trait impl')].stability.feature" '"const_stable_trait_impl_feature"'
-//@ is "$.index[?(@.docs=='const-stable trait impl')].stability.since" '"5.0.0"'
-//@ is "$.index[?(@.docs=='const-stable trait impl')].const_stability.level" '"stable"'
-//@ is "$.index[?(@.docs=='const-stable trait impl')].const_stability.since" '"5.0.0"'
+//@ is "$.index[?(@.docs=='const-stable trait impl')].stability.level.stable.since" '"5.0.0"'
 //@ is "$.index[?(@.docs=='const-stable trait impl')].const_stability.feature" '"const_stable_trait_impl_const_feature"'
+//@ is "$.index[?(@.docs=='const-stable trait impl')].const_stability.level.stable.since" '"5.0.0"'
 /// const-stable trait impl
 #[stable(feature = "const_stable_trait_impl_feature", since = "5.0.0")]
 #[rustc_const_stable(feature = "const_stable_trait_impl_const_feature", since = "5.0.0")]

--- a/tests/rustdoc-json/attrs/stability/impls.rs
+++ b/tests/rustdoc-json/attrs/stability/impls.rs
@@ -33,36 +33,31 @@ pub trait UnstableTraitForImpl {
     fn unstable_trait_method(&self);
 }
 
-//@ is "$.index[?(@.docs=='stable inherent impl')].stability.level" '"stable"'
 //@ is "$.index[?(@.docs=='stable inherent impl')].stability.feature" '"stable_inherent_impl"'
-//@ is "$.index[?(@.docs=='stable inherent impl')].stability.since" '"2.0.0"'
+//@ is "$.index[?(@.docs=='stable inherent impl')].stability.level.stable.since" '"2.0.0"'
 /// stable inherent impl
 #[stable(feature = "stable_inherent_impl", since = "2.0.0")]
 impl StableImplTarget {
-    //@ is "$.index[?(@.name=='stable_inherent_method')].stability.level" '"stable"'
     //@ is "$.index[?(@.name=='stable_inherent_method')].stability.feature" '"stable_inherent_method_feature"'
-    //@ is "$.index[?(@.name=='stable_inherent_method')].stability.since" '"2.1.0"'
+    //@ is "$.index[?(@.name=='stable_inherent_method')].stability.level.stable.since" '"2.1.0"'
     //@ is "$.index[?(@.name=='stable_inherent_method')].attrs" []
     #[stable(feature = "stable_inherent_method_feature", since = "2.1.0")]
     pub fn stable_inherent_method(&self) {}
 
     //@ is "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_IMPL')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_IMPL')].stability.feature" '"unstable_assoc_const_in_impl_feature"'
-    //@ !has "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_IMPL')].stability.since"
     #[unstable(feature = "unstable_assoc_const_in_impl_feature", issue = "none")]
     pub const UNSTABLE_ASSOC_CONST_IN_IMPL: usize = 2;
 }
 
 //@ is "$.index[?(@.docs=='unstable inherent impl')].stability.level" '"unstable"'
 //@ is "$.index[?(@.docs=='unstable inherent impl')].stability.feature" '"unstable_inherent_impl"'
-//@ !has "$.index[?(@.docs=='unstable inherent impl')].stability.since"
 /// unstable inherent impl
 #[unstable(feature = "unstable_inherent_impl", issue = "none")]
 impl StableImplTarget {
     // The instability of the inherent `impl` block is inherited by the item.
     //@ is "$.index[?(@.name=='method_inside_unstable_inherent_impl')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='method_inside_unstable_inherent_impl')].stability.feature" '"unstable_inherent_impl"'
-    //@ !has "$.index[?(@.name=='method_inside_unstable_inherent_impl')].stability.since"
     pub fn method_inside_unstable_inherent_impl(&self) {}
 }
 
@@ -74,9 +69,8 @@ impl StableImplTarget {
 // stability onto the implemented item. The unstable impl case is different: rustc records the
 // impl block's instability on contained impl items, so JSON exposes that inherited instability.
 
-//@ is "$.index[?(@.docs=='stable trait impl with unstable trait method')].stability.level" '"stable"'
 //@ is "$.index[?(@.docs=='stable trait impl with unstable trait method')].stability.feature" '"stable_trait_impl_with_unstable_trait_method"'
-//@ is "$.index[?(@.docs=='stable trait impl with unstable trait method')].stability.since" '"3.0.0"'
+//@ is "$.index[?(@.docs=='stable trait impl with unstable trait method')].stability.level.stable.since" '"3.0.0"'
 /// stable trait impl with unstable trait method
 #[stable(feature = "stable_trait_impl_with_unstable_trait_method", since = "3.0.0")]
 impl StableTraitWithUnstableMethodForImpl for StableImplTarget {
@@ -86,9 +80,8 @@ impl StableTraitWithUnstableMethodForImpl for StableImplTarget {
     fn unstable_trait_method_for_stable_impl(&self) {}
 }
 
-//@ is "$.index[?(@.docs=='stable trait impl')].stability.level" '"stable"'
 //@ is "$.index[?(@.docs=='stable trait impl')].stability.feature" '"stable_trait_impl"'
-//@ is "$.index[?(@.docs=='stable trait impl')].stability.since" '"3.0.0"'
+//@ is "$.index[?(@.docs=='stable trait impl')].stability.level.stable.since" '"3.0.0"'
 /// stable trait impl
 #[stable(feature = "stable_trait_impl", since = "3.0.0")]
 impl StableTraitForImpl for StableImplTarget {
@@ -110,7 +103,6 @@ impl StableTraitForImpl for StableImplTarget {
 
 //@ is "$.index[?(@.docs=='unstable trait impl')].stability.level" '"unstable"'
 //@ is "$.index[?(@.docs=='unstable trait impl')].stability.feature" '"unstable_trait_impl"'
-//@ !has "$.index[?(@.docs=='unstable trait impl')].stability.since"
 /// unstable trait impl
 #[unstable(feature = "unstable_trait_impl", issue = "none")]
 impl UnstableTraitForImpl for StableImplTarget {
@@ -118,19 +110,16 @@ impl UnstableTraitForImpl for StableImplTarget {
 
     //@ is "$.index[?(@.docs=='assoc type inside unstable trait impl')].stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='assoc type inside unstable trait impl')].stability.feature" '"unstable_trait_impl"'
-    //@ !has "$.index[?(@.docs=='assoc type inside unstable trait impl')].stability.since"
     /// assoc type inside unstable trait impl
     type UnstableOutput = usize;
 
     //@ is "$.index[?(@.docs=='assoc const inside unstable trait impl')].stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='assoc const inside unstable trait impl')].stability.feature" '"unstable_trait_impl"'
-    //@ !has "$.index[?(@.docs=='assoc const inside unstable trait impl')].stability.since"
     /// assoc const inside unstable trait impl
     const UNSTABLE_ASSOC_CONST: usize = 0;
 
     //@ is "$.index[?(@.docs=='method inside unstable trait impl')].stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='method inside unstable trait impl')].stability.feature" '"unstable_trait_impl"'
-    //@ !has "$.index[?(@.docs=='method inside unstable trait impl')].stability.since"
     /// method inside unstable trait impl
     fn unstable_trait_method(&self) {}
 }

--- a/tests/rustdoc-json/attrs/stability/item_kinds.rs
+++ b/tests/rustdoc-json/attrs/stability/item_kinds.rs
@@ -3,41 +3,35 @@
 // Mirrors standard-library stability on item kinds that are distinct from ordinary functions,
 // modules, structs, enums, traits, and impls.
 
-//@ is "$.index[?(@.name=='STABLE_CONST')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='STABLE_CONST')].stability.feature" '"stable_const_feature"'
-//@ is "$.index[?(@.name=='STABLE_CONST')].stability.since" '"1.0.0"'
+//@ is "$.index[?(@.name=='STABLE_CONST')].stability.level.stable.since" '"1.0.0"'
 #[stable(feature = "stable_const_feature", since = "1.0.0")]
 pub const STABLE_CONST: usize = 0;
 
 //@ is "$.index[?(@.name=='UNSTABLE_STATIC')].stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='UNSTABLE_STATIC')].stability.feature" '"unstable_static_feature"'
-//@ !has "$.index[?(@.name=='UNSTABLE_STATIC')].stability.since"
 #[unstable(feature = "unstable_static_feature", issue = "none")]
 pub static UNSTABLE_STATIC: usize = 0;
 
-//@ is "$.index[?(@.name=='StableTypeAlias')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='StableTypeAlias')].stability.feature" '"stable_type_alias_feature"'
-//@ is "$.index[?(@.name=='StableTypeAlias')].stability.since" '"1.1.0"'
+//@ is "$.index[?(@.name=='StableTypeAlias')].stability.level.stable.since" '"1.1.0"'
 #[stable(feature = "stable_type_alias_feature", since = "1.1.0")]
 pub type StableTypeAlias = usize;
 
-//@ is "$.index[?(@.name=='StableUnion')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='StableUnion')].stability.feature" '"stable_union_feature"'
-//@ is "$.index[?(@.name=='StableUnion')].stability.since" '"1.3.0"'
+//@ is "$.index[?(@.name=='StableUnion')].stability.level.stable.since" '"1.3.0"'
 #[stable(feature = "stable_union_feature", since = "1.3.0")]
 pub union StableUnion {
     storage: usize,
 }
 
-//@ is "$.index[?(@.inner.extern_crate.name=='stable_extern_crate_self')].stability.level" '"stable"'
 //@ is "$.index[?(@.inner.extern_crate.name=='stable_extern_crate_self')].stability.feature" '"stable_extern_crate_feature"'
-//@ is "$.index[?(@.inner.extern_crate.name=='stable_extern_crate_self')].stability.since" '"1.4.0"'
+//@ is "$.index[?(@.inner.extern_crate.name=='stable_extern_crate_self')].stability.level.stable.since" '"1.4.0"'
 #[stable(feature = "stable_extern_crate_feature", since = "1.4.0")]
 pub extern crate self as stable_extern_crate_self;
 
 //@ is "$.index[?(@.name=='unstable_macro_rules')].stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='unstable_macro_rules')].stability.feature" '"unstable_macro_rules_feature"'
-//@ !has "$.index[?(@.name=='unstable_macro_rules')].stability.since"
 //@ is "$.index[?(@.name=='unstable_macro_rules')].attrs" '["macro_export"]'
 #[unstable(feature = "unstable_macro_rules_feature", issue = "none")]
 #[macro_export]

--- a/tests/rustdoc-json/attrs/stability/modules.rs
+++ b/tests/rustdoc-json/attrs/stability/modules.rs
@@ -3,34 +3,29 @@
 
 #![feature(staged_api)]
 #![stable(feature = "stable_crate_feature", since = "1.0.0")]
-//@ is "$.index[?(@.name=='modules')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='modules')].stability.feature" '"stable_crate_feature"'
-//@ is "$.index[?(@.name=='modules')].stability.since" '"1.0.0"'
+//@ is "$.index[?(@.name=='modules')].stability.level.stable.since" '"1.0.0"'
 
 pub mod inner_stable_module {
     #![stable(feature = "inner_stable_module_feature", since = "1.1.0")]
 
-    //@ is "$.index[?(@.name=='inner_stable_module')].stability.level" '"stable"'
     //@ is "$.index[?(@.name=='inner_stable_module')].stability.feature" '"inner_stable_module_feature"'
-    //@ is "$.index[?(@.name=='inner_stable_module')].stability.since" '"1.1.0"'
+    //@ is "$.index[?(@.name=='inner_stable_module')].stability.level.stable.since" '"1.1.0"'
 }
 
 #[unstable(feature = "unstable_module_feature", issue = "none")]
 pub mod unstable_module {
     //@ is "$.index[?(@.name=='unstable_module')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='unstable_module')].stability.feature" '"unstable_module_feature"'
-    //@ !has "$.index[?(@.name=='unstable_module')].stability.since"
 }
 
 #[stable(feature = "stable_parent_feature", since = "2.0.0")]
 pub mod stable_parent {
-    //@ is "$.index[?(@.name=='stable_parent')].stability.level" '"stable"'
     //@ is "$.index[?(@.name=='stable_parent')].stability.feature" '"stable_parent_feature"'
-    //@ is "$.index[?(@.name=='stable_parent')].stability.since" '"2.0.0"'
+    //@ is "$.index[?(@.name=='stable_parent')].stability.level.stable.since" '"2.0.0"'
 
     //@ is "$.index[?(@.name=='UnstableChildInStable')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='UnstableChildInStable')].stability.feature" '"unstable_child_in_stable"'
-    //@ !has "$.index[?(@.name=='UnstableChildInStable')].stability.since"
     #[unstable(feature = "unstable_child_in_stable", issue = "none")]
     pub struct UnstableChildInStable;
 }
@@ -39,11 +34,9 @@ pub mod stable_parent {
 pub mod unstable_parent {
     //@ is "$.index[?(@.name=='unstable_parent')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='unstable_parent')].stability.feature" '"unstable_parent_feature"'
-    //@ !has "$.index[?(@.name=='unstable_parent')].stability.since"
 
-    //@ is "$.index[?(@.name=='StableChildInUnstable')].stability.level" '"stable"'
     //@ is "$.index[?(@.name=='StableChildInUnstable')].stability.feature" '"stable_child_in_unstable"'
-    //@ is "$.index[?(@.name=='StableChildInUnstable')].stability.since" '"3.0.0"'
+    //@ is "$.index[?(@.name=='StableChildInUnstable')].stability.level.stable.since" '"3.0.0"'
     #[stable(feature = "stable_child_in_unstable", since = "3.0.0")]
     pub struct StableChildInUnstable;
 }

--- a/tests/rustdoc-json/attrs/stability/reexports.rs
+++ b/tests/rustdoc-json/attrs/stability/reexports.rs
@@ -12,9 +12,8 @@
 #[unstable(feature = "unstable_source_mod", issue = "none")]
 pub mod unstable_source_mod {
     //@ set stable_in_unstable = "$.index[?(@.name=='StableInUnstable')].id"
-    //@ is "$.index[?(@.name=='StableInUnstable')].stability.level" '"stable"'
     //@ is "$.index[?(@.name=='StableInUnstable')].stability.feature" '"stable_in_unstable"'
-    //@ is "$.index[?(@.name=='StableInUnstable')].stability.since" '"1.0.0"'
+    //@ is "$.index[?(@.name=='StableInUnstable')].stability.level.stable.since" '"1.0.0"'
     #[stable(feature = "stable_in_unstable", since = "1.0.0")]
     pub struct StableInUnstable;
 
@@ -27,26 +26,22 @@ pub mod unstable_source_mod {
 }
 
 //@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].inner.use.id" $stable_in_unstable
-//@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].stability.level" '"stable"'
 //@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].stability.feature" '"stable_reexport"'
-//@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].stability.since" '"3.0.0"'
+//@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].stability.level.stable.since" '"3.0.0"'
 //@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].attrs" []
 #[stable(feature = "stable_reexport", since = "3.0.0")]
 pub use crate::unstable_source_mod::StableInUnstable as ReexportedStableInUnstable;
 //@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].inner.use.is_glob" true
-//@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].stability.level" '"stable"'
 //@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].stability.feature" '"stable_glob_reexport"'
-//@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].stability.since" '"4.0.0"'
+//@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].stability.level.stable.since" '"4.0.0"'
 #[stable(feature = "stable_glob_reexport", since = "4.0.0")]
 pub use crate::unstable_source_mod::*;
 //@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].inner.use.id" $stable_in_unstable
-//@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].stability.level" '"stable"'
 //@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].stability.feature" '"stable_grouped_reexport"'
-//@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].stability.since" '"3.5.0"'
+//@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].stability.level.stable.since" '"3.5.0"'
 //@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].inner.use.id" $second_stable_in_unstable
-//@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].stability.level" '"stable"'
 //@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].stability.feature" '"stable_grouped_reexport"'
-//@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].stability.since" '"3.5.0"'
+//@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].stability.level.stable.since" '"3.5.0"'
 #[stable(feature = "stable_grouped_reexport", since = "3.5.0")]
 pub use crate::unstable_source_mod::{
     SecondStableInUnstable as SecondGroupedStableReexport,
@@ -74,23 +69,19 @@ pub mod unstable_reexport_source_mod {
 //@ is "$.index[?(@.inner.use.name=='UnstableReexportedStable')].inner.use.id" $stable_for_unstable_reexport
 //@ is "$.index[?(@.inner.use.name=='UnstableReexportedStable')].stability.level" '"unstable"'
 //@ is "$.index[?(@.inner.use.name=='UnstableReexportedStable')].stability.feature" '"unstable_reexport"'
-//@ !has "$.index[?(@.inner.use.name=='UnstableReexportedStable')].stability.since"
 #[unstable(feature = "unstable_reexport", issue = "none")]
 pub use crate::unstable_reexport_source_mod::StableForUnstableReexport as UnstableReexportedStable;
 //@ is "$.index[?(@.inner.use.source=='crate::unstable_reexport_source_mod')].inner.use.is_glob" true
 //@ is "$.index[?(@.inner.use.source=='crate::unstable_reexport_source_mod')].stability.level" '"unstable"'
 //@ is "$.index[?(@.inner.use.source=='crate::unstable_reexport_source_mod')].stability.feature" '"unstable_glob_reexport"'
-//@ !has "$.index[?(@.inner.use.source=='crate::unstable_reexport_source_mod')].stability.since"
 #[unstable(feature = "unstable_glob_reexport", issue = "none")]
 pub use crate::unstable_reexport_source_mod::*;
 //@ is "$.index[?(@.inner.use.name=='GroupedUnstableReexport')].inner.use.id" $grouped_stable_for_unstable_reexport
 //@ is "$.index[?(@.inner.use.name=='GroupedUnstableReexport')].stability.level" '"unstable"'
 //@ is "$.index[?(@.inner.use.name=='GroupedUnstableReexport')].stability.feature" '"unstable_grouped_reexport"'
-//@ !has "$.index[?(@.inner.use.name=='GroupedUnstableReexport')].stability.since"
 //@ is "$.index[?(@.inner.use.name=='SecondGroupedUnstableReexport')].inner.use.id" $second_grouped_stable_for_unstable_reexport
 //@ is "$.index[?(@.inner.use.name=='SecondGroupedUnstableReexport')].stability.level" '"unstable"'
 //@ is "$.index[?(@.inner.use.name=='SecondGroupedUnstableReexport')].stability.feature" '"unstable_grouped_reexport"'
-//@ !has "$.index[?(@.inner.use.name=='SecondGroupedUnstableReexport')].stability.since"
 #[unstable(feature = "unstable_grouped_reexport", issue = "none")]
 pub use crate::unstable_reexport_source_mod::{
     GroupedStableForUnstableReexport as GroupedUnstableReexport,

--- a/tests/rustdoc-json/attrs/stability/stable.rs
+++ b/tests/rustdoc-json/attrs/stability/stable.rs
@@ -1,8 +1,7 @@
 #![feature(staged_api)]
 
-//@ is "$.index[?(@.name=='foo')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='foo')].stability.feature" '"eeeee"'
-//@ is "$.index[?(@.name=='foo')].stability.since" '"2.71.8"'
+//@ is "$.index[?(@.name=='foo')].stability.level.stable.since" '"2.71.8"'
 //@ is "$.index[?(@.name=='foo')].attrs" []
 #[stable(since = "2.71.8", feature = "eeeee")]
 pub fn foo() {}


### PR DESCRIPTION
Using `#[serde(flatten)]` and `#[serde(tag = "` break using rustdoc-json-types with serde serializers like postcard. rustdoc-json-types should work with these, even if rustdoc itself doesn't use this yet.

This is a breaking change to the `FORMAT_VERSION` even though rust reader/writer code is uneffected.

cc @obi1kenobi 
r? @GuillaumeGomez 
