### PR TITLE
Remove outdated comments from `va_list.rs`

### DIFF
--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -249,7 +249,7 @@ const impl<'f> Clone for VaList<'f> {
     /// Clone the [`VaList`], producing a second independent cursor into the variable argument list.
     ///
     /// Corresponds to `va_copy` in C.
-    #[inline] // Avoid codegen when not used to help backends that don't support VaList.
+    #[inline]
     fn clone(&self) -> Self {
         // We only implement Clone and not Copy because some future target might not be able to
         // implement Copy (e.g. because it allocates). For the same reason we use an intrinsic
@@ -265,7 +265,7 @@ const impl<'f> Drop for VaList<'f> {
     /// Drop the [`VaList`].
     ///
     /// Corresponds to `va_end` in C.
-    #[inline] // Avoid codegen when not used to help backends that don't support VaList.
+    #[inline]
     fn drop(&mut self) {
         // Call the rust `va_end` intrinsic, which is a no-op and does not map to LLVM `va_end`.
         // The rust intrinsic exists as a hook for Miri to check for UB.


### PR DESCRIPTION
Since rust-lang/rust#150436 codegen backends haven't needed to implement `va_copy` or `va_end` as they are implemented using intrinsic fallback bodies, so the comments on the `#[inline]` annotations are no longer relevant. I've left the `#[inline]` annotations themselves as they seem worthwhile since `va_copy` and `va_end` are a memcpy and a no-op respectively.