### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -884,9 +884,9 @@ fn is_msvc_link_exe(sess: &Session) -> bool {
         && linker_path.to_str() == Some("link.exe")
 }
 
-fn is_macos_ld(sess: &Session) -> bool {
+fn is_macos_linker(sess: &Session) -> bool {
     let (_, flavor) = linker_and_flavor(sess);
-    sess.target.is_like_darwin && matches!(flavor, LinkerFlavor::Darwin(_, Lld::No))
+    sess.target.is_like_darwin && matches!(flavor, LinkerFlavor::Darwin(..))
 }
 
 fn is_windows_gnu_ld(sess: &Session) -> bool {
@@ -953,8 +953,8 @@ fn report_linker_output(
                 *output += "\r\n"
             }
         });
-    } else if is_macos_ld(sess) {
-        info!("inferred macOS LD");
+    } else if is_macos_linker(sess) {
+        info!("inferred macOS linker");
 
         // FIXME: Tracked by https://github.com/rust-lang/rust/issues/136113
         let deployment_mismatch = |line: &str| {
@@ -967,6 +967,8 @@ fn report_linker_output(
                 && line.contains("building for")
                 && line.contains("but linking with")
                 && line.contains("which was built for newer version"))
+            // lld (ld64.lld / rust-lld):
+            || line.contains("which is newer than target minimum of")
         };
         // FIXME: This is a real warning we would like to show, but it hits too many crates
         // to want to turn it on immediately.

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2069,6 +2069,24 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitOutlivesRequirements {
                                         continue;
                                     };
                                     let index = ty_generics.param_def_id_to_index[&def_id];
+                                    // Removing a `T: 'r` outlives bound can silently change
+                                    // the object lifetime default for `Struct<'r, dyn Trait>`
+                                    // (RFC 599): the explicit bound sets the default to `'r`,
+                                    // so removing it may change it to `'static` (or cause an
+                                    // ambiguity error if there is no unique default). Only
+                                    // suppress the lint for non-higher-ranked predicates when
+                                    // T is not `Sized` (i.e. can hold trait object types).
+                                    // Higher-ranked predicates (`for<'x> T: 'r`) are excluded
+                                    // from RFC 599 object lifetime defaulting and are always
+                                    // safe to remove.
+                                    if predicate.bound_generic_params.is_empty() {
+                                        let ty_param = &ty_generics.own_params[index as usize];
+                                        let param_ty =
+                                            Ty::new_param(cx.tcx, ty_param.index, ty_param.name);
+                                        if !param_ty.is_sized(cx.tcx, cx.typing_env()) {
+                                            continue;
+                                        }
+                                    }
                                     (
                                         Self::lifetimes_outliving_type(
                                             // don't warn if the inferred span actually came from the predicate we're looking at

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2298,33 +2298,7 @@ declare_lint! {
     ///
     /// See [RFC 2093] for more details.
     ///
-    /// > [!WARNING]
-    /// > Implicit lifetime bounds are not semantically equivalent to explicit ones since the latter
-    /// > may affect the implicit lifetime bound of trait object types that are passed as arguments
-    /// > to the overarching struct, enum or union.
-    /// > Rephrased, they participate in [trait object lifetime defaulting][TOLD].
-    /// >
-    /// > Consider the following piece of code where removing bound `T: 'a` would lead to a lifetime
-    /// > error in function `scope`:
-    /// >
-    /// > ```rust,no_run
-    /// > struct Ref<'a, T: ?Sized + 'a>(&'a T);
-    /// >
-    /// > fn scope() {
-    /// >     let buf = String::new();
-    /// >     let str = buf.as_str();
-    /// >     render(Ref(&str));
-    /// > }
-    /// >
-    /// > fn render(_: Ref<dyn std::fmt::Display>) {}
-    /// > ```
-    /// >
-    /// > Consequently, removing explicit outlives-bounds on type parameters of publicly reachable types
-    /// > constitutes a **breaking change** if the lifetime refers to a lifetime parameter and
-    /// > the type parameter is not bounded by `Sized` (thereby admitting trait object types).
-    ///
     /// [RFC 2093]: https://github.com/rust-lang/rfcs/blob/master/text/2093-infer-outlives.md
-    /// [TOLD]: https://doc.rust-lang.org/reference/lifetime-elision.html#default-trait-object-lifetimes
     pub EXPLICIT_OUTLIVES_REQUIREMENTS,
     Allow,
     "outlives requirements can be inferred"

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2298,7 +2298,43 @@ declare_lint! {
     ///
     /// See [RFC 2093] for more details.
     ///
+    /// > [!NOTE]
+    /// > This lint intentionally doesn't get emitted for explicit outlives-bounds on type
+    /// > parameters that aren't bounded by `Sized` (unless they're higher-ranked) since unlike
+    /// > implicit outlives-bounds these may affect the implicit lifetime bound of trait object
+    /// > types that are passed as arguments to the overarching struct, enum or union.
+    /// >
+    /// > Rephrased, they participate in [trait object lifetime defaulting][TOLD].
+    /// >
+    /// > Consider the following piece of code where removing bound `T: 'a` would lead to a lifetime
+    /// > error in function `scope`:
+    /// >
+    /// > ```rust,no_run
+    /// > struct Ref<'a, T: ?Sized + 'a>(&'a T);
+    /// >
+    /// > fn scope() {
+    /// >     let buf = String::new();
+    /// >     let str = buf.as_str();
+    /// >     render(Ref(&str));
+    /// > }
+    /// >
+    /// > fn render(_: Ref<dyn std::fmt::Display>) {}
+    /// > ```
+    /// >
+    /// > Due to the explicit outlives-bound the function `render` above is equivalent to:
+    /// >
+    /// > ```rust,ignore (incomplete)
+    /// > fn render<'r>(_: Ref<'r, dyn std::fmt::Display + 'r>) {}
+    /// > ```
+    /// >
+    /// > If it wasn't for that explicit bound then the function would mean the following instead:
+    /// >
+    /// > ```rust,ignore (incomplete)
+    /// > fn render<'r>(_: Ref<'r, dyn std::fmt::Display + 'static>) {}
+    /// > ```
+    ///
     /// [RFC 2093]: https://github.com/rust-lang/rfcs/blob/master/text/2093-infer-outlives.md
+    /// [TOLD]: https://doc.rust-lang.org/reference/lifetime-elision.html#default-trait-object-lifetimes
     pub EXPLICIT_OUTLIVES_REQUIREMENTS,
     Allow,
     "outlives requirements can be inferred"

--- a/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
@@ -1,12 +1,13 @@
 use std::borrow::Cow;
-use std::cell::RefCell;
 
+use rustc_data_structures::fx::FxHashMap;
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::visit::{NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::*;
+use smallvec::SmallVec;
 
 use super::MaybeBorrowedLocals;
-use crate::{Analysis, GenKill, ResultsCursor};
+use crate::{Analysis, GenKill, Results, ResultsCursor};
 
 /// The set of locals in a MIR body that do not have `StorageLive`/`StorageDead` annotations.
 ///
@@ -111,21 +112,51 @@ impl<'a, 'tcx> Analysis<'tcx> for MaybeStorageDead<'a> {
     }
 }
 
-type BorrowedLocalsResults<'mir, 'tcx> = ResultsCursor<'mir, 'tcx, MaybeBorrowedLocals>;
+/// For each location, records which locals can be killed by `MaybeRequiresStorage`.
+type KillableLocals = FxHashMap<Location, SmallVec<[Local; 4]>>;
 
 /// Dataflow analysis that determines whether each local requires storage at a
 /// given location; i.e. whether its storage can go away without being observed.
-pub struct MaybeRequiresStorage<'mir, 'tcx> {
-    borrowed_locals: RefCell<BorrowedLocalsResults<'mir, 'tcx>>,
+pub struct MaybeRequiresStorage {
+    /// Used to kill locals that are fully moved and have not been borrowed.
+    killable_locals: KillableLocals,
 }
 
-impl<'mir, 'tcx> MaybeRequiresStorage<'mir, 'tcx> {
-    pub fn new(borrowed_locals: BorrowedLocalsResults<'mir, 'tcx>) -> Self {
-        MaybeRequiresStorage { borrowed_locals: RefCell::new(borrowed_locals) }
+impl MaybeRequiresStorage {
+    pub fn new<'tcx>(
+        body: &Body<'tcx>,
+        borrowed_locals: &Results<'tcx, MaybeBorrowedLocals>,
+    ) -> Self {
+        struct KillableLocalsVisitor<'mir, 'tcx> {
+            borrowed_locals_cursor: ResultsCursor<'mir, 'tcx, MaybeBorrowedLocals>,
+            killable_locals: KillableLocals,
+        }
+
+        impl<'tcx> Visitor<'tcx> for KillableLocalsVisitor<'_, 'tcx> {
+            fn visit_local(&mut self, local: Local, context: PlaceContext, loc: Location) {
+                if PlaceContext::NonMutatingUse(NonMutatingUseContext::Move) == context {
+                    self.borrowed_locals_cursor.seek_before_primary_effect(loc);
+                    if !self.borrowed_locals_cursor.get().contains(local) {
+                        self.killable_locals.entry(loc).or_default().push(local);
+                    }
+                }
+            }
+        }
+
+        let mut visitor = KillableLocalsVisitor {
+            borrowed_locals_cursor: ResultsCursor::new_borrowing(body, borrowed_locals),
+            killable_locals: Default::default(),
+        };
+
+        for (bb, data) in body.basic_blocks.iter_enumerated() {
+            visitor.visit_basic_block_data(bb, data);
+        }
+
+        MaybeRequiresStorage { killable_locals: visitor.killable_locals }
     }
 }
 
-impl<'tcx> Analysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
+impl<'tcx> Analysis<'tcx> for MaybeRequiresStorage {
     type Domain = DenseBitSet<Local>;
 
     const NAME: &'static str = "requires_storage";
@@ -182,8 +213,7 @@ impl<'tcx> Analysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
         stmt: &Statement<'tcx>,
         loc: Location,
     ) {
-        // If we move from a place then it only stops needing storage *after*
-        // that statement.
+        // If we move from a place then it only stops needing storage *after* that statement.
         self.check_for_move(state, loc);
 
         match &stmt.kind {
@@ -316,27 +346,12 @@ impl<'tcx> Analysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
     }
 }
 
-impl<'tcx> MaybeRequiresStorage<'_, 'tcx> {
+impl MaybeRequiresStorage {
     /// Kill locals that are fully moved and have not been borrowed.
-    fn check_for_move(&self, state: &mut <Self as Analysis<'tcx>>::Domain, loc: Location) {
-        let mut borrowed_locals = self.borrowed_locals.borrow_mut();
-        let body = borrowed_locals.body();
-        let mut visitor = MoveVisitor { state, borrowed_locals: &mut borrowed_locals };
-        visitor.visit_location(body, loc);
-    }
-}
-
-struct MoveVisitor<'a, 'mir, 'tcx> {
-    borrowed_locals: &'a mut BorrowedLocalsResults<'mir, 'tcx>,
-    state: &'a mut DenseBitSet<Local>,
-}
-
-impl<'tcx> Visitor<'tcx> for MoveVisitor<'_, '_, 'tcx> {
-    fn visit_local(&mut self, local: Local, context: PlaceContext, loc: Location) {
-        if PlaceContext::NonMutatingUse(NonMutatingUseContext::Move) == context {
-            self.borrowed_locals.seek_before_primary_effect(loc);
-            if !self.borrowed_locals.get().contains(local) {
-                self.state.kill(local);
+    fn check_for_move(&self, state: &mut <Self as Analysis<'_>>::Domain, loc: Location) {
+        if let Some(locals) = self.killable_locals.get(&loc) {
+            for &l in locals {
+                state.kill(l);
             }
         }
     }

--- a/compiler/rustc_mir_transform/src/coroutine/layout.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/layout.rs
@@ -93,12 +93,10 @@ pub(super) fn locals_live_across_suspend_points<'tcx>(
 
     // Calculate the MIR locals that have been previously borrowed (even if they are still active).
     let borrowed_locals = MaybeBorrowedLocals.iterate_to_fixpoint(tcx, body, Some("coroutine"));
-    let borrowed_locals_cursor1 = ResultsCursor::new_borrowing(body, &borrowed_locals);
-    let mut borrowed_locals_cursor2 = ResultsCursor::new_borrowing(body, &borrowed_locals);
 
     // Calculate the MIR locals that we need to keep storage around for.
     let requires_storage =
-        MaybeRequiresStorage::new(borrowed_locals_cursor1).iterate_to_fixpoint(tcx, body, None);
+        MaybeRequiresStorage::new(body, &borrowed_locals).iterate_to_fixpoint(tcx, body, None);
     let mut requires_storage_cursor = ResultsCursor::new_borrowing(body, &requires_storage);
 
     // Calculate the liveness of MIR locals ignoring borrows.
@@ -109,6 +107,7 @@ pub(super) fn locals_live_across_suspend_points<'tcx>(
     let mut live_locals_at_suspension_points = Vec::new();
     let mut source_info_at_suspension_points = Vec::new();
     let mut live_locals_at_any_suspension_point = DenseBitSet::new_empty(body.local_decls.len());
+    let mut borrowed_locals_cursor = ResultsCursor::new_owning(body, borrowed_locals);
 
     for (block, data) in body.basic_blocks.iter_enumerated() {
         let TerminatorKind::Yield { .. } = data.terminator().kind else { continue };
@@ -129,8 +128,8 @@ pub(super) fn locals_live_across_suspend_points<'tcx>(
             // If a borrow is converted to a raw reference, we must also assume that it lives
             // forever. Note that the final liveness is still bounded by the storage liveness
             // of the local, which happens using the `intersect` operation below.
-            borrowed_locals_cursor2.seek_before_primary_effect(loc);
-            live_locals.union(borrowed_locals_cursor2.get());
+            borrowed_locals_cursor.seek_before_primary_effect(loc);
+            live_locals.union(borrowed_locals_cursor.get());
         }
 
         // Store the storage liveness for later use so we can restore the state
@@ -236,7 +235,7 @@ fn compute_storage_conflicts<'mir, 'tcx>(
     body: &'mir Body<'tcx>,
     saved_locals: &'mir CoroutineSavedLocals,
     always_live_locals: DenseBitSet<Local>,
-    results: &Results<'tcx, MaybeRequiresStorage<'mir, 'tcx>>,
+    results: &Results<'tcx, MaybeRequiresStorage>,
 ) -> BitMatrix<CoroutineSavedLocal, CoroutineSavedLocal> {
     assert_eq!(body.local_decls.len(), saved_locals.domain_size());
 
@@ -294,12 +293,10 @@ struct StorageConflictVisitor<'a, 'tcx> {
     eligible_storage_live: DenseBitSet<Local>,
 }
 
-impl<'a, 'tcx> ResultsVisitor<'tcx, MaybeRequiresStorage<'a, 'tcx>>
-    for StorageConflictVisitor<'a, 'tcx>
-{
+impl<'a, 'tcx> ResultsVisitor<'tcx, MaybeRequiresStorage> for StorageConflictVisitor<'a, 'tcx> {
     fn visit_after_early_statement_effect(
         &mut self,
-        _analysis: &MaybeRequiresStorage<'a, 'tcx>,
+        _analysis: &MaybeRequiresStorage,
         state: &DenseBitSet<Local>,
         _statement: &Statement<'tcx>,
         loc: Location,
@@ -309,7 +306,7 @@ impl<'a, 'tcx> ResultsVisitor<'tcx, MaybeRequiresStorage<'a, 'tcx>>
 
     fn visit_after_early_terminator_effect(
         &mut self,
-        _analysis: &MaybeRequiresStorage<'a, 'tcx>,
+        _analysis: &MaybeRequiresStorage,
         state: &DenseBitSet<Local>,
         _terminator: &Terminator<'tcx>,
         loc: Location,

--- a/compiler/rustc_resolve/src/diagnostics/impls.rs
+++ b/compiler/rustc_resolve/src/diagnostics/impls.rs
@@ -3667,7 +3667,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     }
 
     /// Gets the `#[diagnostic::on_unknown]` attribute data associated with this `DefId`.
-    fn on_unknown_data(&self, def_id: DefId) -> Option<&Directive> {
+    pub(crate) fn on_unknown_data(&self, def_id: DefId) -> Option<&Directive> {
         match def_id.as_local() {
             Some(local) => Some(self.on_unknown_data.get(&local)?.directive.as_ref()),
             None => find_attr!(self.tcx, def_id, OnUnknown{ directive } => directive)?.as_deref(),

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -390,7 +390,6 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         // Make the base error.
         let mut expected = source.descr_expected();
         let path_str = Segment::names_to_string(path);
-        let item_str = path.last().unwrap().ident;
 
         if let Some(res) = res {
             BaseError {
@@ -423,7 +422,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                     && let Some(item) = items.iter().find(|i| {
                         i.kind.ident().is_some_and(|ident| {
                             // Don't suggest if the item is in Fn signature arguments (#112590).
-                            ident.name == item_str.name && !sig.span.contains(item_span)
+                            ident.name == item_ident.name && !sig.span.contains(item_span)
                         })
                     }) {
                     let sp = item_span.shrink_to_lo();
@@ -533,13 +532,13 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             };
 
             let suggestion =
-                if ["true", "false"].contains(&item_str.to_string().to_lowercase().as_str()) {
+                if ["true", "false"].contains(&item_ident.to_string().to_lowercase().as_str()) {
                     // check if we are in situation of typo like `True` instead of `true`.
-                    let item_typo = item_str.to_string().to_lowercase();
+                    let item_typo = item_ident.to_string().to_lowercase();
                     Some((item_span, "you may want to use a bool value instead", item_typo))
                 // FIXME(vincenzopalazzo): make the check smarter,
                 // and maybe expand with levenshtein distance checks
-                } else if item_str.as_str() == "printf" {
+                } else if item_ident.as_str() == "printf" {
                     Some((
                         item_span,
                         "you may have meant to use the `print` macro",
@@ -548,8 +547,9 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 } else {
                     suggestion
                 };
-            let mut msg =
-                format!("cannot find {expected} `{item_str}` in {mod_prefix}{tick}{mod_str}{tick}");
+            let mut msg = format!(
+                "cannot find {expected} `{item_ident}` in {mod_prefix}{tick}{mod_str}{tick}"
+            );
             let mut fallback_label = if path_str == "async" && expected.starts_with("struct") {
                 "`async` blocks are only allowed in Rust 2018 or later".to_string()
             } else {
@@ -559,7 +559,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             if let Some(module_def_id) = module
                 && let Some(directive) = self.r.on_unknown_data(module_def_id)
             {
-                let args = FormatArgs { unresolved: item_str.to_string(), this: mod_str, .. };
+                let args = FormatArgs { unresolved: item_ident.to_string(), this: mod_str, .. };
                 let CustomDiagnostic {
                     message,
                     label,

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -19,6 +19,7 @@ use rustc_errors::{
     struct_span_code_err,
 };
 use rustc_hir as hir;
+use rustc_hir::attrs::diagnostic::{CustomDiagnostic, FormatArgs};
 use rustc_hir::def::Namespace::{self, *};
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, MacroKinds};
 use rustc_hir::def_id::{CRATE_DEF_ID, DefId};
@@ -163,6 +164,7 @@ struct BaseError {
     could_be_expr: bool,
     suggestion: Option<(Span, &'static str, String)>,
     module: Option<DefId>,
+    notes: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -404,12 +406,13 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 could_be_expr,
                 suggestion: None,
                 module: None,
+                notes: Vec::new(),
             }
         } else {
             let mut span_label = None;
             let item_ident = path.last().unwrap().ident;
             let item_span = item_ident.span;
-            let (mod_prefix, mod_str, module, suggestion) = if path.len() == 1 {
+            let (tick, mod_prefix, mod_str, module, suggestion) = if path.len() == 1 {
                 debug!(?self.diag_metadata.current_impl_items);
                 debug!(?self.diag_metadata.current_function);
                 let suggestion = if self.current_trait_ref.is_none()
@@ -490,15 +493,16 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 } else {
                     None
                 };
-                (String::new(), "this scope".to_string(), None, suggestion)
+                ("", String::new(), "this scope".to_string(), None, suggestion)
             } else if path.len() == 2 && path[0].ident.name == kw::PathRoot {
                 if self.r.tcx.sess.edition() > Edition::Edition2015 {
                     // In edition 2018 onwards, the `::foo` syntax may only pull from the extern prelude
                     // which overrides all other expectations of item type
                     expected = "crate";
-                    (String::new(), "the list of imported crates".to_string(), None, None)
+                    ("", String::new(), "the list of imported crates".to_string(), None, None)
                 } else {
                     (
+                        "",
                         String::new(),
                         "the crate root".to_string(),
                         Some(CRATE_DEF_ID.to_def_id()),
@@ -506,7 +510,13 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                     )
                 }
             } else if path.len() == 2 && path[0].ident.name == kw::Crate {
-                (String::new(), "the crate root".to_string(), Some(CRATE_DEF_ID.to_def_id()), None)
+                (
+                    "",
+                    String::new(),
+                    "the crate root".to_string(),
+                    Some(CRATE_DEF_ID.to_def_id()),
+                    None,
+                )
             } else {
                 let mod_path = &path[..path.len() - 1];
                 let mod_res = self.resolve_path(mod_path, Some(TypeNS), None, source);
@@ -519,7 +529,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
 
                 let mod_prefix =
                     mod_prefix.map_or_else(String::new, |res| format!("{} ", res.descr()));
-                (mod_prefix, format!("`{}`", Segment::names_to_string(mod_path)), module_did, None)
+                ("`", mod_prefix, Segment::names_to_string(mod_path), module_did, None)
             };
 
             let suggestion =
@@ -538,19 +548,46 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 } else {
                     suggestion
                 };
+            let mut msg =
+                format!("cannot find {expected} `{item_str}` in {mod_prefix}{tick}{mod_str}{tick}");
+            let mut fallback_label = if path_str == "async" && expected.starts_with("struct") {
+                "`async` blocks are only allowed in Rust 2018 or later".to_string()
+            } else {
+                format!("not found in {tick}{mod_str}{tick}")
+            };
+            let mut notes = Vec::new();
+            if let Some(module_def_id) = module
+                && let Some(directive) = self.r.on_unknown_data(module_def_id)
+            {
+                let args = FormatArgs { unresolved: item_str.to_string(), this: mod_str, .. };
+                let CustomDiagnostic {
+                    message,
+                    label,
+                    notes: custom_notes,
+                    parent_label: _unreachable,
+                } = directive.eval(None, &args);
+                if let Some(message) = message {
+                    notes.push(msg);
+                    msg = message;
+                }
+                if let Some(label) = label {
+                    fallback_label = label;
+                    if let Some((_, span_label)) = span_label.take() {
+                        notes.push(span_label.to_string());
+                    }
+                }
+                notes.extend(custom_notes);
+            }
 
             BaseError {
-                msg: format!("cannot find {expected} `{item_str}` in {mod_prefix}{mod_str}"),
-                fallback_label: if path_str == "async" && expected.starts_with("struct") {
-                    "`async` blocks are only allowed in Rust 2018 or later".to_string()
-                } else {
-                    format!("not found in {mod_str}")
-                },
+                msg,
+                fallback_label,
                 span: item_span,
                 span_label,
                 could_be_expr,
                 suggestion,
                 module,
+                notes,
             }
         }
     }
@@ -675,6 +712,9 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
 
         if let Some((span, label)) = base_error.span_label {
             err.span_label(span, label);
+        }
+        for note in &base_error.notes {
+            err.note(note.clone());
         }
 
         if let Some(ref sugg) = base_error.suggestion {

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -522,33 +522,30 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 (mod_prefix, format!("`{}`", Segment::names_to_string(mod_path)), module_did, None)
             };
 
-            let (fallback_label, suggestion) = if path_str == "async"
-                && expected.starts_with("struct")
-            {
-                ("`async` blocks are only allowed in Rust 2018 or later".to_string(), suggestion)
-            } else {
-                // check if we are in situation of typo like `True` instead of `true`.
-                let override_suggestion =
-                    if ["true", "false"].contains(&item_str.to_string().to_lowercase().as_str()) {
-                        let item_typo = item_str.to_string().to_lowercase();
-                        Some((item_span, "you may want to use a bool value instead", item_typo))
-                    // FIXME(vincenzopalazzo): make the check smarter,
-                    // and maybe expand with levenshtein distance checks
-                    } else if item_str.as_str() == "printf" {
-                        Some((
-                            item_span,
-                            "you may have meant to use the `print` macro",
-                            "print!".to_owned(),
-                        ))
-                    } else {
-                        suggestion
-                    };
-                (format!("not found in {mod_str}"), override_suggestion)
-            };
+            let suggestion =
+                if ["true", "false"].contains(&item_str.to_string().to_lowercase().as_str()) {
+                    // check if we are in situation of typo like `True` instead of `true`.
+                    let item_typo = item_str.to_string().to_lowercase();
+                    Some((item_span, "you may want to use a bool value instead", item_typo))
+                // FIXME(vincenzopalazzo): make the check smarter,
+                // and maybe expand with levenshtein distance checks
+                } else if item_str.as_str() == "printf" {
+                    Some((
+                        item_span,
+                        "you may have meant to use the `print` macro",
+                        "print!".to_owned(),
+                    ))
+                } else {
+                    suggestion
+                };
 
             BaseError {
                 msg: format!("cannot find {expected} `{item_str}` in {mod_prefix}{mod_str}"),
-                fallback_label,
+                fallback_label: if path_str == "async" && expected.starts_with("struct") {
+                    "`async` blocks are only allowed in Rust 2018 or later".to_string()
+                } else {
+                    format!("not found in {mod_str}")
+                },
                 span: item_span,
                 span_label,
                 could_be_expr,

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1347,16 +1347,12 @@ impl<T: ?Sized> Box<T> {
     /// Recreate a `Box` which was previously converted to a `NonNull`
     /// pointer using [`Box::into_non_null`]:
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// let x = Box::new(5);
     /// let non_null = Box::into_non_null(x);
     /// let x = unsafe { Box::from_non_null(non_null) };
     /// ```
     /// Manually create a `Box` from scratch by using the global allocator:
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// use std::alloc::{alloc, Layout};
     /// use std::ptr::NonNull;
     ///
@@ -1372,7 +1368,7 @@ impl<T: ?Sized> Box<T> {
     ///
     /// [memory layout]: self#memory-layout
     /// [considerations for unsafe code]: self#considerations-for-unsafe-code
-    #[unstable(feature = "box_vec_non_null", issue = "130364")]
+    #[stable(feature = "box_vec_non_null", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     #[must_use = "call `drop(Box::from_non_null(ptr))` if you intend to drop the `Box`"]
     pub unsafe fn from_non_null(ptr: NonNull<T>) -> Self {
@@ -1461,8 +1457,6 @@ impl<T: ?Sized> Box<T> {
     /// Converting the `NonNull` pointer back into a `Box` with [`Box::from_non_null`]
     /// for automatic cleanup:
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// let x = Box::new(String::from("Hello"));
     /// let non_null = Box::into_non_null(x);
     /// let x = unsafe { Box::from_non_null(non_null) };
@@ -1470,8 +1464,6 @@ impl<T: ?Sized> Box<T> {
     /// Manual cleanup by explicitly running the destructor and deallocating
     /// the memory:
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// use std::alloc::{dealloc, Layout};
     ///
     /// let x = Box::new(String::from("Hello"));
@@ -1483,8 +1475,6 @@ impl<T: ?Sized> Box<T> {
     /// ```
     /// Note: This is equivalent to the following:
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// let x = Box::new(String::from("Hello"));
     /// let non_null = Box::into_non_null(x);
     /// unsafe {
@@ -1494,7 +1484,7 @@ impl<T: ?Sized> Box<T> {
     ///
     /// [memory layout]: self#memory-layout
     #[must_use = "losing the pointer will leak memory"]
-    #[unstable(feature = "box_vec_non_null", issue = "130364")]
+    #[stable(feature = "box_vec_non_null", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub fn into_non_null(b: Self) -> NonNull<T> {
         // SAFETY: `Box` is guaranteed to be non-null.
@@ -1611,7 +1601,6 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// [memory layout]: self#memory-layout
     /// [considerations for unsafe code]: self#considerations-for-unsafe-code
     #[unstable(feature = "allocator_api", issue = "32838")]
-    // #[unstable(feature = "box_vec_non_null", issue = "130364")]
     #[inline]
     pub unsafe fn from_non_null_in(raw: NonNull<T>, alloc: A) -> Self {
         // SAFETY: guaranteed by the caller.
@@ -1726,7 +1715,6 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// [memory layout]: self#memory-layout
     #[must_use = "losing the pointer will leak memory"]
     #[unstable(feature = "allocator_api", issue = "32838")]
-    // #[unstable(feature = "box_vec_non_null", issue = "130364")]
     #[inline]
     pub fn into_non_null_with_allocator(b: Self) -> (NonNull<T>, A) {
         let (ptr, alloc) = Box::into_raw_with_allocator(b);

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2079,7 +2079,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(box_vec_non_null)]
+    /// #![feature(vec_as_non_null)]
     ///
     /// // Allocate vector big enough for 4 elements.
     /// let size = 4;
@@ -2099,7 +2099,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// Due to the aliasing guarantee, the following code is legal:
     ///
     /// ```rust
-    /// #![feature(box_vec_non_null)]
+    /// #![feature(vec_as_non_null)]
     ///
     /// unsafe {
     ///     let mut v = vec![0];
@@ -2115,8 +2115,8 @@ impl<T, A: Allocator> Vec<T, A> {
     /// [`as_mut_ptr`]: Vec::as_mut_ptr
     /// [`as_ptr`]: Vec::as_ptr
     /// [`as_non_null`]: Vec::as_non_null
-    #[unstable(feature = "box_vec_non_null", issue = "130364")]
-    #[rustc_const_unstable(feature = "box_vec_non_null", issue = "130364")]
+    #[unstable(feature = "vec_as_non_null", issue = "157843")]
+    #[rustc_const_unstable(feature = "vec_as_non_null", issue = "157843")]
     #[rustc_as_ptr]
     #[inline]
     pub const fn as_non_null(&mut self) -> NonNull<T> {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2117,6 +2117,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// [`as_non_null`]: Vec::as_non_null
     #[unstable(feature = "box_vec_non_null", issue = "130364")]
     #[rustc_const_unstable(feature = "box_vec_non_null", issue = "130364")]
+    #[rustc_as_ptr]
     #[inline]
     pub const fn as_non_null(&mut self) -> NonNull<T> {
         self.buf.non_null()

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -697,8 +697,6 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// let v = vec![1, 2, 3];
     ///
     /// // Deconstruct the vector into parts.
@@ -719,8 +717,6 @@ impl<T> Vec<T> {
     /// Using memory that was allocated elsewhere:
     ///
     /// ```rust
-    /// #![feature(box_vec_non_null)]
-    ///
     /// use std::alloc::{alloc, Layout};
     /// use std::ptr::NonNull;
     ///
@@ -742,8 +738,8 @@ impl<T> Vec<T> {
     /// }
     /// ```
     #[inline]
-    #[unstable(feature = "box_vec_non_null", issue = "130364")]
-    #[rustc_const_unstable(feature = "box_vec_non_null", issue = "130364")]
+    #[stable(feature = "box_vec_non_null", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
     pub const unsafe fn from_parts(ptr: NonNull<T>, length: usize, capacity: usize) -> Self {
         unsafe { Self::from_parts_in(ptr, length, capacity, Global) }
     }
@@ -863,8 +859,6 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// let v: Vec<i32> = vec![-1, 0, 1];
     ///
     /// let (ptr, len, cap) = v.into_parts();
@@ -879,8 +873,8 @@ impl<T> Vec<T> {
     /// assert_eq!(rebuilt, [4294967295, 0, 1]);
     /// ```
     #[must_use = "losing the pointer will leak memory"]
-    #[unstable(feature = "box_vec_non_null", issue = "130364")]
-    #[rustc_const_unstable(feature = "box_vec_non_null", issue = "130364")]
+    #[stable(feature = "box_vec_non_null", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
     pub const fn into_parts(self) -> (NonNull<T>, usize, usize) {
         let (ptr, len, capacity) = self.into_raw_parts();
         // SAFETY: A `Vec` always has a non-null pointer.
@@ -1305,7 +1299,6 @@ impl<T, A: Allocator> Vec<T, A> {
     #[inline]
     #[unstable(feature = "allocator_api", issue = "32838")]
     #[rustc_const_unstable(feature = "allocator_api", issue = "32838")]
-    // #[unstable(feature = "box_vec_non_null", issue = "130364")]
     pub const unsafe fn from_parts_in(
         ptr: NonNull<T>,
         length: usize,
@@ -1410,7 +1403,6 @@ impl<T, A: Allocator> Vec<T, A> {
     #[must_use = "losing the pointer will leak memory"]
     #[unstable(feature = "allocator_api", issue = "32838")]
     #[rustc_const_unstable(feature = "allocator_api", issue = "32838")]
-    // #[unstable(feature = "box_vec_non_null", issue = "130364")]
     pub const fn into_parts_with_alloc(self) -> (NonNull<T>, usize, usize, A) {
         let (ptr, len, capacity, alloc) = self.into_raw_parts_with_alloc();
         // SAFETY: A `Vec` always has a non-null pointer.

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -192,25 +192,20 @@ macro_rules! iterator {
             }
 
             fn next_chunk<const N:usize>(&mut self) -> Result<[$elem; N], crate::array::IntoIter<$elem, N>> {
-                if T::IS_ZST {
+                if T::IS_ZST || len!(self) < N {
                     return crate::array::iter_next_chunk(self);
                 }
-                let len = len!(self);
-                if len >= N {
-                    // SAFETY: we are just getting an array of [T; N] and moving the pointer over a little
-                    let r = unsafe { self.post_inc_start(N).cast_array().$into_ref() }
-                        .$array_ref(); // must convert &[T; N] to [&T; N]
+
+                // SAFETY: the check above ensures len >= N
+                unsafe {
+                    let r = self
+                        .post_inc_start(N)
+                        .cast_array() // NonNull<T> -> NonNull<[T; N]>
+                        // SAFETY: post_inc_start(N) insures we don't return overlapping `&mut`s
+                        .$into_ref() // NonNull<[T; N]> -> &{mut} [T; N]
+                        .$array_ref(); // must convert &{mut} [T; N] to [&{mut} T; N]
+
                     Ok(r)
-                } else {
-                    // cant use $array_ref because theres no builtin for &mut [MU<T>; N] -> [&mut MU<T>; N]
-                    // cant use copy_nonoverlapping as the $elem is of type &{mut} T instead of T
-                    let mut a = [const { crate::mem::MaybeUninit::<$elem>::uninit() }; N];
-                    for into in (&mut a).into_iter().take(len) {
-                        // SAFETY: take(n) limits to remainder (slice produces worse codegen)
-                        into.write(unsafe { self.post_inc_start(1).$into_ref() });
-                    }
-                    // SAFETY: we just initialized elements 0..len
-                    unsafe { Err(crate::array::IntoIter::new_unchecked(a, 0..len)) }
                 }
             }
 

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3432,23 +3432,65 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
     fs_imp::set_permissions(path.as_ref(), perm.0)
 }
 
-/// Set the permissions of a file, unless it is a symlink.
+/// Changes the permissions found on a file or a directory. On certain platforms, if the file
+/// is a symlink, it will change the permissions bits on the symlink itself rather than
+/// the target (e.g. Windows, BSD, MacOS). On other platforms, this results in an error when
+/// attempting to change permissions on a symlink (e.g. Linux).
 ///
-/// Note that the non-final path elements are allowed to be symlinks.
+/// Note that non-final path elements are allowed to be symlinks.
 ///
 /// # Platform-specific behavior
 ///
-/// Currently unimplemented on Windows.
+/// This function currently corresponds to:
+/// * `open` with `O_NOFOLLOW` flag enabled + `fchmod` on WASI
+/// * `fchmodat` function with the flag `AT_SYMLINK_NOFOLLOW` enabled
+///   on Unix platforms
+/// * The flag `FILE_FLAG_OPEN_REPARSE_POINT` is enabled and then the
+///   permissions of the file is set through `SetFileInformationByHandle`
+///   on Windows.
+/// * On all other platforms, the behavior remains the same with
+/// [`fs::set_permissions`].
 ///
-/// On Unix platforms, this results in a [`FilesystemLoop`] error if the last element is a symlink.
+/// [`fs::set_permissions`]: crate::fs::set_permissions
 ///
-/// This behavior may change in the future.
+/// Note that, this [may change in the future][changes].
 ///
-/// [`FilesystemLoop`]: crate::io::ErrorKind::FilesystemLoop
-#[doc(alias = "chmod", alias = "SetFileAttributes")]
+/// [changes]: io#platform-specific-behavior
+///
+/// # Errors
+///
+/// This function will return an error in the following situations, but is not
+/// limited to just these cases:
+///
+/// * `path` does not exist.
+/// * The user lacks the permission to change attributes of the file.
+///
+/// Note: On Linux, this will result in a [`Unsupported`] error
+/// if the final element is a symlink. On BSD-based systems, the
+/// behavior can vary from symlink permission bits changing or
+/// there being no effects on symlinks
+///
+/// [`Unsupported`]: crate::io::ErrorKind::Unsupported
+///
+/// # Examples
+///
+/// ```no_run
+/// #![feature(set_permissions_nofollow)]
+/// use std::fs;
+///
+/// fn main() -> std::io::Result<()> {
+///     let mut perms = fs::symlink_metadata("foo.txt")?.permissions();
+///     perms.set_readonly(true);
+///     // This should result in an error on certain platforms
+///     // or succeed in modifying the permissions of a symlink
+///     fs::set_permissions_nofollow("foo.txt", perms)?;
+///     Ok(())
+/// }
+/// ```
+#[doc(alias = "fchmodat", alias = "SetFileInformationByHandle")]
 #[unstable(feature = "set_permissions_nofollow", issue = "141607")]
 pub fn set_permissions_nofollow<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result<()> {
-    fs_imp::set_permissions_nofollow(path.as_ref(), perm)
+    fs_imp::set_permissions_nofollow(path.as_ref(), perm.0)
 }
 
 impl DirBuilder {

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -614,6 +614,70 @@ fn set_get_unix_permissions() {
 }
 
 #[test]
+fn set_get_permissions_nofollows() {
+    let tmpdir = tmpdir();
+    let filename = tmpdir.join("set_get_unix_permissions_file");
+    check!(File::create(&filename));
+    let file_metadata = check!(fs::metadata(&filename));
+    assert!(!file_metadata.permissions().readonly());
+    let mut permission_bits = file_metadata.permissions();
+    permission_bits.set_readonly(true);
+    let result = fs::set_permissions_nofollow(&filename, permission_bits);
+
+    cfg_select! {
+        any(windows, unix, target_os = "uefi", target_os = "solid_asp3", target_os = "motor") => {
+            assert_eq!(result.unwrap(), ());
+            let metadata0 = check!(fs::metadata(&filename));
+            assert!(metadata0.permissions().readonly());
+        },
+        _ => {
+            let error_kind = result.unwrap_err().kind();
+            assert_eq!(error_kind, crate::io::ErrorKind::Unsupported);
+        }
+    }
+}
+
+// Only Windows and Unix support `fs::set_permissions_nofollow`
+#[test]
+#[cfg(all(any(windows, unix), not(any(target_os = "espidf", target_os = "horizon"))))]
+fn set_get_permissions_nofollows_symlink() {
+    #[cfg(not(windows))]
+    use crate::os::unix::fs::symlink as symlink_dir;
+    #[cfg(windows)]
+    use crate::os::windows::fs::symlink_dir;
+
+    let tmpdir = tmpdir();
+    let filename = tmpdir.join("set_get_unix_permissions_file");
+    let symlink_name = tmpdir.join("set_get_unix_permissions");
+    check!(File::create(&filename));
+    check!(symlink_dir(&filename, &symlink_name));
+
+    let sym_metadata = check!(fs::symlink_metadata(&symlink_name));
+    let mut permission_bits = sym_metadata.permissions();
+    permission_bits.set_readonly(true);
+    let result = fs::set_permissions_nofollow(&symlink_name, permission_bits);
+
+    cfg_select! {
+        any(windows, target_os = "android", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly") => {
+            assert_eq!(result.unwrap(), ());
+            let metadata0 = check!(fs::symlink_metadata(&symlink_name));
+            // So seems like BSD-based systems trying to set permissions
+            // on symlinks could lead to no effect, so we should expect
+            // there being no change to BSD-based systems.
+            // https://superuser.com/questions/1099634/change-permissions-symbolic-link-mac-os
+            #[cfg(windows)]
+            assert!(metadata0.permissions().readonly());
+            #[cfg(not(windows))]
+            assert!(!metadata0.permissions().readonly());
+        },
+        _ => {
+            let error_kind = result.unwrap_err().kind();
+            assert_eq!(error_kind, crate::io::ErrorKind::Unsupported);
+        }
+    }
+}
+
+#[test]
 #[cfg(windows)]
 fn file_test_io_seek_read_write() {
     use crate::os::windows::fs::FileExt;
@@ -1328,6 +1392,29 @@ fn fchmod_works() {
 
     p.set_readonly(false);
     check!(file.set_permissions(p));
+}
+
+#[test]
+fn fchmodat_works() {
+    let tmpdir = tmpdir();
+    let file = tmpdir.join("in.txt");
+
+    check!(File::create(&file));
+    let attr = check!(fs::metadata(&file));
+    assert!(!attr.permissions().readonly());
+    let mut p = attr.permissions();
+    p.set_readonly(true);
+    check!(fs::set_permissions_nofollow(&file, p.clone()));
+    let attr = check!(fs::metadata(&file));
+    assert!(attr.permissions().readonly());
+
+    match fs::set_permissions_nofollow(&tmpdir.join("foo"), p.clone()) {
+        Ok(..) => panic!("wanted an error"),
+        Err(..) => {}
+    }
+
+    p.set_readonly(false);
+    check!(fs::set_permissions_nofollow(&file, p));
 }
 
 #[test]

--- a/library/std/src/sys/fs/hermit.rs
+++ b/library/std/src/sys/fs/hermit.rs
@@ -566,6 +566,10 @@ pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
     Err(Error::from_raw_os_error(22))
 }
 
+pub fn set_perm_nofollow(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
+    unsupported()
+}
+
 pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
     Err(Error::from_raw_os_error(22))
 }

--- a/library/std/src/sys/fs/mod.rs
+++ b/library/std/src/sys/fs/mod.rs
@@ -120,28 +120,8 @@ pub fn set_permissions(path: &Path, perm: FilePermissions) -> io::Result<()> {
     with_native_path(path, &|path| imp::set_perm(path, perm.clone()))
 }
 
-#[cfg(all(unix, not(target_os = "vxworks")))]
-pub fn set_permissions_nofollow(path: &Path, perm: crate::fs::Permissions) -> io::Result<()> {
-    use crate::fs::OpenOptions;
-
-    let mut options = OpenOptions::new();
-
-    // ESP-IDF and Horizon do not support O_NOFOLLOW, so we skip setting it.
-    // Their filesystems do not have symbolic links, so no special handling is required.
-    #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
-    {
-        use crate::os::unix::fs::OpenOptionsExt;
-        options.custom_flags(libc::O_NOFOLLOW);
-    }
-
-    options.open(path)?.set_permissions(perm)
-}
-
-#[cfg(any(not(unix), target_os = "vxworks"))]
-pub fn set_permissions_nofollow(_path: &Path, _perm: crate::fs::Permissions) -> io::Result<()> {
-    crate::unimplemented!(
-        "`set_permissions_nofollow` is currently only implemented on Unix platforms"
-    )
+pub fn set_permissions_nofollow(path: &Path, perm: FilePermissions) -> io::Result<()> {
+    with_native_path(path, &|path| imp::set_perm_nofollow(path, perm.clone()))
 }
 
 pub fn canonicalize(path: &Path) -> io::Result<PathBuf> {

--- a/library/std/src/sys/fs/motor.rs
+++ b/library/std/src/sys/fs/motor.rs
@@ -319,6 +319,11 @@ pub fn remove_dir_all(path: &Path) -> io::Result<()> {
 }
 
 pub fn set_perm(path: &Path, perm: FilePermissions) -> io::Result<()> {
+    // Motor does not support symlinks
+    set_perm_nofollow(path, perm)
+}
+
+pub fn set_perm_nofollow(path: &Path, perm: FilePermissions) -> io::Result<()> {
     let path = path.to_str().ok_or(io::Error::from(io::ErrorKind::InvalidFilename))?;
     moto_rt::fs::set_perm(path, perm.rt_perm).map_err(map_motor_error)
 }

--- a/library/std/src/sys/fs/solid.rs
+++ b/library/std/src/sys/fs/solid.rs
@@ -531,6 +531,11 @@ pub fn rename(old: &Path, new: &Path) -> io::Result<()> {
 }
 
 pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {
+    // Solid does not support symlinks
+    set_perm_nofollow(p, perm)
+}
+
+pub fn set_perm_nofollow(p: &Path, perm: FilePermissions) -> io::Result<()> {
     error::SolidError::err_if_negative(unsafe {
         abi::SOLID_FS_Chmod(cstr(p)?.as_ptr(), perm.0.into())
     })

--- a/library/std/src/sys/fs/uefi.rs
+++ b/library/std/src/sys/fs/uefi.rs
@@ -480,6 +480,11 @@ pub fn rename(old: &Path, new: &Path) -> io::Result<()> {
 }
 
 pub fn set_perm(p: &Path, perm: FilePermissions) -> io::Result<()> {
+    // UEFI does not support symlinks
+    set_perm_nofollow(p, perm)
+}
+
+pub fn set_perm_nofollow(p: &Path, perm: FilePermissions) -> io::Result<()> {
     let f = uefi_fs::File::from_path(p, file::MODE_READ | file::MODE_WRITE, 0)?;
     set_perm_inner(&f, perm)
 }

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2035,6 +2035,40 @@ pub fn set_perm(p: &CStr, perm: FilePermissions) -> io::Result<()> {
     cvt_r(|| unsafe { libc::chmod(p.as_ptr(), perm.mode) }).map(|_| ())
 }
 
+pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
+    // ESP-IDF and Horizon do not support O_NOFOLLOW, so we skip setting it.
+    // Their filesystems do not have symbolic links, so no special handling is required.
+    cfg_select! {
+        // wasm32-wasip1 targets do not support fchmodat, so we fall down to
+        // open + fchmod
+        target_os = "wasi" => {
+            use crate::fs::OpenOptions;
+            use crate::fs::Permissions;
+            use crate::os::wasi::ffi::OsStrExt;
+            use crate::os::wasi::fs::OpenOptionsExt;
+
+            let mut options = OpenOptions::new();
+            options.custom_flags(libc::O_NOFOLLOW);
+
+            let bytes = p.to_bytes();
+            let os_str = OsStr::from_bytes(bytes);
+            options.open(Path::new(os_str))?.set_permissions(Permissions::from_inner(perm))
+        }
+        all(target_os = "linux", not(any(target_os = "espidf", target_os = "horizon"))) => {
+            cvt_r(|| unsafe {
+                libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
+            })
+            .map(|_| ())
+        },
+        _ => {
+            cvt_r(|| unsafe {
+                libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, 0)
+            })
+            .map(|_| ())
+        }
+    }
+}
+
 pub fn rmdir(p: &CStr) -> io::Result<()> {
     cvt(unsafe { libc::rmdir(p.as_ptr()) }).map(|_| ())
 }

--- a/library/std/src/sys/fs/unsupported.rs
+++ b/library/std/src/sys/fs/unsupported.rs
@@ -313,6 +313,10 @@ pub fn set_perm(_p: &Path, perm: FilePermissions) -> io::Result<()> {
     match perm.0 {}
 }
 
+pub fn set_perm_nofollow(_p: &Path, perm: FilePermissions) -> io::Result<()> {
+    match perm.0 {}
+}
+
 pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
     unsupported()
 }

--- a/library/std/src/sys/fs/vexos.rs
+++ b/library/std/src/sys/fs/vexos.rs
@@ -492,6 +492,10 @@ pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
     unsupported()
 }
 
+pub fn set_perm_nofollow(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
+    unsupported()
+}
+
 pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
     unsupported()
 }

--- a/library/std/src/sys/fs/windows.rs
+++ b/library/std/src/sys/fs/windows.rs
@@ -1564,6 +1564,15 @@ pub fn set_perm(p: &WCStr, perm: FilePermissions) -> io::Result<()> {
     }
 }
 
+pub fn set_perm_nofollow(p: &WCStr, perm: FilePermissions) -> io::Result<()> {
+    let mut opts = OpenOptions::new();
+    opts.access_mode(c::FILE_WRITE_ATTRIBUTES);
+    // `FILE_FLAG_OPEN_REPARSE_POINT` for no_follow behavior
+    opts.custom_flags(c::FILE_FLAG_BACKUP_SEMANTICS | c::FILE_FLAG_OPEN_REPARSE_POINT);
+    let file = File::open_native(p, &opts)?;
+    file.set_permissions(perm)
+}
+
 pub fn set_times(p: &WCStr, times: FileTimes) -> io::Result<()> {
     let mut opts = OpenOptions::new();
     opts.access_mode(c::FILE_WRITE_ATTRIBUTES);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1119,6 +1119,7 @@ rustdoc-toolbar {
 	flex-direction: row;
 	flex-wrap: nowrap;
 	min-height: 60px;
+	height: fit-content;
 }
 
 .docblock code, .item-table dd code,

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -114,8 +114,8 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 // will instead cause conflicts. See #94591 for more. (This paragraph and the "Latest feature" line
 // are deliberately not in a doc comment, because they need not be in public docs.)
 //
-// Latest feature: Add default-body stability metadata.
-pub const FORMAT_VERSION: u32 = 60;
+// Latest feature: Make `Stability` work with non-self-describing formats
+pub const FORMAT_VERSION: u32 = 61;
 
 /// The root of the emitted JSON blob.
 ///
@@ -354,14 +354,13 @@ pub struct Stability {
     /// For stable items, this is the historical label recorded when the item was stabilized.
     pub feature: String,
 
-    #[serde(flatten)]
     pub level: StabilityLevel,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "rkyv_0_8", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
 #[cfg_attr(feature = "rkyv_0_8", rkyv(derive(Debug)))]
-#[serde(tag = "level", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum StabilityLevel {
     Stable {
         /// The Rust version in which this item became stable, if available.

--- a/src/rustdoc-json-types/tests.rs
+++ b/src/rustdoc-json-types/tests.rs
@@ -1,4 +1,22 @@
+use std::fmt::Debug;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
 use super::*;
+
+fn check_roundtrips<T: Serialize + DeserializeOwned + PartialEq + Debug>(t: T) {
+    let ser_json = serde_json::to_string(&t).expect("should be able to serialize to json");
+    let de_json: T =
+        serde_json::from_str(&ser_json).expect("should be able to deserialize from json");
+    assert_eq!(t, de_json, "value should be the same after json roundtrip");
+
+    let ser_postcard =
+        ::postcard::to_allocvec(&t).expect("should be able to serialize to postcard");
+    let de_postcard: T =
+        ::postcard::from_bytes(&ser_postcard).expect("should be able to deserialze from postcard");
+    assert_eq!(t, de_postcard, "value should be the same after postcard rountrip");
+}
 
 #[test]
 fn test_struct_info_roundtrip() {
@@ -8,15 +26,7 @@ fn test_struct_info_roundtrip() {
         impls: vec![],
     });
 
-    // JSON
-    let struct_json = serde_json::to_string(&s).unwrap();
-    let de_s = serde_json::from_str(&struct_json).unwrap();
-    assert_eq!(s, de_s);
-
-    // Postcard
-    let encoded: Vec<u8> = postcard::to_allocvec(&s).unwrap();
-    let decoded: ItemEnum = postcard::from_bytes(&encoded).unwrap();
-    assert_eq!(s, decoded);
+    check_roundtrips(s);
 }
 
 #[test]
@@ -28,15 +38,19 @@ fn test_union_info_roundtrip() {
         impls: vec![],
     });
 
-    // JSON
-    let union_json = serde_json::to_string(&u).unwrap();
-    let de_u = serde_json::from_str(&union_json).unwrap();
-    assert_eq!(u, de_u);
+    check_roundtrips(u);
+}
 
-    // Postcard
-    let encoded: Vec<u8> = postcard::to_allocvec(&u).unwrap();
-    let decoded: ItemEnum = postcard::from_bytes(&encoded).unwrap();
-    assert_eq!(u, decoded);
+#[test]
+fn test_stability() {
+    check_roundtrips(Stability {
+        feature: "guam_dotcom".to_owned(),
+        level: StabilityLevel::Stable { since: None },
+    });
+    check_roundtrips(Stability {
+        feature: "bing_mexico".to_owned(),
+        level: StabilityLevel::Unstable,
+    });
 }
 
 #[cfg(feature = "rkyv_0_8")]

--- a/tests/run-make/macos-deployment-target-warning/rmake.rs
+++ b/tests/run-make/macos-deployment-target-warning/rmake.rs
@@ -13,6 +13,7 @@ fn main() {
     let ld_prime_obj = r"ld: warning: object file \(.*\) was built for newer '.+' version \(\d+\.\d+\) than being linked \(\d+\.\d+\)";
     let ld64_dylib = r"ld: warning: dylib \(.*\) was built for newer .+ version \(\d+\.\d+\) than being linked \(\d+\.\d+\)";
     let ld_prime_dylib = r"ld: warning: building for [^ ,]+, but linking with dylib '[^']*' which was built for newer version [0-9.]+";
+    let lld_obj = r"ld64\.lld: warning: .+ has version \d+\.\d+(\.\d+)?, which is newer than target minimum of \d+\.\d+(\.\d+)?";
 
     // Test 1: static archive (object file mismatch)
     cc().arg("-c").arg("-mmacosx-version-min=15.5").output("foo.o").input("foo.c").run();
@@ -54,4 +55,30 @@ fn main() {
         .normalize(ld64_dylib, "NORMALIZED_DYLIB_DEPLOYMENT_MISMATCH_LINKER_WARNING")
         .normalize(ld_prime_dylib, "NORMALIZED_DYLIB_DEPLOYMENT_MISMATCH_LINKER_WARNING")
         .run();
+
+    // Test 3: static archive with lld (object file mismatch)
+    // Skip if lld is not available (not all CI configurations build it).
+    let lld_path = std::path::PathBuf::from(std::env::var("LLVM_BIN_DIR").unwrap()).join("lld");
+    if lld_path.exists() {
+        let ld64_lld = std::env::current_dir().unwrap().join("ld64.lld");
+        std::os::unix::fs::symlink(&lld_path, &ld64_lld)
+            .expect("failed to create ld64.lld symlink");
+
+        let lld_warnings = rustc()
+            .arg("-lstatic=foo")
+            .arg("-Clink-self-contained=-linker")
+            .arg("-Zunstable-options")
+            .arg("-Clinker-flavor=darwin-lld")
+            .linker(&ld64_lld.to_str().unwrap())
+            .input("main.rs")
+            .crate_type("bin")
+            .run()
+            .stderr_utf8();
+
+        diff()
+            .expected_file("warnings.txt")
+            .actual_text("(rustc -W linker-info with lld)", &lld_warnings)
+            .normalize(lld_obj, "NORMALIZED_OBJECT_DEPLOYMENT_MISMATCH_LINKER_WARNING")
+            .run();
+    }
 }

--- a/tests/rustdoc-gui/rustdoc-toolbar.goml
+++ b/tests/rustdoc-gui/rustdoc-toolbar.goml
@@ -1,0 +1,28 @@
+// This test ensures that even if the item name isn't on one line, the rustdoc toolbar buttons
+// height won't change.
+// Regression test for <https://github.com/rust-lang/rust/issues/160086>.
+
+go-to: "file://" + |DOC_PATH| + "/staged_api/struct.Foo.html"
+set-window-size: (1000, 600)
+
+store-value: (heading_selector, ".main-heading")
+store-value: (heading_selector_title, |heading_selector| + " > h1")
+store-value: (heading_selector_sub, |heading_selector| + " .sub-heading")
+
+store-size: ("rustdoc-toolbar", {"height": toolbar_height})
+store-position: ("rustdoc-toolbar", {"x": toolbar_x, "y": toolbar_y})
+store-size: (|heading_selector_title|, {"height": heading_title_height})
+store-size: (|heading_selector_sub|, {"height": heading_sub_height})
+
+assert: |toolbar_height| == (|heading_title_height| + |heading_sub_height|)
+
+// We now change the item name so it takes more than one line.
+set-text: (|heading_selector| + " .struct", "Fosdkfjnsakjdnfkjsadnfkjadsnjfksandkjfndsakjfasndjfa")
+
+store-size: (|heading_selector_title|, {"height": new_heading_title_height})
+
+// The heading should now be taller.
+assert: |new_heading_title_height| > |heading_title_height|
+// However the toolbar size and position shouldn't have changed.
+assert-size: ("rustdoc-toolbar", {"height": |toolbar_height|})
+assert-position: ("rustdoc-toolbar", {"x": |toolbar_x|, "y": |toolbar_y|})

--- a/tests/rustdoc-json/attrs/stability/associated_items.rs
+++ b/tests/rustdoc-json/attrs/stability/associated_items.rs
@@ -3,64 +3,54 @@
 // Trait-associated item declarations only. Items defined inside impl blocks are tested in
 // `impls.rs` because they have different parent-item behavior.
 
-//@ is "$.index[?(@.name=='StableTraitWithAssociatedItems')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='StableTraitWithAssociatedItems')].stability.feature" '"stable_trait_with_associated_items"'
-//@ is "$.index[?(@.name=='StableTraitWithAssociatedItems')].stability.since" '"1.0.0"'
+//@ is "$.index[?(@.name=='StableTraitWithAssociatedItems')].stability.level.stable.since" '"1.0.0"'
 #[stable(feature = "stable_trait_with_associated_items", since = "1.0.0")]
 pub trait StableTraitWithAssociatedItems {
     // Stable trait-associated items need their own stability attributes in staged API crates.
-    //@ is "$.index[?(@.name=='StableAssocType')].stability.level" '"stable"'
     //@ is "$.index[?(@.name=='StableAssocType')].stability.feature" '"stable_assoc_type_feature"'
-    //@ is "$.index[?(@.name=='StableAssocType')].stability.since" '"1.1.0"'
+    //@ is "$.index[?(@.name=='StableAssocType')].stability.level.stable.since" '"1.1.0"'
     //@ is "$.index[?(@.name=='StableAssocType')].attrs" []
     #[stable(feature = "stable_assoc_type_feature", since = "1.1.0")]
     type StableAssocType;
 
     //@ is "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_STABLE_TRAIT')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_STABLE_TRAIT')].stability.feature" '"unstable_assoc_const_in_stable_trait"'
-    //@ !has "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_STABLE_TRAIT')].stability.since"
     #[unstable(feature = "unstable_assoc_const_in_stable_trait", issue = "none")]
     const UNSTABLE_ASSOC_CONST_IN_STABLE_TRAIT: usize = 0;
 
     //@ is "$.index[?(@.name=='unstable_provided_method')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='unstable_provided_method')].stability.feature" '"unstable_provided_method_feature"'
-    //@ !has "$.index[?(@.name=='unstable_provided_method')].stability.since"
     #[unstable(feature = "unstable_provided_method_feature", issue = "none")]
     fn unstable_provided_method(&self) {}
 }
 
 //@ is "$.index[?(@.name=='UnstableTraitWithUnannotatedAssociatedItems')].stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='UnstableTraitWithUnannotatedAssociatedItems')].stability.feature" '"unstable_trait_with_unannotated_associated_items"'
-//@ !has "$.index[?(@.name=='UnstableTraitWithUnannotatedAssociatedItems')].stability.since"
 #[unstable(feature = "unstable_trait_with_unannotated_associated_items", issue = "none")]
 pub trait UnstableTraitWithUnannotatedAssociatedItems {
     // Unannotated associated items in unstable traits inherit the trait's unstable stability.
     //@ is "$.index[?(@.name=='UnannotatedAssocTypeInUnstableTrait')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='UnannotatedAssocTypeInUnstableTrait')].stability.feature" '"unstable_trait_with_unannotated_associated_items"'
-    //@ !has "$.index[?(@.name=='UnannotatedAssocTypeInUnstableTrait')].stability.since"
     type UnannotatedAssocTypeInUnstableTrait;
 
     //@ is "$.index[?(@.name=='UNANNOTATED_ASSOC_CONST_IN_UNSTABLE_TRAIT')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='UNANNOTATED_ASSOC_CONST_IN_UNSTABLE_TRAIT')].stability.feature" '"unstable_trait_with_unannotated_associated_items"'
-    //@ !has "$.index[?(@.name=='UNANNOTATED_ASSOC_CONST_IN_UNSTABLE_TRAIT')].stability.since"
     const UNANNOTATED_ASSOC_CONST_IN_UNSTABLE_TRAIT: usize;
 
     //@ is "$.index[?(@.name=='unannotated_required_method_in_unstable_trait')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='unannotated_required_method_in_unstable_trait')].stability.feature" '"unstable_trait_with_unannotated_associated_items"'
-    //@ !has "$.index[?(@.name=='unannotated_required_method_in_unstable_trait')].stability.since"
     fn unannotated_required_method_in_unstable_trait(&self);
 }
 
 //@ is "$.index[?(@.name=='UnstableTraitWithExplicitAssociatedItem')].stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='UnstableTraitWithExplicitAssociatedItem')].stability.feature" '"unstable_trait_with_explicit_associated_item"'
-//@ !has "$.index[?(@.name=='UnstableTraitWithExplicitAssociatedItem')].stability.since"
 #[unstable(feature = "unstable_trait_with_explicit_associated_item", issue = "none")]
 pub trait UnstableTraitWithExplicitAssociatedItem {
     // It's possble to override the parent's instability with another `#[unstable]` attribute,
     // for example to specify a different feature gate for that item.
     //@ is "$.index[?(@.name=='UnstableAssocTypeInUnstableTrait')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='UnstableAssocTypeInUnstableTrait')].stability.feature" '"unstable_assoc_type_in_unstable_trait"'
-    //@ !has "$.index[?(@.name=='UnstableAssocTypeInUnstableTrait')].stability.since"
     #[unstable(feature = "unstable_assoc_type_in_unstable_trait", issue = "none")]
     type UnstableAssocTypeInUnstableTrait;
 }

--- a/tests/rustdoc-json/attrs/stability/const.rs
+++ b/tests/rustdoc-json/attrs/stability/const.rs
@@ -5,23 +5,19 @@
 pub fn non_const_function() {}
 
 //@ set stable_const_fn = "$.index[?(@.name=='stable_const_fn')].id"
-//@ is "$.index[?(@.name=='stable_const_fn')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='stable_const_fn')].stability.feature" '"stable_const_fn_feature"'
-//@ is "$.index[?(@.name=='stable_const_fn')].stability.since" '"1.0.0"'
-//@ is "$.index[?(@.name=='stable_const_fn')].const_stability.level" '"stable"'
+//@ is "$.index[?(@.name=='stable_const_fn')].stability.level.stable.since" '"1.0.0"'
 //@ is "$.index[?(@.name=='stable_const_fn')].const_stability.feature" '"stable_const_fn_const_feature"'
-//@ is "$.index[?(@.name=='stable_const_fn')].const_stability.since" '"1.1.0"'
+//@ is "$.index[?(@.name=='stable_const_fn')].const_stability.level.stable.since" '"1.1.0"'
 //@ is "$.index[?(@.name=='stable_const_fn')].attrs" []
 #[stable(feature = "stable_const_fn_feature", since = "1.0.0")]
 #[rustc_const_stable(feature = "stable_const_fn_const_feature", since = "1.1.0")]
 pub const fn stable_const_fn() {}
 
-//@ is "$.index[?(@.name=='const_unstable_fn')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='const_unstable_fn')].stability.feature" '"const_unstable_fn_feature"'
-//@ is "$.index[?(@.name=='const_unstable_fn')].stability.since" '"2.0.0"'
+//@ is "$.index[?(@.name=='const_unstable_fn')].stability.level.stable.since" '"2.0.0"'
 //@ is "$.index[?(@.name=='const_unstable_fn')].const_stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='const_unstable_fn')].const_stability.feature" '"const_unstable_fn_const_feature"'
-//@ !has "$.index[?(@.name=='const_unstable_fn')].const_stability.since"
 //@ is "$.index[?(@.name=='const_unstable_fn')].attrs" []
 #[stable(feature = "const_unstable_fn_feature", since = "2.0.0")]
 #[rustc_const_unstable(feature = "const_unstable_fn_const_feature", issue = "none")]
@@ -35,7 +31,6 @@ pub const fn const_unstable_fn() {}
 //@ !has "$.index[?(@.name=='unstable_fn_with_explicit_const_gate')].stability.since"
 //@ is "$.index[?(@.name=='unstable_fn_with_explicit_const_gate')].const_stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='unstable_fn_with_explicit_const_gate')].const_stability.feature" '"explicit_const_gate_on_unstable_fn"'
-//@ !has "$.index[?(@.name=='unstable_fn_with_explicit_const_gate')].const_stability.since"
 //@ is "$.index[?(@.name=='unstable_fn_with_explicit_const_gate')].attrs" []
 #[unstable(feature = "unstable_fn_with_explicit_const_gate_feature", issue = "none")]
 #[rustc_const_unstable(feature = "explicit_const_gate_on_unstable_fn", issue = "none")]

--- a/tests/rustdoc-json/attrs/stability/const_traits.rs
+++ b/tests/rustdoc-json/attrs/stability/const_traits.rs
@@ -20,12 +20,10 @@ impl InherentConstMethodTarget {
     pub const fn unstable_inherent_const_method_without_const_gate(&self) {}
 }
 
-//@ is "$.index[?(@.name=='ConstTrait')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='ConstTrait')].stability.feature" '"const_trait_feature"'
-//@ is "$.index[?(@.name=='ConstTrait')].stability.since" '"2.0.0"'
+//@ is "$.index[?(@.name=='ConstTrait')].stability.level.stable.since" '"2.0.0"'
 //@ is "$.index[?(@.name=='ConstTrait')].const_stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='ConstTrait')].const_stability.feature" '"const_trait_const_feature"'
-//@ !has "$.index[?(@.name=='ConstTrait')].const_stability.since"
 //@ is "$.index[?(@.name=='ConstTrait')].attrs" []
 #[stable(feature = "const_trait_feature", since = "2.0.0")]
 #[rustc_const_unstable(feature = "const_trait_const_feature", issue = "none")]
@@ -33,7 +31,6 @@ pub const trait ConstTrait {
     // This item is *not* usable in a const context, because its parent is const-unstable.
     //@ is "$.index[?(@.docs=='assoc type inside const trait')].const_stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='assoc type inside const trait')].const_stability.feature" '"const_trait_const_feature"'
-    //@ !has "$.index[?(@.docs=='assoc type inside const trait')].const_stability.since"
     /// assoc type inside const trait
     #[stable(feature = "trait_assoc_type_feature", since = "2.1.0")]
     type TraitAssocType;
@@ -41,7 +38,6 @@ pub const trait ConstTrait {
     // This item is also *not* usable in a const context, because its parent is const-unstable.
     //@ is "$.index[?(@.docs=='method inside const trait')].const_stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='method inside const trait')].const_stability.feature" '"const_trait_const_feature"'
-    //@ !has "$.index[?(@.docs=='method inside const trait')].const_stability.since"
     /// method inside const trait
     #[stable(feature = "trait_method_feature", since = "2.2.0")]
     fn trait_method(&self);
@@ -55,7 +51,7 @@ pub const trait ConstTrait {
     const TRAIT_ASSOC_CONST: usize;
 }
 
-//@ is "$.index[?(@.name=='ConstTraitWithUnstableMethod')].stability.level" '"stable"'
+//@ is "$.index[?(@.name=='ConstTraitWithUnstableMethod')].stability.level.stable.since" '"2.4.0"'
 //@ is "$.index[?(@.name=='ConstTraitWithUnstableMethod')].const_stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='ConstTraitWithUnstableMethod')].const_stability.feature" '"const_trait_with_unstable_method_const_feature"'
 #[stable(feature = "const_trait_with_unstable_method_feature", since = "2.4.0")]
@@ -72,12 +68,10 @@ pub const trait ConstTraitWithUnstableMethod {
     fn unstable_method_without_const_gate(&self);
 }
 
-//@ is "$.index[?(@.docs=='const trait impl')].stability.level" '"stable"'
 //@ is "$.index[?(@.docs=='const trait impl')].stability.feature" '"const_trait_impl_feature"'
-//@ is "$.index[?(@.docs=='const trait impl')].stability.since" '"3.0.0"'
+//@ is "$.index[?(@.docs=='const trait impl')].stability.level.stable.since" '"3.0.0"'
 //@ is "$.index[?(@.docs=='const trait impl')].const_stability.level" '"unstable"'
 //@ is "$.index[?(@.docs=='const trait impl')].const_stability.feature" '"const_trait_impl_const_feature"'
-//@ !has "$.index[?(@.docs=='const trait impl')].const_stability.since"
 /// const trait impl
 #[stable(feature = "const_trait_impl_feature", since = "3.0.0")]
 #[rustc_const_unstable(feature = "const_trait_impl_const_feature", issue = "none")]
@@ -85,14 +79,12 @@ const impl ConstTrait for ConstTraitTarget {
     // This item is *not* usable in a const context, because its parent is const-unstable.
     //@ is "$.index[?(@.docs=='assoc type inside const trait impl')].const_stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='assoc type inside const trait impl')].const_stability.feature" '"const_trait_impl_const_feature"'
-    //@ !has "$.index[?(@.docs=='assoc type inside const trait impl')].const_stability.since"
     /// assoc type inside const trait impl
     type TraitAssocType = usize;
 
     // This item is also *not* usable in a const context, because its parent is const-unstable.
     //@ is "$.index[?(@.docs=='method inside const trait impl')].const_stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='method inside const trait impl')].const_stability.feature" '"const_trait_impl_const_feature"'
-    //@ !has "$.index[?(@.docs=='method inside const trait impl')].const_stability.since"
     /// method inside const trait impl
     fn trait_method(&self) {}
 
@@ -107,12 +99,10 @@ const impl ConstTrait for ConstTraitTarget {
 // The `const trait` is const-stable. We indicate that *once* on the trait, but since
 // there are no special cases here (unlike in the const-unstable case with associated consts)
 // we do not duplicate the const-stability to all the associated items so as not to bloat the JSON.
-//@ is "$.index[?(@.name=='ConstStableTrait')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='ConstStableTrait')].stability.feature" '"const_stable_trait_feature"'
-//@ is "$.index[?(@.name=='ConstStableTrait')].stability.since" '"4.0.0"'
-//@ is "$.index[?(@.name=='ConstStableTrait')].const_stability.level" '"stable"'
-//@ is "$.index[?(@.name=='ConstStableTrait')].const_stability.since" '"4.0.0"'
+//@ is "$.index[?(@.name=='ConstStableTrait')].stability.level.stable.since" '"4.0.0"'
 //@ is "$.index[?(@.name=='ConstStableTrait')].const_stability.feature" '"const_stable_trait_const_feature"'
+//@ is "$.index[?(@.name=='ConstStableTrait')].const_stability.level.stable.since" '"4.0.0"'
 #[stable(feature = "const_stable_trait_feature", since = "4.0.0")]
 #[rustc_const_stable(feature = "const_stable_trait_const_feature", since = "4.0.0")]
 pub const trait ConstStableTrait {
@@ -135,12 +125,10 @@ pub const trait ConstStableTrait {
 // The `const impl` is const-stable. We indicate that *once* on the impl itself, but since
 // there are no special cases here (unlike in the const-unstable case with associated consts)
 // we do not duplicate the const-stability to all the associated items so as not to bloat the JSON.
-//@ is "$.index[?(@.docs=='const-stable trait impl')].stability.level" '"stable"'
 //@ is "$.index[?(@.docs=='const-stable trait impl')].stability.feature" '"const_stable_trait_impl_feature"'
-//@ is "$.index[?(@.docs=='const-stable trait impl')].stability.since" '"5.0.0"'
-//@ is "$.index[?(@.docs=='const-stable trait impl')].const_stability.level" '"stable"'
-//@ is "$.index[?(@.docs=='const-stable trait impl')].const_stability.since" '"5.0.0"'
+//@ is "$.index[?(@.docs=='const-stable trait impl')].stability.level.stable.since" '"5.0.0"'
 //@ is "$.index[?(@.docs=='const-stable trait impl')].const_stability.feature" '"const_stable_trait_impl_const_feature"'
+//@ is "$.index[?(@.docs=='const-stable trait impl')].const_stability.level.stable.since" '"5.0.0"'
 /// const-stable trait impl
 #[stable(feature = "const_stable_trait_impl_feature", since = "5.0.0")]
 #[rustc_const_stable(feature = "const_stable_trait_impl_const_feature", since = "5.0.0")]

--- a/tests/rustdoc-json/attrs/stability/impls.rs
+++ b/tests/rustdoc-json/attrs/stability/impls.rs
@@ -33,36 +33,31 @@ pub trait UnstableTraitForImpl {
     fn unstable_trait_method(&self);
 }
 
-//@ is "$.index[?(@.docs=='stable inherent impl')].stability.level" '"stable"'
 //@ is "$.index[?(@.docs=='stable inherent impl')].stability.feature" '"stable_inherent_impl"'
-//@ is "$.index[?(@.docs=='stable inherent impl')].stability.since" '"2.0.0"'
+//@ is "$.index[?(@.docs=='stable inherent impl')].stability.level.stable.since" '"2.0.0"'
 /// stable inherent impl
 #[stable(feature = "stable_inherent_impl", since = "2.0.0")]
 impl StableImplTarget {
-    //@ is "$.index[?(@.name=='stable_inherent_method')].stability.level" '"stable"'
     //@ is "$.index[?(@.name=='stable_inherent_method')].stability.feature" '"stable_inherent_method_feature"'
-    //@ is "$.index[?(@.name=='stable_inherent_method')].stability.since" '"2.1.0"'
+    //@ is "$.index[?(@.name=='stable_inherent_method')].stability.level.stable.since" '"2.1.0"'
     //@ is "$.index[?(@.name=='stable_inherent_method')].attrs" []
     #[stable(feature = "stable_inherent_method_feature", since = "2.1.0")]
     pub fn stable_inherent_method(&self) {}
 
     //@ is "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_IMPL')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_IMPL')].stability.feature" '"unstable_assoc_const_in_impl_feature"'
-    //@ !has "$.index[?(@.name=='UNSTABLE_ASSOC_CONST_IN_IMPL')].stability.since"
     #[unstable(feature = "unstable_assoc_const_in_impl_feature", issue = "none")]
     pub const UNSTABLE_ASSOC_CONST_IN_IMPL: usize = 2;
 }
 
 //@ is "$.index[?(@.docs=='unstable inherent impl')].stability.level" '"unstable"'
 //@ is "$.index[?(@.docs=='unstable inherent impl')].stability.feature" '"unstable_inherent_impl"'
-//@ !has "$.index[?(@.docs=='unstable inherent impl')].stability.since"
 /// unstable inherent impl
 #[unstable(feature = "unstable_inherent_impl", issue = "none")]
 impl StableImplTarget {
     // The instability of the inherent `impl` block is inherited by the item.
     //@ is "$.index[?(@.name=='method_inside_unstable_inherent_impl')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='method_inside_unstable_inherent_impl')].stability.feature" '"unstable_inherent_impl"'
-    //@ !has "$.index[?(@.name=='method_inside_unstable_inherent_impl')].stability.since"
     pub fn method_inside_unstable_inherent_impl(&self) {}
 }
 
@@ -74,9 +69,8 @@ impl StableImplTarget {
 // stability onto the implemented item. The unstable impl case is different: rustc records the
 // impl block's instability on contained impl items, so JSON exposes that inherited instability.
 
-//@ is "$.index[?(@.docs=='stable trait impl with unstable trait method')].stability.level" '"stable"'
 //@ is "$.index[?(@.docs=='stable trait impl with unstable trait method')].stability.feature" '"stable_trait_impl_with_unstable_trait_method"'
-//@ is "$.index[?(@.docs=='stable trait impl with unstable trait method')].stability.since" '"3.0.0"'
+//@ is "$.index[?(@.docs=='stable trait impl with unstable trait method')].stability.level.stable.since" '"3.0.0"'
 /// stable trait impl with unstable trait method
 #[stable(feature = "stable_trait_impl_with_unstable_trait_method", since = "3.0.0")]
 impl StableTraitWithUnstableMethodForImpl for StableImplTarget {
@@ -86,9 +80,8 @@ impl StableTraitWithUnstableMethodForImpl for StableImplTarget {
     fn unstable_trait_method_for_stable_impl(&self) {}
 }
 
-//@ is "$.index[?(@.docs=='stable trait impl')].stability.level" '"stable"'
 //@ is "$.index[?(@.docs=='stable trait impl')].stability.feature" '"stable_trait_impl"'
-//@ is "$.index[?(@.docs=='stable trait impl')].stability.since" '"3.0.0"'
+//@ is "$.index[?(@.docs=='stable trait impl')].stability.level.stable.since" '"3.0.0"'
 /// stable trait impl
 #[stable(feature = "stable_trait_impl", since = "3.0.0")]
 impl StableTraitForImpl for StableImplTarget {
@@ -110,7 +103,6 @@ impl StableTraitForImpl for StableImplTarget {
 
 //@ is "$.index[?(@.docs=='unstable trait impl')].stability.level" '"unstable"'
 //@ is "$.index[?(@.docs=='unstable trait impl')].stability.feature" '"unstable_trait_impl"'
-//@ !has "$.index[?(@.docs=='unstable trait impl')].stability.since"
 /// unstable trait impl
 #[unstable(feature = "unstable_trait_impl", issue = "none")]
 impl UnstableTraitForImpl for StableImplTarget {
@@ -118,19 +110,16 @@ impl UnstableTraitForImpl for StableImplTarget {
 
     //@ is "$.index[?(@.docs=='assoc type inside unstable trait impl')].stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='assoc type inside unstable trait impl')].stability.feature" '"unstable_trait_impl"'
-    //@ !has "$.index[?(@.docs=='assoc type inside unstable trait impl')].stability.since"
     /// assoc type inside unstable trait impl
     type UnstableOutput = usize;
 
     //@ is "$.index[?(@.docs=='assoc const inside unstable trait impl')].stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='assoc const inside unstable trait impl')].stability.feature" '"unstable_trait_impl"'
-    //@ !has "$.index[?(@.docs=='assoc const inside unstable trait impl')].stability.since"
     /// assoc const inside unstable trait impl
     const UNSTABLE_ASSOC_CONST: usize = 0;
 
     //@ is "$.index[?(@.docs=='method inside unstable trait impl')].stability.level" '"unstable"'
     //@ is "$.index[?(@.docs=='method inside unstable trait impl')].stability.feature" '"unstable_trait_impl"'
-    //@ !has "$.index[?(@.docs=='method inside unstable trait impl')].stability.since"
     /// method inside unstable trait impl
     fn unstable_trait_method(&self) {}
 }

--- a/tests/rustdoc-json/attrs/stability/item_kinds.rs
+++ b/tests/rustdoc-json/attrs/stability/item_kinds.rs
@@ -3,41 +3,35 @@
 // Mirrors standard-library stability on item kinds that are distinct from ordinary functions,
 // modules, structs, enums, traits, and impls.
 
-//@ is "$.index[?(@.name=='STABLE_CONST')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='STABLE_CONST')].stability.feature" '"stable_const_feature"'
-//@ is "$.index[?(@.name=='STABLE_CONST')].stability.since" '"1.0.0"'
+//@ is "$.index[?(@.name=='STABLE_CONST')].stability.level.stable.since" '"1.0.0"'
 #[stable(feature = "stable_const_feature", since = "1.0.0")]
 pub const STABLE_CONST: usize = 0;
 
 //@ is "$.index[?(@.name=='UNSTABLE_STATIC')].stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='UNSTABLE_STATIC')].stability.feature" '"unstable_static_feature"'
-//@ !has "$.index[?(@.name=='UNSTABLE_STATIC')].stability.since"
 #[unstable(feature = "unstable_static_feature", issue = "none")]
 pub static UNSTABLE_STATIC: usize = 0;
 
-//@ is "$.index[?(@.name=='StableTypeAlias')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='StableTypeAlias')].stability.feature" '"stable_type_alias_feature"'
-//@ is "$.index[?(@.name=='StableTypeAlias')].stability.since" '"1.1.0"'
+//@ is "$.index[?(@.name=='StableTypeAlias')].stability.level.stable.since" '"1.1.0"'
 #[stable(feature = "stable_type_alias_feature", since = "1.1.0")]
 pub type StableTypeAlias = usize;
 
-//@ is "$.index[?(@.name=='StableUnion')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='StableUnion')].stability.feature" '"stable_union_feature"'
-//@ is "$.index[?(@.name=='StableUnion')].stability.since" '"1.3.0"'
+//@ is "$.index[?(@.name=='StableUnion')].stability.level.stable.since" '"1.3.0"'
 #[stable(feature = "stable_union_feature", since = "1.3.0")]
 pub union StableUnion {
     storage: usize,
 }
 
-//@ is "$.index[?(@.inner.extern_crate.name=='stable_extern_crate_self')].stability.level" '"stable"'
 //@ is "$.index[?(@.inner.extern_crate.name=='stable_extern_crate_self')].stability.feature" '"stable_extern_crate_feature"'
-//@ is "$.index[?(@.inner.extern_crate.name=='stable_extern_crate_self')].stability.since" '"1.4.0"'
+//@ is "$.index[?(@.inner.extern_crate.name=='stable_extern_crate_self')].stability.level.stable.since" '"1.4.0"'
 #[stable(feature = "stable_extern_crate_feature", since = "1.4.0")]
 pub extern crate self as stable_extern_crate_self;
 
 //@ is "$.index[?(@.name=='unstable_macro_rules')].stability.level" '"unstable"'
 //@ is "$.index[?(@.name=='unstable_macro_rules')].stability.feature" '"unstable_macro_rules_feature"'
-//@ !has "$.index[?(@.name=='unstable_macro_rules')].stability.since"
 //@ is "$.index[?(@.name=='unstable_macro_rules')].attrs" '["macro_export"]'
 #[unstable(feature = "unstable_macro_rules_feature", issue = "none")]
 #[macro_export]

--- a/tests/rustdoc-json/attrs/stability/modules.rs
+++ b/tests/rustdoc-json/attrs/stability/modules.rs
@@ -3,34 +3,29 @@
 
 #![feature(staged_api)]
 #![stable(feature = "stable_crate_feature", since = "1.0.0")]
-//@ is "$.index[?(@.name=='modules')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='modules')].stability.feature" '"stable_crate_feature"'
-//@ is "$.index[?(@.name=='modules')].stability.since" '"1.0.0"'
+//@ is "$.index[?(@.name=='modules')].stability.level.stable.since" '"1.0.0"'
 
 pub mod inner_stable_module {
     #![stable(feature = "inner_stable_module_feature", since = "1.1.0")]
 
-    //@ is "$.index[?(@.name=='inner_stable_module')].stability.level" '"stable"'
     //@ is "$.index[?(@.name=='inner_stable_module')].stability.feature" '"inner_stable_module_feature"'
-    //@ is "$.index[?(@.name=='inner_stable_module')].stability.since" '"1.1.0"'
+    //@ is "$.index[?(@.name=='inner_stable_module')].stability.level.stable.since" '"1.1.0"'
 }
 
 #[unstable(feature = "unstable_module_feature", issue = "none")]
 pub mod unstable_module {
     //@ is "$.index[?(@.name=='unstable_module')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='unstable_module')].stability.feature" '"unstable_module_feature"'
-    //@ !has "$.index[?(@.name=='unstable_module')].stability.since"
 }
 
 #[stable(feature = "stable_parent_feature", since = "2.0.0")]
 pub mod stable_parent {
-    //@ is "$.index[?(@.name=='stable_parent')].stability.level" '"stable"'
     //@ is "$.index[?(@.name=='stable_parent')].stability.feature" '"stable_parent_feature"'
-    //@ is "$.index[?(@.name=='stable_parent')].stability.since" '"2.0.0"'
+    //@ is "$.index[?(@.name=='stable_parent')].stability.level.stable.since" '"2.0.0"'
 
     //@ is "$.index[?(@.name=='UnstableChildInStable')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='UnstableChildInStable')].stability.feature" '"unstable_child_in_stable"'
-    //@ !has "$.index[?(@.name=='UnstableChildInStable')].stability.since"
     #[unstable(feature = "unstable_child_in_stable", issue = "none")]
     pub struct UnstableChildInStable;
 }
@@ -39,11 +34,9 @@ pub mod stable_parent {
 pub mod unstable_parent {
     //@ is "$.index[?(@.name=='unstable_parent')].stability.level" '"unstable"'
     //@ is "$.index[?(@.name=='unstable_parent')].stability.feature" '"unstable_parent_feature"'
-    //@ !has "$.index[?(@.name=='unstable_parent')].stability.since"
 
-    //@ is "$.index[?(@.name=='StableChildInUnstable')].stability.level" '"stable"'
     //@ is "$.index[?(@.name=='StableChildInUnstable')].stability.feature" '"stable_child_in_unstable"'
-    //@ is "$.index[?(@.name=='StableChildInUnstable')].stability.since" '"3.0.0"'
+    //@ is "$.index[?(@.name=='StableChildInUnstable')].stability.level.stable.since" '"3.0.0"'
     #[stable(feature = "stable_child_in_unstable", since = "3.0.0")]
     pub struct StableChildInUnstable;
 }

--- a/tests/rustdoc-json/attrs/stability/reexports.rs
+++ b/tests/rustdoc-json/attrs/stability/reexports.rs
@@ -12,9 +12,8 @@
 #[unstable(feature = "unstable_source_mod", issue = "none")]
 pub mod unstable_source_mod {
     //@ set stable_in_unstable = "$.index[?(@.name=='StableInUnstable')].id"
-    //@ is "$.index[?(@.name=='StableInUnstable')].stability.level" '"stable"'
     //@ is "$.index[?(@.name=='StableInUnstable')].stability.feature" '"stable_in_unstable"'
-    //@ is "$.index[?(@.name=='StableInUnstable')].stability.since" '"1.0.0"'
+    //@ is "$.index[?(@.name=='StableInUnstable')].stability.level.stable.since" '"1.0.0"'
     #[stable(feature = "stable_in_unstable", since = "1.0.0")]
     pub struct StableInUnstable;
 
@@ -27,26 +26,22 @@ pub mod unstable_source_mod {
 }
 
 //@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].inner.use.id" $stable_in_unstable
-//@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].stability.level" '"stable"'
 //@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].stability.feature" '"stable_reexport"'
-//@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].stability.since" '"3.0.0"'
+//@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].stability.level.stable.since" '"3.0.0"'
 //@ is "$.index[?(@.inner.use.name=='ReexportedStableInUnstable')].attrs" []
 #[stable(feature = "stable_reexport", since = "3.0.0")]
 pub use crate::unstable_source_mod::StableInUnstable as ReexportedStableInUnstable;
 //@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].inner.use.is_glob" true
-//@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].stability.level" '"stable"'
 //@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].stability.feature" '"stable_glob_reexport"'
-//@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].stability.since" '"4.0.0"'
+//@ is "$.index[?(@.inner.use.source=='crate::unstable_source_mod')].stability.level.stable.since" '"4.0.0"'
 #[stable(feature = "stable_glob_reexport", since = "4.0.0")]
 pub use crate::unstable_source_mod::*;
 //@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].inner.use.id" $stable_in_unstable
-//@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].stability.level" '"stable"'
 //@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].stability.feature" '"stable_grouped_reexport"'
-//@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].stability.since" '"3.5.0"'
+//@ is "$.index[?(@.inner.use.name=='GroupedStableReexport')].stability.level.stable.since" '"3.5.0"'
 //@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].inner.use.id" $second_stable_in_unstable
-//@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].stability.level" '"stable"'
 //@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].stability.feature" '"stable_grouped_reexport"'
-//@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].stability.since" '"3.5.0"'
+//@ is "$.index[?(@.inner.use.name=='SecondGroupedStableReexport')].stability.level.stable.since" '"3.5.0"'
 #[stable(feature = "stable_grouped_reexport", since = "3.5.0")]
 pub use crate::unstable_source_mod::{
     SecondStableInUnstable as SecondGroupedStableReexport,
@@ -74,23 +69,19 @@ pub mod unstable_reexport_source_mod {
 //@ is "$.index[?(@.inner.use.name=='UnstableReexportedStable')].inner.use.id" $stable_for_unstable_reexport
 //@ is "$.index[?(@.inner.use.name=='UnstableReexportedStable')].stability.level" '"unstable"'
 //@ is "$.index[?(@.inner.use.name=='UnstableReexportedStable')].stability.feature" '"unstable_reexport"'
-//@ !has "$.index[?(@.inner.use.name=='UnstableReexportedStable')].stability.since"
 #[unstable(feature = "unstable_reexport", issue = "none")]
 pub use crate::unstable_reexport_source_mod::StableForUnstableReexport as UnstableReexportedStable;
 //@ is "$.index[?(@.inner.use.source=='crate::unstable_reexport_source_mod')].inner.use.is_glob" true
 //@ is "$.index[?(@.inner.use.source=='crate::unstable_reexport_source_mod')].stability.level" '"unstable"'
 //@ is "$.index[?(@.inner.use.source=='crate::unstable_reexport_source_mod')].stability.feature" '"unstable_glob_reexport"'
-//@ !has "$.index[?(@.inner.use.source=='crate::unstable_reexport_source_mod')].stability.since"
 #[unstable(feature = "unstable_glob_reexport", issue = "none")]
 pub use crate::unstable_reexport_source_mod::*;
 //@ is "$.index[?(@.inner.use.name=='GroupedUnstableReexport')].inner.use.id" $grouped_stable_for_unstable_reexport
 //@ is "$.index[?(@.inner.use.name=='GroupedUnstableReexport')].stability.level" '"unstable"'
 //@ is "$.index[?(@.inner.use.name=='GroupedUnstableReexport')].stability.feature" '"unstable_grouped_reexport"'
-//@ !has "$.index[?(@.inner.use.name=='GroupedUnstableReexport')].stability.since"
 //@ is "$.index[?(@.inner.use.name=='SecondGroupedUnstableReexport')].inner.use.id" $second_grouped_stable_for_unstable_reexport
 //@ is "$.index[?(@.inner.use.name=='SecondGroupedUnstableReexport')].stability.level" '"unstable"'
 //@ is "$.index[?(@.inner.use.name=='SecondGroupedUnstableReexport')].stability.feature" '"unstable_grouped_reexport"'
-//@ !has "$.index[?(@.inner.use.name=='SecondGroupedUnstableReexport')].stability.since"
 #[unstable(feature = "unstable_grouped_reexport", issue = "none")]
 pub use crate::unstable_reexport_source_mod::{
     GroupedStableForUnstableReexport as GroupedUnstableReexport,

--- a/tests/rustdoc-json/attrs/stability/stable.rs
+++ b/tests/rustdoc-json/attrs/stability/stable.rs
@@ -1,8 +1,7 @@
 #![feature(staged_api)]
 
-//@ is "$.index[?(@.name=='foo')].stability.level" '"stable"'
 //@ is "$.index[?(@.name=='foo')].stability.feature" '"eeeee"'
-//@ is "$.index[?(@.name=='foo')].stability.since" '"2.71.8"'
+//@ is "$.index[?(@.name=='foo')].stability.level.stable.since" '"2.71.8"'
 //@ is "$.index[?(@.name=='foo')].attrs" []
 #[stable(since = "2.71.8", feature = "eeeee")]
 pub fn foo() {}

--- a/tests/ui/diagnostic_namespace/on_unknown/late_res.rs
+++ b/tests/ui/diagnostic_namespace/on_unknown/late_res.rs
@@ -7,18 +7,18 @@ pub mod empty {}
 fn stuff(x: u32) {
     match x {
         empty::blah => {}
-        //~^ ERROR cannot find unit struct, unit variant or constant `blah` in module `empty` [E0531]
+        //~^ ERROR it works [E0531]
         _ => {}
     }
 
     println!("{}", empty::blah);
-    //~^ ERROR cannot find value `blah` in module `empty` [E0425]
+    //~^ ERROR it works [E0425]
 
     let x = [
         empty::blah,
-        //~^ ERROR cannot find value `blah` in module `empty` [E0425]
+        //~^ ERROR it works [E0425]
 
         empty::blah2,
-        //~^ ERROR cannot find value `blah2` in module `empty` [E0425]
+        //~^ ERROR it works [E0425]
     ];
 }

--- a/tests/ui/diagnostic_namespace/on_unknown/late_res.rs
+++ b/tests/ui/diagnostic_namespace/on_unknown/late_res.rs
@@ -1,24 +1,27 @@
 #![crate_type = "lib"]
 #![feature(diagnostic_on_unknown)]
 
-#[diagnostic::on_unknown(message = "it works")]
+#[diagnostic::on_unknown(
+    message = "it works `{This}` `{Unresolved}`",
+    label = "label it works",
+    note = "note it works"
+)]
 pub mod empty {}
 
 fn stuff(x: u32) {
     match x {
         empty::blah => {}
-        //~^ ERROR it works [E0531]
+        //~^ ERROR it works `empty` `blah` [E0531]
         _ => {}
     }
 
     println!("{}", empty::blah);
-    //~^ ERROR it works [E0425]
+    //~^ ERROR it works `empty` `blah` [E0425]
 
     let x = [
         empty::blah,
-        //~^ ERROR it works [E0425]
-
+        //~^ ERROR it works `empty` `blah` [E0425]
         empty::blah2,
-        //~^ ERROR it works [E0425]
+        //~^ ERROR it works `empty` `blah2` [E0425]
     ];
 }

--- a/tests/ui/diagnostic_namespace/on_unknown/late_res.rs
+++ b/tests/ui/diagnostic_namespace/on_unknown/late_res.rs
@@ -1,0 +1,24 @@
+#![crate_type = "lib"]
+#![feature(diagnostic_on_unknown)]
+
+#[diagnostic::on_unknown(message = "it works")]
+pub mod empty {}
+
+fn stuff(x: u32) {
+    match x {
+        empty::blah => {}
+        //~^ ERROR cannot find unit struct, unit variant or constant `blah` in module `empty` [E0531]
+        _ => {}
+    }
+
+    println!("{}", empty::blah);
+    //~^ ERROR cannot find value `blah` in module `empty` [E0425]
+
+    let x = [
+        empty::blah,
+        //~^ ERROR cannot find value `blah` in module `empty` [E0425]
+
+        empty::blah2,
+        //~^ ERROR cannot find value `blah2` in module `empty` [E0425]
+    ];
+}

--- a/tests/ui/diagnostic_namespace/on_unknown/late_res.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/late_res.stderr
@@ -1,0 +1,28 @@
+error[E0531]: cannot find unit struct, unit variant or constant `blah` in module `empty`
+  --> $DIR/late_res.rs:9:16
+   |
+LL |         empty::blah => {}
+   |                ^^^^ not found in `empty`
+
+error[E0425]: cannot find value `blah` in module `empty`
+  --> $DIR/late_res.rs:14:27
+   |
+LL |     println!("{}", empty::blah);
+   |                           ^^^^ not found in `empty`
+
+error[E0425]: cannot find value `blah` in module `empty`
+  --> $DIR/late_res.rs:18:16
+   |
+LL |         empty::blah,
+   |                ^^^^ not found in `empty`
+
+error[E0425]: cannot find value `blah2` in module `empty`
+  --> $DIR/late_res.rs:21:16
+   |
+LL |         empty::blah2,
+   |                ^^^^^ not found in `empty`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0425, E0531.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/diagnostic_namespace/on_unknown/late_res.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/late_res.stderr
@@ -1,26 +1,34 @@
-error[E0531]: cannot find unit struct, unit variant or constant `blah` in module `empty`
+error[E0531]: it works
   --> $DIR/late_res.rs:9:16
    |
 LL |         empty::blah => {}
    |                ^^^^ not found in `empty`
+   |
+   = note: cannot find unit struct, unit variant or constant `blah` in module `empty`
 
-error[E0425]: cannot find value `blah` in module `empty`
+error[E0425]: it works
   --> $DIR/late_res.rs:14:27
    |
 LL |     println!("{}", empty::blah);
    |                           ^^^^ not found in `empty`
+   |
+   = note: cannot find value `blah` in module `empty`
 
-error[E0425]: cannot find value `blah` in module `empty`
+error[E0425]: it works
   --> $DIR/late_res.rs:18:16
    |
 LL |         empty::blah,
    |                ^^^^ not found in `empty`
+   |
+   = note: cannot find value `blah` in module `empty`
 
-error[E0425]: cannot find value `blah2` in module `empty`
+error[E0425]: it works
   --> $DIR/late_res.rs:21:16
    |
 LL |         empty::blah2,
    |                ^^^^^ not found in `empty`
+   |
+   = note: cannot find value `blah2` in module `empty`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/diagnostic_namespace/on_unknown/late_res.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/late_res.stderr
@@ -1,34 +1,38 @@
-error[E0531]: it works
-  --> $DIR/late_res.rs:9:16
+error[E0531]: it works `empty` `blah`
+  --> $DIR/late_res.rs:13:16
    |
 LL |         empty::blah => {}
-   |                ^^^^ not found in `empty`
+   |                ^^^^ label it works
    |
    = note: cannot find unit struct, unit variant or constant `blah` in module `empty`
+   = note: note it works
 
-error[E0425]: it works
-  --> $DIR/late_res.rs:14:27
+error[E0425]: it works `empty` `blah`
+  --> $DIR/late_res.rs:18:27
    |
 LL |     println!("{}", empty::blah);
-   |                           ^^^^ not found in `empty`
+   |                           ^^^^ label it works
    |
    = note: cannot find value `blah` in module `empty`
+   = note: note it works
 
-error[E0425]: it works
-  --> $DIR/late_res.rs:18:16
+error[E0425]: it works `empty` `blah`
+  --> $DIR/late_res.rs:22:16
    |
 LL |         empty::blah,
-   |                ^^^^ not found in `empty`
+   |                ^^^^ label it works
    |
    = note: cannot find value `blah` in module `empty`
+   = note: note it works
 
-error[E0425]: it works
-  --> $DIR/late_res.rs:21:16
+error[E0425]: it works `empty` `blah2`
+  --> $DIR/late_res.rs:24:16
    |
 LL |         empty::blah2,
-   |                ^^^^^ not found in `empty`
+   |                ^^^^^ label it works
    |
    = note: cannot find value `blah2` in module `empty`
+   = note: note it works
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/generics/unconstrained-param-enum-projection-issue-159811.rs
+++ b/tests/ui/generics/unconstrained-param-enum-projection-issue-159811.rs
@@ -1,0 +1,27 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/159811.
+
+trait Child {
+    type Error;
+}
+
+trait Site {
+    type Child<'a>: Child
+    where
+        Self: 'a;
+    type Error;
+}
+
+enum MyError<P> {
+    Own,
+    Parent(P),
+}
+
+impl<'a, S: Site> From<<S::Child<'a> as Child>::Error> for MyError<S::Error> {
+    //~^ ERROR conflicting implementations of trait
+    //~| ERROR the type parameter `S` is not constrained
+    fn from(_: <S::Child<'a> as Child>::Error) -> Self {
+        Self::Own
+    }
+}
+
+fn main() {}

--- a/tests/ui/generics/unconstrained-param-enum-projection-issue-159811.stderr
+++ b/tests/ui/generics/unconstrained-param-enum-projection-issue-159811.stderr
@@ -1,0 +1,28 @@
+error[E0119]: conflicting implementations of trait `From<MyError<_>>` for type `MyError<_>`
+  --> $DIR/unconstrained-param-enum-projection-issue-159811.rs:19:1
+   |
+LL | impl<'a, S: Site> From<<S::Child<'a> as Child>::Error> for MyError<S::Error> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: conflicting implementation in crate `core`:
+           - impl<T> From<T> for T;
+
+error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-param-enum-projection-issue-159811.rs:19:10
+   |
+LL | impl<'a, S: Site> From<<S::Child<'a> as Child>::Error> for MyError<S::Error> {
+   |          ^ unconstrained type parameter
+   |
+help: use the type parameter `S` in the `MyError` type and use it in the type definition
+   |
+LL ~ enum MyError<P, S> {
+LL |     Own,
+...
+LL |
+LL ~ impl<'a, S: Site> From<<S::Child<'a> as Child>::Error> for MyError<S::Error, S> {
+   |
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0119, E0207.
+For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/lint/dangling-pointers-from-temporaries/methods.rs
+++ b/tests/ui/lint/dangling-pointers-from-temporaries/methods.rs
@@ -1,5 +1,5 @@
 #![deny(dangling_pointers_from_temporaries)]
-#![feature(box_vec_non_null)]
+#![feature(vec_as_non_null)]
 
 fn main() {
     vec![0u8].as_ptr();

--- a/tests/ui/lint/dangling-pointers-from-temporaries/methods.rs
+++ b/tests/ui/lint/dangling-pointers-from-temporaries/methods.rs
@@ -1,8 +1,11 @@
 #![deny(dangling_pointers_from_temporaries)]
+#![feature(box_vec_non_null)]
 
 fn main() {
     vec![0u8].as_ptr();
     //~^ ERROR dangling pointer
     vec![0u8].as_mut_ptr();
+    //~^ ERROR dangling pointer
+    vec![0u8].as_non_null();
     //~^ ERROR dangling pointer
 }

--- a/tests/ui/lint/dangling-pointers-from-temporaries/methods.stderr
+++ b/tests/ui/lint/dangling-pointers-from-temporaries/methods.stderr
@@ -1,5 +1,5 @@
 error: this creates a dangling pointer because temporary `Vec<u8>` is dropped at end of statement
-  --> $DIR/methods.rs:4:15
+  --> $DIR/methods.rs:5:15
    |
 LL |     vec![0u8].as_ptr();
    |     --------- ^^^^^^ pointer created here
@@ -17,7 +17,7 @@ LL | #![deny(dangling_pointers_from_temporaries)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this creates a dangling pointer because temporary `Vec<u8>` is dropped at end of statement
-  --> $DIR/methods.rs:6:15
+  --> $DIR/methods.rs:7:15
    |
 LL |     vec![0u8].as_mut_ptr();
    |     --------- ^^^^^^^^^^ pointer created here
@@ -29,5 +29,18 @@ LL |     vec![0u8].as_mut_ptr();
    = note: returning a pointer to a local variable will always result in a dangling pointer
    = note: for more information, see <https://doc.rust-lang.org/reference/destructors.html>
 
-error: aborting due to 2 previous errors
+error: this creates a dangling pointer because temporary `Vec<u8>` is dropped at end of statement
+  --> $DIR/methods.rs:9:15
+   |
+LL |     vec![0u8].as_non_null();
+   |     --------- ^^^^^^^^^^^ pointer created here
+   |     |
+   |     this `Vec<u8>` is dropped at end of statement
+   |
+   = help: bind the `Vec<u8>` to a variable such that it outlives the pointer returned by `as_non_null`
+   = note: a dangling pointer is safe, but dereferencing one is undefined behavior
+   = note: returning a pointer to a local variable will always result in a dangling pointer
+   = note: for more information, see <https://doc.rust-lang.org/reference/destructors.html>
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/lint/explicit-outlives-unsized-object-lifetime.rs
+++ b/tests/ui/lint/explicit-outlives-unsized-object-lifetime.rs
@@ -1,0 +1,55 @@
+//@ check-pass
+// Regression test for https://github.com/rust-lang/rust/issues/134902
+//
+// `explicit_outlives_requirements` must not suggest removing `T: 'r` when T is not
+// `Sized` (i.e. can hold trait object types). Such a bound can set the object lifetime
+// default for `Struct<'r, dyn Trait>` (RFC 599): removing it may silently change
+// `dyn Trait + 'r` to `dyn Trait + 'static`, breaking callers.
+//
+// Note: higher-ranked predicates (`for<'x> T: 'r`) are excluded from RFC 599 and are
+// always safe to remove; and when T is `Sized` (e.g. `T: ?Sized + Sized` or `T: Clone`),
+// it cannot hold trait object types so the bound is also safe to remove.
+
+#![deny(explicit_outlives_requirements)]
+#![allow(unused)]
+
+trait Test {}
+
+// Inline bound: `T: 'a + ?Sized`.
+struct Ref<'a, T: 'a + ?Sized> {
+    r: &'a T,
+}
+
+// Where clause for the outlives bound, inline `?Sized`.
+struct Ref2<'a, T: ?Sized>
+where
+    T: 'a,
+{
+    r: &'a T,
+}
+
+// Where clause for both.
+struct Ref3<'a, T>
+where
+    T: 'a + ?Sized,
+{
+    r: &'a T,
+}
+
+// Two lifetime params; neither bound should be removed.
+struct Ref4<'a, 'b, T: 'a + 'b + ?Sized> {
+    a: &'a T,
+    b: &'b T,
+}
+
+// Verify the semantics that motivated the fix: a struct field typed `Ref<dyn Test>`
+// (without an explicit lifetime) must resolve to `dyn Test + 'a`, not `dyn Test + 'static`.
+struct Container<'a> {
+    t: Ref<'a, dyn Test>,
+}
+
+fn check<'a>(t: Ref<'a, dyn Test + 'a>, mut c: Container<'a>) {
+    c.t = t;
+}
+
+fn main() {}

--- a/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives.fixed
+++ b/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives.fixed
@@ -801,8 +801,8 @@ where
     yoo: &'a U
 }
 
-// https://github.com/rust-lang/rust/issues/105150
-struct InferredWhereBoundWithInlineBound<'a, T: ?Sized>
+// `T: 'a` is implied by the field — the lint should fire here.
+struct InferredWhereBoundWithInlineBound<'a, T> //~^ ERROR outlives requirements can be inferred
 {
     data: &'a T,
 }

--- a/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives.rs
+++ b/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives.rs
@@ -801,10 +801,9 @@ where
     yoo: &'a U
 }
 
-// https://github.com/rust-lang/rust/issues/105150
-struct InferredWhereBoundWithInlineBound<'a, T: ?Sized>
-//~^ ERROR outlives requirements can be inferred
-    where T: 'a,
+// `T: 'a` is implied by the field — the lint should fire here.
+struct InferredWhereBoundWithInlineBound<'a, T>
+    where T: 'a, //~^ ERROR outlives requirements can be inferred
 {
     data: &'a T,
 }

--- a/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives.stderr
+++ b/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives.stderr
@@ -11,11 +11,10 @@ LL | #![deny(explicit_outlives_requirements)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:805:56
+  --> $DIR/edition-lint-infer-outlives.rs:805:48
    |
-LL |   struct InferredWhereBoundWithInlineBound<'a, T: ?Sized>
-   |  ________________________________________________________^
-LL | |
+LL |   struct InferredWhereBoundWithInlineBound<'a, T>
+   |  ________________________________________________^
 LL | |     where T: 'a,
    | |________________^ help: remove this bound
 

--- a/tests/ui/splat/run-splat.rs
+++ b/tests/ui/splat/run-splat.rs
@@ -1,6 +1,5 @@
 //! Check that splat codegen works for simple cases.
 //@ run-pass
-//@ check-run-results
 #![feature(splat, tuple_trait)]
 #![expect(incomplete_features)]
 
@@ -9,29 +8,29 @@ use std::marker::Tuple;
 struct Foo;
 
 trait MethodArgs: Tuple {
-    fn call_method(self, this: &Foo);
+    fn call_method(self, this: &Foo) -> String;
 }
 
 impl Foo {
-    fn method(&self, #[splat] args: impl MethodArgs) {
+    fn method(&self, #[splat] args: impl MethodArgs) -> String {
         args.call_method(self)
     }
 }
 
 impl MethodArgs for (i32, String) {
-    fn call_method(self, _this: &Foo) {
-        dbg!(self.1, self.0);
+    fn call_method(self, _this: &Foo) -> String {
+        format!("{}-{}", self.0, self.1)
     }
 }
 
 impl MethodArgs for (f64,) {
-    fn call_method(self, _this: &Foo) {
-        dbg!(self.0);
+    fn call_method(self, _this: &Foo) -> String {
+        format!("{}", self.0)
     }
 }
 
 fn main() {
     let foo = Foo;
-    foo.method(42, "hello splat".to_string());
-    foo.method(3.141);
+    assert_eq!(foo.method(42, "hello splat".to_string()), "42-hello splat");
+    assert_eq!(foo.method(3.1), "3.1");
 }

--- a/tests/ui/splat/run-splat.run.stderr
+++ b/tests/ui/splat/run-splat.run.stderr
@@ -1,3 +1,0 @@
-[$DIR/run-splat.rs:23:9] self.1 = "hello splat"
-[$DIR/run-splat.rs:23:9] self.0 = 42
-[$DIR/run-splat.rs:29:9] self.0 = 3.141

--- a/tests/ui/splat/splat-assoc-fn-tuple-simple.rs
+++ b/tests/ui/splat/splat-assoc-fn-tuple-simple.rs
@@ -13,10 +13,6 @@ impl Foo {
 }
 
 fn main() {
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-    // Add a tupled test for each call if they are.
-    //Foo::tuple_1((1u32,));
-
     Foo::tuple_1(1u32);
     Foo::tuple_3(1u32, 2i32, 3i8);
 }

--- a/tests/ui/splat/splat-fn-tuple-generic-fail.rs
+++ b/tests/ui/splat/splat-fn-tuple-generic-fail.rs
@@ -11,15 +11,11 @@ fn splat_generic_tuple<T: Tuple>(#[splat] _t: T) {}
 fn f<Args: Tuple>(#[splat] args: Args) {}
 
 fn main() {
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-
     // Calling with un-splatted arguments might look like it works, but the actual generic type is
     // a tuple inside another tuple. Aren't generics great?
     splat_generic_tuple((1, 2));
     splat_generic_tuple((1u32, 2i8));
 
-    // FIXME(splat): Make the splat generic handling code handle tuples inside tuples
-    // (if we want to support tupled calls)
     splat_generic_tuple::<(((u32, i8)))>((1, 2)); //~ ERROR this splatted function takes 2 arguments, but 1 was provided
     splat_generic_tuple::<(((u32, i8)))>((1u32, 2i8)); //~ ERROR this splatted function takes 2 arguments, but 1 was provided
 

--- a/tests/ui/splat/splat-fn-tuple-generic-fail.stderr
+++ b/tests/ui/splat/splat-fn-tuple-generic-fail.stderr
@@ -1,41 +1,41 @@
 error[E0057]: this splatted function takes 2 arguments, but 1 was provided
-  --> $DIR/splat-fn-tuple-generic-fail.rs:23:5
+  --> $DIR/splat-fn-tuple-generic-fail.rs:19:5
    |
 LL |     splat_generic_tuple::<(((u32, i8)))>((1, 2));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0057]: this splatted function takes 2 arguments, but 1 was provided
-  --> $DIR/splat-fn-tuple-generic-fail.rs:24:5
+  --> $DIR/splat-fn-tuple-generic-fail.rs:20:5
    |
 LL |     splat_generic_tuple::<(((u32, i8)))>((1u32, 2i8));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0057]: this splatted function takes 2 arguments, but 1 was provided
-  --> $DIR/splat-fn-tuple-generic-fail.rs:26:5
+  --> $DIR/splat-fn-tuple-generic-fail.rs:22:5
    |
 LL |     splat_generic_tuple::<((u32, i8))>((1, 2));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0057]: this splatted function takes 2 arguments, but 1 was provided
-  --> $DIR/splat-fn-tuple-generic-fail.rs:27:5
+  --> $DIR/splat-fn-tuple-generic-fail.rs:23:5
    |
 LL |     splat_generic_tuple::<((u32, i8))>((1u32, 2i8));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0057]: this splatted function takes 2 arguments, but 1 was provided
-  --> $DIR/splat-fn-tuple-generic-fail.rs:29:5
+  --> $DIR/splat-fn-tuple-generic-fail.rs:25:5
    |
 LL |     splat_generic_tuple::<(u32, i8)>((1, 2));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0057]: this splatted function takes 2 arguments, but 1 was provided
-  --> $DIR/splat-fn-tuple-generic-fail.rs:30:5
+  --> $DIR/splat-fn-tuple-generic-fail.rs:26:5
    |
 LL |     splat_generic_tuple::<(u32, i8)>((1u32, 2i8));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/splat-fn-tuple-generic-fail.rs:32:31
+  --> $DIR/splat-fn-tuple-generic-fail.rs:28:31
    |
 LL |     const F1: fn((u8, u32)) = f::<(u8, u32)>;
    |               -------------   ^^^^^^^^^^^^^^ expected fn with no splatted arg, found fn with arg 0 splatted

--- a/tests/ui/splat/splat-fn-tuple-simple.rs
+++ b/tests/ui/splat/splat-fn-tuple-simple.rs
@@ -10,11 +10,6 @@ fn splat_non_terminal_arg(#[splat] (_a, _b): (u32, i8), _c: f64) {}
 
 fn main() {
     tuple_args(1, 2);
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-    // Add a tupled test for each call if they are.
-    //tuple_args((1, 2));
-
-    tuple_args(1, 2);
     tuple_args(1u32, 2i8);
 
     splat_non_terminal_arg(1, 2, 3.5);

--- a/tests/ui/splat/splat-generics-everywhere.rs
+++ b/tests/ui/splat/splat-generics-everywhere.rs
@@ -54,10 +54,6 @@ impl<T> BarTrait<T> for Foo<T> {
 }
 
 fn main() {
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-    // Add a tupled test for each call if they are.
-    //Foo::<i64>::assoc(("u",));
-
     Foo::<f32>::assoc("u");
     Foo::<f32>::trait_assoc("w");
 

--- a/tests/ui/splat/splat-method-tuple-simple.rs
+++ b/tests/ui/splat/splat-method-tuple-simple.rs
@@ -27,11 +27,6 @@ impl TupleStruct {
 
 fn main() {
     let foo = Foo;
-
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-    // Add a tupled test for each call if they are.
-    //foo.tuple_2((1, 2));
-
     foo.tuple_2(1u32, 2i8);
     foo.tuple_4(1u32, 2i8, (), 3f32);
 

--- a/tests/ui/splat/splat-overload-at-home.rs
+++ b/tests/ui/splat/splat-overload-at-home.rs
@@ -30,12 +30,6 @@ impl Foo {
 
 fn main() {
     let foo = Foo;
-
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-    // Add a tupled test for each call if they are.
-    //foo.method(());
-    //foo.method((42i32,));
-
     // Generic tuple trait implementers work without explicit tuple type parameters.
     foo.method::<()>();
     foo.method();

--- a/tests/ui/splat/splat-trait-tuple.rs
+++ b/tests/ui/splat/splat-trait-tuple.rs
@@ -30,12 +30,6 @@ impl FooTrait for TupleStruct {
 
 fn main() {
     let foo = Foo;
-
-    // FIXME(splat): should splatted functions be callable with tupled and un-tupled arguments?
-    // Add a tupled test for each call if they are.
-    //Foo::tuple_1_trait((1u32,));
-    //foo.tuple_2_trait((1, 3.5));
-
     Foo::tuple_1_trait(1u32);
     foo.tuple_2_trait(1, 3.5);
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#158168 (Added implementation on `set_permissions_nofollow` for all primary platforms)
 - rust-lang/rust#160055 (Simplify `MaybeRequiresStorage`)
 - rust-lang/rust#157226 (Partially stabilize `box_vec_non_null`)
 - rust-lang/rust#158879 (simplify `slice::Iter[Mut]::next_chunk` implementation)
 - rust-lang/rust#159413 (Enable `#[diagnostic::on_unknown]` during late res)
 - rust-lang/rust#160091 (Fix rustdoc toolbar height when title is taller than one line)
 - rust-lang/rust#158615 (fix: don't fire `explicit_outlives_requirements` on `?Sized` type params)
 - rust-lang/rust#159666 (fix(ld64.lld): route version mismatch warnings to linker_info on macOS)
 - rust-lang/rust#160032 (rustdoc-json: Make `Stability` compatible with non-self-describing serde formats)
 - rust-lang/rust#160039 (Add regression test for enum unconstrained parameter )
 - rust-lang/rust#160049 (Use assert_eq! in splat codegen tests)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=158168,160055,157226,158879,159413,160091,158615,159666,160032,160039,160049)
<!-- homu-ignore:end -->

