### PR TITLE
Fix a splat legacy demangling display bug

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1513,8 +1513,18 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         let splatted_arg_index = splatted.map(usize::from);
         let mut input_iter = inputs.iter().copied();
         if let Some(index) = splatted_arg_index {
-            self.comma_sep((&mut input_iter).take(usize::from(index)))?;
-            write!(self, ", #[rustc_splat]")?;
+            self.comma_sep((&mut input_iter).take(index))?;
+            // Splitting the comma-separated list can miss a comma, but we only need that comma if
+            // there are arguments before the splat.
+            // FIXME(splat): if splatting becomes part of the type, we can remove this hack
+            if index > 0 {
+                if self.comma_sep_has_space() {
+                    write!(self, ", ")?;
+                } else {
+                    write!(self, ",")?;
+                }
+            }
+            write!(self, "#[rustc_splat] ")?;
             self.comma_sep(input_iter)?;
         } else {
             self.comma_sep(input_iter)?;

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -289,7 +289,8 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         f(value.as_ref().skip_binder(), self)
     }
 
-    /// Prints comma-separated elements.
+    /// Prints comma-separated elements. If `comma_sep_has_space` is `true`, there is a space after
+    /// each comma.
     fn comma_sep<T>(&mut self, mut elems: impl Iterator<Item = T>) -> Result<(), PrintError>
     where
         T: Print<Self>,
@@ -297,11 +298,19 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         if let Some(first) = elems.next() {
             first.print(self)?;
             for elem in elems {
-                self.write_str(", ")?;
+                if self.comma_sep_has_space() {
+                    self.write_str(", ")?;
+                } else {
+                    self.write_str(",")?;
+                }
                 elem.print(self)?;
             }
         }
         Ok(())
+    }
+
+    fn comma_sep_has_space(&self) -> bool {
+        true
     }
 
     /// Prints `{f: t}` or `{f as t}` depending on the `cast` argument
@@ -1512,6 +1521,8 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         }
         if c_variadic {
             if !inputs.is_empty() {
+                // In legacy mangling, most comma-separated lists have no spaces. But here we print
+                // a space before the `...` for readability.
                 write!(self, ", ")?;
             }
             write!(self, "...")?;
@@ -1968,6 +1979,8 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                             let mut first = true;
                             for (field_def, field) in iter::zip(&variant_def.fields, fields) {
                                 if !first {
+                                    // FIXME(legacy mangling): if this appears, should we enable
+                                    // spaces depending on `comma_sep_has_space`?
                                     write!(self, ", ")?;
                                 }
                                 write!(self, "{}: ", field_def.name)?;

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -289,7 +289,8 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         f(value.as_ref().skip_binder(), self)
     }
 
-    /// Prints comma-separated elements.
+    /// Prints comma-separated elements. If `comma_sep_has_space` is `true`, there is a space after
+    /// each comma.
     fn comma_sep<T>(&mut self, mut elems: impl Iterator<Item = T>) -> Result<(), PrintError>
     where
         T: Print<Self>,
@@ -297,11 +298,19 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         if let Some(first) = elems.next() {
             first.print(self)?;
             for elem in elems {
-                self.write_str(", ")?;
+                if self.comma_sep_has_space() {
+                    self.write_str(", ")?;
+                } else {
+                    self.write_str(",")?;
+                }
                 elem.print(self)?;
             }
         }
         Ok(())
+    }
+
+    fn comma_sep_has_space(&self) -> bool {
+        true
     }
 
     /// Prints `{f: t}` or `{f as t}` depending on the `cast` argument
