### PR TITLE
Use correct feature gates for `f16`/`f128` `From` impls

### DIFF
--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -138,27 +138,27 @@ impl_from!(i16 => isize, #[stable(feature = "lossless_iusize_conv", since = "1.2
 // of the `f16`/`f128` impls can be used on stable as the `f16` and `f128` types are unstable).
 
 // signed integer -> float
-impl_from!(i8 => f16, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
+impl_from!(i8 => f16, #[unstable(feature = "f16", issue = "116909")], #[unstable_feature_bound(f16)]);
 impl_from!(i8 => f32, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(i8 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
-impl_from!(i8 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
+impl_from!(i8 => f128, #[unstable(feature = "f128", issue = "116909")], #[unstable_feature_bound(f128)]);
 impl_from!(i16 => f32, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(i16 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
-impl_from!(i16 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
+impl_from!(i16 => f128, #[unstable(feature = "f128", issue = "116909")], #[unstable_feature_bound(f128)]);
 impl_from!(i32 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
-impl_from!(i32 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
+impl_from!(i32 => f128, #[unstable(feature = "f128", issue = "116909")], #[unstable_feature_bound(f128)]);
 impl_from!(i64 => f128, #[unstable(feature = "f128", issue = "116909")], #[unstable_feature_bound(f128)]);
 
 // unsigned integer -> float
-impl_from!(u8 => f16, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
+impl_from!(u8 => f16, #[unstable(feature = "f16", issue = "116909")], #[unstable_feature_bound(f16)]);
 impl_from!(u8 => f32, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(u8 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
-impl_from!(u8 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
+impl_from!(u8 => f128, #[unstable(feature = "f128", issue = "116909")], #[unstable_feature_bound(f128)]);
 impl_from!(u16 => f32, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
 impl_from!(u16 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
-impl_from!(u16 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
+impl_from!(u16 => f128, #[unstable(feature = "f128", issue = "116909")], #[unstable_feature_bound(f128)]);
 impl_from!(u32 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
-impl_from!(u32 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
+impl_from!(u32 => f128, #[unstable(feature = "f128", issue = "116909")], #[unstable_feature_bound(f128)]);
 impl_from!(u64 => f128, #[unstable(feature = "f128", issue = "116909")], #[unstable_feature_bound(f128)]);
 
 // float -> float
@@ -170,20 +170,22 @@ impl_from!(u64 => f128, #[unstable(feature = "f128", issue = "116909")], #[unsta
 //
 // See also <https://github.com/rust-lang/rust/issues/123831>.
 impl_from!(f16 => f32, #[unstable(feature = "f32_from_f16", issue = "154005")], #[unstable_feature_bound(f32_from_f16)]);
-impl_from!(f16 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
-impl_from!(f16 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
+impl_from!(f16 => f64, #[unstable(feature = "f16", issue = "116909")], #[unstable_feature_bound(f16)]);
+// Also #[unstable(feature = "f16", issue = "116909")]:
+impl_from!(f16 => f128, #[unstable(feature = "f128", issue = "116909")], #[unstable_feature_bound(f16, f128)]);
 impl_from!(f32 => f64, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
-impl_from!(f32 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
-impl_from!(f64 => f128, #[stable(feature = "lossless_float_conv", since = "1.6.0")]);
+impl_from!(f32 => f128, #[unstable(feature = "f128", issue = "116909")], #[unstable_feature_bound(f128)]);
+impl_from!(f64 => f128, #[unstable(feature = "f128", issue = "116909")], #[unstable_feature_bound(f128)]);
 
 macro_rules! impl_float_from_bool {
     (
+        $(#[$attr:meta])*
         $float:ty $(;
             doctest_prefix: $(#[doc = $doctest_prefix:literal])*
             doctest_suffix: $(#[doc = $doctest_suffix:literal])*
         )?
     ) => {
-        #[stable(feature = "float_from_bool", since = "1.68.0")]
+        $(#[$attr])*
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
             const impl From<bool> for $float {
             #[doc = concat!("Converts a [`bool`] to [`", stringify!($float),"`] losslessly.")]
@@ -210,6 +212,8 @@ macro_rules! impl_float_from_bool {
 
 // boolean -> float
 impl_float_from_bool!(
+    #[unstable(feature = "f16", issue = "116909")]
+    #[unstable_feature_bound(f16)]
     f16;
     doctest_prefix:
     // rustdoc doesn't remove the conventional space after the `///`
@@ -220,9 +224,17 @@ impl_float_from_bool!(
     doctest_suffix:
     ///# }
 );
-impl_float_from_bool!(f32);
-impl_float_from_bool!(f64);
 impl_float_from_bool!(
+    #[stable(feature = "float_from_bool", since = "1.68.0")]
+    f32
+);
+impl_float_from_bool!(
+    #[stable(feature = "float_from_bool", since = "1.68.0")]
+    f64
+);
+impl_float_from_bool!(
+    #[unstable(feature = "f128", issue = "116909")]
+    #[unstable_feature_bound(f128)]
     f128;
     doctest_prefix:
     ///# #![allow(unused_features)]

--- a/tests/ui/feature-gates/feature-gate-f128.e2015.stderr
+++ b/tests/ui/feature-gates/feature-gate-f128.e2015.stderr
@@ -19,27 +19,127 @@ LL |     let a: f128 = 100.0;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the type `f128` is unstable
-  --> $DIR/feature-gate-f128.rs:13:12
+  --> $DIR/feature-gate-f128.rs:13:18
    |
-LL |     let d: f128 = 1i64.into();
-   |            ^^^^
-   |
-   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
-   = help: add `#![feature(f128)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: the type `f128` is unstable
-  --> $DIR/feature-gate-f128.rs:16:12
-   |
-LL |     let e: f128 = 1u64.into();
-   |            ^^^^
+LL |     let from_i8: f128 = 1_i8.into();
+   |                  ^^^^
    |
    = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
    = help: add `#![feature(f128)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the type `f128` is unstable
-  --> $DIR/feature-gate-f128.rs:21:11
+  --> $DIR/feature-gate-f128.rs:16:18
+   |
+LL |     let from_u8: f128 = 1_u8.into();
+   |                  ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:17:19
+   |
+LL |     let from_i16: f128 = 1_i16.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:18:19
+   |
+LL |     let from_u16: f128 = 1_u16.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:19:19
+   |
+LL |     let from_i32: f128 = 1_i32.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:20:19
+   |
+LL |     let from_u32: f128 = 1_u32.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:21:19
+   |
+LL |     let from_i64: f128 = 1_i64.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:22:19
+   |
+LL |     let from_u64: f128 = 1_u64.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:23:19
+   |
+LL |     let from_f16: f128 = 1.0_f16.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:26:19
+   |
+LL |     let from_f32: f128 = 1.0_f32.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:27:19
+   |
+LL |     let from_f64: f128 = 1.0_f64.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:28:20
+   |
+LL |     let from_bool: f128 = true.into();
+   |                    ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:32:11
    |
 LL | fn foo(a: f128) {}
    |           ^^^^
@@ -49,7 +149,7 @@ LL | fn foo(a: f128) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the type `f128` is unstable
-  --> $DIR/feature-gate-f128.rs:24:8
+  --> $DIR/feature-gate-f128.rs:35:8
    |
 LL |     a: f128,
    |        ^^^^
@@ -78,17 +178,27 @@ LL |     let c = 0f128;
    = help: add `#![feature(f128)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature `f128`
-  --> $DIR/feature-gate-f128.rs:13:24
+error[E0658]: the type `f16` is unstable
+  --> $DIR/feature-gate-f128.rs:23:26
    |
-LL |     let d: f128 = 1i64.into();
-   |                        ^^^^
+LL |     let from_f16: f128 = 1.0_f16.into();
+   |                          ^^^^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f16)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `f128`
+  --> $DIR/feature-gate-f128.rs:13:30
+   |
+LL |     let from_i8: f128 = 1_i8.into();
+   |                              ^^^^
    |
    = help: add `#![feature(f128)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: required for `f128` to implement `From<i64>`
-   = note: required for `i64` to implement `Into<f128>`
+   = note: required for `f128` to implement `From<i8>`
+   = note: required for `i8` to implement `Into<f128>`
 
-error: aborting due to 9 previous errors
+error: aborting due to 20 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-f128.e2018.stderr
+++ b/tests/ui/feature-gates/feature-gate-f128.e2018.stderr
@@ -19,27 +19,127 @@ LL |     let a: f128 = 100.0;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the type `f128` is unstable
-  --> $DIR/feature-gate-f128.rs:13:12
+  --> $DIR/feature-gate-f128.rs:13:18
    |
-LL |     let d: f128 = 1i64.into();
-   |            ^^^^
-   |
-   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
-   = help: add `#![feature(f128)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: the type `f128` is unstable
-  --> $DIR/feature-gate-f128.rs:16:12
-   |
-LL |     let e: f128 = 1u64.into();
-   |            ^^^^
+LL |     let from_i8: f128 = 1_i8.into();
+   |                  ^^^^
    |
    = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
    = help: add `#![feature(f128)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the type `f128` is unstable
-  --> $DIR/feature-gate-f128.rs:21:11
+  --> $DIR/feature-gate-f128.rs:16:18
+   |
+LL |     let from_u8: f128 = 1_u8.into();
+   |                  ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:17:19
+   |
+LL |     let from_i16: f128 = 1_i16.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:18:19
+   |
+LL |     let from_u16: f128 = 1_u16.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:19:19
+   |
+LL |     let from_i32: f128 = 1_i32.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:20:19
+   |
+LL |     let from_u32: f128 = 1_u32.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:21:19
+   |
+LL |     let from_i64: f128 = 1_i64.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:22:19
+   |
+LL |     let from_u64: f128 = 1_u64.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:23:19
+   |
+LL |     let from_f16: f128 = 1.0_f16.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:26:19
+   |
+LL |     let from_f32: f128 = 1.0_f32.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:27:19
+   |
+LL |     let from_f64: f128 = 1.0_f64.into();
+   |                   ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:28:20
+   |
+LL |     let from_bool: f128 = true.into();
+   |                    ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f128.rs:32:11
    |
 LL | fn foo(a: f128) {}
    |           ^^^^
@@ -49,7 +149,7 @@ LL | fn foo(a: f128) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the type `f128` is unstable
-  --> $DIR/feature-gate-f128.rs:24:8
+  --> $DIR/feature-gate-f128.rs:35:8
    |
 LL |     a: f128,
    |        ^^^^
@@ -78,17 +178,27 @@ LL |     let c = 0f128;
    = help: add `#![feature(f128)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature `f128`
-  --> $DIR/feature-gate-f128.rs:13:24
+error[E0658]: the type `f16` is unstable
+  --> $DIR/feature-gate-f128.rs:23:26
    |
-LL |     let d: f128 = 1i64.into();
-   |                        ^^^^
+LL |     let from_f16: f128 = 1.0_f16.into();
+   |                          ^^^^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f16)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `f128`
+  --> $DIR/feature-gate-f128.rs:13:30
+   |
+LL |     let from_i8: f128 = 1_i8.into();
+   |                              ^^^^
    |
    = help: add `#![feature(f128)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: required for `f128` to implement `From<i64>`
-   = note: required for `i64` to implement `Into<f128>`
+   = note: required for `f128` to implement `From<i8>`
+   = note: required for `i8` to implement `Into<f128>`
 
-error: aborting due to 9 previous errors
+error: aborting due to 20 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-f128.rs
+++ b/tests/ui/feature-gates/feature-gate-f128.rs
@@ -10,11 +10,22 @@ pub fn main() {
     let a: f128 = 100.0; //~ ERROR the type `f128` is unstable
     let b = 0.0f128; //~ ERROR the type `f128` is unstable
     let c = 0f128; //~ ERROR the type `f128` is unstable
-    let d: f128 = 1i64.into();
+    let from_i8: f128 = 1_i8.into();
     //~^ ERROR the type `f128` is unstable
     //~| ERROR use of unstable library feature `f128`
-    let e: f128 = 1u64.into();
+    let from_u8: f128 = 1_u8.into(); //~ ERROR the type `f128` is unstable
+    let from_i16: f128 = 1_i16.into(); //~ ERROR the type `f128` is unstable
+    let from_u16: f128 = 1_u16.into(); //~ ERROR the type `f128` is unstable
+    let from_i32: f128 = 1_i32.into(); //~ ERROR the type `f128` is unstable
+    let from_u32: f128 = 1_u32.into(); //~ ERROR the type `f128` is unstable
+    let from_i64: f128 = 1_i64.into(); //~ ERROR the type `f128` is unstable
+    let from_u64: f128 = 1_u64.into(); //~ ERROR the type `f128` is unstable
+    let from_f16: f128 = 1.0_f16.into();
     //~^ ERROR the type `f128` is unstable
+    //~| ERROR the type `f16` is unstable
+    let from_f32: f128 = 1.0_f32.into(); //~ ERROR the type `f128` is unstable
+    let from_f64: f128 = 1.0_f64.into(); //~ ERROR the type `f128` is unstable
+    let from_bool: f128 = true.into(); //~ ERROR the type `f128` is unstable
     foo(1.23);
 }
 

--- a/tests/ui/feature-gates/feature-gate-f16.e2015.stderr
+++ b/tests/ui/feature-gates/feature-gate-f16.e2015.stderr
@@ -18,8 +18,48 @@ LL |     let a: f16 = 100.0;
    = help: add `#![feature(f16)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f16.rs:17:20
+   |
+LL |     let into_f128: f128 = 1.0_f16.into();
+   |                    ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: the type `f16` is unstable
-  --> $DIR/feature-gate-f16.rs:19:11
+  --> $DIR/feature-gate-f16.rs:20:18
+   |
+LL |     let from_i8: f16 = 1_i8.into();
+   |                  ^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f16)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f16` is unstable
+  --> $DIR/feature-gate-f16.rs:21:18
+   |
+LL |     let from_u8: f16 = 1_u8.into();
+   |                  ^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f16)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f16` is unstable
+  --> $DIR/feature-gate-f16.rs:22:20
+   |
+LL |     let from_bool: f16 = true.into();
+   |                    ^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f16)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f16` is unstable
+  --> $DIR/feature-gate-f16.rs:26:11
    |
 LL | fn foo(a: f16) {}
    |           ^^^
@@ -29,7 +69,7 @@ LL | fn foo(a: f16) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the type `f16` is unstable
-  --> $DIR/feature-gate-f16.rs:22:8
+  --> $DIR/feature-gate-f16.rs:29:8
    |
 LL |     a: f16,
    |        ^^^
@@ -59,26 +99,46 @@ LL |     let c = 0f16;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the type `f16` is unstable
-  --> $DIR/feature-gate-f16.rs:13:18
+  --> $DIR/feature-gate-f16.rs:13:25
    |
-LL |     let d: f32 = 1.0f16.into();
-   |                  ^^^^^^
+LL |     let into_f32: f32 = 1.0f16.into();
+   |                         ^^^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f16)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f16` is unstable
+  --> $DIR/feature-gate-f16.rs:16:25
+   |
+LL |     let into_f64: f64 = 1.0_f16.into();
+   |                         ^^^^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f16)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f16` is unstable
+  --> $DIR/feature-gate-f16.rs:17:27
+   |
+LL |     let into_f128: f128 = 1.0_f16.into();
+   |                           ^^^^^^^
    |
    = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
    = help: add `#![feature(f16)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `f32_from_f16`
-  --> $DIR/feature-gate-f16.rs:13:25
+  --> $DIR/feature-gate-f16.rs:13:32
    |
-LL |     let d: f32 = 1.0f16.into();
-   |                         ^^^^
+LL |     let into_f32: f32 = 1.0f16.into();
+   |                                ^^^^
    |
    = help: add `#![feature(f32_from_f16)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: required for `f32` to implement `From<f16>`
    = note: required for `f16` to implement `Into<f32>`
 
-error: aborting due to 8 previous errors
+error: aborting due to 14 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-f16.e2018.stderr
+++ b/tests/ui/feature-gates/feature-gate-f16.e2018.stderr
@@ -18,8 +18,48 @@ LL |     let a: f16 = 100.0;
    = help: add `#![feature(f16)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: the type `f128` is unstable
+  --> $DIR/feature-gate-f16.rs:17:20
+   |
+LL |     let into_f128: f128 = 1.0_f16.into();
+   |                    ^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: the type `f16` is unstable
-  --> $DIR/feature-gate-f16.rs:19:11
+  --> $DIR/feature-gate-f16.rs:20:18
+   |
+LL |     let from_i8: f16 = 1_i8.into();
+   |                  ^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f16)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f16` is unstable
+  --> $DIR/feature-gate-f16.rs:21:18
+   |
+LL |     let from_u8: f16 = 1_u8.into();
+   |                  ^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f16)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f16` is unstable
+  --> $DIR/feature-gate-f16.rs:22:20
+   |
+LL |     let from_bool: f16 = true.into();
+   |                    ^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f16)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f16` is unstable
+  --> $DIR/feature-gate-f16.rs:26:11
    |
 LL | fn foo(a: f16) {}
    |           ^^^
@@ -29,7 +69,7 @@ LL | fn foo(a: f16) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the type `f16` is unstable
-  --> $DIR/feature-gate-f16.rs:22:8
+  --> $DIR/feature-gate-f16.rs:29:8
    |
 LL |     a: f16,
    |        ^^^
@@ -59,26 +99,46 @@ LL |     let c = 0f16;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the type `f16` is unstable
-  --> $DIR/feature-gate-f16.rs:13:18
+  --> $DIR/feature-gate-f16.rs:13:25
    |
-LL |     let d: f32 = 1.0f16.into();
-   |                  ^^^^^^
+LL |     let into_f32: f32 = 1.0f16.into();
+   |                         ^^^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f16)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f16` is unstable
+  --> $DIR/feature-gate-f16.rs:16:25
+   |
+LL |     let into_f64: f64 = 1.0_f16.into();
+   |                         ^^^^^^^
+   |
+   = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
+   = help: add `#![feature(f16)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the type `f16` is unstable
+  --> $DIR/feature-gate-f16.rs:17:27
+   |
+LL |     let into_f128: f128 = 1.0_f16.into();
+   |                           ^^^^^^^
    |
    = note: see issue #116909 <https://github.com/rust-lang/rust/issues/116909> for more information
    = help: add `#![feature(f16)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `f32_from_f16`
-  --> $DIR/feature-gate-f16.rs:13:25
+  --> $DIR/feature-gate-f16.rs:13:32
    |
-LL |     let d: f32 = 1.0f16.into();
-   |                         ^^^^
+LL |     let into_f32: f32 = 1.0f16.into();
+   |                                ^^^^
    |
    = help: add `#![feature(f32_from_f16)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: required for `f32` to implement `From<f16>`
    = note: required for `f16` to implement `Into<f32>`
 
-error: aborting due to 8 previous errors
+error: aborting due to 14 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-f16.rs
+++ b/tests/ui/feature-gates/feature-gate-f16.rs
@@ -10,9 +10,16 @@ pub fn main() {
     let a: f16 = 100.0; //~ ERROR the type `f16` is unstable
     let b = 0.0f16; //~ ERROR the type `f16` is unstable
     let c = 0f16; //~ ERROR the type `f16` is unstable
-    let d: f32 = 1.0f16.into();
+    let into_f32: f32 = 1.0f16.into();
     //~^ ERROR the type `f16` is unstable
     //~| ERROR use of unstable library feature `f32_from_f16`
+    let into_f64: f64 = 1.0_f16.into(); //~ ERROR the type `f16` is unstable
+    let into_f128: f128 = 1.0_f16.into();
+    //~^ ERROR the type `f16` is unstable
+    //~| ERROR the type `f128` is unstable
+    let from_i8: f16 = 1_i8.into(); //~ ERROR the type `f16` is unstable
+    let from_u8: f16 = 1_u8.into(); //~ ERROR the type `f16` is unstable
+    let from_bool: f16 = true.into(); //~ ERROR the type `f16` is unstable
     foo(1.23);
 }
 


### PR DESCRIPTION
This PR updates the `f16`/`f128` `From` impls in `core` to be annotated with the correct feature gates, instead of the feature gate that was used to stabilise the impls for `f32` and `f64`. The impls are already inaccessible on stable as it is impossible to use them without explicitly naming `f16`/`f128`, so this is just to improve the documentation of what things are stable.

r? @tgross35

Tracking issue: rust-lang/rust#116909