### PR TITLE
Generalize Decodable impl for arrays to all types

### DIFF
--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -336,15 +336,11 @@ impl<S: Encoder, T: Encodable<S>, const N: usize> Encodable<S> for [T; N] {
     }
 }
 
-impl<D: Decoder, const N: usize> Decodable<D> for [u8; N] {
-    fn decode(d: &mut D) -> [u8; N] {
+impl<D: Decoder, T: Decodable<D>, const N: usize> Decodable<D> for [T; N] {
+    fn decode(d: &mut D) -> [T; N] {
         let len = d.read_usize();
         assert!(len == N);
-        let mut v = [0u8; N];
-        for i in 0..len {
-            v[i] = Decodable::decode(d);
-        }
-        v
+        std::array::from_fn(move |_| Decodable::decode(d))
     }
 }
 

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -332,14 +332,14 @@ impl<D: Decoder, T: Decodable<D>> Decodable<D> for Vec<T> {
 
 impl<S: Encoder, T: Encodable<S>, const N: usize> Encodable<S> for [T; N] {
     fn encode(&self, s: &mut S) {
-        self.as_slice().encode(s);
+        for e in self {
+            e.encode(s);
+        }
     }
 }
 
 impl<D: Decoder, T: Decodable<D>, const N: usize> Decodable<D> for [T; N] {
     fn decode(d: &mut D) -> [T; N] {
-        let len = d.read_usize();
-        assert!(len == N);
         std::array::from_fn(move |_| Decodable::decode(d))
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160111)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This is almost the only impl that is not symetric with its Encodable counterpart. I tried to find out why in the history but it looks like this impl predates most of the generic symetric ones that are in this file, so it looks like it's not intentional.

I bumped into this randomly by changing a Vec to an array in some Mir types. The error was pretty confusing and It took me a while to figure out so I think it's worth generalizing this for somebody else in the future,  even though it's technically not necessary at the moment.

~~We piggyback off of `SmallVec` impl to avoid adding a `Default` bound or `MaybeUninit` unsafe dance. This moves the assert from the begining to the end of the loop.~~ We use `array::from_fn`