### PR TITLE
Fix ICE when dumping the dep graph with the parallel frontend

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/retained.rs
+++ b/compiler/rustc_middle/src/dep_graph/retained.rs
@@ -26,6 +26,8 @@ impl RetainedDepGraph {
         Self { inner, indices }
     }
 
+    /// Adds `node` at its dep-graph index. Indices are allocated to threads in batches, so the
+    /// index space is sparse and the slots skipped over hold no node.
     pub fn push(&mut self, index: DepNodeIndex, node: DepNode, edges: &[DepNodeIndex]) {
         let source = NodeIndex(index.as_usize());
         self.inner.add_node_with_idx(source, node);
@@ -37,7 +39,7 @@ impl RetainedDepGraph {
     }
 
     pub fn nodes(&self) -> Vec<&DepNode> {
-        self.inner.all_nodes().iter().map(|n| n.data.as_ref().unwrap()).collect()
+        self.inner.all_nodes().iter().filter_map(|n| n.data.as_ref()).collect()
     }
 
     pub fn edges(&self) -> Vec<(&DepNode, &DepNode)> {

--- a/tests/run-make/dep-graph/rmake.rs
+++ b/tests/run-make/dep-graph/rmake.rs
@@ -1,18 +1,22 @@
-// Just verify that we successfully run and produce dep graphs when requested.
+// Just verify that we successfully run and produce dep graphs when requested. The parallel
+// frontend is covered too, because it leaves unused dep-graph indices that the dump must skip.
 
 //@ ignore-cross-compile
 
 use run_make_support::{path, rustc};
 
 fn main() {
-    rustc()
-        .input("foo.rs")
-        .incremental(path("incr"))
-        .arg("-Zquery-dep-graph")
-        .arg("-Zdump-dep-graph")
-        .env("RUST_DEP_GRAPH", path("dep-graph"))
-        .run();
+    for threads in ["1", "2"] {
+        rustc()
+            .input("foo.rs")
+            .incremental(path(format!("incr-{threads}")))
+            .arg("-Zquery-dep-graph")
+            .arg("-Zdump-dep-graph")
+            .arg(format!("-Zthreads={threads}"))
+            .env("RUST_DEP_GRAPH", path(format!("dep-graph-{threads}")))
+            .run();
 
-    assert!(path("dep-graph.txt").is_file());
-    assert!(path("dep-graph.dot").is_file());
+        assert!(path(format!("dep-graph-{threads}.txt")).is_file());
+        assert!(path(format!("dep-graph-{threads}.dot")).is_file());
+    }
 }


### PR DESCRIPTION
`-Zquery-dep-graph -Zdump-dep-graph` ICEs whenever `-Zthreads` is greater than 1:

```console
$ echo 'fn main() {}' > foo.rs
$ rustc -C incremental=incr -Zquery-dep-graph -Zdump-dep-graph -Zthreads=2 foo.rs
thread 'rustc' panicked at compiler/rustc_middle/src/dep_graph/retained.rs:40:63:
called `Option::unwrap()` on a `None` value
```

Reproduces on nightly on 15 of 15 runs at `-Zthreads` 2, 4 and 8. `-Zthreads=1` passes.

Dep-graph indices are handed to threads in batches of 256 and `EncoderState::finish` abandons each worker's unused tail, so `LinkedGraph::add_node_with_idx` back-fills the skipped slots with `data: None`. `RetainedDepGraph::nodes` unwrapped every slot, instead we skip the empty ones.