### PR TITLE
Use assert_eq! in splat codegen tests

### DIFF
--- a/tests/ui/splat/run-splat.rs
+++ b/tests/ui/splat/run-splat.rs
@@ -1,6 +1,5 @@
 //! Check that splat codegen works for simple cases.
 //@ run-pass
-//@ check-run-results
 #![feature(splat, tuple_trait)]
 #![expect(incomplete_features)]
 
@@ -9,29 +8,29 @@ use std::marker::Tuple;
 struct Foo;
 
 trait MethodArgs: Tuple {
-    fn call_method(self, this: &Foo);
+    fn call_method(self, this: &Foo) -> String;
 }
 
 impl Foo {
-    fn method(&self, #[splat] args: impl MethodArgs) {
+    fn method(&self, #[splat] args: impl MethodArgs) -> String {
         args.call_method(self)
     }
 }
 
 impl MethodArgs for (i32, String) {
-    fn call_method(self, _this: &Foo) {
-        dbg!(self.1, self.0);
+    fn call_method(self, _this: &Foo) -> String {
+        format!("{}-{}", self.0, self.1)
     }
 }
 
 impl MethodArgs for (f64,) {
-    fn call_method(self, _this: &Foo) {
-        dbg!(self.0);
+    fn call_method(self, _this: &Foo) -> String {
+        format!("{}", self.0)
     }
 }
 
 fn main() {
     let foo = Foo;
-    foo.method(42, "hello splat".to_string());
-    foo.method(3.141);
+    assert_eq!(foo.method(42, "hello splat".to_string()), "42-hello splat");
+    assert_eq!(foo.method(3.1), "3.1");
 }

--- a/tests/ui/splat/run-splat.run.stderr
+++ b/tests/ui/splat/run-splat.run.stderr
@@ -1,3 +1,0 @@
-[$DIR/run-splat.rs:23:9] self.1 = "hello splat"
-[$DIR/run-splat.rs:23:9] self.0 = 42
-[$DIR/run-splat.rs:29:9] self.0 = 3.141

--- a/tests/ui/splat/splat-assoc-fn-tuple-simple.rs
+++ b/tests/ui/splat/splat-assoc-fn-tuple-simple.rs
@@ -13,10 +13,6 @@ impl Foo {
 }
 
 fn main() {
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-    // Add a tupled test for each call if they are.
-    //Foo::tuple_1((1u32,));
-
     Foo::tuple_1(1u32);
     Foo::tuple_3(1u32, 2i32, 3i8);
 }

--- a/tests/ui/splat/splat-fn-tuple-generic-fail.rs
+++ b/tests/ui/splat/splat-fn-tuple-generic-fail.rs
@@ -11,15 +11,11 @@ fn splat_generic_tuple<T: Tuple>(#[splat] _t: T) {}
 fn f<Args: Tuple>(#[splat] args: Args) {}
 
 fn main() {
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-
     // Calling with un-splatted arguments might look like it works, but the actual generic type is
     // a tuple inside another tuple. Aren't generics great?
     splat_generic_tuple((1, 2));
     splat_generic_tuple((1u32, 2i8));
 
-    // FIXME(splat): Make the splat generic handling code handle tuples inside tuples
-    // (if we want to support tupled calls)
     splat_generic_tuple::<(((u32, i8)))>((1, 2)); //~ ERROR this splatted function takes 2 arguments, but 1 was provided
     splat_generic_tuple::<(((u32, i8)))>((1u32, 2i8)); //~ ERROR this splatted function takes 2 arguments, but 1 was provided
 

--- a/tests/ui/splat/splat-fn-tuple-generic-fail.stderr
+++ b/tests/ui/splat/splat-fn-tuple-generic-fail.stderr
@@ -1,41 +1,41 @@
 error[E0057]: this splatted function takes 2 arguments, but 1 was provided
-  --> $DIR/splat-fn-tuple-generic-fail.rs:23:5
+  --> $DIR/splat-fn-tuple-generic-fail.rs:19:5
    |
 LL |     splat_generic_tuple::<(((u32, i8)))>((1, 2));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0057]: this splatted function takes 2 arguments, but 1 was provided
-  --> $DIR/splat-fn-tuple-generic-fail.rs:24:5
+  --> $DIR/splat-fn-tuple-generic-fail.rs:20:5
    |
 LL |     splat_generic_tuple::<(((u32, i8)))>((1u32, 2i8));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0057]: this splatted function takes 2 arguments, but 1 was provided
-  --> $DIR/splat-fn-tuple-generic-fail.rs:26:5
+  --> $DIR/splat-fn-tuple-generic-fail.rs:22:5
    |
 LL |     splat_generic_tuple::<((u32, i8))>((1, 2));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0057]: this splatted function takes 2 arguments, but 1 was provided
-  --> $DIR/splat-fn-tuple-generic-fail.rs:27:5
+  --> $DIR/splat-fn-tuple-generic-fail.rs:23:5
    |
 LL |     splat_generic_tuple::<((u32, i8))>((1u32, 2i8));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0057]: this splatted function takes 2 arguments, but 1 was provided
-  --> $DIR/splat-fn-tuple-generic-fail.rs:29:5
+  --> $DIR/splat-fn-tuple-generic-fail.rs:25:5
    |
 LL |     splat_generic_tuple::<(u32, i8)>((1, 2));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0057]: this splatted function takes 2 arguments, but 1 was provided
-  --> $DIR/splat-fn-tuple-generic-fail.rs:30:5
+  --> $DIR/splat-fn-tuple-generic-fail.rs:26:5
    |
 LL |     splat_generic_tuple::<(u32, i8)>((1u32, 2i8));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/splat-fn-tuple-generic-fail.rs:32:31
+  --> $DIR/splat-fn-tuple-generic-fail.rs:28:31
    |
 LL |     const F1: fn((u8, u32)) = f::<(u8, u32)>;
    |               -------------   ^^^^^^^^^^^^^^ expected fn with no splatted arg, found fn with arg 0 splatted

--- a/tests/ui/splat/splat-fn-tuple-simple.rs
+++ b/tests/ui/splat/splat-fn-tuple-simple.rs
@@ -10,11 +10,6 @@ fn splat_non_terminal_arg(#[splat] (_a, _b): (u32, i8), _c: f64) {}
 
 fn main() {
     tuple_args(1, 2);
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-    // Add a tupled test for each call if they are.
-    //tuple_args((1, 2));
-
-    tuple_args(1, 2);
     tuple_args(1u32, 2i8);
 
     splat_non_terminal_arg(1, 2, 3.5);

--- a/tests/ui/splat/splat-generics-everywhere.rs
+++ b/tests/ui/splat/splat-generics-everywhere.rs
@@ -54,10 +54,6 @@ impl<T> BarTrait<T> for Foo<T> {
 }
 
 fn main() {
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-    // Add a tupled test for each call if they are.
-    //Foo::<i64>::assoc(("u",));
-
     Foo::<f32>::assoc("u");
     Foo::<f32>::trait_assoc("w");
 

--- a/tests/ui/splat/splat-method-tuple-simple.rs
+++ b/tests/ui/splat/splat-method-tuple-simple.rs
@@ -27,11 +27,6 @@ impl TupleStruct {
 
 fn main() {
     let foo = Foo;
-
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-    // Add a tupled test for each call if they are.
-    //foo.tuple_2((1, 2));
-
     foo.tuple_2(1u32, 2i8);
     foo.tuple_4(1u32, 2i8, (), 3f32);
 

--- a/tests/ui/splat/splat-overload-at-home.rs
+++ b/tests/ui/splat/splat-overload-at-home.rs
@@ -30,12 +30,6 @@ impl Foo {
 
 fn main() {
     let foo = Foo;
-
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-    // Add a tupled test for each call if they are.
-    //foo.method(());
-    //foo.method((42i32,));
-
     // Generic tuple trait implementers work without explicit tuple type parameters.
     foo.method::<()>();
     foo.method();

--- a/tests/ui/splat/splat-trait-tuple.rs
+++ b/tests/ui/splat/splat-trait-tuple.rs
@@ -30,12 +30,6 @@ impl FooTrait for TupleStruct {
 
 fn main() {
     let foo = Foo;
-
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-    // Add a tupled test for each call if they are.
-    //Foo::tuple_1_trait((1u32,));
-    //foo.tuple_2_trait((1, 3.5));
-
     Foo::tuple_1_trait(1u32);
     foo.tuple_2_trait(1, 3.5);
 


### PR DESCRIPTION
Tracking issue: rust-lang/rust#153629

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR does some cleanups in the splat UI tests from folkert's PR rust-lang/rust#159643 review:
- move rustfmt::skip to main() and deduplicate it: https://github.com/rust-lang/rust/pull/159643#discussion_r3650148585
- use assert_eq!() to test codegen rather than println!(): https://github.com/rust-lang/rust/pull/159643#discussion_r3650150884
- delete resolved FIXME comments about supporting tupled and de-tupled calls to splatted functions

r? @folkertdev

@rustbot label +F-splat +C-cleanup