### PR TITLE
Preserve IndexMap order when removing entries

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -173,8 +173,7 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
     }
 
     pub(crate) fn get_buffered_mut_error(&mut self, span: Span) -> Option<(Diag<'diag>, usize)> {
-        // FIXME(#120456) - is `swap_remove` correct?
-        self.diags_buffer.buffered_mut_errors.swap_remove(&span)
+        self.diags_buffer.buffered_mut_errors.shift_remove(&span)
     }
 
     pub(crate) fn buffer_mut_error(&mut self, span: Span, diag: Diag<'diag>, count: usize) {

--- a/compiler/rustc_borrowck/src/used_muts.rs
+++ b/compiler/rustc_borrowck/src/used_muts.rs
@@ -59,8 +59,7 @@ impl GatherUsedMutsVisitor<'_, '_, '_, '_> {
         // be those that were never initialized - we will consider those as being used as
         // they will either have been removed by unreachable code optimizations; or linted
         // as unused variables.
-        // FIXME(#120456) - is `swap_remove` correct?
-        self.never_initialized_mut_locals.swap_remove(&into.local);
+        self.never_initialized_mut_locals.shift_remove(&into.local);
     }
 }
 

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -138,8 +138,7 @@ fn asm_target_features(tcx: TyCtxt<'_>, did: DefId) -> &FxIndexSet<Symbol> {
         match attrs.instruction_set {
             None => {}
             Some(InstructionSetAttr::ArmA32) => {
-                // FIXME(#120456) - is `swap_remove` correct?
-                target_features.swap_remove(&sym::thumb_mode);
+                target_features.shift_remove(&sym::thumb_mode);
             }
             Some(InstructionSetAttr::ArmT32) => {
                 target_features.insert(sym::thumb_mode);

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -137,8 +137,7 @@ impl<K: Hash + Eq, V> interpret::AllocMap<K, V> for FxIndexMap<K, V> {
     where
         K: Borrow<Q>,
     {
-        // FIXME(#120456) - is `swap_remove` correct?
-        FxIndexMap::swap_remove(self, k)
+        FxIndexMap::shift_remove(self, k)
     }
 
     #[inline(always)]

--- a/compiler/rustc_const_eval/src/interpret/intern.rs
+++ b/compiler/rustc_const_eval/src/interpret/intern.rs
@@ -109,8 +109,7 @@ fn intern_shallow<'tcx, M: CompileTimeMachine<'tcx>>(
 ) -> Result<impl Iterator<Item = CtfeProvenance> + 'tcx, InternError> {
     trace!("intern_shallow {:?}", alloc_id);
     // remove allocation
-    // FIXME(#120456) - is `swap_remove` correct?
-    let Some((kind, mut alloc)) = ecx.memory.alloc_map.swap_remove(&alloc_id) else {
+    let Some((kind, mut alloc)) = ecx.memory.alloc_map.shift_remove(&alloc_id) else {
         return Err(InternError::DanglingPointer);
     };
 

--- a/compiler/rustc_errors/src/decorate_diag.rs
+++ b/compiler/rustc_errors/src/decorate_diag.rs
@@ -62,8 +62,7 @@ impl LintBuffer {
     }
 
     pub fn take(&mut self, id: NodeId) -> Vec<BufferedEarlyLint> {
-        // FIXME(#120456) - is `swap_remove` correct?
-        self.map.swap_remove(&id).unwrap_or_default()
+        self.map.shift_remove(&id).unwrap_or_default()
     }
 
     pub fn buffer_lint(

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -633,9 +633,8 @@ impl<'a> DiagCtxtHandle<'a> {
     /// and [`StashKey`] as the key. Panics if the found diagnostic is an
     /// error.
     pub fn steal_non_err(self, span: Span, key: StashKey) -> Option<Diag<'a, ()>> {
-        // FIXME(#120456) - is `swap_remove` correct?
         let (diag, guar, _) = self.inner.borrow_mut().stashed_diagnostics.get_mut(&key).and_then(
-            |stashed_diagnostics| stashed_diagnostics.swap_remove(&span.with_parent(None)),
+            |stashed_diagnostics| stashed_diagnostics.shift_remove(&span.with_parent(None)),
         )?;
         assert!(!diag.is_error());
         assert!(guar.is_none());
@@ -655,9 +654,8 @@ impl<'a> DiagCtxtHandle<'a> {
     where
         F: FnMut(&mut Diag<'_>),
     {
-        // FIXME(#120456) - is `swap_remove` correct?
         let err = self.inner.borrow_mut().stashed_diagnostics.get_mut(&key).and_then(
-            |stashed_diagnostics| stashed_diagnostics.swap_remove(&span.with_parent(None)),
+            |stashed_diagnostics| stashed_diagnostics.shift_remove(&span.with_parent(None)),
         );
         err.map(|(err, guar, _)| {
             // The use of `::<ErrorGuaranteed>` is safe because level is `Level::Error`.
@@ -679,9 +677,8 @@ impl<'a> DiagCtxtHandle<'a> {
         key: StashKey,
         new_err: Diag<'_>,
     ) -> ErrorGuaranteed {
-        // FIXME(#120456) - is `swap_remove` correct?
         let old_err = self.inner.borrow_mut().stashed_diagnostics.get_mut(&key).and_then(
-            |stashed_diagnostics| stashed_diagnostics.swap_remove(&span.with_parent(None)),
+            |stashed_diagnostics| stashed_diagnostics.shift_remove(&span.with_parent(None)),
         );
         match old_err {
             Some((old_err, guar, _)) => {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1589,8 +1589,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let ctxt = {
             let mut enclosing_breakables = self.enclosing_breakables.borrow_mut();
             debug_assert!(enclosing_breakables.stack.len() == index + 1);
-            // FIXME(#120456) - is `swap_remove` correct?
-            enclosing_breakables.by_id.swap_remove(&id).expect("missing breakable context");
+            enclosing_breakables.by_id.shift_remove(&id).expect("missing breakable context");
             enclosing_breakables.stack.pop().expect("missing breakable context")
         };
         (ctxt, result)

--- a/compiler/rustc_infer/src/infer/opaque_types/table.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/table.rs
@@ -40,8 +40,7 @@ impl<'tcx> OpaqueTypeStorage<'tcx> {
         if let Some(prev) = prev {
             *self.opaque_types.get_mut(&key).unwrap() = prev;
         } else {
-            // FIXME(#120456) - is `swap_remove` correct?
-            match self.opaque_types.swap_remove(&key) {
+            match self.opaque_types.shift_remove(&key) {
                 None => bug!("reverted opaque type inference that was never registered: {:?}", key),
                 Some(_) => {}
             }

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -992,9 +992,8 @@ pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
     // available as we'd like it to be.
     // FIXME: only remove `libc` when `stdbuild` is enabled.
     // FIXME: remove special casing for `test`.
-    // FIXME(#120456) - is `swap_remove` correct?
-    remaining_lib_features.swap_remove(&sym::libc);
-    remaining_lib_features.swap_remove(&sym::test);
+    remaining_lib_features.shift_remove(&sym::libc);
+    remaining_lib_features.shift_remove(&sym::test);
 
     /// For each feature in `defined_features`..
     ///
@@ -1035,8 +1034,7 @@ pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
                     unnecessary_stable_feature_lint(tcx, *span, feature, since);
                 }
             }
-            // FIXME(#120456) - is `swap_remove` correct?
-            remaining_lib_features.swap_remove(&feature);
+            remaining_lib_features.shift_remove(&feature);
 
             // `feature` is the feature doing the implying, but `implied_by` is the feature with
             // the attribute that establishes this relationship. `implied_by` is guaranteed to be a

--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -93,8 +93,7 @@ impl<'a, 'ra, 'tcx> UnusedImportCheckVisitor<'a, 'ra, 'tcx> {
         } else {
             // This trait import is definitely used, in a way other than
             // method resolution.
-            // FIXME(#120456) - is `swap_remove` correct?
-            self.r.maybe_unused_trait_imports.swap_remove(&def_id);
+            self.r.maybe_unused_trait_imports.shift_remove(&def_id);
             if let Some(i) = self.unused_imports.get_mut(&self.base_id) {
                 i.unused.remove(&id);
             }

--- a/src/tools/rust-analyzer/crates/hir-ty/src/next_solver/infer/opaque_types/table.rs
+++ b/src/tools/rust-analyzer/crates/hir-ty/src/next_solver/infer/opaque_types/table.rs
@@ -39,8 +39,7 @@ impl<'db> OpaqueTypeStorage<'db> {
         if let Some(prev) = prev {
             *self.opaque_types.get_mut(&key).unwrap() = prev;
         } else {
-            // FIXME(#120456) - is `swap_remove` correct?
-            match self.opaque_types.swap_remove(&key) {
+            match self.opaque_types.shift_remove(&key) {
                 None => {
                     panic!("reverted opaque type inference that was never registered: {key:?}")
                 }


### PR DESCRIPTION
When IndexMap::remove was deprecated, these call sites were migrated to swap_remove, which can reorder the remaining entries.

Use shift_remove instead to preserve the previous insertion-order semantics, and remove the associated FIXME(rust-lang/rust#120456) comments.

Testing: python x.py test compiler/rustc_errors compiler/rustc_borrowck compiler/rustc_const_eval compiler/rustc_hir_typeck compiler/rustc_infer compiler/rustc_passes compiler/rustc_resolve compiler/rustc_codegen_ssa --stage 1