### PR TITLE
Avoid weak-linking `gettid` on musl

### DIFF
--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -335,6 +335,13 @@ pub fn current_os_id() -> Option<u64> {
     // The OS thread ID is used rather than `pthread_self` so as to match what will be displayed
     // for process inspection (debuggers, trace, `top`, etc.).
     cfg_select! {
+        // Under fat LTO, weak-linking `gettid` can turn strong declarations weak.
+        // musl provides `gettid`, so call it directly. See #154439.
+        all(target_os = "linux", target_env = "musl") => {
+            // SAFETY: FFI call with no preconditions.
+            let id: libc::pid_t = unsafe { libc::gettid() };
+            Some(id as u64)
+        }
         // Most platforms have a function returning a `pid_t` or int, which is an `i32`.
         any(target_os = "android", target_os = "linux") => {
             use crate::sys::pal::weak::syscall;

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -335,9 +335,9 @@ pub fn current_os_id() -> Option<u64> {
     // The OS thread ID is used rather than `pthread_self` so as to match what will be displayed
     // for process inspection (debuggers, trace, `top`, etc.).
     cfg_select! {
-        // Under fat LTO, weak-linking `gettid` can turn strong declarations weak.
-        // musl provides `gettid`, so call it directly. See #154439.
         all(target_os = "linux", target_env = "musl") => {
+            // Under fat LTO, weak-linking `gettid` can turn strong declarations weak.
+            // musl provides `gettid`, so call it directly. See #154439.
             // SAFETY: FFI call with no preconditions.
             let id: libc::pid_t = unsafe { libc::gettid() };
             Some(id as u64)

--- a/tests/ui/linking/auxiliary/strong-gettid-ref.rs
+++ b/tests/ui/linking/auxiliary/strong-gettid-ref.rs
@@ -1,0 +1,14 @@
+// This crate must sort after `std` to reproduce #154439.
+
+//@ no-prefer-dynamic
+//@ compile-flags: -Copt-level=3
+
+#![crate_type = "rlib"]
+
+unsafe extern "C" {
+    safe fn gettid() -> i32;
+}
+
+pub fn tid() -> i32 {
+    gettid()
+}

--- a/tests/ui/linking/lto-weak-gettid-issue-154439.rs
+++ b/tests/ui/linking/lto-weak-gettid-issue-154439.rs
@@ -1,0 +1,14 @@
+//! Regression test for std weakening a strong `gettid` reference under fat LTO (#154439).
+
+//@ run-pass
+//@ only-musl
+//@ aux-build: strong-gettid-ref.rs
+//@ no-prefer-dynamic
+//@ compile-flags: -Copt-level=3 -Clto=fat -Ctarget-feature=+crt-static
+
+extern crate strong_gettid_ref;
+
+fn main() {
+    // The main thread's TID equals its PID.
+    assert_eq!(strong_gettid_ref::tid() as u32, std::process::id());
+}

--- a/tests/ui/linking/lto-weak-gettid-issue-154439.rs
+++ b/tests/ui/linking/lto-weak-gettid-issue-154439.rs
@@ -1,7 +1,7 @@
 //! Regression test for std weakening a strong `gettid` reference under fat LTO (#154439).
 
 //@ run-pass
-//@ only-musl
+//@ only-linux
 //@ aux-build: strong-gettid-ref.rs
 //@ no-prefer-dynamic
 //@ compile-flags: -Copt-level=3 -Clto=fat -Ctarget-feature=+crt-static


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160114)*
<!-- homu-ignore:end -->

> Mitigates rust-lang/rust#154439.

## Brief

`current_os_id` weak-links `gettid` so older glibc can fall back to a raw syscall.

## Details

During fat LTO, LLVM can merge the weak declaration with a strong declaration from another crate and keep the weak linkage. A static linker then does not extract `gettid.o` from `libc.a`, leaving the strong call without a definition.

@bjorn3 traced the underlying compiler problem to fat LTO using LLVM’s legacy `ModuleLinker`. Changing that compiler-level behavior is intentionally out of scope here, so that issue should remain open.

Note that Rust-supported musl versions provide `gettid`, so musl does not need that probe.

This PR calls `gettid` directly on musl. It follows the musl-specific branch suggested by @tgross35 in rust-lang/rust#154439.

r? @tgross35