### PR TITLE
miri ui tests: don't run native tests on stage 0

### DIFF
--- a/src/tools/miri/tests/ui.rs
+++ b/src/tools/miri/tests/ui.rs
@@ -440,7 +440,10 @@ fn main() -> Result<()> {
 
     ui(Mode::Pass { native: false }, "tests/pass", &target, WithoutDeps, tmpdir.path())?;
     ui(Mode::Pass { native: false }, "tests/pass-dep", &target, WithDeps, tmpdir.path())?;
-    if target == host {
+    if target == host
+        // Skip native test execution during bootstrap as the sysroot is not quite right there.
+        && env::var("RUSTC_STAGE").ok().is_none_or(|s| s != "0")
+    {
         ui(Mode::Pass { native: true }, "tests/pass", &target, WithoutDeps, tmpdir.path())?;
         ui(Mode::Pass { native: true }, "tests/pass-dep", &target, WithDeps, tmpdir.path())?;
     }


### PR DESCRIPTION
This seems to always fail. There's probably a way to make it work, but IMO it's enough if the native tests run in rustc CI (and in the Miri repo of course).

r? @oli-obk 