### PR TITLE
Mutable closure captures through opaque casts

### DIFF
--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -347,6 +347,10 @@ pub enum ExprKind<'tcx> {
     Use {
         source: ExprId,
     },
+    /// A compiler-generated opaque cast that preserves place semantics.
+    PlaceOpaqueCast {
+        source: ExprId,
+    },
     /// A coercion from `!` to any type.
     NeverToAny {
         source: ExprId,

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -71,7 +71,7 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         }
         Unary { arg, op: _ } => visitor.visit_expr(&visitor.thir()[arg]),
         Cast { source } => visitor.visit_expr(&visitor.thir()[source]),
-        Use { source } => visitor.visit_expr(&visitor.thir()[source]),
+        Use { source } | PlaceOpaqueCast { source } => visitor.visit_expr(&visitor.thir()[source]),
         NeverToAny { source } => visitor.visit_expr(&visitor.thir()[source]),
         PointerCoercion { source, cast: _, is_from_as_cast: _ } => {
             visitor.visit_expr(&visitor.thir()[source])

--- a/compiler/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_place.rs
@@ -544,6 +544,18 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 block.and(PlaceBuilder::from(temp).project(PlaceElem::UnwrapUnsafeBinder(expr.ty)))
             }
 
+            ExprKind::PlaceOpaqueCast { source } => {
+                let place_builder = unpack!(
+                    block = this.expr_as_place(
+                        block,
+                        source,
+                        mutability,
+                        fake_borrow_temps,
+                    )
+                );
+                block.and(place_builder.project(PlaceElem::OpaqueCast(expr.ty)))
+            }
+
             ExprKind::Array { .. }
             | ExprKind::Tuple { .. }
             | ExprKind::Adt { .. }

--- a/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -407,6 +407,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::InlineAsm { .. }
             | ExprKind::PlaceTypeAscription { .. }
             | ExprKind::ValueTypeAscription { .. }
+            | ExprKind::PlaceOpaqueCast { .. }
             | ExprKind::PlaceUnwrapUnsafeBinder { .. }
             | ExprKind::ValueUnwrapUnsafeBinder { .. } => {
                 // these do not have corresponding `Rvalue` variants,
@@ -709,9 +710,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
         };
 
+        let has_opaque_cast = arg_place_builder
+            .projection()
+            .iter()
+            .any(|elem| matches!(elem, ProjectionElem::OpaqueCast(_)));
+
         let borrow_kind = match mutability {
-            Mutability::Not => BorrowKind::Mut { kind: MutBorrowKind::ClosureCapture },
-            Mutability::Mut => BorrowKind::Mut { kind: MutBorrowKind::Default },
+            // `ClosureCapture` assumes that the mutation which caused the capture
+            // is checked separately. For a capture through an opaque cast, this
+            // borrow may be the only mutable use, so let borrowck validate it.
+            Mutability::Not if !has_opaque_cast => {
+                BorrowKind::Mut { kind: MutBorrowKind::ClosureCapture }
+            }
+            Mutability::Not | Mutability::Mut => BorrowKind::Mut { kind: MutBorrowKind::Default },
         };
 
         let arg_place = arg_place_builder.to_place(this);

