### PR TITLE
Move "macro only" check for `#[allow_internal_unsafe/unstable]` to attribute parser

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
@@ -2,6 +2,7 @@ use std::iter;
 
 use rustc_feature::AttributeStability;
 
+use super::macro_attrs::check_macro_only;
 use super::prelude::*;
 use crate::session_diagnostics;
 
@@ -27,6 +28,10 @@ impl CombineAttributeParser for AllowInternalUnstableParser {
         parse_unstable(cx, args, <Self as CombineAttributeParser>::PATH[0])
             .into_iter()
             .zip(iter::repeat(cx.attr_span))
+    }
+
+    fn finalize_check(cx: &FinalizeCheckContext<'_, '_>, attr_span: Span) {
+        check_macro_only(cx, attr_span);
     }
 }
 

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -1,8 +1,10 @@
 use rustc_feature::AttributeStability;
 use rustc_hir::attrs::{CollapseMacroDebuginfo, MacroUseArgs};
+use rustc_hir::find_attr;
 use rustc_session::lint::builtin::INVALID_MACRO_EXPORT_ARGUMENTS;
 
 use super::prelude::*;
+use crate::session_diagnostics::MacroOnlyAttribute;
 
 pub(crate) struct MacroEscapeParser;
 impl NoArgsAttributeParser for MacroEscapeParser {
@@ -113,6 +115,17 @@ impl AttributeParser for MacroUseParser {
     }
 }
 
+/// `#[allow_internal_unsafe]` and `#[allow_internal_unstable]` may only be applied to macros.
+/// Applying them to a function is only allowed if that function is a procedural macro, i.e. it
+/// also carries `#[proc_macro]`, `#[proc_macro_attribute]`, or `#[proc_macro_derive]`.
+pub(crate) fn check_macro_only(cx: &FinalizeCheckContext<'_, '_>, attr_span: Span) {
+    if cx.target == Target::Fn
+        && !find_attr!(cx.parsed_attrs, ProcMacro | ProcMacroAttribute | ProcMacroDerive { .. })
+    {
+        cx.emit_err(MacroOnlyAttribute { attr_span, span: cx.target_span });
+    }
+}
+
 pub(crate) struct AllowInternalUnsafeParser;
 
 impl NoArgsAttributeParser for AllowInternalUnsafeParser {
@@ -126,6 +139,10 @@ impl NoArgsAttributeParser for AllowInternalUnsafeParser {
     ]);
     const STABILITY: AttributeStability = unstable!(allow_internal_unsafe);
     const CREATE: fn(Span) -> AttributeKind = |span| AttributeKind::AllowInternalUnsafe(span);
+
+    fn finalize_check(cx: &FinalizeCheckContext<'_, '_>, attr_span: Span) {
+        check_macro_only(cx, attr_span);
+    }
 }
 
 pub(crate) struct MacroExportParser;

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -30,6 +30,15 @@ pub(crate) struct RustcPubTransparent {
 }
 
 #[derive(Diagnostic)]
+#[diag("attribute should be applied to a macro")]
+pub(crate) struct MacroOnlyAttribute {
+    #[primary_span]
+    pub attr_span: Span,
+    #[label("not a macro")]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("{$attr_str} attribute cannot have empty value")]
 pub(crate) struct DocAliasEmpty<'a> {
     #[primary_span]

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -190,10 +190,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             AttributeKind::Inline(kind, attr_span) => {
                 self.check_inline(hir_id, *attr_span, kind, target)
             }
-            AttributeKind::AllowInternalUnsafe(attr_span)
-            | AttributeKind::AllowInternalUnstable(.., attr_span) => {
-                self.check_macro_only_attr(*attr_span, span, target, attrs)
-            }
             AttributeKind::RustcAllowConstFnUnstable(_, first_span) => {
                 self.check_rustc_allow_const_fn_unstable(hir_id, *first_span, span, target)
             }
@@ -241,6 +237,8 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
 
             // All of the following attributes have no specific checks.
             // tidy-alphabetical-start
+            AttributeKind::AllowInternalUnsafe(..) => (),
+            AttributeKind::AllowInternalUnstable(..) => (),
             AttributeKind::AutomaticallyDerived => (),
             AttributeKind::CfgAttrTrace(..) => (),
             AttributeKind::CfgTrace(..) => (),
@@ -1286,31 +1284,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 hint_spans.collect::<Vec<Span>>(),
                 diagnostics::ReprConflictingLint,
             );
-        }
-    }
-
-    /// Outputs an error for attributes that can only be applied to macros, such as
-    /// `#[allow_internal_unsafe]` and `#[allow_internal_unstable]`.
-    /// (Allows proc_macro functions)
-    // FIXME(jdonszelmann): if possible, move to attr parsing
-    fn check_macro_only_attr(
-        &self,
-        attr_span: Span,
-        span: Span,
-        target: Target,
-        attrs: &[Attribute],
-    ) {
-        match target {
-            Target::Fn => {
-                for attr in attrs {
-                    if attr.is_proc_macro_attr() {
-                        // return on proc macros
-                        return;
-                    }
-                }
-                self.tcx.dcx().emit_err(diagnostics::MacroOnlyAttribute { attr_span, span });
-            }
-            _ => {}
         }
     }
 

--- a/compiler/rustc_passes/src/diagnostics.rs
+++ b/compiler/rustc_passes/src/diagnostics.rs
@@ -216,15 +216,6 @@ pub(crate) struct ReprConflicting {
 pub(crate) struct ReprConflictingLint;
 
 #[derive(Diagnostic)]
-#[diag("attribute should be applied to a macro")]
-pub(crate) struct MacroOnlyAttribute {
-    #[primary_span]
-    pub attr_span: Span,
-    #[label("not a macro")]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag("couldn't read {$file}: {$error}")]
 pub(crate) struct DebugVisualizerUnreadable<'a> {
     #[primary_span]

--- a/tests/ui/attributes/macro-only-attribute.rs
+++ b/tests/ui/attributes/macro-only-attribute.rs
@@ -1,0 +1,19 @@
+//! `#[allow_internal_unstable]` and `#[allow_internal_unsafe]` may only be applied to macros.
+//! Applying them to an ordinary (non-procedural-macro) function is an error.
+#![feature(allow_internal_unstable)]
+#![feature(allow_internal_unsafe)]
+
+#[allow_internal_unstable(something)] //~ ERROR attribute should be applied to a macro
+fn not_a_macro_unstable() {}
+
+#[allow_internal_unsafe] //~ ERROR attribute should be applied to a macro
+fn not_a_macro_unsafe() {}
+
+// Applying them to a `macro_rules!` macro is fine.
+#[allow_internal_unstable(something)]
+#[allow_internal_unsafe]
+macro_rules! ok_on_macro {
+    () => {};
+}
+
+fn main() {}

--- a/tests/ui/attributes/macro-only-attribute.stderr
+++ b/tests/ui/attributes/macro-only-attribute.stderr
@@ -1,0 +1,18 @@
+error: attribute should be applied to a macro
+  --> $DIR/macro-only-attribute.rs:6:1
+   |
+LL | #[allow_internal_unstable(something)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn not_a_macro_unstable() {}
+   | ---------------------------- not a macro
+
+error: attribute should be applied to a macro
+  --> $DIR/macro-only-attribute.rs:9:1
+   |
+LL | #[allow_internal_unsafe]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn not_a_macro_unsafe() {}
+   | -------------------------- not a macro
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Part of rust-lang/rust#131229 which is the parent issue of rust-lang/rust#153101 

@JonathanBrouwer 