### PR TITLE
Mark a doctest as requiring unwinding

### DIFF
--- a/library/alloc/src/io/buffered/bufwriter.rs
+++ b/library/alloc/src/io/buffered/bufwriter.rs
@@ -490,6 +490,10 @@ impl<W: ?Sized + Write> BufWriter<W> {
 /// # Example
 ///
 /// ```
+/// # // This test requires unwinding to work.
+/// # // Disable it when unwinding isn't available.
+/// # #[cfg(panic = "unwind")]
+/// # fn main() {
 /// use std::io::{self, BufWriter, Write};
 /// use std::panic::{catch_unwind, AssertUnwindSafe};
 ///
@@ -508,6 +512,9 @@ impl<W: ?Sized + Write> BufWriter<W> {
 /// let (recovered_writer, buffered_data) = stream.into_parts();
 /// assert!(matches!(recovered_writer, PanickingWriter));
 /// assert_eq!(buffered_data.unwrap_err().into_inner(), b"some data");
+/// # }
+/// # #[cfg(not(panic = "unwind"))]
+/// # fn main() {}
 /// ```
 pub struct WriterPanicked {
     buf: Vec<u8>,


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/158547 moved `std::io::BufWriter` to `alloc::io::BufWriter`. That allows it to be used in `no-std` configurations, and in particular on platforms where unwinding isn't supported.

However one of the doc tests uses `catch_unwind`, which fails on platforms which cannot unwind. Fix this by copying the magic incantation from a similar doctest in library/core/src/range.rs

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
