### PR TITLE
Stabilize `windows_process_extensions_main_thread_handle`

### DIFF
--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -437,14 +437,23 @@ impl CommandExt for process::Command {
     }
 }
 
-#[unstable(feature = "windows_process_extensions_main_thread_handle", issue = "96723")]
+#[stable(
+    feature = "windows_process_extensions_main_thread_handle",
+    since = "CURRENT_RUSTC_VERSION"
+)]
 pub impl(self) trait ChildExt {
     /// Extracts the main thread raw handle, without taking ownership
-    #[unstable(feature = "windows_process_extensions_main_thread_handle", issue = "96723")]
+    #[stable(
+        feature = "windows_process_extensions_main_thread_handle",
+        since = "CURRENT_RUSTC_VERSION"
+    )]
     fn main_thread_handle(&self) -> BorrowedHandle<'_>;
 }
 
-#[unstable(feature = "windows_process_extensions_main_thread_handle", issue = "96723")]
+#[stable(
+    feature = "windows_process_extensions_main_thread_handle",
+    since = "CURRENT_RUSTC_VERSION"
+)]
 impl ChildExt for process::Child {
     fn main_thread_handle(&self) -> BorrowedHandle<'_> {
         self.handle.main_thread_handle()

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -435,14 +435,23 @@ impl CommandExt for process::Command {
     }
 }
 
-#[unstable(feature = "windows_process_extensions_main_thread_handle", issue = "96723")]
+#[stable(
+    feature = "windows_process_extensions_main_thread_handle",
+    since = "CURRENT_RUSTC_VERSION"
+)]
 pub impl(self) trait ChildExt {
     /// Extracts the main thread raw handle, without taking ownership
-    #[unstable(feature = "windows_process_extensions_main_thread_handle", issue = "96723")]
+    #[stable(
+        feature = "windows_process_extensions_main_thread_handle",
+        since = "CURRENT_RUSTC_VERSION"
+    )]
     fn main_thread_handle(&self) -> BorrowedHandle<'_>;
 }
 
-#[unstable(feature = "windows_process_extensions_main_thread_handle", issue = "96723")]
+#[stable(
+    feature = "windows_process_extensions_main_thread_handle",
+    since = "CURRENT_RUSTC_VERSION"
+)]
 impl ChildExt for process::Child {
     fn main_thread_handle(&self) -> BorrowedHandle<'_> {
         self.handle.main_thread_handle()


### PR DESCRIPTION
I propose we stabilize the library feature `windows_process_extensions_main_thread_handle` (tracking issue https://github.com/rust-lang/rust/issues/96723).

## Stabilization Report

### Implementation History

This feature was added in https://github.com/rust-lang/rust/pull/96725, and not changed since.

### API Summary

```rust
// std::os::windows::process

pub trait ChildExt: Sealed {
    fn main_thread_handle(&self) -> BorrowedHandle<'_>;
}
```

This method gives access to the handle to the main thread of a spawned child process on Windows. It is not possible to get after spawning using documented APIs, and it's useful for example for resuming a process that started as suspended (while it's possible to enumerate all threads and resume them all, that's slower and more complicated).

### Experience Report

My personal reason for this is wanting to use it for this case exactly (resuming a suspended process) in rust-analyzer, see https://github.com/rust-lang/rust-analyzer/pull/22763#issuecomment-4997862266. Other people seem to want this for the same reason as well (for example in the tracking issue). [Searching GitHub for `.main_thread_handle()` gives 269 results](https://github.com/search?q=%22.main_thread_handle%28%29%22+language%3Arust&type=code). Some are for resuming processes, but there are also others - for example, [injecting a DLL](https://github.com/garyttierney/me3/blob/a1e26958d8e141864d3adfcbbef4f2f669b5c8ef/crates/launcher/src/game.rs#L98). I [even found a project](https://github.com/GitFlameAI/GitFlame-CodeRAG/blob/3684d2dc846831f9805bec4486e60296c232f974/datasets/repositories/repo_020_hyperfine/code/src/timer/windows_timer.rs#L71) that gates using this method behind a feature, and if it's not set, uses an undocumented Windows API instead.

### Unresolved Questions

There are two unresolved questions:

 - The naming - should it be the "main thread" or the "primary thread". Microsoft's documentation refers to it as the "primary thread", but our own docs mention "main thread" (https://doc.rust-lang.org/std/thread/index.html), as stated in https://github.com/rust-lang/rust/issues/96723#issuecomment-1869909355. I left it as "main thread".
 - Should it return `Option<BorrowedHandle<'_>>`? This will enable conversion from a handle to `std::process::Child` (such conversion is not supported currently). Such conversion is not supported for any OS currently though, and making this function returning `Option` will complicate code using it, so I chose to not do that.

r? libs-api