### PR TITLE
Unimplement `fmt::Debug` for `c_void`

### DIFF
--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -18,7 +18,6 @@ pub use self::c_str::FromBytesUntilNulError;
 #[doc(inline)]
 #[stable(feature = "core_c_str", since = "1.64.0")]
 pub use self::c_str::FromBytesWithNulError;
-use crate::fmt;
 
 #[stable(feature = "c_str_module", since = "1.88.0")]
 pub mod c_str;
@@ -48,6 +47,7 @@ pub use self::primitives::{c_ptrdiff_t, c_size_t, c_ssize_t};
 #[lang = "c_void"]
 #[repr(u8)]
 #[stable(feature = "core_c_void", since = "1.30.0")]
+#[allow(missing_debug_implementations)]
 pub enum c_void {
     #[unstable(
         feature = "c_void_variant",
@@ -63,13 +63,6 @@ pub enum c_void {
     )]
     #[doc(hidden)]
     __variant2,
-}
-
-#[stable(feature = "std_debug", since = "1.16.0")]
-impl fmt::Debug for c_void {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("c_void").finish()
-    }
 }
 
 // Link the MSVC default lib

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -18,7 +18,6 @@ pub use self::c_str::FromBytesUntilNulError;
 #[doc(inline)]
 #[stable(feature = "core_c_str", since = "1.64.0")]
 pub use self::c_str::FromBytesWithNulError;
-use crate::fmt;
 
 #[stable(feature = "c_str_module", since = "1.88.0")]
 pub mod c_str;
@@ -48,6 +47,7 @@ pub use self::primitives::{c_ptrdiff_t, c_size_t, c_ssize_t};
 #[lang = "c_void"]
 #[repr(u8)]
 #[stable(feature = "core_c_void", since = "1.30.0")]
+#[expect(missing_debug_implementations)]
 pub enum c_void {
     #[unstable(
         feature = "c_void_variant",
@@ -63,13 +63,6 @@ pub enum c_void {
     )]
     #[doc(hidden)]
     __variant2,
-}
-
-#[stable(feature = "std_debug", since = "1.16.0")]
-impl fmt::Debug for c_void {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("c_void").finish()
-    }
 }
 
 // Link the MSVC default lib


### PR DESCRIPTION
Taking a shared reference to `c_void` is never correct, and this impl should never have been added.

This is obviously a breaking change, so needs crater and FCP.

@rustbot label T-libs-api needs-fcp A-FFI
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

See also https://github.com/rust-lang/rust/pull/159986, https://github.com/rust-lang/rust/pull/159935