### PR TITLE
Create on-demand CI job for testing EC2 instances

### DIFF
--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -77,3 +77,13 @@ auto_build_failed = [
     "-S-waiting-on-crater",
     "-S-waiting-on-team",
 ]
+
+[ec2_runners]
+runner_group_id = 8
+label_prefix = "ec2"
+region = "us-east-2"
+images = {
+    "ubuntu26.04" = "/aws/service/canonical/ubuntu/server/26.04/stable/current/amd64/hvm/ebs-gp3/ami-id"
+}
+jit_runner = "organization"
+allowed_instances = ["c8a.12xlarge"]

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -189,6 +189,21 @@ optional:
     env:
       IMAGE: pr-check-1
     <<: *job-linux-4c
+  - name: dist-x86_64-linux-ec2
+    os: ec2-ubuntu26.04-c8a.12xlarge-x64-linux-$github.run_id-$github.run_attempt
+    free_disk: true
+    env:
+      IMAGE: dist-x86_64-linux
+      CODEGEN_BACKENDS: llvm,cranelift
+      DOCKER_SCRIPT: dist.sh
+  - name: dist-x86_64-linux-ec2-quick
+    os: ec2-ubuntu26.04-c8a.12xlarge-x64-linux-$github.run_id-$github.run_attempt
+    free_disk: true
+    env:
+      IMAGE: dist-x86_64-linux
+      CODEGEN_BACKENDS: llvm,cranelift
+      DOCKER_SCRIPT: dist.sh
+      DIST_TRY_BUILD: 1
 
 # Main CI jobs that have to be green to merge a commit into the default branch.
 #


### PR DESCRIPTION
This job is designed to be executed manually using `@bors try`.

We want to test the cooperation of this job with bors and its new functionality to start EC2 instances to run jobs.
