### PR TITLE
Structurally prevent zero-count `BackendRepr::SimdVector`s

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Write};
+use std::num::NonZero;
 use std::ops::Deref;
 use std::range::{RangeFrom, RangeInclusive, RangeToInclusive};
 use std::{cmp, iter};
@@ -9,8 +10,8 @@ use rustc_index::bit_set::BitMatrix;
 use tracing::{debug, trace};
 
 use crate::{
-    AbiAlign, Align, BackendRepr, FieldsShape, HasDataLayout, IndexSlice, IndexVec, Integer,
-    LayoutData, Niche, NonZeroUsize, NumScalableVectors, Primitive, ReprOptions, Scalar, Size,
+    AbiAlign, Align, BackendLaneCount, BackendRepr, FieldsShape, HasDataLayout, IndexSlice,
+    IndexVec, Integer, LayoutData, Niche, NumScalableVectors, Primitive, ReprOptions, Scalar, Size,
     StructKind, TagEncoding, TargetDataLayout, VariantLayout, Variants, WrappingRange,
 };
 
@@ -127,7 +128,7 @@ pub enum LayoutCalculatorError<F> {
     ZeroLengthSimdType,
 
     /// The length of an SIMD type exceeds the maximum number of lanes
-    OversizedSimdType { max_lanes: u64 },
+    OversizedSimdType { max_lanes: usize },
 
     /// An element type of an SIMD type isn't a primitive
     NonPrimitiveSimdType(F),
@@ -495,7 +496,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
             },
         };
 
