### PR TITLE
fix query cycle in `coroutine_hidden_types` for the next solver

### DIFF
--- a/compiler/rustc_traits/src/coroutine_witnesses.rs
+++ b/compiler/rustc_traits/src/coroutine_witnesses.rs
@@ -47,11 +47,18 @@ pub(crate) fn coroutine_hidden_types<'tcx>(
     )
 }
 
+// FIXME: The assumptions are only used in the old solver when `-Zhigher-ranked-assumptions`
+// is true. `-Zhigher-ranked-assumptions` is superseded by `assumptions-on-binders`.
+// We can remove this function soon.
 fn compute_assumptions<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: DefId,
     bound_tys: &'tcx ty::List<Ty<'tcx>>,
 ) -> &'tcx ty::List<ty::ArgOutlivesPredicate<'tcx>> {
+    if tcx.next_trait_solver_globally() || !tcx.sess.opts.unstable_opts.higher_ranked_assumptions {
+        return &ty::List::empty();
+    }
+
     let infcx = tcx
         .infer_ctxt()
         .build(ty::TypingMode::Typeck { defining_opaque_types_and_generators: ty::List::empty() });

--- a/tests/ui/traits/next-solver/coroutine_query_cycle.rs
+++ b/tests/ui/traits/next-solver/coroutine_query_cycle.rs
@@ -1,0 +1,20 @@
+//@ compile-flags: -Znext-solver
+//@ edition: 2024
+//@ check-pass
+
+// Regression test for trait-system-refactor-initiative#282
+// Previously we always computed higher ranked assumptions for coroutines.
+// It led to query cycle in recursive functions like the one below.
+// Thoses assumptions are not used in the next solver and
+// the functionality is superseded by `assumptions-on-binders`.
+
+fn go() -> impl Future + Send + 'static {
+    spawn(async {
+        go().await;
+    })
+}
+fn spawn(_: impl Future + Send + 'static) -> impl Future {
+    async {}
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/282

When computing assumptions for coroutine hidden types, we are required to prove the `Send` bound on the same coroutine type again thus the query cycle.
We can just disable the higher-ranked-assumptions feature for the next solver.

r? @ShoyuVanilla 
cc @lcnr