### PR TITLE
bootstrap: Enable rustdoc mergeable CCI for std and internal docs

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -420,8 +420,9 @@ impl CommandLineStep for Rustc {
 
 /// Represents a compiler that can check something.
 ///
-/// If the compiler was created for `Mode::ToolRustcPrivate` or `Mode::Codegen`, it will also contain
-/// .rmeta artifacts from rustc that was already checked using `build_compiler`.
+/// If the compiler was created for `Mode::ToolRustcPrivate`, `Mode::Codegen`, or
+/// `Mode::RustcDoc`, it will also contain .rmeta artifacts from rustc that was already checked
+/// using `build_compiler`.
 ///
 /// All steps that use this struct in a "general way" (i.e. they don't know exactly what kind of
 /// thing is being built) should call `configure_cargo` to ensure that the rmeta artifacts are
@@ -515,7 +516,7 @@ pub fn prepare_compiler_for_check(
             std_rmeta_sysroot = prepare_std(builder, build_compiler, target);
             build_compiler
         }
-        Mode::Rustc => {
+        Mode::Rustc | Mode::RustcDoc => {
             // This is a horrible hack, because we actually change the compiler stage numbering
             // here. If you do `x check --stage 1 --host FOO`, we build stage 1 host rustc,
             // and use that to check stage 1 FOO rustc (which actually makes that stage 2 FOO

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -420,9 +420,8 @@ impl CommandLineStep for Rustc {
 
 /// Represents a compiler that can check something.
 ///
-/// If the compiler was created for `Mode::ToolRustcPrivate`, `Mode::Codegen`, or
-/// `Mode::RustcDoc`, it will also contain .rmeta artifacts from rustc that was already checked
-/// using `build_compiler`.
+/// If the compiler was created for `Mode::ToolRustcPrivate` or `Mode::Codegen`, it will also contain
+/// .rmeta artifacts from rustc that was already checked using `build_compiler`.
 ///
 /// All steps that use this struct in a "general way" (i.e. they don't know exactly what kind of
 /// thing is being built) should call `configure_cargo` to ensure that the rmeta artifacts are
@@ -516,7 +515,7 @@ pub fn prepare_compiler_for_check(
             std_rmeta_sysroot = prepare_std(builder, build_compiler, target);
             build_compiler
         }
-        Mode::Rustc | Mode::RustcDoc => {
+        Mode::Rustc => {
             // This is a horrible hack, because we actually change the compiler stage numbering
             // here. If you do `x check --stage 1 --host FOO`, we build stage 1 host rustc,
             // and use that to check stage 1 FOO rustc (which actually makes that stage 2 FOO
@@ -537,6 +536,7 @@ pub fn prepare_compiler_for_check(
             // stage 0 stdlib is used to compile build scripts and proc macros.
             builder.compiler(builder.top_stage, host)
         }
+        Mode::RustcDoc => unreachable!("RustcDoc is only used for docs"),
     };
     CompilerForCheck { build_compiler, rustc_rmeta_sysroot, std_rmeta_sysroot }
 }

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -394,9 +394,8 @@ impl CommandLineStep for Rustc {
 
 /// Represents a compiler that can check something.
 ///
-/// If the compiler was created for `Mode::ToolRustcPrivate`, `Mode::Codegen`, or
-/// `Mode::RustcDoc`, it will also contain .rmeta artifacts from rustc that was already checked
-/// using `build_compiler`.
+/// If the compiler was created for `Mode::ToolRustcPrivate` or `Mode::Codegen`, it will also contain
+/// .rmeta artifacts from rustc that was already checked using `build_compiler`.
 ///
 /// All steps that use this struct in a "general way" (i.e. they don't know exactly what kind of
 /// thing is being built) should call `configure_cargo` to ensure that the rmeta artifacts are
@@ -490,7 +489,7 @@ pub fn prepare_compiler_for_check(
             std_rmeta_sysroot = prepare_std(builder, build_compiler, target);
             build_compiler
         }
-        Mode::Rustc | Mode::RustcDoc => {
+        Mode::Rustc => {
             // This is a horrible hack, because we actually change the compiler stage numbering
             // here. If you do `x check --stage 1 --host FOO`, we build stage 1 host rustc,
             // and use that to check stage 1 FOO rustc (which actually makes that stage 2 FOO
@@ -511,6 +510,7 @@ pub fn prepare_compiler_for_check(
             // stage 0 stdlib is used to compile build scripts and proc macros.
             builder.compiler(builder.top_stage, host)
         }
+        Mode::RustcDoc => unreachable!("RustcDoc is only used for docs"),
     };
     CompilerForCheck { build_compiler, rustc_rmeta_sysroot, std_rmeta_sysroot }
 }

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -394,8 +394,9 @@ impl CommandLineStep for Rustc {
 
 /// Represents a compiler that can check something.
 ///
-/// If the compiler was created for `Mode::ToolRustcPrivate` or `Mode::Codegen`, it will also contain
-/// .rmeta artifacts from rustc that was already checked using `build_compiler`.
+/// If the compiler was created for `Mode::ToolRustcPrivate`, `Mode::Codegen`, or
+/// `Mode::RustcDoc`, it will also contain .rmeta artifacts from rustc that was already checked
+/// using `build_compiler`.
 ///
 /// All steps that use this struct in a "general way" (i.e. they don't know exactly what kind of
 /// thing is being built) should call `configure_cargo` to ensure that the rmeta artifacts are
@@ -489,7 +490,7 @@ pub fn prepare_compiler_for_check(
             std_rmeta_sysroot = prepare_std(builder, build_compiler, target);
             build_compiler
         }
-        Mode::Rustc => {
+        Mode::Rustc | Mode::RustcDoc => {
             // This is a horrible hack, because we actually change the compiler stage numbering
             // here. If you do `x check --stage 1 --host FOO`, we build stage 1 host rustc,
             // and use that to check stage 1 FOO rustc (which actually makes that stage 2 FOO

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -1034,8 +1034,7 @@ impl CommandLineStep for Rustc {
 macro_rules! tool_doc {
     (
         $tool: ident,
-        $path: literal,
-        mode = $mode:expr
+        $path: literal
         $(, is_library = $is_library:expr )?
         $(, crates = $crates:expr )?
         // Subset of nightly features that are allowed to be used when documenting
@@ -1062,26 +1061,16 @@ macro_rules! tool_doc {
 
             fn make_run(run: RunConfig<'_>) {
                 let target = run.target;
-                let build_compiler = match $mode {
-                    Mode::ToolRustcPrivate => {
-                        // Rustdoc needs the rustc sysroot available to build.
-                        let compilers = RustcPrivateCompilers::new(run.builder, run.builder.top_stage, target);
+                let build_compiler = {
+                    // Rustdoc needs the rustc sysroot available to build.
+                    let compilers = RustcPrivateCompilers::new(run.builder, run.builder.top_stage, target);
 
-                        // Build rustc docs so that we generate relative links.
-                        run.builder.ensure(Rustc::from_build_compiler(run.builder, compilers.build_compiler(), target));
-                        compilers.build_compiler()
-                    }
-                    Mode::ToolTarget => {
-                        // when shipping multiple docs together in one folder,
-                        // they all need to use the same rustdoc version
-                        prepare_doc_compiler(run.builder, run.builder.host_target, run.builder.top_stage)
-                    }
-                    _ => {
-                        panic!("Unexpected tool mode for documenting: {:?}", $mode);
-                    }
+                    // Build rustc docs so that we generate relative links.
+                    run.builder.ensure(Rustc::from_build_compiler(run.builder, compilers.build_compiler(), target));
+                    compilers.build_compiler()
                 };
 
-                run.builder.ensure($tool { build_compiler, mode: $mode, target });
+                run.builder.ensure($tool { build_compiler, mode: Mode::RustcDoc, target });
             }
 
             /// Generates documentation for a tool.
@@ -1173,40 +1162,14 @@ macro_rules! tool_doc {
 }
 
 // NOTE: make sure to register these in `Builder::get_step_description`.
-tool_doc!(
-    BuildHelper,
-    "src/build_helper",
-    // ideally, this would use ToolBootstrap,
-    // but we distribute these docs together in the same folder
-    // as a bunch of stage1 tools, and you can't mix rustdoc versions
-    // because that breaks cross-crate data (particularly search)
-    mode = Mode::ToolTarget,
-    is_library = true,
-    crates = ["build_helper"]
-);
-tool_doc!(
-    Rustdoc,
-    "src/tools/rustdoc",
-    mode = Mode::ToolRustcPrivate,
-    crates = ["rustdoc", "rustdoc-json-types"]
-);
-tool_doc!(
-    Rustfmt,
-    "src/tools/rustfmt",
-    mode = Mode::ToolRustcPrivate,
-    crates = ["rustfmt-nightly", "rustfmt-config_proc_macro"]
-);
-tool_doc!(
-    Clippy,
-    "src/tools/clippy",
-    mode = Mode::ToolRustcPrivate,
-    crates = ["clippy_config", "clippy_utils"]
-);
-tool_doc!(Miri, "src/tools/miri", mode = Mode::ToolRustcPrivate, crates = ["miri"]);
+tool_doc!(BuildHelper, "src/build_helper", is_library = true, crates = ["build_helper"]);
+tool_doc!(Rustdoc, "src/tools/rustdoc", crates = ["rustdoc", "rustdoc-json-types"]);
+tool_doc!(Rustfmt, "src/tools/rustfmt", crates = ["rustfmt-nightly", "rustfmt-config_proc_macro"]);
+tool_doc!(Clippy, "src/tools/clippy", crates = ["clippy_config", "clippy_utils"]);
+tool_doc!(Miri, "src/tools/miri", crates = ["miri"]);
 tool_doc!(
     Cargo,
     "src/tools/cargo",
-    mode = Mode::ToolTarget,
     crates = [
         "cargo",
         "cargo-credential",
@@ -1223,28 +1186,15 @@ tool_doc!(
     // "specialization" feature in its build script when it detects a nightly toolchain.
     allow_features: "specialization"
 );
-tool_doc!(Tidy, "src/tools/tidy", mode = Mode::ToolTarget, crates = ["tidy"]);
-tool_doc!(
-    Bootstrap,
-    "src/bootstrap",
-    mode = Mode::ToolTarget,
-    is_library = true,
-    crates = ["bootstrap"]
-);
+tool_doc!(Tidy, "src/tools/tidy", crates = ["tidy"]);
+tool_doc!(Bootstrap, "src/bootstrap", is_library = true, crates = ["bootstrap"]);
 tool_doc!(
     RunMakeSupport,
     "src/tools/run-make-support",
-    mode = Mode::ToolTarget,
     is_library = true,
     crates = ["run_make_support"]
 );
-tool_doc!(
-    Compiletest,
-    "src/tools/compiletest",
-    mode = Mode::ToolTarget,
-    is_library = true,
-    crates = ["compiletest"]
-);
+tool_doc!(Compiletest, "src/tools/compiletest", is_library = true, crates = ["compiletest"]);
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct ErrorIndex {

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -1033,8 +1033,7 @@ impl CommandLineStep for Rustc {
 macro_rules! tool_doc {
     (
         $tool: ident,
-        $path: literal,
-        mode = $mode:expr
+        $path: literal
         $(, is_library = $is_library:expr )?
         $(, crates = $crates:expr )?
         // Subset of nightly features that are allowed to be used when documenting
@@ -1061,26 +1060,16 @@ macro_rules! tool_doc {
 
             fn make_run(run: RunConfig<'_>) {
                 let target = run.target;
-                let build_compiler = match $mode {
-                    Mode::ToolRustcPrivate => {
-                        // Rustdoc needs the rustc sysroot available to build.
-                        let compilers = RustcPrivateCompilers::new(run.builder, run.builder.top_stage, target);
+                let build_compiler = {
+                    // Rustdoc needs the rustc sysroot available to build.
+                    let compilers = RustcPrivateCompilers::new(run.builder, run.builder.top_stage, target);
 
-                        // Build rustc docs so that we generate relative links.
-                        run.builder.ensure(Rustc::from_build_compiler(run.builder, compilers.build_compiler(), target));
-                        compilers.build_compiler()
-                    }
-                    Mode::ToolTarget => {
-                        // when shipping multiple docs together in one folder,
-                        // they all need to use the same rustdoc version
-                        prepare_doc_compiler(run.builder, run.builder.host_target, run.builder.top_stage)
-                    }
-                    _ => {
-                        panic!("Unexpected tool mode for documenting: {:?}", $mode);
-                    }
+                    // Build rustc docs so that we generate relative links.
+                    run.builder.ensure(Rustc::from_build_compiler(run.builder, compilers.build_compiler(), target));
+                    compilers.build_compiler()
                 };
 
-                run.builder.ensure($tool { build_compiler, mode: $mode, target });
+                run.builder.ensure($tool { build_compiler, mode: Mode::RustcDoc, target });
             }
 
             /// Generates documentation for a tool.
@@ -1172,40 +1161,14 @@ macro_rules! tool_doc {
 }
 
 // NOTE: make sure to register these in `Builder::get_step_description`.
-tool_doc!(
-    BuildHelper,
-    "src/build_helper",
-    // ideally, this would use ToolBootstrap,
-    // but we distribute these docs together in the same folder
-    // as a bunch of stage1 tools, and you can't mix rustdoc versions
-    // because that breaks cross-crate data (particularly search)
-    mode = Mode::ToolTarget,
-    is_library = true,
-    crates = ["build_helper"]
-);
-tool_doc!(
-    Rustdoc,
-    "src/tools/rustdoc",
-    mode = Mode::ToolRustcPrivate,
-    crates = ["rustdoc", "rustdoc-json-types"]
-);
-tool_doc!(
-    Rustfmt,
-    "src/tools/rustfmt",
-    mode = Mode::ToolRustcPrivate,
-    crates = ["rustfmt-nightly", "rustfmt-config_proc_macro"]
-);
-tool_doc!(
-    Clippy,
-    "src/tools/clippy",
-    mode = Mode::ToolRustcPrivate,
-    crates = ["clippy_config", "clippy_utils"]
-);
-tool_doc!(Miri, "src/tools/miri", mode = Mode::ToolRustcPrivate, crates = ["miri"]);
+tool_doc!(BuildHelper, "src/build_helper", is_library = true, crates = ["build_helper"]);
+tool_doc!(Rustdoc, "src/tools/rustdoc", crates = ["rustdoc", "rustdoc-json-types"]);
+tool_doc!(Rustfmt, "src/tools/rustfmt", crates = ["rustfmt-nightly", "rustfmt-config_proc_macro"]);
+tool_doc!(Clippy, "src/tools/clippy", crates = ["clippy_config", "clippy_utils"]);
+tool_doc!(Miri, "src/tools/miri", crates = ["miri"]);
 tool_doc!(
     Cargo,
     "src/tools/cargo",
-    mode = Mode::ToolTarget,
     crates = [
         "cargo",
         "cargo-credential",
@@ -1222,28 +1185,15 @@ tool_doc!(
     // "specialization" feature in its build script when it detects a nightly toolchain.
     allow_features: "specialization"
 );
-tool_doc!(Tidy, "src/tools/tidy", mode = Mode::ToolTarget, crates = ["tidy"]);
-tool_doc!(
-    Bootstrap,
-    "src/bootstrap",
-    mode = Mode::ToolTarget,
-    is_library = true,
-    crates = ["bootstrap"]
-);
+tool_doc!(Tidy, "src/tools/tidy", crates = ["tidy"]);
+tool_doc!(Bootstrap, "src/bootstrap", is_library = true, crates = ["bootstrap"]);
 tool_doc!(
     RunMakeSupport,
     "src/tools/run-make-support",
-    mode = Mode::ToolTarget,
     is_library = true,
     crates = ["run_make_support"]
 );
-tool_doc!(
-    Compiletest,
-    "src/tools/compiletest",
-    mode = Mode::ToolTarget,
-    is_library = true,
-    crates = ["compiletest"]
-);
+tool_doc!(Compiletest, "src/tools/compiletest", is_library = true, crates = ["compiletest"]);
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct ErrorIndex {

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -711,6 +711,9 @@ impl Builder<'_> {
         }
 
         if cmd_kind == Kind::Doc {
+            // Will be stabilized soon -> let's dogfood it.
+            // No effect on doc output but massive doc-generation time improvements.
+            cargo.arg("-Zrustdoc-mergeable-info");
             let my_out = match mode {
                 // This is the intended out directory for compiler documentation.
                 Mode::Rustc | Mode::ToolRustcPrivate | Mode::ToolBootstrap | Mode::ToolTarget => {

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -26,9 +26,11 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &str, Option<&[&'static str]>)] = &[
     (Some(Mode::Rustc), "bootstrap", None),
     (Some(Mode::Codegen), "bootstrap", None),
     (Some(Mode::ToolRustcPrivate), "bootstrap", None),
+    (Some(Mode::RustcDoc), "bootstrap", None),
     (Some(Mode::ToolStd), "bootstrap", None),
     (Some(Mode::ToolRustcPrivate), "rust_analyzer", None),
     (Some(Mode::ToolStd), "rust_analyzer", None),
+    (Some(Mode::RustcDoc), "rust_analyzer", None),
     // Any library specific cfgs like `target_os`, `target_arch` should be put in
     // priority the `[lints.rust.unexpected_cfgs.check-cfg]` table
     // in the appropriate `library/{std,alloc,core}/Cargo.toml`
@@ -716,9 +718,11 @@ impl Builder<'_> {
             cargo.arg("-Zrustdoc-mergeable-info");
             let my_out = match mode {
                 // This is the intended out directory for compiler documentation.
-                Mode::Rustc | Mode::ToolRustcPrivate | Mode::ToolBootstrap | Mode::ToolTarget => {
-                    self.compiler_doc_out(target)
-                }
+                Mode::Rustc
+                | Mode::RustcDoc
+                | Mode::ToolRustcPrivate
+                | Mode::ToolBootstrap
+                | Mode::ToolTarget => self.compiler_doc_out(target),
                 Mode::Std => {
                     if self.config.cmd.json() {
                         out_dir.join(target).join("json-doc")
@@ -804,7 +808,11 @@ impl Builder<'_> {
         // sysroot. Passing this cfg enables raw-dylib support instead, which makes the native
         // library unnecessary. This can be removed when windows-rs enables raw-dylib
         // unconditionally.
-        if let Mode::Rustc | Mode::ToolRustcPrivate | Mode::ToolBootstrap | Mode::ToolTarget = mode
+        if let Mode::Rustc
+        | Mode::RustcDoc
+        | Mode::ToolRustcPrivate
+        | Mode::ToolBootstrap
+        | Mode::ToolTarget = mode
         {
             rustflags.arg("--cfg=windows_raw_dylib");
         }
@@ -888,7 +896,7 @@ impl Builder<'_> {
 
         match mode {
             Mode::Std | Mode::ToolBootstrap | Mode::ToolStd | Mode::ToolTarget => {}
-            Mode::Rustc | Mode::Codegen | Mode::ToolRustcPrivate => {
+            Mode::Rustc | Mode::RustcDoc | Mode::Codegen | Mode::ToolRustcPrivate => {
                 // Build proc macros both for the host and the target unless proc-macros are not
                 // supported by the target.
                 if target != compiler.host && cmd_kind != Kind::Check {
@@ -951,7 +959,9 @@ impl Builder<'_> {
                 "binary-dep-depinfo,proc_macro_span,proc_macro_span_shrink,proc_macro_diagnostic"
                     .to_string()
             }
-            Mode::Std | Mode::Rustc | Mode::Codegen | Mode::ToolRustcPrivate => String::new(),
+            Mode::Std | Mode::Rustc | Mode::RustcDoc | Mode::Codegen | Mode::ToolRustcPrivate => {
+                String::new()
+            }
         };
 
         cargo.arg("-j").arg(self.jobs().to_string());
@@ -1088,7 +1098,7 @@ impl Builder<'_> {
         }
 
         let debuginfo_level = match mode {
-            Mode::Rustc | Mode::Codegen => self.config.rust_debuginfo_level_rustc,
+            Mode::Rustc | Mode::RustcDoc | Mode::Codegen => self.config.rust_debuginfo_level_rustc,
             Mode::Std => self.config.rust_debuginfo_level_std,
             Mode::ToolBootstrap | Mode::ToolStd | Mode::ToolRustcPrivate | Mode::ToolTarget => {
                 self.config.rust_debuginfo_level_tools
@@ -1102,7 +1112,7 @@ impl Builder<'_> {
             profile_var("DEBUG_ASSERTIONS"),
             match mode {
                 Mode::Std => self.config.std_debug_assertions,
-                Mode::Rustc | Mode::Codegen => self.config.rustc_debug_assertions,
+                Mode::Rustc | Mode::RustcDoc | Mode::Codegen => self.config.rustc_debug_assertions,
                 Mode::ToolBootstrap | Mode::ToolStd | Mode::ToolRustcPrivate | Mode::ToolTarget => {
                     self.config.tools_debug_assertions
                 }
@@ -1135,7 +1145,7 @@ impl Builder<'_> {
             // Any library crate that's part of the sysroot should be marked unstable
             // (including third-party dependencies), unless it uses a staged_api
             // `#![stable(..)]` attribute to explicitly mark itself stable.
-            Mode::Std | Mode::Codegen | Mode::Rustc => {
+            Mode::Std | Mode::Codegen | Mode::Rustc | Mode::RustcDoc => {
                 cargo.env("RUSTC_FORCE_UNSTABLE", "1");
             }
 
@@ -1168,7 +1178,7 @@ impl Builder<'_> {
         // `RUSTC_DEBUGINFO_MAP` is used to pass through to the underlying rustc
         // `--remap-path-prefix`.
         match mode {
-            Mode::Rustc | Mode::Codegen => {
+            Mode::Rustc | Mode::RustcDoc | Mode::Codegen => {
                 if let Some(ref map_to) =
                     self.build.debuginfo_map_to(GitRepo::Rustc, RemapScheme::NonCompiler)
                 {

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -668,9 +668,11 @@ impl Builder<'_> {
             cargo.arg("-Zrustdoc-mergeable-info");
             let my_out = match mode {
                 // This is the intended out directory for compiler documentation.
-                Mode::Rustc | Mode::ToolRustcPrivate | Mode::ToolBootstrap | Mode::ToolTarget => {
-                    self.compiler_doc_out(target)
-                }
+                Mode::Rustc
+                | Mode::RustcDoc
+                | Mode::ToolRustcPrivate
+                | Mode::ToolBootstrap
+                | Mode::ToolTarget => self.compiler_doc_out(target),
                 Mode::Std => {
                     if self.config.cmd.json() {
                         out_dir.join(target).join("json-doc")
@@ -750,7 +752,11 @@ impl Builder<'_> {
         // sysroot. Passing this cfg enables raw-dylib support instead, which makes the native
         // library unnecessary. This can be removed when windows-rs enables raw-dylib
         // unconditionally.
-        if let Mode::Rustc | Mode::ToolRustcPrivate | Mode::ToolBootstrap | Mode::ToolTarget = mode
+        if let Mode::Rustc
+        | Mode::RustcDoc
+        | Mode::ToolRustcPrivate
+        | Mode::ToolBootstrap
+        | Mode::ToolTarget = mode
         {
             rustflags.arg("--cfg=windows_raw_dylib");
         }
@@ -834,7 +840,7 @@ impl Builder<'_> {
 
         match mode {
             Mode::Std | Mode::ToolBootstrap | Mode::ToolStd | Mode::ToolTarget => {}
-            Mode::Rustc | Mode::Codegen | Mode::ToolRustcPrivate => {
+            Mode::Rustc | Mode::RustcDoc | Mode::Codegen | Mode::ToolRustcPrivate => {
                 // Build proc macros both for the host and the target unless proc-macros are not
                 // supported by the target.
                 if target != compiler.host && cmd_kind != Kind::Check {
@@ -897,7 +903,9 @@ impl Builder<'_> {
                 "binary-dep-depinfo,proc_macro_span,proc_macro_span_shrink,proc_macro_diagnostic"
                     .to_string()
             }
-            Mode::Std | Mode::Rustc | Mode::Codegen | Mode::ToolRustcPrivate => String::new(),
+            Mode::Std | Mode::Rustc | Mode::RustcDoc | Mode::Codegen | Mode::ToolRustcPrivate => {
+                String::new()
+            }
         };
 
         cargo.arg("-j").arg(self.jobs().to_string());
@@ -1034,7 +1042,7 @@ impl Builder<'_> {
         }
 
         let debuginfo_level = match mode {
-            Mode::Rustc | Mode::Codegen => self.config.rust_debuginfo_level_rustc,
+            Mode::Rustc | Mode::RustcDoc | Mode::Codegen => self.config.rust_debuginfo_level_rustc,
             Mode::Std => self.config.rust_debuginfo_level_std,
             Mode::ToolBootstrap | Mode::ToolStd | Mode::ToolRustcPrivate | Mode::ToolTarget => {
                 self.config.rust_debuginfo_level_tools
@@ -1048,7 +1056,7 @@ impl Builder<'_> {
             profile_var("DEBUG_ASSERTIONS"),
             match mode {
                 Mode::Std => self.config.std_debug_assertions,
-                Mode::Rustc | Mode::Codegen => self.config.rustc_debug_assertions,
+                Mode::Rustc | Mode::RustcDoc | Mode::Codegen => self.config.rustc_debug_assertions,
                 Mode::ToolBootstrap | Mode::ToolStd | Mode::ToolRustcPrivate | Mode::ToolTarget => {
                     self.config.tools_debug_assertions
                 }
@@ -1081,7 +1089,7 @@ impl Builder<'_> {
             // Any library crate that's part of the sysroot should be marked unstable
             // (including third-party dependencies), unless it uses a staged_api
             // `#![stable(..)]` attribute to explicitly mark itself stable.
-            Mode::Std | Mode::Codegen | Mode::Rustc => {
+            Mode::Std | Mode::Codegen | Mode::Rustc | Mode::RustcDoc => {
                 cargo.env("RUSTC_FORCE_UNSTABLE", "1");
             }
 
@@ -1114,7 +1122,7 @@ impl Builder<'_> {
         // `RUSTC_DEBUGINFO_MAP` is used to pass through to the underlying rustc
         // `--remap-path-prefix`.
         match mode {
-            Mode::Rustc | Mode::Codegen => {
+            Mode::Rustc | Mode::RustcDoc | Mode::Codegen => {
                 if let Some(ref map_to) =
                     self.build.debuginfo_map_to(GitRepo::Rustc, RemapScheme::NonCompiler)
                 {
@@ -1438,7 +1446,8 @@ impl Builder<'_> {
         if matches!(mode, Mode::Std) {
             rustflags.arg("-Cprefer-dynamic");
         }
-        if matches!(mode, Mode::Rustc) && !self.link_std_into_rustc_driver(target) {
+        if matches!(mode, Mode::Rustc | Mode::RustcDoc) && !self.link_std_into_rustc_driver(target)
+        {
             rustflags.arg("-Cprefer-dynamic");
         }
 

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -663,6 +663,9 @@ impl Builder<'_> {
         }
 
         if cmd_kind == Kind::Doc {
+            // Will be stabilized soon -> let's dogfood it.
+            // No effect on doc output but massive doc-generation time improvements.
+            cargo.arg("-Zrustdoc-mergeable-info");
             let my_out = match mode {
                 // This is the intended out directory for compiler documentation.
                 Mode::Rustc | Mode::ToolRustcPrivate | Mode::ToolBootstrap | Mode::ToolTarget => {

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2444,8 +2444,11 @@ mod snapshot {
         insta::assert_snapshot!(
             ctx.config("doc")
                 .path("cargo")
-                .render_steps(), @r"
+                .render_steps(), @"
+        [build] llvm <host>
+        [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustdoc 0 <host>
+        [doc] rustc 0 <host> -> rustc 1 <host>
         [doc] rustc 0 <host> -> Cargo 1 <host>
         ");
     }
@@ -2456,11 +2459,13 @@ mod snapshot {
             ctx.config("doc")
                 .path("cargo")
                 .stage(2)
-                .render_steps(), @r"
+                .render_steps(), @"
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 1 <host> -> rustc 2 <host>
         [build] rustdoc 1 <host>
+        [doc] rustc 1 <host> -> rustc 2 <host>
         [doc] rustc 1 <host> -> Cargo 2 <host>
         ");
     }
@@ -2576,8 +2581,11 @@ mod snapshot {
             ctx.config("doc")
                 .path("src/tools/compiletest")
                 .stage(1)
-                .render_steps(), @r"
+                .render_steps(), @"
+        [build] llvm <host>
+        [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustdoc 0 <host>
+        [doc] rustc 0 <host> -> rustc 1 <host>
         [doc] rustc 0 <host> -> Compiletest 1 <host>
         ");
     }
@@ -2589,11 +2597,13 @@ mod snapshot {
             ctx.config("doc")
                 .path("src/tools/compiletest")
                 .stage(2)
-                .render_steps(), @r"
+                .render_steps(), @"
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 1 <host> -> rustc 2 <host>
         [build] rustdoc 1 <host>
+        [doc] rustc 1 <host> -> rustc 2 <host>
         [doc] rustc 1 <host> -> Compiletest 2 <host>
         ");
     }

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2511,8 +2511,11 @@ mod snapshot {
         insta::assert_snapshot!(
             ctx.config("doc")
                 .path("cargo")
-                .render_steps(), @r"
+                .render_steps(), @"
+        [build] llvm <host>
+        [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustdoc 0 <host>
+        [doc] rustc 0 <host> -> rustc 1 <host>
         [doc] rustc 0 <host> -> Cargo 1 <host>
         ");
     }
@@ -2523,11 +2526,13 @@ mod snapshot {
             ctx.config("doc")
                 .path("cargo")
                 .stage(2)
-                .render_steps(), @r"
+                .render_steps(), @"
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 1 <host> -> rustc 2 <host>
         [build] rustdoc 1 <host>
+        [doc] rustc 1 <host> -> rustc 2 <host>
         [doc] rustc 1 <host> -> Cargo 2 <host>
         ");
     }
@@ -2643,8 +2648,11 @@ mod snapshot {
             ctx.config("doc")
                 .path("src/tools/compiletest")
                 .stage(1)
-                .render_steps(), @r"
+                .render_steps(), @"
+        [build] llvm <host>
+        [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustdoc 0 <host>
+        [doc] rustc 0 <host> -> rustc 1 <host>
         [doc] rustc 0 <host> -> Compiletest 1 <host>
         ");
     }
@@ -2656,11 +2664,13 @@ mod snapshot {
             ctx.config("doc")
                 .path("src/tools/compiletest")
                 .stage(2)
-                .render_steps(), @r"
+                .render_steps(), @"
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 1 <host> -> rustc 2 <host>
         [build] rustdoc 1 <host>
+        [doc] rustc 1 <host> -> rustc 2 <host>
         [doc] rustc 1 <host> -> Compiletest 2 <host>
         ");
     }

--- a/src/bootstrap/src/core/session.rs
+++ b/src/bootstrap/src/core/session.rs
@@ -166,6 +166,24 @@ pub(crate) enum Mode {
     /// everything that links to rustc as a library, such as rustdoc, clippy,
     /// rustfmt, miri, etc.
     ToolRustcPrivate,
+
+    /// Used only for documentation, places the crate build output in stageN-rustc
+    /// but without the compiler-specific build options.
+    ///
+    /// `/build/[your arch]/compiler-docs/`, a.k.a.
+    /// <https://doc.rust-lang.org/nightly/nightly-rustc/>, is a documentation
+    /// bundle of the non-stdlib code in rust-lang/rust. It's built for the
+    /// benefit of compiler devs (including `--document-private-items`), so we
+    /// want intra-doc links, search, and impls across the entire codebase,
+    /// including tools like Bootstrap, Rustdoc, and Clippy.
+    ///
+    /// Some Rustdoc features rely on intermediate build artifacts for
+    /// cross-crate information, especially when that information flows
+    /// "upstream" from dependency crates to appear on the dependent's page.
+    /// That metadata is stored in the build directory, so any crates that
+    /// want to appear in the compiler-docs bundle need to share a build dir.
+    /// These metadata formats are also unstable, so we need a single version.
+    RustcDoc,
 }
 
 impl Mode {
@@ -176,7 +194,8 @@ impl Mode {
             | Mode::ToolRustcPrivate
             | Mode::ToolStd
             | Mode::ToolTarget
-            | Mode::Rustc => false,
+            | Mode::Rustc
+            | Mode::RustcDoc => false,
         }
     }
 }
@@ -771,7 +790,7 @@ impl Build {
             // Std is special, stage N std is built with stage N rustc
             Mode::Std => (Some(build_compiler.stage), "std"),
             // The rest of things are built with stage N-1 rustc
-            Mode::Rustc => (Some(build_compiler.stage + 1), "rustc"),
+            Mode::Rustc | Mode::RustcDoc => (Some(build_compiler.stage + 1), "rustc"),
             Mode::Codegen => (Some(build_compiler.stage + 1), "codegen"),
             Mode::ToolBootstrap => bootstrap_tool(),
             Mode::ToolStd | Mode::ToolRustcPrivate => (Some(build_compiler.stage + 1), "tools"),
@@ -916,6 +935,7 @@ impl Build {
             // Other things have stage corresponding to their build compiler + 1
             Some(
                 Mode::Rustc
+                | Mode::RustcDoc
                 | Mode::Codegen
                 | Mode::ToolBootstrap
                 | Mode::ToolTarget

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -349,6 +349,20 @@ pub enum Mode {
 
     /// Used only for documentation, places the crate build output in stageN-rustc
     /// but without the compiler-specific build options.
+    ///
+    /// `/build/[your arch]/compiler-docs/`, a.k.a.
+    /// <https://doc.rust-lang.org/nightly/nightly-rustc/>, is a documentation
+    /// bundle of the non-stdlib code in rust-lang/rust. It's built for the
+    /// benefit of compiler devs (including `--document-private-items`), so we
+    /// want intra-doc links, search, and impls across the entire codebase,
+    /// including tools like Bootstrap, Rustdoc, and Clippy.
+    ///
+    /// Some Rustdoc features rely on intermediate build artifacts for
+    /// cross-crate information, especially when that information flows
+    /// "upstream" from dependency crates to appear on the dependent's page.
+    /// That metadata is stored in the build directory, so any crates that
+    /// want to appear in the compiler-docs bundle need to share a build dir.
+    /// These metadata formats are also unstable, so we need a single version.
     RustcDoc,
 }
 

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -85,9 +85,11 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &str, Option<&[&'static str]>)] = &[
     (Some(Mode::Rustc), "bootstrap", None),
     (Some(Mode::Codegen), "bootstrap", None),
     (Some(Mode::ToolRustcPrivate), "bootstrap", None),
+    (Some(Mode::RustcDoc), "bootstrap", None),
     (Some(Mode::ToolStd), "bootstrap", None),
     (Some(Mode::ToolRustcPrivate), "rust_analyzer", None),
     (Some(Mode::ToolStd), "rust_analyzer", None),
+    (Some(Mode::RustcDoc), "rust_analyzer", None),
     // Any library specific cfgs like `target_os`, `target_arch` should be put in
     // priority the `[lints.rust.unexpected_cfgs.check-cfg]` table
     // in the appropriate `library/{std,alloc,core}/Cargo.toml`
@@ -344,6 +346,10 @@ pub enum Mode {
     /// everything that links to rustc as a library, such as rustdoc, clippy,
     /// rustfmt, miri, etc.
     ToolRustcPrivate,
+
+    /// Used only for documentation, places the crate build output in stageN-rustc
+    /// but without the compiler-specific build options.
+    RustcDoc,
 }
 
 impl Mode {
@@ -354,7 +360,8 @@ impl Mode {
             | Mode::ToolRustcPrivate
             | Mode::ToolStd
             | Mode::ToolTarget
-            | Mode::Rustc => false,
+            | Mode::Rustc
+            | Mode::RustcDoc => false,
         }
     }
 }
@@ -937,7 +944,7 @@ impl Build {
             // Std is special, stage N std is built with stage N rustc
             Mode::Std => (Some(build_compiler.stage), "std"),
             // The rest of things are built with stage N-1 rustc
-            Mode::Rustc => (Some(build_compiler.stage + 1), "rustc"),
+            Mode::Rustc | Mode::RustcDoc => (Some(build_compiler.stage + 1), "rustc"),
             Mode::Codegen => (Some(build_compiler.stage + 1), "codegen"),
             Mode::ToolBootstrap => bootstrap_tool(),
             Mode::ToolStd | Mode::ToolRustcPrivate => (Some(build_compiler.stage + 1), "tools"),
@@ -1145,6 +1152,7 @@ impl Build {
             // Other things have stage corresponding to their build compiler + 1
             Some(
                 Mode::Rustc
+                | Mode::RustcDoc
                 | Mode::Codegen
                 | Mode::ToolBootstrap
                 | Mode::ToolTarget


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160098)*
<!-- homu-ignore:end -->

This feature is unstable but will be stabilized soon, and this is a good way of dogfooding it to make sure it works properly. It should have no effect on the generated docs, but it provides a significant speedup. For example, I measure a 3x speedup locally (3m 11s -> 1m 1s) for `x doc src/tools` -- note that this is with the latest rustdoc perf improvements (rust-lang/rust#159854).

r? @Kobzol 