### PR TITLE
iter: specialize Take::count using advance_by

### DIFF
--- a/library/core/src/iter/adapters/take.rs
+++ b/library/core/src/iter/adapters/take.rs
@@ -57,6 +57,19 @@ where
     }
 
     #[inline]
+    fn count(mut self) -> usize {
+        if self.n == 0 {
+            return 0;
+        }
+        // Advancing consumes the same elements `next` would have yielded,
+        // while benefiting from the inner iterator's `advance_by` fast path.
+        match self.iter.advance_by(self.n) {
+            Ok(()) => self.n,
+            Err(remaining) => self.n - remaining.get(),
+        }
+    }
+
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.n == 0 {
             return (0, Some(0));

--- a/library/coretests/tests/iter/adapters/take.rs
+++ b/library/coretests/tests/iter/adapters/take.rs
@@ -260,3 +260,66 @@ fn test_reverse_on_zip() {
         assert_eq!((1, 0), (one, zero));
     }
 }
+
+#[test]
+fn test_iterator_take_count() {
+    let xs = [0, 1, 2, 3, 5, 13, 15, 16, 17, 19];
+
+    // take shorter than, equal to, and longer than the underlying iterator
+    assert_eq!(xs.iter().take(0).count(), 0);
+    assert_eq!(xs.iter().take(5).count(), 5);
+    assert_eq!(xs.iter().take(10).count(), 10);
+    assert_eq!(xs.iter().take(11).count(), 10);
+    assert_eq!(xs.iter().take(usize::MAX).count(), 10);
+
+    // partially consumed
+    let mut it = xs.iter().take(5);
+    it.next();
+    it.next();
+    assert_eq!(it.count(), 3);
+
+    let mut it = xs.iter().take(20);
+    it.next();
+    assert_eq!(it.count(), 9);
+
+    // `count` must observe the same elements `next` would have yielded:
+    // a side-effecting inner iterator sees exactly min(n, len) closure calls.
+    let mut calls = 0;
+    let count = (0..10)
+        .map(|x| {
+            calls += 1;
+            x
+        })
+        .take(3)
+        .count();
+    assert_eq!(count, 3);
+    assert_eq!(calls, 3);
+
+    // stateful filter: count agrees with the number of elements actually yielded
+    let mut budget = 7;
+    let yielded: Vec<u32> = (1..100)
+        .filter(|&x| {
+            if x <= budget {
+                budget -= 1;
+                true
+            } else {
+                false
+            }
+        })
+        .take(10)
+        .collect();
+
+    let mut budget = 7;
+    let counted = (1..100)
+        .filter(|&x| {
+            if x <= budget {
+                budget -= 1;
+                true
+            } else {
+                false
+            }
+        })
+        .take(10)
+        .count();
+    assert_eq!(counted, yielded.len());
+}


### PR DESCRIPTION
Right now, when you call .count() on a Take iterator, it visits every single item one by one just to count them. That's slow.

For example, if you have 1000 items and call .take(5).count(), it should just skip 5 items and return 5 — but today it actually goes through each item manually.

This PR fixes that by using advance_by to skip items in bulk instead of visiting each one. After the skip, we know exactly how many items were consumed, so we return that number directly.

This makes .count() faster for Take iterators, especially when the underlying iterator supports fast skipping.
