### PR TITLE
Avoid relating erased regions in valtree field types

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -1165,6 +1165,10 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
                                         .type_of(field_def.did)
                                         .instantiate(tcx, args)
                                         .skip_norm_wip();
+                                    // Lifetimes stored in valtree constants are erased, so avoid
+                                    // relating those erased regions with the field's original
+                                    // regions during well-formedness checking.
+                                    let field_ty = tcx.erase_and_anonymize_regions(field_ty);
                                     let predicate = ty::PredicateKind::Clause(
                                         ty::ClauseKind::ConstArgHasType(field_val, field_ty),
                                     );

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -1151,6 +1151,10 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
                                         .type_of(field_def.did)
                                         .instantiate(tcx, args)
                                         .skip_norm_wip();
+                                    // Lifetimes stored in valtree constants are erased, so avoid
+                                    // relating those erased regions with the field's original
+                                    // regions during well-formedness checking.
+                                    let field_ty = tcx.erase_and_anonymize_regions(field_ty);
                                     let predicate = ty::PredicateKind::Clause(
                                         ty::ClauseKind::ConstArgHasType(field_val, field_ty),
                                     );

--- a/tests/ui/const-generics/mgca/valtree-erased-region-issue-159688.rs
+++ b/tests/ui/const-generics/mgca/valtree-erased-region-issue-159688.rs
@@ -1,0 +1,29 @@
+//@ check-fail
+
+#![feature(min_generic_const_args)]
+#![feature(min_adt_const_params)]
+#![expect(incomplete_features)]
+
+pub struct Foo {
+    slice: &'static [u8],
+}
+
+#[derive(PartialEq, Eq)]
+pub struct Foo_<const F: Foo>;
+//~^ ERROR `Foo` must implement `ConstParamTy`
+//~| ERROR `Foo` must implement `ConstParamTy`
+//~| ERROR `Foo` must implement `ConstParamTy`
+//~| ERROR `Foo` must implement `ConstParamTy`
+
+impl
+    Foo_<
+        {
+            Foo {
+                slice: &[1, 2, 3],
+            }
+        },
+    >
+{
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/valtree-erased-region-issue-159688.stderr
+++ b/tests/ui/const-generics/mgca/valtree-erased-region-issue-159688.stderr
@@ -1,0 +1,54 @@
+error[E0741]: `Foo` must implement `ConstParamTy` to be used as the type of a const generic parameter
+  --> $DIR/valtree-erased-region-issue-159688.rs:12:26
+   |
+LL | pub struct Foo_<const F: Foo>;
+   |                          ^^^
+   |
+help: add `#[derive(ConstParamTy, PartialEq, Eq)]` to the struct
+   |
+LL + #[derive(ConstParamTy, PartialEq, Eq)]
+LL | pub struct Foo {
+   |
+
+error[E0741]: `Foo` must implement `ConstParamTy` to be used as the type of a const generic parameter
+  --> $DIR/valtree-erased-region-issue-159688.rs:12:26
+   |
+LL | pub struct Foo_<const F: Foo>;
+   |                          ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add `#[derive(ConstParamTy, PartialEq, Eq)]` to the struct
+   |
+LL + #[derive(ConstParamTy, PartialEq, Eq)]
+LL | pub struct Foo {
+   |
+
+error[E0741]: `Foo` must implement `ConstParamTy` to be used as the type of a const generic parameter
+  --> $DIR/valtree-erased-region-issue-159688.rs:12:26
+   |
+LL | pub struct Foo_<const F: Foo>;
+   |                          ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add `#[derive(ConstParamTy, PartialEq, Eq)]` to the struct
+   |
+LL + #[derive(ConstParamTy, PartialEq, Eq)]
+LL | pub struct Foo {
+   |
+
+error[E0741]: `Foo` must implement `ConstParamTy` to be used as the type of a const generic parameter
+  --> $DIR/valtree-erased-region-issue-159688.rs:12:26
+   |
+LL | pub struct Foo_<const F: Foo>;
+   |                          ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add `#[derive(ConstParamTy, PartialEq, Eq)]` to the struct
+   |
+LL + #[derive(ConstParamTy, PartialEq, Eq)]
+LL | pub struct Foo {
+   |
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0741`.


### PR DESCRIPTION
Fixes rust-lang/rust#159688