### PR TITLE
bootstrap: remove use-lld config alias

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -607,7 +607,6 @@ impl Config {
             stack_protector: rust_stack_protector,
             strip: rust_strip,
             bootstrap_override_lld: rust_bootstrap_override_lld,
-            bootstrap_override_lld_legacy: rust_bootstrap_override_lld_legacy,
             std_features: rust_std_features,
             break_on_ice: rust_break_on_ice,
             rustflags: rust_rustflags,
@@ -717,14 +716,7 @@ impl Config {
         let pgo_rustdoc = init_pgo(pgo_rustdoc, "rustdoc");
         let pgo_cargo = init_pgo(pgo_cargo, "cargo");
 
-        if rust_bootstrap_override_lld.is_some() && rust_bootstrap_override_lld_legacy.is_some() {
-            panic!(
-                "Cannot use both `rust.use-lld` and `rust.bootstrap-override-lld`. Please use only `rust.bootstrap-override-lld`"
-            );
-        }
-
-        let bootstrap_override_lld =
-            rust_bootstrap_override_lld.or(rust_bootstrap_override_lld_legacy).unwrap_or_default();
+        let bootstrap_override_lld = rust_bootstrap_override_lld.unwrap_or_default();
 
         if rust_optimize.as_ref().is_some_and(|v| matches!(v, RustOptimize::Bool(false))) {
             eprintln!(

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -252,16 +252,6 @@ fn rust_lld() {
         parse("rust.bootstrap-override-lld = false").bootstrap_override_lld,
         BootstrapOverrideLld::None
     ));
-
-    // Also check the legacy options
-    assert!(matches!(
-        parse("rust.use-lld = true").bootstrap_override_lld,
-        BootstrapOverrideLld::External
-    ));
-    assert!(matches!(
-        parse("rust.use-lld = false").bootstrap_override_lld,
-        BootstrapOverrideLld::None
-    ));
 }
 
 #[test]

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -51,8 +51,6 @@ define_config! {
         llvm_bitcode_linker: Option<bool> = "llvm-bitcode-linker",
         lld: Option<bool> = "lld",
         bootstrap_override_lld: Option<BootstrapOverrideLld> = "bootstrap-override-lld",
-        // FIXME: Remove this option in Spring 2026
-        bootstrap_override_lld_legacy: Option<BootstrapOverrideLld> = "use-lld",
         llvm_tools: Option<bool> = "llvm-tools",
         deny_warnings: Option<bool> = "deny-warnings",
         backtrace_on_ice: Option<bool> = "backtrace-on-ice",
@@ -385,7 +383,6 @@ pub fn check_incompatible_options_for_ci_rustc(
         break_on_ice: _,
         parallel_frontend_threads: _,
         bootstrap_override_lld: _,
-        bootstrap_override_lld_legacy: _,
         rustflags: _,
     } = ci_rust_config;
 

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -661,4 +661,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "Obsolete option `build.compiletest-use-stage0-libtest` has no effect and has been removed.",
     },
+    ChangeInfo {
+        change_id: 160142,
+        severity: ChangeSeverity::Warning,
+        summary: "The `rust.use-lld` option has been removed. Use `rust.bootstrap-override-lld` instead.",
+    },
 ];


### PR DESCRIPTION
This removes the deprecated rust.use-lld configuration alias.

rust.bootstrap-override-lld has replaced this option, and the compatibility period has ended. The old alias is no longer parsed or merged with the new setting, and its legacy compatibility tests are removed.

A regression test now verifies that rust.use-lld is rejected as an unknown configuration option.