@@ -1512,6 +1521,8 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         }
         if c_variadic {
             if !inputs.is_empty() {
+                // In legacy mangling, most comma-separated lists have no spaces. But here we print
+                // a space before the `...` for readability.
                 write!(self, ", ")?;
             }
             write!(self, "...")?;
@@ -1967,6 +1978,8 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                             let mut first = true;
                             for (field_def, field) in iter::zip(&variant_def.fields, fields) {
                                 if !first {
+                                    // FIXME(legacy mangling): if this appears, should we enable
+                                    // spaces depending on `comma_sep_has_space`?
                                     write!(self, ", ")?;
                                 }
                                 write!(self, "{}: ", field_def.name)?;

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -487,19 +487,9 @@ impl<'tcx> PrettyPrinter<'tcx> for LegacySymbolMangler<'tcx> {
         false
     }
 
-    // Identical to `PrettyPrinter::comma_sep` except there is no space after each comma.
-    fn comma_sep<T>(&mut self, mut elems: impl Iterator<Item = T>) -> Result<(), PrintError>
-    where
-        T: Print<Self>,
-    {
-        if let Some(first) = elems.next() {
-            first.print(self)?;
-            for elem in elems {
-                self.write_str(",")?;
-                elem.print(self)?;
-            }
-        }
-        Ok(())
+    // In symbol mangling, there is no space after the commas in a comma-separated list.
+    fn comma_sep_has_space(&self) -> bool {
+        false
     }
 
     fn generic_delimiters(

--- a/tests/ui/splat/splat-fn-ptr-cast-fail.stderr
+++ b/tests/ui/splat/splat-fn-ptr-cast-fail.stderr
@@ -20,13 +20,13 @@ LL |     let _fn_ptr: fn((u32, i8), f64) = splat_non_terminal_arg;
    = note: expected fn pointer `fn((_, _), _)`
                  found fn item `fn(#[rustc_splat] (_, _), _) {splat_non_terminal_arg}`
 
-error[E0605]: non-primitive cast: `fn(, #[rustc_splat](u32, i8)) {tuple_args}` as `fn((u32, i8))`
+error[E0605]: non-primitive cast: `fn(#[rustc_splat] (u32, i8)) {tuple_args}` as `fn((u32, i8))`
   --> $DIR/splat-fn-ptr-cast-fail.rs:19:34
    |
 LL |     let _fn_ptr: fn((u32, i8)) = tuple_args as fn((u32, i8));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid cast
 
-error[E0605]: non-primitive cast: `fn(, #[rustc_splat](u32, i8), f64) {splat_non_terminal_arg}` as `fn((u32, i8), f64)`
+error[E0605]: non-primitive cast: `fn(#[rustc_splat] (u32, i8), f64) {splat_non_terminal_arg}` as `fn((u32, i8), f64)`
   --> $DIR/splat-fn-ptr-cast-fail.rs:20:39
    |
 LL |     let _fn_ptr: fn((u32, i8), f64) = splat_non_terminal_arg as fn((u32, i8), f64);

--- a/tests/ui/splat/splat-mangling.default.stderr
+++ b/tests/ui/splat/splat-mangling.default.stderr
@@ -1,323 +1,323 @@
 error: symbol-name(_RMNvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwThmEEuE)
-  --> $DIR/splat-mangling.rs:23:5
+  --> $DIR/splat-mangling.rs:24:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u8, u32))>>)
-  --> $DIR/splat-mangling.rs:23:5
+  --> $DIR/splat-mangling.rs:24:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u8, u32))>>)
-  --> $DIR/splat-mangling.rs:23:5
+  --> $DIR/splat-mangling.rs:24:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFThmEEuE)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u8, u32))>>)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn((u8, u32))>>)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs0_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTThmEEEuE)
-  --> $DIR/splat-mangling.rs:41:5
+  --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] ((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:41:5
+  --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] ((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:41:5
+  --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs1_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTThmEEEuE)
-  --> $DIR/splat-mangling.rs:50:5
+  --> $DIR/splat-mangling.rs:51:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:50:5
+  --> $DIR/splat-mangling.rs:51:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:50:5
+  --> $DIR/splat-mangling.rs:51:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs2_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFwTmaEEuE)
-  --> $DIR/splat-mangling.rs:59:5
+  --> $DIR/splat-mangling.rs:60:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn(#[splat] (u32, i8))>>)
-  --> $DIR/splat-mangling.rs:59:5
+  --> $DIR/splat-mangling.rs:60:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*const fn(#[splat] (u32, i8))>>)
-  --> $DIR/splat-mangling.rs:59:5
+  --> $DIR/splat-mangling.rs:60:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs3_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFTmaEEuE)
-  --> $DIR/splat-mangling.rs:68:5
+  --> $DIR/splat-mangling.rs:69:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn((u32, i8))>>)
-  --> $DIR/splat-mangling.rs:68:5
+  --> $DIR/splat-mangling.rs:69:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*const fn((u32, i8))>>)
-  --> $DIR/splat-mangling.rs:68:5
+  --> $DIR/splat-mangling.rs:69:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs4_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTmaEdEuE)
-  --> $DIR/splat-mangling.rs:78:5
+  --> $DIR/splat-mangling.rs:79:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:78:5
+  --> $DIR/splat-mangling.rs:79:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:78:5
+  --> $DIR/splat-mangling.rs:79:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs5_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTmaEdEuE)
-  --> $DIR/splat-mangling.rs:87:5
+  --> $DIR/splat-mangling.rs:88:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:87:5
+  --> $DIR/splat-mangling.rs:88:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn((u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:87:5
+  --> $DIR/splat-mangling.rs:88:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs6_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmawTdEEuE)
-  --> $DIR/splat-mangling.rs:97:5
+  --> $DIR/splat-mangling.rs:98:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
-  --> $DIR/splat-mangling.rs:97:5
+  --> $DIR/splat-mangling.rs:98:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
-  --> $DIR/splat-mangling.rs:97:5
+  --> $DIR/splat-mangling.rs:98:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs7_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmaTdEEuE)
-  --> $DIR/splat-mangling.rs:106:5
+  --> $DIR/splat-mangling.rs:107:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*mut fn(u32, i8, (f64,))>>)
-  --> $DIR/splat-mangling.rs:106:5
+  --> $DIR/splat-mangling.rs:107:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, (f64,))>>)
-  --> $DIR/splat-mangling.rs:106:5
+  --> $DIR/splat-mangling.rs:107:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs8_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmwTafjEdEuE)
-  --> $DIR/splat-mangling.rs:116:5
+  --> $DIR/splat-mangling.rs:117:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:116:5
+  --> $DIR/splat-mangling.rs:117:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:116:5
+  --> $DIR/splat-mangling.rs:117:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs9_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmTafjEdEuE)
-  --> $DIR/splat-mangling.rs:125:5
+  --> $DIR/splat-mangling.rs:126:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:125:5
+  --> $DIR/splat-mangling.rs:126:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:125:5
+  --> $DIR/splat-mangling.rs:126:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsa_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmwudEuE)
-  --> $DIR/splat-mangling.rs:134:5
+  --> $DIR/splat-mangling.rs:135:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&mut fn(u32, #[splat] (), f64)>>)
-  --> $DIR/splat-mangling.rs:134:5
+  --> $DIR/splat-mangling.rs:135:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&mut fn(u32, #[splat] (), f64)>>)
-  --> $DIR/splat-mangling.rs:134:5
+  --> $DIR/splat-mangling.rs:135:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsb_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmudEuE)
-  --> $DIR/splat-mangling.rs:143:5
+  --> $DIR/splat-mangling.rs:144:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&mut fn(u32, (), f64)>>)
-  --> $DIR/splat-mangling.rs:143:5
+  --> $DIR/splat-mangling.rs:144:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&mut fn(u32, (), f64)>>)
-  --> $DIR/splat-mangling.rs:143:5
+  --> $DIR/splat-mangling.rs:144:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsc_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFwuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:153:5
+  --> $DIR/splat-mangling.rs:154:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:153:5
+  --> $DIR/splat-mangling.rs:154:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:153:5
+  --> $DIR/splat-mangling.rs:154:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsd_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFwuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:162:5
+  --> $DIR/splat-mangling.rs:163:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:162:5
+  --> $DIR/splat-mangling.rs:163:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:162:5
+  --> $DIR/splat-mangling.rs:163:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMse_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:171:5
+  --> $DIR/splat-mangling.rs:172:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:171:5
+  --> $DIR/splat-mangling.rs:172:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:171:5
+  --> $DIR/splat-mangling.rs:172:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsf_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:180:5
+  --> $DIR/splat-mangling.rs:181:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:180:5
+  --> $DIR/splat-mangling.rs:181:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:180:5
+  --> $DIR/splat-mangling.rs:181:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-mangling.default.stderr
+++ b/tests/ui/splat/splat-mangling.default.stderr
@@ -17,307 +17,307 @@ LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFThmEEuE)
-  --> $DIR/splat-mangling.rs:33:5
+  --> $DIR/splat-mangling.rs:32:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u8, u32))>>)
-  --> $DIR/splat-mangling.rs:33:5
+  --> $DIR/splat-mangling.rs:32:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn((u8, u32))>>)
-  --> $DIR/splat-mangling.rs:33:5
+  --> $DIR/splat-mangling.rs:32:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs0_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTThmEEEuE)
-  --> $DIR/splat-mangling.rs:43:5
+  --> $DIR/splat-mangling.rs:41:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] ((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:43:5
+  --> $DIR/splat-mangling.rs:41:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] ((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:43:5
+  --> $DIR/splat-mangling.rs:41:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs1_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTThmEEEuE)
-  --> $DIR/splat-mangling.rs:53:5
+  --> $DIR/splat-mangling.rs:50:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:53:5
+  --> $DIR/splat-mangling.rs:50:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:53:5
+  --> $DIR/splat-mangling.rs:50:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs2_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFwTmaEEuE)
-  --> $DIR/splat-mangling.rs:63:5
+  --> $DIR/splat-mangling.rs:59:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn(#[splat] (u32, i8))>>)
-  --> $DIR/splat-mangling.rs:63:5
+  --> $DIR/splat-mangling.rs:59:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*const fn(#[splat] (u32, i8))>>)
-  --> $DIR/splat-mangling.rs:63:5
+  --> $DIR/splat-mangling.rs:59:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs3_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFTmaEEuE)
-  --> $DIR/splat-mangling.rs:73:5
+  --> $DIR/splat-mangling.rs:68:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn((u32, i8))>>)
-  --> $DIR/splat-mangling.rs:73:5
+  --> $DIR/splat-mangling.rs:68:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*const fn((u32, i8))>>)
-  --> $DIR/splat-mangling.rs:73:5
+  --> $DIR/splat-mangling.rs:68:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs4_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTmaEdEuE)
-  --> $DIR/splat-mangling.rs:84:5
+  --> $DIR/splat-mangling.rs:78:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:84:5
+  --> $DIR/splat-mangling.rs:78:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:84:5
+  --> $DIR/splat-mangling.rs:78:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs5_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTmaEdEuE)
-  --> $DIR/splat-mangling.rs:94:5
+  --> $DIR/splat-mangling.rs:87:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:94:5
+  --> $DIR/splat-mangling.rs:87:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn((u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:94:5
+  --> $DIR/splat-mangling.rs:87:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs6_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmawTdEEuE)
-  --> $DIR/splat-mangling.rs:105:5
+  --> $DIR/splat-mangling.rs:97:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
-  --> $DIR/splat-mangling.rs:105:5
+  --> $DIR/splat-mangling.rs:97:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
-  --> $DIR/splat-mangling.rs:105:5
+  --> $DIR/splat-mangling.rs:97:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs7_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmaTdEEuE)
-  --> $DIR/splat-mangling.rs:115:5
+  --> $DIR/splat-mangling.rs:106:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*mut fn(u32, i8, (f64,))>>)
-  --> $DIR/splat-mangling.rs:115:5
+  --> $DIR/splat-mangling.rs:106:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, (f64,))>>)
-  --> $DIR/splat-mangling.rs:115:5
+  --> $DIR/splat-mangling.rs:106:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs8_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmwTafjEdEuE)
-  --> $DIR/splat-mangling.rs:126:5
+  --> $DIR/splat-mangling.rs:116:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:126:5
+  --> $DIR/splat-mangling.rs:116:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:126:5
+  --> $DIR/splat-mangling.rs:116:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs9_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmTafjEdEuE)
-  --> $DIR/splat-mangling.rs:136:5
+  --> $DIR/splat-mangling.rs:125:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:136:5
+  --> $DIR/splat-mangling.rs:125:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:136:5
+  --> $DIR/splat-mangling.rs:125:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsa_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmwudEuE)
-  --> $DIR/splat-mangling.rs:146:5
+  --> $DIR/splat-mangling.rs:134:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&mut fn(u32, #[splat] (), f64)>>)
-  --> $DIR/splat-mangling.rs:146:5
+  --> $DIR/splat-mangling.rs:134:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&mut fn(u32, #[splat] (), f64)>>)
-  --> $DIR/splat-mangling.rs:146:5
+  --> $DIR/splat-mangling.rs:134:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsb_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmudEuE)
-  --> $DIR/splat-mangling.rs:156:5
+  --> $DIR/splat-mangling.rs:143:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&mut fn(u32, (), f64)>>)
-  --> $DIR/splat-mangling.rs:156:5
+  --> $DIR/splat-mangling.rs:143:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&mut fn(u32, (), f64)>>)
-  --> $DIR/splat-mangling.rs:156:5
+  --> $DIR/splat-mangling.rs:143:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsc_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFwuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:167:5
+  --> $DIR/splat-mangling.rs:153:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:167:5
+  --> $DIR/splat-mangling.rs:153:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:167:5
+  --> $DIR/splat-mangling.rs:153:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsd_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFwuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:177:5
+  --> $DIR/splat-mangling.rs:162:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:177:5
+  --> $DIR/splat-mangling.rs:162:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:177:5
+  --> $DIR/splat-mangling.rs:162:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMse_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:187:5
+  --> $DIR/splat-mangling.rs:171:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:187:5
+  --> $DIR/splat-mangling.rs:171:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:187:5
+  --> $DIR/splat-mangling.rs:171:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsf_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:197:5
+  --> $DIR/splat-mangling.rs:180:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:197:5
+  --> $DIR/splat-mangling.rs:180:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:197:5
+  --> $DIR/splat-mangling.rs:180:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-mangling.default.stderr
+++ b/tests/ui/splat/splat-mangling.default.stderr
@@ -1,146 +1,326 @@
 error: symbol-name(_RMNvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwThmEEuE)
