### PR TITLE
Preserve explicit register names in inline asm diagnostics

### DIFF
--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -173,25 +173,33 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         })
                     }
                 };
+                let explicit_reg_name = |&reg| match reg {
+                    InlineAsmRegOrRegClass::Reg(reg) => Some(reg),
+                    InlineAsmRegOrRegClass::RegClass(_) => None,
+                };
 
                 let op = match op {
                     InlineAsmOperand::In { reg, expr } => hir::InlineAsmOperand::In {
                         reg: lower_reg(reg),
+                        explicit_reg_name: explicit_reg_name(reg),
                         expr: self.lower_expr(expr),
                     },
                     InlineAsmOperand::Out { reg, late, expr } => hir::InlineAsmOperand::Out {
                         reg: lower_reg(reg),
+                        explicit_reg_name: explicit_reg_name(reg),
                         late: *late,
                         expr: expr.as_ref().map(|expr| self.lower_expr(expr)),
                     },
                     InlineAsmOperand::InOut { reg, late, expr } => hir::InlineAsmOperand::InOut {
                         reg: lower_reg(reg),
+                        explicit_reg_name: explicit_reg_name(reg),
                         late: *late,
                         expr: self.lower_expr(expr),
                     },
                     InlineAsmOperand::SplitInOut { reg, late, in_expr, out_expr } => {
                         hir::InlineAsmOperand::SplitInOut {
                             reg: lower_reg(reg),
+                            explicit_reg_name: explicit_reg_name(reg),
                             late: *late,
                             in_expr: self.lower_expr(in_expr),
                             out_expr: out_expr.as_ref().map(|expr| self.lower_expr(expr)),
@@ -393,24 +401,18 @@ impl<'hir> LoweringContext<'_, 'hir> {
                                     }
                                     _ => None,
                                 };
-                                let reg_str = |idx| -> &str {
-                                    // HIR asm doesn't preserve the original alias string of the explicit register,
-                                    // so we have to retrieve it from AST
-                                    let (op, _): &(InlineAsmOperand, Span) = &asm.operands[idx];
-                                    if let Some(ast::InlineAsmRegOrRegClass::Reg(reg_sym)) =
-                                        op.reg()
-                                    {
-                                        reg_sym.as_str()
-                                    } else {
-                                        unreachable!("{op:?} is not a register operand");
-                                    }
+                                let Some(reg1_name) = op.explicit_reg_name() else {
+                                    unreachable!("{op:?} has no source register name");
+                                };
+                                let Some(reg2_name) = op2.explicit_reg_name() else {
+                                    unreachable!("{op2:?} has no source register name");
                                 };
 
                                 self.dcx().emit_err(RegisterConflict {
                                     op_span1: op_sp,
                                     op_span2: op_sp2,
-                                    reg1_name: reg_str(idx),
-                                    reg2_name: reg_str(idx2),
+                                    reg1_name: reg1_name.as_str(),
+                                    reg2_name: reg2_name.as_str(),
                                     in_out,
                                 });
                             }
@@ -458,6 +460,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     operands.push((
                         hir::InlineAsmOperand::Out {
                             reg: asm::InlineAsmRegOrRegClass::Reg(clobber),
+                            // ABI clobbers are compiler-generated, so they have no source name.
+                            explicit_reg_name: None,
                             late: true,
                             expr: None,
                         },

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3966,24 +3966,32 @@ pub enum TyKind<'hir, Unambig = ()> {
     Infer(Unambig),
 }
 
+/// An inline assembly operand in HIR.
+///
+/// Explicit-register operands keep the register name written in the source for diagnostics. The
+/// canonical `reg` value remains the only value used for validation and code generation.
 #[derive(Debug, Clone, Copy, StableHash)]
 pub enum InlineAsmOperand<'hir> {
     In {
         reg: InlineAsmRegOrRegClass,
+        explicit_reg_name: Option<Symbol>,
         expr: &'hir Expr<'hir>,
     },
     Out {
         reg: InlineAsmRegOrRegClass,
+        explicit_reg_name: Option<Symbol>,
         late: bool,
         expr: Option<&'hir Expr<'hir>>,
     },
     InOut {
         reg: InlineAsmRegOrRegClass,
+        explicit_reg_name: Option<Symbol>,
         late: bool,
         expr: &'hir Expr<'hir>,
     },
     SplitInOut {
         reg: InlineAsmRegOrRegClass,
+        explicit_reg_name: Option<Symbol>,
         late: bool,
         in_expr: &'hir Expr<'hir>,
         out_expr: Option<&'hir Expr<'hir>>,
@@ -4017,10 +4025,26 @@ impl<'hir> InlineAsmOperand<'hir> {
         }
     }
 
+    /// Returns the register name written in the source for an explicit-register operand.
+    ///
+    /// Register-class operands and compiler-generated operands do not have a source register name.
+    pub fn explicit_reg_name(&self) -> Option<&Symbol> {
+        match self {
+            Self::In { explicit_reg_name, .. }
+            | Self::Out { explicit_reg_name, .. }
+            | Self::InOut { explicit_reg_name, .. }
+            | Self::SplitInOut { explicit_reg_name, .. } => explicit_reg_name.as_ref(),
+            Self::Const { .. }
+            | Self::SymFn { .. }
+            | Self::SymStatic { .. }
+            | Self::Label { .. } => None,
+        }
+    }
+
     pub fn is_clobber(&self) -> bool {
         matches!(
             self,
-            InlineAsmOperand::Out { reg: InlineAsmRegOrRegClass::Reg(_), late: _, expr: None }
+            InlineAsmOperand::Out { reg: InlineAsmRegOrRegClass::Reg(_), expr: None, .. }
         )
     }
 }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1465,7 +1465,7 @@ impl<'a> State<'a> {
         self.commasep(Consistent, &args, |s, arg| match *arg {
             AsmArg::Template(ref template) => s.print_string(template, ast::StrStyle::Cooked),
             AsmArg::Operand(op) => match *op {
-                hir::InlineAsmOperand::In { reg, expr } => {
+                hir::InlineAsmOperand::In { reg, expr, .. } => {
                     s.word("in");
                     s.popen();
                     s.word(format!("{reg}"));
@@ -1473,7 +1473,7 @@ impl<'a> State<'a> {
                     s.space();
                     s.print_expr(expr);
                 }
-                hir::InlineAsmOperand::Out { reg, late, ref expr } => {
+                hir::InlineAsmOperand::Out { reg, late, ref expr, .. } => {
                     s.word(if late { "lateout" } else { "out" });
                     s.popen();
                     s.word(format!("{reg}"));
@@ -1484,7 +1484,7 @@ impl<'a> State<'a> {
                         None => s.word("_"),
                     }
                 }
-                hir::InlineAsmOperand::InOut { reg, late, expr } => {
+                hir::InlineAsmOperand::InOut { reg, late, expr, .. } => {
                     s.word(if late { "inlateout" } else { "inout" });
                     s.popen();
                     s.word(format!("{reg}"));
@@ -1492,7 +1492,7 @@ impl<'a> State<'a> {
                     s.space();
                     s.print_expr(expr);
                 }
-                hir::InlineAsmOperand::SplitInOut { reg, late, in_expr, ref out_expr } => {
+                hir::InlineAsmOperand::SplitInOut { reg, late, in_expr, ref out_expr, .. } => {
                     s.word(if late { "inlateout" } else { "inout" });
                     s.popen();
                     s.word(format!("{reg}"));

--- a/compiler/rustc_hir_typeck/src/inline_asm.rs
+++ b/compiler/rustc_hir_typeck/src/inline_asm.rs
@@ -453,7 +453,11 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
                         &self.tcx().sess.target,
                         op.is_clobber(),
                     ) {
-                        let msg = format!("cannot use register `{}`: {}", reg.name(), msg);
+                        let reg_name = match op.explicit_reg_name() {
+                            Some(reg_name) => reg_name.as_str(),
+                            None => &reg.name(),
+                        };
+                        let msg = format!("cannot use register `{reg_name}`: {msg}");
                         self.fcx.dcx().span_err(op_sp, msg);
                         continue;
                     }
@@ -518,18 +522,18 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
             }
 
             match op {
-                hir::InlineAsmOperand::In { reg, expr } => {
+                hir::InlineAsmOperand::In { reg, expr, .. } => {
                     self.check_asm_operand_type(idx, reg, expr, asm.template, true, None);
                 }
-                hir::InlineAsmOperand::Out { reg, late: _, expr } => {
+                hir::InlineAsmOperand::Out { reg, expr, .. } => {
                     if let Some(expr) = expr {
                         self.check_asm_operand_type(idx, reg, expr, asm.template, false, None);
                     }
                 }
-                hir::InlineAsmOperand::InOut { reg, late: _, expr } => {
+                hir::InlineAsmOperand::InOut { reg, expr, .. } => {
                     self.check_asm_operand_type(idx, reg, expr, asm.template, false, None);
                 }
-                hir::InlineAsmOperand::SplitInOut { reg, late: _, in_expr, out_expr } => {
+                hir::InlineAsmOperand::SplitInOut { reg, in_expr, out_expr, .. } => {
                     let in_ty =
                         self.check_asm_operand_type(idx, reg, in_expr, asm.template, true, None);
                     if let Some(out_expr) = out_expr {

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -792,27 +792,31 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     .operands
                     .iter()
                     .map(|(op, _op_sp)| match *op {
-                        hir::InlineAsmOperand::In { reg, expr } => {
+                        hir::InlineAsmOperand::In { reg, expr, .. } => {
                             InlineAsmOperand::In { reg, expr: self.mirror_expr(expr) }
                         }
-                        hir::InlineAsmOperand::Out { reg, late, ref expr } => {
+                        hir::InlineAsmOperand::Out { reg, late, ref expr, .. } => {
                             InlineAsmOperand::Out {
                                 reg,
                                 late,
                                 expr: expr.map(|expr| self.mirror_expr(expr)),
                             }
                         }
-                        hir::InlineAsmOperand::InOut { reg, late, expr } => {
+                        hir::InlineAsmOperand::InOut { reg, late, expr, .. } => {
                             InlineAsmOperand::InOut { reg, late, expr: self.mirror_expr(expr) }
                         }
-                        hir::InlineAsmOperand::SplitInOut { reg, late, in_expr, ref out_expr } => {
-                            InlineAsmOperand::SplitInOut {
-                                reg,
-                                late,
-                                in_expr: self.mirror_expr(in_expr),
-                                out_expr: out_expr.map(|expr| self.mirror_expr(expr)),
-                            }
-                        }
+                        hir::InlineAsmOperand::SplitInOut {
+                            reg,
+                            late,
+                            in_expr,
+                            ref out_expr,
+                            ..
+                        } => InlineAsmOperand::SplitInOut {
+                            reg,
+                            late,
+                            in_expr: self.mirror_expr(in_expr),
+                            out_expr: out_expr.map(|expr| self.mirror_expr(expr)),
+                        },
                         hir::InlineAsmOperand::Const { ref anon_const } => {
                             let ty = self.typeck_results.node_type(anon_const.hir_id);
                             let did = anon_const.def_id;

--- a/src/tools/clippy/clippy_utils/src/hir_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/hir_utils.rs
@@ -1275,18 +1275,18 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                 asm.options.hash(&mut self.s);
                 for (op, _op_sp) in asm.operands {
                     match op {
-                        InlineAsmOperand::In { reg, expr } => {
+                        InlineAsmOperand::In { reg, expr, .. } => {
                             reg.hash(&mut self.s);
                             self.hash_expr(expr);
                         },
-                        InlineAsmOperand::Out { reg, late, expr } => {
+                        InlineAsmOperand::Out { reg, late, expr, .. } => {
                             reg.hash(&mut self.s);
                             late.hash(&mut self.s);
                             if let Some(expr) = expr {
                                 self.hash_expr(expr);
                             }
                         },
-                        InlineAsmOperand::InOut { reg, late, expr } => {
+                        InlineAsmOperand::InOut { reg, late, expr, .. } => {
                             reg.hash(&mut self.s);
                             late.hash(&mut self.s);
                             self.hash_expr(expr);
@@ -1296,6 +1296,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                             late,
                             in_expr,
                             out_expr,
+                            ..
                         } => {
                             reg.hash(&mut self.s);
                             late.hash(&mut self.s);

--- a/tests/ui/asm/sparc/bad-reg.rs
+++ b/tests/ui/asm/sparc/bad-reg.rs
@@ -28,7 +28,7 @@ fn f() {
         asm!("", out("g3") _);
         asm!("", out("g4") _);
         asm!("", out("g5") _);
-        //[sparc,sparcv8plus]~^ ERROR cannot use register `r5`: g5 is reserved for system on SPARC32
+        //[sparc,sparcv8plus]~^ ERROR cannot use register `g5`: g5 is reserved for system on SPARC32
         asm!("", out("g6") _);
         //~^ ERROR invalid register `g6`: reserved for system and cannot be used as an operand for inline asm
         asm!("", out("g7") _);

--- a/tests/ui/asm/sparc/bad-reg.sparc.stderr
+++ b/tests/ui/asm/sparc/bad-reg.sparc.stderr
@@ -64,7 +64,7 @@ error: register class `yreg` can only be used as a clobber, not as an input or o
 LL |         asm!("/* {} */", out(yreg) _);
    |                          ^^^^^^^^^^^
 
-error: cannot use register `r5`: g5 is reserved for system on SPARC32
+error: cannot use register `g5`: g5 is reserved for system on SPARC32
   --> $DIR/bad-reg.rs:30:18
    |
 LL |         asm!("", out("g5") _);

--- a/tests/ui/asm/sparc/bad-reg.sparcv8plus.stderr
+++ b/tests/ui/asm/sparc/bad-reg.sparcv8plus.stderr
@@ -64,7 +64,7 @@ error: register class `yreg` can only be used as a clobber, not as an input or o
 LL |         asm!("/* {} */", out(yreg) _);
    |                          ^^^^^^^^^^^
 
-error: cannot use register `r5`: g5 is reserved for system on SPARC32
+error: cannot use register `g5`: g5 is reserved for system on SPARC32
   --> $DIR/bad-reg.rs:30:18
    |
 LL |         asm!("", out("g5") _);

--- a/tests/ui/asm/x86-explicit-register-alias-diagnostic.rs
+++ b/tests/ui/asm/x86-explicit-register-alias-diagnostic.rs
@@ -1,0 +1,51 @@
+// Check that inline assembly diagnostics use the explicit register name from the source.
+//
+// On 32-bit x86, vector registers 8 and higher are unavailable. Registers 16 through 31
+// share a canonical `zmm` representation, but diagnostics must still use the `xmm`, `ymm`,
+// or `zmm` name that the user wrote.
+//
+// Regression test for <https://github.com/rust-lang/rust/issues/159409>.
+
+//@ add-minicore
+//@ revisions: x86 x86_64
+//@[x86] compile-flags: --target i686-unknown-linux-gnu
+//@[x86] needs-llvm-components: x86
+//@[x86] check-fail
+//@[x86_64] compile-flags: --target x86_64-unknown-linux-gnu
+//@[x86_64] needs-llvm-components: x86
+//@[x86_64] check-pass
+//@ ignore-backends: gcc
+
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+fn main() {
+    unsafe {
+        // Register 15 is the last register with separate canonical representations.
+        asm!("", lateout("xmm15") _);
+        //[x86]~^ ERROR cannot use register `xmm15`
+        asm!("", lateout("ymm15") _);
+        //[x86]~^ ERROR cannot use register `ymm15`
+        asm!("", lateout("zmm15") _);
+        //[x86]~^ ERROR cannot use register `zmm15`
+
+        // Register 16 is the first register whose aliases share the canonical `zmm` representation.
+        asm!("", lateout("xmm16") _);
+        //[x86]~^ ERROR cannot use register `xmm16`
+        asm!("", lateout("ymm16") _);
+        //[x86]~^ ERROR cannot use register `ymm16`
+        asm!("", lateout("zmm16") _);
+        //[x86]~^ ERROR cannot use register `zmm16`
+
+        // Register 31 is the upper boundary of the affected register range.
+        asm!("", lateout("xmm31") _);
+        //[x86]~^ ERROR cannot use register `xmm31`
+        asm!("", lateout("ymm31") _);
+        //[x86]~^ ERROR cannot use register `ymm31`
+        asm!("", lateout("zmm31") _);
+        //[x86]~^ ERROR cannot use register `zmm31`
+    }
+}

--- a/tests/ui/asm/x86-explicit-register-alias-diagnostic.x86.stderr
+++ b/tests/ui/asm/x86-explicit-register-alias-diagnostic.x86.stderr
@@ -16,13 +16,13 @@ error: cannot use register `zmm15`: register is only available on x86_64
 LL |         asm!("", lateout("zmm15") _);
    |                  ^^^^^^^^^^^^^^^^^^
 
-error: cannot use register `zmm16`: register is only available on x86_64
+error: cannot use register `xmm16`: register is only available on x86_64
   --> $DIR/x86-explicit-register-alias-diagnostic.rs:36:18
    |
 LL |         asm!("", lateout("xmm16") _);
    |                  ^^^^^^^^^^^^^^^^^^
 
-error: cannot use register `zmm16`: register is only available on x86_64
+error: cannot use register `ymm16`: register is only available on x86_64
   --> $DIR/x86-explicit-register-alias-diagnostic.rs:38:18
    |
 LL |         asm!("", lateout("ymm16") _);
@@ -34,13 +34,13 @@ error: cannot use register `zmm16`: register is only available on x86_64
 LL |         asm!("", lateout("zmm16") _);
    |                  ^^^^^^^^^^^^^^^^^^
 
-error: cannot use register `zmm31`: register is only available on x86_64
+error: cannot use register `xmm31`: register is only available on x86_64
   --> $DIR/x86-explicit-register-alias-diagnostic.rs:44:18
    |
 LL |         asm!("", lateout("xmm31") _);
    |                  ^^^^^^^^^^^^^^^^^^
 
-error: cannot use register `zmm31`: register is only available on x86_64
+error: cannot use register `ymm31`: register is only available on x86_64
   --> $DIR/x86-explicit-register-alias-diagnostic.rs:46:18
    |
 LL |         asm!("", lateout("ymm31") _);

--- a/tests/ui/asm/x86-explicit-register-alias-diagnostic.x86.stderr
+++ b/tests/ui/asm/x86-explicit-register-alias-diagnostic.x86.stderr
@@ -1,0 +1,56 @@
+error: cannot use register `xmm15`: register is only available on x86_64
+  --> $DIR/x86-explicit-register-alias-diagnostic.rs:28:18
+   |
+LL |         asm!("", lateout("xmm15") _);
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error: cannot use register `ymm15`: register is only available on x86_64
+  --> $DIR/x86-explicit-register-alias-diagnostic.rs:30:18
+   |
+LL |         asm!("", lateout("ymm15") _);
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error: cannot use register `zmm15`: register is only available on x86_64
+  --> $DIR/x86-explicit-register-alias-diagnostic.rs:32:18
+   |
+LL |         asm!("", lateout("zmm15") _);
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error: cannot use register `zmm16`: register is only available on x86_64
+  --> $DIR/x86-explicit-register-alias-diagnostic.rs:36:18
+   |
+LL |         asm!("", lateout("xmm16") _);
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error: cannot use register `zmm16`: register is only available on x86_64
+  --> $DIR/x86-explicit-register-alias-diagnostic.rs:38:18
+   |
+LL |         asm!("", lateout("ymm16") _);
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error: cannot use register `zmm16`: register is only available on x86_64
+  --> $DIR/x86-explicit-register-alias-diagnostic.rs:40:18
+   |
+LL |         asm!("", lateout("zmm16") _);
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error: cannot use register `zmm31`: register is only available on x86_64
+  --> $DIR/x86-explicit-register-alias-diagnostic.rs:44:18
+   |
+LL |         asm!("", lateout("xmm31") _);
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error: cannot use register `zmm31`: register is only available on x86_64
+  --> $DIR/x86-explicit-register-alias-diagnostic.rs:46:18
+   |
+LL |         asm!("", lateout("ymm31") _);
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error: cannot use register `zmm31`: register is only available on x86_64
+  --> $DIR/x86-explicit-register-alias-diagnostic.rs:48:18
+   |
+LL |         asm!("", lateout("zmm31") _);
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 9 previous errors
+


### PR DESCRIPTION
This PR adds diagnostic-only metadata directly to each register-bearing HIR operand, and replaces rust-lang/rust#117912 AST lookup with the new HIR metadata.

Fixes rust-lang/rust#159409