### PR TITLE
Add missing `needs-unwind` annotation to `add-spawn-hook-reentrancy-159923` test

### DIFF
--- a/tests/ui/std/add-spawn-hook-reentrancy-159923.rs
+++ b/tests/ui/std/add-spawn-hook-reentrancy-159923.rs
@@ -2,6 +2,7 @@
 //@ edition:2024
 //@ run-pass
 //@ needs-threads
+//@ needs-unwind
 
 #![feature(alloc_error_hook, thread_spawn_hook)]
 


### PR DESCRIPTION


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
