### PR TITLE
Refactor tidy detection of stability attribute

### DIFF
--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -470,6 +470,104 @@ fn get_and_check_lib_features(
     lib_features
 }
 
+/// `mf` gets the feature or an error if it is invalid, the file path passed as `file`, and the attribute's line number.
+fn extract_lib_features<'c, 'p>(
+    contents: &'c str,
+    file: &'p Path,
+    mf: &mut (dyn Send + Sync + FnMut(Result<(&'c str, Feature), &'static str>, &'p Path, usize)),
+) {
+    let handle_issue_none = |s| match s {
+        "none" => None,
+        issue => {
+            let n = issue.parse().expect("issue number is not a valid integer");
+            assert_ne!(n, 0, "\"none\" should be used when there is no issue, not \"0\"");
+            NonZeroU32::new(n)
+        }
+    };
+    for attr in static_regex!(
+        r"#!?\[\s*(?<attr_name>rustc_const_unstable|unstable|stable)\s*(?<attr_meta>(\((?s).*?)\)|)\]"
+    )
+    .captures_iter(contents)
+    {
+        let match_index = attr.get_match().start();
+        let before_match = &contents[..match_index];
+        let before_match_line = match before_match.rsplit_once('\n') {
+            Some((_, it)) => it,
+            None => before_match,
+        };
+        if static_regex!(r"^\s*//").is_match(before_match_line) {
+            // It starts inside a comment, exclude (this does not handle block comments).
+            // Technically this will mis-handle things like:
+            // ```
+            // // #[stable
+            // #[stable(...)]
+            // ```
+            // Hopefully that's not a problem.
+            continue;
+        }
+
+        let line = before_match.bytes().filter(|b| *b == b'\n').count() + 1;
+
+        macro_rules! err {
+            ($msg:expr) => {{
+                mf(Err($msg), file, line);
+                continue;
+            }};
+        }
+
+        let attr_meta = attr.name("attr_meta").unwrap().as_str();
+        let level = match &attr["attr_name"] {
+            "rustc_const_unstable" => {
+                // `const fn` features are handled specially.
+                let feature_name = match find_attr_val(attr_meta, "feature") {
+                    Some(name) => name,
+                    None => err!("malformed stability attribute: missing `feature` key"),
+                };
+                let feature = Feature {
+                    level: Status::Unstable,
+                    since: None,
+                    has_gate_test: false,
+                    tracking_issue: find_attr_val(attr_meta, "issue").and_then(handle_issue_none),
+                    file: file.to_path_buf(),
+                    line,
+                    description: None,
+                };
+                mf(Ok((feature_name, feature)), file, line);
+                continue;
+            }
+            "unstable" => Status::Unstable,
+            "stable" => Status::Accepted,
+            _ => unreachable!("unexpected attribute name"),
+        };
+        let feature_name = match find_attr_val(attr_meta, "feature") {
+            Some(name) => name,
+            None => err!("malformed stability attribute: missing `feature` key"),
+        };
+        let since = match find_attr_val(attr_meta, "since").map(|x| x.parse()) {
+            Some(Ok(since)) => Some(since),
+            Some(Err(_err)) => {
+                err!("malformed stability attribute: can't parse `since` key");
+            }
+            None if level == Status::Accepted => {
+                err!("malformed stability attribute: missing the `since` key");
+            }
+            None => None,
+        };
+        let tracking_issue = find_attr_val(attr_meta, "issue").and_then(handle_issue_none);
+
+        let feature = Feature {
+            level,
+            since,
+            has_gate_test: false,
+            tracking_issue,
+            file: file.to_path_buf(),
+            line,
+            description: None,
+        };
+        mf(Ok((feature_name, feature)), file, line);
+    }
+}
+
 fn map_lib_features(
     base_src_path: &Path,
     mf: &mut (dyn Send + Sync + FnMut(Result<(&str, Feature), &str>, &Path, usize)),
@@ -488,118 +586,7 @@ fn map_lib_features(
                 return;
             }
 
-            // This is an early exit -- all the attributes we're concerned with must contain this:
-            // * rustc_const_unstable(
-            // * unstable(
-            // * stable(
-            if !contents.contains("stable(") {
-                return;
-            }
-
-            let handle_issue_none = |s| match s {
-                "none" => None,
-                issue => {
-                    let n = issue.parse().expect("issue number is not a valid integer");
-                    assert_ne!(n, 0, "\"none\" should be used when there is no issue, not \"0\"");
-                    NonZeroU32::new(n)
-                }
-            };
-            let mut becoming_feature: Option<(&str, Feature)> = None;
-            let mut iter_lines = contents.lines().enumerate().peekable();
-            while let Some((i, line)) = iter_lines.next() {
-                macro_rules! err {
-                    ($msg:expr) => {{
-                        mf(Err($msg), file, i + 1);
-                        continue;
-                    }};
-                }
-
-                // exclude commented out lines
-                if static_regex!(r"^\s*//").is_match(line) {
-                    continue;
-                }
-
-                if let Some((name, ref mut f)) = becoming_feature {
-                    if f.tracking_issue.is_none() {
-                        f.tracking_issue = find_attr_val(line, "issue").and_then(handle_issue_none);
-                    }
-                    if line.ends_with(']') {
-                        mf(Ok((name, f.clone())), file, i + 1);
-                    } else if !line.ends_with(',') && !line.ends_with('\\') && !line.ends_with('"')
-                    {
-                        // We need to bail here because we might have missed the
-                        // end of a stability attribute above because the ']'
-                        // might not have been at the end of the line.
-                        // We could then get into the very unfortunate situation that
-                        // we continue parsing the file assuming the current stability
-                        // attribute has not ended, and ignoring possible feature
-                        // attributes in the process.
-                        err!("malformed stability attribute");
-                    } else {
-                        continue;
-                    }
-                }
-                becoming_feature = None;
-                if line.contains("rustc_const_unstable(") {
-                    // `const fn` features are handled specially.
-                    let feature_name = match find_attr_val(line, "feature").or_else(|| {
-                        iter_lines.peek().and_then(|next| find_attr_val(next.1, "feature"))
-                    }) {
-                        Some(name) => name,
-                        None => err!("malformed stability attribute: missing `feature` key"),
-                    };
-                    let feature = Feature {
-                        level: Status::Unstable,
-                        since: None,
-                        has_gate_test: false,
-                        tracking_issue: find_attr_val(line, "issue").and_then(handle_issue_none),
-                        file: file.to_path_buf(),
-                        line: i + 1,
-                        description: None,
-                    };
-                    mf(Ok((feature_name, feature)), file, i + 1);
-                    continue;
-                }
-                let level = if line.contains("[unstable(") {
-                    Status::Unstable
-                } else if line.contains("[stable(") {
-                    Status::Accepted
-                } else {
-                    continue;
-                };
-                let feature_name = match find_attr_val(line, "feature")
-                    .or_else(|| iter_lines.peek().and_then(|next| find_attr_val(next.1, "feature")))
-                {
-                    Some(name) => name,
-                    None => err!("malformed stability attribute: missing `feature` key"),
-                };
-                let since = match find_attr_val(line, "since").map(|x| x.parse()) {
-                    Some(Ok(since)) => Some(since),
-                    Some(Err(_err)) => {
-                        err!("malformed stability attribute: can't parse `since` key");
-                    }
-                    None if level == Status::Accepted => {
-                        err!("malformed stability attribute: missing the `since` key");
-                    }
-                    None => None,
-                };
-                let tracking_issue = find_attr_val(line, "issue").and_then(handle_issue_none);
-
-                let feature = Feature {
-                    level,
-                    since,
-                    has_gate_test: false,
-                    tracking_issue,
-                    file: file.to_path_buf(),
-                    line: i + 1,
-                    description: None,
-                };
-                if line.contains(']') {
-                    mf(Ok((feature_name, feature)), file, i + 1);
-                } else {
-                    becoming_feature = Some((feature_name, feature));
-                }
-            }
+            extract_lib_features(contents, file, mf);
         },
     );
 }

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -470,6 +470,103 @@ fn get_and_check_lib_features(
     lib_features
 }
 
+fn extract_lib_features<'c, 'p>(
+    contents: &'c str,
+    file: &'p Path,
+    mf: &mut (dyn Send + Sync + FnMut(Result<(&'c str, Feature), &'static str>, &'p Path, usize)),
+) {
+    let handle_issue_none = |s| match s {
+        "none" => None,
+        issue => {
+            let n = issue.parse().expect("issue number is not a valid integer");
+            assert_ne!(n, 0, "\"none\" should be used when there is no issue, not \"0\"");
+            NonZeroU32::new(n)
+        }
+    };
+    for attr in static_regex!(
+        r"#!?\[\s*(?<attr_name>rustc_const_unstable|unstable|stable)\s*(?<attr_meta>(\((?s).*?)\)|)\]"
+    )
+    .captures_iter(contents)
+    {
+        let match_index = attr.get_match().start();
+        let before_match = &contents[..match_index];
+        let before_match_line = match before_match.rsplit_once('\n') {
+            Some((_, it)) => it,
+            None => before_match,
+        };
+        if static_regex!(r"^\s*//").is_match(before_match_line) {
+            // It starts inside a comment, exclude (this does not handle block comments).
+            // Technically this will mis-handle things like:
+            // ```
+            // // #[stable
+            // #[stable(...)]
+            // ```
+            // Hopefully that's not a problem.
+            continue;
+        }
+
+        let line = before_match.bytes().filter(|b| *b == b'\n').count() + 1;
+
+        macro_rules! err {
+            ($msg:expr) => {{
+                mf(Err($msg), file, line);
+                continue;
+            }};
+        }
+
+        let attr_meta = attr.name("attr_meta").unwrap().as_str();
+        let level = match &attr["attr_name"] {
+            "rustc_const_unstable" => {
+                // `const fn` features are handled specially.
+                let feature_name = match find_attr_val(attr_meta, "feature") {
+                    Some(name) => name,
+                    None => err!("malformed stability attribute: missing `feature` key"),
+                };
+                let feature = Feature {
+                    level: Status::Unstable,
+                    since: None,
+                    has_gate_test: false,
+                    tracking_issue: find_attr_val(attr_meta, "issue").and_then(handle_issue_none),
+                    file: file.to_path_buf(),
+                    line,
+                    description: None,
+                };
+                mf(Ok((feature_name, feature)), file, line);
+                continue;
+            }
+            "unstable" => Status::Unstable,
+            "stable" => Status::Accepted,
+            _ => unreachable!("unexpected attribute name"),
+        };
+        let feature_name = match find_attr_val(attr_meta, "feature") {
+            Some(name) => name,
+            None => err!("malformed stability attribute: missing `feature` key"),
+        };
+        let since = match find_attr_val(attr_meta, "since").map(|x| x.parse()) {
+            Some(Ok(since)) => Some(since),
+            Some(Err(_err)) => {
+                err!("malformed stability attribute: can't parse `since` key");
+            }
+            None if level == Status::Accepted => {
+                err!("malformed stability attribute: missing the `since` key");
+            }
+            None => None,
+        };
+        let tracking_issue = find_attr_val(attr_meta, "issue").and_then(handle_issue_none);
+
+        let feature = Feature {
+            level,
+            since,
+            has_gate_test: false,
+            tracking_issue,
+            file: file.to_path_buf(),
+            line,
+            description: None,
+        };
+        mf(Ok((feature_name, feature)), file, line);
+    }
+}
+
 fn map_lib_features(
     base_src_path: &Path,
     mf: &mut (dyn Send + Sync + FnMut(Result<(&str, Feature), &str>, &Path, usize)),
@@ -488,118 +585,7 @@ fn map_lib_features(
                 return;
             }
 
-            // This is an early exit -- all the attributes we're concerned with must contain this:
-            // * rustc_const_unstable(
-            // * unstable(
-            // * stable(
-            if !contents.contains("stable(") {
-                return;
-            }
-
-            let handle_issue_none = |s| match s {
-                "none" => None,
-                issue => {
-                    let n = issue.parse().expect("issue number is not a valid integer");
-                    assert_ne!(n, 0, "\"none\" should be used when there is no issue, not \"0\"");
-                    NonZeroU32::new(n)
-                }
-            };
-            let mut becoming_feature: Option<(&str, Feature)> = None;
-            let mut iter_lines = contents.lines().enumerate().peekable();
-            while let Some((i, line)) = iter_lines.next() {
-                macro_rules! err {
-                    ($msg:expr) => {{
-                        mf(Err($msg), file, i + 1);
-                        continue;
-                    }};
-                }
-
-                // exclude commented out lines
-                if static_regex!(r"^\s*//").is_match(line) {
-                    continue;
-                }
-
-                if let Some((name, ref mut f)) = becoming_feature {
-                    if f.tracking_issue.is_none() {
-                        f.tracking_issue = find_attr_val(line, "issue").and_then(handle_issue_none);
-                    }
-                    if line.ends_with(']') {
-                        mf(Ok((name, f.clone())), file, i + 1);
-                    } else if !line.ends_with(',') && !line.ends_with('\\') && !line.ends_with('"')
-                    {
-                        // We need to bail here because we might have missed the
-                        // end of a stability attribute above because the ']'
-                        // might not have been at the end of the line.
-                        // We could then get into the very unfortunate situation that
-                        // we continue parsing the file assuming the current stability
-                        // attribute has not ended, and ignoring possible feature
-                        // attributes in the process.
-                        err!("malformed stability attribute");
-                    } else {
-                        continue;
-                    }
-                }
-                becoming_feature = None;
-                if line.contains("rustc_const_unstable(") {
-                    // `const fn` features are handled specially.
-                    let feature_name = match find_attr_val(line, "feature").or_else(|| {
-                        iter_lines.peek().and_then(|next| find_attr_val(next.1, "feature"))
-                    }) {
-                        Some(name) => name,
-                        None => err!("malformed stability attribute: missing `feature` key"),
-                    };
-                    let feature = Feature {
-                        level: Status::Unstable,
-                        since: None,
-                        has_gate_test: false,
-                        tracking_issue: find_attr_val(line, "issue").and_then(handle_issue_none),
-                        file: file.to_path_buf(),
-                        line: i + 1,
-                        description: None,
-                    };
-                    mf(Ok((feature_name, feature)), file, i + 1);
-                    continue;
-                }
-                let level = if line.contains("[unstable(") {
-                    Status::Unstable
-                } else if line.contains("[stable(") {
-                    Status::Accepted
-                } else {
-                    continue;
-                };
-                let feature_name = match find_attr_val(line, "feature")
-                    .or_else(|| iter_lines.peek().and_then(|next| find_attr_val(next.1, "feature")))
-                {
-                    Some(name) => name,
-                    None => err!("malformed stability attribute: missing `feature` key"),
-                };
-                let since = match find_attr_val(line, "since").map(|x| x.parse()) {
-                    Some(Ok(since)) => Some(since),
-                    Some(Err(_err)) => {
-                        err!("malformed stability attribute: can't parse `since` key");
-                    }
-                    None if level == Status::Accepted => {
-                        err!("malformed stability attribute: missing the `since` key");
-                    }
-                    None => None,
-                };
-                let tracking_issue = find_attr_val(line, "issue").and_then(handle_issue_none);
-
-                let feature = Feature {
-                    level,
-                    since,
-                    has_gate_test: false,
-                    tracking_issue,
-                    file: file.to_path_buf(),
-                    line: i + 1,
-                    description: None,
-                };
-                if line.contains(']') {
-                    mf(Ok((feature_name, feature)), file, i + 1);
-                } else {
-                    becoming_feature = Some((feature_name, feature));
-                }
-            }
+            extract_lib_features(contents, file, mf);
         },
     );
 }

--- a/src/tools/tidy/src/features/tests.rs
+++ b/src/tools/tidy/src/features/tests.rs
@@ -7,3 +7,58 @@ fn test_find_attr_val() {
     assert_eq!(find_attr_val(s, "issue"), Some("58402"));
     assert_eq!(find_attr_val(s, "since"), None);
 }
+
+#[track_caller]
+fn check_extract_lib_features(contents: &str, expected: &[(Result<(), &str>, usize)]) {
+    let mut expected = expected.iter().cloned().collect::<Vec<_>>();
+    expected.sort_unstable_by_key(|(_, line)| *line);
+
+    let mut found = Vec::with_capacity(expected.len());
+    extract_lib_features(contents, Path::new(""), &mut |result, _, line| {
+        found.push((result.map(drop), line))
+    });
+    expected.sort_unstable_by_key(|(_, line)| *line);
+
+    assert_eq!(expected, found);
+}
+
+#[test]
+fn extract_lib_features_invalid() {
+    check_extract_lib_features(
+        r#"
+#[stable]
+#![stable]
+    // #[stable]
+#[stable(feature = "foo")]
+#[stable(since = "1.97.0")]
+#[stable(feature = "foo", since = "something")]
+#[unstable(issue = "foo")]
+#[rustc_const_unstable(issue = "foo")]
+// #[unstable(feature = "foo")] // FIXME: Is not putting `issue` really fine?
+    "#,
+        &[
+            (Err("malformed stability attribute: missing `feature` key"), 2),
+            (Err("malformed stability attribute: missing `feature` key"), 3),
+            (Err("malformed stability attribute: missing the `since` key"), 5),
+            (Err("malformed stability attribute: missing `feature` key"), 6),
+            (Err("malformed stability attribute: can't parse `since` key"), 7),
+            (Err("malformed stability attribute: missing `feature` key"), 8),
+            (Err("malformed stability attribute: missing `feature` key"), 9),
+        ],
+    );
+}
+
+#[test]
+fn extract_lib_features_invalid_multiline() {
+    check_extract_lib_features(
+        r#"
+// #[stable(
+// )]
+    #[stable(
+        feature = "windows_process_extensions_main_thread_handle",
+        since = "CURRENT_RUSTC_VERSION"
+    )]
+    "#,
+        &[(Ok(()), 4)],
+    );
+}


### PR DESCRIPTION
And fix support for multi-line attributes. And add some tests.

Necessary for https://github.com/rust-lang/rust/pull/160108 which confused tidy.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
