### PR TITLE
mir-opt: avoid speculative scalar reads in EarlyOtherwiseBranch

### DIFF
--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -290,6 +290,13 @@ fn evaluate_candidate<'tcx>(
         let Operand::Copy(child_place) = child_discr else {
             return None;
         };
+
+        // A reachable parent `otherwise` path skips the child switch. Reading a distinct
+        // place here would therefore be speculative and may introduce UB.
+        if !otherwise_is_empty_unreachable && parent_discr.place() != Some(*child_place) {
+            return None;
+        }
+
         *child_place
     };
     let destination = if otherwise_is_empty_unreachable {

--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -292,7 +292,7 @@ fn evaluate_candidate<'tcx>(
         };
 
         // A reachable parent `otherwise` path skips the child switch. Reading a distinct
-        // place here would therefore be speculative and may introduce UB.
+        // place here would therefore be speculative and may introduce UB (#159591).
         if !otherwise_is_empty_unreachable && parent_discr.place() != Some(*child_place) {
             return None;
         }
@@ -372,25 +372,6 @@ fn verify_candidate_branch<'tcx>(
         // For <https://github.com/rust-lang/rust/issues/95162>, we adopt a conservative approach and
         // consider only the `otherwise` branch has no statements and an unreachable terminator.
         if need_hoist_discriminant {
-            return false;
-        }
-        // For <https://github.com/rust-lang/rust/issues/159591>:
-        // ```
-        // bb0: {
-        //     switchInt(copy _1) -> [1: bb1, 2: bb2, otherwise: bb5];
-        // }
-        // bb1: {
-        //     switchInt(copy (*_2)) -> [1: bb3, otherwise: bb5];
-        // }
-        // bb2: {
-        //     switchInt(copy (*_2)) -> [2: bb4, otherwise: bb5];
-        // }
-        // ```
-        // We cannot hoist the dereference of `_2` to `bb0`,
-        // because execution can reach `bb5` without dereferencing `_2`.
-        if let Some(place) = switch_op.place()
-            && !place.is_stable_offset()
-        {
             return false;
         }
     }

--- a/tests/mir-opt/early_otherwise_branch.opt5.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt5.EarlyOtherwiseBranch.diff
@@ -8,7 +8,6 @@
       let mut _3: (u32, u32);
       let mut _4: u32;
       let mut _5: u32;
