### PR TITLE
Add NEON support for is_ascii and eq_ignore_ascii_case

### DIFF
--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -62,7 +62,10 @@ impl [u8] {
             return false;
         }
 
-        #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+        #[cfg(any(
+            all(target_arch = "x86_64", target_feature = "sse2"),
+            all(target_arch = "aarch64", target_feature = "neon")
+        ))]
         {
             const CHUNK_SIZE: usize = 16;
             // The following function has two invariants:
@@ -108,7 +111,10 @@ impl [u8] {
     ///
     /// The caller must guarantee that the slices are equal in length, and the
     /// slice lengths are greater than or equal to `N` bytes.
-    #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+    #[cfg(any(
+        all(target_arch = "x86_64", target_feature = "sse2"),
+        all(target_arch = "aarch64", target_feature = "neon")
+    ))]
     #[inline]
     const fn eq_ignore_ascii_case_chunks<const N: usize>(&self, other: &[u8]) -> bool {
         // FIXME(const-hack): The while-loops that follow should be replaced by
@@ -451,7 +457,8 @@ pub const fn is_ascii_simple(mut bytes: &[u8]) -> bool {
 /// (above) returns true, then we know the answer is false.
 #[cfg(not(any(
     all(target_arch = "x86_64", target_feature = "sse2"),
-    all(target_arch = "loongarch64", target_feature = "lsx")
+    all(target_arch = "loongarch64", target_feature = "lsx"),
+    all(target_arch = "aarch64", target_feature = "neon")
 )))]
 #[inline]
 #[rustc_allow_const_fn_unstable(const_eval_select)] // fallback impl has same behavior
@@ -584,16 +591,73 @@ fn is_ascii_sse2(bytes: &[u8]) -> bool {
     rest.iter().all(|b| b.is_ascii())
 }
 
