### PR TITLE
atomic volatile: add intrinsics

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -873,6 +873,7 @@ fn codegen_regular_intrinsic_call<'tcx>(
         sym::atomic_load => {
             intrinsic_args!(fx, args => (ptr); intrinsic);
             let ptr = ptr.load_scalar(fx);
+            // FIXME: this ignores the atomic ordering and the volatile flag.
 
             let ty = generic_args.type_at(0);
             match ty.kind() {
@@ -908,6 +909,7 @@ fn codegen_regular_intrinsic_call<'tcx>(
         sym::atomic_store => {
             intrinsic_args!(fx, args => (ptr, val); intrinsic);
             let ptr = ptr.load_scalar(fx);
+            // FIXME: this ignores the atomic ordering and the volatile flag.
 
             let ty = generic_args.type_at(0);
             match ty.kind() {

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -81,8 +81,13 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
             AtomicOrdering::AcqRel | AtomicOrdering::Release => AtomicOrdering::Acquire,
             _ => order,
         };
-        let previous_value =
-            self.atomic_load(dst.get_type(), dst, load_ordering, Size::from_bytes(size));
+        let previous_value = self.atomic_load(
+            dst.get_type(),
+            dst,
+            load_ordering,
+            /* volatile */ false,
+            Size::from_bytes(size),
+        );
         let previous_var =
             func.new_local(self.location, previous_value.get_type(), "previous_value");
         let return_value = func.new_local(self.location, previous_value.get_type(), "return_value");
@@ -1008,6 +1013,7 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         _ty: Type<'gcc>,
         ptr: RValue<'gcc>,
         order: AtomicOrdering,
+        _volatile: bool, // FIXME we are always making the load volatile
         size: Size,
     ) -> RValue<'gcc> {
         // FIXME(antoyo): use ty.
@@ -1177,6 +1183,7 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         value: RValue<'gcc>,
         ptr: RValue<'gcc>,
         order: AtomicOrdering,
+        _volatile: bool, // FIXME we are always making the store volatile
         size: Size,
     ) {
         // FIXME(antoyo): handle alignment.

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -81,8 +81,13 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
             AtomicOrdering::AcqRel | AtomicOrdering::Release => AtomicOrdering::Acquire,
             _ => order,
         };
-        let previous_value =
-            self.atomic_load(dst.get_type(), dst, load_ordering, Size::from_bytes(size));
+        let previous_value = self.atomic_load(
+            dst.get_type(),
+            dst,
+            load_ordering,
+            /* volatile */ false,
+            Size::from_bytes(size),
+        );
         let previous_var =
             func.new_local(self.location, previous_value.get_type(), "previous_value");
         let return_value = func.new_local(self.location, previous_value.get_type(), "return_value");
@@ -1008,6 +1013,7 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         _ty: Type<'gcc>,
         ptr: RValue<'gcc>,
         order: AtomicOrdering,
+        _volatile: bool, // FIXME we are ignoring this
         size: Size,
     ) -> RValue<'gcc> {
         // FIXME(antoyo): use ty.
@@ -1177,6 +1183,7 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         value: RValue<'gcc>,
         ptr: RValue<'gcc>,
         order: AtomicOrdering,
