### PR TITLE
Simplify exception handling on wasm

### DIFF
--- a/library/panic_unwind/src/gcc.rs
+++ b/library/panic_unwind/src/gcc.rs
@@ -86,7 +86,9 @@ pub(crate) unsafe fn cleanup(ptr: *mut u8) -> Box<dyn Any + Send> {
     unsafe {
         let exception = ptr as *mut uw::_Unwind_Exception;
         if (*exception).exception_class != RUST_EXCEPTION_CLASS {
-            uw::_Unwind_DeleteException(exception);
+            if let Some(exception_cleanup) = (*exception).exception_cleanup {
+                exception_cleanup(uw::_URC_FOREIGN_EXCEPTION_CAUGHT, exception);
+            }
             super::__rust_foreign_exception();
         }
 

--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -18,6 +18,11 @@ cfg_select! {
     target_env = "msvc" => {
         // Windows MSVC no extra unwinder support needed
     }
+    target_family = "wasm" => {
+        mod types;
+        mod wasm;
+        pub use wasm::*;
+    }
     any(
         target_os = "l4re",
         target_os = "none",
@@ -32,17 +37,11 @@ cfg_select! {
         target_os = "psp",
         target_os = "solid_asp3",
         all(target_vendor = "fortanix", target_env = "sgx"),
-        all(target_os = "wasi", panic = "unwind"),
         target_os = "xous",
     ) => {
         mod libunwind;
         pub use libunwind::*;
         mod types;
-    }
-    target_family = "wasm" => {
-        mod types;
-        mod wasm;
-        pub use wasm::*;
     }
     _ => {
         // no unwinder on the system!
@@ -213,6 +212,10 @@ cfg_select! {
 
 #[cfg(target_os = "hurd")]
 #[link(name = "gcc_s")]
+unsafe extern "C" {}
+
+#[cfg(all(target_os = "wasi", panic = "unwind"))]
+#[link(name = "unwind")]
 unsafe extern "C" {}
 
 #[cfg(all(target_os = "windows", target_env = "gnu", target_abi = "llvm"))]

--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -26,13 +26,6 @@ pub enum _Unwind_Context {}
     all(feature = "llvm-libunwind", any(target_os = "fuchsia", target_os = "linux")),
     link(name = "unwind", kind = "static", modifiers = "-bundle")
 )]
-// Explicitly link the `unwind` library on WASI targets.
-//
-// This is provided in the self-contained sysroot for WASI targets by default.
-// Note that Rust defaults to `-Cpanic=abort` on WASI targets meaning that this
-// doesn't end up getting used by default, but this does mean that with
-// `-Zbuild-std` this'll automatically link it in.
-#[cfg_attr(target_os = "wasi", link(name = "unwind"))]
 unsafe extern "C-unwind" {
     pub fn _Unwind_Resume(exception: *mut _Unwind_Exception) -> !;
 }

--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -37,7 +37,6 @@ unsafe extern "C-unwind" {
     pub fn _Unwind_Resume(exception: *mut _Unwind_Exception) -> !;
 }
 unsafe extern "C" {
-    pub fn _Unwind_DeleteException(exception: *mut _Unwind_Exception);
     pub fn _Unwind_GetLanguageSpecificData(ctx: *mut _Unwind_Context) -> *mut c_void;
     pub fn _Unwind_GetRegionStart(ctx: *mut _Unwind_Context) -> _Unwind_Ptr;
     pub fn _Unwind_GetTextRelBase(ctx: *mut _Unwind_Context) -> _Unwind_Ptr;

--- a/library/unwind/src/types.rs
+++ b/library/unwind/src/types.rs
@@ -36,7 +36,6 @@ pub const unwinder_private_data_size: usize = cfg_select! {
     target_arch = "s390x" => 2,
     any(target_arch = "sparc", target_arch = "sparc64") => 2,
     any(target_arch = "riscv64", target_arch = "riscv32") => 2,
-    all(target_family = "wasm", target_os = "emscripten") => 20,
     target_family = "wasm" => 2,
     target_arch = "hexagon" => 5,
     any(target_arch = "loongarch32", target_arch = "loongarch64") => 2,

--- a/library/unwind/src/wasm.rs
+++ b/library/unwind/src/wasm.rs
@@ -28,12 +28,6 @@ core::arch::global_asm!(
 
 pub use crate::types::*;
 
-pub unsafe fn _Unwind_DeleteException(exception: *mut _Unwind_Exception) {
-    if let Some(exception_cleanup) = unsafe { (*exception).exception_cleanup } {
-        exception_cleanup(_URC_FOREIGN_EXCEPTION_CAUGHT, exception);
-    }
-}
-
 pub unsafe fn _Unwind_RaiseException(exception: *mut _Unwind_Exception) -> _Unwind_Reason_Code {
     // This implementation is only used for `wasm*-unknown-unknown` targets. Such targets are not
     // guaranteed to support exceptions, and they default to `-C panic=abort`. Because an unknown


### PR DESCRIPTION
* Fix `_Unwind_Exception` size on Emscripten.
* Inline `_Unwind_DeleteException` on all targets.
* Use `llvm.wasm.throw` on all wasm targets.

Follow up to https://github.com/rust-lang/rust/pull/159785