### PR TITLE
add additional license option for third-party dependencies

### DIFF
--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -38,6 +38,7 @@ macro_rules! location {
 #[rustfmt::skip]
 const LICENSES: &[&str] = &[
     // tidy-alphabetical-start
+    "(MIT OR Apache-2.0) AND MIT",
     "0BSD OR MIT OR Apache-2.0",                           // adler2 license
     "Apache-2.0 / MIT",
     "Apache-2.0 OR ISC OR MIT",


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
This license will be required by one of our dependencies. Specifically https://github.com/mattico/elasticlunr-rs/commit/46d35f0fef5f481c440d894be2ecdac9b9625ecb.
See the failure in https://github.com/rust-lang/rust/pull/160121#issuecomment-5114398465.

Note that we already accept `MIT AND (MIT OR Apache-2.0)` so this is just another way of writing the same license.
<!-- homu-ignore:end -->