+        _volatile: bool, // FIXME we are ignoring this
         size: Size,
     ) {
         // FIXME(antoyo): handle alignment.

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -703,12 +703,16 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         ty: &'ll Type,
         ptr: &'ll Value,
         order: rustc_middle::ty::AtomicOrdering,
+        volatile: bool,
         size: Size,
     ) -> &'ll Value {
         unsafe {
             let load = llvm::LLVMBuildLoad2(self.llbuilder, ty, ptr, UNNAMED);
             // Set atomic ordering
             llvm::LLVMSetOrdering(load, AtomicOrdering::from_generic(order));
+            if volatile {
+                llvm::LLVMSetVolatile(load, llvm::TRUE);
+            }
             // LLVM requires the alignment of atomic loads to be at least the size of the type.
             llvm::LLVMSetAlignment(load, size.bytes() as c_uint);
             load
@@ -930,6 +934,7 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         val: &'ll Value,
         ptr: &'ll Value,
         order: rustc_middle::ty::AtomicOrdering,
+        volatile: bool,
         size: Size,
     ) {
         debug!("Store {:?} -> {:?}", val, ptr);
@@ -938,6 +943,9 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
             let store = llvm::LLVMBuildStore(self.llbuilder, val, ptr);
             // Set atomic ordering
             llvm::LLVMSetOrdering(store, AtomicOrdering::from_generic(order));
+            if volatile {
+                llvm::LLVMSetVolatile(store, llvm::TRUE);
+            }
             // LLVM requires the alignment of atomic stores to be at least the size of the type.
             llvm::LLVMSetAlignment(store, size.bytes() as c_uint);
         }

--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -381,12 +381,14 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     return IntrinsicResult::Err(err);
                 }
                 let ordering = fn_args.const_at(1).to_value();
+                let volatile = fn_args.const_at(2).to_value();
                 let layout = bx.layout_of(ty);
                 let source = args[0].immediate();
                 OperandValue::Immediate(bx.atomic_load(
                     bx.backend_type(layout),
                     source,
                     parse_atomic_ordering(ordering),
+                    volatile.to_leaf().try_to_bool().unwrap(),
                     layout.size,
                 ))
             }
@@ -397,10 +399,17 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     return IntrinsicResult::Err(err);
                 }
                 let ordering = fn_args.const_at(1).to_value();
+                let volatile = fn_args.const_at(2).to_value();
                 let size = bx.layout_of(ty).size;
                 let val = args[1].immediate();
                 let ptr = args[0].immediate();
-                bx.atomic_store(val, ptr, parse_atomic_ordering(ordering), size);
+                bx.atomic_store(
+                    val,
+                    ptr,
+                    parse_atomic_ordering(ordering),
+                    volatile.to_leaf().try_to_bool().unwrap(),
+                    size,
+                );
                 OperandValue::ZeroSized
             }
             // These are all AtomicRMW ops

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -250,6 +250,7 @@ pub trait BuilderMethods<'a, 'tcx>:
         ty: Self::Type,
         ptr: Self::Value,
         order: AtomicOrdering,
+        volatile: bool,
         size: Size,
     ) -> Self::Value;
     fn load_from_place(&mut self, ty: Self::Type, place: PlaceValue<Self::Value>) -> Self::Value {
@@ -330,6 +331,7 @@ pub trait BuilderMethods<'a, 'tcx>:
         val: Self::Value,
         ptr: Self::Value,
         order: AtomicOrdering,
+        volatile: bool,
         size: Size,
     );
 

--- a/compiler/rustc_const_eval/src/interpret/intrinsics/atomic.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/atomic.rs
@@ -27,6 +27,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         match intrinsic_name {
             sym::atomic_load => {
                 let ord = get_ord_at(1);
+                let _volatile = generic_args.const_at(2).to_value(); // makes no difference for us
                 let [ptr] = args else { span_bug!(self.cur_span(), "invalid `atomic_load` call") };
 
                 let place = self.deref_pointer(ptr)?;
@@ -35,6 +36,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             }
             sym::atomic_store => {
                 let ord = get_ord_at(1);
+                let _volatile = generic_args.const_at(2).to_value(); // makes no difference for us
                 let [ptr, val] = args else {
                     span_bug!(self.cur_span(), "invalid `atomic_store` call")
                 };

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -812,8 +812,8 @@ pub(crate) fn check_intrinsic_type(
             vec![Ty::new_mut_ptr(tcx, param(0)), param(0), param(0)],
             Ty::new_tup(tcx, &[param(0), tcx.types.bool]),
         ),
-        sym::atomic_load => (1, 1, vec![Ty::new_imm_ptr(tcx, param(0))], param(0)),
-        sym::atomic_store => (1, 1, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], tcx.types.unit),
+        sym::atomic_load => (1, 2, vec![Ty::new_imm_ptr(tcx, param(0))], param(0)),
+        sym::atomic_store => (1, 2, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], tcx.types.unit),
 
         sym::atomic_xchg
         | sym::atomic_max

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -790,8 +790,8 @@ pub(crate) fn check_intrinsic_type(
             vec![Ty::new_mut_ptr(tcx, param(0)), param(0), param(0)],
             Ty::new_tup(tcx, &[param(0), tcx.types.bool]),
         ),
