### PR TITLE
Improve trailing semicolon suggestion for closures

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -2420,38 +2420,97 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         span: Span,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
     ) -> bool {
+        if !trait_pred.self_ty().skip_binder().is_unit() {
+            return false;
+        }
+
+        let Some(typeck_results) = &self.typeck_results else {
+            return false;
+        };
+
+        let find_candidate = |blk: &'tcx hir::Block<'tcx>| {
+            if blk.expr.is_some() {
+                return None;
+            }
+            let [.., stmt] = blk.stmts else {
+                return None;
+            };
+            let hir::StmtKind::Semi(expr) = stmt.kind else {
+                return None;
+            };
+            let ty = typeck_results.expr_ty_opt(expr)?;
+            let new_obligation = self.mk_trait_obligation_with_new_self_ty(
+                obligation.param_env,
+                trait_pred.map_bound(|trait_pred| (trait_pred, ty)),
+            );
+            self.predicate_may_hold(&new_obligation).then_some((stmt, expr, ty))
+        };
+
         let node = self.tcx.hir_node_by_def_id(obligation.cause.body_def_id);
-        if let hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn {sig, body: body_id, .. }, .. }) = node
+        let mut candidate = if let hir::Node::Item(hir::Item {
+            kind: hir::ItemKind::Fn { sig, body: body_id, .. },
+            ..
+        }) = node
             && let hir::ExprKind::Block(blk, _) = &self.tcx.hir_body(*body_id).value.kind
             && sig.decl.output.span().overlaps(span)
             && blk.expr.is_none()
-            && trait_pred.self_ty().skip_binder().is_unit()
-            && let Some(stmt) = blk.stmts.last()
-            && let hir::StmtKind::Semi(expr) = stmt.kind
-            // Only suggest this if the expression behind the semicolon implements the predicate
-            && let Some(typeck_results) = &self.typeck_results
-            && let Some(ty) = typeck_results.expr_ty_opt(expr)
-            && self.predicate_may_hold(&self.mk_trait_obligation_with_new_self_ty(
-                obligation.param_env, trait_pred.map_bound(|trait_pred| (trait_pred, ty))
-            ))
         {
-            err.span_label(
-                expr.span,
-                format!(
-                    "this expression has type `{}`, which implements `{}`",
-                    ty,
-                    trait_pred.print_modifiers_and_trait_path()
-                ),
-            );
-            err.span_suggestion(
-                self.tcx.sess.source_map().end_point(stmt.span),
-                "remove this semicolon",
-                "",
-                Applicability::MachineApplicable,
-            );
-            return true;
+            find_candidate(blk)
+        } else {
+            None
+        };
+
+        if candidate.is_none() {
+            // A failed bound on a closure's inferred return type points at the outer call. Recover
+            // that call so we can inspect the closure body that produced `()`.
+            let Some(body) = self.tcx.hir_maybe_body_owned_by(obligation.cause.body_def_id) else {
+                return false;
+            };
+            let mut expr_finder = FindExprBySpan::new(span, self.tcx);
+            expr_finder.visit_expr(body.value);
+            let Some(call_expr) = expr_finder.result else {
+                return false;
+            };
+            let args = match call_expr.kind {
+                hir::ExprKind::Call(_, args) | hir::ExprKind::MethodCall(_, _, args, _) => args,
+                _ => return false,
+            };
+            let mut candidates = args.iter().filter_map(|arg| {
+                let hir::ExprKind::Closure(closure) = arg.kind else {
+                    return None;
+                };
+                let hir::ExprKind::Block(blk, _) = self.tcx.hir_body(closure.body).value.kind
+                else {
+                    return None;
+                };
+                find_candidate(blk)
+            });
+            // With multiple plausible closure arguments we cannot tell which one introduced the
+            // failing bound, so avoid suggesting an edit to the wrong closure.
+            candidate = candidates.next();
+            if candidates.next().is_some() {
+                return false;
+            }
         }
