### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1261,7 +1261,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1388,7 +1388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2166,7 +2166,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2653,7 +2653,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5083,7 +5083,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5515,7 +5515,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5534,7 +5534,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5904,9 +5904,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -6512,7 +6512,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -5,7 +5,7 @@ use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
 #[derive(Default)]
 pub(crate) struct OnConstParser {
-    span: Option<Span>,
+    path_span: Option<Span>,
     directive: Option<(Span, Directive)>,
 }
 
@@ -21,8 +21,8 @@ impl AttributeParser for OnConstParser {
                 return;
             }
 
-            let span = cx.attr_span;
-            this.span = Some(span);
+            let path_span = cx.attr_path.span;
+            this.path_span = Some(path_span);
 
             let mode = Mode::DiagnosticOnConst;
 
@@ -31,7 +31,7 @@ impl AttributeParser for OnConstParser {
             let Some(directive) = parse_directive_items(cx, mode, items.mixed(), true) else {
                 return;
             };
-            merge_directives(cx, &mut this.directive, (span, directive));
+            merge_directives(cx, &mut this.directive, (path_span, directive));
         },
     )];
 
@@ -44,8 +44,11 @@ impl AttributeParser for OnConstParser {
     ]);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
-        if let Some(span) = self.span {
-            Some(AttributeKind::OnConst { span, directive: self.directive.map(|d| Box::new(d.1)) })
+        if let Some(path_span) = self.path_span {
+            Some(AttributeKind::OnConst {
+                span: path_span,
+                directive: self.directive.map(|d| Box::new(d.1)),
+            })
         } else {
             None
         }

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -210,7 +210,7 @@ impl AttributeParser for ConstStabilityParser {
                 {
                     this.stability = Some((
                         PartialConstStability { level, feature, promotable: false },
-                        cx.attr_span,
+                        cx.attr_path.span,
                     ));
                 }
             },
@@ -225,7 +225,7 @@ impl AttributeParser for ConstStabilityParser {
                 {
                     this.stability = Some((
                         PartialConstStability { level, feature, promotable: false },
-                        cx.attr_span,
+                        cx.attr_path.span,
                     ));
                 }
             },

--- a/compiler/rustc_attr_parsing/src/diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/diagnostics.rs
@@ -814,7 +814,7 @@ pub(crate) enum InvalidOnClause {
 pub(crate) struct DupesNotAllowed;
 
 #[derive(Diagnostic)]
-#[diag("usage of the unsafe `#[{$attr_path}]` attribute")]
+#[diag("usage of the unsafe `{$attr_path}` attribute")]
 #[note("{$note}")]
 pub(crate) struct UnsafeAttribute {
     pub attr_path: AttrPath,

--- a/compiler/rustc_builtin_macros/src/diagnostics.rs
+++ b/compiler/rustc_builtin_macros/src/diagnostics.rs
@@ -1036,7 +1036,7 @@ pub(crate) struct TakesNoArguments<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag("the `#[{$path}]` attribute is only usable with crates of the `proc-macro` crate type")]
+#[diag("the `{$path}` attribute is only usable with crates of the `proc-macro` crate type")]
 pub(crate) struct AttributeOnlyUsableWithCrateType<'a> {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
+++ b/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
@@ -230,9 +230,10 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
         }
 
         if !self.is_proc_macro_crate {
+            let path = &attr.get_normal_item().path;
             self.dcx
                 .create_err(diagnostics::AttributeOnlyUsableWithCrateType {
-                    span: attr.span,
+                    span: path.span,
                     path: &pprust::path_to_string(&attr.get_normal_item().path),
                 })
                 .emit();

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -96,13 +96,13 @@ pub(crate) fn expand_test(
 
 pub(crate) fn expand_bench(
     cx: &mut ExtCtxt<'_>,
-    attr_sp: Span,
+    attr_path_sp: Span,
     meta_item: &ast::MetaItem,
     item: Annotatable,
 ) -> Vec<Annotatable> {
     check_builtin_macro_attribute(cx, meta_item, sym::bench);
     warn_on_duplicate_attribute(cx, &item, sym::bench);
-    expand_test_or_bench(cx, attr_sp, item, true)
+    expand_test_or_bench(cx, attr_path_sp, item, true)
 }
 
 pub(crate) fn expand_test_or_bench(
@@ -413,7 +413,7 @@ pub(crate) fn expand_test_or_bench(
 fn not_testable_error(cx: &ExtCtxt<'_>, is_bench: bool, attr_sp: Span, item: Option<&ast::Item>) {
     let dcx = cx.dcx();
     let name = if is_bench { "bench" } else { "test" };
-    let msg = format!("the `#[{name}]` attribute may only be used on a free function");
+    let msg = format!("the `{name}` attribute may only be used on a free function");
     let level = match item.map(|i| &i.kind) {
         // These were a warning before #92959 and need to continue being that to avoid breaking
         // stable user code (#94508).
@@ -432,7 +432,7 @@ fn not_testable_error(cx: &ExtCtxt<'_>, is_bench: bool, attr_sp: Span, item: Opt
             ),
         );
     }
-    err.span_label(attr_sp, format!("the `#[{name}]` macro causes a function to be run as a test and has no effect on non-functions"));
+    err.span_label(attr_sp, format!("the `{name}` attribute causes a function to be run as a test and has no effect on non-functions"));
 
     if !is_bench {
         err.with_span_suggestion(attr_sp,

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1217,6 +1217,7 @@ pub enum AttributeKind {
 
     /// Represents `#[diagnostic::on_const]`.
     OnConst {
+        /// The attribute path span.
         span: Span,
         /// None if the directive was malformed in some way.
         directive: Option<Box<Directive>>,

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1389,7 +1389,8 @@ pub enum AttributeKind {
     /// Represents `#[rustc_const_stable]` and `#[rustc_const_unstable]`.
     RustcConstStability {
         stability: PartialConstStability,
-        /// Span of the `#[rustc_const_stable(...)]` or `#[rustc_const_unstable(...)]` attribute
+        /// Path span of the `#[rustc_const_stable(...)]` or `#[rustc_const_unstable(...)]`
+        /// attribute.
         span: Span,
     },
 

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -3399,7 +3399,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     return;
                 };
 
-                let name = self.ty_to_value_string(actual);
+                let name = self.ty_to_string(actual);
                 let inner_id = kind.did();
                 let mutable = if let Some(AutorefOrPtrAdjustment::Autoref { mutbl, .. }) =
                     pick.autoref_or_ptr_adjustment
@@ -3868,7 +3868,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// Print out the type for use in value namespace.
     fn ty_to_value_string(&self, ty: Ty<'tcx>) -> String {
         match ty.kind() {
-            ty::Adt(def, args) => self.tcx.def_path_str_with_args(def.did(), args),
+            ty::Adt(def, args) => self.tcx.value_path_str_with_args(def.did(), args),
             _ => self.ty_to_string(ty),
         }
     }

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -54,6 +54,8 @@ impl<'a> Parser<'a> {
         force_collect: ForceCollect,
         force_full_expr: bool,
     ) -> PResult<'a, Stmt> {
+        self.current_closure.take();
+
         let pre_attr_pos = self.collect_pos();
         let attrs = self.parse_outer_attributes()?;
         let lo = self.token.span;

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -52,7 +52,9 @@ use rustc_trait_selection::traits::ObligationCtxt;
 use crate::diagnostics;
 
 #[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_const]` can only be applied to non-const trait implementations")]
+#[diag(
+    "the `diagnostic::on_const` attribute can only be applied to non-const trait implementations"
+)]
 struct DiagnosticOnConstOnlyForNonConstTraitImpls {
     #[label("this is a const trait implementation")]
     item_span: Span,
@@ -568,7 +570,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     /// Checks if `#[diagnostic::on_const]` is applied to a on-const trait impl
     fn check_diagnostic_on_const(
         &self,
-        attr_span: Span,
+        attr_path_span: Span,
         hir_id: HirId,
         target: Target,
         item: Option<&'tcx Item<'tcx>>,
@@ -608,7 +610,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     self.tcx.emit_node_span_lint(
                         MISPLACED_DIAGNOSTIC_ATTRIBUTES,
                         hir_id,
-                        attr_span,
+                        attr_path_span,
                         DiagnosticOnConstOnlyForNonConstTraitImpls { item_span },
                     );
                     return;

--- a/compiler/rustc_passes/src/diagnostics.rs
+++ b/compiler/rustc_passes/src/diagnostics.rs
@@ -810,13 +810,13 @@ pub(crate) struct MissingConstErr {
 
 #[derive(Diagnostic)]
 #[diag(
-    "attribute `#[rustc_const_stable]` can only be applied to functions that are declared `#[stable]`"
+    "the `rustc_const_stable` attribute can only be applied to functions marked with the `stable` attribute"
 )]
 pub(crate) struct ConstStableNotStable {
     #[primary_span]
     pub fn_sig_span: Span,
     #[label("attribute specified here")]
-    pub const_span: Span,
+    pub path_span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_passes/src/diagnostics.rs
+++ b/compiler/rustc_passes/src/diagnostics.rs
@@ -405,7 +405,7 @@ pub(crate) struct AbiNe {
 
 #[derive(Diagnostic)]
 #[diag(
-    "`#[rustc_abi]` can only be applied to function items, type aliases, and associated functions"
+    "the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions"
 )]
 pub(crate) struct AbiInvalidAttribute {
     #[primary_span]

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -397,11 +397,11 @@ impl<'tcx> MissingStabilityAnnotations<'tcx> {
             && let Some(fn_sig) = fn_sig
             && const_stab.is_const_stable()
             && !stab.is_some_and(|s| s.is_stable())
-            && let Some(const_span) = find_attr_span!(RustcConstStability)
+            && let Some(path_span) = find_attr_span!(RustcConstStability)
         {
             self.tcx.dcx().emit_err(diagnostics::ConstStableNotStable {
                 fn_sig_span: fn_sig.span,
-                const_span,
+                path_span,
             });
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "browser-ui-test": "^0.24.1",
+    "browser-ui-test": "^0.25.0",
     "es-check": "^9.4.4",
     "eslint": "^8.57.1",
     "typescript": "^5.8.3"

--- a/tests/rustdoc-gui/code-example-buttons.goml
+++ b/tests/rustdoc-gui/code-example-buttons.goml
@@ -1,5 +1,6 @@
 // This test ensures that code blocks buttons are displayed on hover and when you click on them.
 go-to: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html"
+permissions: ["clipboard-read"]
 include: "utils.goml"
 
 // First we check we "hover".

--- a/tests/rustdoc-gui/copy-code.goml
+++ b/tests/rustdoc-gui/copy-code.goml
@@ -2,6 +2,7 @@
 // isn't broken.
 include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html"
+permissions: ["clipboard-read"]
 
 define-function: (
     "check-copy-button",

--- a/tests/rustdoc-gui/copy-path.goml
+++ b/tests/rustdoc-gui/copy-path.goml
@@ -1,6 +1,7 @@
 // Checks that the "copy path" button is not triggering JS error and its display
 // isn't broken and the copied path is as expected.
 go-to: "file://" + |DOC_PATH| + "/test_docs/foreign_impl_order/trait.Foo.html"
+permissions: ["clipboard-read"]
 
 // We ensure that the clipboard is empty.
 assert-clipboard: ""

--- a/tests/rustdoc-ui/proc_macro_bug.rs
+++ b/tests/rustdoc-ui/proc_macro_bug.rs
@@ -6,7 +6,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 
 #[proc_macro_derive(DeriveA)]
-//~^ ERROR the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
+//~^ ERROR the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
 pub fn a_derive(input: TokenStream) -> TokenStream {
     input
 }

--- a/tests/rustdoc-ui/proc_macro_bug.stderr
+++ b/tests/rustdoc-ui/proc_macro_bug.stderr
@@ -1,8 +1,8 @@
-error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/proc_macro_bug.rs:8:1
+error: the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/proc_macro_bug.rs:8:3
    |
 LL | #[proc_macro_derive(DeriveA)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/abi/debug.generic.stderr
+++ b/tests/ui/abi/debug.generic.stderr
@@ -264,7 +264,7 @@ error: fn_abi_of(test_generic) = FnAbi {
 LL | fn test_generic<T>(_x: *const T) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
+error: the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:43:1
    |
 LL | const C: () = ();
@@ -845,7 +845,7 @@ LL | type TestAbiEqNonsense = (fn((str, str)), fn((str, str)));
    = help: the trait `Sized` is not implemented for `str`
    = note: only the last element of a tuple may have a dynamically sized type
 
-error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
+error: the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:47:5
    |
 LL |     const C: () = ();

--- a/tests/ui/abi/debug.loongarch64.stderr
+++ b/tests/ui/abi/debug.loongarch64.stderr
@@ -264,7 +264,7 @@ error: fn_abi_of(test_generic) = FnAbi {
 LL | fn test_generic<T>(_x: *const T) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
+error: the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:43:1
    |
 LL | const C: () = ();
@@ -845,7 +845,7 @@ LL | type TestAbiEqNonsense = (fn((str, str)), fn((str, str)));
    = help: the trait `Sized` is not implemented for `str`
    = note: only the last element of a tuple may have a dynamically sized type
 
-error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
+error: the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:47:5
    |
 LL |     const C: () = ();

--- a/tests/ui/abi/debug.riscv64.stderr
+++ b/tests/ui/abi/debug.riscv64.stderr
@@ -264,7 +264,7 @@ error: fn_abi_of(test_generic) = FnAbi {
 LL | fn test_generic<T>(_x: *const T) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
+error: the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:43:1
    |
 LL | const C: () = ();
@@ -845,7 +845,7 @@ LL | type TestAbiEqNonsense = (fn((str, str)), fn((str, str)));
    = help: the trait `Sized` is not implemented for `str`
    = note: only the last element of a tuple may have a dynamically sized type
 
-error: `#[rustc_abi]` can only be applied to function items, type aliases, and associated functions
+error: the `rustc_abi` attribute can only be applied to function items, type aliases, and associated functions
   --> $DIR/debug.rs:47:5
    |
 LL |     const C: () = ();

--- a/tests/ui/abi/debug.rs
+++ b/tests/ui/abi/debug.rs
@@ -40,11 +40,11 @@ type TestFnPtr = fn(bool) -> u8; //~ ERROR: fn_abi
 fn test_generic<T>(_x: *const T) {} //~ ERROR: fn_abi
 
 #[rustc_abi(debug)] //~ ERROR: the `rustc_abi` attribute cannot be used on constants
-const C: () = (); //~ ERROR: `#[rustc_abi]` can only be applied to
+const C: () = (); //~ ERROR: the `rustc_abi` attribute can only be applied to
 
 impl S {
     #[rustc_abi(debug)] //~ ERROR: the `rustc_abi` attribute cannot be used on assoc
-    const C: () = (); //~ ERROR: `#[rustc_abi]` can only be applied to
+    const C: () = (); //~ ERROR: the `rustc_abi` attribute can only be applied to
 }
 
 impl S {

--- a/tests/ui/associated-types/fn-ptr-coercion-normalize-ice-132767.rs
+++ b/tests/ui/associated-types/fn-ptr-coercion-normalize-ice-132767.rs
@@ -1,0 +1,45 @@
+// Regression test for #132767. Coercing the fn item `bar` to a fn pointer while
+// `Foo::value` holds the associated-type projection `<<T as Func>::Ret as Id>::Assoc`
+// used to ICE during normalization ("maybe try to call `try_normalize_erasing_regions`
+// instead"). It should now report the ordinary `u32: Id` trait error instead of crashing.
+
+use std::hint::black_box;
+
+trait Func {
+    type Ret: Id;
+}
+
+trait Id {
+    type Assoc;
+}
+
+impl Id for i32 {
+    type Assoc = i32;
+}
+
+impl<F: FnOnce() -> R, R: Id> Func for F {
+    type Ret = R;
+}
+
+fn bar() -> impl Copy + Id {
+    //~^ ERROR the trait bound `u32: Id` is not satisfied
+    0u32
+}
+
+struct Foo<T: Func> {
+    _func: T,
+    value: Option<<<T as Func>::Ret as Id>::Assoc>,
+}
+
+fn main() {
+    let mut fn_def = black_box(Foo {
+        _func: bar,
+        value: None,
+    });
+    let fn_ptr = black_box(Foo {
+        _func: bar as fn() -> _,
+        value: None,
+    });
+    fn_def.value = fn_ptr.value;
+    black_box(fn_def);
+}

--- a/tests/ui/associated-types/fn-ptr-coercion-normalize-ice-132767.stderr
+++ b/tests/ui/associated-types/fn-ptr-coercion-normalize-ice-132767.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `u32: Id` is not satisfied
+  --> $DIR/fn-ptr-coercion-normalize-ice-132767.rs:24:13
+   |
+LL | fn bar() -> impl Copy + Id {
+   |             ^^^^^^^^^^^^^^ the trait `Id` is not implemented for `u32`
+LL |
+LL |     0u32
+   |     ---- return type was inferred to be `u32` here
+   |
+help: the trait `Id` is implemented for `i32`
+  --> $DIR/fn-ptr-coercion-normalize-ice-132767.rs:16:1
+   |
+LL | impl Id for i32 {
+   | ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/attributes/malformed-attrs.rs
+++ b/tests/ui/attributes/malformed-attrs.rs
@@ -105,7 +105,7 @@
 //~| WARN previously accepted
 #[proc_macro = 18]
 //~^ ERROR malformed
-//~| ERROR the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
+//~| ERROR the `proc_macro` attribute is only usable with crates of the `proc-macro` crate type
 #[cfg]
 //~^ ERROR malformed
 #[cfg_attr]
@@ -122,14 +122,14 @@ fn test() {
 
 #[proc_macro_attribute = 19]
 //~^ ERROR malformed
-//~| ERROR the `#[proc_macro_attribute]` attribute is only usable with crates of the `proc-macro` crate type
+//~| ERROR the `proc_macro_attribute` attribute is only usable with crates of the `proc-macro` crate type
 #[must_use = 1]
 //~^ ERROR malformed
 fn test2() { }
 
 #[proc_macro_derive]
 //~^ ERROR malformed `proc_macro_derive` attribute
-//~| ERROR the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
+//~| ERROR the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
 pub fn test3() {}
 
 #[must_not_suspend()]

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -108,23 +108,23 @@ LL | #[forbid(lint1, lint2, ...)]
 LL | #[forbid(lint1, lint2, lint3, reason = "...")]
    |         +++++++++++++++++++++++++++++++++++++
 
-error: the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:106:1
+error: the `proc_macro` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/malformed-attrs.rs:106:3
    |
 LL | #[proc_macro = 18]
-   | ^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^
 
-error: the `#[proc_macro_attribute]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:123:1
+error: the `proc_macro_attribute` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/malformed-attrs.rs:123:3
    |
 LL | #[proc_macro_attribute = 19]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
 
-error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:130:1
+error: the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/malformed-attrs.rs:130:3
    |
 LL | #[proc_macro_derive]
-   | ^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `windows_subsystem` attribute input
   --> $DIR/malformed-attrs.rs:26:4

--- a/tests/ui/attributes/unsafe/proc-unsafe-attributes.stderr
+++ b/tests/ui/attributes/unsafe/proc-unsafe-attributes.stderr
@@ -23,29 +23,29 @@ help: escape `unsafe` to use it as an identifier
 LL | #[unsafe(allow(r#unsafe(dead_code)))]
    |                ++
 
-error: the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/proc-unsafe-attributes.rs:1:1
+error: the `proc_macro` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/proc-unsafe-attributes.rs:1:10
    |
 LL | #[unsafe(proc_macro)]
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^
 
-error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/proc-unsafe-attributes.rs:7:1
+error: the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/proc-unsafe-attributes.rs:7:10
    |
 LL | #[unsafe(proc_macro_derive(Foo))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^^^^^^^^
 
-error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/proc-unsafe-attributes.rs:12:1
+error: the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/proc-unsafe-attributes.rs:12:3
    |
 LL | #[proc_macro_derive(unsafe(Foo))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
 
-error: the `#[proc_macro_attribute]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/proc-unsafe-attributes.rs:18:1
+error: the `proc_macro_attribute` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/proc-unsafe-attributes.rs:18:10
    |
 LL | #[unsafe(proc_macro_attribute)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^^^^^^^^^^^
 
 error[E0452]: malformed lint attribute input
   --> $DIR/proc-unsafe-attributes.rs:27:16

--- a/tests/ui/consts/rustc-const-stability-require-const.rs
+++ b/tests/ui/consts/rustc-const-stability-require-const.rs
@@ -50,9 +50,9 @@ pub const fn barfoo() {}
 
 #[rustc_const_stable(feature = "barfoo_const", since = "1.0.0")]
 const fn barfoo_unmarked() {}
-//~^ ERROR can only be applied to functions that are declared `#[stable]`
+//~^ ERROR can only be applied to functions marked with the `stable` attribute
 
 #[unstable(feature = "unstable", issue = "none")]
 #[rustc_const_stable(feature = "barfoo_const", since = "1.0.0")]
 pub const fn barfoo_unstable() {}
-//~^ ERROR can only be applied to functions that are declared `#[stable]`
+//~^ ERROR can only be applied to functions marked with the `stable` attribute

--- a/tests/ui/consts/rustc-const-stability-require-const.stderr
+++ b/tests/ui/consts/rustc-const-stability-require-const.stderr
@@ -46,19 +46,19 @@ help: make the function or method const
 LL | pub extern "C" fn foo_c() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: attribute `#[rustc_const_stable]` can only be applied to functions that are declared `#[stable]`
+error: the `rustc_const_stable` attribute can only be applied to functions marked with the `stable` attribute
   --> $DIR/rustc-const-stability-require-const.rs:52:1
    |
 LL | #[rustc_const_stable(feature = "barfoo_const", since = "1.0.0")]
-   | ---------------------------------------------------------------- attribute specified here
+   |   ------------------ attribute specified here
 LL | const fn barfoo_unmarked() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: attribute `#[rustc_const_stable]` can only be applied to functions that are declared `#[stable]`
+error: the `rustc_const_stable` attribute can only be applied to functions marked with the `stable` attribute
   --> $DIR/rustc-const-stability-require-const.rs:57:1
    |
 LL | #[rustc_const_stable(feature = "barfoo_const", since = "1.0.0")]
-   | ---------------------------------------------------------------- attribute specified here
+   |   ------------------ attribute specified here
 LL | pub const fn barfoo_unstable() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
@@ -6,7 +6,7 @@
 pub struct Foo;
 
 #[diagnostic::on_const(message = "tadaa", note = "boing")]
-//~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
+//~^ ERROR: the `diagnostic::on_const` attribute can only be applied to non-const trait implementations
 const impl PartialEq for Foo {
     fn eq(&self, _other: &Foo) -> bool {
         true

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
@@ -1,8 +1,8 @@
-error: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
-  --> $DIR/misplaced_attr.rs:8:1
+error: the `diagnostic::on_const` attribute can only be applied to non-const trait implementations
+  --> $DIR/misplaced_attr.rs:8:3
    |
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | const impl PartialEq for Foo {
    | ---------------------------- this is a const trait implementation

--- a/tests/ui/expr/malformed_closure/missing-braces-before-close-brace.rs
+++ b/tests/ui/expr/malformed_closure/missing-braces-before-close-brace.rs
@@ -1,0 +1,11 @@
+// Regression test for https://github.com/rust-lang/rust/issues/159989
+
+fn main() {
+    for<> || -> () {};
+    //~^ ERROR `for<...>` binders for closures are experimental
+    for<'a> || -> () |_;
+    //~^ ERROR expected one of `,`, `:`, or `|`, found `;`
+    //~| ERROR expected one of `,`, `:`, or `|`, found `;`
+    //~| ERROR expected `{`, found `|`
+    //~| ERROR `for<...>` binders for closures are experimental
+}

--- a/tests/ui/expr/malformed_closure/missing-braces-before-close-brace.stderr
+++ b/tests/ui/expr/malformed_closure/missing-braces-before-close-brace.stderr
@@ -1,0 +1,45 @@
+error: expected one of `,`, `:`, or `|`, found `;`
+  --> $DIR/missing-braces-before-close-brace.rs:6:24
+   |
+LL |     for<'a> || -> () |_;
+   |                        ^ expected one of `,`, `:`, or `|`
+
+error: expected one of `,`, `:`, or `|`, found `;`
+  --> $DIR/missing-braces-before-close-brace.rs:6:24
+   |
+LL |     for<'a> || -> () |_;
+   |                        ^ expected one of `,`, `:`, or `|`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected `{`, found `|`
+  --> $DIR/missing-braces-before-close-brace.rs:6:22
+   |
+LL |     for<'a> || -> () |_;
+   |                      ^ expected `{`
+
+error[E0658]: `for<...>` binders for closures are experimental
+  --> $DIR/missing-braces-before-close-brace.rs:4:5
+   |
+LL |     for<> || -> () {};
+   |     ^^^^^
+   |
+   = note: see issue #97362 <https://github.com/rust-lang/rust/issues/97362> for more information
+   = help: add `#![feature(closure_lifetime_binder)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: consider removing `for<...>`
+
+error[E0658]: `for<...>` binders for closures are experimental
+  --> $DIR/missing-braces-before-close-brace.rs:6:5
+   |
+LL |     for<'a> || -> () |_;
+   |     ^^^^^^^
+   |
+   = note: see issue #97362 <https://github.com/rust-lang/rust/issues/97362> for more information
+   = help: add `#![feature(closure_lifetime_binder)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: consider removing `for<...>`
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/gating-of-test-attrs.rs
+++ b/tests/ui/feature-gates/gating-of-test-attrs.rs
@@ -3,22 +3,22 @@
 // test is a built-in macro, not a built-in attribute, but it kind of acts like both.
 // check its target checking anyway here
 #[test]
-//~^ ERROR the `#[test]` attribute may only be used on a free function
+//~^ ERROR the `test` attribute may only be used on a free function
 mod test {
     mod inner { #![test] }
     //~^ ERROR inner macro attributes are unstable
-    //~| ERROR the `#[test]` attribute may only be used on a free function
+    //~| ERROR the `test` attribute may only be used on a free function
 
     #[test]
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     struct S;
 
     #[test]
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     type T = S;
 
     #[test]
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     impl S { }
 }
 
@@ -26,22 +26,22 @@ mod test {
 // non-crate-level #[bench] attributes seem to be ignored.
 
 #[bench]
-//~^ ERROR the `#[bench]` attribute may only be used on a free function
+//~^ ERROR the `bench` attribute may only be used on a free function
 mod bench {
     mod inner { #![bench] }
     //~^ ERROR inner macro attributes are unstable
-    //~| ERROR the `#[bench]` attribute may only be used on a free function
+    //~| ERROR the `bench` attribute may only be used on a free function
 
     #[bench]
-    //~^ ERROR the `#[bench]` attribute may only be used on a free function
+    //~^ ERROR the `bench` attribute may only be used on a free function
     struct S;
 
     #[bench]
-    //~^ ERROR the `#[bench]` attribute may only be used on a free function
+    //~^ ERROR the `bench` attribute may only be used on a free function
     type T = S;
 
     #[bench]
-    //~^ ERROR the `#[bench]` attribute may only be used on a free function
+    //~^ ERROR the `bench` attribute may only be used on a free function
     impl S { }
 }
 

--- a/tests/ui/feature-gates/gating-of-test-attrs.stderr
+++ b/tests/ui/feature-gates/gating-of-test-attrs.stderr
@@ -1,8 +1,8 @@
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:5:1
    |
 LL |   #[test]
-   |   ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |   ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL | / mod test {
 LL | |     mod inner { #![test] }
@@ -27,13 +27,13 @@ LL |     mod inner { #![test] }
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:8:17
    |
 LL |     mod inner { #![test] }
    |     ------------^^^^^^^^--
    |     |           |
-   |     |           the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     |           the `test` attribute causes a function to be run as a test and has no effect on non-functions
    |     expected a non-associated function, found a module
    |
 help: replace with conditional compilation to make the item only exist when tests are being run
@@ -42,11 +42,11 @@ LL -     mod inner { #![test] }
 LL +     mod inner { #[cfg(test)] }
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:12:5
    |
 LL |     #[test]
-   |     ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     struct S;
    |     --------- expected a non-associated function, found a struct
@@ -57,11 +57,11 @@ LL -     #[test]
 LL +     #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:16:5
    |
 LL |     #[test]
-   |     ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     type T = S;
    |     ----------- expected a non-associated function, found a type alias
@@ -72,11 +72,11 @@ LL -     #[test]
 LL +     #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:20:5
    |
 LL |     #[test]
-   |     ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     impl S { }
    |     ---------- expected a non-associated function, found an implementation
@@ -87,11 +87,11 @@ LL -     #[test]
 LL +     #[cfg(test)]
    |
 
-error: the `#[bench]` attribute may only be used on a free function
+error: the `bench` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:28:1
    |
 LL |   #[bench]
-   |   ^^^^^^^^ the `#[bench]` macro causes a function to be run as a test and has no effect on non-functions
+   |   ^^^^^^^^ the `bench` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL | / mod bench {
 LL | |     mod inner { #![bench] }
@@ -110,38 +110,38 @@ LL |     mod inner { #![bench] }
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: the `#[bench]` attribute may only be used on a free function
+error: the `bench` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:31:17
    |
 LL |     mod inner { #![bench] }
    |     ------------^^^^^^^^^--
    |     |           |
-   |     |           the `#[bench]` macro causes a function to be run as a test and has no effect on non-functions
+   |     |           the `bench` attribute causes a function to be run as a test and has no effect on non-functions
    |     expected a non-associated function, found a module
 
-error: the `#[bench]` attribute may only be used on a free function
+error: the `bench` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:35:5
    |
 LL |     #[bench]
-   |     ^^^^^^^^ the `#[bench]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^^ the `bench` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     struct S;
    |     --------- expected a non-associated function, found a struct
 
-error: the `#[bench]` attribute may only be used on a free function
+error: the `bench` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:39:5
    |
 LL |     #[bench]
-   |     ^^^^^^^^ the `#[bench]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^^ the `bench` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     type T = S;
    |     ----------- expected a non-associated function, found a type alias
 
-error: the `#[bench]` attribute may only be used on a free function
+error: the `bench` attribute may only be used on a free function
   --> $DIR/gating-of-test-attrs.rs:43:5
    |
 LL |     #[bench]
-   |     ^^^^^^^^ the `#[bench]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^^ the `bench` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     impl S { }
    |     ---------- expected a non-associated function, found an implementation

--- a/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.rs
@@ -14,7 +14,7 @@ mod proc_macro_derive2 {
     //~^ ERROR attribute cannot be used on
 
     #[proc_macro_derive(Test)] fn f() { }
-    //~^ ERROR the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro`
+    //~^ ERROR the `proc_macro_derive` attribute is only usable with crates of the `proc-macro`
 
     #[proc_macro_derive(Test)] struct S;
     //~^ ERROR attribute cannot be used on

--- a/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-proc_macro_derive.stderr
@@ -1,8 +1,8 @@
-error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:16:5
+error: the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:16:7
    |
 LL |     #[proc_macro_derive(Test)] fn f() { }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^
 
 error: the `proc_macro_derive` attribute cannot be used on modules
   --> $DIR/issue-43106-gating-of-proc_macro_derive.rs:5:3

--- a/tests/ui/lint/lint-unsafe-code.rs
+++ b/tests/ui/lint/lint-unsafe-code.rs
@@ -25,18 +25,18 @@ mod allowed_unsafe {
 
 macro_rules! unsafe_in_macro {
     () => {{
-        #[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `#[no_mangle]` attribute
-        #[no_mangle] static FOO: u32 = 5; //~ ERROR: usage of the unsafe `#[no_mangle]` attribute
+        #[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `no_mangle` attribute
+        #[no_mangle] static FOO: u32 = 5; //~ ERROR: usage of the unsafe `no_mangle` attribute
         #[export_name = "bar"] fn bar() {}
-        //~^ ERROR: usage of the unsafe `#[export_name]` attribute
+        //~^ ERROR: usage of the unsafe `export_name` attribute
         #[export_name = "BAR"] static BAR: u32 = 5;
-        //~^ ERROR: usage of the unsafe `#[export_name]` attribute
+        //~^ ERROR: usage of the unsafe `export_name` attribute
         unsafe {} //~ ERROR: usage of an `unsafe` block
     }}
 }
 
-#[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `#[no_mangle]` attribute
-#[no_mangle] static FOO: u32 = 5; //~ ERROR: usage of the unsafe `#[no_mangle]` attribute
+#[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `no_mangle` attribute
+#[no_mangle] static FOO: u32 = 5; //~ ERROR: usage of the unsafe `no_mangle` attribute
 
 trait AssocFnTrait {
     fn foo();
@@ -45,27 +45,27 @@ trait AssocFnTrait {
 struct AssocFnFoo;
 
 impl AssocFnFoo {
-    #[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `#[no_mangle]` attribute
+    #[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `no_mangle` attribute
 }
 
 impl AssocFnTrait for AssocFnFoo {
-    #[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `#[no_mangle]` attribute
+    #[no_mangle] fn foo() {} //~ ERROR: usage of the unsafe `no_mangle` attribute
 }
 
-#[export_name = "bar"] fn bar() {} //~ ERROR: usage of the unsafe `#[export_name]` attribute
-#[export_name = "BAR"] static BAR: u32 = 5; //~ ERROR: usage of the unsafe `#[export_name]` attribute
+#[export_name = "bar"] fn bar() {} //~ ERROR: usage of the unsafe `export_name` attribute
+#[export_name = "BAR"] static BAR: u32 = 5; //~ ERROR: usage of the unsafe `export_name` attribute
 
-#[link_section = "__TEXT,__text"] fn uwu() {} //~ ERROR: usage of the unsafe `#[link_section]` attribute
-#[link_section = "__TEXT,__text"] static UWU: u32 = 5; //~ ERROR: usage of the unsafe `#[link_section]` attribute
+#[link_section = "__TEXT,__text"] fn uwu() {} //~ ERROR: usage of the unsafe `link_section` attribute
+#[link_section = "__TEXT,__text"] static UWU: u32 = 5; //~ ERROR: usage of the unsafe `link_section` attribute
 
 struct AssocFnBar;
 
 impl AssocFnBar {
-    #[export_name = "bar"] fn bar() {} //~ ERROR: usage of the unsafe `#[export_name]` attribute
+    #[export_name = "bar"] fn bar() {} //~ ERROR: usage of the unsafe `export_name` attribute
 }
 
 impl AssocFnTrait for AssocFnBar {
-    #[export_name = "bar"] fn foo() {} //~ ERROR: usage of the unsafe `#[export_name]` attribute
+    #[export_name = "bar"] fn foo() {} //~ ERROR: usage of the unsafe `export_name` attribute
 }
 
 unsafe fn baz() {} //~ ERROR: declaration of an `unsafe` function
@@ -137,48 +137,48 @@ fn main() {
 }
 
 #[unsafe(naked)] fn naked1() { naked_asm!("halt") }
-//~^ ERROR usage of the unsafe `#[naked]` attribute
+//~^ ERROR usage of the unsafe `naked` attribute
 
 struct Naked;
 impl Naked {
     #[unsafe(naked)] fn naked2() { naked_asm!("halt") }
-    //~^ ERROR usage of the unsafe `#[naked]` attribute
+    //~^ ERROR usage of the unsafe `naked` attribute
 }
 
 trait NakedTrait {
     #[unsafe(naked)] fn naked3() { naked_asm!("halt") }
-    //~^ ERROR usage of the unsafe `#[naked]` attribute
+    //~^ ERROR usage of the unsafe `naked` attribute
     fn naked4();
 }
 impl NakedTrait for Naked {
     #[unsafe(naked)] fn naked4() { naked_asm!("halt") }
-    //~^ ERROR usage of the unsafe `#[naked]` attribute
+    //~^ ERROR usage of the unsafe `naked` attribute
 }
 
 extern "C" {
     #[unsafe(ffi_pure)]
-    //~^ ERROR usage of the unsafe `#[ffi_pure]` attribute
+    //~^ ERROR usage of the unsafe `ffi_pure` attribute
     fn ffi_pure();
 
     #[unsafe(ffi_const)]
-    //~^ ERROR usage of the unsafe `#[ffi_const]` attribute
+    //~^ ERROR usage of the unsafe `ffi_const` attribute
     fn ffi_const();
 }
 
 #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-//~^ ERROR usage of the unsafe `#[force_target_feature]` attribute
+//~^ ERROR usage of the unsafe `force_target_feature` attribute
 
 struct ForceTargetFeature;
 impl ForceTargetFeature {
     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-    //~^ ERROR usage of the unsafe `#[force_target_feature]` attribute
+    //~^ ERROR usage of the unsafe `force_target_feature` attribute
 }
 
 trait ForceTargetFeatureTrait {
     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-    //~^ ERROR usage of the unsafe `#[force_target_feature]` attribute
+    //~^ ERROR usage of the unsafe `force_target_feature` attribute
 }
 impl ForceTargetFeatureTrait for ForceTargetFeature {
     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
-    //~^ ERROR usage of the unsafe `#[force_target_feature]` attribute
+    //~^ ERROR usage of the unsafe `force_target_feature` attribute
 }

--- a/tests/ui/lint/lint-unsafe-code.stderr
+++ b/tests/ui/lint/lint-unsafe-code.stderr
@@ -93,7 +93,7 @@ LL |     unsafe_in_macro!()
    |
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: usage of the unsafe `#[no_mangle]` attribute
+error: usage of the unsafe `no_mangle` attribute
   --> $DIR/lint-unsafe-code.rs:38:3
    |
 LL | #[no_mangle] fn foo() {}
@@ -101,7 +101,7 @@ LL | #[no_mangle] fn foo() {}
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[no_mangle]` attribute
+error: usage of the unsafe `no_mangle` attribute
   --> $DIR/lint-unsafe-code.rs:39:3
    |
 LL | #[no_mangle] static FOO: u32 = 5;
@@ -109,7 +109,7 @@ LL | #[no_mangle] static FOO: u32 = 5;
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[export_name]` attribute
+error: usage of the unsafe `export_name` attribute
   --> $DIR/lint-unsafe-code.rs:55:3
    |
 LL | #[export_name = "bar"] fn bar() {}
@@ -117,7 +117,7 @@ LL | #[export_name = "bar"] fn bar() {}
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[export_name]` attribute
+error: usage of the unsafe `export_name` attribute
   --> $DIR/lint-unsafe-code.rs:56:3
    |
 LL | #[export_name = "BAR"] static BAR: u32 = 5;
@@ -125,7 +125,7 @@ LL | #[export_name = "BAR"] static BAR: u32 = 5;
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[link_section]` attribute
+error: usage of the unsafe `link_section` attribute
   --> $DIR/lint-unsafe-code.rs:58:3
    |
 LL | #[link_section = "__TEXT,__text"] fn uwu() {}
@@ -133,7 +133,7 @@ LL | #[link_section = "__TEXT,__text"] fn uwu() {}
    |
    = note: the program's behavior with overridden link sections on items is unpredictable and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[link_section]` attribute
+error: usage of the unsafe `link_section` attribute
   --> $DIR/lint-unsafe-code.rs:59:3
    |
 LL | #[link_section = "__TEXT,__text"] static UWU: u32 = 5;
@@ -141,7 +141,7 @@ LL | #[link_section = "__TEXT,__text"] static UWU: u32 = 5;
    |
    = note: the program's behavior with overridden link sections on items is unpredictable and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[no_mangle]` attribute
+error: usage of the unsafe `no_mangle` attribute
   --> $DIR/lint-unsafe-code.rs:28:11
    |
 LL |         #[no_mangle] fn foo() {}
@@ -153,7 +153,7 @@ LL |     unsafe_in_macro!()
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: usage of the unsafe `#[no_mangle]` attribute
+error: usage of the unsafe `no_mangle` attribute
   --> $DIR/lint-unsafe-code.rs:29:11
    |
 LL |         #[no_mangle] static FOO: u32 = 5;
@@ -165,7 +165,7 @@ LL |     unsafe_in_macro!()
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: usage of the unsafe `#[export_name]` attribute
+error: usage of the unsafe `export_name` attribute
   --> $DIR/lint-unsafe-code.rs:30:11
    |
 LL |         #[export_name = "bar"] fn bar() {}
@@ -177,7 +177,7 @@ LL |     unsafe_in_macro!()
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: usage of the unsafe `#[export_name]` attribute
+error: usage of the unsafe `export_name` attribute
   --> $DIR/lint-unsafe-code.rs:32:11
    |
 LL |         #[export_name = "BAR"] static BAR: u32 = 5;
@@ -189,7 +189,7 @@ LL |     unsafe_in_macro!()
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: usage of the unsafe `#[naked]` attribute
+error: usage of the unsafe `naked` attribute
   --> $DIR/lint-unsafe-code.rs:139:3
    |
 LL | #[unsafe(naked)] fn naked1() { naked_asm!("halt") }
@@ -197,7 +197,7 @@ LL | #[unsafe(naked)] fn naked1() { naked_asm!("halt") }
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
 
-error: usage of the unsafe `#[force_target_feature]` attribute
+error: usage of the unsafe `force_target_feature` attribute
   --> $DIR/lint-unsafe-code.rs:168:3
    |
 LL | #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
@@ -205,7 +205,7 @@ LL | #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() 
    |
    = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
-error: usage of the unsafe `#[naked]` attribute
+error: usage of the unsafe `naked` attribute
   --> $DIR/lint-unsafe-code.rs:149:7
    |
 LL |     #[unsafe(naked)] fn naked3() { naked_asm!("halt") }
@@ -213,7 +213,7 @@ LL |     #[unsafe(naked)] fn naked3() { naked_asm!("halt") }
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
 
-error: usage of the unsafe `#[force_target_feature]` attribute
+error: usage of the unsafe `force_target_feature` attribute
   --> $DIR/lint-unsafe-code.rs:178:7
    |
 LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
@@ -221,7 +221,7 @@ LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_featur
    |
    = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
-error: usage of the unsafe `#[no_mangle]` attribute
+error: usage of the unsafe `no_mangle` attribute
   --> $DIR/lint-unsafe-code.rs:48:7
    |
 LL |     #[no_mangle] fn foo() {}
@@ -229,7 +229,7 @@ LL |     #[no_mangle] fn foo() {}
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[no_mangle]` attribute
+error: usage of the unsafe `no_mangle` attribute
   --> $DIR/lint-unsafe-code.rs:52:7
    |
 LL |     #[no_mangle] fn foo() {}
@@ -237,7 +237,7 @@ LL |     #[no_mangle] fn foo() {}
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[export_name]` attribute
+error: usage of the unsafe `export_name` attribute
   --> $DIR/lint-unsafe-code.rs:64:7
    |
 LL |     #[export_name = "bar"] fn bar() {}
@@ -245,7 +245,7 @@ LL |     #[export_name = "bar"] fn bar() {}
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[export_name]` attribute
+error: usage of the unsafe `export_name` attribute
   --> $DIR/lint-unsafe-code.rs:68:7
    |
 LL |     #[export_name = "bar"] fn foo() {}
@@ -253,7 +253,7 @@ LL |     #[export_name = "bar"] fn foo() {}
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
-error: usage of the unsafe `#[naked]` attribute
+error: usage of the unsafe `naked` attribute
   --> $DIR/lint-unsafe-code.rs:144:7
    |
 LL |     #[unsafe(naked)] fn naked2() { naked_asm!("halt") }
@@ -261,7 +261,7 @@ LL |     #[unsafe(naked)] fn naked2() { naked_asm!("halt") }
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
 
-error: usage of the unsafe `#[naked]` attribute
+error: usage of the unsafe `naked` attribute
   --> $DIR/lint-unsafe-code.rs:154:7
    |
 LL |     #[unsafe(naked)] fn naked4() { naked_asm!("halt") }
@@ -269,7 +269,7 @@ LL |     #[unsafe(naked)] fn naked4() { naked_asm!("halt") }
    |
    = note: the `#[naked]` attribute adds the safety obligation that the function's body must respect the function’s calling convention, uphold its signature, and either return or diverge (i.e., not fall through past the end of the assembly code).
 
-error: usage of the unsafe `#[force_target_feature]` attribute
+error: usage of the unsafe `force_target_feature` attribute
   --> $DIR/lint-unsafe-code.rs:173:7
    |
 LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
@@ -277,7 +277,7 @@ LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_featur
    |
    = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
-error: usage of the unsafe `#[force_target_feature]` attribute
+error: usage of the unsafe `force_target_feature` attribute
   --> $DIR/lint-unsafe-code.rs:182:7
    |
 LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_feature() { }
@@ -285,7 +285,7 @@ LL |     #[unsafe(force_target_feature(enable = "avx2"))] fn force_target_featur
    |
    = note: a function with the signature of the function the attribute is applied to must only be callable if the force-enabled features are guaranteed to be present
 
-error: usage of the unsafe `#[ffi_pure]` attribute
+error: usage of the unsafe `ffi_pure` attribute
   --> $DIR/lint-unsafe-code.rs:159:7
    |
 LL |     #[unsafe(ffi_pure)]
@@ -293,7 +293,7 @@ LL |     #[unsafe(ffi_pure)]
    |
    = note: `#[ffi_pure]` functions shall have no effects except for its return value, which shall not change across two consecutive function calls with the same parameters.
 
-error: usage of the unsafe `#[ffi_const]` attribute
+error: usage of the unsafe `ffi_const` attribute
   --> $DIR/lint-unsafe-code.rs:163:7
    |
 LL |     #[unsafe(ffi_const)]

--- a/tests/ui/macros/issue-111749.rs
+++ b/tests/ui/macros/issue-111749.rs
@@ -6,7 +6,7 @@ macro_rules! cbor_map {
 
 fn main() {
     cbor_map! { #[test(test)] 4i32};
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     //~| ERROR attribute must be of the form `#[test]`
     //~| WARNING this was previously accepted by the compiler but is being phased out
 }

--- a/tests/ui/macros/issue-111749.stderr
+++ b/tests/ui/macros/issue-111749.stderr
@@ -1,8 +1,8 @@
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/issue-111749.rs:8:17
    |
 LL |     cbor_map! { #[test(test)] 4i32};
-   |                 ^^^^^^^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |                 ^^^^^^^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
    |
 help: replace with conditional compilation to make the item only exist when tests are being run
    |

--- a/tests/ui/macros/test-on-crate-root.rs
+++ b/tests/ui/macros/test-on-crate-root.rs
@@ -4,7 +4,7 @@
 // when referring to the attribute with full path specifically.
 #![core::prelude::v1::test]
 //~^ ERROR inner macro attributes are unstable
-//~| ERROR the `#[test]` attribute may only be used on a free function
+//~| ERROR the `test` attribute may only be used on a free function
 
 
 fn main() {}

--- a/tests/ui/macros/test-on-crate-root.stderr
+++ b/tests/ui/macros/test-on-crate-root.stderr
@@ -8,11 +8,11 @@ LL | #![core::prelude::v1::test]
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-crate-root.rs:5:1
    |
 LL | #![core::prelude::v1::test]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
    |
 help: replace with conditional compilation to make the item only exist when tests are being run
    |

--- a/tests/ui/methods/associated-fn-turbofish-issue-159813.fixed
+++ b/tests/ui/methods/associated-fn-turbofish-issue-159813.fixed
@@ -1,0 +1,17 @@
+//@ run-rustfix
+
+// The associated-function suggestion must use turbofish syntax for a generic ADT.
+
+trait Kind {
+    fn kind();
+}
+
+impl<T> Kind for Option<T> {
+    fn kind() {}
+}
+
+fn main() {
+    let _value = Some(2_i32);
+    Option::<i32>::kind();
+    //~^ ERROR no method named `kind` found for enum `Option<T>`
+}

--- a/tests/ui/methods/associated-fn-turbofish-issue-159813.rs
+++ b/tests/ui/methods/associated-fn-turbofish-issue-159813.rs
@@ -1,3 +1,5 @@
+//@ run-rustfix
+
 // The associated-function suggestion must use turbofish syntax for a generic ADT.
 
 trait Kind {
@@ -9,7 +11,7 @@ impl<T> Kind for Option<T> {
 }
 
 fn main() {
-    let value = Some(2_i32);
-    value.kind();
+    let _value = Some(2_i32);
+    _value.kind();
     //~^ ERROR no method named `kind` found for enum `Option<T>`
 }

--- a/tests/ui/methods/associated-fn-turbofish-issue-159813.stderr
+++ b/tests/ui/methods/associated-fn-turbofish-issue-159813.stderr
@@ -1,19 +1,19 @@
 error[E0599]: no method named `kind` found for enum `Option<T>` in the current scope
-  --> $DIR/issue-159813.rs:13:11
+  --> $DIR/associated-fn-turbofish-issue-159813.rs:15:12
    |
-LL |     value.kind();
-   |           ^^^^ this is an associated function, not a method
+LL |     _value.kind();
+   |            ^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
 note: the candidate is defined in the trait `Kind`
-  --> $DIR/issue-159813.rs:4:5
+  --> $DIR/associated-fn-turbofish-issue-159813.rs:6:5
    |
 LL |     fn kind();
    |     ^^^^^^^^^^
 help: use associated function syntax instead
    |
-LL -     value.kind();
-LL +     Option<i32>::kind();
+LL -     _value.kind();
+LL +     Option::<i32>::kind();
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/methods/issue-159813.rs
+++ b/tests/ui/methods/issue-159813.rs
@@ -1,0 +1,15 @@
+// The associated-function suggestion must use turbofish syntax for a generic ADT.
+
+trait Kind {
+    fn kind();
+}
+
+impl<T> Kind for Option<T> {
+    fn kind() {}
+}
+
+fn main() {
+    let value = Some(2_i32);
+    value.kind();
+    //~^ ERROR no method named `kind` found for enum `Option<T>`
+}

--- a/tests/ui/methods/issue-159813.stderr
+++ b/tests/ui/methods/issue-159813.stderr
@@ -1,0 +1,21 @@
+error[E0599]: no method named `kind` found for enum `Option<T>` in the current scope
+  --> $DIR/issue-159813.rs:13:11
+   |
+LL |     value.kind();
+   |           ^^^^ this is an associated function, not a method
+   |
+   = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
+note: the candidate is defined in the trait `Kind`
+  --> $DIR/issue-159813.rs:4:5
+   |
+LL |     fn kind();
+   |     ^^^^^^^^^^
+help: use associated function syntax instead
+   |
+LL -     value.kind();
+LL +     Option<i32>::kind();
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/proc-macro/illegal-proc-macro-derive-use.stderr
+++ b/tests/ui/proc-macro/illegal-proc-macro-derive-use.stderr
@@ -1,8 +1,8 @@
-error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/illegal-proc-macro-derive-use.rs:3:1
+error: the `proc_macro_derive` attribute is only usable with crates of the `proc-macro` crate type
+  --> $DIR/illegal-proc-macro-derive-use.rs:3:3
    |
 LL | #[proc_macro_derive(Foo)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^
 
 error: the `proc_macro_derive` attribute cannot be used on structs
   --> $DIR/illegal-proc-macro-derive-use.rs:10:3

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-missing.stderr
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-missing.stderr
@@ -1,8 +1,8 @@
 error: feature `const_bar` implying `const_foobar` does not exist
-  --> $DIR/const-stability-attribute-implies-missing.rs:10:1
+  --> $DIR/const-stability-attribute-implies-missing.rs:10:3
    |
 LL | #[rustc_const_unstable(feature = "const_foobar", issue = "1", implied_by = "const_bar")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/test-attrs/issue-109816.rs
+++ b/tests/ui/test-attrs/issue-109816.rs
@@ -3,6 +3,6 @@
 
 fn align_offset_weird_strides() {
     #[test]
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     struct A5(u32, u8);
 }

--- a/tests/ui/test-attrs/issue-109816.stderr
+++ b/tests/ui/test-attrs/issue-109816.stderr
@@ -1,8 +1,8 @@
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/issue-109816.rs:5:5
    |
 LL |     #[test]
-   |     ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL |
 LL |     struct A5(u32, u8);
    |     ------------------- expected a non-associated function, found a struct

--- a/tests/ui/test-attrs/test-attr-non-associated-functions.rs
+++ b/tests/ui/test-attrs/test-attr-non-associated-functions.rs
@@ -5,12 +5,12 @@ struct A {}
 
 impl A {
     #[test]
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     fn new() -> A {
         A {}
     }
     #[test]
-    //~^ ERROR the `#[test]` attribute may only be used on a free function
+    //~^ ERROR the `test` attribute may only be used on a free function
     fn recovery_witness() -> A {
         A {}
     }

--- a/tests/ui/test-attrs/test-attr-non-associated-functions.stderr
+++ b/tests/ui/test-attrs/test-attr-non-associated-functions.stderr
@@ -1,8 +1,8 @@
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-attr-non-associated-functions.rs:7:5
    |
 LL |     #[test]
-   |     ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
    |
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
@@ -10,11 +10,11 @@ LL -     #[test]
 LL +     #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-attr-non-associated-functions.rs:12:5
    |
 LL |     #[test]
-   |     ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |     ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
    |
 help: replace with conditional compilation to make the item only exist when tests are being run
    |

--- a/tests/ui/test-attrs/test-on-not-fn.rs
+++ b/tests/ui/test-attrs/test-on-not-fn.rs
@@ -1,10 +1,10 @@
 //@ compile-flags: --test
 //@ reference: attributes.testing.test.allowed-positions
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 mod test {}
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 mod loooooooooooooong_teeeeeeeeeest {
     /*
     this is a comment
@@ -18,37 +18,37 @@ mod loooooooooooooong_teeeeeeeeeest {
     */
 }
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 extern "C" {}
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 trait Foo {}
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 impl Foo for i32 {}
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 const FOO: i32 = -1_i32;
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 static BAR: u64 = 10_000_u64;
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 enum MyUnit {
     Unit,
 }
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 struct NewI32(i32);
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 union Spooky {
     x: i32,
     y: u32,
 }
 
 #[repr(C, align(64))]
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a free function
+#[test] //~ ERROR: the `test` attribute may only be used on a free function
 #[derive(Copy, Clone, Debug)]
 struct MoreAttrs {
     a: i32,
@@ -59,7 +59,7 @@ macro_rules! foo {
     () => {};
 }
 
-#[test] //~ WARN: the `#[test]` attribute may only be used on a free function
+#[test] //~ WARN: the `test` attribute may only be used on a free function
 foo!();
 
 // make sure it doesn't erroneously trigger on a real test

--- a/tests/ui/test-attrs/test-on-not-fn.stderr
+++ b/tests/ui/test-attrs/test-on-not-fn.stderr
@@ -1,8 +1,8 @@
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:4:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | mod test {}
    | ----------- expected a non-associated function, found a module
    |
@@ -12,11 +12,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:7:1
    |
 LL |   #[test]
-   |   ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |   ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | / mod loooooooooooooong_teeeeeeeeeest {
 LL | |     /*
 LL | |     this is a comment
@@ -32,11 +32,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:21:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | extern "C" {}
    | ------------- expected a non-associated function, found an extern block
    |
@@ -46,11 +46,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:24:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | trait Foo {}
    | ------------ expected a non-associated function, found a trait
    |
@@ -60,11 +60,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:27:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | impl Foo for i32 {}
    | ------------------- expected a non-associated function, found an implementation
    |
@@ -74,11 +74,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:30:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | const FOO: i32 = -1_i32;
    | ------------------------ expected a non-associated function, found a constant item
    |
@@ -88,11 +88,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:33:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | static BAR: u64 = 10_000_u64;
    | ----------------------------- expected a non-associated function, found a static item
    |
@@ -102,11 +102,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:36:1
    |
 LL |   #[test]
-   |   ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |   ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | / enum MyUnit {
 LL | |     Unit,
 LL | | }
@@ -118,11 +118,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:41:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | struct NewI32(i32);
    | ------------------- expected a non-associated function, found a struct
    |
@@ -132,11 +132,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:44:1
    |
 LL |   #[test]
-   |   ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |   ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | / union Spooky {
 LL | |     x: i32,
 LL | |     y: u32,
@@ -149,11 +149,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-error: the `#[test]` attribute may only be used on a free function
+error: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:51:1
    |
 LL |   #[test]
-   |   ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   |   ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL |   #[derive(Copy, Clone, Debug)]
 LL | / struct MoreAttrs {
 LL | |     a: i32,
@@ -167,11 +167,11 @@ LL - #[test]
 LL + #[cfg(test)]
    |
 
-warning: the `#[test]` attribute may only be used on a free function
+warning: the `test` attribute may only be used on a free function
   --> $DIR/test-on-not-fn.rs:62:1
    |
 LL | #[test]
-   | ^^^^^^^ the `#[test]` macro causes a function to be run as a test and has no effect on non-functions
+   | ^^^^^^^ the `test` attribute causes a function to be run as a test and has no effect on non-functions
 LL | foo!();
    | ------- expected a non-associated function, found an item macro invocation
    |

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,7 +76,7 @@
 
 "@puppeteer/browsers@3.0.6":
   version "3.0.6"
-  resolved "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz"
+  resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-3.0.6.tgz#6b772e0fc11deb255c8a3c14219e34a16a2ab23d"
   integrity sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==
   dependencies:
     modern-tar "^0.7.6"
@@ -114,7 +114,7 @@ ansi-regex@^5.0.1:
 
 ansi-regex@^6.2.2:
   version "6.2.2"
-  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
   integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
 
 ansi-styles@^4.1.0:
@@ -126,7 +126,7 @@ ansi-styles@^4.1.0:
 
 ansi-styles@^6.2.1:
   version "6.2.3"
-  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 argparse@^2.0.1:
@@ -154,10 +154,10 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browser-ui-test@^0.24.1:
-  version "0.24.1"
-  resolved "https://registry.yarnpkg.com/browser-ui-test/-/browser-ui-test-0.24.1.tgz#1b186b652e2c6593ae1d698408d0e6ba0f32bff5"
-  integrity sha512-+S+gDOxc7GGfDUmZeRUcCAUzBVbD6qS7TzZSg1CFN/lgJyXf2MCG8CUbvHTsEi/oG5Iuuza1XzKDPpAAvfSUNw==
+browser-ui-test@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/browser-ui-test/-/browser-ui-test-0.25.0.tgz#e24352d63009f07ec42583c96330a1ca57487d88"
+  integrity sha512-DBSpC3UFzQTKhj9cc11AiRliCUiWut1GAJ6sLPEYYPCmF6gTQGg/eynwev0NXPiDpuawiVxSpXPttHQePRK6Ug==
   dependencies:
     css-unit-converter "^1.1.2"
     pngjs "^3.4.0"
@@ -177,17 +177,17 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chromium-bidi@16.0.1:
-  version "16.0.1"
-  resolved "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-16.0.1.tgz"
-  integrity sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==
+chromium-bidi@17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-17.0.2.tgz#921a586deecd0c2d8b9242c4c1b73c3aa39ff77c"
+  integrity sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==
   dependencies:
     mitt "^3.0.1"
     zod "^3.24.1"
 
 cliui@^9.0.1:
   version "9.0.1"
-  resolved "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-9.0.1.tgz#6f7890f386f6f1f79953adc1f78dec46fcc2d291"
   integrity sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==
   dependencies:
     string-width "^7.2.0"
@@ -222,7 +222,7 @@ cross-spawn@^7.0.2:
 
 css-unit-converter@^1.1.2:
   version "1.1.2"
-  resolved "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/css-unit-converter/-/css-unit-converter-1.1.2.tgz#4c77f5a1954e6dbff60695ecb214e3270436ab21"
   integrity sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==
 
 debug@^4.3.1, debug@^4.3.2:
@@ -237,10 +237,10 @@ deep-is@^0.1.3:
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-devtools-protocol@0.0.1638949:
-  version "0.0.1638949"
-  resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1638949.tgz"
-  integrity sha512-mXwg4Fqnv0WR4iuAT/gYUmctNkjILwXFHyZ+m7Ty1dfr0ezZt2U3gnrrJTfRobJTHoXf+IbuFvFITzLrLFjwJA==
+devtools-protocol@0.0.1653615:
+  version "0.0.1653615"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1653615.tgz#c600e0c619612156b2422a66d958ba188d87dbe8"
+  integrity sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -251,7 +251,7 @@ doctrine@^3.0.0:
 
 emoji-regex@^10.3.0:
   version "10.6.0"
-  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
   integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
 
 es-check@^9.4.4:
@@ -264,7 +264,7 @@ es-check@^9.4.4:
 
 escalade@^3.1.1:
   version "3.2.0"
-  resolved "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
 escape-string-regexp@^4.0.0:
@@ -438,12 +438,12 @@ fs.realpath@^1.0.0:
 
 get-caller-file@^2.0.5:
   version "2.0.5"
-  resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-east-asian-width@^1.0.0:
+get-east-asian-width@^1.0.0, get-east-asian-width@^1.5.0:
   version "1.6.0"
-  resolved "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz"
+  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz#216900f91df11a8b2c198c3e1d93d6c035a776b9"
   integrity sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==
 
 glob-parent@^5.1.2:
@@ -586,7 +586,7 @@ levn@^0.4.1:
 
 lilconfig@^3.1.3:
   version "3.1.3"
-  resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
   integrity sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==
 
 locate-path@^6.0.0:
@@ -623,13 +623,13 @@ minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
 
 mitt@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
 modern-tar@^0.7.6:
-  version "0.7.6"
-  resolved "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz"
-  integrity sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/modern-tar/-/modern-tar-0.7.7.tgz#ca71d79603630076b10733b0751ccab284bbc1ef"
+  integrity sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==
 
 ms@^2.1.3:
   version "2.1.3"
@@ -703,7 +703,7 @@ picomatch@^2.3.1:
 
 pngjs@^3.4.0:
   version "3.4.0"
-  resolved "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
   integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
 
 prelude-ls@^1.2.1:
@@ -716,28 +716,28 @@ punycode@^2.1.0:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-puppeteer-core@25.3.0:
-  version "25.3.0"
-  resolved "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.3.0.tgz"
-  integrity sha512-fm+wpUr2oigH1PXZvwgATrM2tYWHMDG8ASzTEe9uukCye4X5Ldx1K5BTHPFKITrIWvQQAQ256d1NpbEveBcKjA==
+puppeteer-core@25.4.0:
+  version "25.4.0"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-25.4.0.tgz#2fcba53a9ab94d55f196e1e42dbe794bbadf8759"
+  integrity sha512-K1plkLOdeoUnGeT1OvdqF3qxl33v+Ra/uH5VyPEhXdMcpvGiEskHzxxEU3fgpccJpJLIipB/rPUsvkZRWeKqOA==
   dependencies:
     "@puppeteer/browsers" "3.0.6"
-    chromium-bidi "16.0.1"
-    devtools-protocol "0.0.1638949"
+    chromium-bidi "17.0.2"
+    devtools-protocol "0.0.1653615"
     typed-query-selector "^2.12.2"
     webdriver-bidi-protocol "0.4.2"
-    ws "^8.21.0"
+    ws "^8.21.1"
 
 puppeteer@^25.1.0:
-  version "25.3.0"
-  resolved "https://registry.npmjs.org/puppeteer/-/puppeteer-25.3.0.tgz"
-  integrity sha512-O1tx8S315aw8eI99HZ5ZNcVEzJ9+jKF//eO5UvfZ3cXJ6okZ5sX3Y50u7DJaM+ewEK4LqXP068tBhfRaWikj+g==
+  version "25.4.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-25.4.0.tgz#87b549a666ffc4f68fee2f195c42d67eba9b8168"
+  integrity sha512-xfQp8dFBcGaLc1hEMaVr7s+oW4ZkAurr8Y9H81ilKhu6QoLfSTkZjU7IavnyJ/VWpB9ni3KNJUQHUatslLWyGw==
   dependencies:
     "@puppeteer/browsers" "3.0.6"
-    chromium-bidi "16.0.1"
-    devtools-protocol "0.0.1638949"
+    chromium-bidi "17.0.2"
+    devtools-protocol "0.0.1653615"
     lilconfig "^3.1.3"
-    puppeteer-core "25.3.0"
+    puppeteer-core "25.4.0"
     typed-query-selector "^2.12.2"
 
 queue-microtask@^1.2.2:
@@ -747,7 +747,7 @@ queue-microtask@^1.2.2:
 
 readline-sync@^1.4.10:
   version "1.4.10"
-  resolved "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz"
+  resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
   integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
 
 resolve-from@^4.0.0:
@@ -788,12 +788,20 @@ shebang-regex@^3.0.0:
 
 string-width@^7.0.0, string-width@^7.2.0:
   version "7.2.0"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
   integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
   dependencies:
     emoji-regex "^10.3.0"
     get-east-asian-width "^1.0.0"
     strip-ansi "^7.1.0"
+
+string-width@^8.2.1:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-8.2.2.tgz#7310516493df575742fe98af6fae87d85d5ed0ac"
+  integrity sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==
+  dependencies:
+    get-east-asian-width "^1.5.0"
+    strip-ansi "^7.1.2"
 
 strip-ansi@^6.0.1:
   version "6.0.1"
@@ -802,9 +810,9 @@ strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.1.0:
+strip-ansi@^7.1.0, strip-ansi@^7.1.2:
   version "7.2.0"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
   integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
   dependencies:
     ansi-regex "^6.2.2"
@@ -847,7 +855,7 @@ type-fest@^0.20.2:
 
 typed-query-selector@^2.12.2:
   version "2.12.2"
-  resolved "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz"
+  resolved "https://registry.yarnpkg.com/typed-query-selector/-/typed-query-selector-2.12.2.tgz#65e2462ac6b0aecfae1bfac1a4f3027070dbabaa"
   integrity sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==
 
 typescript@^5.8.3:
@@ -864,7 +872,7 @@ uri-js@^4.2.2:
 
 webdriver-bidi-protocol@0.4.2:
   version "0.4.2"
-  resolved "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz"
+  resolved "https://registry.yarnpkg.com/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz#f51bb71c2606e90e3d5727607c728b25d617b58b"
   integrity sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==
 
 which@^2.0.1:
@@ -881,7 +889,7 @@ word-wrap@^1.2.5:
 
 wrap-ansi@^9.0.0:
   version "9.0.2"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz#956832dea9494306e6d209eb871643bb873d7c98"
   integrity sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==
   dependencies:
     ansi-styles "^6.2.1"
@@ -893,30 +901,30 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^8.21.0:
-  version "8.21.0"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz"
-  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
+ws@^8.21.1:
+  version "8.21.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.1.tgz#045650cd4b1207809e7547146223c3814a9af586"
+  integrity sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==
 
 y18n@^5.0.5:
   version "5.0.8"
-  resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yargs-parser@^22.0.0:
   version "22.0.0"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-22.0.0.tgz#87b82094051b0567717346ecd00fd14804b357c8"
   integrity sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==
 
 yargs@^18.0.0:
-  version "18.0.0"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz"
-  integrity sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-18.1.0.tgz#cd7e98c703ef51695bbbf062ed58f28e94291b56"
+  integrity sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==
   dependencies:
     cliui "^9.0.1"
     escalade "^3.1.1"
     get-caller-file "^2.0.5"
-    string-width "^7.2.0"
+    string-width "^8.2.1"
     y18n "^5.0.5"
     yargs-parser "^22.0.0"
 
@@ -927,5 +935,5 @@ yocto-queue@^0.1.0:
 
 zod@^3.24.1:
   version "3.25.76"
-  resolved "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#160008 (Avoid stale closure recovery state across statements)
 - rust-lang/rust#160027 (Add regression test for rust-lang/rust#132767)
 - rust-lang/rust#160030 (Update `browser-ui-test` version to `0.25.0`)
 - rust-lang/rust#160046 (Improve consistency of attribute error messages (part 2))
 - rust-lang/rust#160056 (Fix associated function suggestion for generic ADTs)
 - rust-lang/rust#160069 (Update Rust crate tracing-subscriber to v0.3.23 [SECURITY])

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=160008,160027,160030,160046,160056,160069)
<!-- homu-ignore:end -->