-        sym::atomic_load => (1, 1, vec![Ty::new_imm_ptr(tcx, param(0))], param(0)),
-        sym::atomic_store => (1, 1, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], tcx.types.unit),
+        sym::atomic_load => (1, 2, vec![Ty::new_imm_ptr(tcx, param(0))], param(0)),
+        sym::atomic_store => (1, 2, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], tcx.types.unit),
 
         sym::atomic_xchg
         | sym::atomic_max

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -130,7 +130,9 @@ pub const unsafe fn atomic_cxchgweak<
 /// [`atomic`] types via the `load` method. For example, [`AtomicBool::load`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub const unsafe fn atomic_load<T: Copy, const ORD: AtomicOrdering>(src: *const T) -> T;
+pub const unsafe fn atomic_load<T: Copy, const ORD: AtomicOrdering, const VOLATILE: bool>(
+    src: *const T,
+) -> T;
 
 /// Stores the value at the specified memory location.
 /// `T` must be an integer or pointer type.
@@ -139,7 +141,10 @@ pub const unsafe fn atomic_load<T: Copy, const ORD: AtomicOrdering>(src: *const 
 /// [`atomic`] types via the `store` method. For example, [`AtomicBool::store`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub const unsafe fn atomic_store<T: Copy, const ORD: AtomicOrdering>(dst: *mut T, val: T);
+pub const unsafe fn atomic_store<T: Copy, const ORD: AtomicOrdering, const VOLATILE: bool>(
+    dst: *mut T,
+    val: T,
+);
 
 /// Stores the value at the specified memory location, returning the old value.
 /// `T` must be an integer or pointer type.

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -759,7 +759,9 @@ impl AtomicBool {
     pub const fn load(&self, order: Ordering) -> bool {
         // SAFETY: any data races are prevented by atomic intrinsics and the raw
         // pointer passed in is valid because we got it from a reference.
-        unsafe { atomic_load(self.v.get().cast::<u8>(), order) != 0 }
+        unsafe {
+            atomic_load::<_, /* VOLATILE */ false>(self.v.get().cast::<u8>(), order) != 0
+        }
     }
 
     /// Stores a value into the bool.
@@ -790,7 +792,7 @@ impl AtomicBool {
         // SAFETY: any data races are prevented by atomic intrinsics and the raw
         // pointer passed in is valid because we got it from a reference.
         unsafe {
-            atomic_store(self.v.get().cast::<u8>(), val as u8, order);
+            atomic_store::<_, /* VOLATILE */ false>(self.v.get().cast::<u8>(), val as u8, order);
         }
     }
 
@@ -1762,7 +1764,9 @@ impl<T> AtomicPtr<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub const fn load(&self, order: Ordering) -> *mut T {
         // SAFETY: data races are prevented by atomic intrinsics.
-        unsafe { atomic_load(self.as_ptr(), order) }
+        unsafe {
+            atomic_load::<_, /* VOLATILE */ false>(self.as_ptr(), order)
+        }
     }
 
     /// Stores a value into the pointer.
@@ -1794,7 +1798,7 @@ impl<T> AtomicPtr<T> {
     pub const fn store(&self, ptr: *mut T, order: Ordering) {
         // SAFETY: data races are prevented by atomic intrinsics.
         unsafe {
-            atomic_store(self.as_ptr(), ptr, order);
+            atomic_store::<_, /* VOLATILE */ false>(self.as_ptr(), ptr, order);
         }
     }
 
@@ -2913,7 +2917,7 @@ macro_rules! atomic_int {
             #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
             pub const fn load(&self, order: Ordering) -> $int_type {
                 // SAFETY: data races are prevented by atomic intrinsics.
-                unsafe { atomic_load(self.as_ptr(), order) }
+                unsafe { atomic_load::<_, /* VOLATILE */ false>(self.as_ptr(), order) }
             }
 
             /// Stores a value into the atomic integer.
@@ -2943,7 +2947,7 @@ macro_rules! atomic_int {
             #[rustc_should_not_be_called_on_const_items]
             pub const fn store(&self, val: $int_type, order: Ordering) {
                 // SAFETY: data races are prevented by atomic intrinsics.
-                unsafe { atomic_store(self.as_ptr(), val, order); }
+                unsafe { atomic_store::<_, /* VOLATILE */ false>(self.as_ptr(), val, order); }
             }
 
             /// Stores a value into the atomic integer, returning the previous value.
@@ -3971,13 +3975,13 @@ const fn strongest_failure_ordering(order: Ordering) -> Ordering {
 #[inline]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 #[rustc_const_unstable(feature = "const_atomic", issue = "160078")]
-const unsafe fn atomic_store<T: Copy>(dst: *mut T, val: T, order: Ordering) {
+const unsafe fn atomic_store<T: Copy, const VOLATILE: bool>(dst: *mut T, val: T, order: Ordering) {
     // SAFETY: the caller must uphold the safety contract for `atomic_store`.
     unsafe {
         match order {
-            Relaxed => intrinsics::atomic_store::<T, { AO::Relaxed }>(dst, val),
-            Release => intrinsics::atomic_store::<T, { AO::Release }>(dst, val),
-            SeqCst => intrinsics::atomic_store::<T, { AO::SeqCst }>(dst, val),
+            Relaxed => intrinsics::atomic_store::<T, { AO::Relaxed }, VOLATILE>(dst, val),
+            Release => intrinsics::atomic_store::<T, { AO::Release }, VOLATILE>(dst, val),
+            SeqCst => intrinsics::atomic_store::<T, { AO::SeqCst }, VOLATILE>(dst, val),
             Acquire => panic!("there is no such thing as an acquire store"),
             AcqRel => panic!("there is no such thing as an acquire-release store"),
         }
@@ -3987,13 +3991,13 @@ const unsafe fn atomic_store<T: Copy>(dst: *mut T, val: T, order: Ordering) {
 #[inline]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 #[rustc_const_unstable(feature = "const_atomic", issue = "160078")]
-const unsafe fn atomic_load<T: Copy>(dst: *const T, order: Ordering) -> T {
+const unsafe fn atomic_load<T: Copy, const VOLATILE: bool>(dst: *const T, order: Ordering) -> T {
     // SAFETY: the caller must uphold the safety contract for `atomic_load`.
     unsafe {
         match order {
-            Relaxed => intrinsics::atomic_load::<T, { AO::Relaxed }>(dst),
-            Acquire => intrinsics::atomic_load::<T, { AO::Acquire }>(dst),
-            SeqCst => intrinsics::atomic_load::<T, { AO::SeqCst }>(dst),
+            Relaxed => intrinsics::atomic_load::<T, { AO::Relaxed }, VOLATILE>(dst),
+            Acquire => intrinsics::atomic_load::<T, { AO::Acquire }, VOLATILE>(dst),
+            SeqCst => intrinsics::atomic_load::<T, { AO::SeqCst }, VOLATILE>(dst),
             Release => panic!("there is no such thing as a release load"),
             AcqRel => panic!("there is no such thing as an acquire-release load"),
         }

--- a/library/panic_unwind/src/seh.rs
+++ b/library/panic_unwind/src/seh.rs
@@ -337,24 +337,24 @@ unsafe fn throw_exception(data: Option<Box<dyn Any + Send>>) -> ! {
     // express more operations in statics (and we may never be able to).
     unsafe {
         #[allow(function_casts_as_integer)]
-        atomic_store::<_, { AtomicOrdering::SeqCst }>(
+        atomic_store::<_, { AtomicOrdering::SeqCst }, /* VOLATILE */ false>(
             (&raw mut THROW_INFO.pmfnUnwind).cast(),
             ptr_t::new(exception_cleanup as *mut u8).raw(),
         );
-        atomic_store::<_, { AtomicOrdering::SeqCst }>(
+        atomic_store::<_, { AtomicOrdering::SeqCst }, /* VOLATILE */ false>(
             (&raw mut THROW_INFO.pCatchableTypeArray).cast(),
             ptr_t::new((&raw mut CATCHABLE_TYPE_ARRAY).cast()).raw(),
         );
-        atomic_store::<_, { AtomicOrdering::SeqCst }>(
+        atomic_store::<_, { AtomicOrdering::SeqCst }, /* VOLATILE */ false>(
             (&raw mut CATCHABLE_TYPE_ARRAY.arrayOfCatchableTypes[0]).cast(),
             ptr_t::new((&raw mut CATCHABLE_TYPE).cast()).raw(),
         );
-        atomic_store::<_, { AtomicOrdering::SeqCst }>(
+        atomic_store::<_, { AtomicOrdering::SeqCst }, /* VOLATILE */ false>(
             (&raw mut CATCHABLE_TYPE.pType).cast(),
             ptr_t::new((&raw mut TYPE_DESCRIPTOR).cast()).raw(),
         );
         #[allow(function_casts_as_integer)]
-        atomic_store::<_, { AtomicOrdering::SeqCst }>(
+        atomic_store::<_, { AtomicOrdering::SeqCst }, /* VOLATILE */ false>(
             (&raw mut CATCHABLE_TYPE.copyFunction).cast(),
             ptr_t::new(exception_copy as *mut u8).raw(),
         );

--- a/src/tools/miri/tests/fail/unaligned_pointers/atomic_unaligned.rs
+++ b/src/tools/miri/tests/fail/unaligned_pointers/atomic_unaligned.rs
@@ -8,7 +8,7 @@ fn main() {
     let z = [0u32; 2];
     let zptr = &z as *const _ as *const u64;
     unsafe {
-        intrinsics::atomic_load::<_, { intrinsics::AtomicOrdering::SeqCst }>(zptr);
+        intrinsics::atomic_load::<_, { intrinsics::AtomicOrdering::SeqCst }, false>(zptr);
         //~^ERROR: accessing memory with alignment 4, but alignment 8 is required
     }
 }

--- a/src/tools/miri/tests/fail/unaligned_pointers/atomic_unaligned.stderr
+++ b/src/tools/miri/tests/fail/unaligned_pointers/atomic_unaligned.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: accessing memory with alignment ALIGN, but alignment ALIGN is required
   --> tests/fail/unaligned_pointers/atomic_unaligned.rs:LL:CC
    |
-LL |         intrinsics::atomic_load::<_, { intrinsics::AtomicOrdering::SeqCst }>(zptr);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |         intrinsics::atomic_load::<_, { intrinsics::AtomicOrdering::SeqCst }, false>(zptr);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this usually indicates that your program performed an invalid operation and caused Undefined Behavior
    = help: but due to `-Zmiri-symbolic-alignment-check`, alignment errors can also be false positives

--- a/tests/codegen-llvm/atomic-operations.rs
+++ b/tests/codegen-llvm/atomic-operations.rs
@@ -1,6 +1,7 @@
 // Code generation of atomic operations.
 //@ compile-flags: -Copt-level=3
 #![crate_type = "lib"]
+#![feature(core_intrinsics)]
 
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::Ordering::*;
@@ -81,4 +82,27 @@ pub fn compare_exchange_weak(w: &AtomicI32) {
     let _ = w.compare_exchange_weak(1, 50, SeqCst, Relaxed);
     let _ = w.compare_exchange_weak(1, 51, SeqCst, Acquire);
     let _ = w.compare_exchange_weak(1, 52, SeqCst, SeqCst);
+}
+
+// CHECK-LABEL: @atomic_volatile
+#[no_mangle]
+fn atomic_volatile(w: &AtomicI32) {
+    use std::intrinsics::*;
+
+    let ptr = w.as_ptr();
+    unsafe {
+        // CHECK: load atomic volatile i32, ptr %{{.*}} monotonic, align 4
+        // CHECK: load atomic volatile i32, ptr %{{.*}} acquire, align 4
+        // CHECK: load atomic volatile i32, ptr %{{.*}} seq_cst, align 4
+        atomic_load::<_, { AtomicOrdering::Relaxed }, /* VOLATILE */ true>(ptr);
+        atomic_load::<_, { AtomicOrdering::Acquire }, /* VOLATILE */ true>(ptr);
+        atomic_load::<_, { AtomicOrdering::SeqCst }, /* VOLATILE */ true>(ptr);
+
+        // CHECK: store atomic volatile i32 0, ptr %{{.*}} monotonic, align 4
+        // CHECK: store atomic volatile i32 0, ptr %{{.*}} release, align 4
+        // CHECK: store atomic volatile i32 0, ptr %{{.*}} seq_cst, align 4
+        atomic_store::<_, { AtomicOrdering::Relaxed }, /* VOLATILE */ true>(ptr, 0);
+        atomic_store::<_, { AtomicOrdering::Release }, /* VOLATILE */ true>(ptr, 0);
+        atomic_store::<_, { AtomicOrdering::SeqCst }, /* VOLATILE */ true>(ptr, 0);
+    }
 }

--- a/tests/ui/intrinsics/intrinsic-atomics.rs
+++ b/tests/ui/intrinsics/intrinsic-atomics.rs
@@ -6,13 +6,13 @@ pub fn main() {
     unsafe {
         let mut x: Box<_> = Box::new(1);
 
-        assert_eq!(rusti::atomic_load::<_, { SeqCst }>(&*x), 1);
+        assert_eq!(rusti::atomic_load::<_, { SeqCst }, false>(&*x), 1);
         *x = 5;
-        assert_eq!(rusti::atomic_load::<_, { Acquire }>(&*x), 5);
+        assert_eq!(rusti::atomic_load::<_, { Acquire }, false>(&*x), 5);
 
-        rusti::atomic_store::<_, { SeqCst }>(&mut *x, 3);
+        rusti::atomic_store::<_, { SeqCst }, false>(&mut *x, 3);
         assert_eq!(*x, 3);
-        rusti::atomic_store::<_, { Release }>(&mut *x, 1);
+        rusti::atomic_store::<_, { Release }, false>(&mut *x, 1);
         assert_eq!(*x, 1);
 
         assert_eq!(rusti::atomic_cxchg::<_, { SeqCst }, { SeqCst }>(&mut *x, 1, 2), (1, true));

--- a/tests/ui/intrinsics/non-integer-atomic.rs
+++ b/tests/ui/intrinsics/non-integer-atomic.rs
@@ -12,12 +12,12 @@ pub type Bar = &'static dyn Fn();
 pub type Quux = [u8; 100];
 
 pub unsafe fn test_bool_load(p: &mut bool, v: bool) {
-    intrinsics::atomic_load::<_, { SeqCst }>(p);
+    intrinsics::atomic_load::<_, { SeqCst }, false>(p);
     //~^ ERROR `atomic_load` intrinsic: expected basic integer or pointer type, found `bool`
 }
 
 pub unsafe fn test_bool_store(p: &mut bool, v: bool) {
-    intrinsics::atomic_store::<_, { SeqCst }>(p, v);
+    intrinsics::atomic_store::<_, { SeqCst }, false>(p, v);
     //~^ ERROR `atomic_store` intrinsic: expected basic integer or pointer type, found `bool`
 }
 
@@ -32,12 +32,12 @@ pub unsafe fn test_bool_cxchg(p: &mut bool, v: bool) {
 }
 
 pub unsafe fn test_Foo_load(p: &mut Foo, v: Foo) {
-    intrinsics::atomic_load::<_, { SeqCst }>(p);
+    intrinsics::atomic_load::<_, { SeqCst }, false>(p);
     //~^ ERROR `atomic_load` intrinsic: expected basic integer or pointer type, found `Foo`
 }
 
 pub unsafe fn test_Foo_store(p: &mut Foo, v: Foo) {
-    intrinsics::atomic_store::<_, { SeqCst }>(p, v);
+    intrinsics::atomic_store::<_, { SeqCst }, false>(p, v);
     //~^ ERROR `atomic_store` intrinsic: expected basic integer or pointer type, found `Foo`
 }
 
@@ -52,12 +52,12 @@ pub unsafe fn test_Foo_cxchg(p: &mut Foo, v: Foo) {
 }
 
 pub unsafe fn test_Bar_load(p: &mut Bar, v: Bar) {
-    intrinsics::atomic_load::<_, { SeqCst }>(p);
+    intrinsics::atomic_load::<_, { SeqCst }, false>(p);
     //~^ ERROR expected basic integer or pointer type, found `&dyn Fn()`
 }
 
 pub unsafe fn test_Bar_store(p: &mut Bar, v: Bar) {
-    intrinsics::atomic_store::<_, { SeqCst }>(p, v);
+    intrinsics::atomic_store::<_, { SeqCst }, false>(p, v);
     //~^ ERROR expected basic integer or pointer type, found `&dyn Fn()`
 }
 
@@ -72,12 +72,12 @@ pub unsafe fn test_Bar_cxchg(p: &mut Bar, v: Bar) {
 }
 
 pub unsafe fn test_Quux_load(p: &mut Quux, v: Quux) {
-    intrinsics::atomic_load::<_, { SeqCst }>(p);
+    intrinsics::atomic_load::<_, { SeqCst }, false>(p);
     //~^ ERROR `atomic_load` intrinsic: expected basic integer or pointer type, found `[u8; 100]`
 }
 
 pub unsafe fn test_Quux_store(p: &mut Quux, v: Quux) {
-    intrinsics::atomic_store::<_, { SeqCst }>(p, v);
+    intrinsics::atomic_store::<_, { SeqCst }, false>(p, v);
     //~^ ERROR `atomic_store` intrinsic: expected basic integer or pointer type, found `[u8; 100]`
 }
 

--- a/tests/ui/intrinsics/non-integer-atomic.stderr
+++ b/tests/ui/intrinsics/non-integer-atomic.stderr
@@ -1,8 +1,8 @@
 error[E0511]: invalid monomorphization of `atomic_load` intrinsic: expected basic integer or pointer type, found `&dyn Fn()`
   --> $DIR/non-integer-atomic.rs:55:5
    |
-LL |     intrinsics::atomic_load::<_, { SeqCst }>(p);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     intrinsics::atomic_load::<_, { SeqCst }, false>(p);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `atomic_xchg` intrinsic: expected basic integer or pointer type, found `&dyn Fn()`
   --> $DIR/non-integer-atomic.rs:65:5
@@ -13,8 +13,8 @@ LL |     intrinsics::atomic_xchg::<_, { SeqCst }>(p, v);
 error[E0511]: invalid monomorphization of `atomic_load` intrinsic: expected basic integer or pointer type, found `Foo`
   --> $DIR/non-integer-atomic.rs:35:5
    |
-LL |     intrinsics::atomic_load::<_, { SeqCst }>(p);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     intrinsics::atomic_load::<_, { SeqCst }, false>(p);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `atomic_xchg` intrinsic: expected basic integer or pointer type, found `Foo`
   --> $DIR/non-integer-atomic.rs:45:5
@@ -31,8 +31,8 @@ LL |     intrinsics::atomic_cxchg::<_, { SeqCst }, { SeqCst }>(p, v, v);
 error[E0511]: invalid monomorphization of `atomic_store` intrinsic: expected basic integer or pointer type, found `&dyn Fn()`
   --> $DIR/non-integer-atomic.rs:60:5
    |
-LL |     intrinsics::atomic_store::<_, { SeqCst }>(p, v);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     intrinsics::atomic_store::<_, { SeqCst }, false>(p, v);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `atomic_cxchg` intrinsic: expected basic integer or pointer type, found `Foo`
   --> $DIR/non-integer-atomic.rs:50:5
@@ -43,14 +43,14 @@ LL |     intrinsics::atomic_cxchg::<_, { SeqCst }, { SeqCst }>(p, v, v);
 error[E0511]: invalid monomorphization of `atomic_store` intrinsic: expected basic integer or pointer type, found `Foo`
   --> $DIR/non-integer-atomic.rs:40:5
    |
-LL |     intrinsics::atomic_store::<_, { SeqCst }>(p, v);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     intrinsics::atomic_store::<_, { SeqCst }, false>(p, v);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `atomic_load` intrinsic: expected basic integer or pointer type, found `[u8; 100]`
   --> $DIR/non-integer-atomic.rs:75:5
    |
-LL |     intrinsics::atomic_load::<_, { SeqCst }>(p);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     intrinsics::atomic_load::<_, { SeqCst }, false>(p);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `atomic_xchg` intrinsic: expected basic integer or pointer type, found `[u8; 100]`
   --> $DIR/non-integer-atomic.rs:85:5
@@ -61,8 +61,8 @@ LL |     intrinsics::atomic_xchg::<_, { SeqCst }>(p, v);
 error[E0511]: invalid monomorphization of `atomic_load` intrinsic: expected basic integer or pointer type, found `bool`
   --> $DIR/non-integer-atomic.rs:15:5
    |
-LL |     intrinsics::atomic_load::<_, { SeqCst }>(p);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     intrinsics::atomic_load::<_, { SeqCst }, false>(p);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `atomic_xchg` intrinsic: expected basic integer or pointer type, found `bool`
   --> $DIR/non-integer-atomic.rs:25:5
@@ -79,8 +79,8 @@ LL |     intrinsics::atomic_cxchg::<_, { SeqCst }, { SeqCst }>(p, v, v);
 error[E0511]: invalid monomorphization of `atomic_store` intrinsic: expected basic integer or pointer type, found `[u8; 100]`
   --> $DIR/non-integer-atomic.rs:80:5
    |
-LL |     intrinsics::atomic_store::<_, { SeqCst }>(p, v);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     intrinsics::atomic_store::<_, { SeqCst }, false>(p, v);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `atomic_cxchg` intrinsic: expected basic integer or pointer type, found `bool`
   --> $DIR/non-integer-atomic.rs:30:5
@@ -91,8 +91,8 @@ LL |     intrinsics::atomic_cxchg::<_, { SeqCst }, { SeqCst }>(p, v, v);
 error[E0511]: invalid monomorphization of `atomic_store` intrinsic: expected basic integer or pointer type, found `bool`
   --> $DIR/non-integer-atomic.rs:20:5
    |
-LL |     intrinsics::atomic_store::<_, { SeqCst }>(p, v);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     intrinsics::atomic_store::<_, { SeqCst }, false>(p, v);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 16 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160058)*
<!-- homu-ignore:end -->

Extend the atomic load/store intrinsics to also support volatile atomic load/store.
Tracking issue: https://github.com/rust-lang/rust/issues/158947.
Library APIs that use these intrinsics will be added inn a future PR.

The GCC and cranelift implementations ignore the volatile flag, not sure how that should be implemented for them.