### PR TITLE
Remove unnecessary format usage

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -1366,8 +1366,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 if kind1 == kind2 && alias1 == alias2 && !self.tcx.sess.opts.verbose =>
             {
                 let mut strs = (DiagStyledString::new(), DiagStyledString::new());
-                strs.0.push_normal(format!("_"));
-                strs.1.push_normal(format!("_"));
+                strs.0.push_normal("_");
+                strs.1.push_normal("_");
                 strs
             }
 
@@ -1376,14 +1376,14 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 match (alias1.kind, alias2.kind) {
                     (ty::Projection { def_id: def_id1 }, ty::Projection { def_id: def_id2 }) => {
                         // `<Type as Trait>::Name<args>`
-                        values.0.push_normal(format!("<"));
-                        values.1.push_normal(format!("<"));
+                        values.0.push_normal("<");
+                        values.1.push_normal("<");
                         let (trait_ref1, args1) = alias1.trait_ref_and_own_args(self.tcx);
                         let (trait_ref2, args2) = alias2.trait_ref_and_own_args(self.tcx);
                         self.recurse(trait_ref1.self_ty(), trait_ref2.self_ty(), &mut values);
 
-                        values.0.push_normal(format!(" as "));
-                        values.1.push_normal(format!(" as "));
+                        values.0.push_normal(" as ");
+                        values.1.push_normal(" as ");
                         if trait_ref1.def_id == trait_ref2.def_id {
                             if self.tcx.sess.opts.verbose {
                                 values
@@ -1414,8 +1414,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                                 .1
                                 .push_highlighted(format!("{}", trait_ref2.print_trait_sugared()));
                         }
-                        values.0.push_normal(format!(">::"));
-                        values.1.push_normal(format!(">::"));
+                        values.0.push_normal(">::");
+                        values.1.push_normal(">::");
                         let name1 = self.tcx.item_name(def_id1);
                         let name2 = self.tcx.item_name(def_id2);
                         if def_id1 == def_id2 {


### PR DESCRIPTION
## Summary

Remove unnecessary uses of `format!()` in code where simpler alternatives exist in the same file.

For string literals (`format!("_")`, `format!("<")`, etc.): format! invokes the formatting machinery (creates Arguments, calls fmt::Write) only to produce an already-known constant string. Passing `"_"` directly is simpler, faster, and idiomatic.

No behavioral change — only removes redundant formatting calls.

## Test plan

- No new tests needed (no behavioral change)
- Existing UI tests for type mismatch diagnostics continue to pass