### PR TITLE
Avoid TrustedLen specialization that optimize poorly in collect_remaining_errors

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -183,6 +183,7 @@ where
     }
 
     fn collect_remaining_errors(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<E> {
+        #[allow(clippy::iter_skip_zero)]
         self.obligations
             .pending
             .drain(..)
@@ -194,6 +195,12 @@ where
                     .map(|obligation| NextSolverError::Overflow(obligation)),
             )
             .map(|e| E::from_solver_error(infcx, e))
+            // Skip doesn't implement TrustedLen, so we use it to
+            // avoid Vec::from_iter specialization that seems
+            // to optimize poorly in combination with ThinVec::drain
+            // on this particular sequence.
+            // See https://github.com/rust-lang/rust/pull/160073
+            .skip(0)
             .collect()
     }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160073)*
<!-- homu-ignore:end -->

see https://github.com/rust-lang/rust/issues/160048

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
