### PR TITLE
Work around Wine bug 60084 by calling WSAStartup at most once

### DIFF
--- a/library/std/src/sys/pal/windows/winsock.rs
+++ b/library/std/src/sys/pal/windows/winsock.rs
@@ -1,18 +1,17 @@
 use super::c;
 use crate::ffi::c_int;
-use crate::sync::atomic::Atomic;
-use crate::sync::atomic::Ordering::{AcqRel, Relaxed};
+use crate::sync::Once;
 use crate::{io, mem};
 
-static WSA_STARTED: Atomic<bool> = Atomic::<bool>::new(false);
+static WSA_INIT: Once = Once::new();
 
 /// Checks whether the Windows socket interface has been started already, and
 /// if not, starts it.
 #[inline]
 pub fn startup() {
-    if !WSA_STARTED.load(Relaxed) {
-        wsa_startup();
-    }
+    // Make sure to only call `WSAStartup` once, because it's not thread-safe
+    // on Wine: https://bugs.winehq.org/show_bug.cgi?id=60084.
+    WSA_INIT.call_once_force(|_| wsa_startup());
 }
 
 #[cold]
@@ -24,11 +23,6 @@ fn wsa_startup() {
             &mut data,
         );
         assert_eq!(ret, 0);
-        if WSA_STARTED.swap(true, AcqRel) {
-            // If another thread raced with us and called WSAStartup first then call
-            // WSACleanup so it's as though WSAStartup was only called once.
-            c::WSACleanup();
-        }
     }
 }
 


### PR DESCRIPTION
CC [Wine bug 60084](https://bugs.winehq.org/show_bug.cgi?id=60084)
CC https://github.com/tokio-rs/mio/issues/1980

Wine's `WSAStartup`/`WSACleanup` are currently not thread-safe (though they probably should be, which is why I reported an upstream bug).

Before https://github.com/rust-lang/rust/pull/141809 (and Rust 1.90), Rust used to call `WSAStartup` at most once. This PR restores that behavior.

I believe that this is not a regression for real Windows, since the hot path of a `Once` already having executed is well-optimized, it's just one atomic load, like before.