### PR TITLE
Add regression test for imperfect derive diagnostic

### DIFF
--- a/tests/ui/derives/imperfect-derive-associated-type-issue-52560.rs
+++ b/tests/ui/derives/imperfect-derive-associated-type-issue-52560.rs
@@ -1,0 +1,27 @@
+// Regression test for issue #52560. An unsatisfied bound introduced by an
+// imperfect derive should be explained where the derived implementation is
+// generated.
+
+use std::fmt::Debug;
+
+#[derive(Debug)]
+struct Foo<B: Bar>(B::Item);
+
+trait Bar {
+    type Item: Debug;
+}
+
+fn foo<B: Bar>(value: Foo<B>) {
+    println!("{value:?}");
+    //~^ ERROR `B` doesn't implement `Debug`
+}
+
+struct Concrete;
+
+impl Bar for Concrete {
+    type Item = String;
+}
+
+fn main() {
+    foo(Foo::<Concrete>("value".into()));
+}

--- a/tests/ui/derives/imperfect-derive-associated-type-issue-52560.stderr
+++ b/tests/ui/derives/imperfect-derive-associated-type-issue-52560.stderr
@@ -1,0 +1,23 @@
+error[E0277]: `B` doesn't implement `Debug`
+  --> $DIR/imperfect-derive-associated-type-issue-52560.rs:15:15
+   |
+LL |     println!("{value:?}");
+   |               ^^^^^^^^^ `B` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+note: required for `Foo<B>` to implement `Debug`
+  --> $DIR/imperfect-derive-associated-type-issue-52560.rs:8:8
+   |
+LL | #[derive(Debug)]
+   |          ----- in this derive macro expansion
+LL | struct Foo<B: Bar>(B::Item);
+   |        ^^^ - type parameter would need to implement `Debug`
+   = help: consider manually implementing `Debug` to avoid undesired bounds caused by "imperfect derives"
+   = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
+help: consider further restricting type parameter `B` with trait `Debug`
+   |
+LL | fn foo<B: Bar + std::fmt::Debug>(value: Foo<B>) {
+   |               +++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Adds a UI regression test for the associated-type `Debug` derive case from rust-lang/rust#52560.

The stderr snapshot verifies that the diagnostic points back to the derived implementation, explains the implicit `B: Debug` requirement, and includes the guidance for imperfect derives.

This protects the improved diagnostic from regressing.

Closes rust-lang/rust#52560.

## Validation

- `./x test tests/ui/derives/imperfect-derive-associated-type-issue-52560.rs`
- `./x test tidy`
- `./x fmt --check`
