### PR TITLE
fix 404 url in src/doc/rustdoc.md

### DIFF
--- a/src/doc/rustdoc.md
+++ b/src/doc/rustdoc.md
@@ -1,3 +1,3 @@
 % Rust Documentation
 
-This has been moved [into the rustdoc book](rustdoc/index.html).
+This has been moved [into the rustdoc book](rustdoc/src).


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


fix 404 url in src/doc/rustdoc.md

The previous link will lead to a 404 page.

<img width="2744" height="1238" alt="image" src="https://github.com/user-attachments/assets/b1c81c69-2181-4cb1-8a06-83e7b32ebd6c" />