-+     let mut _6: bool;
   
       bb0: {
           StorageLive(_3);
@@ -19,56 +18,44 @@
           _3 = (move _4, move _5);
           StorageDead(_5);
           StorageDead(_4);
--         switchInt(copy (_3.0: u32)) -> [1: bb2, 2: bb3, 3: bb4, otherwise: bb1];
-+         _6 = Ne(copy (_3.0: u32), copy (_3.1: u32));
-+         switchInt(move _6) -> [0: bb6, otherwise: bb1];
+          switchInt(copy (_3.0: u32)) -> [1: bb2, 2: bb3, 3: bb4, otherwise: bb1];
       }
   
       bb1: {
           _0 = const 0_u32;
--         goto -> bb8;
-+         goto -> bb5;
+          goto -> bb8;
       }
   
       bb2: {
--         switchInt(copy (_3.1: u32)) -> [1: bb7, otherwise: bb1];
-+         _0 = const 6_u32;
-+         goto -> bb5;
+          switchInt(copy (_3.1: u32)) -> [1: bb7, otherwise: bb1];
       }
   
       bb3: {
--         switchInt(copy (_3.1: u32)) -> [2: bb6, otherwise: bb1];
-+         _0 = const 5_u32;
-+         goto -> bb5;
+          switchInt(copy (_3.1: u32)) -> [2: bb6, otherwise: bb1];
       }
   
       bb4: {
--         switchInt(copy (_3.1: u32)) -> [3: bb5, otherwise: bb1];
-+         _0 = const 4_u32;
-+         goto -> bb5;
+          switchInt(copy (_3.1: u32)) -> [3: bb5, otherwise: bb1];
       }
   
       bb5: {
--         _0 = const 6_u32;
--         goto -> bb8;
-+         StorageDead(_3);
-+         return;
+          _0 = const 6_u32;
+          goto -> bb8;
       }
   
       bb6: {
--         _0 = const 5_u32;
--         goto -> bb8;
--     }
-- 
--     bb7: {
--         _0 = const 4_u32;
--         goto -> bb8;
--     }
-- 
--     bb8: {
--         StorageDead(_3);
--         return;
-+         switchInt(copy (_3.0: u32)) -> [1: bb4, 2: bb3, 3: bb2, otherwise: bb1];
+          _0 = const 5_u32;
+          goto -> bb8;
+      }
+  
+      bb7: {
+          _0 = const 4_u32;
+          goto -> bb8;
+      }
+  
+      bb8: {
+          StorageDead(_3);
+          return;
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch.rs
+++ b/tests/mir-opt/early_otherwise_branch.rs
@@ -84,11 +84,14 @@ fn opt4(x: Option2<u32>, y: Option2<u32>) -> u32 {
 
 // EMIT_MIR early_otherwise_branch.opt5.EarlyOtherwiseBranch.diff
 fn opt5(x: u32, y: u32) -> u32 {
+    // The reachable wildcard can be selected without reading the second tuple field.
     // CHECK-LABEL: fn opt5(
-    // CHECK: let mut [[CMP_LOCAL:_.*]]: bool;
+    // CHECK: let mut [[PAIR:_.*]]: (u32, u32);
     // CHECK: bb0: {
-    // CHECK: [[CMP_LOCAL]] = Ne(
-    // CHECK: switchInt(move [[CMP_LOCAL]]) -> [
+    // CHECK-NOT: copy ([[PAIR]].1: u32)
+    // CHECK-NOT: move ([[PAIR]].1: u32)
+    // CHECK-NOT: bb{{[0-9]+}}:
+    // CHECK: switchInt(copy ([[PAIR]].0: u32)) -> [
     // CHECK-NEXT: }
     match (x, y) {
         (1, 1) => 4,
@@ -125,6 +128,95 @@ fn opt5_failed_type(x: u32, y: u64) -> u32 {
         (2, 2) => 5,
         (3, 3) => 6,
         _ => 0,
+    }
+}
+
+// EMIT_MIR early_otherwise_branch.scalar_unreachable.EarlyOtherwiseBranch.diff
+#[custom_mir(dialect = "runtime")]
+fn scalar_unreachable(x: u32, y: u32) -> u32 {
+    // CHECK-LABEL: fn scalar_unreachable(
+    // CHECK-SAME: [[X:_.*]]: u32, [[Y:_.*]]: u32) -> u32 {
+    // CHECK: let mut [[CMP:_.*]]: bool;
+    // CHECK: bb0: {
+    // CHECK-NEXT: [[CMP]] = Ne(copy [[X]], copy [[Y]]);
+    // CHECK-NEXT: switchInt(move [[CMP]]) -> [
+    // CHECK-NEXT: }
+    mir! {
+        {
+            match x {
+                1 => bb1,
+                2 => bb2,
+                _ => bbu,
+            }
+        }
+
+        bb1 = {
+            match y {
+                1 => bb3,
+                _ => bb5,
+            }
+        }
+
+        bb2 = {
+            match y {
+                2 => bb4,
+                _ => bb5,
+            }
+        }
+
+        bb3 = {
+            RET = 1;
+            Return()
+        }
+
+        bb4 = {
+            RET = 2;
+            Return()
+        }
+
+        bb5 = {
+            RET = 0;
+            Return()
+        }
+
+        bbu = {
+            Unreachable()
+        }
+    }
+}
+
+// EMIT_MIR early_otherwise_branch.same_place_move_copy.EarlyOtherwiseBranch.diff
+#[custom_mir(dialect = "runtime")]
+fn same_place_move_copy(pair: (i32, i32)) {
+    // CHECK-LABEL: fn same_place_move_copy(
+    // CHECK-SAME: [[PAIR:_.*]]: (i32, i32)) -> () {
+    // CHECK: let mut [[CMP:_.*]]: bool;
+    // CHECK: bb0: {
+    // CHECK-NEXT: [[CMP]] = Ne(copy ([[PAIR]].0: i32), copy ([[PAIR]].0: i32));
+    // CHECK-NEXT: switchInt(move [[CMP]]) -> [
+    // CHECK-NEXT: }
+    mir! {
+        {
+            match Move(pair.0) {
+                0 => bb1,
+                _ => bb3,
+            }
+        }
+
+        bb1 = {
+            match pair.0 {
+                0 => bb2,
+                _ => bb3,
+            }
+        }
+
+        bb2 = {
+            Return()
+        }
+
+        bb3 = {
+            Return()
+        }
     }
 }
 

--- a/tests/mir-opt/early_otherwise_branch.rs
+++ b/tests/mir-opt/early_otherwise_branch.rs
@@ -220,6 +220,44 @@ fn same_place_move_copy(pair: (i32, i32)) {
     }
 }
 
+// The parent switch has already evaluated `*p` before any reachable `otherwise` target.
+// CHECK-LABEL: fn same_place_deref(
+// CHECK: [[CMP:_.*]] = Ne(copy (*_1), copy (*_1));
+// CHECK: switchInt(move [[CMP]]) -> [
+#[custom_mir(dialect = "runtime")]
+fn same_place_deref(p: *const u64) {
+    mir! {
+        {
+            match *p {
+                1 => bb1,
+                2 => bb2,
+                _ => bb3,
+            }
+        }
+        bb1 = {
+            match *p {
+                1 => bb4,
+                _ => bb3,
+            }
+        }
+        bb2 = {
+            match *p {
+                2 => bb5,
+                _ => bb3,
+            }
+        }
+        bb3 = {
+            Return()
+        }
+        bb4 = {
+            Return()
+        }
+        bb5 = {
+            Return()
+        }
+    }
+}
+
 // EMIT_MIR early_otherwise_branch.target_self.EarlyOtherwiseBranch.diff
 #[custom_mir(dialect = "runtime")]
 fn target_self(val: i32) {

--- a/tests/mir-opt/early_otherwise_branch.same_place_move_copy.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.same_place_move_copy.EarlyOtherwiseBranch.diff
@@ -1,0 +1,28 @@
+- // MIR for `same_place_move_copy` before EarlyOtherwiseBranch
++ // MIR for `same_place_move_copy` after EarlyOtherwiseBranch
+  
+  fn same_place_move_copy(_1: (i32, i32)) -> () {
+      let mut _0: ();
++     let mut _2: bool;
+  
+      bb0: {
+-         switchInt(move (_1.0: i32)) -> [0: bb1, otherwise: bb3];
++         _2 = Ne(copy (_1.0: i32), copy (_1.0: i32));
++         switchInt(move _2) -> [0: bb3, otherwise: bb2];
+      }
+  
+      bb1: {
+-         switchInt(copy (_1.0: i32)) -> [0: bb2, otherwise: bb3];
++         return;
+      }
+  
+      bb2: {
+          return;
+      }
+  
+      bb3: {
+-         return;
++         switchInt(copy (_1.0: i32)) -> [0: bb1, otherwise: bb2];
+      }
+  }
+  

--- a/tests/mir-opt/early_otherwise_branch.scalar_unreachable.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.scalar_unreachable.EarlyOtherwiseBranch.diff
@@ -1,0 +1,48 @@
+- // MIR for `scalar_unreachable` before EarlyOtherwiseBranch
++ // MIR for `scalar_unreachable` after EarlyOtherwiseBranch
+  
+  fn scalar_unreachable(_1: u32, _2: u32) -> u32 {
+      let mut _0: u32;
++     let mut _3: bool;
+  
+      bb0: {
+-         switchInt(copy _1) -> [1: bb1, 2: bb2, otherwise: bb6];
++         _3 = Ne(copy _1, copy _2);
++         switchInt(move _3) -> [0: bb5, otherwise: bb3];
+      }
+  
+      bb1: {
+-         switchInt(copy _2) -> [1: bb3, otherwise: bb5];
+-     }
+- 
+-     bb2: {
+-         switchInt(copy _2) -> [2: bb4, otherwise: bb5];
+-     }
+- 
+-     bb3: {
+          _0 = const 1_u32;
+          return;
+      }
+  
+-     bb4: {
++     bb2: {
+          _0 = const 2_u32;
+          return;
+      }
+  
+-     bb5: {
++     bb3: {
+          _0 = const 0_u32;
+          return;
+      }
+  
+-     bb6: {
++     bb4: {
+          unreachable;
++     }
++ 
++     bb5: {
++         switchInt(copy _1) -> [1: bb1, 2: bb2, otherwise: bb4];
+      }
+  }
+  

--- a/tests/mir-opt/early_otherwise_branch_dead_local.constant_parent_dead_local.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_dead_local.constant_parent_dead_local.EarlyOtherwiseBranch.diff
@@ -1,0 +1,34 @@
+- // MIR for `constant_parent_dead_local` before EarlyOtherwiseBranch
++ // MIR for `constant_parent_dead_local` after EarlyOtherwiseBranch
+  
+  fn constant_parent_dead_local() -> () {
+      let mut _0: ();
+      let mut _1: u64;
+      let mut _2: u64;
+  
+      bb0: {
+          StorageLive(_1);
+          _1 = const 0_u64;
+          StorageDead(_1);
+          switchInt(const 1_u64) -> [0: bb1, otherwise: bb3];
+      }
+  
+      bb1: {
+          switchInt(copy _1) -> [0: bb2, otherwise: bb3];
+      }
+  
+      bb2: {
+          _2 = const 2_u64;
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _2 = const 3_u64;
+          goto -> bb4;
+      }
+  
+      bb4: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/early_otherwise_branch_dead_local.dead_local.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_dead_local.dead_local.EarlyOtherwiseBranch.diff
@@ -1,0 +1,34 @@
+- // MIR for `dead_local` before EarlyOtherwiseBranch
++ // MIR for `dead_local` after EarlyOtherwiseBranch
+  
+  fn dead_local(_1: u64) -> () {
+      let mut _0: ();
+      let mut _2: u64;
+      let mut _3: u64;
+  
+      bb0: {
+          StorageLive(_2);
+          _2 = const 0_u64;
+          StorageDead(_2);
+          switchInt(copy _1) -> [0: bb1, otherwise: bb3];
+      }
+  
+      bb1: {
+          switchInt(copy _2) -> [0: bb2, otherwise: bb3];
+      }
+  
+      bb2: {
+          _3 = const 2_u64;
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _3 = const 3_u64;
+          goto -> bb4;
+      }
+  
+      bb4: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/early_otherwise_branch_dead_local.rs
+++ b/tests/mir-opt/early_otherwise_branch_dead_local.rs
@@ -1,0 +1,109 @@
+//@ test-mir-pass: EarlyOtherwiseBranch
+//@ compile-flags: -Zlint-mir=no
+
+#![feature(core_intrinsics, custom_mir)]
+
+use std::intrinsics::mir::*;
+
+fn main() {
+    dead_local(1);
+    constant_parent_dead_local();
+}
+
+// EMIT_MIR early_otherwise_branch_dead_local.dead_local.EarlyOtherwiseBranch.diff
+#[custom_mir(dialect = "runtime", phase = "post-cleanup")]
+#[inline(never)]
+fn dead_local(a: u64) {
+    // CHECK-LABEL: fn dead_local(
+    // CHECK-SAME: [[A:_.*]]: u64) -> () {
+    // CHECK: let mut [[B:_.*]]: u64;
+    // CHECK: bb0: {
+    // CHECK-NEXT: StorageLive([[B]]);
+    // CHECK-NEXT: [[B]] = const 0_u64;
+    // CHECK-NEXT: StorageDead([[B]]);
+    // CHECK-NEXT: switchInt(copy [[A]]) -> [0: bb{{[0-9]+}}, otherwise: bb{{[0-9]+}}];
+    // CHECK-NEXT: }
+    mir! {
+        let b: u64;
+        let marker: u64;
+
+        {
+            StorageLive(b);
+            b = 0;
+            StorageDead(b);
+            match a {
+                0 => bb1,
+                _ => bb3,
+            }
+        }
+
+        bb1 = {
+            match b {
+                0 => bb2,
+                _ => bb3,
+            }
+        }
+
+        bb2 = {
+            marker = 2;
+            Goto(bb4)
+        }
+
+        bb3 = {
+            marker = 3;
+            Goto(bb4)
+        }
+
+        bb4 = {
+            Return()
+        }
+    }
+}
+
+// EMIT_MIR early_otherwise_branch_dead_local.constant_parent_dead_local.EarlyOtherwiseBranch.diff
+#[custom_mir(dialect = "runtime", phase = "post-cleanup")]
+fn constant_parent_dead_local() {
+    // CHECK-LABEL: fn constant_parent_dead_local(
+    // CHECK: let mut [[B:_.*]]: u64;
+    // CHECK: bb0: {
+    // CHECK-NEXT: StorageLive([[B]]);
+    // CHECK-NEXT: [[B]] = const 0_u64;
+    // CHECK-NEXT: StorageDead([[B]]);
+    // CHECK-NEXT: switchInt(const 1_u64) -> [0: bb{{[0-9]+}}, otherwise: bb{{[0-9]+}}];
+    // CHECK-NEXT: }
+    mir! {
+        let b: u64;
+        let marker: u64;
+
+        {
+            StorageLive(b);
+            b = 0;
+            StorageDead(b);
+            match 1_u64 {
+                0 => bb1,
+                _ => bb3,
+            }
+        }
+
+        bb1 = {
+            match b {
+                0 => bb2,
+                _ => bb3,
+            }
+        }
+
+        bb2 = {
+            marker = 2;
+            Goto(bb4)
+        }
+
+        bb3 = {
+            marker = 3;
+            Goto(bb4)
+        }
+
+        bb4 = {
+            Return()
+        }
+    }
+}


### PR DESCRIPTION
Fixes rust-lang/rust#159618.

`EarlyOtherwiseBranch` could hoist a child scalar read onto a reachable `otherwise` path where that place was not originally evaluated. If the child place is dead, the transformed MIR introduces UB.

Require the parent and child discriminants to reference the same complete `Place` before applying this scalar optimization when `otherwise` is reachable. Empty-unreachable defaults and same-place `Move`/`Copy` candidates remain optimized. Recovering the distinct-place case would require proving that the child read is valid on the parent otherwise path.

Tests cover dead child locals, constant parents, distinct projections, and both preserved optimization cases.

Validation:

- `./x test --stage 1 tests/mir-opt` — 407 passed
- Focused MIR/UI tests and Miri with the pass disabled and enabled
- `./x fmt --check`
- `./x test --stage 1 tidy`
