### PR TITLE
Distinguish the dep-graph index space from the live node count

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -178,12 +178,12 @@ impl DepGraph {
         prev_work_products: WorkProductMap,
         encoder: FileEncoder<'static>,
     ) -> DepGraph {
-        let prev_graph_node_count = prev_graph.node_count();
+        let prev_index_space_len = prev_graph.index_space_len();
 
         let current =
-            CurrentDepGraph::new(session, prev_graph_node_count, encoder, Arc::clone(&prev_graph));
+            CurrentDepGraph::new(session, prev_index_space_len, encoder, Arc::clone(&prev_graph));
 
-        let colors = DepNodeColorMap::new(prev_graph_node_count);
+        let colors = DepNodeColorMap::new(prev_index_space_len);
 
         // Instantiate a node with zero dependencies only once for anonymous queries.
         let _green_node_index = current.alloc_new_node(
@@ -202,7 +202,7 @@ impl DepGraph {
             Fingerprint::ZERO,
         );
         assert_eq!(red_node_index, DepNodeIndex::FOREVER_RED_NODE);
-        if prev_graph_node_count > 0 {
+        if prev_index_space_len > 0 {
             let prev_index =
                 const { SerializedDepNodeIndex::from_u32(DepNodeIndex::FOREVER_RED_NODE.as_u32()) };
             let result = colors.try_set_color(prev_index, DesiredColor::Red);
@@ -1199,7 +1199,7 @@ pub(super) struct CurrentDepGraph {
 impl CurrentDepGraph {
     fn new(
         session: &Session,
-        prev_graph_node_count: usize,
+        prev_index_space_len: usize,
         encoder: FileEncoder<'static>,
         previous: Arc<SerializedDepGraph>,
     ) -> Self {
@@ -1216,10 +1216,10 @@ impl CurrentDepGraph {
             Err(_) => None,
         };
 
-        let new_node_count_estimate = 102 * prev_graph_node_count / 100 + 200;
+        let new_node_count_estimate = 102 * previous.live_node_count() / 100 + 200;
 
         CurrentDepGraph {
-            encoder: GraphEncoder::new(session, encoder, prev_graph_node_count, previous),
+            encoder: GraphEncoder::new(session, encoder, prev_index_space_len, previous),
             anon_node_to_index: ShardedHashMap::with_capacity(
                 // FIXME: The count estimate is off as anon nodes are only a portion of the nodes.
                 new_node_count_estimate / sharded::shards(),

--- a/compiler/rustc_middle/src/dep_graph/serialized.rs
+++ b/compiler/rustc_middle/src/dep_graph/serialized.rs
@@ -116,6 +116,9 @@ pub struct SerializedDepGraph {
     /// [`SerializedDepNodeIndex`] via the node's key fingerprint. See
     /// [`LazyNodeIndex`].
     reverse_index: LazyNodeIndex,
+    /// The number of nodes actually encoded, which is below [`Self::index_space_len`]
+    /// whenever a thread left part of its batch of indices unused.
+    live_node_count: usize,
     /// The number of previous compilation sessions. This is used to generate
     /// unique anon dep nodes per session.
     session_count: u64,
@@ -133,6 +136,7 @@ impl std::fmt::Debug for SerializedDepGraph {
             .field("edge_list_indices", &self.edge_list_indices)
             .field("edge_list_data", &self.edge_list_data)
             .field("reverse_index", &self.reverse_index)
+            .field("live_node_count", &self.live_node_count)
             .field("session_count", &self.session_count)
             .finish_non_exhaustive()
     }
@@ -251,9 +255,15 @@ impl SerializedDepGraph {
         self.value_fingerprints[dep_node_index]
     }
 
+    /// The number of dep-node indices, counting those that hold no node.
     #[inline]
-    pub fn node_count(&self) -> usize {
+    pub fn index_space_len(&self) -> usize {
         self.nodes.len()
+    }
+
+    #[inline]
+    pub fn live_node_count(&self) -> usize {
+        self.live_node_count
     }
 
     #[inline]
@@ -414,6 +424,7 @@ impl SerializedDepGraph {
             edge_list_indices,
             edge_list_data,
             reverse_index,
+            live_node_count: node_count,
             session_count,
             profiler: Some(profiler.clone()),
         })
@@ -892,14 +903,14 @@ impl GraphEncoder {
     pub(crate) fn new(
         sess: &Session,
         encoder: FileEncoder<'static>,
-        prev_node_count: usize,
+        prev_index_space_len: usize,
         previous: Arc<SerializedDepGraph>,
     ) -> Self {
         let retained_graph = sess
             .opts
             .unstable_opts
             .query_dep_graph
-            .then(|| Lock::new(RetainedDepGraph::new(prev_node_count)));
+            .then(|| Lock::new(RetainedDepGraph::new(prev_index_space_len)));
         let status = EncoderState::new(encoder, sess.opts.unstable_opts.incremental_info, previous);
         GraphEncoder { status, retained_graph, profiler: sess.prof.clone() }
     }


### PR DESCRIPTION
`SerializedDepGraph::node_count()` returns `nodes.len()`, the size of the index space, which includes indices that batch allocation left unused. In the same file, the local `node_count` in `decode` is the number of nodes actually encoded. The two differ and are easy to confuse.