-/// ASCII test optimized to use the `pmovmskb` instruction on `x86-64`.
-///
-/// Uses explicit SSE2 intrinsics to prevent LLVM from auto-vectorizing with
-/// broken AVX-512 code that extracts mask bits one-by-one.
-#[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+/// Chunk size for NEON vectorized ASCII checking (4x 16-byte loads).
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+const NEON_CHUNK_SIZE: usize = 64;
+
+/// Width of a single NEON vector, used to vectorize the tail left over by the
+/// unrolled `NEON_CHUNK_SIZE` loop.
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+const NEON_VECTOR_SIZE: usize = 16;
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[inline]
+fn is_ascii_neon(bytes: &[u8]) -> bool {
+    use crate::arch::aarch64::{vld1q_u8, vmaxvq_u8, vorrq_u8};
+
+    let (chunks, rest) = bytes.as_chunks::<NEON_CHUNK_SIZE>();
+
+    for chunk in chunks {
+        let ptr = chunk.as_ptr();
+        // SAFETY: chunk is 64 bytes, and `vld1q_u8` has no alignment requirement.
+        let max = unsafe {
+            let a1 = vld1q_u8(ptr);
+            let a2 = vld1q_u8(ptr.add(16));
+            let b1 = vld1q_u8(ptr.add(32));
+            let b2 = vld1q_u8(ptr.add(48));
+            // OR all chunks - if any byte has high bit set, combined will too.
+            let combined = vorrq_u8(vorrq_u8(a1, a2), vorrq_u8(b1, b2));
+            // `vmaxvq_u8` is a horizontal reduction with a longer latency than
+            // `vorrq_u8`, so it runs once per 64 bytes rather than once per load.
+            vmaxvq_u8(combined)
+        };
+        if max >= 128 {
+            return false;
+        }
+    }
+
+    // The unrolled loop above leaves up to 63 bytes, so sweep those a vector at
+    // a time before falling back to a byte-at-a-time check.
+    let (vectors, rest) = rest.as_chunks::<NEON_VECTOR_SIZE>();
+
+    for vector in vectors {
+        // SAFETY: vector is 16 bytes, and `vld1q_u8` has no alignment requirement.
+        let max = unsafe { vmaxvq_u8(vld1q_u8(vector.as_ptr())) };
+        if max >= 128 {
+            return false;
+        }
+    }
+
+    // Handle remaining bytes
+    rest.iter().all(|b| b.is_ascii())
+}
+
+/// Uses explicit SIMD intrinsics to prevent LLVM from auto-vectorizing with
+/// broken code (e.g., AVX-512 on x86-64 that extracts mask bits one-by-one).
+#[cfg(any(
+    all(target_arch = "x86_64", target_feature = "sse2"),
+    all(target_arch = "aarch64", target_feature = "neon")
+))]
 #[inline]
 #[rustc_allow_const_fn_unstable(const_eval_select)]
 const fn is_ascii(bytes: &[u8]) -> bool {
     const USIZE_SIZE: usize = size_of::<usize>();
     const NONASCII_MASK: usize = usize::MAX / 255 * 0x80;
+
+    #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+    const SIMD_MIN_LEN: usize = SSE2_CHUNK_SIZE;
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    const SIMD_MIN_LEN: usize = NEON_CHUNK_SIZE;
 
     const_eval_select!(
         @capture { bytes: &[u8] } -> bool:
@@ -601,7 +665,7 @@ const fn is_ascii(bytes: &[u8]) -> bool {
             is_ascii_simple(bytes)
         } else {
             // For small inputs, use usize-at-a-time processing to avoid SSE2 call overhead.
-            if bytes.len() < SSE2_CHUNK_SIZE {
+            if bytes.len() < SIMD_MIN_LEN {
                 let chunks = bytes.chunks_exact(USIZE_SIZE);
                 let remainder = chunks.remainder();
                 for chunk in chunks {
@@ -613,7 +677,10 @@ const fn is_ascii(bytes: &[u8]) -> bool {
                 return remainder.iter().all(|b| b.is_ascii());
             }
 
-            is_ascii_sse2(bytes)
+            #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+            { is_ascii_sse2(bytes) }
+            #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+            { is_ascii_neon(bytes) }
         }
     )
 }

--- a/library/coretests/benches/str/eq_ignore_ascii_case.rs
+++ b/library/coretests/benches/str/eq_ignore_ascii_case.rs
@@ -43,3 +43,23 @@ fn bench_large_str_eq(b: &mut Bencher) {
     let other = black_box(en::LARGE);
     b.iter(|| assert!(s.eq_ignore_ascii_case(other)))
 }
+
+#[bench]
+fn bench_medium_str_early_mismatch(b: &mut Bencher) {
+    // Differs in the first byte, exercising the early-return path of the
+    // chunked comparison.
+    let other_owned = ["_", &en::MEDIUM[1..]].concat();
+    let s = black_box(en::MEDIUM);
+    let other = black_box(&*other_owned);
+    b.iter(|| assert!(!s.eq_ignore_ascii_case(other)))
+}
+
+#[bench]
+fn bench_medium_str_tail_mismatch(b: &mut Bencher) {
+    // Differs in the last byte, exercising the `last_chunk` tail handling of
+    // the chunked comparison.
+    let other_owned = [&en::MEDIUM[..en::MEDIUM.len() - 1], "_"].concat();
+    let s = black_box(en::MEDIUM);
+    let other = black_box(&*other_owned);
+    b.iter(|| assert!(!s.eq_ignore_ascii_case(other)))
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Results on my aarch64 machine.

## 1. `is_ascii`

### 1.1 Raw Data (ns/iter, case00_libcore only — the path that calls `bytes.is_ascii()`)

| Input | Baseline (NEON off) | Optimized (NEON on) | Change |
|---|---|---|---|
| long | 19.69 | 6.46 | **-67.2%** |
| unaligned_both_long | 22.60 | 8.92 | **-60.5%** |
| unaligned_head_long | 20.62 | 8.81 | **-57.3%** |
| unaligned_tail_long | 21.15 | 8.68 | **-59.0%** |
| medium | 3.10 | 2.92 | -5.8% |
| short | 3.77 | 3.81 | +1.1% |
| unaligned_both_medium | 2.59 | 2.83 | +9.3% |
| unaligned_head_medium | 2.95 | 5.00 | +69.5% |
| unaligned_tail_medium | 2.37 | 2.96 | +24.9% |

### 1.2 Grouped Comparison (case00_libcore — the path affected by the change)

| Group | Baseline sum (ns) | Optimized sum (ns) | Change |
|---|---|---|---|
| **LONG (~350B, 4 items)** | 84.06 | 32.87 | **-60.9%** |
| **MEDIUM/SHORT (~16–32B, 5 items)** | 14.78 | 17.52 | +18.5% |
| All 9 items | 98.84 | 50.39 | **-49.0%** |

## 2. `eq_ignore_ascii_case`

### 2.1 Raw Data (ns/iter)

| Bench | Baseline (NEON off) | Optimized (NEON on) | Change |
|---|---|---|---|
| bench_large_str_eq | 6235.89 | 546.61 | **-91.2%** |
| bench_medium_str_eq | 780.81 | 68.05 | **-91.3%** |
| bench_medium_str_tail_mismatch | 786.84 | 65.76 | **-91.6%** |
| bench_str_31_bytes_eq | 35.87 | 3.98 | **-88.9%** |
| bench_str_17_bytes_eq | 19.62 | 4.05 | **-79.4%** |
| bench_medium_str_early_mismatch | 1.32 | 2.42 | +0.75 ns |
| bench_str_of_8_bytes_eq | 9.20 | 9.20 | 0.0% |
| bench_str_under_8_bytes_eq | 3.49 | 3.49 | 0.0% |

### 2.2 Grouped Comparison

| Group | Scenario | Baseline | Optimized | Change |
|---|---|---|---|---|
| **≥16B equal** | 17B / 31B / MEDIUM / LARGE | 19.6–6236 ns | 4.0–547 ns | **-79% ~ -91%** |
| **≥16B tail mismatch** | MEDIUM, last byte differs | 786.84 ns | 65.76 ns | **-91.6%** |
| **≥16B early mismatch** | MEDIUM, first byte differs | 1.32 ns | 2.42 ns | +0.75 ns |
| **<16B** | 8B / <8B equal | 3.49–9.20 ns | 3.49–9.20 ns | no change |


r? @Amanieu