### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -641,7 +641,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // Unlike all the other GC helpers where we check if an `AllocId` is found in the interpreter or
         // is live, here all the IDs in the map are for dead allocations so we don't
         // need to check for liveness.
-        #[allow(rustc::potential_query_instability)] // Only used from Miri, not queries.
         self.memory.dead_alloc_map.retain(|id, _| reachable_allocs.contains(id));
     }
 }

--- a/compiler/rustc_macros/src/diagnostics/subdiagnostic.rs
+++ b/compiler/rustc_macros/src/diagnostics/subdiagnostic.rs
@@ -92,8 +92,6 @@ impl SubdiagnosticDerive {
 
         let diag = &self.diag;
 
-        // FIXME(edition_2024): Fix the `keyword_idents_2024` lint to not trigger here?
-        #[allow(keyword_idents_2024)]
         let ret = structure.gen_impl(quote! {
             gen impl rustc_errors::Subdiagnostic for @Self {
                 fn add_to_diag<__G>(

--- a/compiler/rustc_macros/src/lib.rs
+++ b/compiler/rustc_macros/src/lib.rs
@@ -1,5 +1,4 @@
 // tidy-alphabetical-start
-#![allow(rustc::default_hash_types)]
 #![feature(never_type)]
 #![feature(proc_macro_diagnostic)]
 #![feature(proc_macro_tracked_env)]

--- a/compiler/rustc_macros/src/print_attribute.rs
+++ b/compiler/rustc_macros/src/print_attribute.rs
@@ -120,7 +120,6 @@ pub(crate) fn print_attribute(input: Structure<'_>) -> TokenStream {
         }
     };
 
-    #[allow(keyword_idents_2024)]
     input.gen_impl(quote! {
         #[allow(unused)]
         gen impl PrintAttribute for @Self {

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1407,7 +1407,7 @@ where
     ) -> QueryResultOrRerunNonErased<I> {
         self.inspect.make_canonical_response(shallow_certainty);
 
-        let goals_certainty = self.try_evaluate_added_goals()?;
+        let added_goals_certainty = self.try_evaluate_added_goals()?;
         assert_eq!(
             self.tainted,
             Ok(()),
@@ -1415,11 +1415,8 @@ where
             previous call to `try_evaluate_added_goals!`"
         );
 
-        let goals_certainty = match self.delegate.cx().assumptions_on_binders() {
-            true => {
-                let certainty = self.eagerly_handle_placeholders()?;
-                certainty.and(goals_certainty)
-            }
+        let placeholder_certainty = match self.delegate.cx().assumptions_on_binders() {
+            true => self.eagerly_handle_placeholders()?,
             false => {
                 // We only check for leaks from universes which were entered inside
                 // of the query.
@@ -1428,9 +1425,10 @@ where
                     NoSolution
                 })?;
 
-                goals_certainty
+                Certainty::Yes
             }
         };
+        let goals_certainty = placeholder_certainty.and(added_goals_certainty);
 
         let (certainty, normalization_nested_goals) =
             match (self.current_goal_kind, shallow_certainty) {
@@ -1444,12 +1442,13 @@ where
                 (CurrentGoalKind::ProjectionComputeAssocTermCandidate, Certainty::Yes) => {
                     let goals = std::mem::take(&mut self.nested_goals);
                     // As we return all ambiguous nested goals, we can ignore the certainty
-                    // returned by `self.try_evaluate_added_goals()`.
+                    // returned by `self.try_evaluate_added_goals()`. However, placeholder
+                    // handling may independently be ambiguous, so preserve its certainty.
                     if goals.is_empty() {
-                        assert!(matches!(goals_certainty, Certainty::Yes));
+                        assert!(matches!(added_goals_certainty, Certainty::Yes));
                     }
                     (
-                        Certainty::Yes,
+                        placeholder_certainty,
                         NestedNormalizationGoals(
                             goals.into_iter().map(|(s, g, _)| (s, g)).collect(),
                         ),

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -3,7 +3,7 @@
 //! [`rustc`] module.
 
 // tidy-alphabetical-start
-#![allow(unused_crate_dependencies)]
+#![cfg_attr(test, allow(unused_crate_dependencies))] // Used for integration tests, not unit tests
 // tidy-alphabetical-end
 
 pub(crate) mod checks;

--- a/compiler/rustc_session/src/config/sigpipe.rs
+++ b/compiler/rustc_session/src/config/sigpipe.rs
@@ -5,21 +5,17 @@
 ///
 /// Note that `SIG_IGN` has been the Rust default since 2014. See
 /// <https://github.com/rust-lang/rust/issues/62569>.
-#[allow(dead_code)]
 pub const DEFAULT: u8 = 0;
 
 /// Do not touch `SIGPIPE`. Use whatever the parent process uses.
-#[allow(dead_code)]
 pub const INHERIT: u8 = 1;
 
 /// Change `SIGPIPE` to `SIG_IGN` so that failed writes results in `EPIPE`
 /// that are eventually converted to `ErrorKind::BrokenPipe`.
-#[allow(dead_code)]
 pub const SIG_IGN: u8 = 2;
 
 /// Change `SIGPIPE` to `SIG_DFL` so that the process is killed when trying
 /// to write to a closed pipe. This is usually the desired behavior for CLI
 /// apps that produce textual output that you want to pipe to other programs
 /// such as `head -n 1`.
-#[allow(dead_code)]
 pub const SIG_DFL: u8 = 3;

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -4639,7 +4639,7 @@ pub struct StdSemverCheck {
     commit: String,
 }
 
-impl Step for StdSemverCheck {
+impl CommandLineStep for StdSemverCheck {
     type Output = ();
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -13,6 +13,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, fs, iter};
 
+use build_helper::git::get_closest_upstream_commit;
+
 use crate::core::build_steps::compile::{ArtifactKeepMode, Std, run_cargo};
 use crate::core::build_steps::doc::{DocumentationFormat, prepare_doc_compiler};
 use crate::core::build_steps::gcc::{Gcc, GccTargetPair, add_cg_gcc_cargo_flags};
@@ -4611,5 +4613,92 @@ impl CommandLineStep for RemoteTestClientTests {
             builder,
             record_failed_tests,
         );
+    }
+}
+
+fn check_if_cargo_semver_checks_is_installed(builder: &Builder<'_>) -> bool {
+    command("cargo")
+        .allow_failure()
+        .arg("semver-checks")
+        .arg("--version")
+        // Cache the output to avoid running this command more than once (per builder).
+        .cached()
+        .run_capture_stdout(builder)
+        .is_success()
+}
+
+/// Run cargo-semver-checks on the standard library and compare its API
+/// versus a previous baseline, using rustdoc JSON data.
+///
+/// Fails if a semver-breaking change is detected.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StdSemverCheck {
+    build_compiler: Compiler,
+    target: TargetSelection,
+    /// The baseline commit that we are comparing the local stdlib API against.
+    commit: String,
+}
+
+impl Step for StdSemverCheck {
+    type Output = ();
+
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        run.alias("std-semver-check")
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        if !check_if_cargo_semver_checks_is_installed(run.builder) {
+            panic!("cargo-semver-checks was not found, please install it");
+        }
+
+        let baseline_commit = match get_closest_upstream_commit(
+            Some(&run.builder.config.src),
+            &run.builder.config.git_config(),
+            run.builder.config.ci_env,
+        ) {
+            Ok(Some(commit)) => commit,
+            Ok(None) => {
+                panic!("No baseline parent commit found for std-semver-check");
+            }
+            Err(error) => {
+                panic!("Cannot get baseline parent commit for std-semver-check: {error:?}");
+            }
+        };
+
+        run.builder.ensure(Self {
+            build_compiler: run.builder.compiler_for_std(run.builder.top_stage),
+            target: run.target,
+            commit: baseline_commit,
+        });
+    }
+
+    fn run(self, builder: &Builder<'_>) {
+        let Some(docs_dir) = builder.config.download_std_json_docs(self.target, &self.commit)
+        else {
+            return;
+        };
+
+        let directory = builder.ensure(crate::core::build_steps::doc::Std::from_build_compiler(
+            self.build_compiler,
+            self.target,
+            DocumentationFormat::Json,
+        ));
+        let baseline_dir = docs_dir.join("share").join("doc").join("rust").join("json");
+
+        for library in ["core", "alloc", "std"] {
+            println!("Checking semver compatibility of {library}");
+            let mut cmd = command("cargo");
+            cmd.arg("semver-checks")
+                .arg("-Z")
+                .arg("unstable-options")
+                .arg("--stability-aware")
+                .arg("--release-type")
+                .arg("minor")
+                .arg("--current-rustdoc")
+                .arg(directory.join(format!("{library}.json")))
+                .arg("--baseline-rustdoc")
+                .arg(baseline_dir.join(format!("{library}.json")));
+            cmd.run(builder);
+        }
     }
 }

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_semver_check.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_semver_check.snap
@@ -1,0 +1,7 @@
+---
+source: src/bootstrap/src/core/builder/cli_paths/tests.rs
+expression: test std-semver-check
+---
+[Test] test::StdSemverCheck
+    targets: [aarch64-unknown-linux-gnu]
+    - Set({test::std-semver-check})

--- a/src/bootstrap/src/core/builder/cli_paths/tests.rs
+++ b/src/bootstrap/src/core/builder/cli_paths/tests.rs
@@ -170,6 +170,7 @@ declare_tests!(
     (x_test_librustdoc_rustdoc_html, "test librustdoc rustdoc-html"),
     (x_test_rustdoc, "test rustdoc"),
     (x_test_rustdoc_html, "test rustdoc-html"),
+    (x_test_semver_check, "test std-semver-check"),
     (x_test_skip_coverage, "test --skip=coverage"),
     (x_test_skip_coverage_map, "test --skip=coverage-map"),
     (x_test_skip_coverage_run, "test --skip=coverage-run"),

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -974,6 +974,7 @@ impl<'a> Builder<'a> {
                 test::RunMake,
                 test::RunMakeCargo,
                 test::BuildStd,
+                test::StdSemverCheck,
                 test::IntrinsicTest,
             ),
             Kind::Miri => describe!(test::Crate),

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -173,6 +173,30 @@ impl Config {
         );
     }
 
+    pub(crate) fn download_std_json_docs(
+        &self,
+        target: TargetSelection,
+        commit: &str,
+    ) -> Option<PathBuf> {
+        if self.dry_run() {
+            return None;
+        }
+
+        self.do_if_verbose(|| println!("using downloaded std json docs from CI (commit {commit})"));
+
+        let version = self.artifact_version_part(commit);
+        download_component(
+            DownloadContext::from(self),
+            &self.out,
+            DownloadSource::CI,
+            format!("rust-docs-json-{version}-{target}.tar.xz"),
+            "rust-docs-json-preview",
+            // When using DownloadSource::CI, the key is assumed to end with -llvm-assertions
+            &format!("{commit}-{}", self.llvm_assertions),
+            "ci-docs-json",
+        )
+    }
+
     fn download_toolchain(
         &self,
         version: &str,
@@ -785,11 +809,11 @@ fn download_component<'a>(
     prefix: &str,
     key: &str,
     destination: &str,
-) {
+) -> Option<PathBuf> {
     let dwn_ctx = dwn_ctx.as_ref();
 
     if dwn_ctx.exec_ctx.dry_run() {
-        return;
+        return None;
     }
 
     let cache_dst =
@@ -834,8 +858,7 @@ fn download_component<'a>(
         let sha256 = dwn_ctx.stage0_metadata.checksums_sha256.get(&url).expect(&error);
         if tarball.exists() {
             if verify(dwn_ctx.exec_ctx, &tarball, sha256) {
-                unpack(dwn_ctx.exec_ctx, &tarball, &bin_root, prefix);
-                return;
+                return Some(unpack(dwn_ctx.exec_ctx, &tarball, &bin_root, prefix));
             } else {
                 dwn_ctx.exec_ctx.do_if_verbose(|| {
                     println!(
@@ -848,8 +871,7 @@ fn download_component<'a>(
         }
         Some(sha256)
     } else if tarball.exists() {
-        unpack(dwn_ctx.exec_ctx, &tarball, &bin_root, prefix);
-        return;
+        return Some(unpack(dwn_ctx.exec_ctx, &tarball, &bin_root, prefix));
     } else {
         None
     };
@@ -872,7 +894,7 @@ download-rustc = false
         panic!("failed to verify {}", tarball.display());
     }
 
-    unpack(dwn_ctx.exec_ctx, &tarball, &bin_root, prefix);
+    Some(unpack(dwn_ctx.exec_ctx, &tarball, &bin_root, prefix))
 }
 
 pub(crate) fn verify(exec_ctx: &ExecutionContext, path: &Path, expected: &str) -> bool {
@@ -916,7 +938,7 @@ pub(crate) fn verify(exec_ctx: &ExecutionContext, path: &Path, expected: &str) -
     verified
 }
 
-fn unpack(exec_ctx: &ExecutionContext, tarball: &Path, dst: &Path, pattern: &str) {
+fn unpack(exec_ctx: &ExecutionContext, tarball: &Path, dst: &Path, pattern: &str) -> PathBuf {
     eprintln!("extracting {} to {}", tarball.display(), dst.display());
     if !dst.exists() {
         t!(fs::create_dir_all(dst));
@@ -979,6 +1001,7 @@ fn unpack(exec_ctx: &ExecutionContext, tarball: &Path, dst: &Path, pattern: &str
     if dst_dir.exists() {
         t!(fs::remove_dir_all(&dst_dir), format!("failed to remove {}", dst_dir.display()));
     }
+    dst.to_path_buf()
 }
 
 fn download_file<'a>(

--- a/src/ci/citool/Cargo.lock
+++ b/src/ci/citool/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "askama"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e1676b346cadfec169374f949d7490fd80a24193d37d2afce0c047cf695e57"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
 dependencies = [
  "askama_macros",
  "itoa",
@@ -79,12 +79,13 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7661ff56517787343f376f75db037426facd7c8d3049cef8911f1e75016f3a37"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
 dependencies = [
  "askama_parser",
  "basic-toml",
+ "glob",
  "memchr",
  "proc-macro2",
  "quote",
@@ -96,18 +97,18 @@ dependencies = [
 
 [[package]]
 name = "askama_macros"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713ee4dbfd1eb719c2dab859465b01fa1d21cb566684614a713a6b7a99a4e47b"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
 dependencies = [
  "askama_derive",
 ]
 
 [[package]]
 name = "askama_parser"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d62d674238a526418b30c0def480d5beadb9d8964e7f38d635b03bf639c704c"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -379,6 +380,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "glob-match"
@@ -1105,9 +1112,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]

--- a/src/ci/citool/src/test_dashboard.rs
+++ b/src/ci/citool/src/test_dashboard.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::{Path, PathBuf};
@@ -17,12 +17,14 @@ pub fn generate_test_dashboard(
     output_dir: &Path,
 ) -> anyhow::Result<()> {
     let metrics = download_auto_job_metrics(&db, None, current)?;
-    let suites = gather_test_suites(&metrics);
+    let mut suites = gather_test_suites(&metrics);
 
     std::fs::create_dir_all(output_dir)?;
 
+    let jobsets = assign_jobsets(&mut suites);
+
     let test_count = suites.test_count();
-    write_page(output_dir, "index.html", &TestSuitesPage { suites, test_count })?;
+    write_page(output_dir, "index.html", &TestSuitesPage { suites, test_count, jobsets })?;
 
     Ok(())
 }
@@ -31,6 +33,45 @@ fn write_page<T: Template>(dir: &Path, name: &str, template: &T) -> anyhow::Resu
     let mut file = BufWriter::new(File::create(dir.join(name))?);
     Template::write_into(template, &mut file)?;
     Ok(())
+}
+
+struct JobSets {
+    sets: Vec<(u32, Vec<String>)>,
+}
+
+fn assign_jobsets(suites: &mut TestSuites) -> JobSets {
+    let mut jobsets: HashMap<Vec<String>, u32> = HashMap::new();
+
+    fn visit(jobsets: &mut HashMap<Vec<String>, u32>, group: &mut TestGroup) {
+        for (_, test) in &mut group.root_tests {
+            for (_, results) in &mut test.revisions {
+                let mut jobset: HashSet<String> = HashSet::new();
+                for test in &results.passed {
+                    jobset.insert(test.job.to_string());
+                }
+                let mut jobset: Vec<String> = jobset.into_iter().collect();
+                jobset.sort();
+
+                let jobset_count = jobsets.len() as u32;
+                let jobset_id = jobsets.entry(jobset).or_insert_with(|| jobset_count);
+                results.passed_jobset = Some(*jobset_id);
+            }
+        }
+        for (_, group) in &mut group.groups {
+            visit(jobsets, group);
+        }
+    }
+    for suite in &mut suites.suites {
+        visit(&mut jobsets, &mut suite.group);
+    }
+
+    let mut jobsets: Vec<(u32, Vec<String>)> = jobsets.into_iter().map(|(k, v)| (v, k)).collect();
+    jobsets.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    for (_, set) in &mut jobsets {
+        set.sort_unstable();
+    }
+
+    JobSets { sets: jobsets }
 }
 
 fn gather_test_suites(job_metrics: &HashMap<JobName, JobMetrics>) -> TestSuites<'_> {
@@ -68,10 +109,9 @@ fn gather_test_suites(job_metrics: &HashMap<JobName, JobMetrics>) -> TestSuites<
                     .tests
                     .entry(test_name.clone())
                     .or_insert_with(|| Test { revisions: Default::default() });
-                let variant_entry = test_entry
-                    .revisions
-                    .entry(variant_name)
-                    .or_insert_with(|| TestResults { passed: vec![], ignored: vec![] });
+                let variant_entry = test_entry.revisions.entry(variant_name).or_insert_with(|| {
+                    TestResults { passed: vec![], passed_jobset: None, ignored: vec![] }
+                });
 
                 match test.outcome {
                     TestOutcome::Passed => {
@@ -161,6 +201,8 @@ struct TestSuite<'a> {
 
 struct TestResults<'a> {
     passed: Vec<TestMetadata<'a>>,
+    /// An id representing a set of jobs on which this test has passed.
+    passed_jobset: Option<u32>,
     ignored: Vec<TestMetadata<'a>>,
 }
 
@@ -213,4 +255,5 @@ impl<'a> TestGroup<'a> {
 struct TestSuitesPage<'a> {
     suites: TestSuites<'a>,
     test_count: u64,
+    jobsets: JobSets,
 }

--- a/src/ci/citool/templates/test_group.askama
+++ b/src/ci/citool/templates/test_group.askama
@@ -1,5 +1,5 @@
-{% macro test_result(r) -%}
-passed: {{ r.passed.len() }}, ignored: {{ r.ignored.len() }}
+{% macro test_result(r, jobset) -%}
+<a href="#job-{{ jobset }}">passed: {{ r.passed.len() }}</a>, ignored: {{ r.ignored.len() }}
 {%- endmacro %}
 
 <li>
@@ -24,12 +24,12 @@ passed: {{ r.passed.len() }}, ignored: {{ r.ignored.len() }}
     {% for (name, test) in root_tests %}
         <li>
         {% if let Some(result) = test.single_test() %}
-            <b>{{ name }}</b> ({% call test_result(result) %}{% endcall %})
+            <b>{{ name }}</b> ({% call test_result(result, result.passed_jobset.as_ref().unwrap()) %}{% endcall %})
         {% else %}
             <b>{{ name }}</b> ({{ test.revisions.len() }} revision{{ test.revisions.len() | pluralize }})
             <ul>
             {% for (revision, result) in test.revisions %}
-                <li>#<i>{{ revision }}</i> ({% call test_result(result) %}{% endcall %})</li>
+                <li>#<i>{{ revision }}</i> ({% call test_result(result, result.passed_jobset.as_ref().unwrap()) %}{% endcall %})</li>
             {% endfor %}
             </ul>
         {% endif %}

--- a/src/ci/citool/templates/test_suites.askama
+++ b/src/ci/citool/templates/test_suites.askama
@@ -20,11 +20,26 @@ the count includes all combinations of "stage" x "target" x "CI job where the te
         </div>
     </div>
 
-    <ul>
+    <ul class="tests">
     {% for suite in suites.suites %}
         {{ suite.group|safe }}
     {% endfor %}
     </ul>
+    <div class="jobsets">
+        <h2>Job sets</h2>
+        <div>
+        {% for (id, jobs) in jobsets.sets %}
+            {% if !jobs.is_empty() %}
+            <div id="job-{{ id }}"><b>J{{ id }}</b></div>
+            <ul style="margin: 0">
+            {% for job in jobs %}
+                <li>{{ job }}</li>
+            {% endfor %}
+            </ul>
+            {% endif %}
+        {% endfor %}
+        </div>
+    </div>
 </div>
 {% endblock %}
 
@@ -33,6 +48,9 @@ h1 {
     text-align: center;
     color: #333333;
     margin-bottom: 30px;
+}
+a:visited {
+  color: blue;
 }
 
 .summary {
@@ -55,10 +73,14 @@ ul {
     padding-left: 0;
 }
 
-li {
+.tests li {
     list-style: none;
     padding-left: 20px;
 }
+.jobsets li {
+    margin-left: 30px;
+}
+
 summary {
     margin-bottom: 5px;
     padding: 6px;

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -38,6 +38,7 @@ macro_rules! location {
 #[rustfmt::skip]
 const LICENSES: &[&str] = &[
     // tidy-alphabetical-start
+    "(MIT OR Apache-2.0) AND MIT",
     "0BSD OR MIT OR Apache-2.0",                           // adler2 license
     "Apache-2.0 / MIT",
     "Apache-2.0 OR ISC OR MIT",

--- a/tests/ui/assumptions_on_binders/ambiguous-placeholder-certainty-issue-159896.rs
+++ b/tests/ui/assumptions_on_binders/ambiguous-placeholder-certainty-issue-159896.rs
@@ -1,0 +1,28 @@
+// Regression test for issue #159896.
+//
+// An ambiguous result from eagerly handling placeholders must be preserved
+// when returning nested normalization goals, instead of causing an ICE.
+
+//@ check-fail
+//@ dont-check-compiler-stderr
+//@ dont-require-annotations: ERROR
+//@ compile-flags: -Znext-solver=globally -Zassumptions-on-binders
+//@ edition: 2021
+
+#![feature(type_alias_impl_trait)]
+
+type FooArg<'a> = &'a impl Iterator<Item = FooItem>;
+type FooRet = impl Iterator<Item = FooItem>;
+type FooItem = Box<dyn Fn(FooArg) -> FooRet>;
+
+struct Bar;
+
+impl Iterator for Bar {
+    type Item = FooItem;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#159671 (Add semver check test command for checking API compatibility of stdlib)
 - rust-lang/rust#159964 (Preserve placeholder ambiguity during normalization)
 - rust-lang/rust#159994 (Show jobs where a given test was executed in `test-dashboard`)
 - rust-lang/rust#160085 (Remove various superfluous lint attributes)
 - rust-lang/rust#160123 (add additional license option for third-party dependencies)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=159671,159964,159994,160085,160123)
<!-- homu-ignore:end -->

