### PR TITLE
tests: Remove `-Zthreads` options from tests in `ui/parallel-rustc`

### DIFF
--- a/tests/run-make/mir-opt-bisect-limit/rmake.rs
+++ b/tests/run-make/mir-opt-bisect-limit/rmake.rs
@@ -82,7 +82,6 @@ fn compile_case(dump_dir: &str, extra_flags: &[&str]) -> (bool, usize, usize, Co
         .arg("--emit=mir")
         .arg("-Zmir-opt-level=2")
         .arg("-Copt-level=2")
-        .arg("-Zthreads=1")
         .arg("-Zdump-mir=Inline")
         .arg(format!("-Zdump-mir-dir={dump_dir}"));
 

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -1051,7 +1051,7 @@ Broad category of tests about panics in general, often but not necessarily using
 
 ## `tests/ui/parallel-rustc/`
 
-Efforts towards a [Parallel Rustc Front-end](https://github.com/rust-lang/rust/issues/113349). Includes `-Zthreads=`.
+Regression tests for [Parallel Rustc Front-end](https://github.com/rust-lang/rust/issues/113349).
 
 ## `tests/ui/parser/`
 

--- a/tests/ui/parallel-rustc/cache-after-waiting-issue-111528.rs
+++ b/tests/ui/parallel-rustc/cache-after-waiting-issue-111528.rs
@@ -1,8 +1,6 @@
 // Test for #111528, the ice issue cause waiting on a query that panicked
-//
-//@ compile-flags: -Z threads=16
+
 //@ build-fail
-//@ compare-output-by-lines
 
 #![crate_type = "rlib"]
 #![allow(warnings)]

--- a/tests/ui/parallel-rustc/cache-after-waiting-issue-111528.stderr
+++ b/tests/ui/parallel-rustc/cache-after-waiting-issue-111528.stderr
@@ -1,5 +1,5 @@
 error: symbol `fail` is already defined
-  --> $DIR/cache-after-waiting-issue-111528.rs:14:1
+  --> $DIR/cache-after-waiting-issue-111528.rs:12:1
    |
 LL | pub fn b() {
    | ^^^^^^^^^^

--- a/tests/ui/parallel-rustc/cycle_crash-issue-135870.rs
+++ b/tests/ui/parallel-rustc/cycle_crash-issue-135870.rs
@@ -1,7 +1,4 @@
 // Test for #135870, which causes a deadlock bug
-//
-//@ compile-flags: -Z threads=2
-//@ compare-output-by-lines
 
 const FOO: usize = FOO; //~ ERROR cycle detected
 

--- a/tests/ui/parallel-rustc/cycle_crash-issue-135870.stderr
+++ b/tests/ui/parallel-rustc/cycle_crash-issue-135870.stderr
@@ -1,5 +1,5 @@
 error[E0391]: cycle detected when checking if `FOO` is a trivial const
-  --> $DIR/cycle_crash-issue-135870.rs:6:1
+  --> $DIR/cycle_crash-issue-135870.rs:3:1
    |
 LL | const FOO: usize = FOO;
    | ^^^^^^^^^^^^^^^^

--- a/tests/ui/parallel-rustc/default-trait-shadow-cycle-issue-151358.rs
+++ b/tests/ui/parallel-rustc/default-trait-shadow-cycle-issue-151358.rs
@@ -1,9 +1,6 @@
 // Test for #151358, assertion failed: !worker_thread.is_null()
 //~^ ERROR internal compiler error: query cycle when printing cycle detected
 //~^^ ERROR cycle detected when getting the resolver for lowering
-//
-//@ compile-flags: -Z threads=2
-//@ compare-output-by-lines
 
 trait Default {}
 use std::num::NonZero;

--- a/tests/ui/parallel-rustc/export-symbols-deadlock-issue-118205-2.rs
+++ b/tests/ui/parallel-rustc/export-symbols-deadlock-issue-118205-2.rs
@@ -1,9 +1,8 @@
 // Test for #118205, which causes a deadlock bug
-//
-//@ compile-flags:-C extra-filename=-1 -Z threads=16
+
+//@ compile-flags:-C extra-filename=-1
 //@ no-prefer-dynamic
 //@ build-pass
-//@ compare-output-by-lines
 
 #![crate_name = "crateresolve1"]
 #![crate_type = "lib"]

--- a/tests/ui/parallel-rustc/export-symbols-deadlock-issue-118205.rs
+++ b/tests/ui/parallel-rustc/export-symbols-deadlock-issue-118205.rs
@@ -1,8 +1,6 @@
 // Test for #118205, which causes a deadlock bug
-//
-//@ compile-flags: -Z threads=16
+
 //@ build-pass
-//@ compare-output-by-lines
 
 pub static GLOBAL: isize = 3;
 

--- a/tests/ui/parallel-rustc/fn-sig-cycle-ice-153391.rs
+++ b/tests/ui/parallel-rustc/fn-sig-cycle-ice-153391.rs
@@ -1,9 +1,7 @@
 // Regression test for #153391.
-//
+
 //@ edition:2024
-//@ compile-flags: -Z threads=16
-//@ compare-output-by-lines
-//@ ignore-test (#142063)
+//@ ignore-parallel-frontend query cycle
 
 trait A {
     fn g() -> B;

--- a/tests/ui/parallel-rustc/fn-sig-cycle-ice-153391.stderr
+++ b/tests/ui/parallel-rustc/fn-sig-cycle-ice-153391.stderr
@@ -1,16 +1,5 @@
 error[E0782]: expected a type, found a trait
-  --> $DIR/fn-sig-cycle-ice-153391.rs:8:15
-   |
-LL |     fn g() -> B;
-   |               ^
-   |
-help: `B` is dyn-incompatible, use `impl B` to return an opaque type, as long as you return a single underlying type
-   |
-LL |     fn g() -> impl B;
-   |               ++++
-
-error[E0782]: expected a type, found a trait
-  --> $DIR/fn-sig-cycle-ice-153391.rs:13:23
+  --> $DIR/fn-sig-cycle-ice-153391.rs:12:23
    |
 LL |     fn bar(&self, x: &A);
    |                       ^
@@ -25,6 +14,21 @@ help: you can also use an opaque type, but users won't be able to specify the ty
    |
 LL |     fn bar(&self, x: &impl A);
    |                       ++++
+
+error[E0782]: expected a type, found a trait
+  --> $DIR/fn-sig-cycle-ice-153391.rs:7:15
+   |
+LL |     fn g() -> B;
+   |               ^
+   |
+help: use `impl B` to return an opaque type, as long as you return a single underlying type
+   |
+LL |     fn g() -> impl B;
+   |               ++++
+help: alternatively, you can return an owned trait object
+   |
+LL |     fn g() -> Box<dyn B>;
+   |               +++++++  +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parallel-rustc/hello_world.rs
+++ b/tests/ui/parallel-rustc/hello_world.rs
@@ -1,9 +1,0 @@
-// Test for the basic function of parallel front end
-//
-//@ compile-flags: -Z threads=8
-//@ run-pass
-//@ compare-output-by-lines
-
-fn main() {
-    println!("Hello world!");
-}

--- a/tests/ui/parallel-rustc/read-stolen-value-issue-111520.rs
+++ b/tests/ui/parallel-rustc/read-stolen-value-issue-111520.rs
@@ -1,8 +1,6 @@
 // Test for #111520, which causes an ice bug cause of reading stolen value
-//
-//@ compile-flags: -Z threads=16
+
 //@ run-pass
-//@ compare-output-by-lines
 
 #[repr(transparent)]
 struct Sched {

--- a/tests/ui/parallel-rustc/recursive-struct-oncelock-issue-151226.rs
+++ b/tests/ui/parallel-rustc/recursive-struct-oncelock-issue-151226.rs
@@ -1,7 +1,4 @@
 // Test for #151226, Unable to verify registry association
-//
-//@ compile-flags: -Z threads=2
-//@ compare-output-by-lines
 
 struct A<T>(std::sync::OnceLock<Self>);
 //~^ ERROR recursive type `A` has infinite size

--- a/tests/ui/parallel-rustc/recursive-struct-oncelock-issue-151226.stderr
+++ b/tests/ui/parallel-rustc/recursive-struct-oncelock-issue-151226.stderr
@@ -1,5 +1,5 @@
 error[E0072]: recursive type `A` has infinite size
-  --> $DIR/recursive-struct-oncelock-issue-151226.rs:6:1
+  --> $DIR/recursive-struct-oncelock-issue-151226.rs:3:1
    |
 LL | struct A<T>(std::sync::OnceLock<Self>);
    | ^^^^^^^^^^^ ------------------------- recursive without indirection

--- a/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.rs
+++ b/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.rs
@@ -1,7 +1,4 @@
 // Test for #142064, internal error: entered unreachable code
-//
-//@ compile-flags: -Zthreads=2
-//@ compare-output-by-lines
 
 #![crate_type = "rlib"]
 trait A { fn foo() -> A; }

--- a/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.stderr
+++ b/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.stderr
@@ -1,5 +1,5 @@
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:23
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:4:23
    |
 LL | trait A { fn foo() -> A; }
    |                       ^
@@ -13,7 +13,7 @@ LL | trait A { fn foo() -> dyn A; }
    |                       +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:23
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:4:23
    |
 LL | trait A { fn foo() -> A; }
    |                       ^
@@ -26,42 +26,15 @@ help: if this is a dyn-compatible trait, use `dyn`
 LL | trait A { fn foo() -> dyn A; }
    |                       +++
 
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
-   |
-LL | trait B { fn foo() -> A; }
-   |                       ^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is a dyn-compatible trait, use `dyn`
-   |
-LL | trait B { fn foo() -> dyn A; }
-   |                       +++
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
-   |
-LL | trait B { fn foo() -> A; }
-   |                       ^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: if this is a dyn-compatible trait, use `dyn`
-   |
-LL | trait B { fn foo() -> dyn A; }
-   |                       +++
-
 error[E0038]: the trait `A` is not dyn compatible
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:23
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:4:23
    |
 LL | trait A { fn foo() -> A; }
    |                       ^ `A` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:14
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:4:14
    |
 LL | trait A { fn foo() -> A; }
    |       -      ^^^ ...because associated function `foo` has no `self` parameter
@@ -81,15 +54,42 @@ LL - trait A { fn foo() -> A; }
 LL + trait A { fn foo() -> Self; }
    |
 
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:10:23
+   |
+LL | trait B { fn foo() -> A; }
+   |                       ^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: if this is a dyn-compatible trait, use `dyn`
+   |
+LL | trait B { fn foo() -> dyn A; }
+   |                       +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:10:23
+   |
+LL | trait B { fn foo() -> A; }
+   |                       ^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/warnings-promoted-to-error.html>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: if this is a dyn-compatible trait, use `dyn`
+   |
+LL | trait B { fn foo() -> dyn A; }
+   |                       +++
+
 error[E0038]: the trait `A` is not dyn compatible
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:13:23
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:10:23
    |
 LL | trait B { fn foo() -> A; }
    |                       ^ `A` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:7:14
+  --> $DIR/recursive-trait-fn-sig-issue-142064.rs:4:14
    |
 LL | trait A { fn foo() -> A; }
    |       -      ^^^ ...because associated function `foo` has no `self` parameter

--- a/tests/ui/parallel-rustc/trait-solver-global-cache.rs
+++ b/tests/ui/parallel-rustc/trait-solver-global-cache.rs
@@ -1,8 +1,6 @@
-//@ compile-flags: -Zthreads=16
-
 // original issue: https://github.com/rust-lang/rust/issues/129112
 // Previously, the "next" solver asserted that each successful solution is only obtained once.
-// This test exhibits a repro that, with next-solver + -Zthreads, triggered that old assert.
+// This test exhibits a repro that, with next-solver + parallel frontend, triggered that old assert.
 // In the presence of multithreaded solving, it's possible to concurrently evaluate things twice,
 // which leads to replacing already-solved solutions in the global solution cache!
 // We assume this is fine if we check to make sure they are solved the same way each time.

--- a/tests/ui/parallel-rustc/trait-solver-global-cache.stderr
+++ b/tests/ui/parallel-rustc/trait-solver-global-cache.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `T: Clone` is not satisfied
-  --> $DIR/global-cache-and-parallel-frontend.rs:16:12
+  --> $DIR/trait-solver-global-cache.rs:14:12
    |
 LL | #[derive(Clone, Eq)]
    |                 -- in this derive macro expansion
@@ -7,7 +7,7 @@ LL | pub struct Struct<T>(T);
    |            ^^^^^^ the trait `Clone` is not implemented for `T`
    |
 note: required for `Struct<T>` to implement `PartialEq`
-  --> $DIR/global-cache-and-parallel-frontend.rs:18:19
+  --> $DIR/trait-solver-global-cache.rs:16:19
    |
 LL | impl<T: Clone, U> PartialEq<U> for Struct<T>
    |         -----     ^^^^^^^^^^^^     ^^^^^^^^^

--- a/tests/ui/parallel-rustc/ty-variance-issue-124423.rs
+++ b/tests/ui/parallel-rustc/ty-variance-issue-124423.rs
@@ -1,7 +1,4 @@
 // Test for #124423, which causes an ice bug: only `variances_of` returns `&[ty::Variance]`
-//
-//@ compile-flags: -Z threads=16
-//@ compare-output-by-lines
 
 use std::fmt::Debug;
 

--- a/tests/ui/parallel-rustc/ty-variance-issue-124423.stderr
+++ b/tests/ui/parallel-rustc/ty-variance-issue-124423.stderr
@@ -1,5 +1,5 @@
 error: ambiguous `+` in a type
-  --> $DIR/ty-variance-issue-124423.rs:8:15
+  --> $DIR/ty-variance-issue-124423.rs:5:15
    |
 LL | fn elided(_: &impl Copy + 'a) -> _ { x }
    |               ^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | fn elided(_: &(impl Copy + 'a)) -> _ { x }
    |               +              +
 
 error: ambiguous `+` in a type
-  --> $DIR/ty-variance-issue-124423.rs:13:24
+  --> $DIR/ty-variance-issue-124423.rs:10:24
    |
 LL | fn explicit<'b>(_: &'a impl Copy + 'a) -> impl 'a { x }
    |                        ^^^^^^^^^^^^^^
@@ -21,19 +21,19 @@ LL | fn explicit<'b>(_: &'a (impl Copy + 'a)) -> impl 'a { x }
    |                        +              +
 
 error: expected identifier, found keyword `impl`
-  --> $DIR/ty-variance-issue-124423.rs:20:13
+  --> $DIR/ty-variance-issue-124423.rs:17:13
    |
 LL | fn elided2( impl 'b) -> impl 'a + 'a { x }
    |             ^^^^ expected identifier, found keyword
 
 error: expected one of `:` or `|`, found `'b`
-  --> $DIR/ty-variance-issue-124423.rs:20:18
+  --> $DIR/ty-variance-issue-124423.rs:17:18
    |
 LL | fn elided2( impl 'b) -> impl 'a + 'a { x }
    |                  ^^ expected one of `:` or `|`
 
 error: ambiguous `+` in a type
-  --> $DIR/ty-variance-issue-124423.rs:27:25
+  --> $DIR/ty-variance-issue-124423.rs:24:25
    |
 LL | fn explicit2<'a>(_: &'a impl Copy + 'a) -> impl Copy + 'a { x }
    |                         ^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL | fn explicit2<'a>(_: &'a (impl Copy + 'a)) -> impl Copy + 'a { x }
    |                         +              +
 
 error: ambiguous `+` in a type
-  --> $DIR/ty-variance-issue-124423.rs:30:16
+  --> $DIR/ty-variance-issue-124423.rs:27:16
    |
 LL | fn foo<'a>(_: &impl Copy + 'a) -> impl 'b + 'a { x }
    |                ^^^^^^^^^^^^^^
@@ -55,7 +55,7 @@ LL | fn foo<'a>(_: &(impl Copy + 'a)) -> impl 'b + 'a { x }
    |                +              +
 
 error: ambiguous `+` in a type
-  --> $DIR/ty-variance-issue-124423.rs:35:16
+  --> $DIR/ty-variance-issue-124423.rs:32:16
    |
 LL | fn elided3(_: &impl Copy + 'a) -> Box<dyn 'a> { Box::new(x) }
    |                ^^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ LL | fn elided3(_: &(impl Copy + 'a)) -> Box<dyn 'a> { Box::new(x) }
    |                +              +
 
 error: ambiguous `+` in a type
-  --> $DIR/ty-variance-issue-124423.rs:41:17
+  --> $DIR/ty-variance-issue-124423.rs:38:17
    |
 LL | fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |                 ^^^^^^^^^^^^^^
@@ -77,7 +77,7 @@ LL | fn x<'b>(_: &'a (impl Copy + 'a)) -> Box<dyn 'b> { Box::u32(x) }
    |                 +              +
 
 error: ambiguous `+` in a type
-  --> $DIR/ty-variance-issue-124423.rs:48:16
+  --> $DIR/ty-variance-issue-124423.rs:45:16
    |
 LL | fn elided4(_: &impl Copy + 'a) ->  new  { x(x) }
    |                ^^^^^^^^^^^^^^
@@ -88,25 +88,25 @@ LL | fn elided4(_: &(impl Copy + 'a)) ->  new  { x(x) }
    |                +              +
 
 error: at least one trait must be specified
-  --> $DIR/ty-variance-issue-124423.rs:13:43
+  --> $DIR/ty-variance-issue-124423.rs:10:43
    |
 LL | fn explicit<'b>(_: &'a impl Copy + 'a) -> impl 'a { x }
    |                                           ^^^^^^^
 
 error: at least one trait must be specified
-  --> $DIR/ty-variance-issue-124423.rs:20:25
+  --> $DIR/ty-variance-issue-124423.rs:17:25
    |
 LL | fn elided2( impl 'b) -> impl 'a + 'a { x }
    |                         ^^^^^^^^^^^^
 
 error: at least one trait must be specified
-  --> $DIR/ty-variance-issue-124423.rs:30:35
+  --> $DIR/ty-variance-issue-124423.rs:27:35
    |
 LL | fn foo<'a>(_: &impl Copy + 'a) -> impl 'b + 'a { x }
    |                                   ^^^^^^^^^^^^
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-124423.rs:8:27
+  --> $DIR/ty-variance-issue-124423.rs:5:27
    |
 LL | fn elided(_: &impl Copy + 'a) -> _ { x }
    |                           ^^ undeclared lifetime
@@ -117,7 +117,7 @@ LL | fn elided<'a>(_: &impl Copy + 'a) -> _ { x }
    |          ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-124423.rs:13:21
+  --> $DIR/ty-variance-issue-124423.rs:10:21
    |
 LL | fn explicit<'b>(_: &'a impl Copy + 'a) -> impl 'a { x }
    |                     ^^ undeclared lifetime
@@ -128,7 +128,7 @@ LL | fn explicit<'a, 'b>(_: &'a impl Copy + 'a) -> impl 'a { x }
    |             +++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-124423.rs:13:36
+  --> $DIR/ty-variance-issue-124423.rs:10:36
    |
 LL | fn explicit<'b>(_: &'a impl Copy + 'a) -> impl 'a { x }
    |                                    ^^ undeclared lifetime
@@ -139,7 +139,7 @@ LL | fn explicit<'a, 'b>(_: &'a impl Copy + 'a) -> impl 'a { x }
    |             +++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-124423.rs:13:48
+  --> $DIR/ty-variance-issue-124423.rs:10:48
    |
 LL | fn explicit<'b>(_: &'a impl Copy + 'a) -> impl 'a { x }
    |                                                ^^ undeclared lifetime
@@ -150,7 +150,7 @@ LL | fn explicit<'a, 'b>(_: &'a impl Copy + 'a) -> impl 'a { x }
    |             +++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-124423.rs:20:30
+  --> $DIR/ty-variance-issue-124423.rs:17:30
    |
 LL | fn elided2( impl 'b) -> impl 'a + 'a { x }
    |                              ^^ undeclared lifetime
@@ -161,7 +161,7 @@ LL | fn elided2<'a>( impl 'b) -> impl 'a + 'a { x }
    |           ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-124423.rs:20:35
+  --> $DIR/ty-variance-issue-124423.rs:17:35
    |
 LL | fn elided2( impl 'b) -> impl 'a + 'a { x }
    |                                   ^^ undeclared lifetime
@@ -172,7 +172,7 @@ LL | fn elided2<'a>( impl 'b) -> impl 'a + 'a { x }
    |           ++++
 
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/ty-variance-issue-124423.rs:30:40
+  --> $DIR/ty-variance-issue-124423.rs:27:40
    |
 LL | fn foo<'a>(_: &impl Copy + 'a) -> impl 'b + 'a { x }
    |                                        ^^ undeclared lifetime
@@ -183,7 +183,7 @@ LL | fn foo<'b, 'a>(_: &impl Copy + 'a) -> impl 'b + 'a { x }
    |        +++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-124423.rs:35:28
+  --> $DIR/ty-variance-issue-124423.rs:32:28
    |
 LL | fn elided3(_: &impl Copy + 'a) -> Box<dyn 'a> { Box::new(x) }
    |                            ^^ undeclared lifetime
@@ -194,7 +194,7 @@ LL | fn elided3<'a>(_: &impl Copy + 'a) -> Box<dyn 'a> { Box::new(x) }
    |           ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-124423.rs:35:43
+  --> $DIR/ty-variance-issue-124423.rs:32:43
    |
 LL | fn elided3(_: &impl Copy + 'a) -> Box<dyn 'a> { Box::new(x) }
    |                                           ^^ undeclared lifetime
@@ -205,7 +205,7 @@ LL | fn elided3<'a>(_: &impl Copy + 'a) -> Box<dyn 'a> { Box::new(x) }
    |           ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-124423.rs:41:14
+  --> $DIR/ty-variance-issue-124423.rs:38:14
    |
 LL | fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |              ^^ undeclared lifetime
@@ -216,7 +216,7 @@ LL | fn x<'a, 'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |      +++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-124423.rs:41:29
+  --> $DIR/ty-variance-issue-124423.rs:38:29
    |
 LL | fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |                             ^^ undeclared lifetime
@@ -227,7 +227,7 @@ LL | fn x<'a, 'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |      +++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-124423.rs:48:28
+  --> $DIR/ty-variance-issue-124423.rs:45:28
    |
 LL | fn elided4(_: &impl Copy + 'a) ->  new  { x(x) }
    |                            ^^ undeclared lifetime
@@ -238,37 +238,37 @@ LL | fn elided4<'a>(_: &impl Copy + 'a) ->  new  { x(x) }
    |           ++++
 
 error[E0425]: cannot find type `new` in this scope
-  --> $DIR/ty-variance-issue-124423.rs:48:36
+  --> $DIR/ty-variance-issue-124423.rs:45:36
    |
 LL | fn elided4(_: &impl Copy + 'a) ->  new  { x(x) }
    |                                    ^^^ not found in this scope
 
 error[E0224]: at least one trait is required for an object type
-  --> $DIR/ty-variance-issue-124423.rs:55:40
-   |
-LL | impl<'a> LifetimeTrait<'a> for &'a Box<dyn 'a> {}
-   |                                        ^^^^^^
-
-error[E0224]: at least one trait is required for an object type
-  --> $DIR/ty-variance-issue-124423.rs:41:40
+  --> $DIR/ty-variance-issue-124423.rs:38:40
    |
 LL | fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |                                        ^^^^^^
 
 error[E0224]: at least one trait is required for an object type
-  --> $DIR/ty-variance-issue-124423.rs:35:39
+  --> $DIR/ty-variance-issue-124423.rs:32:39
    |
 LL | fn elided3(_: &impl Copy + 'a) -> Box<dyn 'a> { Box::new(x) }
    |                                       ^^^^^^
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/ty-variance-issue-124423.rs:8:34
+  --> $DIR/ty-variance-issue-124423.rs:5:34
    |
 LL | fn elided(_: &impl Copy + 'a) -> _ { x }
    |                                  ^ not allowed in type signatures
 
+error[E0224]: at least one trait is required for an object type
+  --> $DIR/ty-variance-issue-124423.rs:52:40
+   |
+LL | impl<'a> LifetimeTrait<'a> for &'a Box<dyn 'a> {}
+   |                                        ^^^^^^
+
 error[E0599]: no associated function or constant named `u32` found for struct `Box<_, _>` in the current scope
-  --> $DIR/ty-variance-issue-124423.rs:41:55
+  --> $DIR/ty-variance-issue-124423.rs:38:55
    |
 LL | fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |                                                       ^^^ associated function or constant not found in `Box<_, _>`

--- a/tests/ui/parallel-rustc/ty-variance-issue-127971.rs
+++ b/tests/ui/parallel-rustc/ty-variance-issue-127971.rs
@@ -1,7 +1,4 @@
 // Test for #127971, which causes an ice bug: only `variances_of` returns `&[ty::Variance]`
-//
-//@ compile-flags: -Z threads=16
-//@ compare-output-by-lines
 
 use std::fmt::Debug;
 

--- a/tests/ui/parallel-rustc/ty-variance-issue-127971.stderr
+++ b/tests/ui/parallel-rustc/ty-variance-issue-127971.stderr
@@ -1,5 +1,5 @@
 error: ambiguous `+` in a type
-  --> $DIR/ty-variance-issue-127971.rs:8:15
+  --> $DIR/ty-variance-issue-127971.rs:5:15
    |
 LL | fn elided(_: &impl Copy + 'a) -> _ { x }
    |               ^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | fn elided(_: &(impl Copy + 'a)) -> _ { x }
    |               +              +
 
 error: ambiguous `+` in a type
-  --> $DIR/ty-variance-issue-127971.rs:13:16
+  --> $DIR/ty-variance-issue-127971.rs:10:16
    |
 LL | fn foo<'a>(_: &impl Copy + 'a) -> impl 'b + 'a { x }
    |                ^^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ LL | fn foo<'a>(_: &(impl Copy + 'a)) -> impl 'b + 'a { x }
    |                +              +
 
 error: ambiguous `+` in a type
-  --> $DIR/ty-variance-issue-127971.rs:18:17
+  --> $DIR/ty-variance-issue-127971.rs:15:17
    |
 LL | fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |                 ^^^^^^^^^^^^^^
@@ -32,13 +32,13 @@ LL | fn x<'b>(_: &'a (impl Copy + 'a)) -> Box<dyn 'b> { Box::u32(x) }
    |                 +              +
 
 error: at least one trait must be specified
-  --> $DIR/ty-variance-issue-127971.rs:13:35
+  --> $DIR/ty-variance-issue-127971.rs:10:35
    |
 LL | fn foo<'a>(_: &impl Copy + 'a) -> impl 'b + 'a { x }
    |                                   ^^^^^^^^^^^^
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-127971.rs:8:27
+  --> $DIR/ty-variance-issue-127971.rs:5:27
    |
 LL | fn elided(_: &impl Copy + 'a) -> _ { x }
    |                           ^^ undeclared lifetime
@@ -49,7 +49,7 @@ LL | fn elided<'a>(_: &impl Copy + 'a) -> _ { x }
    |          ++++
 
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/ty-variance-issue-127971.rs:13:40
+  --> $DIR/ty-variance-issue-127971.rs:10:40
    |
 LL | fn foo<'a>(_: &impl Copy + 'a) -> impl 'b + 'a { x }
    |                                        ^^ undeclared lifetime
@@ -60,7 +60,7 @@ LL | fn foo<'b, 'a>(_: &impl Copy + 'a) -> impl 'b + 'a { x }
    |        +++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-127971.rs:18:14
+  --> $DIR/ty-variance-issue-127971.rs:15:14
    |
 LL | fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |              ^^ undeclared lifetime
@@ -71,7 +71,7 @@ LL | fn x<'a, 'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |      +++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/ty-variance-issue-127971.rs:18:29
+  --> $DIR/ty-variance-issue-127971.rs:15:29
    |
 LL | fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |                             ^^ undeclared lifetime
@@ -82,19 +82,19 @@ LL | fn x<'a, 'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |      +++
 
 error[E0224]: at least one trait is required for an object type
-  --> $DIR/ty-variance-issue-127971.rs:18:40
+  --> $DIR/ty-variance-issue-127971.rs:15:40
    |
 LL | fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |                                        ^^^^^^
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/ty-variance-issue-127971.rs:8:34
+  --> $DIR/ty-variance-issue-127971.rs:5:34
    |
 LL | fn elided(_: &impl Copy + 'a) -> _ { x }
    |                                  ^ not allowed in type signatures
 
 error[E0599]: no associated function or constant named `u32` found for struct `Box<_, _>` in the current scope
-  --> $DIR/ty-variance-issue-127971.rs:18:55
+  --> $DIR/ty-variance-issue-127971.rs:15:55
    |
 LL | fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
    |                                                       ^^^ associated function or constant not found in `Box<_, _>`

--- a/tests/ui/parallel-rustc/undefined-function-issue-120760.rs
+++ b/tests/ui/parallel-rustc/undefined-function-issue-120760.rs
@@ -1,8 +1,6 @@
 // Test for #120760, which causes an ice bug: no index for a field
-//
-//@ compile-flags: -Z threads=45
+
 //@ edition: 2021
-//@ compare-output-by-lines
 
 type BoxFuture<T> = std::pin::Pin<Box<dyn std::future::Future<Output = T>>>;
 

--- a/tests/ui/parallel-rustc/undefined-function-issue-120760.stderr
+++ b/tests/ui/parallel-rustc/undefined-function-issue-120760.stderr
@@ -1,5 +1,5 @@
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/undefined-function-issue-120760.rs:20:16
+  --> $DIR/undefined-function-issue-120760.rs:18:16
    |
 LL |     pub name: &'a str,
    |                ^^ undeclared lifetime
@@ -9,25 +9,25 @@ help: consider introducing lifetime `'a` here
 LL | pub struct User<'a, 'dep> {
    |                 +++
 
+error[E0425]: cannot find function `run` in this scope
+  --> $DIR/undefined-function-issue-120760.rs:12:5
+   |
+LL |     run("dependency").await;
+   |     ^^^ not found in this scope
+
+error[E0425]: cannot find function `run` in this scope
+  --> $DIR/undefined-function-issue-120760.rs:59:17
+   |
+LL |         let _ = run("dependency").await;
+   |                 ^^^ not found in this scope
+
 error[E0560]: struct `User<'_>` has no field named `dep`
-  --> $DIR/undefined-function-issue-120760.rs:70:12
+  --> $DIR/undefined-function-issue-120760.rs:68:12
    |
 LL |     User { dep }.save().await;
    |            ^^^ `User<'_>` does not have this field
    |
    = note: available fields are: `name`
-
-error[E0425]: cannot find function `run` in this scope
-  --> $DIR/undefined-function-issue-120760.rs:61:17
-   |
-LL |         let _ = run("dependency").await;
-   |                 ^^^ not found in this scope
-
-error[E0425]: cannot find function `run` in this scope
-  --> $DIR/undefined-function-issue-120760.rs:14:5
-   |
-LL |     run("dependency").await;
-   |     ^^^ not found in this scope
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/parallel-rustc/unexpected-type-issue-120601.rs
+++ b/tests/ui/parallel-rustc/unexpected-type-issue-120601.rs
@@ -1,8 +1,6 @@
-//@ edition:2015
 // Test for #120601, which causes an ice bug cause of unexpected type
-//
-//@ compile-flags: -Z threads=40
-//@ compare-output-by-lines
+
+//@ edition:2015
 
 struct T;
 struct Tuple(i32);

--- a/tests/ui/parallel-rustc/unexpected-type-issue-120601.stderr
+++ b/tests/ui/parallel-rustc/unexpected-type-issue-120601.stderr
@@ -1,5 +1,5 @@
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/unexpected-type-issue-120601.rs:10:1
+  --> $DIR/unexpected-type-issue-120601.rs:8:1
    |
 LL | async fn foo() -> Result<(), ()> {
    | ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -8,7 +8,7 @@ LL | async fn foo() -> Result<(), ()> {
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/unexpected-type-issue-120601.rs:16:1
+  --> $DIR/unexpected-type-issue-120601.rs:14:1
    |
 LL | async fn tuple() -> Tuple {
    | ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -17,7 +17,7 @@ LL | async fn tuple() -> Tuple {
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
-  --> $DIR/unexpected-type-issue-120601.rs:21:1
+  --> $DIR/unexpected-type-issue-120601.rs:19:1
    |
 LL | async fn match_() {
    | ^^^^^ to use `async fn`, switch to Rust 2018 or later
@@ -25,8 +25,14 @@ LL | async fn match_() {
    = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
+error[E0425]: cannot find function, tuple struct or tuple variant `Unstable2` in this scope
+  --> $DIR/unexpected-type-issue-120601.rs:9:5
+   |
+LL |     Unstable2(())
+   |     ^^^^^^^^^ not found in this scope
+
 error[E0308]: mismatched types
-  --> $DIR/unexpected-type-issue-120601.rs:23:9
+  --> $DIR/unexpected-type-issue-120601.rs:21:9
    |
 LL |     match tuple() {
    |           ------- this expression has type `impl Future<Output = Tuple>`
@@ -39,12 +45,6 @@ help: consider `await`ing on the `Future`
    |
 LL |     match tuple().await {
    |                  ++++++
-
-error[E0425]: cannot find function, tuple struct or tuple variant `Unstable2` in this scope
-  --> $DIR/unexpected-type-issue-120601.rs:11:5
-   |
-LL |     Unstable2(())
-   |     ^^^^^^^^^ not found in this scope
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
The number of threads is now passed by compiletest through `--parallel-frontend-threads=N` in parallel testing runs.
If it becomes necessary, we'll be able to set a larger number of threads or iterations for the `ui/parallel-rustc` tests specifically.

r? @jieyouxu 