--- a/compiler/rustc_mir_build/src/builder/expr/category.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/category.rs
@@ -42,6 +42,7 @@ impl Category {
             | ExprKind::VarRef { .. }
             | ExprKind::PlaceTypeAscription { .. }
             | ExprKind::ValueTypeAscription { .. }
+            | ExprKind::PlaceOpaqueCast { .. }
             | ExprKind::PlaceUnwrapUnsafeBinder { .. }
             | ExprKind::ValueUnwrapUnsafeBinder { .. } => Some(Category::Place),
 

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -840,6 +840,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::UpvarRef { .. }
             | ExprKind::PlaceTypeAscription { .. }
             | ExprKind::ValueTypeAscription { .. }
+            | ExprKind::PlaceOpaqueCast { .. }
             | ExprKind::PlaceUnwrapUnsafeBinder { .. }
             | ExprKind::ValueUnwrapUnsafeBinder { .. } => {
                 debug_assert!(Category::of(&expr.kind) == Some(Category::Place));

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -347,7 +347,8 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
             | ExprKind::VarRef { .. }
             | ExprKind::UpvarRef { .. }
             | ExprKind::Scope { .. }
-            | ExprKind::Cast { .. } => {}
+            | ExprKind::Cast { .. }
+            | ExprKind::PlaceOpaqueCast { .. } => {}
 
             ExprKind::RawBorrow { .. }
             | ExprKind::Adt { .. }

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -1561,7 +1561,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     name: field,
                 },
                 HirProjectionKind::OpaqueCast => {
-                    ExprKind::Use { source: self.thir.exprs.push(captured_place_expr) }
+                    ExprKind::PlaceOpaqueCast { source: self.thir.exprs.push(captured_place_expr) }
                 }
                 HirProjectionKind::UnwrapUnsafeBinder => ExprKind::PlaceUnwrapUnsafeBinder {
                     source: self.thir.exprs.push(captured_place_expr),

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -316,6 +316,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
             NeverToAny { source }
             | Cast { source }
             | Use { source }
+            | PlaceOpaqueCast { source }
             | PointerCoercion { source, .. }
             | PlaceTypeAscription { source, .. }
             | ValueTypeAscription { source, .. }

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -307,6 +307,12 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
                 self.print_expr(*source, depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl);
             }
+            PlaceOpaqueCast { source } => {
+                print_indented!(self, "PlaceOpaqueCast {", depth_lvl);
+                print_indented!(self, "source:", depth_lvl + 1);
+                self.print_expr(*source, depth_lvl + 2);
+                print_indented!(self, "}", depth_lvl);
+            }
             NeverToAny { source } => {
                 print_indented!(self, "NeverToAny {", depth_lvl);
                 print_indented!(self, "source:", depth_lvl + 1);

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -205,6 +205,7 @@ fn recurse_build<'tcx>(
         // we dont permit let stmts so `VarRef` and `UpvarRef` cant happen
         ExprKind::VarRef { .. }
         | ExprKind::UpvarRef { .. }
+        | ExprKind::PlaceOpaqueCast { .. }
         | ExprKind::StaticRef { .. }
         | ExprKind::ThreadLocalRef(_) => {
             error(GenericConstantTooComplexSub::OperationNotSupported(node.span))?
@@ -273,6 +274,7 @@ impl<'a, 'tcx> IsThirPolymorphic<'a, 'tcx> {
             | thir::ExprKind::Unary { .. }
             | thir::ExprKind::Cast { .. }
             | thir::ExprKind::Use { .. }
+            | thir::ExprKind::PlaceOpaqueCast { .. }
             | thir::ExprKind::NeverToAny { .. }
             | thir::ExprKind::PointerCoercion { .. }
             | thir::ExprKind::Loop { .. }

--- a/tests/ui/type-alias-impl-trait/mutable-capture-through-opaque-cast-issue-160120.next.stderr
+++ b/tests/ui/type-alias-impl-trait/mutable-capture-through-opaque-cast-issue-160120.next.stderr
@@ -1,0 +1,14 @@
+error[E0596]: cannot borrow `foo.0` as mutable, as it is not declared as mutable
+  --> $DIR/mutable-capture-through-opaque-cast-issue-160120.rs:16:17
+   |
+LL |         let Foo(ref mut _cdr) = foo;
+   |                 ^^^^^^^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut foo: T = Foo((2, 2));
+   |         +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/type-alias-impl-trait/mutable-capture-through-opaque-cast-issue-160120.old.stderr
+++ b/tests/ui/type-alias-impl-trait/mutable-capture-through-opaque-cast-issue-160120.old.stderr
@@ -1,0 +1,17 @@
+error[E0596]: cannot borrow `foo.0` as mutable, as `foo` is not declared as mutable
+  --> $DIR/mutable-capture-through-opaque-cast-issue-160120.rs:14:20
+   |
+LL |     let _closure = || {
+   |                    ^^ cannot borrow as mutable
+LL |
+LL |         let Foo(ref mut _cdr) = foo;
+   |                                 --- mutable borrow occurs due to use of `foo.0` in closure
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut foo: T = Foo((2, 2));
+   |         +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/type-alias-impl-trait/mutable-capture-through-opaque-cast-issue-160120.rs
+++ b/tests/ui/type-alias-impl-trait/mutable-capture-through-opaque-cast-issue-160120.rs
@@ -1,0 +1,19 @@
+//@ revisions: old next
+//@ edition: 2021
+//@[next] compile-flags: -Znext-solver=globally
+
+#![feature(type_alias_impl_trait)]
+
+#[derive(Copy, Clone)]
+struct Foo((u32, u32));
+
+fn main() {
+    type T = impl Copy;
+    let foo: T = Foo((2, 2));
+
+    let _closure = || {
+        //[old]~^ ERROR cannot borrow `foo.0` as mutable
+        let Foo(ref mut _cdr) = foo;
+        //[next]~^ ERROR cannot borrow `foo.0` as mutable
+    };
+}


### PR DESCRIPTION
fixes rust-lang/rust#160120
Preserve place semantics for opaque projections in closure captures instead of lowering them through `ExprKind::Use` and ensures mutable captures through TAIT opaque casts are validated by borrowck with both solvers