-        let Some(union_field_count) = NonZeroUsize::new(only_variant.len()) else {
+        let Some(union_field_count) = NonZero::new(only_variant.len()) else {
             return Err(LayoutCalculatorError::EmptyUnion);
         };
 
@@ -1476,19 +1477,17 @@ where
     F: AsRef<LayoutData<FieldIdx, VariantIdx>> + fmt::Debug,
 {
     let elt = element.as_ref();
-    if count == 0 {
-        return Err(LayoutCalculatorError::ZeroLengthSimdType);
-    } else if count > crate::MAX_SIMD_LANES {
-        return Err(LayoutCalculatorError::OversizedSimdType { max_lanes: crate::MAX_SIMD_LANES });
-    }
+    let count = BackendLaneCount::new(count)?;
 
     let BackendRepr::Scalar(element) = elt.backend_repr else {
         return Err(LayoutCalculatorError::NonPrimitiveSimdType(element));
     };
 
     // Compute the size and alignment of the vector
-    let size =
-        elt.size.checked_mul(count, dl).ok_or_else(|| LayoutCalculatorError::SizeOverflow)?;
+    let size = elt
+        .size
+        .checked_mul(count.as_u64(), dl)
+        .ok_or_else(|| LayoutCalculatorError::SizeOverflow)?;
     let (repr, size, align) = match kind {
         SimdVectorKind::Scalable(number_of_vectors) => (
             BackendRepr::SimdScalableVector { element, count, number_of_vectors },
@@ -1521,6 +1520,6 @@ where
         align: AbiAlign::new(align),
         max_repr_align: None,
         unadjusted_abi_align: elt.align.abi,
-        randomization_seed: elt.randomization_seed.wrapping_add(Hash64::new(count)),
+        randomization_seed: elt.randomization_seed.wrapping_add(Hash64::new(count.as_u64())),
     })
 }

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -40,7 +40,7 @@ use std::cmp::min;
 use std::fmt;
 #[cfg(feature = "nightly")]
 use std::iter::Step;
-use std::num::{NonZeroUsize, ParseIntError};
+use std::num::{NonZero, ParseIntError};
 use std::ops::{Add, AddAssign, Deref, Mul, Sub};
 use std::range::RangeInclusive;
 use std::str::FromStr;
@@ -244,7 +244,42 @@ impl ReprOptions {
 /// This value is selected based on backend support:
 /// * LLVM does not appear to have a vector width limit.
 /// * Cranelift stores the base-2 log of the lane count in a 4 bit integer.
-pub const MAX_SIMD_LANES: u64 = 1 << 0xF;
+pub const MAX_SIMD_LANES: u16 = 1 << 0xF;
+
+/// The number of lanes in a [`BackendRepr::SimdVector`], `1..=`[`MAX_SIMD_LANES`].
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "nightly", derive(Encodable_NoContext, Decodable_NoContext, StableHash))]
+pub struct BackendLaneCount(NonZero<u16>);
+
+impl BackendLaneCount {
+    pub fn new<N>(count: u64) -> Result<Self, LayoutCalculatorError<N>> {
+        let Ok(count @ ..=MAX_SIMD_LANES) = u16::try_from(count) else {
+            return Err(LayoutCalculatorError::OversizedSimdType {
+                max_lanes: crate::MAX_SIMD_LANES.into(),
+            });
+        };
+        if let Some(count) = NonZero::new(count) {
+            Ok(BackendLaneCount(count))
+        } else {
+            Err(LayoutCalculatorError::ZeroLengthSimdType)
+        }
+    }
+
+    #[inline]
+    pub fn is_power_of_two(self) -> bool {
+        self.0.is_power_of_two()
+    }
+
+    #[inline]
+    pub fn as_u64(self) -> u64 {
+        self.0.get().into()
+    }
+
+    #[inline]
+    pub fn as_u32(self) -> u32 {
+        self.0.get().into()
+    }
+}
 
 /// How pointers are represented in a given address space
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -1611,7 +1646,7 @@ pub enum FieldsShape<FieldIdx: Idx> {
     Primitive,
 
     /// All fields start at no offset. The `usize` is the field count.
-    Union(NonZeroUsize),
+    Union(NonZero<usize>),
 
     /// Array/vector-like placement, with all fields of identical types.
     Array { stride: Size, count: u64 },
@@ -1770,12 +1805,12 @@ pub enum BackendRepr {
     },
     SimdScalableVector {
         element: Scalar,
-        count: u64,
+        count: BackendLaneCount,
         number_of_vectors: NumScalableVectors,
     },
     SimdVector {
         element: Scalar,
-        count: u64,
+        count: BackendLaneCount,
     },
     // FIXME: I sometimes use memory, sometimes use an IR aggregate!
     Memory {
@@ -2260,7 +2295,7 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
     }
 
     /// Returns the elements count of a scalable vector.
-    pub fn scalable_vector_element_count(&self) -> Option<u64> {
+    pub fn scalable_vector_element_count(&self) -> Option<BackendLaneCount> {
         match self.backend_repr {
             BackendRepr::SimdScalableVector { count, .. } => Some(count),
             _ => None,

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -60,7 +60,7 @@ pub(crate) fn clif_vector_type<'tcx>(tcx: TyCtxt<'tcx>, layout: TyAndLayout<'tcx
         _ => unreachable!(),
     };
 
-    scalar_to_clif_type(tcx, element).by(u32::try_from(count).unwrap()).unwrap()
+    scalar_to_clif_type(tcx, element).by(count.as_u32()).unwrap()
 }
 
 fn simd_for_each_lane<'tcx>(

--- a/compiler/rustc_codegen_cranelift/src/value_and_place.rs
+++ b/compiler/rustc_codegen_cranelift/src/value_and_place.rs
@@ -132,9 +132,7 @@ impl<'tcx> CValue<'tcx> {
                 let clif_ty = match layout.backend_repr {
                     BackendRepr::Scalar(scalar) => scalar_to_clif_type(fx.tcx, scalar),
                     BackendRepr::SimdVector { element, count } => {
-                        scalar_to_clif_type(fx.tcx, element)
-                            .by(u32::try_from(count).unwrap())
-                            .unwrap()
+                        scalar_to_clif_type(fx.tcx, element).by(count.as_u32()).unwrap()
                     }
                     _ => unreachable!("{:?}", layout.ty),
                 };

--- a/compiler/rustc_codegen_gcc/src/type_of.rs
+++ b/compiler/rustc_codegen_gcc/src/type_of.rs
@@ -73,7 +73,7 @@ fn uncached_gcc_type<'gcc, 'tcx>(
                 else {
                     element
                 };
-            return cx.context.new_vector_type(element, count);
+            return cx.context.new_vector_type(element, count.as_u64());
         }
         BackendRepr::ScalarPair { .. } => {
             return cx.type_struct(

--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -1119,8 +1119,9 @@ fn llvm_fixup_input<'ll, 'tcx>(
             BackendRepr::SimdVector { element, count },
         ) if layout.size.bytes() == 8 => {
             let elem_ty = llvm_asm_scalar_type(bx.cx, element);
-            let vec_ty = bx.cx.type_vector(elem_ty, count);
-            let indices: Vec<_> = (0..count * 2).map(|x| bx.const_i32(x as i32)).collect();
+            let count = count.as_u32();
+            let vec_ty = bx.cx.type_vector(elem_ty, u64::from(count));
+            let indices: Vec<_> = (0..count * 2).map(|x| bx.const_u32(x)).collect();
             bx.shuffle_vector(value, bx.const_undef(vec_ty), bx.const_vector(&indices))
         }
         (X86(X86InlineAsmRegClass::reg_abcd), BackendRepr::Scalar(s))
@@ -1165,8 +1166,11 @@ fn llvm_fixup_input<'ll, 'tcx>(
                 | X86InlineAsmRegClass::ymm_reg
                 | X86InlineAsmRegClass::zmm_reg,
             ),
-            BackendRepr::SimdVector { element, count: count @ (8 | 16) },
-        ) if element.primitive() == Primitive::Float(Float::F16) => {
+            BackendRepr::SimdVector { element, count },
+        ) if let count = count.as_u64()
+            && let 8 | 16 = count
+            && element.primitive() == Primitive::Float(Float::F16) =>
+        {
             bx.bitcast(value, bx.type_vector(bx.type_i16(), count))
         }
         (
@@ -1202,8 +1206,11 @@ fn llvm_fixup_input<'ll, 'tcx>(
                 | ArmInlineAsmRegClass::qreg_low4
                 | ArmInlineAsmRegClass::qreg_low8,
             ),
-            BackendRepr::SimdVector { element, count: count @ (4 | 8) },
-        ) if element.primitive() == Primitive::Float(Float::F16) => {
+            BackendRepr::SimdVector { element, count },
+        ) if let count = count.as_u64()
+            && let 4 | 8 = count
+            && element.primitive() == Primitive::Float(Float::F16) =>
+        {
             bx.bitcast(value, bx.type_vector(bx.type_i16(), count))
         }
         (LoongArch(LoongArchInlineAsmRegClass::freg), BackendRepr::Scalar(s))
@@ -1291,6 +1298,7 @@ fn llvm_fixup_output<'ll, 'tcx>(
             BackendRepr::SimdVector { element, count },
         ) if layout.size.bytes() == 8 => {
             let elem_ty = llvm_asm_scalar_type(bx.cx, element);
+            let count = count.as_u64();
             let vec_ty = bx.cx.type_vector(elem_ty, count * 2);
             let indices: Vec<_> = (0..count).map(|x| bx.const_i32(x as i32)).collect();
             bx.shuffle_vector(value, bx.const_undef(vec_ty), bx.const_vector(&indices))
@@ -1333,8 +1341,11 @@ fn llvm_fixup_output<'ll, 'tcx>(
                 | X86InlineAsmRegClass::ymm_reg
                 | X86InlineAsmRegClass::zmm_reg,
             ),
-            BackendRepr::SimdVector { element, count: count @ (8 | 16) },
-        ) if element.primitive() == Primitive::Float(Float::F16) => {
+            BackendRepr::SimdVector { element, count },
+        ) if let count = count.as_u64()
+            && let 8 | 16 = count
+            && element.primitive() == Primitive::Float(Float::F16) =>
+        {
             bx.bitcast(value, bx.type_vector(bx.type_f16(), count))
         }
         (
@@ -1370,8 +1381,11 @@ fn llvm_fixup_output<'ll, 'tcx>(
                 | ArmInlineAsmRegClass::qreg_low4
                 | ArmInlineAsmRegClass::qreg_low8,
             ),
-            BackendRepr::SimdVector { element, count: count @ (4 | 8) },
-        ) if element.primitive() == Primitive::Float(Float::F16) => {
+            BackendRepr::SimdVector { element, count },
+        ) if let count = count.as_u64()
+            && let 4 | 8 = count
+            && element.primitive() == Primitive::Float(Float::F16) =>
+        {
             bx.bitcast(value, bx.type_vector(bx.type_f16(), count))
         }
         (LoongArch(LoongArchInlineAsmRegClass::freg), BackendRepr::Scalar(s))
@@ -1445,7 +1459,7 @@ fn llvm_fixup_output_type<'ll, 'tcx>(
             BackendRepr::SimdVector { element, count },
         ) if layout.size.bytes() == 8 => {
             let elem_ty = llvm_asm_scalar_type(cx, element);
-            cx.type_vector(elem_ty, count * 2)
+            cx.type_vector(elem_ty, count.as_u64() * 2)
         }
         (X86(X86InlineAsmRegClass::reg_abcd), BackendRepr::Scalar(s))
             if s.primitive() == Primitive::Float(Float::F64) =>
@@ -1482,8 +1496,11 @@ fn llvm_fixup_output_type<'ll, 'tcx>(
                 | X86InlineAsmRegClass::ymm_reg
                 | X86InlineAsmRegClass::zmm_reg,
             ),
-            BackendRepr::SimdVector { element, count: count @ (8 | 16) },
-        ) if element.primitive() == Primitive::Float(Float::F16) => {
+            BackendRepr::SimdVector { element, count },
+        ) if let count = count.as_u64()
+            && let 8 | 16 = count
+            && element.primitive() == Primitive::Float(Float::F16) =>
+        {
             cx.type_vector(cx.type_i16(), count)
         }
         (
@@ -1519,8 +1536,11 @@ fn llvm_fixup_output_type<'ll, 'tcx>(
                 | ArmInlineAsmRegClass::qreg_low4
                 | ArmInlineAsmRegClass::qreg_low8,
             ),
-            BackendRepr::SimdVector { element, count: count @ (4 | 8) },
-        ) if element.primitive() == Primitive::Float(Float::F16) => {
+            BackendRepr::SimdVector { element, count },
+        ) if let count = count.as_u64()
+            && let 4 | 8 = count
+            && element.primitive() == Primitive::Float(Float::F16) =>
+        {
             cx.type_vector(cx.type_i16(), count)
         }
         (LoongArch(LoongArchInlineAsmRegClass::freg), BackendRepr::Scalar(s))

--- a/compiler/rustc_codegen_llvm/src/type_.rs
+++ b/compiler/rustc_codegen_llvm/src/type_.rs
@@ -64,8 +64,8 @@ impl<'ll, CX: Borrow<SCx<'ll>>> GenericCx<'ll, CX> {
         llvm::LLVMIntTypeInContext(self.llcx(), num_bits as c_uint)
     }
 
-    pub(crate) fn type_vector(&self, ty: &'ll Type, len: u64) -> &'ll Type {
-        unsafe { llvm::LLVMVectorType(ty, len as c_uint) }
+    pub(crate) fn type_vector(&self, ty: &'ll Type, count: u64) -> &'ll Type {
+        unsafe { llvm::LLVMVectorType(ty, count as c_uint) }
     }
 
     pub(crate) fn type_scalable_vector(&self, ty: &'ll Type, count: u64) -> &'ll Type {

--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -22,7 +22,7 @@ fn uncached_llvm_type<'a, 'tcx>(
         BackendRepr::Scalar(_) => bug!("handled elsewhere"),
         BackendRepr::SimdVector { element, count } => {
             let element = layout.scalar_llvm_type_at(cx, element);
-            return cx.type_vector(element, count);
+            return cx.type_vector(element, count.as_u64());
         }
         BackendRepr::SimdScalableVector { ref element, count, number_of_vectors } => {
             let element = if element.is_bool() {
@@ -31,7 +31,7 @@ fn uncached_llvm_type<'a, 'tcx>(
                 layout.scalar_llvm_type_at(cx, *element)
             };
 
-            let vector_type = cx.type_scalable_vector(element, count);
+            let vector_type = cx.type_scalable_vector(element, count.as_u64());
             return match number_of_vectors.0 {
                 1 => vector_type,
                 2 => cx.type_struct(&[vector_type, vector_type], false),

--- a/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
+++ b/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
@@ -124,7 +124,7 @@ fn check_validity_requirement_lax<'tcx>(
             BackendRepr::ScalarPair { a: s1, b: s2, b_offset: _ } => {
                 scalar_allows_raw_init(s1) && scalar_allows_raw_init(s2)
             }
-            BackendRepr::SimdVector { element: s, count } => count == 0 || scalar_allows_raw_init(s),
+            BackendRepr::SimdVector { element: s, count: _ } => scalar_allows_raw_init(s),
             BackendRepr::Memory { .. } => true, // Fields are checked below.
             BackendRepr::SimdScalableVector { element, .. } => scalar_allows_raw_init(element),
         };

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -25,6 +25,7 @@
 #![feature(min_specialization)]
 #![feature(negative_impls)]
 #![feature(never_type)]
+#![feature(nonzero_internals)]
 #![feature(pattern_type_macro)]
 #![feature(pattern_types)]
 #![feature(ptr_alignment_type)]

--- a/compiler/rustc_data_structures/src/stable_hash.rs
+++ b/compiler/rustc_data_structures/src/stable_hash.rs
@@ -238,14 +238,7 @@ impl<T> StableHash for PhantomData<T> {
     fn stable_hash<Hcx>(&self, _hcx: &mut Hcx, _hasher: &mut StableHasher) {}
 }
 
-impl StableHash for NonZero<u32> {
-    #[inline]
-    fn stable_hash<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
-        self.get().stable_hash(hcx, hasher)
-    }
-}
-
-impl StableHash for NonZero<usize> {
+impl<T: StableHash + std::num::ZeroablePrimitive> StableHash for NonZero<T> {
     #[inline]
     fn stable_hash<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.get().stable_hash(hcx, hasher)

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1,7 +1,7 @@
 use std::cell::LazyCell;
 use std::ops::ControlFlow;
 
-use rustc_abi::{ExternAbi, FieldIdx, ScalableElt};
+use rustc_abi::{ExternAbi, FieldIdx, MAX_SIMD_LANES, ScalableElt};
 use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_errors::codes::*;
 use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, MultiSpan};
@@ -17,7 +17,7 @@ use rustc_middle::hir::nested_filter;
 use rustc_middle::middle::resolve_bound_vars::ResolvedArg;
 use rustc_middle::middle::stability::EvalResult;
 use rustc_middle::ty::error::TypeErrorToStringExt;
-use rustc_middle::ty::layout::{LayoutError, MAX_SIMD_LANES};
+use rustc_middle::ty::layout::LayoutError;
 use rustc_middle::ty::util::Discr;
 use rustc_middle::ty::{
     AdtDef, BottomUpFolder, FnSig, GenericArgKind, RegionKind, TypeFoldable, TypeSuperVisitable,
@@ -1493,7 +1493,7 @@ fn check_simd(tcx: TyCtxt<'_>, sp: Span, def_id: LocalDefId) {
             if len == 0 {
                 struct_span_code_err!(tcx.dcx(), sp, E0075, "SIMD vector cannot be empty").emit();
                 return;
-            } else if len > MAX_SIMD_LANES {
+            } else if len > MAX_SIMD_LANES.into() {
                 struct_span_code_err!(
                     tcx.dcx(),
                     sp,

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -196,8 +196,6 @@ pub const WIDE_PTR_ADDR: usize = 0;
 /// - For a slice, this is the length.
 pub const WIDE_PTR_EXTRA: usize = 1;
 
-pub const MAX_SIMD_LANES: u64 = rustc_abi::MAX_SIMD_LANES;
-
 /// Used in `check_validity_requirement` to indicate the kind of initialization
 /// that is checked to be valid
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, StableHash)]
@@ -239,7 +237,7 @@ pub enum SimdLayoutError {
     ZeroLength,
     /// The vector has more lanes than supported or permitted by
     /// #\[rustc_simd_monomorphize_lane_limit\].
-    TooManyLanes(u64),
+    TooManyLanes(Limit),
 }
 
 #[derive(Copy, Clone, Debug, StableHash, TyEncodable, TyDecodable)]

--- a/compiler/rustc_public/src/unstable/convert/stable/abi.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/abi.rs
@@ -261,6 +261,18 @@ impl<'tcx> Stable<'tcx> for rustc_abi::NumScalableVectors {
     }
 }
 
+impl<'tcx> Stable<'tcx> for rustc_abi::BackendLaneCount {
+    type T = u64;
+
+    fn stable<'cx>(
+        &self,
+        _tables: &mut Tables<'cx, BridgeTys>,
+        _cx: &CompilerCtxt<'cx, BridgeTys>,
+    ) -> Self::T {
+        self.as_u64()
+    }
+}
+
 impl<'tcx> Stable<'tcx> for rustc_abi::BackendRepr {
     type T = ValueAbi;
 
@@ -278,13 +290,14 @@ impl<'tcx> Stable<'tcx> for rustc_abi::BackendRepr {
                     b_offset: second_offset.stable(tables, cx),
                 }
             }
-            rustc_abi::BackendRepr::SimdVector { element, count } => {
-                ValueAbi::Vector { element: element.stable(tables, cx), count }
-            }
+            rustc_abi::BackendRepr::SimdVector { element, count } => ValueAbi::Vector {
+                element: element.stable(tables, cx),
+                count: count.stable(tables, cx),
+            },
             rustc_abi::BackendRepr::SimdScalableVector { element, count, number_of_vectors } => {
                 ValueAbi::ScalableVector {
                     element: element.stable(tables, cx),
-                    count,
+                    count: count.stable(tables, cx),
                     number_of_vectors: number_of_vectors.stable(tables, cx),
                 }
             }

--- a/compiler/rustc_serialize/src/lib.rs
+++ b/compiler/rustc_serialize/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(core_intrinsics)]
 #![feature(min_specialization)]
 #![feature(never_type)]
+#![feature(nonzero_internals)]
 #![feature(sized_hierarchy)]
 // tidy-alphabetical-end
 

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -5,7 +5,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::hash::{BuildHasher, Hash};
 use std::marker::{PhantomData, PointeeSized};
-use std::num::NonZero;
+use std::num::{NonZero, ZeroablePrimitive};
 use std::path;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -241,15 +241,15 @@ impl<D: Decoder> Decodable<D> for ! {
     }
 }
 
-impl<S: Encoder> Encodable<S> for NonZero<u32> {
+impl<T: ZeroablePrimitive + Encodable<S>, S: Encoder> Encodable<S> for NonZero<T> {
     fn encode(&self, s: &mut S) {
-        s.emit_u32(self.get());
+        self.get().encode(s)
     }
 }
 
-impl<D: Decoder> Decodable<D> for NonZero<u32> {
+impl<T: ZeroablePrimitive + Decodable<D>, D: Decoder> Decodable<D> for NonZero<T> {
     fn decode(d: &mut D) -> Self {
-        NonZero::new(d.read_u32()).unwrap()
+        NonZero::new(T::decode(d)).unwrap()
     }
 }
 

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -9,6 +9,7 @@ use rustc_abi::{
     LayoutCalculatorError, LayoutData, Niche, ReprOptions, Scalar, Size, StructKind, TagEncoding,
     VariantIdx, Variants, WrappingRange,
 };
+use rustc_data_structures::Limit;
 use rustc_hashes::Hash64;
 use rustc_hir as hir;
 use rustc_hir::find_attr;
@@ -156,7 +157,7 @@ fn map_error<'tcx>(
         }
         LayoutCalculatorError::OversizedSimdType { max_lanes } => {
             // Can't be caught in typeck if the array length is generic.
-            LayoutError::InvalidSimd { ty, kind: SimdLayoutError::TooManyLanes(max_lanes) }
+            LayoutError::InvalidSimd { ty, kind: SimdLayoutError::TooManyLanes(Limit(max_lanes)) }
         }
         LayoutCalculatorError::NonPrimitiveSimdType(field) => {
             // This error isn't caught in typeck, e.g., if
@@ -678,9 +679,7 @@ fn layout_of_uncached<'tcx>(
                     return Err(map_error(
                         &cx,
                         ty,
-                        rustc_abi::LayoutCalculatorError::OversizedSimdType {
-                            max_lanes: limit.0 as u64,
-                        },
+                        rustc_abi::LayoutCalculatorError::OversizedSimdType { max_lanes: limit.0 },
                     ));
                 }
             }

--- a/compiler/rustc_ty_utils/src/layout/invariant.rs
+++ b/compiler/rustc_ty_utils/src/layout/invariant.rs
@@ -276,7 +276,7 @@ pub(super) fn layout_sanity_check<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayou
                 // Currently, vectors must always be aligned to at least their elements:
                 assert!(align >= element_align);
                 // And the size has to be element * count plus alignment padding, of course
-                assert!(size == (element_size * count).align_to(align));
+                assert!(size == (element_size * count.as_u64()).align_to(align));
             }
             BackendRepr::Memory { .. } | BackendRepr::SimdScalableVector { .. } => {} // Nothing to check.
         }

--- a/src/tools/clippy/clippy_utils/src/ty/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ty/mod.rs
@@ -532,7 +532,7 @@ fn is_uninit_value_valid_for_layout<'tcx>(cx: &LateContext<'tcx>, layout: TyAndL
     match layout.layout.backend_repr {
         BackendRepr::Scalar(s) => s.is_uninit_valid(),
         BackendRepr::ScalarPair { a, b, .. } => a.is_uninit_valid() && b.is_uninit_valid(),
-        BackendRepr::SimdVector { element, count } => count == 0 || element.is_uninit_valid(),
+        BackendRepr::SimdVector { element, count: _ } => element.is_uninit_valid(),
         BackendRepr::SimdScalableVector { element, .. } => element.is_uninit_valid(),
         // Here validity is determined by the structural fields instead.
         BackendRepr::Memory { .. } => match &layout.layout.variants {


### PR DESCRIPTION
This is already *supposed* to be impossible in layout, but this emphasizes that better.  This PR makes no behaviour changes; just `BackendLaneCount` instead of `u64` in https://doc.rust-lang.org/nightly/nightly-rustc/rustc_abi/enum.BackendRepr.html

Ironically I was inspired to do this as part of [looking at making `Simd<T, 0>` *work*](https://rust-lang.zulipchat.com/#narrow/channel/257879-project-portable-simd/topic/Allow.20N.3D.3D0.3F/with/613345298), but importantly if that's going to happen I think it should be `BackendRepr::Memory` like other ZSTs, *not* a `BackendRepr::ScalarVector` that would need to carry around a useless LLVM value in `OperandValue::Immediate` (where it's not even clear what the LLVM type of that value would be).
