### PR TITLE
bootstrap: remove temporary bors email lookup

### DIFF
--- a/src/build_helper/src/git.rs
+++ b/src/build_helper/src/git.rs
@@ -165,11 +165,6 @@ pub fn changes_since(git_dir: &Path, base: &str, paths: &[&str]) -> Result<Vec<P
     })
 }
 
-// Temporary e-mail used by new bors for merge commits for a few days, until it learned how to reuse
-// the original homu e-mail
-// FIXME: remove in Q2 2026
-const TEMPORARY_BORS_EMAIL: &str = "122020455+rust-bors[bot]@users.noreply.github.com";
-
 /// Escape characters from the git user e-mail, so that git commands do not interpret it as regex
 /// special characters.
 fn escape_email_git_regex(text: &str) -> String {
@@ -208,11 +203,6 @@ fn get_latest_upstream_commit_that_modified_files(
         "--author",
         &escape_email_git_regex(git_config.git_merge_commit_email),
     ]);
-
-    // Also search for temporary bors account
-    if git_config.git_merge_commit_email != TEMPORARY_BORS_EMAIL {
-        git.args(["--author", &escape_email_git_regex(TEMPORARY_BORS_EMAIL)]);
-    }
 
     if !target_paths.is_empty() {
         git.arg("--").args(target_paths);
@@ -262,11 +252,6 @@ pub fn get_closest_upstream_commit(
         "-n1",
         base,
     ]);
-
-    // Also search for temporary bors account
-    if config.git_merge_commit_email != TEMPORARY_BORS_EMAIL {
-        git.args(["--author", &escape_email_git_regex(TEMPORARY_BORS_EMAIL)]);
-    }
 
     let output = output_result(&mut git)?.trim().to_owned();
     if output.is_empty() { Ok(None) } else { Ok(Some(output)) }


### PR DESCRIPTION
This removes the temporary rust-bors[bot] author lookup from build_helper.

The temporary compatibility window ended in Q2 2026, and bors now uses the original homu email again. Keeping this lookup would cause local freshness detection to continue considering an obsolete merge author.