-        false
+
+        let Some((stmt, expr, ty)) = candidate else {
+            return false;
+        };
+        err.span_label(
+            expr.span,
+            format!(
+                "this expression has type `{}`, which implements `{}`",
+                ty,
+                trait_pred.print_modifiers_and_trait_path()
+            ),
+        );
+        err.span_suggestion(
+            self.tcx.sess.source_map().end_point(stmt.span),
+            "remove this semicolon",
+            "",
+            Applicability::MachineApplicable,
+        );
+        true
     }
 
     pub(super) fn suggest_borrow_for_unsized_closure_return<G: EmissionGuarantee>(

--- a/tests/ui/closures/closure-trailing-semicolon-impl-trait-issue-54771.rs
+++ b/tests/ui/closures/closure-trailing-semicolon-impl-trait-issue-54771.rs
@@ -1,0 +1,18 @@
+// Regression test for issue #54771.
+
+trait Bar {}
+
+impl Bar for u8 {} //~ HELP the trait `Bar` is implemented for `u8`
+
+fn bar<R: Bar>(_: impl Fn() -> R) {}
+
+fn main() {
+    bar(|| { //~ ERROR the trait bound `(): Bar` is not satisfied
+        5u8; //~ HELP remove this semicolon
+    });
+
+    bar(|| { //~ ERROR the trait bound `(): Bar` is not satisfied
+        5u8;
+        ()
+    });
+}

--- a/tests/ui/closures/closure-trailing-semicolon-impl-trait-issue-54771.stderr
+++ b/tests/ui/closures/closure-trailing-semicolon-impl-trait-issue-54771.stderr
@@ -1,0 +1,40 @@
+error[E0277]: the trait bound `(): Bar` is not satisfied
+  --> $DIR/closure-trailing-semicolon-impl-trait-issue-54771.rs:10:5
+   |
+LL | /     bar(|| {
+LL | |         5u8;
+   | |         ---- help: remove this semicolon
+   | |         |
+   | |         this expression has type `u8`, which implements `Bar`
+LL | |     });
+   | |______^ the trait `Bar` is not implemented for `()`
+   |
+note: required by a bound in `bar`
+  --> $DIR/closure-trailing-semicolon-impl-trait-issue-54771.rs:7:11
+   |
+LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
+   |           ^^^ required by this bound in `bar`
+
+error[E0277]: the trait bound `(): Bar` is not satisfied
+  --> $DIR/closure-trailing-semicolon-impl-trait-issue-54771.rs:14:5
+   |
+LL | /     bar(|| {
+LL | |         5u8;
+LL | |         ()
+LL | |     });
+   | |______^ the trait `Bar` is not implemented for `()`
+   |
+help: the trait `Bar` is implemented for `u8`
+  --> $DIR/closure-trailing-semicolon-impl-trait-issue-54771.rs:5:1
+   |
+LL | impl Bar for u8 {}
+   | ^^^^^^^^^^^^^^^
+note: required by a bound in `bar`
+  --> $DIR/closure-trailing-semicolon-impl-trait-issue-54771.rs:7:11
+   |
+LL | fn bar<R: Bar>(_: impl Fn() -> R) {}
+   |           ^^^ required by this bound in `bar`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes rust-lang/rust#54771.

When a closure passed to a generic function accidentally ends its return expression with a semicolon, its inferred return type becomes `()`. The resulting trait-bound error is reported at the outer call, so the existing trailing-semicolon diagnostic—which only inspected an ordinary function body—could not find the closure expression responsible.

This extends the diagnostic to:

- recover direct closure arguments from the failing call;
- verify that the discarded expression's type may satisfy the failed trait predicate before suggesting an edit;
- avoid guessing when multiple closure arguments are plausible candidates.

The existing function-return behavior is preserved. The regression test also includes an explicit `()` tail to ensure that an unhelpful semicolon-removal suggestion is not emitted.

Validation:

- `./x test --force-rerun tests/ui/closures`
- `./x test --force-rerun tests/ui/suggestions/impl-trait-return-trailing-semicolon.rs tests/ui/closures/closure-trailing-semicolon-impl-trait-issue-54771.rs`
- `./x test tidy`
- `./x fmt --check`
