### PR TITLE
refactor(mir-transform): Calculate optimization status inside `run_passes_inner`

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -56,7 +56,7 @@ impl<'tcx> crate::MirPass<'tcx> for InstrumentCoverage {
     }
 
     fn is_required(&self) -> bool {
-        false
+        true
     }
 }
 

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -422,7 +422,6 @@ fn mir_built(tcx: TyCtxt<'_>, def: LocalDefId) -> &Steal<Body<'_>> {
             &Lint(sanity_check::SanityCheck),
         ],
         None,
-        pm::Optimizations::Allowed,
     );
     tcx.alloc_steal_mir(body)
 }
@@ -479,7 +478,6 @@ fn mir_promoted(
         &mut body,
         &[&promote_pass, &simplify::SimplifyCfg::PromoteConsts, &coverage::InstrumentCoverage],
         Some(MirPhase::Analysis(AnalysisPhase::Initial)),
-        pm::Optimizations::Allowed,
     );
 
     lint_tail_expr_drop_order::run_lint(tcx, def, &body);
@@ -526,7 +524,7 @@ fn inner_mir_for_ctfe(tcx: TyCtxt<'_>, def: LocalDefId) -> Body<'_> {
     } else {
         &[&ctfe_limit::CtfeLimit]
     };
-    pm::run_passes(tcx, &mut body, passes, None, pm::Optimizations::Allowed);
+    pm::run_passes(tcx, &mut body, passes, None);
 
     body
 }
@@ -613,7 +611,6 @@ pub fn run_analysis_to_runtime_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'
                 &Lint(post_drop_elaboration::CheckLiveDrops),
             ],
             None,
-            pm::Optimizations::Allowed,
         );
     }
 
@@ -638,13 +635,7 @@ fn run_analysis_cleanup_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         &deref_separator::Derefer,
     ];
 
-    pm::run_passes(
-        tcx,
-        body,
-        passes,
-        Some(MirPhase::Analysis(AnalysisPhase::PostCleanup)),
-        pm::Optimizations::Allowed,
-    );
+    pm::run_passes(tcx, body, passes, Some(MirPhase::Analysis(AnalysisPhase::PostCleanup)));
 }
 
 /// Returns the sequence of passes that lowers analysis to runtime MIR.
@@ -682,13 +673,7 @@ fn run_runtime_cleanup_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         &simplify::SimplifyCfg::PreOptimizations,
     ];
 
-    pm::run_passes(
-        tcx,
-        body,
-        passes,
-        Some(MirPhase::Runtime(RuntimePhase::PostCleanup)),
-        pm::Optimizations::Allowed,
-    );
+    pm::run_passes(tcx, body, passes, Some(MirPhase::Runtime(RuntimePhase::PostCleanup)));
 
     // Clear this by anticipation. Optimizations and runtime MIR have no reason to look
     // into this information, which is meant for borrowck diagnostics.
@@ -701,15 +686,6 @@ pub(crate) fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'
     fn o1<T>(x: T) -> WithMinOptLevel<T> {
         WithMinOptLevel(1, x)
     }
-
-    let def_id = body.source.def_id();
-    let optimizations = if tcx.def_kind(def_id).has_codegen_attrs()
-        && tcx.codegen_fn_attrs(def_id).optimize.do_not_optimize()
-    {
-        pm::Optimizations::Suppressed
-    } else {
-        pm::Optimizations::Allowed
-    };
 
     // The main optimizations that we do on MIR.
     pm::run_passes(
@@ -793,7 +769,6 @@ pub(crate) fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'
             &prettify::ReorderLocals,
         ],
         Some(MirPhase::Runtime(RuntimePhase::Optimized)),
-        optimizations,
     );
 }
 

--- a/compiler/rustc_mir_transform/src/pass_manager.rs
+++ b/compiler/rustc_mir_transform/src/pass_manager.rs
@@ -185,7 +185,9 @@ where
 /// [required]: MirPass::is_required
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Optimizations {
+    /// The current function has `#[optimize(none)]`.
     Suppressed,
+    /// Normal optimizations may run.
     Allowed,
 }
 
@@ -197,7 +199,7 @@ pub(super) fn run_passes_no_validate<'tcx>(
     passes: &[&dyn MirPass<'tcx>],
     phase_change: Option<MirPhase>,
 ) {
-    run_passes_inner(tcx, body, passes, phase_change, false, Optimizations::Allowed);
+    run_passes_inner(tcx, body, passes, phase_change, false);
 }
 
 /// The optional `phase_change` is applied after executing all the passes, if present
