### PR TITLE
Make `#[fundamental]` only apply to the first argument of `Box`

### DIFF
--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -942,6 +942,7 @@ bidirectional_lang_item_map! {
 // tidy-alphabetical-start
     DynMetadata,
     Option,
+    OwnedBox,
     Poll,
 // tidy-alphabetical-end
 }

--- a/compiler/rustc_next_trait_solver/src/coherence.rs
+++ b/compiler/rustc_next_trait_solver/src/coherence.rs
@@ -3,6 +3,7 @@ use std::ops::ControlFlow;
 
 use derive_where::derive_where;
 use rustc_type_ir::inherent::*;
+use rustc_type_ir::lang_items::SolverAdtLangItem;
 use rustc_type_ir::{
     self as ty, InferCtxtLike, Interner, Region, TrivialTypeTraversalImpls, TypeVisitable,
     TypeVisitableExt, TypeVisitor,
@@ -407,12 +408,17 @@ where
             }
 
             // For fundamental types, we just look inside of them.
+            // Certain lang items (currently, `Box`) have special behaviour here
+            // and so are special cased.
             ty::Ref(_, ty, _) => ty.visit_with(self),
             ty::Adt(def, args) => {
                 if self.def_id_is_local(def.def_id()) {
                     ControlFlow::Break(OrphanCheckEarlyExit::LocalTy(ty))
                 } else if def.is_fundamental() {
-                    args.visit_with(self)
+                    match self.infcx.cx().as_adt_lang_item(def.def_id()) {
+                        Some(SolverAdtLangItem::OwnedBox) => args.type_at(0).visit_with(self),
+                        Some(..) | None => args.visit_with(self)
+                    }
                 } else {
                     self.found_non_local_ty(ty)
                 }

--- a/compiler/rustc_type_ir/src/lang_items.rs
+++ b/compiler/rustc_type_ir/src/lang_items.rs
@@ -21,6 +21,7 @@ pub enum SolverAdtLangItem {
     // tidy-alphabetical-start
     DynMetadata,
     Option,
+    OwnedBox,
     Poll,
     // tidy-alphabetical-end
 }

--- a/tests/ui/coherence/impl-foreign-for-box[foreign_local].rs
+++ b/tests/ui/coherence/impl-foreign-for-box[foreign_local].rs
@@ -1,0 +1,27 @@
+//@ compile-flags:--crate-name=test
+//@ aux-build:coherence_lib.rs
+
+// Ensure that `Box` in particular isn't fundamental over
+// the allocator parameter (but is over T).
+
+#![feature(allocator_api)]
+
+extern crate coherence_lib as lib;
+
+use lib::*;
+use std::alloc::{Allocator, AllocError, Layout};
+use std::ptr::NonNull;
+
+struct Local;
+
+unsafe impl Allocator for Local {
+    fn allocate(&self, _layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        Err(AllocError)
+    }
+    unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {}
+}
+
+impl Remote for Box<str, Local> {}
+  //~^ ERROR: only traits defined in the current crate can be implemented for types defined outside of the crate [E0117]
+
+fn main() {}

--- a/tests/ui/coherence/impl-foreign-for-box[foreign_local].stderr
+++ b/tests/ui/coherence/impl-foreign-for-box[foreign_local].stderr
@@ -1,0 +1,15 @@
+error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
+  --> $DIR/impl-foreign-for-box[foreign_local].rs:24:1
+   |
+LL | impl Remote for Box<str, Local> {}
+   | ^^^^^^^^^^^^^^^^---------------
+   |                 |
+   |                 `str` is not defined in the current crate
+   |
+   = note: impl doesn't have any local type before any uncovered type parameters
+   = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
+   = note: define and implement a trait or new type instead
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0117`.

--- a/tests/ui/coherence/impl-foreign-for-fundamental[foreign].stderr
+++ b/tests/ui/coherence/impl-foreign-for-fundamental[foreign].stderr
@@ -2,10 +2,9 @@ error[E0117]: only traits defined in the current crate can be implemented for ty
   --> $DIR/impl-foreign-for-fundamental[foreign].rs:10:1
    |
 LL | impl Remote for Box<i32> {
-   | ^^^^^------^^^^^--------
-   |      |          |
-   |      |          `i32` is not defined in the current crate
-   |      `std::alloc::Global` is not defined in the current crate
+   | ^^^^^^^^^^^^^^^^--------
+   |                 |
+   |                 `i32` is not defined in the current crate
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
@@ -15,10 +14,9 @@ error[E0117]: only traits defined in the current crate can be implemented for ty
   --> $DIR/impl-foreign-for-fundamental[foreign].rs:14:1
    |
 LL | impl<T> Remote for Box<Rc<T>> {
-   | ^^^^^^^^------^^^^^----------
-   |         |          |
-   |         |          `Rc` is not defined in the current crate
-   |         `std::alloc::Global` is not defined in the current crate
+   | ^^^^^^^^^^^^^^^^^^^----------
+   |                    |
+   |                    `Rc` is not defined in the current crate
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules

--- a/tests/ui/coherence/impl-foreign[fundemental[foreign]]-for-foreign.stderr
+++ b/tests/ui/coherence/impl-foreign[fundemental[foreign]]-for-foreign.stderr
@@ -6,7 +6,6 @@ LL | impl Remote1<Box<String>> for i32 {
    |      |                        |
    |      |                        `i32` is not defined in the current crate
    |      `String` is not defined in the current crate
-   |      `std::alloc::Global` is not defined in the current crate
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
@@ -20,7 +19,6 @@ LL | impl Remote1<Box<Rc<i32>>> for f64 {
    |      |                         |
    |      |                         `f64` is not defined in the current crate
    |      `Rc` is not defined in the current crate
-   |      `std::alloc::Global` is not defined in the current crate
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
@@ -34,7 +32,6 @@ LL | impl<T> Remote1<Box<Rc<T>>> for f32 {
    |         |                       |
    |         |                       `f32` is not defined in the current crate
    |         `Rc` is not defined in the current crate
-   |         `std::alloc::Global` is not defined in the current crate
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160162)*
<!-- homu-ignore:end -->

Per a [discussion with lang](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/.60.23.5Bfundamental.5D.60.20and.20.60Box.3CT.2C.20A.3E.60/with/613236766), it was decided that we want `Box<T, A>` to only be fundamental in `T`. ~~Given that `Box` is the only fundamental type with two generic params, simply make it so only the first param is considered for fundamentalness.~~ ~~`Tuple` is also fundamental, but has its own path in coherence checking and so isn't impacted by this; `Box` is the only thing that is.~~

Since this is just an internal detail and `#[fundamental]` is not in a rush to get stabilised, lang's opinion was that t-compiler has free rein on how to implement this so I figured I'd go with the most straightforward implementation for now. The main alternative I see would be supporting param-position `#[fundamental]` & have the semantics that:
```rust
#[fundamental]
struct Foo<T, U>(T, U);
```
is equivalent to
```rust
struct Foo<#[fundamental] T, #[fundamental] U>(T, U);
```
though given that there's no usecase for this right now, it seemed somewhat unnecessary.

r? compiler