### PR TITLE
use unstable features when updating dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,17 @@
     // (still gated by dashboard approval for now)
     ":maintainLockFilesMonthly",
   ],
+  // Cargo manifests in this repository use unstable features.
+  "env": {
+    "RUSTC_BOOTSTRAP": "1"
+  },
+  // The compiler and rustbook workspaces have path dependencies in these
+  // submodules.
+  "cloneSubmodules": true,
+  "cloneSubmodulesFilter": [
+    "src/doc/book",
+    "src/doc/reference"
+  ],
   // Require manual approval from the Dependency Dashboard before opening PRs
   "dependencyDashboardApproval": true,
   // Renovate shouldn't update a PR if it is in the bors merge queue.
@@ -18,6 +29,22 @@
       // No dashboard approval necessary for GitHub Actions updates
       "matchManagers": ["github-actions"],
       "dependencyDashboardApproval": false
+    },
+    {
+      // Only maintain the Cargo lockfiles managed by update-lockfile.sh.
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "matchFileNames": [
+        "Cargo.toml",
+        "library/Cargo.toml",
+        "src/tools/rustbook/Cargo.toml"
+      ],
+      "enabled": true
     }
   ],
   // Don't manage dependencies inside subtrees. They are updated upstream and


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
I asked Renovate via the rust-lang/rust#134129 to update the lockfile. This was the PR: https://github.com/rust-lang/rust/pull/160020 
This PR should hopefully fix the errors in those PR comments.
<!-- homu-ignore:end -->
r? @Kobzol 