@@ -206,9 +208,8 @@ pub(super) fn run_passes<'tcx>(
     body: &mut Body<'tcx>,
     passes: &[&dyn MirPass<'tcx>],
     phase_change: Option<MirPhase>,
-    optimizations: Optimizations,
 ) {
-    run_passes_inner(tcx, body, passes, phase_change, true, optimizations);
+    run_passes_inner(tcx, body, passes, phase_change, true);
 }
 
 pub(super) fn should_run_pass<'tcx, P>(
@@ -245,7 +246,6 @@ fn run_passes_inner<'tcx>(
     passes: &[&dyn MirPass<'tcx>],
     phase_change: Option<MirPhase>,
     validate_each: bool,
-    optimizations: Optimizations,
 ) {
     let overridden_passes = &tcx.sess.opts.unstable_opts.mir_enable_passes;
     trace!(?overridden_passes);
@@ -286,6 +286,15 @@ fn run_passes_inner<'tcx>(
     if !body.should_skip() {
         let validate = validate_each & tcx.sess.opts.unstable_opts.validate_mir;
         let lint = tcx.sess.opts.unstable_opts.lint_mir;
+
+        let def_id = body.source.def_id();
+        let optimizations = if tcx.def_kind(def_id).has_codegen_attrs()
+            && tcx.codegen_fn_attrs(def_id).optimize.do_not_optimize()
+        {
+            Optimizations::Suppressed
+        } else {
+            Optimizations::Allowed
+        };
 
         for pass in passes {
             let pass_name = pass.name();

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -119,7 +119,6 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, shim: ty::ShimKind<'tcx>) -> Body<'tcx> {
                         &add_call_guards::CriticalCallEdges,
                     ],
                     Some(MirPhase::Runtime(RuntimePhase::Optimized)),
-                    pm::Optimizations::Allowed,
                 );
 
                 return body;
@@ -143,7 +142,6 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, shim: ty::ShimKind<'tcx>) -> Body<'tcx> {
                     &add_call_guards::CriticalCallEdges,
                 ],
                 Some(MirPhase::Runtime(RuntimePhase::PostCleanup)),
-                pm::Optimizations::Allowed,
             );
             run_optimization_passes(tcx, &mut body);
             debug!("make_shim({:?}) = {:?}", shim, body);

--- a/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
+++ b/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
@@ -37,7 +37,6 @@ pub(super) fn build_async_destructor_ctor_shim<'tcx>(
             &add_call_guards::CriticalCallEdges,
         ],
         None,
-        pm::Optimizations::Allowed,
     );
     body
 }

--- a/tests/mir-opt/optimize_none.rs
+++ b/tests/mir-opt/optimize_none.rs
@@ -16,12 +16,12 @@ pub fn add_noopt() -> i32 {
 pub fn const_branch() -> i32 {
     // CHECK-LABEL: fn const_branch(
     // CHECK: [[BOOL:_[0-9]+]] = const true;
-    // CHECK: switchInt(move [[BOOL]]) -> [0: [[BB_FALSE:bb[0-9]+]], otherwise: [[BB_TRUE:bb[0-9]+]]];
+    // CHECK: switchInt(move [[BOOL]]) -> [0: [[BB_FALSE_SHIM:bb[0-9]+]], otherwise: [[BB_TRUE:bb[0-9]+]]];
     // CHECK-NEXT: }
+    // CHECK: [[BB_FALSE_SHIM]]: {
+    // CHECK-NEXT: goto -> [[BB_FALSE:bb[0-9]+]]
     // CHECK: [[BB_FALSE]]: {
     // CHECK-NEXT: _0 = const 0
-    // CHECK-NEXT: goto
-    // CHECK-NEXT: }
     // CHECK: [[BB_TRUE]]: {
     // CHECK-NEXT: _0 = const 1
     // CHECK-NEXT: goto


### PR DESCRIPTION
The `Optimizations` enum represents whether `#[optimize(none)]` has been applied to a function. Currently, `run_passes` takes an `Optimizations` which is confusing (https://github.com/rust-lang/rust/pull/160015#discussion_r3663238318).
Calculate this in `run_passes_inner` instead (which also means `#[optimize(none)]` is applied more consistently.

r? @RalfJung 