### PR TITLE
test: fail benchmarks that skip iter

### DIFF
--- a/library/test/src/bench.rs
+++ b/library/test/src/bench.rs
@@ -220,11 +220,7 @@ pub fn benchmark<F>(
             TestResult::TrBench(bs)
         }
         Ok(Ok(None)) => {
-            // iter not called, so no data.
-            // FIXME: error in this case?
-            let samples: &mut [f64] = &mut [0.0_f64; 1];
-            let bs = BenchSamples { ns_iter_summ: stats::Summary::new(samples), mb_s: 0 };
-            TestResult::TrBench(bs)
+            TestResult::TrFailedMsg("benchmark function did not call Bencher::iter".into())
         }
         Err(_) => TestResult::TrFailed,
         Ok(Err(_)) => TestResult::TrFailed,

--- a/library/test/src/stats/tests.rs
+++ b/library/test/src/stats/tests.rs
@@ -587,6 +587,3 @@ fn sum_many_f64(b: &mut Bencher) {
         v.sum();
     })
 }
-
-#[bench]
-fn no_iter(_: &mut Bencher) {}

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -786,7 +786,10 @@ fn test_bench_no_iter() {
     };
 
     crate::bench::benchmark(TestId(0), desc, tx, true, f);
-    rx.recv().unwrap();
+    assert_eq!(
+        rx.recv().unwrap().result,
+        TrFailedMsg("benchmark function did not call Bencher::iter".to_string())
+    );
 }
 
 #[test]

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -88,7 +88,7 @@ pub use crate::path_helpers::{
     shallow_find_files, source_root,
 };
 // Convenience helpers for running binaries and other commands.
-pub use crate::run::{cmd, run, run_fail, run_with_args};
+pub use crate::run::{cmd, run, run_fail, run_fail_with_args, run_with_args};
 // Helpers for scoped test execution where certain properties are attempted to be maintained.
 pub use crate::scoped_run::{run_in_tmpdir, test_while_readonly};
 pub use crate::string::{

--- a/src/tools/run-make-support/src/run.rs
+++ b/src/tools/run-make-support/src/run.rs
@@ -74,6 +74,12 @@ pub fn run_with_args(name: &str, args: &[&str]) -> CompletedProcess {
     run_common(name, Some(args)).run()
 }
 
+/// Run a built binary with one or more argument(s) and make sure it fails.
+#[track_caller]
+pub fn run_fail_with_args(name: &str, args: &[&str]) -> CompletedProcess {
+    run_common(name, Some(args)).run_fail()
+}
+
 /// Run a built binary and make sure it fails.
 #[track_caller]
 pub fn run_fail(name: &str) -> CompletedProcess {

--- a/tests/run-make/libtest-padding/tests.rs
+++ b/tests/run-make/libtest-padding/tests.rs
@@ -8,7 +8,11 @@ fn short_test_name() {}
 fn this_is_a_really_long_test_name() {}
 
 #[bench]
-fn short_bench_name(b: &mut test::Bencher) {}
+fn short_bench_name(b: &mut test::Bencher) {
+    b.iter(|| {});
+}
 
 #[bench]
-fn this_is_a_really_long_bench_name(b: &mut test::Bencher) {}
+fn this_is_a_really_long_bench_name(b: &mut test::Bencher) {
+    b.iter(|| {});
+}

--- a/tests/run-make/test-benches/rmake.rs
+++ b/tests/run-make/test-benches/rmake.rs
@@ -10,13 +10,13 @@
 //@ needs-unwind
 // Reason: #[bench] and -Zpanic-abort-tests can't be combined
 
-use run_make_support::{run, run_with_args, rustc};
+use run_make_support::{run, run_fail_with_args, run_with_args, rustc};
 
 fn main() {
     // Smoke-test that #[bench] isn't entirely broken.
     rustc().arg("--test").input("smokebench.rs").opt().run();
-    run_with_args("smokebench", &["--bench"]);
-    run_with_args("smokebench", &["--bench", "noiter"]);
+    run_fail_with_args("smokebench", &["--bench"]);
+    run_fail_with_args("smokebench", &["--bench", "noiter"]);
     run_with_args("smokebench", &["--bench", "yesiter"]);
     run("smokebench");
 }


### PR DESCRIPTION
A benchmark such as:
```
#[bench]
fn smoke_noiter(_: &mut test::Bencher) {}
```
previously reported success with a synthetic 0 ns/iter result, despite never measuring any work.

This changes --bench to report such a benchmark as failed with:
```
benchmark function did not call Bencher::iter
```
Regular test execution remains unchanged. The unit test now asserts this failure result, and the test-benches run-make test checks that no-iter benchmarks fail while a benchmark that calls iter succeeds.

Testing: python x.py test library/test --test-args test_bench_no_iter