### PR TITLE
GVN: preserve borrowed mutable reference retags

### DIFF
--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -2122,7 +2122,16 @@ impl<'tcx> MutVisitor<'tcx> for VnState<'_, '_, 'tcx> {
             // `local` as reusable if we have an exact type match.
             && self.local_decls[local].ty == rvalue_ty
         {
-            let value = value.unwrap_or_else(|| self.new_opaque(rvalue_ty));
+            // A borrowed mutable-reference local has a distinct retag. Treating it as equivalent
+            // to its source would allow individual uses to be replaced without replacing the
+            // borrow, which can introduce UB.
+            let value = if rvalue_ty.ref_mutability() == Some(Mutability::Mut)
+                && self.ssa.borrowed_locals().contains(local)
+            {
+                self.new_opaque(rvalue_ty)
+            } else {
+                value.unwrap_or_else(|| self.new_opaque(rvalue_ty))
+            };
             self.assign(local, value);
         }
     }

--- a/tests/mir-opt/gvn_mut_ref_retag.main.GVN.diff
+++ b/tests/mir-opt/gvn_mut_ref_retag.main.GVN.diff
@@ -1,0 +1,75 @@
+- // MIR for `main` before GVN
++ // MIR for `main` after GVN
+  
+  fn main() -> () {
+      let mut _0: ();
+      let mut _1: std::string::String;
+      let mut _3: &mut std::string::String;
+      let mut _5: &mut std::string::String;
+      let _6: ();
+      let mut _7: &mut std::string::String;
+      let _8: ();
+      let mut _9: &&mut std::string::String;
+      let _10: &&mut std::string::String;
+      scope 1 {
+          debug value => _1;
+          let _2: *mut std::string::String;
+          scope 2 {
+              debug pointer => _2;
+              let _4: &mut std::string::String;
+              scope 3 {
+                  debug reference => _4;
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);
+          _1 = <String as From<&str>>::from(const "hello") -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageLive(_2);
+          StorageLive(_3);
+          _3 = &mut _1;
+          _2 = &raw mut (*_3);
+          StorageDead(_3);
+          StorageLive(_4);
+          StorageLive(_5);
+          _5 = &mut (*_2);
+          _4 = copy _5;
+          StorageDead(_5);
+          StorageLive(_7);
+          _7 = no_retag copy _4;
+-         _6 = use_mut_ref(move _7) -> [return: bb2, unwind unreachable];
++         _6 = use_mut_ref(copy _4) -> [return: bb2, unwind unreachable];
+      }
+  
+      bb2: {
+          StorageDead(_7);
+          StorageLive(_9);
+          StorageLive(_10);
+          _10 = &_4;
+          _9 = copy _10;
+-         _8 = borrow_mut_ref(move _9) -> [return: bb3, unwind unreachable];
++         _8 = borrow_mut_ref(copy _10) -> [return: bb3, unwind unreachable];
+      }
+  
+      bb3: {
+          StorageDead(_9);
+          StorageDead(_10);
+          StorageDead(_4);
+          StorageDead(_2);
+          drop(_1) -> [return: bb4, unwind unreachable];
+      }
+  
+      bb4: {
+          StorageDead(_1);
+          return;
+      }
+  }
+  
+  ALLOC0 (size: 5, align: 1) {
+      68 65 6c 6c 6f                                  │ hello
+  }
+  

--- a/tests/mir-opt/gvn_mut_ref_retag.rs
+++ b/tests/mir-opt/gvn_mut_ref_retag.rs
@@ -1,0 +1,25 @@
+//@ test-mir-pass: GVN
+//@ compile-flags: -Zmir-opt-level=1 -Cpanic=abort
+
+// EMIT_MIR gvn_mut_ref_retag.main.GVN.diff
+
+fn use_mut_ref(value: &mut String) {
+    value.push_str(" world");
+}
+
+fn borrow_mut_ref(value: &&mut String) {
+    let _value = &**value;
+}
+
+fn main() {
+    // CHECK-LABEL: fn main(
+    // CHECK: [[SOURCE:_.*]] = &mut (*_2);
+    // CHECK: [[REFERENCE:_.*]] = copy [[SOURCE]];
+    // CHECK: _6 = use_mut_ref(copy [[REFERENCE]])
+    let mut value = String::from("hello");
+    let pointer = &mut value as *mut String;
+
+    let reference = unsafe { &mut *pointer };
+    use_mut_ref(reference);
+    borrow_mut_ref(&reference);
+}


### PR DESCRIPTION
Fixes rust-lang/rust#160004.

GVN can currently assign the same value number to a copied mutable reference and its source. If the copied local is later borrowed, selectively replacing one of its uses with the source bypasses the copied local's distinct retag and can introduce undefined behavior.

This change gives borrowed SSA locals of mutable-reference type an opaque value number. The restriction is limited to locals whose address is observed by a borrow, so the existing optimization remains available for other mutable references.

A MIR-opt regression test checks that GVN keeps the copied, retagged reference at the call site.

## Test verification (RED → GREEN)

Upstream `main` with only the regression test:

```text
REFERENCE = _4
actual: _6 = use_mut_ref(copy _5)
test result: FAILED. 0 passed; 1 failed
```

With this patch:

```text
test result: ok. 1 passed; 0 failed
```

Full validation:

```text
./x fmt --check
./x test tidy
./x test tests/mir-opt --force-rerun
test result: ok. 408 passed; 0 failed; 0 ignored
```

The patch was developed with assistance from Codex. I reviewed the final diff and test results.