-  --> $DIR/splat-mangling.rs:22:5
+  --> $DIR/splat-mangling.rs:23:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u8, u32))>>)
-  --> $DIR/splat-mangling.rs:22:5
+  --> $DIR/splat-mangling.rs:23:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u8, u32))>>)
-  --> $DIR/splat-mangling.rs:22:5
+  --> $DIR/splat-mangling.rs:23:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFThmEEuE)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u8, u32))>>)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn((u8, u32))>>)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs0_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTThmEEEuE)
-  --> $DIR/splat-mangling.rs:42:5
+  --> $DIR/splat-mangling.rs:43:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] ((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:42:5
+  --> $DIR/splat-mangling.rs:43:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] ((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:42:5
+  --> $DIR/splat-mangling.rs:43:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs1_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTThmEEEuE)
-  --> $DIR/splat-mangling.rs:52:5
+  --> $DIR/splat-mangling.rs:53:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:52:5
+  --> $DIR/splat-mangling.rs:53:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:52:5
+  --> $DIR/splat-mangling.rs:53:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs2_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFwTmaEEuE)
-  --> $DIR/splat-mangling.rs:62:5
+  --> $DIR/splat-mangling.rs:63:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn(#[splat] (u32, i8))>>)
-  --> $DIR/splat-mangling.rs:62:5
+  --> $DIR/splat-mangling.rs:63:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*const fn(#[splat] (u32, i8))>>)
-  --> $DIR/splat-mangling.rs:62:5
+  --> $DIR/splat-mangling.rs:63:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs3_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFTmaEEuE)
-  --> $DIR/splat-mangling.rs:72:5
+  --> $DIR/splat-mangling.rs:73:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn((u32, i8))>>)
-  --> $DIR/splat-mangling.rs:72:5
+  --> $DIR/splat-mangling.rs:73:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*const fn((u32, i8))>>)
-  --> $DIR/splat-mangling.rs:72:5
+  --> $DIR/splat-mangling.rs:73:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs4_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTmaEdEuE)
-  --> $DIR/splat-mangling.rs:82:5
+  --> $DIR/splat-mangling.rs:84:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:82:5
+  --> $DIR/splat-mangling.rs:84:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:82:5
+  --> $DIR/splat-mangling.rs:84:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs5_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTmaEdEuE)
-  --> $DIR/splat-mangling.rs:92:5
+  --> $DIR/splat-mangling.rs:94:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:92:5
+  --> $DIR/splat-mangling.rs:94:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn((u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:92:5
+  --> $DIR/splat-mangling.rs:94:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 24 previous errors
+error: symbol-name(_RMs6_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmawTdEEuE)
+  --> $DIR/splat-mangling.rs:105:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
+  --> $DIR/splat-mangling.rs:105:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
+  --> $DIR/splat-mangling.rs:105:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs7_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmaTdEEuE)
+  --> $DIR/splat-mangling.rs:115:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*mut fn(u32, i8, (f64,))>>)
+  --> $DIR/splat-mangling.rs:115:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, (f64,))>>)
+  --> $DIR/splat-mangling.rs:115:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs8_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmwTafjEdEuE)
+  --> $DIR/splat-mangling.rs:126:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
+  --> $DIR/splat-mangling.rs:126:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
+  --> $DIR/splat-mangling.rs:126:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs9_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmTafjEdEuE)
+  --> $DIR/splat-mangling.rs:136:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
+  --> $DIR/splat-mangling.rs:136:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
+  --> $DIR/splat-mangling.rs:136:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMsa_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmwudEuE)
+  --> $DIR/splat-mangling.rs:146:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&mut fn(u32, #[splat] (), f64)>>)
+  --> $DIR/splat-mangling.rs:146:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<&mut fn(u32, #[splat] (), f64)>>)
+  --> $DIR/splat-mangling.rs:146:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMsb_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmudEuE)
+  --> $DIR/splat-mangling.rs:156:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&mut fn(u32, (), f64)>>)
+  --> $DIR/splat-mangling.rs:156:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<&mut fn(u32, (), f64)>>)
+  --> $DIR/splat-mangling.rs:156:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMsc_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFwuEuaEdEuEE)
+  --> $DIR/splat-mangling.rs:167:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:167:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:167:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMsd_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFwuEuaEdEuEE)
+  --> $DIR/splat-mangling.rs:177:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:177:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:177:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMse_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFuEuaEdEuEE)
+  --> $DIR/splat-mangling.rs:187:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:187:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:187:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMsf_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFuEuaEdEuEE)
+  --> $DIR/splat-mangling.rs:197:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, (fn(()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:197:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:197:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 54 previous errors
 

--- a/tests/ui/splat/splat-mangling.legacy.stderr
+++ b/tests/ui/splat/splat-mangling.legacy.stderr
@@ -1,323 +1,323 @@
 error: symbol-name(_ZN14splat_mangling4main69Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u8$C$u32$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:23:5
+  --> $DIR/splat-mangling.rs:24:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn(#[rustc_splat] (u8,u32))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:23:5
+  --> $DIR/splat-mangling.rs:24:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn(#[rustc_splat] (u8,u32))>)
-  --> $DIR/splat-mangling.rs:23:5
+  --> $DIR/splat-mangling.rs:24:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main38Type$LT$fn$LP$$LP$u8$C$u32$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn((u8,u32))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn((u8,u32))>)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main80Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:41:5
+  --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn(#[rustc_splat] ((u8,u32),))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:41:5
+  --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn(#[rustc_splat] ((u8,u32),))>)
-  --> $DIR/splat-mangling.rs:41:5
+  --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main49Type$LT$fn$LP$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:50:5
+  --> $DIR/splat-mangling.rs:51:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn(((u8,u32),))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:50:5
+  --> $DIR/splat-mangling.rs:51:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn(((u8,u32),))>)
-  --> $DIR/splat-mangling.rs:50:5
+  --> $DIR/splat-mangling.rs:51:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main83Type$LT$$BP$const$u20$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u32$C$i8$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:59:5
+  --> $DIR/splat-mangling.rs:60:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<*const fn(#[rustc_splat] (u32,i8))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:59:5
+  --> $DIR/splat-mangling.rs:60:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<*const fn(#[rustc_splat] (u32,i8))>)
-  --> $DIR/splat-mangling.rs:59:5
+  --> $DIR/splat-mangling.rs:60:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main52Type$LT$$BP$const$u20$fn$LP$$LP$u32$C$i8$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:68:5
+  --> $DIR/splat-mangling.rs:69:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<*const fn((u32,i8))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:68:5
+  --> $DIR/splat-mangling.rs:69:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<*const fn((u32,i8))>)
-  --> $DIR/splat-mangling.rs:68:5
+  --> $DIR/splat-mangling.rs:69:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main75Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u32$C$i8$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:78:5
+  --> $DIR/splat-mangling.rs:79:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn(#[rustc_splat] (u32,i8),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:78:5
+  --> $DIR/splat-mangling.rs:79:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn(#[rustc_splat] (u32,i8),f64)>)
-  --> $DIR/splat-mangling.rs:78:5
+  --> $DIR/splat-mangling.rs:79:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main44Type$LT$fn$LP$$LP$u32$C$i8$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:87:5
+  --> $DIR/splat-mangling.rs:88:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn((u32,i8),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:87:5
+  --> $DIR/splat-mangling.rs:88:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn((u32,i8),f64)>)
-  --> $DIR/splat-mangling.rs:87:5
+  --> $DIR/splat-mangling.rs:88:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main90Type$LT$$BP$mut$u20$fn$LP$u32$C$i8$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$f64$C$$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:97:5
+  --> $DIR/splat-mangling.rs:98:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<*mut fn(u32,i8,#[rustc_splat] (f64,))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:97:5
+  --> $DIR/splat-mangling.rs:98:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<*mut fn(u32,i8,#[rustc_splat] (f64,))>)
-  --> $DIR/splat-mangling.rs:97:5
+  --> $DIR/splat-mangling.rs:98:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main59Type$LT$$BP$mut$u20$fn$LP$u32$C$i8$C$$LP$f64$C$$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:106:5
+  --> $DIR/splat-mangling.rs:107:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<*mut fn(u32,i8,(f64,))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:106:5
+  --> $DIR/splat-mangling.rs:107:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<*mut fn(u32,i8,(f64,))>)
-  --> $DIR/splat-mangling.rs:106:5
+  --> $DIR/splat-mangling.rs:107:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main93Type$LT$$RF$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$i8$C$f32$C$usize$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:116:5
+  --> $DIR/splat-mangling.rs:117:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<&fn(u32,#[rustc_splat] (i8,f32,usize),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:116:5
+  --> $DIR/splat-mangling.rs:117:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<&fn(u32,#[rustc_splat] (i8,f32,usize),f64)>)
-  --> $DIR/splat-mangling.rs:116:5
+  --> $DIR/splat-mangling.rs:117:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main62Type$LT$$RF$fn$LP$u32$C$$LP$i8$C$f32$C$usize$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:125:5
+  --> $DIR/splat-mangling.rs:126:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<&fn(u32,(i8,f32,usize),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:125:5
+  --> $DIR/splat-mangling.rs:126:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<&fn(u32,(i8,f32,usize),f64)>)
-  --> $DIR/splat-mangling.rs:125:5
+  --> $DIR/splat-mangling.rs:126:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main85Type$LT$$RF$mut$u20$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:134:5
+  --> $DIR/splat-mangling.rs:135:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<&mut fn(u32,#[rustc_splat] (),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:134:5
+  --> $DIR/splat-mangling.rs:135:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<&mut fn(u32,#[rustc_splat] (),f64)>)
-  --> $DIR/splat-mangling.rs:134:5
+  --> $DIR/splat-mangling.rs:135:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main54Type$LT$$RF$mut$u20$fn$LP$u32$C$$LP$$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:143:5
+  --> $DIR/splat-mangling.rs:144:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<&mut fn(u32,(),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:143:5
+  --> $DIR/splat-mangling.rs:144:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<&mut fn(u32,(),f64)>)
-  --> $DIR/splat-mangling.rs:143:5
+  --> $DIR/splat-mangling.rs:144:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main152Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:153:5
+  --> $DIR/splat-mangling.rs:154:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(#[rustc_splat] ()),i8),f64)>>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:153:5
+  --> $DIR/splat-mangling.rs:154:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(#[rustc_splat] ()),i8),f64)>>)
-  --> $DIR/splat-mangling.rs:153:5
+  --> $DIR/splat-mangling.rs:154:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main121Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$LP$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:162:5
+  --> $DIR/splat-mangling.rs:163:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(#[rustc_splat] ()),i8),f64)>>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:162:5
+  --> $DIR/splat-mangling.rs:163:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(#[rustc_splat] ()),i8),f64)>>)
-  --> $DIR/splat-mangling.rs:162:5
+  --> $DIR/splat-mangling.rs:163:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main121Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$fn$LP$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:171:5
+  --> $DIR/splat-mangling.rs:172:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(()),i8),f64)>>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:171:5
+  --> $DIR/splat-mangling.rs:172:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(()),i8),f64)>>)
-  --> $DIR/splat-mangling.rs:171:5
+  --> $DIR/splat-mangling.rs:172:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main90Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$LP$fn$LP$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:180:5
+  --> $DIR/splat-mangling.rs:181:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(()),i8),f64)>>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:180:5
+  --> $DIR/splat-mangling.rs:181:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(()),i8),f64)>>)
-  --> $DIR/splat-mangling.rs:180:5
+  --> $DIR/splat-mangling.rs:181:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-mangling.legacy.stderr
+++ b/tests/ui/splat/splat-mangling.legacy.stderr
@@ -1,146 +1,326 @@
-error: symbol-name(_ZN14splat_mangling4main72Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u8$C$u32$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:22:5
+error: symbol-name(_ZN14splat_mangling4main69Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u8$C$u32$RP$$RP$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:23:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(splat_mangling::main::Type<fn(, #[rustc_splat](u8,u32))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:22:5
+error: demangling(splat_mangling::main::Type<fn(#[rustc_splat] (u8,u32))>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:23:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat](u8,u32))>)
-  --> $DIR/splat-mangling.rs:22:5
+error: demangling-alt(splat_mangling::main::Type<fn(#[rustc_splat] (u8,u32))>)
+  --> $DIR/splat-mangling.rs:23:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main38Type$LT$fn$LP$$LP$u8$C$u32$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn((u8,u32))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn((u8,u32))>)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN14splat_mangling4main83Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:42:5
+error: symbol-name(_ZN14splat_mangling4main80Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:43:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(splat_mangling::main::Type<fn(, #[rustc_splat]((u8,u32),))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:42:5
+error: demangling(splat_mangling::main::Type<fn(#[rustc_splat] ((u8,u32),))>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:43:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat]((u8,u32),))>)
-  --> $DIR/splat-mangling.rs:42:5
+error: demangling-alt(splat_mangling::main::Type<fn(#[rustc_splat] ((u8,u32),))>)
+  --> $DIR/splat-mangling.rs:43:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main49Type$LT$fn$LP$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:52:5
+  --> $DIR/splat-mangling.rs:53:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn(((u8,u32),))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:52:5
+  --> $DIR/splat-mangling.rs:53:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn(((u8,u32),))>)
-  --> $DIR/splat-mangling.rs:52:5
+  --> $DIR/splat-mangling.rs:53:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN14splat_mangling4main86Type$LT$$BP$const$u20$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u32$C$i8$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:62:5
+error: symbol-name(_ZN14splat_mangling4main83Type$LT$$BP$const$u20$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u32$C$i8$RP$$RP$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:63:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(splat_mangling::main::Type<*const fn(, #[rustc_splat](u32,i8))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:62:5
+error: demangling(splat_mangling::main::Type<*const fn(#[rustc_splat] (u32,i8))>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:63:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(splat_mangling::main::Type<*const fn(, #[rustc_splat](u32,i8))>)
-  --> $DIR/splat-mangling.rs:62:5
+error: demangling-alt(splat_mangling::main::Type<*const fn(#[rustc_splat] (u32,i8))>)
+  --> $DIR/splat-mangling.rs:63:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main52Type$LT$$BP$const$u20$fn$LP$$LP$u32$C$i8$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:72:5
+  --> $DIR/splat-mangling.rs:73:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<*const fn((u32,i8))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:72:5
+  --> $DIR/splat-mangling.rs:73:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<*const fn((u32,i8))>)
-  --> $DIR/splat-mangling.rs:72:5
+  --> $DIR/splat-mangling.rs:73:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN14splat_mangling4main78Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u32$C$i8$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:82:5
+error: symbol-name(_ZN14splat_mangling4main75Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u32$C$i8$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:84:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(splat_mangling::main::Type<fn(, #[rustc_splat](u32,i8),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:82:5
+error: demangling(splat_mangling::main::Type<fn(#[rustc_splat] (u32,i8),f64)>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:84:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat](u32,i8),f64)>)
-  --> $DIR/splat-mangling.rs:82:5
+error: demangling-alt(splat_mangling::main::Type<fn(#[rustc_splat] (u32,i8),f64)>)
+  --> $DIR/splat-mangling.rs:84:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main44Type$LT$fn$LP$$LP$u32$C$i8$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:92:5
+  --> $DIR/splat-mangling.rs:94:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn((u32,i8),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:92:5
+  --> $DIR/splat-mangling.rs:94:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn((u32,i8),f64)>)
-  --> $DIR/splat-mangling.rs:92:5
+  --> $DIR/splat-mangling.rs:94:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 24 previous errors
+error: symbol-name(_ZN14splat_mangling4main90Type$LT$$BP$mut$u20$fn$LP$u32$C$i8$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$f64$C$$RP$$RP$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:105:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(splat_mangling::main::Type<*mut fn(u32,i8,#[rustc_splat] (f64,))>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:105:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(splat_mangling::main::Type<*mut fn(u32,i8,#[rustc_splat] (f64,))>)
+  --> $DIR/splat-mangling.rs:105:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_ZN14splat_mangling4main59Type$LT$$BP$mut$u20$fn$LP$u32$C$i8$C$$LP$f64$C$$RP$$RP$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:115:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(splat_mangling::main::Type<*mut fn(u32,i8,(f64,))>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:115:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(splat_mangling::main::Type<*mut fn(u32,i8,(f64,))>)
+  --> $DIR/splat-mangling.rs:115:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_ZN14splat_mangling4main93Type$LT$$RF$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$i8$C$f32$C$usize$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:126:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(splat_mangling::main::Type<&fn(u32,#[rustc_splat] (i8,f32,usize),f64)>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:126:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(splat_mangling::main::Type<&fn(u32,#[rustc_splat] (i8,f32,usize),f64)>)
+  --> $DIR/splat-mangling.rs:126:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_ZN14splat_mangling4main62Type$LT$$RF$fn$LP$u32$C$$LP$i8$C$f32$C$usize$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:136:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(splat_mangling::main::Type<&fn(u32,(i8,f32,usize),f64)>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:136:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(splat_mangling::main::Type<&fn(u32,(i8,f32,usize),f64)>)
+  --> $DIR/splat-mangling.rs:136:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_ZN14splat_mangling4main85Type$LT$$RF$mut$u20$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:146:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(splat_mangling::main::Type<&mut fn(u32,#[rustc_splat] (),f64)>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:146:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(splat_mangling::main::Type<&mut fn(u32,#[rustc_splat] (),f64)>)
+  --> $DIR/splat-mangling.rs:146:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_ZN14splat_mangling4main54Type$LT$$RF$mut$u20$fn$LP$u32$C$$LP$$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:156:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(splat_mangling::main::Type<&mut fn(u32,(),f64)>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:156:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(splat_mangling::main::Type<&mut fn(u32,(),f64)>)
+  --> $DIR/splat-mangling.rs:156:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_ZN14splat_mangling4main152Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:167:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(#[rustc_splat] ()),i8),f64)>>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:167:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(#[rustc_splat] ()),i8),f64)>>)
+  --> $DIR/splat-mangling.rs:167:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_ZN14splat_mangling4main121Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$LP$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:177:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(#[rustc_splat] ()),i8),f64)>>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:177:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(#[rustc_splat] ()),i8),f64)>>)
+  --> $DIR/splat-mangling.rs:177:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_ZN14splat_mangling4main121Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$fn$LP$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:187:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(()),i8),f64)>>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:187:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(()),i8),f64)>>)
+  --> $DIR/splat-mangling.rs:187:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_ZN14splat_mangling4main90Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$LP$fn$LP$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT$17hCRATE_HASHE)
+  --> $DIR/splat-mangling.rs:197:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(()),i8),f64)>>::hCRATE_HASH)
+  --> $DIR/splat-mangling.rs:197:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(()),i8),f64)>>)
+  --> $DIR/splat-mangling.rs:197:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 54 previous errors
 

--- a/tests/ui/splat/splat-mangling.legacy.stderr
+++ b/tests/ui/splat/splat-mangling.legacy.stderr
@@ -17,307 +17,307 @@ LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main38Type$LT$fn$LP$$LP$u8$C$u32$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:33:5
+  --> $DIR/splat-mangling.rs:32:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn((u8,u32))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:33:5
+  --> $DIR/splat-mangling.rs:32:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn((u8,u32))>)
-  --> $DIR/splat-mangling.rs:33:5
+  --> $DIR/splat-mangling.rs:32:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main80Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:43:5
+  --> $DIR/splat-mangling.rs:41:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn(#[rustc_splat] ((u8,u32),))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:43:5
+  --> $DIR/splat-mangling.rs:41:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn(#[rustc_splat] ((u8,u32),))>)
-  --> $DIR/splat-mangling.rs:43:5
+  --> $DIR/splat-mangling.rs:41:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main49Type$LT$fn$LP$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:53:5
+  --> $DIR/splat-mangling.rs:50:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn(((u8,u32),))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:53:5
+  --> $DIR/splat-mangling.rs:50:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn(((u8,u32),))>)
-  --> $DIR/splat-mangling.rs:53:5
+  --> $DIR/splat-mangling.rs:50:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main83Type$LT$$BP$const$u20$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u32$C$i8$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:63:5
+  --> $DIR/splat-mangling.rs:59:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<*const fn(#[rustc_splat] (u32,i8))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:63:5
+  --> $DIR/splat-mangling.rs:59:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<*const fn(#[rustc_splat] (u32,i8))>)
-  --> $DIR/splat-mangling.rs:63:5
+  --> $DIR/splat-mangling.rs:59:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main52Type$LT$$BP$const$u20$fn$LP$$LP$u32$C$i8$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:73:5
+  --> $DIR/splat-mangling.rs:68:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<*const fn((u32,i8))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:73:5
+  --> $DIR/splat-mangling.rs:68:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<*const fn((u32,i8))>)
-  --> $DIR/splat-mangling.rs:73:5
+  --> $DIR/splat-mangling.rs:68:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main75Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u32$C$i8$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:84:5
+  --> $DIR/splat-mangling.rs:78:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn(#[rustc_splat] (u32,i8),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:84:5
+  --> $DIR/splat-mangling.rs:78:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn(#[rustc_splat] (u32,i8),f64)>)
-  --> $DIR/splat-mangling.rs:84:5
+  --> $DIR/splat-mangling.rs:78:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main44Type$LT$fn$LP$$LP$u32$C$i8$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:94:5
+  --> $DIR/splat-mangling.rs:87:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<fn((u32,i8),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:94:5
+  --> $DIR/splat-mangling.rs:87:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<fn((u32,i8),f64)>)
-  --> $DIR/splat-mangling.rs:94:5
+  --> $DIR/splat-mangling.rs:87:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main90Type$LT$$BP$mut$u20$fn$LP$u32$C$i8$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$f64$C$$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:105:5
+  --> $DIR/splat-mangling.rs:97:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<*mut fn(u32,i8,#[rustc_splat] (f64,))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:105:5
+  --> $DIR/splat-mangling.rs:97:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<*mut fn(u32,i8,#[rustc_splat] (f64,))>)
-  --> $DIR/splat-mangling.rs:105:5
+  --> $DIR/splat-mangling.rs:97:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main59Type$LT$$BP$mut$u20$fn$LP$u32$C$i8$C$$LP$f64$C$$RP$$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:115:5
+  --> $DIR/splat-mangling.rs:106:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<*mut fn(u32,i8,(f64,))>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:115:5
+  --> $DIR/splat-mangling.rs:106:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<*mut fn(u32,i8,(f64,))>)
-  --> $DIR/splat-mangling.rs:115:5
+  --> $DIR/splat-mangling.rs:106:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main93Type$LT$$RF$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$i8$C$f32$C$usize$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:126:5
+  --> $DIR/splat-mangling.rs:116:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<&fn(u32,#[rustc_splat] (i8,f32,usize),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:126:5
+  --> $DIR/splat-mangling.rs:116:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<&fn(u32,#[rustc_splat] (i8,f32,usize),f64)>)
-  --> $DIR/splat-mangling.rs:126:5
+  --> $DIR/splat-mangling.rs:116:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main62Type$LT$$RF$fn$LP$u32$C$$LP$i8$C$f32$C$usize$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:136:5
+  --> $DIR/splat-mangling.rs:125:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<&fn(u32,(i8,f32,usize),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:136:5
+  --> $DIR/splat-mangling.rs:125:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<&fn(u32,(i8,f32,usize),f64)>)
-  --> $DIR/splat-mangling.rs:136:5
+  --> $DIR/splat-mangling.rs:125:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main85Type$LT$$RF$mut$u20$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:146:5
+  --> $DIR/splat-mangling.rs:134:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<&mut fn(u32,#[rustc_splat] (),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:146:5
+  --> $DIR/splat-mangling.rs:134:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<&mut fn(u32,#[rustc_splat] (),f64)>)
-  --> $DIR/splat-mangling.rs:146:5
+  --> $DIR/splat-mangling.rs:134:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main54Type$LT$$RF$mut$u20$fn$LP$u32$C$$LP$$RP$$C$f64$RP$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:156:5
+  --> $DIR/splat-mangling.rs:143:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<&mut fn(u32,(),f64)>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:156:5
+  --> $DIR/splat-mangling.rs:143:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<&mut fn(u32,(),f64)>)
-  --> $DIR/splat-mangling.rs:156:5
+  --> $DIR/splat-mangling.rs:143:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main152Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:167:5
+  --> $DIR/splat-mangling.rs:153:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(#[rustc_splat] ()),i8),f64)>>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:167:5
+  --> $DIR/splat-mangling.rs:153:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(#[rustc_splat] ()),i8),f64)>>)
-  --> $DIR/splat-mangling.rs:167:5
+  --> $DIR/splat-mangling.rs:153:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main121Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$LP$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:177:5
+  --> $DIR/splat-mangling.rs:162:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(#[rustc_splat] ()),i8),f64)>>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:177:5
+  --> $DIR/splat-mangling.rs:162:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(#[rustc_splat] ()),i8),f64)>>)
-  --> $DIR/splat-mangling.rs:177:5
+  --> $DIR/splat-mangling.rs:162:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main121Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$fn$LP$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:187:5
+  --> $DIR/splat-mangling.rs:171:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(()),i8),f64)>>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:187:5
+  --> $DIR/splat-mangling.rs:171:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(()),i8),f64)>>)
-  --> $DIR/splat-mangling.rs:187:5
+  --> $DIR/splat-mangling.rs:171:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_ZN14splat_mangling4main90Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$LP$fn$LP$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT$17hCRATE_HASHE)
-  --> $DIR/splat-mangling.rs:197:5
+  --> $DIR/splat-mangling.rs:180:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(()),i8),f64)>>::hCRATE_HASH)
-  --> $DIR/splat-mangling.rs:197:5
+  --> $DIR/splat-mangling.rs:180:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(()),i8),f64)>>)
-  --> $DIR/splat-mangling.rs:197:5
+  --> $DIR/splat-mangling.rs:180:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-mangling.rs
+++ b/tests/ui/splat/splat-mangling.rs
@@ -7,6 +7,7 @@
 
 // CRATE_HASH normalization doesn't seem to work on some of these symbol logs
 //@ normalize-stderr: "splat_mangling\[([0-9a-f]{16})\]::" -> "splat_mangling[CRATE_HASH]::"
+//@ normalize-stderr: "alloc\[([0-9a-f]{16})\]::" -> "alloc[CRATE_HASH]::"
 //@ normalize-stderr: "h([0-9a-f]{16})E\)" -> "hCRATE_HASHE)"
 //@ normalize-stderr: "::h([0-9a-f]{16})\)" -> "::hCRATE_HASH)"
 
@@ -16,13 +17,13 @@
 fn main() {
     struct Type<T: ?Sized>(T);
 
+    // Single argument splat, with different numbers of arguments inside the splat
     // FIXME(rustfmt): the attribute gets deleted by rustfmt
     #[rustfmt::skip]
-    // FIXME(splat, legacy mangling): the first comma is in the wrong place
     #[rustc_dump_symbol_name]
-           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main72Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u8$C$u32$RP$$RP$$GT
-           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[rustc_splat](u8,u32))>::
-           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat](u8,u32))>)
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main69Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u8$C$u32$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(#[rustc_splat] (u8,u32))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(#[rustc_splat] (u8,u32))>)
     //[v0,default]~^^^^ ERROR symbol-name(_RMNvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwThmEEuE)
        //[v0,default]~| ERROR demangling(<splat_mangling[
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u8, u32))>>)
@@ -40,9 +41,9 @@ fn main() {
 
     #[rustfmt::skip]
     #[rustc_dump_symbol_name]
-           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main83Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT
-           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[rustc_splat]((u8,u32),))>::
-           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat]((u8,u32),))>)
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main80Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(#[rustc_splat] ((u8,u32),))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(#[rustc_splat] ((u8,u32),))>)
     //[v0,default]~^^^^ ERROR symbol-name(_RMs0_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTThmEEEuE)
        //[v0,default]~| ERROR demangling(<splat_mangling[
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(#[splat] ((u8, u32),))>>)
@@ -60,9 +61,9 @@ fn main() {
 
     #[rustfmt::skip]
     #[rustc_dump_symbol_name]
-           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main86Type$LT$$BP$const$u20$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u32$C$i8$RP$$RP$$GT
-           //[legacy]~| ERROR demangling(splat_mangling::main::Type<*const fn(, #[rustc_splat](u32,i8))>::
-           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<*const fn(, #[rustc_splat](u32,i8))>)
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main83Type$LT$$BP$const$u20$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u32$C$i8$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<*const fn(#[rustc_splat] (u32,i8))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<*const fn(#[rustc_splat] (u32,i8))>)
     //[v0,default]~^^^^ ERROR symbol-name(_RMs2_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFwTmaEEuE)
        //[v0,default]~| ERROR demangling(<splat_mangling[
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<*const fn(#[splat] (u32, i8))>>)
@@ -78,11 +79,12 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<*const fn((u32, i8))>>)
     impl Type<*const fn((u32, i8))> {}
 
+    // Multi-argument, leading splat
     #[rustfmt::skip]
     #[rustc_dump_symbol_name]
-           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main78Type$LT$fn$LP$$C$$u20$$u23$$u5b$rustc_splat$u5d$$LP$u32$C$i8$RP$$C$f64$RP$$GT
-           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(, #[rustc_splat](u32,i8),f64)>::
-           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(, #[rustc_splat](u32,i8),f64)>)
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main75Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u32$C$i8$RP$$C$f64$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(#[rustc_splat] (u32,i8),f64)>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<fn(#[rustc_splat] (u32,i8),f64)>)
     //[v0,default]~^^^^ ERROR symbol-name(_RMs4_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTmaEdEuE)
        //[v0,default]~| ERROR demangling(<splat_mangling[
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u32, i8), f64)>>)
@@ -97,4 +99,107 @@ fn main() {
        //[v0,default]~| ERROR demangling(<splat_mangling[
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn((u32, i8), f64)>>)
     impl Type<fn((u32, i8), f64)> {}
+
+    // Multi-argument, trailing splat
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main90Type$LT$$BP$mut$u20$fn$LP$u32$C$i8$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$f64$C$$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<*mut fn(u32,i8,#[rustc_splat] (f64,))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<*mut fn(u32,i8,#[rustc_splat] (f64,))>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMs6_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmawTdEEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
+    impl Type<*mut fn(u32, i8, #[rustc_splat] (f64,))> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main59Type$LT$$BP$mut$u20$fn$LP$u32$C$i8$C$$LP$f64$C$$RP$$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<*mut fn(u32,i8,(f64,))>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<*mut fn(u32,i8,(f64,))>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMs7_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmaTdEEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, (f64,))>>)
+    impl Type<*mut fn(u32, i8, (f64,))> {}
+
+    // Multi-argument, middle splat
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main93Type$LT$$RF$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$i8$C$f32$C$usize$RP$$C$f64$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<&fn(u32,#[rustc_splat] (i8,f32,usize),f64)>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<&fn(u32,#[rustc_splat] (i8,f32,usize),f64)>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMs8_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmwTafjEdEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
+    impl Type<&fn(u32, #[rustc_splat] (i8, f32, usize), f64)> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main62Type$LT$$RF$fn$LP$u32$C$$LP$i8$C$f32$C$usize$RP$$C$f64$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<&fn(u32,(i8,f32,usize),f64)>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<&fn(u32,(i8,f32,usize),f64)>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMs9_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmTafjEdEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
+    impl Type<&fn(u32, (i8, f32, usize), f64)> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main85Type$LT$$RF$mut$u20$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$C$f64$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<&mut fn(u32,#[rustc_splat] (),f64)>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<&mut fn(u32,#[rustc_splat] (),f64)>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMsa_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmwudEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<&mut fn(u32, #[splat] (), f64)>>)
+    impl Type<&mut fn(u32, #[rustc_splat] (), f64)> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main54Type$LT$$RF$mut$u20$fn$LP$u32$C$$LP$$RP$$C$f64$RP$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<&mut fn(u32,(),f64)>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<&mut fn(u32,(),f64)>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMsb_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmudEuE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<&mut fn(u32, (), f64)>>)
+    impl Type<&mut fn(u32, (), f64)> {}
+
+    // Splats within splats
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main152Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(#[rustc_splat] ()),i8),f64)>>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(#[rustc_splat] ()),i8),f64)>>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMsc_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFwuEuaEdEuEE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
+    impl Type<Box<fn(u32, #[rustc_splat] (fn(#[rustc_splat] ()), i8), f64)>> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main121Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$LP$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(#[rustc_splat] ()),i8),f64)>>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(#[rustc_splat] ()),i8),f64)>>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMsd_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFwuEuaEdEuEE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
+    impl Type<Box<fn(u32, (fn(#[rustc_splat] ()), i8), f64)>> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main121Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$fn$LP$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(()),i8),f64)>>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(()),i8),f64)>>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMse_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFuEuaEdEuEE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
+    impl Type<Box<fn(u32, #[rustc_splat] (fn(()), i8), f64)>> {}
+
+    #[rustfmt::skip]
+    #[rustc_dump_symbol_name]
+           //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main90Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$LP$fn$LP$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT
+           //[legacy]~| ERROR demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(()),i8),f64)>>::
+           //[legacy]~| ERROR demangling-alt(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(()),i8),f64)>>)
+    //[v0,default]~^^^^ ERROR symbol-name(_RMsf_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFuEuaEdEuEE)
+       //[v0,default]~| ERROR demangling(<splat_mangling[
+       //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(()), i8), f64)>>>)
+    impl Type<Box<fn(u32, (fn(()), i8), f64)>> {}
 }

--- a/tests/ui/splat/splat-mangling.rs
+++ b/tests/ui/splat/splat-mangling.rs
@@ -14,12 +14,12 @@
 #![allow(incomplete_features)]
 #![feature(splat, rustc_attrs)]
 
+// FIXME(rustfmt): the attribute gets deleted by rustfmt
+#[rustfmt::skip]
 fn main() {
     struct Type<T: ?Sized>(T);
 
     // Single argument splat, with different numbers of arguments inside the splat
-    // FIXME(rustfmt): the attribute gets deleted by rustfmt
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main69Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u8$C$u32$RP$$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(#[rustc_splat] (u8,u32))>::
@@ -29,7 +29,6 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u8, u32))>>)
     impl Type<fn(#[rustc_splat] (u8, u32))> {}
 
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main38Type$LT$fn$LP$$LP$u8$C$u32$RP$$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn((u8,u32))>::
@@ -39,7 +38,6 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn((u8, u32))>>)
     impl Type<fn((u8, u32))> {}
 
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main80Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(#[rustc_splat] ((u8,u32),))>::
@@ -49,7 +47,6 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(#[splat] ((u8, u32),))>>)
     impl Type<fn(#[rustc_splat] ((u8, u32),))> {}
 
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main49Type$LT$fn$LP$$LP$$LP$u8$C$u32$RP$$C$$RP$$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(((u8,u32),))>::
@@ -59,7 +56,6 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(((u8, u32),))>>)
     impl Type<fn(((u8, u32),))> {}
 
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main83Type$LT$$BP$const$u20$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u32$C$i8$RP$$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<*const fn(#[rustc_splat] (u32,i8))>::
@@ -69,7 +65,6 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<*const fn(#[splat] (u32, i8))>>)
     impl Type<*const fn(#[rustc_splat] (u32, i8))> {}
 
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main52Type$LT$$BP$const$u20$fn$LP$$LP$u32$C$i8$RP$$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<*const fn((u32,i8))>::
@@ -80,7 +75,6 @@ fn main() {
     impl Type<*const fn((u32, i8))> {}
 
     // Multi-argument, leading splat
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main75Type$LT$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$u32$C$i8$RP$$C$f64$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn(#[rustc_splat] (u32,i8),f64)>::
@@ -90,7 +84,6 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u32, i8), f64)>>)
     impl Type<fn(#[rustc_splat] (u32, i8), f64)> {}
 
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main44Type$LT$fn$LP$$LP$u32$C$i8$RP$$C$f64$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<fn((u32,i8),f64)>::
@@ -101,7 +94,6 @@ fn main() {
     impl Type<fn((u32, i8), f64)> {}
 
     // Multi-argument, trailing splat
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main90Type$LT$$BP$mut$u20$fn$LP$u32$C$i8$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$f64$C$$RP$$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<*mut fn(u32,i8,#[rustc_splat] (f64,))>::
@@ -111,7 +103,6 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
     impl Type<*mut fn(u32, i8, #[rustc_splat] (f64,))> {}
 
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main59Type$LT$$BP$mut$u20$fn$LP$u32$C$i8$C$$LP$f64$C$$RP$$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<*mut fn(u32,i8,(f64,))>::
@@ -122,7 +113,6 @@ fn main() {
     impl Type<*mut fn(u32, i8, (f64,))> {}
 
     // Multi-argument, middle splat
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main93Type$LT$$RF$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$i8$C$f32$C$usize$RP$$C$f64$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<&fn(u32,#[rustc_splat] (i8,f32,usize),f64)>::
@@ -132,7 +122,6 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
     impl Type<&fn(u32, #[rustc_splat] (i8, f32, usize), f64)> {}
 
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main62Type$LT$$RF$fn$LP$u32$C$$LP$i8$C$f32$C$usize$RP$$C$f64$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<&fn(u32,(i8,f32,usize),f64)>::
@@ -142,7 +131,6 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
     impl Type<&fn(u32, (i8, f32, usize), f64)> {}
 
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main85Type$LT$$RF$mut$u20$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$C$f64$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<&mut fn(u32,#[rustc_splat] (),f64)>::
@@ -152,7 +140,6 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<&mut fn(u32, #[splat] (), f64)>>)
     impl Type<&mut fn(u32, #[rustc_splat] (), f64)> {}
 
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main54Type$LT$$RF$mut$u20$fn$LP$u32$C$$LP$$RP$$C$f64$RP$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<&mut fn(u32,(),f64)>::
@@ -163,7 +150,6 @@ fn main() {
     impl Type<&mut fn(u32, (), f64)> {}
 
     // Splats within splats
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main152Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(#[rustc_splat] ()),i8),f64)>>::
@@ -173,7 +159,6 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
     impl Type<Box<fn(u32, #[rustc_splat] (fn(#[rustc_splat] ()), i8), f64)>> {}
 
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main121Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$LP$fn$LP$$u23$$u5b$rustc_splat$u5d$$u20$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(#[rustc_splat] ()),i8),f64)>>::
@@ -183,7 +168,6 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
     impl Type<Box<fn(u32, (fn(#[rustc_splat] ()), i8), f64)>> {}
 
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main121Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$u23$$u5b$rustc_splat$u5d$$u20$$LP$fn$LP$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,#[rustc_splat] (fn(()),i8),f64)>>::
@@ -193,7 +177,6 @@ fn main() {
        //[v0,default]~| ERROR demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
     impl Type<Box<fn(u32, #[rustc_splat] (fn(()), i8), f64)>> {}
 
-    #[rustfmt::skip]
     #[rustc_dump_symbol_name]
            //[legacy]~^ ERROR symbol-name(_ZN14splat_mangling4main90Type$LT$alloc..boxed..Box$LT$fn$LP$u32$C$$LP$fn$LP$$LP$$RP$$RP$$C$i8$RP$$C$f64$RP$$GT$$GT
            //[legacy]~| ERROR demangling(splat_mangling::main::Type<alloc::boxed::Box<fn(u32,(fn(()),i8),f64)>>::

--- a/tests/ui/splat/splat-mangling.rs
+++ b/tests/ui/splat/splat-mangling.rs
@@ -6,10 +6,11 @@
 //@ build-fail
 
 // CRATE_HASH normalization doesn't seem to work on some of these symbol logs
-//@ normalize-stderr: "splat_mangling\[([0-9a-f]{16})\]::" -> "splat_mangling[CRATE_HASH]::"
-//@ normalize-stderr: "alloc\[([0-9a-f]{16})\]::" -> "alloc[CRATE_HASH]::"
-//@ normalize-stderr: "h([0-9a-f]{16})E\)" -> "hCRATE_HASHE)"
-//@ normalize-stderr: "::h([0-9a-f]{16})\)" -> "::hCRATE_HASH)"
+// FIXME: When rustc-demangle/94 is in rust's deps, change this to '{16}' (fixed-length hashes)
+//@ normalize-stderr: "splat_mangling\[([0-9a-f]{8,16})\]::" -> "splat_mangling[CRATE_HASH]::"
+//@ normalize-stderr: "alloc\[([0-9a-f]{8,16})\]::" -> "alloc[CRATE_HASH]::"
+//@ normalize-stderr: "h([0-9a-f]{8,16})E\)" -> "hCRATE_HASHE)"
+//@ normalize-stderr: "::h([0-9a-f]{8,16})\)" -> "::hCRATE_HASH)"
 
 #![allow(incomplete_features)]
 #![feature(splat, rustc_attrs)]

--- a/tests/ui/splat/splat-mangling.v0.stderr
+++ b/tests/ui/splat/splat-mangling.v0.stderr
@@ -1,323 +1,323 @@
 error: symbol-name(_RMNvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwThmEEuE)
-  --> $DIR/splat-mangling.rs:23:5
+  --> $DIR/splat-mangling.rs:24:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u8, u32))>>)
-  --> $DIR/splat-mangling.rs:23:5
+  --> $DIR/splat-mangling.rs:24:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u8, u32))>>)
-  --> $DIR/splat-mangling.rs:23:5
+  --> $DIR/splat-mangling.rs:24:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFThmEEuE)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u8, u32))>>)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn((u8, u32))>>)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs0_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTThmEEEuE)
-  --> $DIR/splat-mangling.rs:41:5
+  --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] ((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:41:5
+  --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] ((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:41:5
+  --> $DIR/splat-mangling.rs:42:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs1_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTThmEEEuE)
-  --> $DIR/splat-mangling.rs:50:5
+  --> $DIR/splat-mangling.rs:51:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:50:5
+  --> $DIR/splat-mangling.rs:51:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:50:5
+  --> $DIR/splat-mangling.rs:51:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs2_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFwTmaEEuE)
-  --> $DIR/splat-mangling.rs:59:5
+  --> $DIR/splat-mangling.rs:60:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn(#[splat] (u32, i8))>>)
-  --> $DIR/splat-mangling.rs:59:5
+  --> $DIR/splat-mangling.rs:60:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*const fn(#[splat] (u32, i8))>>)
-  --> $DIR/splat-mangling.rs:59:5
+  --> $DIR/splat-mangling.rs:60:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs3_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFTmaEEuE)
-  --> $DIR/splat-mangling.rs:68:5
+  --> $DIR/splat-mangling.rs:69:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn((u32, i8))>>)
-  --> $DIR/splat-mangling.rs:68:5
+  --> $DIR/splat-mangling.rs:69:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*const fn((u32, i8))>>)
-  --> $DIR/splat-mangling.rs:68:5
+  --> $DIR/splat-mangling.rs:69:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs4_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTmaEdEuE)
-  --> $DIR/splat-mangling.rs:78:5
+  --> $DIR/splat-mangling.rs:79:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:78:5
+  --> $DIR/splat-mangling.rs:79:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:78:5
+  --> $DIR/splat-mangling.rs:79:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs5_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTmaEdEuE)
-  --> $DIR/splat-mangling.rs:87:5
+  --> $DIR/splat-mangling.rs:88:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:87:5
+  --> $DIR/splat-mangling.rs:88:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn((u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:87:5
+  --> $DIR/splat-mangling.rs:88:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs6_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmawTdEEuE)
-  --> $DIR/splat-mangling.rs:97:5
+  --> $DIR/splat-mangling.rs:98:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
-  --> $DIR/splat-mangling.rs:97:5
+  --> $DIR/splat-mangling.rs:98:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
-  --> $DIR/splat-mangling.rs:97:5
+  --> $DIR/splat-mangling.rs:98:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs7_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmaTdEEuE)
-  --> $DIR/splat-mangling.rs:106:5
+  --> $DIR/splat-mangling.rs:107:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*mut fn(u32, i8, (f64,))>>)
-  --> $DIR/splat-mangling.rs:106:5
+  --> $DIR/splat-mangling.rs:107:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, (f64,))>>)
-  --> $DIR/splat-mangling.rs:106:5
+  --> $DIR/splat-mangling.rs:107:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs8_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmwTafjEdEuE)
-  --> $DIR/splat-mangling.rs:116:5
+  --> $DIR/splat-mangling.rs:117:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:116:5
+  --> $DIR/splat-mangling.rs:117:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:116:5
+  --> $DIR/splat-mangling.rs:117:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs9_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmTafjEdEuE)
-  --> $DIR/splat-mangling.rs:125:5
+  --> $DIR/splat-mangling.rs:126:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:125:5
+  --> $DIR/splat-mangling.rs:126:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:125:5
+  --> $DIR/splat-mangling.rs:126:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsa_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmwudEuE)
-  --> $DIR/splat-mangling.rs:134:5
+  --> $DIR/splat-mangling.rs:135:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&mut fn(u32, #[splat] (), f64)>>)
-  --> $DIR/splat-mangling.rs:134:5
+  --> $DIR/splat-mangling.rs:135:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&mut fn(u32, #[splat] (), f64)>>)
-  --> $DIR/splat-mangling.rs:134:5
+  --> $DIR/splat-mangling.rs:135:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsb_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmudEuE)
-  --> $DIR/splat-mangling.rs:143:5
+  --> $DIR/splat-mangling.rs:144:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&mut fn(u32, (), f64)>>)
-  --> $DIR/splat-mangling.rs:143:5
+  --> $DIR/splat-mangling.rs:144:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&mut fn(u32, (), f64)>>)
-  --> $DIR/splat-mangling.rs:143:5
+  --> $DIR/splat-mangling.rs:144:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsc_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFwuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:153:5
+  --> $DIR/splat-mangling.rs:154:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:153:5
+  --> $DIR/splat-mangling.rs:154:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:153:5
+  --> $DIR/splat-mangling.rs:154:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsd_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFwuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:162:5
+  --> $DIR/splat-mangling.rs:163:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:162:5
+  --> $DIR/splat-mangling.rs:163:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:162:5
+  --> $DIR/splat-mangling.rs:163:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMse_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:171:5
+  --> $DIR/splat-mangling.rs:172:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:171:5
+  --> $DIR/splat-mangling.rs:172:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:171:5
+  --> $DIR/splat-mangling.rs:172:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsf_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:180:5
+  --> $DIR/splat-mangling.rs:181:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:180:5
+  --> $DIR/splat-mangling.rs:181:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:180:5
+  --> $DIR/splat-mangling.rs:181:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-mangling.v0.stderr
+++ b/tests/ui/splat/splat-mangling.v0.stderr
@@ -17,307 +17,307 @@ LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFThmEEuE)
-  --> $DIR/splat-mangling.rs:33:5
+  --> $DIR/splat-mangling.rs:32:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u8, u32))>>)
-  --> $DIR/splat-mangling.rs:33:5
+  --> $DIR/splat-mangling.rs:32:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn((u8, u32))>>)
-  --> $DIR/splat-mangling.rs:33:5
+  --> $DIR/splat-mangling.rs:32:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs0_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTThmEEEuE)
-  --> $DIR/splat-mangling.rs:43:5
+  --> $DIR/splat-mangling.rs:41:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] ((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:43:5
+  --> $DIR/splat-mangling.rs:41:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] ((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:43:5
+  --> $DIR/splat-mangling.rs:41:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs1_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTThmEEEuE)
-  --> $DIR/splat-mangling.rs:53:5
+  --> $DIR/splat-mangling.rs:50:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:53:5
+  --> $DIR/splat-mangling.rs:50:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:53:5
+  --> $DIR/splat-mangling.rs:50:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs2_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFwTmaEEuE)
-  --> $DIR/splat-mangling.rs:63:5
+  --> $DIR/splat-mangling.rs:59:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn(#[splat] (u32, i8))>>)
-  --> $DIR/splat-mangling.rs:63:5
+  --> $DIR/splat-mangling.rs:59:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*const fn(#[splat] (u32, i8))>>)
-  --> $DIR/splat-mangling.rs:63:5
+  --> $DIR/splat-mangling.rs:59:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs3_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFTmaEEuE)
-  --> $DIR/splat-mangling.rs:73:5
+  --> $DIR/splat-mangling.rs:68:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn((u32, i8))>>)
-  --> $DIR/splat-mangling.rs:73:5
+  --> $DIR/splat-mangling.rs:68:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*const fn((u32, i8))>>)
-  --> $DIR/splat-mangling.rs:73:5
+  --> $DIR/splat-mangling.rs:68:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs4_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTmaEdEuE)
-  --> $DIR/splat-mangling.rs:84:5
+  --> $DIR/splat-mangling.rs:78:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:84:5
+  --> $DIR/splat-mangling.rs:78:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:84:5
+  --> $DIR/splat-mangling.rs:78:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs5_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTmaEdEuE)
-  --> $DIR/splat-mangling.rs:94:5
+  --> $DIR/splat-mangling.rs:87:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:94:5
+  --> $DIR/splat-mangling.rs:87:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn((u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:94:5
+  --> $DIR/splat-mangling.rs:87:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs6_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmawTdEEuE)
-  --> $DIR/splat-mangling.rs:105:5
+  --> $DIR/splat-mangling.rs:97:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
-  --> $DIR/splat-mangling.rs:105:5
+  --> $DIR/splat-mangling.rs:97:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
-  --> $DIR/splat-mangling.rs:105:5
+  --> $DIR/splat-mangling.rs:97:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs7_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmaTdEEuE)
-  --> $DIR/splat-mangling.rs:115:5
+  --> $DIR/splat-mangling.rs:106:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*mut fn(u32, i8, (f64,))>>)
-  --> $DIR/splat-mangling.rs:115:5
+  --> $DIR/splat-mangling.rs:106:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, (f64,))>>)
-  --> $DIR/splat-mangling.rs:115:5
+  --> $DIR/splat-mangling.rs:106:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs8_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmwTafjEdEuE)
-  --> $DIR/splat-mangling.rs:126:5
+  --> $DIR/splat-mangling.rs:116:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:126:5
+  --> $DIR/splat-mangling.rs:116:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:126:5
+  --> $DIR/splat-mangling.rs:116:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs9_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmTafjEdEuE)
-  --> $DIR/splat-mangling.rs:136:5
+  --> $DIR/splat-mangling.rs:125:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:136:5
+  --> $DIR/splat-mangling.rs:125:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
-  --> $DIR/splat-mangling.rs:136:5
+  --> $DIR/splat-mangling.rs:125:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsa_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmwudEuE)
-  --> $DIR/splat-mangling.rs:146:5
+  --> $DIR/splat-mangling.rs:134:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&mut fn(u32, #[splat] (), f64)>>)
-  --> $DIR/splat-mangling.rs:146:5
+  --> $DIR/splat-mangling.rs:134:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&mut fn(u32, #[splat] (), f64)>>)
-  --> $DIR/splat-mangling.rs:146:5
+  --> $DIR/splat-mangling.rs:134:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsb_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmudEuE)
-  --> $DIR/splat-mangling.rs:156:5
+  --> $DIR/splat-mangling.rs:143:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&mut fn(u32, (), f64)>>)
-  --> $DIR/splat-mangling.rs:156:5
+  --> $DIR/splat-mangling.rs:143:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<&mut fn(u32, (), f64)>>)
-  --> $DIR/splat-mangling.rs:156:5
+  --> $DIR/splat-mangling.rs:143:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsc_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFwuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:167:5
+  --> $DIR/splat-mangling.rs:153:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:167:5
+  --> $DIR/splat-mangling.rs:153:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:167:5
+  --> $DIR/splat-mangling.rs:153:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsd_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFwuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:177:5
+  --> $DIR/splat-mangling.rs:162:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:177:5
+  --> $DIR/splat-mangling.rs:162:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:177:5
+  --> $DIR/splat-mangling.rs:162:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMse_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:187:5
+  --> $DIR/splat-mangling.rs:171:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:187:5
+  --> $DIR/splat-mangling.rs:171:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:187:5
+  --> $DIR/splat-mangling.rs:171:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMsf_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFuEuaEdEuEE)
-  --> $DIR/splat-mangling.rs:197:5
+  --> $DIR/splat-mangling.rs:180:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:197:5
+  --> $DIR/splat-mangling.rs:180:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(()), i8), f64)>>>)
-  --> $DIR/splat-mangling.rs:197:5
+  --> $DIR/splat-mangling.rs:180:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/splat/splat-mangling.v0.stderr
+++ b/tests/ui/splat/splat-mangling.v0.stderr
@@ -1,146 +1,326 @@
 error: symbol-name(_RMNvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwThmEEuE)
-  --> $DIR/splat-mangling.rs:22:5
+  --> $DIR/splat-mangling.rs:23:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u8, u32))>>)
-  --> $DIR/splat-mangling.rs:22:5
+  --> $DIR/splat-mangling.rs:23:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u8, u32))>>)
-  --> $DIR/splat-mangling.rs:22:5
+  --> $DIR/splat-mangling.rs:23:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFThmEEuE)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u8, u32))>>)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn((u8, u32))>>)
-  --> $DIR/splat-mangling.rs:32:5
+  --> $DIR/splat-mangling.rs:33:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs0_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTThmEEEuE)
-  --> $DIR/splat-mangling.rs:42:5
+  --> $DIR/splat-mangling.rs:43:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] ((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:42:5
+  --> $DIR/splat-mangling.rs:43:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] ((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:42:5
+  --> $DIR/splat-mangling.rs:43:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs1_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTThmEEEuE)
-  --> $DIR/splat-mangling.rs:52:5
+  --> $DIR/splat-mangling.rs:53:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:52:5
+  --> $DIR/splat-mangling.rs:53:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(((u8, u32),))>>)
-  --> $DIR/splat-mangling.rs:52:5
+  --> $DIR/splat-mangling.rs:53:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs2_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFwTmaEEuE)
-  --> $DIR/splat-mangling.rs:62:5
+  --> $DIR/splat-mangling.rs:63:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn(#[splat] (u32, i8))>>)
-  --> $DIR/splat-mangling.rs:62:5
+  --> $DIR/splat-mangling.rs:63:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*const fn(#[splat] (u32, i8))>>)
-  --> $DIR/splat-mangling.rs:62:5
+  --> $DIR/splat-mangling.rs:63:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs3_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypePFTmaEEuE)
-  --> $DIR/splat-mangling.rs:72:5
+  --> $DIR/splat-mangling.rs:73:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*const fn((u32, i8))>>)
-  --> $DIR/splat-mangling.rs:72:5
+  --> $DIR/splat-mangling.rs:73:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<*const fn((u32, i8))>>)
-  --> $DIR/splat-mangling.rs:72:5
+  --> $DIR/splat-mangling.rs:73:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs4_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFwTmaEdEuE)
-  --> $DIR/splat-mangling.rs:82:5
+  --> $DIR/splat-mangling.rs:84:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn(#[splat] (u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:82:5
+  --> $DIR/splat-mangling.rs:84:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn(#[splat] (u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:82:5
+  --> $DIR/splat-mangling.rs:84:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: symbol-name(_RMs5_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeFTmaEdEuE)
-  --> $DIR/splat-mangling.rs:92:5
+  --> $DIR/splat-mangling.rs:94:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling(<splat_mangling[CRATE_HASH]::main::Type<fn((u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:92:5
+  --> $DIR/splat-mangling.rs:94:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: demangling-alt(<splat_mangling::main::Type<fn((u32, i8), f64)>>)
-  --> $DIR/splat-mangling.rs:92:5
+  --> $DIR/splat-mangling.rs:94:5
    |
 LL |     #[rustc_dump_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 24 previous errors
+error: symbol-name(_RMs6_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmawTdEEuE)
+  --> $DIR/splat-mangling.rs:105:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
+  --> $DIR/splat-mangling.rs:105:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, #[splat] (f64,))>>)
+  --> $DIR/splat-mangling.rs:105:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs7_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeOFmaTdEEuE)
+  --> $DIR/splat-mangling.rs:115:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<*mut fn(u32, i8, (f64,))>>)
+  --> $DIR/splat-mangling.rs:115:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<*mut fn(u32, i8, (f64,))>>)
+  --> $DIR/splat-mangling.rs:115:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs8_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmwTafjEdEuE)
+  --> $DIR/splat-mangling.rs:126:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
+  --> $DIR/splat-mangling.rs:126:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<&fn(u32, #[splat] (i8, f32, usize), f64)>>)
+  --> $DIR/splat-mangling.rs:126:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMs9_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeRFmTafjEdEuE)
+  --> $DIR/splat-mangling.rs:136:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
+  --> $DIR/splat-mangling.rs:136:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<&fn(u32, (i8, f32, usize), f64)>>)
+  --> $DIR/splat-mangling.rs:136:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMsa_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmwudEuE)
+  --> $DIR/splat-mangling.rs:146:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&mut fn(u32, #[splat] (), f64)>>)
+  --> $DIR/splat-mangling.rs:146:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<&mut fn(u32, #[splat] (), f64)>>)
+  --> $DIR/splat-mangling.rs:146:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMsb_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeQFmudEuE)
+  --> $DIR/splat-mangling.rs:156:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<&mut fn(u32, (), f64)>>)
+  --> $DIR/splat-mangling.rs:156:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<&mut fn(u32, (), f64)>>)
+  --> $DIR/splat-mangling.rs:156:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMsc_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFwuEuaEdEuEE)
+  --> $DIR/splat-mangling.rs:167:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:167:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(#[splat] ()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:167:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMsd_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFwuEuaEdEuEE)
+  --> $DIR/splat-mangling.rs:177:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:177:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(#[splat] ()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:177:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMse_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmwTFuEuaEdEuEE)
+  --> $DIR/splat-mangling.rs:187:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:187:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, #[splat] (fn(()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:187:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: symbol-name(_RMsf_NvCsCRATE_HASH_14splat_mangling4mainINtB<REF>_4TypeINtNtCsCRATE_HASH_5alloc5boxed3BoxFmTFuEuaEdEuEE)
+  --> $DIR/splat-mangling.rs:197:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<splat_mangling[CRATE_HASH]::main::Type<alloc[CRATE_HASH]::boxed::Box<fn(u32, (fn(()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:197:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<splat_mangling::main::Type<alloc::boxed::Box<fn(u32, (fn(()), i8), f64)>>>)
+  --> $DIR/splat-mangling.rs:197:5
+   |
+LL |     #[rustc_dump_symbol_name]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 54 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160050)*
<!-- homu-ignore:end -->

Tracking issue: https://github.com/rust-lang/rust/issues/153629

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR fixes a splat legacy demangling display bug, where the comma is in the wrong place in the argument list.

It also does a cleanup from @folkertdev's PR rust-lang/rust#159643 review:
- move rustfmt::skip to main() and deduplicate it: https://github.com/rust-lang/rust/pull/159643#discussion_r3650148585

@rustbot label +F-splat +C-bug +A-name-mangling

Edit: this PR now accepts 8-16 character crate hashes in normalisation regexes, so it no longer depends on https://github.com/rust-lang/rustc-demangle/pull/94 being reviewed, merged, and updated in rustc's deps