### PR TITLE
Fix Windows on Arm PAC default

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -530,9 +530,7 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
         to_add.extend(sanitize_attrs(cx, tcx, codegen_fn_attrs.sanitizers));
 
         // For non-naked functions, set branch protection attributes on aarch64.
-        if let Some(BranchProtection { bti, pac_ret, gcs }) =
-            sess.opts.unstable_opts.branch_protection
-        {
+        if let Some(BranchProtection { bti, pac_ret, gcs }) = sess.branch_protection() {
             assert!(sess.target.arch == Arch::AArch64);
             if bti {
                 to_add.push(llvm::CreateAttrString(cx.llcx, "branch-target-enforcement"));

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -405,8 +405,7 @@ pub(crate) unsafe fn create_module<'ll>(
         );
     }
 
-    if let Some(BranchProtection { bti, pac_ret, gcs }) = sess.opts.unstable_opts.branch_protection
-    {
+    if let Some(BranchProtection { bti, pac_ret, gcs }) = sess.branch_protection() {
         if sess.target.arch == Arch::AArch64 {
             llvm::add_module_flag_u32(
                 llmod,
@@ -420,7 +419,11 @@ pub(crate) unsafe fn create_module<'ll>(
                 "sign-return-address",
                 pac_ret.is_some().into(),
             );
-            let pac_opts = pac_ret.unwrap_or(PacRet { leaf: false, pc: false, key: PAuthKey::A });
+            let pac_opts = pac_ret.unwrap_or_else(|| {
+                // Windows on Arm only supports PAC key B.
+                let key = if sess.target.os == Os::Windows { PAuthKey::B } else { PAuthKey::A };
+                PacRet { leaf: false, pc: false, key }
+            });
             llvm::add_module_flag_u32(
                 llmod,
                 llvm::ModuleFlagMergeBehavior::Min,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2016,6 +2016,10 @@ pub mod parse {
                     match opt {
                         "bti" => slot.bti = true,
                         "pac-ret" if slot.pac_ret.is_none() => {
+                            // Note: some targets only support certain keys (Windows on Arm only
+                            // supports Key B) and this possible discrepancy is handled by the
+                            // session's `branch_protection` accessor, when we have both the target
+                            // tuple and branch protection information available.
                             slot.pac_ret = Some(PacRet { leaf: false, pc: false, key: PAuthKey::A })
                         }
                         "leaf" => match slot.pac_ret.as_mut() {
@@ -2385,6 +2389,7 @@ options! {
         (default: no)"),
     box_noalias: bool = (true, parse_bool, [TRACKED],
         "emit noalias metadata for box (default: yes)"),
+    #[rustc_lint_opt_deny_field_access("use `Session::branch_protection` instead of this field")]
     branch_protection: Option<BranchProtection> = (None, parse_branch_protection, [TRACKED] { TARGET_MODIFIER: BranchProtection },
         "set options for branch target identification and pointer authentication on AArch64"),
     build_sdylib_interface: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -36,9 +36,9 @@ use rustc_target::spec::{
 use crate::code_stats::CodeStats;
 pub use crate::code_stats::{DataTypeKind, FieldInfo, FieldKind, SizeKind, VariantInfo};
 use crate::config::{
-    self, Cfg, CheckCfg, CoverageLevel, CoverageOptions, CrateType, DebugInfo, ErrorOutputType,
-    FunctionReturn, Input, InstrumentCoverage, InstrumentMcount, NATIVE_CPU, OptLevel, OutFileName,
-    OutputType, PointerAuthOption, SwitchWithOptPath,
+    self, BranchProtection, Cfg, CheckCfg, CoverageLevel, CoverageOptions, CrateType, DebugInfo,
+    ErrorOutputType, FunctionReturn, Input, InstrumentCoverage, InstrumentMcount, NATIVE_CPU,
+    OptLevel, OutFileName, OutputType, PAuthKey, PointerAuthOption, SwitchWithOptPath,
 };
 use crate::filesearch::FileSearch;
 use crate::lint::LintId;
@@ -997,6 +997,30 @@ impl Session {
         } else {
             StackProtector::None
         }
+    }
+
+    /// Returns the `-Zbranch-protection` info. Note that it is adjusted to the current target, e.g.
+    /// some targets only support certain Pointer Authentication Code keys.
+    ///
+    /// Accessing the session's unstable `branch_protection` option fields directly is linted
+    /// against.
+    pub fn branch_protection(&self) -> Option<BranchProtection> {
+        let mut bp = self.opts.unstable_opts.branch_protection;
+
+        if let Some(bp) = bp.as_mut() {
+            // Windows on Arm only supports PAC Key B for return address signing, as shown in
+            // https://github.com/llvm/llvm-project/pull/203989. We parse the CLI flags for branch
+            // protection and target separately though, so we adjust this possible discrepancy here.
+            if self.target.os == Os::Windows && self.target.arch == Arch::AArch64 {
+                if let Some(pac_ret) = bp.pac_ret.as_mut()
+                    && pac_ret.key == PAuthKey::A
+                {
+                    pac_ret.key = PAuthKey::B;
+                }
+            }
+        }
+
+        bp
     }
 
     pub fn must_emit_unwind_tables(&self) -> bool {


### PR DESCRIPTION
Windows on Arm's branch protection only supports PAC Key B for return address signing. The CLI parsing sets it to Key A though, and it doesn't have access to the target information to fix it. This PR adds an accessor function where we can fix this possible discrepancy, and lints against using the `branch_protection` unstable option field directly.

I don't think we need to have a generic mechanism to allow targets to define the valid options themselves, at least not yet. So this is the rustc version of https://github.com/llvm/llvm-project/pull/203989 and uses basically the same idea to set the correct default.

This fixes the `pointer-auth-link-with-c` run-make [failure](https://triage.rust-lang.org/gha-logs/rust-lang/rust/90283463228) happening in the [LLVM23 update PR](https://github.com/rust-lang/rust/pull/158734).

It's probable people will want to add a `standard` value for branch protection, matching clang, and the current accessor will be a good place to do that, compared to e.g. only having an accessor for `PacRet::key`.