### PR TITLE
renovate: group lockfiles PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,25 +31,40 @@
       "dependencyDashboardApproval": false
     },
     {
-      // Only maintain the Cargo lockfiles managed by update-lockfile.sh.
+      // Update all Cargo.lock files except library/Cargo.lock in one PR.
       "matchManagers": ["cargo"],
       "matchUpdateTypes": ["lockFileMaintenance"],
-      "enabled": false
+      "groupName": "Cargo lock file maintenance",
+      "commitMessageAction": "Cargo lock file maintenance"
     },
     {
+      // Update library/Cargo.lock in a dedicated PR.
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "matchFileNames": ["library/Cargo.lock"],
+      "groupName": "library lock file maintenance",
+      "commitMessageAction": "Library lock file maintenance"
+    },
+    {
+      // These packages don't have a committed Cargo.lock file.
       "matchManagers": ["cargo"],
       "matchUpdateTypes": ["lockFileMaintenance"],
       "matchFileNames": [
-        "Cargo.toml",
-        "library/Cargo.toml",
-        "src/tools/rustbook/Cargo.toml"
+        "library/rustc-std-workspace-*/Cargo.toml",
       ],
-      "enabled": true
+      "enabled": false
+    },
+    {
+      // Update yarn.lock in a dedicated PR.
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "groupName": "Yarn lock file maintenance",
+      "commitMessageAction": "Yarn lock file maintenance"
     }
   ],
-  // Don't manage dependencies inside subtrees. They are updated upstream and
-  // synced in. See `src/doc/rustc-dev-guide/src/external-repos.md` for the list.
   "ignorePaths": [
+    // Don't manage dependencies inside subtrees. They are updated upstream and
+    // synced in. See `src/doc/rustc-dev-guide/src/external-repos.md` for the list.
     "compiler/rustc_codegen_cranelift/**",
     "compiler/rustc_codegen_gcc/**",
     "library/compiler-builtins/**",
@@ -59,6 +74,10 @@
     "src/tools/clippy/**",
     "src/tools/miri/**",
     "src/tools/rust-analyzer/**",
-    "src/tools/rustfmt/**"
+    "src/tools/rustfmt/**",
+
+    // Test manifests are fixtures; their versions and lockfiles may
+    // intentionally be part of the test input.
+    "tests/**",
   ]
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
In the last attempt of renovate to update lockfiles (https://github.com/rust-lang/rust/pull/160121), Renovate updated only one Cargo.lock file.
This is probably due to the `matchFileNames` filter being wrong.

Instead of trying to fix the filter, I decided to remove the filter completely, except for `library/Cargo.lock` which has its own PR.

<!-- homu-ignore:end -->
r? @Kobzol