### PR TITLE
Improve consistency of attribute error messages (part 2)

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -5,7 +5,7 @@ use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
 #[derive(Default)]
 pub(crate) struct OnConstParser {
-    span: Option<Span>,
+    path_span: Option<Span>,
     directive: Option<(Span, Directive)>,
 }
 
@@ -21,8 +21,8 @@ impl AttributeParser for OnConstParser {
                 return;
             }
 
-            let span = cx.attr_span;
-            this.span = Some(span);
+            let path_span = cx.attr_path.span;
+            this.path_span = Some(path_span);
 
             let mode = Mode::DiagnosticOnConst;
 
@@ -31,7 +31,7 @@ impl AttributeParser for OnConstParser {
             let Some(directive) = parse_directive_items(cx, mode, items.mixed(), true) else {
                 return;
             };
-            merge_directives(cx, &mut this.directive, (span, directive));
+            merge_directives(cx, &mut this.directive, (path_span, directive));
         },
     )];
 
@@ -44,8 +44,11 @@ impl AttributeParser for OnConstParser {
     ]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
-        if let Some(span) = self.span {
-            Some(AttributeKind::OnConst { span, directive: self.directive.map(|d| Box::new(d.1)) })
+        if let Some(path_span) = self.path_span {
+            Some(AttributeKind::OnConst {
+                span: path_span,
+                directive: self.directive.map(|d| Box::new(d.1)),
+            })
         } else {
             None
         }

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -210,7 +210,7 @@ impl AttributeParser for ConstStabilityParser {
                 {
                     this.stability = Some((
                         PartialConstStability { level, feature, promotable: false },
-                        cx.attr_span,
+                        cx.attr_path.span,
                     ));
                 }
             },
@@ -225,7 +225,7 @@ impl AttributeParser for ConstStabilityParser {
                 {
                     this.stability = Some((
                         PartialConstStability { level, feature, promotable: false },
-                        cx.attr_span,
+                        cx.attr_path.span,
                     ));
                 }
             },

--- a/compiler/rustc_attr_parsing/src/diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/diagnostics.rs
@@ -814,7 +814,7 @@ pub(crate) enum InvalidOnClause {
 pub(crate) struct DupesNotAllowed;
 
 #[derive(Diagnostic)]
-#[diag("usage of the unsafe `#[{$attr_path}]` attribute")]
+#[diag("usage of the unsafe `{$attr_path}` attribute")]
 #[note("{$note}")]
 pub(crate) struct UnsafeAttribute {
     pub attr_path: AttrPath,

--- a/compiler/rustc_builtin_macros/src/diagnostics.rs
+++ b/compiler/rustc_builtin_macros/src/diagnostics.rs
@@ -1036,7 +1036,7 @@ pub(crate) struct TakesNoArguments<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag("the `#[{$path}]` attribute is only usable with crates of the `proc-macro` crate type")]
+#[diag("the `{$path}` attribute is only usable with crates of the `proc-macro` crate type")]
 pub(crate) struct AttributeOnlyUsableWithCrateType<'a> {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
+++ b/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
@@ -230,9 +230,10 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
         }
 
         if !self.is_proc_macro_crate {
+            let path = &attr.get_normal_item().path;
             self.dcx
                 .create_err(diagnostics::AttributeOnlyUsableWithCrateType {
-                    span: attr.span,
+                    span: path.span,
                     path: &pprust::path_to_string(&attr.get_normal_item().path),
                 })
                 .emit();

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -96,13 +96,13 @@ pub(crate) fn expand_test(
 
 pub(crate) fn expand_bench(
     cx: &mut ExtCtxt<'_>,
-    attr_sp: Span,
+    attr_path_sp: Span,
     meta_item: &ast::MetaItem,
     item: Annotatable,
 ) -> Vec<Annotatable> {
     check_builtin_macro_attribute(cx, meta_item, sym::bench);
     warn_on_duplicate_attribute(cx, &item, sym::bench);
-    expand_test_or_bench(cx, attr_sp, item, true)
+    expand_test_or_bench(cx, attr_path_sp, item, true)
 }
 
 pub(crate) fn expand_test_or_bench(
@@ -413,7 +413,7 @@ pub(crate) fn expand_test_or_bench(
 fn not_testable_error(cx: &ExtCtxt<'_>, is_bench: bool, attr_sp: Span, item: Option<&ast::Item>) {
     let dcx = cx.dcx();
     let name = if is_bench { "bench" } else { "test" };
-    let msg = format!("the `#[{name}]` attribute may only be used on a free function");
+    let msg = format!("the `{name}` attribute may only be used on a free function");
     let level = match item.map(|i| &i.kind) {
         // These were a warning before #92959 and need to continue being that to avoid breaking
         // stable user code (#94508).
@@ -432,7 +432,7 @@ fn not_testable_error(cx: &ExtCtxt<'_>, is_bench: bool, attr_sp: Span, item: Opt
             ),
         );
     }
-    err.span_label(attr_sp, format!("the `#[{name}]` macro causes a function to be run as a test and has no effect on non-functions"));
+    err.span_label(attr_sp, format!("the `{name}` attribute causes a function to be run as a test and has no effect on non-functions"));
 
     if !is_bench {
         err.with_span_suggestion(attr_sp,

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1217,6 +1217,7 @@ pub enum AttributeKind {
 
     /// Represents `#[diagnostic::on_const]`.
     OnConst {
+        /// The attribute path span.
         span: Span,
         /// None if the directive was malformed in some way.
         directive: Option<Box<Directive>>,

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1389,7 +1389,8 @@ pub enum AttributeKind {
     /// Represents `#[rustc_const_stable]` and `#[rustc_const_unstable]`.
     RustcConstStability {
         stability: PartialConstStability,
-        /// Span of the `#[rustc_const_stable(...)]` or `#[rustc_const_unstable(...)]` attribute
+        /// Path span of the `#[rustc_const_stable(...)]` or `#[rustc_const_unstable(...)]`
+        /// attribute.
         span: Span,
     },
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -52,7 +52,9 @@ use rustc_trait_selection::traits::ObligationCtxt;
 use crate::diagnostics;
 
 #[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_const]` can only be applied to non-const trait implementations")]
+#[diag(
+    "the `diagnostic::on_const` attribute can only be applied to non-const trait implementations"
+)]
 struct DiagnosticOnConstOnlyForNonConstTraitImpls {
     #[label("this is a const trait implementation")]
     item_span: Span,
@@ -568,7 +570,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     /// Checks if `#[diagnostic::on_const]` is applied to a on-const trait impl
     fn check_diagnostic_on_const(
         &self,
-        attr_span: Span,
+        attr_path_span: Span,
         hir_id: HirId,
         target: Target,
         item: Option<&'tcx Item<'tcx>>,
@@ -608,7 +610,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     self.tcx.emit_node_span_lint(
                         MISPLACED_DIAGNOSTIC_ATTRIBUTES,
                         hir_id,
-                        attr_span,
+                        attr_path_span,
                         DiagnosticOnConstOnlyForNonConstTraitImpls { item_span },
                     );
                     return;

--- a/compiler/rustc_passes/src/diagnostics.rs
+++ b/compiler/rustc_passes/src/diagnostics.rs
@@ -810,13 +810,13 @@ pub(crate) struct MissingConstErr {
 
 #[derive(Diagnostic)]
 #[diag(
-    "attribute `#[rustc_const_stable]` can only be applied to functions that are declared `#[stable]`"
+    "the `rustc_const_stable` attribute can only be applied to functions marked with the `stable` attribute"
 )]
 pub(crate) struct ConstStableNotStable {
     #[primary_span]
     pub fn_sig_span: Span,
     #[label("attribute specified here")]
-    pub const_span: Span,
+    pub path_span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_passes/src/diagnostics.rs
+++ b/compiler/rustc_passes/src/diagnostics.rs
@@ -405,7 +405,7 @@ pub(crate) struct AbiNe {
 
 #[derive(Diagnostic)]
 #[diag(
-    "`#[rustc_abi]` can only be applied to function items, type aliases, and associated functions"
+    "the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions"
 )]
 pub(crate) struct AbiInvalidAttribute {
     #[primary_span]

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -397,11 +397,11 @@ impl<'tcx> MissingStabilityAnnotations<'tcx> {
             && let Some(fn_sig) = fn_sig
             && const_stab.is_const_stable()
             && !stab.is_some_and(|s| s.is_stable())
-            && let Some(const_span) = find_attr_span!(RustcConstStability)
+            && let Some(path_span) = find_attr_span!(RustcConstStability)
         {
             self.tcx.dcx().emit_err(diagnostics::ConstStableNotStable {
                 fn_sig_span: fn_sig.span,
-                const_span,
+                path_span,
             });
         }
 

--- a/tests/rustdoc-ui/proc_macro_bug.rs
+++ b/tests/rustdoc-ui/proc_macro_bug.rs
@@ -6,7 +6,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 
 #[proc_macro_derive(DeriveA)]
-//~^ ERROR the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
+//~^ ERROR the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
 pub fn a_derive(input: TokenStream) -> TokenStream {
     input
 }

--- a/tests/rustdoc-ui/proc_macro_bug.stderr
+++ b/tests/rustdoc-ui/proc_macro_bug.stderr
@@ -1,8 +1,8 @@
-error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/proc_macro_bug.rs:8:1
+error: the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/proc_macro_bug.rs:8:3
    |
 LL | #[proc_macro_derive(DeriveA)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/abi/debug.generic.stderr
+++ b/tests/ui/abi/debug.generic.stderr
@@ -264,7 +264,7 @@ error: fn_abi_of(test_generic) = FnAbi {
 LL | fn test_generic<T>(_x: *const T) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
+error: the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:43:1
    |
 LL | const C: () = ();
@@ -845,7 +845,7 @@ LL | type TestAbiEqNonsense = (fn((str, str)), fn((str, str)));
    = help: the trait `Sized` is not implemented for `str`
    = note: only the last element of a tuple may have a dynamically sized type
 
-error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
+error: the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:47:5
    |
 LL |     const C: () = ();

--- a/tests/ui/abi/debug.loongarch64.stderr
+++ b/tests/ui/abi/debug.loongarch64.stderr
@@ -264,7 +264,7 @@ error: fn_abi_of(test_generic) = FnAbi {
 LL | fn test_generic<T>(_x: *const T) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
+error: the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:43:1
    |
 LL | const C: () = ();
@@ -845,7 +845,7 @@ LL | type TestAbiEqNonsense = (fn((str, str)), fn((str, str)));
    = help: the trait `Sized` is not implemented for `str`
    = note: only the last element of a tuple may have a dynamically sized type
 
-error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
+error: the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:47:5
    |
 LL |     const C: () = ();

--- a/tests/ui/abi/debug.riscv64.stderr
+++ b/tests/ui/abi/debug.riscv64.stderr
@@ -264,7 +264,7 @@ error: fn_abi_of(test_generic) = FnAbi {
 LL | fn test_generic<T>(_x: *const T) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
+error: the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:43:1
    |
 LL | const C: () = ();
@@ -845,7 +845,7 @@ LL | type TestAbiEqNonsense = (fn((str, str)), fn((str, str)));
    = help: the trait `Sized` is not implemented for `str`
    = note: only the last element of a tuple may have a dynamically sized type
 
-error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
+error: the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:47:5
    |
 LL |     const C: () = ();

--- a/tests/ui/abi/debug.rs
+++ b/tests/ui/abi/debug.rs
@@ -40,11 +40,11 @@ type TestFnPtr = fn(bool) -> u8; //~ ERROR: fn_abi
 fn test_generic<T>(_x: *const T) {} //~ ERROR: fn_abi
 
 #[rustc_abi(debug)] //~ ERROR: the `rustc_abi` attribute cannot be used on constants
-const C: () = (); //~ ERROR: `#[rustc_abi]` can only be applied to
+const C: () = (); //~ ERROR: the `rustc_abi` attribute can only be applied to
 
 impl S {
     #[rustc_abi(debug)] //~ ERROR: the `rustc_abi` attribute cannot be used on assoc
-    const C: () = (); //~ ERROR: `#[rustc_abi]` can only be applied to
+    const C: () = (); //~ ERROR: the `rustc_abi` attribute can only be applied to
 }
 
 impl S {

--- a/tests/ui/attributes/malformed-attrs.rs
+++ b/tests/ui/attributes/malformed-attrs.rs
@@ -105,7 +105,7 @@
 //~| WARN previously accepted
 #[proc_macro = 18]
 //~^ ERROR malformed
-//~| ERROR the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
+//~| ERROR the `proc_macro` attribute is only usable with crates of the `proc-macro` crate type
 #[cfg]
 //~^ ERROR malformed
 #[cfg_attr]
@@ -122,14 +122,14 @@ fn test() {
 
 #[proc_macro_attribute = 19]
 //~^ ERROR malformed
-//~| ERROR the `#[proc_macro_attribute]` attribute is only usable with crates of the `proc-macro` crate type
+//~| ERROR the `proc_macro_attribute` attribute is only usable with crates of the `proc-macro` crate type
 #[must_use = 1]
 //~^ ERROR malformed
 fn test2() { }
 
 #[proc_macro_derive]
 //~^ ERROR malformed `proc_macro_derive` attribute
-//~| ERROR the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
+//~| ERROR the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
 pub fn test3() {}
 
 #[must_not_suspend()]

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -108,23 +108,23 @@ LL | #[forbid(lint1, lint2, ...)]
 LL | #[forbid(lint1, lint2, lint3, reason = "...")]
    |         +++++++++++++++++++++++++++++++++++++
 
-error: the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:106:1
+error: the `proc_macro` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/malformed-attrs.rs:106:3
    |
 LL | #[proc_macro = 18]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
 
-error: the `#[proc_macro_attribute]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:123:1
+error: the `proc_macro_attribute` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/malformed-attrs.rs:123:3
    |
 LL | #[proc_macro_attribute = 19]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
 
-error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:130:1
+error: the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/malformed-attrs.rs:130:3
    |
 LL | #[proc_macro_derive]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `windows_subsystem` attribute input
   --> $DIR/malformed-attrs.rs:26:4

--- a/tests/ui/attributes/unsafe/proc-unsafe-attributes.stderr
+++ b/tests/ui/attributes/unsafe/proc-unsafe-attributes.stderr
@@ -23,29 +23,29 @@ help: escape `unsafe` to use it as an identifier
 LL | #[unsafe(allow(r#unsafe(dead_code)))]
    |                ++
 
-error: the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/proc-unsafe-attributes.rs:1:1
+error: the `proc_macro` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/proc-unsafe-attributes.rs:1:10
    |
 LL | #[unsafe(proc_macro)]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^
 
-error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/proc-unsafe-attributes.rs:7:1
+error: the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/proc-unsafe-attributes.rs:7:10
    |
 LL | #[unsafe(proc_macro_derive(Foo))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^^^^^^^^
 
-error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/proc-unsafe-attributes.rs:12:1
+error: the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/proc-unsafe-attributes.rs:12:3
    |
 LL | #[proc_macro_derive(unsafe(Foo))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
 
-error: the `#[proc_macro_attribute]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/proc-unsafe-attributes.rs:18:1
+error: the `proc_macro_attribute` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/proc-unsafe-attributes.rs:18:10
    |
 LL | #[unsafe(proc_macro_attribute)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^^^^^^^^^^^
 
 error[E0452]: malformed lint attribute input
   --> $DIR/proc-unsafe-attributes.rs:27:16

--- a/tests/ui/consts/rustc-const-stability-require-const.rs
+++ b/tests/ui/consts/rustc-const-stability-require-const.rs
@@ -50,9 +50,9 @@ pub const fn barfoo() {}
 
 #[rustc_const_stable(feature = "barfoo_const", since = "1.0.0")]
 const fn barfoo_unmarked() {}
-//~^ ERROR can only be applied to functions that are declared `#[stable]`
+//~^ ERROR can only be applied to functions marked with the `stable` attribute
 
 #[unstable(feature = "unstable", issue = "none")]
 #[rustc_const_stable(feature = "barfoo_const", since = "1.0.0")]
 pub const fn barfoo_unstable() {}
-//~^ ERROR can only be applied to functions that are declared `#[stable]`
+//~^ ERROR can only be applied to functions marked with the `stable` attribute

--- a/tests/ui/consts/rustc-const-stability-require-const.stderr
+++ b/tests/ui/consts/rustc-const-stability-require-const.stderr
@@ -46,19 +46,19 @@ help: make the function or method const
 LL | pub extern "C" fn foo_c() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: attribute `#[rustc_const_stable]` can only be applied to functions that are declared `#[stable]`
+error: the `rustc_const_stable` attribute can only be applied to functions marked with the `stable` attribute
   --> $DIR/rustc-const-stability-require-const.rs:52:1
    |
 LL | #[rustc_const_stable(feature = "barfoo_const", since = "1.0.0")]
-   | ---------------------------------------------------------------- attribute specified here
+   |   ------------------ attribute specified here
 LL | const fn barfoo_unmarked() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: attribute `#[rustc_const_stable]` can only be applied to functions that are declared `#[stable]`
+error: the `rustc_const_stable` attribute can only be applied to functions marked with the `stable` attribute
   --> $DIR/rustc-const-stability-require-const.rs:57:1
    |
 LL | #[rustc_const_stable(feature = "barfoo_const", since = "1.0.0")]
-   | ---------------------------------------------------------------- attribute specified here
+   |   ------------------ attribute specified here
 LL | pub const fn barfoo_unstable() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
@@ -6,7 +6,7 @@
 pub struct Foo;
 
 #[diagnostic::on_const(message = "tadaa", note = "boing")]
-//~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
+//~^ ERROR: the `diagnostic::on_const` attribute can only be applied to non-const trait implementations
 const impl PartialEq for Foo {
     fn eq(&self, _other: &Foo) -> bool {
         true

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
@@ -1,8 +1,8 @@
-error: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
-  --> $DIR/misplaced_attr.rs:8:1
+error: the `diagnostic::on_const` attribute can only be applied to non-const trait implementations
+  --> $DIR/misplaced_attr.rs:8:3
    |
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | const impl PartialEq for Foo {
    | ---------------------------- this is a const trait implementation

--- a/tests/ui/feature-gates/gating-of-test-attrs.rs
+++ b/tests/ui/feature-gates/gating-of-test-attrs.rs
@@ -3,22 +3,22 @@
 // test is a built-in macro, not a built-in attribute, but it kind of acts like both.
 // check its target checking anyway here
 #[test]
-//~^ ERROR the `#[test]` attribute may only be used on a free function
+//~^ ERROR the `test` attribute may only be used on a free function
 mod test {
     mod inner { #![test] }
     //~^ ERROR inner macro attributes are unstable
-    //~| ERROR the `#[test]` attribute may only be used on a free function
+    //~| ERROR the `test` attribute may only be used on a free function
 
     #[test]
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     struct S;
 
     #[test]
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     type T = S;
 
     #[test]
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     impl S { }
 }
 
@@ -26,22 +26,22 @@ mod test {
 // non-crate-level #[bench] attributes seem to be ignored.
 
 #[bench]
-//~^ ERROR the `#[bench]` attribute may only be used on a free function
+//~^ ERROR the `bench` attribute may only be used on a free function
 mod bench {
     mod inner { #![bench] }
     //~^ ERROR inner macro attributes are unstable
-    //~| ERROR the `#[bench]` attribute may only be used on a free function
+    //~| ERROR the `bench` attribute may only be used on a free function
 
     #[bench]
-    //~^ ERROR the `#[bench]` attribute may only be used on a free function
+    //~^ ERROR the `bench` attribute may only be used on a free function
     struct S;
 
     #[bench]
-    //~^ ERROR the `#[bench]` attribute may only be used on a free function
+    //~^ ERROR the `bench` attribute may only be used on a free function
     type T = S;
 
     #[bench]
-    //~^ ERROR the `#[bench]` attribute may only be used on a free function
+    //~^ ERROR the `bench` attribute may only be used on a free function
     impl S { }
 }
 

--- a/tests/ui/feature-gates/gating-of-test-attrs.stderr
+++ b/tests/ui/feature-gates/gating-of-test-attrs.stderr
@@ -1,8 +1,8 @@
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:5:1
    |
 LL |   #[test]
-   |   ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |   ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL | / mod test {
 LL | |     mod inner { #![test] }
@@ -27,13 +27,13 @@ LL |     mod inner { #![test] }
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:8:17
    |
 LL |     mod inner { #![test] }
    |     ------------^^^^^^^^--
    |     |           |
-   |     |           the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     |           the `test` attribute causes a function to be run as a test and has no effect on non-functions
    |     expected a non-associated function, found a module
    |
 help: replace with conditional compilation to make the item only exist when tests are being run
@@ -42,11 +42,11 @@ LL -     mod inner { #![test] }
 LL +     mod inner { #[cfg(test)] }
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:12:5
    |
 LL |     #[test]
-   |     ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     struct S;
    |     --------- expected a non-associated function, found a struct
@@ -57,11 +57,11 @@ LL -     #[test]
 LL +     #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:16:5
    |
 LL |     #[test]
-   |     ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     type T = S;
    |     ----------- expected a non-associated function, found a type alias
@@ -72,11 +72,11 @@ LL -     #[test]
 LL +     #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:20:5
    |
 LL |     #[test]
-   |     ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     impl S { }
    |     ---------- expected a non-associated function, found an implementation
@@ -87,11 +87,11 @@ LL -     #[test]
 LL +     #[cfg(test)]
    |
 
-error: the `#[bench]` attribute may only be used on a free function
+error: the `bench` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:28:1
    |
 LL |   #[bench]
-   |   ^^^^^^^^ the `#[bench]` macro causes a function to be run as a test and has no effect on non-functions
+   |   ^^^^^^^^ the `bench` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL | / mod bench {
 LL | |     mod inner { #![bench] }
@@ -110,38 +110,38 @@ LL |     mod inner { #![bench] }
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: the `#[bench]` attribute may only be used on a free function
+error: the `bench` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:31:17
    |
 LL |     mod inner { #![bench] }
    |     ------------^^^^^^^^^--
    |     |           |
-   |     |           the `#[bench]` macro causes a function to be run as a test and has no effect on non-functions
+   |     |           the `bench` attribute causes a function to be run as a test and has no effect on non-functions
    |     expected a non-associated function, found a module
 
-error: the `#[bench]` attribute may only be used on a free function
+error: the `bench` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:35:5
    |
 LL |     #[bench]
-   |     ^^^^^^^^ the `#[bench]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^^ the `bench` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     struct S;
    |     --------- expected a non-associated function, found a struct
 
-error: the `#[bench]` attribute may only be used on a free function
+error: the `bench` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:39:5
    |
 LL |     #[bench]
-   |     ^^^^^^^^ the `#[bench]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^^ the `bench` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     type T = S;
    |     ----------- expected a non-associated function, found a type alias
 
-error: the `#[bench]` attribute may only be used on a free function
+error: the `bench` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:43:5
    |
 LL |     #[bench]
-   |     ^^^^^^^^ the `#[bench]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^^ the `bench` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     impl S { }
    |     ---------- expected a non-associated function, found an implementation

--- a/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.rs
@@ -14,7 +14,7 @@ mod proc_macro_derive2 {
     //~^ ERROR attribute cannot be used on
 
     #[proc_macro_derive(Test)] fn f() { }
-    //~^ ERROR the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro`
+    //~^ ERROR the `proc_macro_derive` attribute is only usable with crates of the `proc-macro`
 
     #[proc_macro_derive(Test)] struct S;
     //~^ ERROR attribute cannot be used on

--- a/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.stderr
@@ -1,8 +1,8 @@
-error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:16:5
+error: the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:16:7
    |
 LL |     #[proc_macro_derive(Test)] fn f() { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^
 
 error: the `proc_macro_derive` attribute cannot be used on modules
   --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:5:3

--- a/tests/ui/lint/lint-unsafe-code.rs
+++ b/tests/ui/lint/lint-unsafe-code.rs
@@ -25,18 +25,18 @@ mod allowed_unsafe {
 
 macro_rules! unsafe_in_macro {
     () => {{
-        #[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `#[no_mangle]` attribute
-        #[no_mangle] static FOO: u32 = 5; //~ ERROR: usage of the unsafe `#[no_mangle]` attribute
+        #[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `no_mangle` attribute
+        #[no_mangle] static FOO: u32 = 5; //~ ERROR: usage of the unsafe `no_mangle` attribute
         #[export_name = "bar"] fn bar() {}
-        //~^ ERROR: usage of the unsafe `#[export_name]` attribute
+        //~^ ERROR: usage of the unsafe `export_name` attribute
         #[export_name = "BAR"] static BAR: u32 = 5;
-        //~^ ERROR: usage of the unsafe `#[export_name]` attribute
+        //~^ ERROR: usage of the unsafe `export_name` attribute
         unsafe {} //~ ERROR: usage of an `unsafe` block
     }}
 }
 
-#[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `#[no_mangle]` attribute
-#[no_mangle] static FOO: u32 = 5; //~ ERROR: usage of the unsafe `#[no_mangle]` attribute
+#[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `no_mangle` attribute
+#[no_mangle] static FOO: u32 = 5; //~ ERROR: usage of the unsafe `no_mangle` attribute
 
 trait AssocFnTrait {
     fn foo();
@@ -45,27 +45,27 @@ trait AssocFnTrait {
 struct AssocFnFoo;
 
 impl AssocFnFoo {
-    #[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `#[no_mangle]` attribute
+    #[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `no_mangle` attribute
 }
 
 impl AssocFnTrait for AssocFnFoo {
-    #[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `#[no_mangle]` attribute
+    #[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `no_mangle` attribute
 }
 
-#[export_name = "bar"] fn bar() {} //~ ERROR: usage of the unsafe `#[export_name]` attribute
-#[export_name = "BAR"] static BAR: u32 = 5; //~ ERROR: usage of the unsafe `#[export_name]` attribute
+#[export_name = "bar"] fn bar() {} //~ ERROR: usage of the unsafe `export_name` attribute
+#[export_name = "BAR"] static BAR: u32 = 5; //~ ERROR: usage of the unsafe `export_name` attribute
 
-#[link_section = "__TEXT,__text"] fn uwu() {} //~ ERROR: usage of the unsafe `#[link_section]` attribute
-#[link_section = "__TEXT,__text"] static UWU: u32 = 5; //~ ERROR: usage of the unsafe `#[link_section]` attribute
+#[link_section = "__TEXT,__text"] fn uwu() {} //~ ERROR: usage of the unsafe `link_section` attribute
+#[link_section = "__TEXT,__text"] static UWU: u32 = 5; //~ ERROR: usage of the unsafe `link_section` attribute
 
 struct AssocFnBar;
 
 impl AssocFnBar {
-    #[export_name = "bar"] fn bar() {} //~ ERROR: usage of the unsafe `#[export_name]` attribute
+    #[export_name = "bar"] fn bar() {} //~ ERROR: usage of the unsafe `export_name` attribute
 }
 
 impl AssocFnTrait for AssocFnBar {
-    #[export_name = "bar"] fn foo() {} //~ ERROR: usage of the unsafe `#[export_name]` attribute
+    #[export_name = "bar"] fn foo() {} //~ ERROR: usage of the unsafe `export_name` attribute
 }
 
 unsafe fn baz() {} //~ ERROR: declaration of an `unsafe` function
@@ -137,48 +137,48 @@ fn main() {
 }
 
 #[unsafe(naked)] fn naked1() { naked_asm!("halt") }
-//~^ ERROR usage of the unsafe `#[naked]` attribute
+//~^ ERROR usage of the unsafe `naked` attribute
 
 struct Naked;
 impl Naked {
     #[unsafe(naked)] fn naked2() { naked_asm!("halt") }
-    //~^ ERROR usage of the unsafe `#[naked]` attribute
+    //~^ ERROR usage of the unsafe `naked` attribute
 }
 
 trait NakedTrait {
     #[unsafe(naked)] fn naked3() { naked_asm!("halt") }
-    //~^ ERROR usage of the unsafe `#[naked]` attribute
+    //~^ ERROR usage of the unsafe `naked` attribute
     fn naked4();
 }
 impl NakedTrait for Naked {
     #[unsafe(naked)] fn naked4() { naked_asm!("halt") }
-    //~^ ERROR usage of the unsafe `#[naked]` attribute
+    //~^ ERROR usage of the unsafe `naked` attribute
 }
 
 extern "C" {
     #[unsafe(ffi_pure)]
-    //~^ ERROR usage of the unsafe `#[ffi_pure]` attribute
+    //~^ ERROR usage of the unsafe `ffi_pure` attribute
     fn ffi_pure();
 
     #[unsafe(ffi_const)]
-    //~^ ERROR usage of the unsafe `#[ffi_const]` attribute
+    //~^ ERROR usage of the unsafe `ffi_const` attribute
     fn ffi_const();
 }
 
 #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-//~^ ERROR usage of the unsafe `#[force_target_feature]` attribute
+//~^ ERROR usage of the unsafe `force_target_feature` attribute
 
 struct ForceTargetFeature;
 impl ForceTargetFeature {
     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-    //~^ ERROR usage of the unsafe `#[force_target_feature]` attribute
+    //~^ ERROR usage of the unsafe `force_target_feature` attribute
 }
 
 trait ForceTargetFeatureTrait {
     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-    //~^ ERROR usage of the unsafe `#[force_target_feature]` attribute
+    //~^ ERROR usage of the unsafe `force_target_feature` attribute
 }
 impl ForceTargetFeatureTrait for ForceTargetFeature {
     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-    //~^ ERROR usage of the unsafe `#[force_target_feature]` attribute
+    //~^ ERROR usage of the unsafe `force_target_feature` attribute
 }

--- a/tests/ui/lint/lint-unsafe-code.stderr
+++ b/tests/ui/lint/lint-unsafe-code.stderr
@@ -93,7 +93,7 @@ LL |     unsafe_in_macro!()
    |
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: usage of the unsafe `#[no_mangle]` attribute
+error: usage of the unsafe `no_mangle` attribute
   --> $DIR/lint-unsafe-code.rs:38:3
    |
 LL | #[no_mangle] fn foo() {}
@@ -101,7 +101,7 @@ LL | #[no_mangle] fn foo() {}
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[no_mangle]` attribute
+error: usage of the unsafe `no_mangle` attribute
   --> $DIR/lint-unsafe-code.rs:39:3
    |
 LL | #[no_mangle] static FOO: u32 = 5;
@@ -109,7 +109,7 @@ LL | #[no_mangle] static FOO: u32 = 5;
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[export_name]` attribute
+error: usage of the unsafe `export_name` attribute
   --> $DIR/lint-unsafe-code.rs:55:3
    |
 LL | #[export_name = "bar"] fn bar() {}
@@ -117,7 +117,7 @@ LL | #[export_name = "bar"] fn bar() {}
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[export_name]` attribute
+error: usage of the unsafe `export_name` attribute
   --> $DIR/lint-unsafe-code.rs:56:3
    |
 LL | #[export_name = "BAR"] static BAR: u32 = 5;
@@ -125,7 +125,7 @@ LL | #[export_name = "BAR"] static BAR: u32 = 5;
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[link_section]` attribute
+error: usage of the unsafe `link_section` attribute
   --> $DIR/lint-unsafe-code.rs:58:3
    |
 LL | #[link_section = "__TEXT,__text"] fn uwu() {}
@@ -133,7 +133,7 @@ LL | #[link_section = "__TEXT,__text"] fn uwu() {}
    |
    = note: the program's behavior with overridden link sections on items is unpredictable and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[link_section]` attribute
+error: usage of the unsafe `link_section` attribute
   --> $DIR/lint-unsafe-code.rs:59:3
    |
 LL | #[link_section = "__TEXT,__text"] static UWU: u32 = 5;
@@ -141,7 +141,7 @@ LL | #[link_section = "__TEXT,__text"] static UWU: u32 = 5;
    |
    = note: the program's behavior with overridden link sections on items is unpredictable and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[no_mangle]` attribute
+error: usage of the unsafe `no_mangle` attribute
   --> $DIR/lint-unsafe-code.rs:28:11
    |
 LL |         #[no_mangle] fn foo() {}
@@ -153,7 +153,7 @@ LL |     unsafe_in_macro!()
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: usage of the unsafe `#[no_mangle]` attribute
+error: usage of the unsafe `no_mangle` attribute
   --> $DIR/lint-unsafe-code.rs:29:11
    |
 LL |         #[no_mangle] static FOO: u32 = 5;
@@ -165,7 +165,7 @@ LL |     unsafe_in_macro!()
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: usage of the unsafe `#[export_name]` attribute
+error: usage of the unsafe `export_name` attribute
   --> $DIR/lint-unsafe-code.rs:30:11
    |
 LL |         #[export_name = "bar"] fn bar() {}
@@ -177,7 +177,7 @@ LL |     unsafe_in_macro!()
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: usage of the unsafe `#[export_name]` attribute
+error: usage of the unsafe `export_name` attribute
   --> $DIR/lint-unsafe-code.rs:32:11
    |
 LL |         #[export_name = "BAR"] static BAR: u32 = 5;
@@ -189,7 +189,7 @@ LL |     unsafe_in_macro!()
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: usage of the unsafe `#[naked]` attribute
+error: usage of the unsafe `naked` attribute
   --> $DIR/lint-unsafe-code.rs:139:3
    |
 LL | #[unsafe(naked)] fn naked1() { naked_asm!("halt") }
@@ -197,7 +197,7 @@ LL | #[unsafe(naked)] fn naked1() { naked_asm!("halt") }
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
 
-error: usage of the unsafe `#[force_target_feature]` attribute
+error: usage of the unsafe `force_target_feature` attribute
   --> $DIR/lint-unsafe-code.rs:168:3
    |
 LL | #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
@@ -205,7 +205,7 @@ LL | #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() 
    |
    = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
-error: usage of the unsafe `#[naked]` attribute
+error: usage of the unsafe `naked` attribute
   --> $DIR/lint-unsafe-code.rs:149:7
    |
 LL |     #[unsafe(naked)] fn naked3() { naked_asm!("halt") }
@@ -213,7 +213,7 @@ LL |     #[unsafe(naked)] fn naked3() { naked_asm!("halt") }
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
 
-error: usage of the unsafe `#[force_target_feature]` attribute
+error: usage of the unsafe `force_target_feature` attribute
   --> $DIR/lint-unsafe-code.rs:178:7
    |
 LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
@@ -221,7 +221,7 @@ LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_featur
    |
    = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
-error: usage of the unsafe `#[no_mangle]` attribute
+error: usage of the unsafe `no_mangle` attribute
   --> $DIR/lint-unsafe-code.rs:48:7
    |
 LL |     #[no_mangle] fn foo() {}
@@ -229,7 +229,7 @@ LL |     #[no_mangle] fn foo() {}
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[no_mangle]` attribute
+error: usage of the unsafe `no_mangle` attribute
   --> $DIR/lint-unsafe-code.rs:52:7
    |
 LL |     #[no_mangle] fn foo() {}
@@ -237,7 +237,7 @@ LL |     #[no_mangle] fn foo() {}
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[export_name]` attribute
+error: usage of the unsafe `export_name` attribute
   --> $DIR/lint-unsafe-code.rs:64:7
    |
 LL |     #[export_name = "bar"] fn bar() {}
@@ -245,7 +245,7 @@ LL |     #[export_name = "bar"] fn bar() {}
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[export_name]` attribute
+error: usage of the unsafe `export_name` attribute
   --> $DIR/lint-unsafe-code.rs:68:7
    |
 LL |     #[export_name = "bar"] fn foo() {}
@@ -253,7 +253,7 @@ LL |     #[export_name = "bar"] fn foo() {}
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[naked]` attribute
+error: usage of the unsafe `naked` attribute
   --> $DIR/lint-unsafe-code.rs:144:7
    |
 LL |     #[unsafe(naked)] fn naked2() { naked_asm!("halt") }
@@ -261,7 +261,7 @@ LL |     #[unsafe(naked)] fn naked2() { naked_asm!("halt") }
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
 
-error: usage of the unsafe `#[naked]` attribute
+error: usage of the unsafe `naked` attribute
   --> $DIR/lint-unsafe-code.rs:154:7
    |
 LL |     #[unsafe(naked)] fn naked4() { naked_asm!("halt") }
@@ -269,7 +269,7 @@ LL |     #[unsafe(naked)] fn naked4() { naked_asm!("halt") }
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
 
-error: usage of the unsafe `#[force_target_feature]` attribute
+error: usage of the unsafe `force_target_feature` attribute
   --> $DIR/lint-unsafe-code.rs:173:7
    |
 LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
@@ -277,7 +277,7 @@ LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_featur
    |
    = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
-error: usage of the unsafe `#[force_target_feature]` attribute
+error: usage of the unsafe `force_target_feature` attribute
   --> $DIR/lint-unsafe-code.rs:182:7
    |
 LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
@@ -285,7 +285,7 @@ LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_featur
    |
    = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
-error: usage of the unsafe `#[ffi_pure]` attribute
+error: usage of the unsafe `ffi_pure` attribute
   --> $DIR/lint-unsafe-code.rs:159:7
    |
 LL |     #[unsafe(ffi_pure)]
@@ -293,7 +293,7 @@ LL |     #[unsafe(ffi_pure)]
    |
    = note: `#[ffi_pure]` functions shall have no effects except for its return value, which shall not change across two consecutive function calls with the same parameters.
 
-error: usage of the unsafe `#[ffi_const]` attribute
+error: usage of the unsafe `ffi_const` attribute
   --> $DIR/lint-unsafe-code.rs:163:7
    |
 LL |     #[unsafe(ffi_const)]

--- a/tests/ui/macros/issue-111749.rs
+++ b/tests/ui/macros/issue-111749.rs
@@ -6,7 +6,7 @@ macro_rules! cbor_map {
 
 fn main() {
     cbor_map! { #[test(test)] 4i32};
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     //~| ERROR attribute must be of the form `#[test]`
     //~| WARNING this was previously accepted by the compiler but is being phased out
 }

--- a/tests/ui/macros/issue-111749.stderr
+++ b/tests/ui/macros/issue-111749.stderr
@@ -1,8 +1,8 @@
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/issue-111749.rs:8:17
    |
 LL |     cbor_map! { #[test(test)] 4i32};
-   |                 ^^^^^^^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |                 ^^^^^^^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
    |
 help: replace with conditional compilation to make the item only exist when tests are being run
    |

--- a/tests/ui/macros/test-on-crate-root.rs
+++ b/tests/ui/macros/test-on-crate-root.rs
@@ -4,7 +4,7 @@
 // when referring to the attribute with full path specifically.
 #![core::prelude::v1::test]
 //~^ ERROR inner macro attributes are unstable
-//~| ERROR the `#[test]` attribute may only be used on a free function
+//~| ERROR the `test` attribute may only be used on a free function
 
 
 fn main() {}

--- a/tests/ui/macros/test-on-crate-root.stderr
+++ b/tests/ui/macros/test-on-crate-root.stderr
@@ -8,11 +8,11 @@ LL | #![core::prelude::v1::test]
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-crate-root.rs:5:1
    |
 LL | #![core::prelude::v1::test]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
    |
 help: replace with conditional compilation to make the item only exist when tests are being run
    |

--- a/tests/ui/proc-macro/illegal-proc-macro-derive-use.stderr
+++ b/tests/ui/proc-macro/illegal-proc-macro-derive-use.stderr
@@ -1,8 +1,8 @@
-error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/illegal-proc-macro-derive-use.rs:3:1
+error: the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/illegal-proc-macro-derive-use.rs:3:3
    |
 LL | #[proc_macro_derive(Foo)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
 
 error: the `proc_macro_derive` attribute cannot be used on structs
   --> $DIR/illegal-proc-macro-derive-use.rs:10:3

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-missing.stderr
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-missing.stderr
@@ -1,8 +1,8 @@
 error: feature `const_bar` implying `const_foobar` does not exist
-  --> $DIR/const-stability-attribute-implies-missing.rs:10:1
+  --> $DIR/const-stability-attribute-implies-missing.rs:10:3
    |
 LL | #[rustc_const_unstable(feature = "const_foobar", issue = "1", implied_by = "const_bar")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/test-attrs/issue-109816.rs
+++ b/tests/ui/test-attrs/issue-109816.rs
@@ -3,6 +3,6 @@
 
 fn align_offset_weird_strides() {
     #[test]
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     struct A5(u32, u8);
 }

--- a/tests/ui/test-attrs/issue-109816.stderr
+++ b/tests/ui/test-attrs/issue-109816.stderr
@@ -1,8 +1,8 @@
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/issue-109816.rs:5:5
    |
 LL |     #[test]
-   |     ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     struct A5(u32, u8);
    |     ------------------- expected a non-associated function, found a struct

--- a/tests/ui/test-attrs/test-attr-non-associated-functions.rs
+++ b/tests/ui/test-attrs/test-attr-non-associated-functions.rs
@@ -5,12 +5,12 @@ struct A {}
 
 impl A {
     #[test]
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     fn new() -> A {
         A {}
     }
     #[test]
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     fn recovery_witness() -> A {
         A {}
     }

--- a/tests/ui/test-attrs/test-attr-non-associated-functions.stderr
+++ b/tests/ui/test-attrs/test-attr-non-associated-functions.stderr
@@ -1,8 +1,8 @@
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-attr-non-associated-functions.rs:7:5
    |
 LL |     #[test]
-   |     ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
    |
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
@@ -10,11 +10,11 @@ LL -     #[test]
 LL +     #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-attr-non-associated-functions.rs:12:5
    |
 LL |     #[test]
-   |     ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
    |
 help: replace with conditional compilation to make the item only exist when tests are being run
    |

--- a/tests/ui/test-attrs/test-on-not-fn.rs
+++ b/tests/ui/test-attrs/test-on-not-fn.rs
@@ -1,10 +1,10 @@
 //@ compile-flags: --test
 //@ reference: attributes.testing.test.allowed-positions
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 mod test {}
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 mod loooooooooooooong_teeeeeeeeeest {
     /*
     this is a comment
@@ -18,37 +18,37 @@ mod loooooooooooooong_teeeeeeeeeest {
     */
 }
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 extern "C" {}
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 trait Foo {}
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 impl Foo for i32 {}
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 const FOO: i32 = -1_i32;
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 static BAR: u64 = 10_000_u64;
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 enum MyUnit {
     Unit,
 }
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 struct NewI32(i32);
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 union Spooky {
     x: i32,
     y: u32,
 }
 
 #[repr(C, align(64))]
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 #[derive(Copy, Clone, Debug)]
 struct MoreAttrs {
     a: i32,
@@ -59,7 +59,7 @@ macro_rules! foo {
     () => {};
 }
 
-#[test] //~ WARN: the `#[test]` attribute may only be used on a free function
+#[test] //~ WARN: the `test` attribute may only be used on a free function
 foo!();
 
 // make sure it doesn't erroneously trigger on a real test

--- a/tests/ui/test-attrs/test-on-not-fn.stderr
+++ b/tests/ui/test-attrs/test-on-not-fn.stderr
@@ -1,8 +1,8 @@
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:4:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | mod test {}
    | ----------- expected a non-associated function, found a module
    |
@@ -12,11 +12,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:7:1
    |
 LL |   #[test]
-   |   ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |   ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | / mod loooooooooooooong_teeeeeeeeeest {
 LL | |     /*
 LL | |     this is a comment
@@ -32,11 +32,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:21:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | extern "C" {}
    | ------------- expected a non-associated function, found an extern block
    |
@@ -46,11 +46,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:24:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | trait Foo {}
    | ------------ expected a non-associated function, found a trait
    |
@@ -60,11 +60,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:27:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | impl Foo for i32 {}
    | ------------------- expected a non-associated function, found an implementation
    |
@@ -74,11 +74,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:30:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | const FOO: i32 = -1_i32;
    | ------------------------ expected a non-associated function, found a constant item
    |
@@ -88,11 +88,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:33:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | static BAR: u64 = 10_000_u64;
    | ----------------------------- expected a non-associated function, found a static item
    |
@@ -102,11 +102,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:36:1
    |
 LL |   #[test]
-   |   ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |   ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | / enum MyUnit {
 LL | |     Unit,
 LL | | }
@@ -118,11 +118,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:41:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | struct NewI32(i32);
    | ------------------- expected a non-associated function, found a struct
    |
@@ -132,11 +132,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:44:1
    |
 LL |   #[test]
-   |   ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |   ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | / union Spooky {
 LL | |     x: i32,
 LL | |     y: u32,
@@ -149,11 +149,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:51:1
    |
 LL |   #[test]
-   |   ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |   ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL |   #[derive(Copy, Clone, Debug)]
 LL | / struct MoreAttrs {
 LL | |     a: i32,
@@ -167,11 +167,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-warning: the `#[test]` attribute may only be used on a free function
+warning: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:62:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | foo!();
    | ------- expected a non-associated function, found an item macro invocation
    |


### PR DESCRIPTION
A sequel to rust-lang/rust#159755.

r? @estebank 