### PR TITLE
Add regression test for enum unconstrained parameter 

### DIFF
--- a/tests/ui/generics/unconstrained-param-enum-projection-issue-159811.rs
+++ b/tests/ui/generics/unconstrained-param-enum-projection-issue-159811.rs
@@ -1,0 +1,27 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/159811.
+
+trait Child {
+    type Error;
+}
+
+trait Site {
+    type Child<'a>: Child
+    where
+        Self: 'a;
+    type Error;
+}
+
+enum MyError<P> {
+    Own,
+    Parent(P),
+}
+
+impl<'a, S: Site> From<<S::Child<'a> as Child>::Error> for MyError<S::Error> {
+    //~^ ERROR conflicting implementations of trait
+    //~| ERROR the type parameter `S` is not constrained
+    fn from(_: <S::Child<'a> as Child>::Error) -> Self {
+        Self::Own
+    }
+}
+
+fn main() {}

--- a/tests/ui/generics/unconstrained-param-enum-projection-issue-159811.stderr
+++ b/tests/ui/generics/unconstrained-param-enum-projection-issue-159811.stderr
@@ -1,0 +1,28 @@
+error[E0119]: conflicting implementations of trait `From<MyError<_>>` for type `MyError<_>`
+  --> $DIR/unconstrained-param-enum-projection-issue-159811.rs:19:1
+   |
+LL | impl<'a, S: Site> From<<S::Child<'a> as Child>::Error> for MyError<S::Error> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: conflicting implementation in crate `core`:
+           - impl<T> From<T> for T;
+
+error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-param-enum-projection-issue-159811.rs:19:10
+   |
+LL | impl<'a, S: Site> From<<S::Child<'a> as Child>::Error> for MyError<S::Error> {
+   |          ^ unconstrained type parameter
+   |
+help: use the type parameter `S` in the `MyError` type and use it in the type definition
+   |
+LL ~ enum MyError<P, S> {
+LL |     Own,
+...
+LL |
+LL ~ impl<'a, S: Site> From<<S::Child<'a> as Child>::Error> for MyError<S::Error, S> {
+   |
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0119, E0207.
+For more information about an error, try `rustc --explain E0119`.


### PR DESCRIPTION
Fixes rust-lang/rust#159811

It's fixed by https://github.com/rust-lang/rust/pull/157846