### PR TITLE
Refactored docs for `std::fs::set_permissions_nofollow` + fix BSD-based systems to use fchmodat with AT_SYMLINK_NOFOLLOW flag

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3471,17 +3471,24 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// # Platform-specific behavior
 ///
 /// This function currently corresponds to the following underlying operations:
-/// * Linux, BSD-based platforms, Android: `fchmodat` with `AT_SYMLINK_NOFOLLOW`.
+/// * Linux: `fchmodat` with `AT_SYMLINK_NOFOLLOW` with a fallback behavior to use
+/// `open` with `O_NOFOLLOW` followed by behavior denoted in [`fs::set_permissions`] when
+/// the former `fchmodat` call errors with `ENOTSUP`[^1].
+/// * BSD-based platforms, Android: `fchmodat` with `AT_SYMLINK_NOFOLLOW`
 /// * Other Unix-based platforms with symlinks: `open` with `O_NOFOLLOW` followed by behavior
 ///   denoted in [`fs::set_permissions`].
-/// * Other Unix-based platforms without symlinks: `open` with followed by behavior
+/// * Other Unix-based platforms without symlinks: `open` followed by behavior
 ///   denoted in [`fs::set_permissions`].
 /// * Windows: `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT` followed
 ///   by `SetFileInformationByHandle`.
 ///
 /// Note that, this [may change in the future][changes].
 ///
+/// [^1]: Ubuntu 20.04, for example, makes `fchmodat` with `AT_SYMLINK_NOFOLLOW` return `ENOTSUP`
+/// on both symlinks and non-symlinks
+///
 /// [changes]: io#platform-specific-behavior
+///
 /// [`fs::set_permissions`]: crate::fs::set_permissions
 ///
 /// # Errors
@@ -3494,11 +3501,11 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 ///
 /// Note: On Linux, this will result in an [`Unsupported`] error
 /// if the final element is a symlink. On other Unix-based platforms
-/// with symlinks (non-BSD-based), this will result in an [`InvalidInput`]
+/// with symlinks (non-BSD-based), this will result in a [`FilesystemLoop`]
 /// error.
 ///
 /// [`Unsupported`]: crate::io::ErrorKind::Unsupported
-/// [`InvalidInput`]: crate::io::ErrorKind::InvalidInput
+/// [`FilesystemLoop`]: crate::io::ErrorKind::FilesystemLoop
 ///
 /// # Examples
 ///

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3470,17 +3470,12 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 ///
 /// # Platform-specific behavior
 ///
-/// This function currently corresponds to:
-/// * `open` with `O_NOFOLLOW` flag enabled + `fchmod` on WASI
-/// * `fchmodat` function with the flag `AT_SYMLINK_NOFOLLOW` enabled
-///   on Unix platforms
-/// * The flag `FILE_FLAG_OPEN_REPARSE_POINT` is enabled and then the
-///   permissions of the file is set through `SetFileInformationByHandle`
-///   on Windows.
-/// * On all other platforms, the behavior remains the same with
-/// [`fs::set_permissions`].
-///
-/// [`fs::set_permissions`]: crate::fs::set_permissions
+/// This function currently corresponds to the following underlying operations:
+/// * WASI: `open` with `O_NOFOLLOW` followed by `fchmod`.
+/// * Unix: `fchmodat` with `AT_SYMLINK_NOFOLLOW` (or no flag is set if `AT_SYMLINK_NOFOLLOW` does
+///   not exist on a specific Unix-based platform)
+/// * Windows: `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT` followed
+///   by `SetFileInformationByHandle`.
 ///
 /// Note that, this [may change in the future][changes].
 ///
@@ -3496,8 +3491,8 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 ///
 /// Note: On Linux, this will result in a [`Unsupported`] error
 /// if the final element is a symlink. On BSD-based systems, the
-/// behavior can vary from symlink permission bits changing or
-/// there being no effects on symlinks
+/// behavior in this case can vary: the operation may have no effect at all
+/// or it may change the permission bits of the symlink itself.
 ///
 /// [`Unsupported`]: crate::io::ErrorKind::Unsupported
 ///
@@ -3510,8 +3505,9 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// fn main() -> std::io::Result<()> {
 ///     let mut perms = fs::symlink_metadata("foo.txt")?.permissions();
 ///     perms.set_readonly(true);
-///     // This should result in an error on certain platforms
-///     // or succeed in modifying the permissions of a symlink
+///     // This should result in an error on certain platforms,
+///     // succeed in modifying the permissions of a symlink,
+///     // or do nothing at all.
 ///     fs::set_permissions_nofollow("foo.txt", perms)?;
 ///     Ok(())
 /// }

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3471,15 +3471,18 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// # Platform-specific behavior
 ///
 /// This function currently corresponds to the following underlying operations:
-/// * WASI: `open` with `O_NOFOLLOW` followed by `fchmod`.
-/// * Unix: `fchmodat` with `AT_SYMLINK_NOFOLLOW` (or no flag is set if `AT_SYMLINK_NOFOLLOW` does
-///   not exist on a specific Unix-based platform)
+/// * Linux, BSD-based platforms, Android: `fchmodat` with `AT_SYMLINK_NOFOLLOW`.
+/// * Other Unix-based platforms with symlinks: `open` with `O_NOFOLLOW` followed by behavior
+///   denoted in [`fs::set_permissions`].
+/// * Other Unix-based platforms without symlinks: `open` with followed by behavior
+///   denoted in [`fs::set_permissions`].
 /// * Windows: `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT` followed
 ///   by `SetFileInformationByHandle`.
 ///
 /// Note that, this [may change in the future][changes].
 ///
 /// [changes]: io#platform-specific-behavior
+/// [`fs::set_permissions`]: crate::fs::set_permissions
 ///
 /// # Errors
 ///
@@ -3489,12 +3492,13 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// * `path` does not exist.
 /// * The user lacks the permission to change attributes of the file.
 ///
-/// Note: On Linux, this will result in a [`Unsupported`] error
-/// if the final element is a symlink. On BSD-based systems, the
-/// behavior in this case can vary: the operation may have no effect at all
-/// or it may change the permission bits of the symlink itself.
+/// Note: On Linux, this will result in an [`Unsupported`] error
+/// if the final element is a symlink. On other Unix-based platforms
+/// with symlinks (non-BSD-based), this will result in an [`InvalidInput`]
+/// error.
 ///
 /// [`Unsupported`]: crate::io::ErrorKind::Unsupported
+/// [`InvalidInput`]: crate::io::ErrorKind::InvalidInput
 ///
 /// # Examples
 ///
@@ -3505,9 +3509,8 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// fn main() -> std::io::Result<()> {
 ///     let mut perms = fs::symlink_metadata("foo.txt")?.permissions();
 ///     perms.set_readonly(true);
-///     // This should result in an error on certain platforms,
-///     // succeed in modifying the permissions of a symlink,
-///     // or do nothing at all.
+///     // This should result in an error on certain platforms or
+///     // succeed in modifying the permissions of a symlink
 ///     fs::set_permissions_nofollow("foo.txt", perms)?;
 ///     Ok(())
 /// }

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3471,21 +3471,16 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// # Platform-specific behavior
 ///
 /// This function currently corresponds to the following underlying operations:
-/// * Linux: `fchmodat` with `AT_SYMLINK_NOFOLLOW` with a fallback behavior to use
-/// `open` with `O_NOFOLLOW` followed by behavior denoted in [`fs::set_permissions`] when
-/// the former `fchmodat` call errors with `ENOTSUP`[^1].
-/// * BSD-based platforms, Android: `fchmodat` with `AT_SYMLINK_NOFOLLOW`
-/// * Other Unix-based platforms with symlinks: `open` with `O_NOFOLLOW` followed by behavior
-///   denoted in [`fs::set_permissions`].
-/// * Other Unix-based platforms without symlinks: `open` followed by behavior
-///   denoted in [`fs::set_permissions`].
+/// * Android: returns [`Unsupported`] on all files.
+/// * Linux, BSD-based platforms, QNX, NTO: `fchmodat` with `AT_SYMLINK_NOFOLLOW`.
+/// If that is not supported, we fall back to:
+///   * Unix-based platforms with symlinks: `open` with `O_NOFOLLOW` followed by
+///   [`fs::set_permissions`].
+///   * Unix-based platforms without symlinks: `open` followed by [`fs::set_permissions`].
 /// * Windows: `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT` followed
 ///   by `SetFileInformationByHandle`.
 ///
 /// Note that, this [may change in the future][changes].
-///
-/// [^1]: Ubuntu 20.04, for example, makes `fchmodat` with `AT_SYMLINK_NOFOLLOW` return `ENOTSUP`
-/// on both symlinks and non-symlinks
 ///
 /// [changes]: io#platform-specific-behavior
 ///
@@ -3499,13 +3494,10 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// * `path` does not exist.
 /// * The user lacks the permission to change attributes of the file.
 ///
-/// Note: On Linux, this will result in an [`Unsupported`] error
-/// if the final element is a symlink. On other Unix-based platforms
-/// with symlinks (non-BSD-based), this will result in a [`FilesystemLoop`]
-/// error.
+/// Note: On Linux and other Unix-based platforms with symlinks (non-BSD-based),
+/// this will result in an [`Unsupported`] error if the final element is a symlink.
 ///
 /// [`Unsupported`]: crate::io::ErrorKind::Unsupported
-/// [`FilesystemLoop`]: crate::io::ErrorKind::FilesystemLoop
 ///
 /// # Examples
 ///

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3449,15 +3449,18 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// # Platform-specific behavior
 ///
 /// This function currently corresponds to the following underlying operations:
-/// * WASI: `open` with `O_NOFOLLOW` followed by `fchmod`.
-/// * Unix: `fchmodat` with `AT_SYMLINK_NOFOLLOW` (or no flag is set if `AT_SYMLINK_NOFOLLOW` does
-///   not exist on a specific Unix-based platform)
+/// * Linux, BSD-based platforms, Android: `fchmodat` with `AT_SYMLINK_NOFOLLOW`.
+/// * Other Unix-based platforms with symlinks: `open` with `O_NOFOLLOW` followed by behavior
+///   denoted in [`fs::set_permissions`].
+/// * Other Unix-based platforms without symlinks: `open` with followed by behavior
+///   denoted in [`fs::set_permissions`].
 /// * Windows: `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT` followed
 ///   by `SetFileInformationByHandle`.
 ///
 /// Note that, this [may change in the future][changes].
 ///
 /// [changes]: io#platform-specific-behavior
+/// [`fs::set_permissions`]: crate::fs::set_permissions
 ///
 /// # Errors
 ///
@@ -3467,12 +3470,13 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// * `path` does not exist.
 /// * The user lacks the permission to change attributes of the file.
 ///
-/// Note: On Linux, this will result in a [`Unsupported`] error
-/// if the final element is a symlink. On BSD-based systems, the
-/// behavior in this case can vary: the operation may have no effect at all
-/// or it may change the permission bits of the symlink itself.
+/// Note: On Linux, this will result in an [`Unsupported`] error
+/// if the final element is a symlink. On other Unix-based platforms
+/// with symlinks (non-BSD-based), this will result in an [`InvalidInput`]
+/// error.
 ///
 /// [`Unsupported`]: crate::io::ErrorKind::Unsupported
+/// [`InvalidInput`]: crate::io::ErrorKind::InvalidInput
 ///
 /// # Examples
 ///
@@ -3483,9 +3487,8 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// fn main() -> std::io::Result<()> {
 ///     let mut perms = fs::symlink_metadata("foo.txt")?.permissions();
 ///     perms.set_readonly(true);
-///     // This should result in an error on certain platforms,
-///     // succeed in modifying the permissions of a symlink,
-///     // or do nothing at all.
+///     // This should result in an error on certain platforms or
+///     // succeed in modifying the permissions of a symlink
 ///     fs::set_permissions_nofollow("foo.txt", perms)?;
 ///     Ok(())
 /// }

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3448,17 +3448,12 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 ///
 /// # Platform-specific behavior
 ///
-/// This function currently corresponds to:
-/// * `open` with `O_NOFOLLOW` flag enabled + `fchmod` on WASI
-/// * `fchmodat` function with the flag `AT_SYMLINK_NOFOLLOW` enabled
-///   on Unix platforms
-/// * The flag `FILE_FLAG_OPEN_REPARSE_POINT` is enabled and then the
-///   permissions of the file is set through `SetFileInformationByHandle`
-///   on Windows.
-/// * On all other platforms, the behavior remains the same with
-/// [`fs::set_permissions`].
-///
-/// [`fs::set_permissions`]: crate::fs::set_permissions
+/// This function currently corresponds to the following underlying operations:
+/// * WASI: `open` with `O_NOFOLLOW` followed by `fchmod`.
+/// * Unix: `fchmodat` with `AT_SYMLINK_NOFOLLOW` (or no flag is set if `AT_SYMLINK_NOFOLLOW` does
+///   not exist on a specific Unix-based platform)
+/// * Windows: `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT` followed
+///   by `SetFileInformationByHandle`.
 ///
 /// Note that, this [may change in the future][changes].
 ///
@@ -3474,8 +3469,8 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 ///
 /// Note: On Linux, this will result in a [`Unsupported`] error
 /// if the final element is a symlink. On BSD-based systems, the
-/// behavior can vary from symlink permission bits changing or
-/// there being no effects on symlinks
+/// behavior in this case can vary: the operation may have no effect at all
+/// or it may change the permission bits of the symlink itself.
 ///
 /// [`Unsupported`]: crate::io::ErrorKind::Unsupported
 ///
@@ -3488,8 +3483,9 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result
 /// fn main() -> std::io::Result<()> {
 ///     let mut perms = fs::symlink_metadata("foo.txt")?.permissions();
 ///     perms.set_readonly(true);
-///     // This should result in an error on certain platforms
-///     // or succeed in modifying the permissions of a symlink
+///     // This should result in an error on certain platforms,
+///     // succeed in modifying the permissions of a symlink,
+///     // or do nothing at all.
 ///     fs::set_permissions_nofollow("foo.txt", perms)?;
 ///     Ok(())
 /// }

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -649,7 +649,10 @@ fn set_get_permissions_nofollows() {
 
 // Only Windows and Unix support `fs::set_permissions_nofollow`
 #[test]
-#[cfg(all(any(windows, unix), not(any(target_os = "espidf", target_os = "horizon"))))]
+#[cfg(all(
+    any(windows, unix),
+    not(any(target_os = "espidf", target_os = "horizon", target_os = "wasi"))
+))]
 fn set_get_permissions_nofollows_symlink() {
     #[cfg(not(windows))]
     use crate::os::unix::fs::symlink as symlink_dir;
@@ -668,15 +671,7 @@ fn set_get_permissions_nofollows_symlink() {
     let result = fs::set_permissions_nofollow(&symlink_name, permission_bits);
 
     cfg_select! {
-        any(
-            windows,
-            target_os = "android",
-            target_os = "macos",
-            target_os = "freebsd",
-            target_os = "openbsd",
-            target_os = "netbsd",
-            target_os = "dragonfly"
-        ) => {
+        any(windows, target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly") => {
             assert_eq!(result.unwrap(), ());
             let metadata0 = check!(fs::symlink_metadata(&symlink_name));
             // On these systems, it's confirmed the symlink itself is marked readonly

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -679,14 +679,9 @@ fn set_get_permissions_nofollows_symlink() {
         ) => {
             assert_eq!(result.unwrap(), ());
             let metadata0 = check!(fs::symlink_metadata(&symlink_name));
-            // So seems like BSD-based systems trying to set permissions
-            // on symlinks could lead to no effect, so we should expect
-            // there being no change to BSD-based systems.
+            // On these systems, it's confirmed the symlink itself is marked readonly
             // https://superuser.com/questions/1099634/change-permissions-symbolic-link-mac-os
-            #[cfg(windows)]
             assert!(metadata0.permissions().readonly());
-            #[cfg(not(windows))]
-            assert!(!metadata0.permissions().readonly());
 
             // Reset the read-only bit under Windows 7: avoids the
             // `TempDir::drop` from crashing on a permission denial when

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -613,6 +613,7 @@ fn set_get_unix_permissions() {
     assert_eq!(mask & metadata1.permissions().mode(), 0o0777);
 }
 
+#[cfg(not(target_os = "android"))]
 #[test]
 fn set_get_permissions_nofollows() {
     let tmpdir = tmpdir();
@@ -655,40 +656,65 @@ fn set_get_permissions_nofollows() {
 ))]
 fn set_get_permissions_nofollows_symlink() {
     #[cfg(not(windows))]
-    use crate::os::unix::fs::symlink as symlink_dir;
+    use crate::os::unix::fs::symlink as symlink_file;
     #[cfg(windows)]
-    use crate::os::windows::fs::symlink_dir;
+    use crate::os::windows::fs::symlink_file;
 
     let tmpdir = tmpdir();
     let filename = tmpdir.join("set_get_unix_permissions_file");
     let symlink_name = tmpdir.join("set_get_unix_permissions");
     check!(File::create(&filename));
-    check!(symlink_dir(&filename, &symlink_name));
+    check!(symlink_file(&filename, &symlink_name));
 
-    let sym_metadata = check!(fs::symlink_metadata(&symlink_name));
-    let mut permission_bits = sym_metadata.permissions();
-    permission_bits.set_readonly(true);
-    let result = fs::set_permissions_nofollow(&symlink_name, permission_bits);
+    let init_symlink_metadata = check!(fs::symlink_metadata(&symlink_name));
+    let mut init_symlink_permissions = init_symlink_metadata.permissions();
+
+    let init_target_metadata = check!(fs::metadata(&symlink_name));
+    let init_target_permissions = init_target_metadata.permissions();
+
+    // Set symlink permissions to readonly
+    init_symlink_permissions.set_readonly(true);
+    let result = fs::set_permissions_nofollow(&symlink_name, init_symlink_permissions);
 
     cfg_select! {
-        any(windows, target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly") => {
+        any(
+            windows,
+            target_os = "macos",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "dragonfly",
+            target_os = "nto",
+            target_os = "qnx"
+        ) => {
             assert_eq!(result.unwrap(), ());
-            let metadata0 = check!(fs::symlink_metadata(&symlink_name));
+
+            let after_target_metadata = check!(fs::metadata(&symlink_name));
+            // We should expect the target file to not have its permission bits
+            // changed
+            assert_eq!(after_target_metadata.permissions(), init_target_permissions);
+
+            let after_symlink_metadata = check!(fs::symlink_metadata(&symlink_name));
             // On these systems, it's confirmed the symlink itself is marked readonly
             // https://superuser.com/questions/1099634/change-permissions-symbolic-link-mac-os
-            assert!(metadata0.permissions().readonly());
+            assert!(after_symlink_metadata.permissions().readonly());
 
             // Reset the read-only bit under Windows 7: avoids the
             // `TempDir::drop` from crashing on a permission denial when
             // trying to delete the file that has it.
             #[cfg(all(windows, target_vendor = "win7"))]
             {
-                let mut permission_bits = metadata0.permissions();
-                permission_bits.set_readonly(false);
-                check!(fs::set_permissions_nofollow(&symlink_name, permission_bits));
+                let mut symlink_permission_bits = after_symlink_metadata.permissions();
+                symlink_permission_bits.set_readonly(false);
+                check!(fs::set_permissions_nofollow(&symlink_name, symlink_permission_bits));
             }
         }
         _ => {
+            let after_target_metadata = check!(fs::metadata(&symlink_name));
+            // We should expect the target file to not have its permission bits
+            // changed
+            assert_eq!(after_target_metadata.permissions(), init_target_permissions);
+
             let error_kind = result.unwrap_err().kind();
             assert_eq!(error_kind, crate::io::ErrorKind::Unsupported);
         }
@@ -1416,6 +1442,7 @@ fn fchmod_works() {
     check!(file.set_permissions(p));
 }
 
+#[cfg(not(target_os = "android"))]
 #[test]
 fn fchmodat_works() {
     let tmpdir = tmpdir();

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -671,14 +671,9 @@ fn set_get_permissions_nofollows_symlink() {
         any(windows, target_os = "android", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly") => {
             assert_eq!(result.unwrap(), ());
             let metadata0 = check!(fs::symlink_metadata(&symlink_name));
-            // So seems like BSD-based systems trying to set permissions
-            // on symlinks could lead to no effect, so we should expect
-            // there being no change to BSD-based systems.
+            // On these systems, it's confirmed the symlink itself is marked readonly
             // https://superuser.com/questions/1099634/change-permissions-symbolic-link-mac-os
-            #[cfg(windows)]
             assert!(metadata0.permissions().readonly());
-            #[cfg(not(windows))]
-            assert!(!metadata0.permissions().readonly());
 
             // Reset the read-only bit under Windows 7: avoids the
             // `TempDir::drop` from crashing on a permission denial when

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -649,7 +649,10 @@ fn set_get_permissions_nofollows() {
 
 // Only Windows and Unix support `fs::set_permissions_nofollow`
 #[test]
-#[cfg(all(any(windows, unix), not(any(target_os = "espidf", target_os = "horizon"))))]
+#[cfg(all(
+    any(windows, unix),
+    not(any(target_os = "espidf", target_os = "horizon", target_os = "wasi"))
+))]
 fn set_get_permissions_nofollows_symlink() {
     #[cfg(not(windows))]
     use crate::os::unix::fs::symlink as symlink_dir;
@@ -668,7 +671,7 @@ fn set_get_permissions_nofollows_symlink() {
     let result = fs::set_permissions_nofollow(&symlink_name, permission_bits);
 
     cfg_select! {
-        any(windows, target_os = "android", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly") => {
+        any(windows, target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly") => {
             assert_eq!(result.unwrap(), ());
             let metadata0 = check!(fs::symlink_metadata(&symlink_name));
             // On these systems, it's confirmed the symlink itself is marked readonly

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2377,7 +2377,7 @@ pub struct NormalizeError;
 impl Path {
     // The following (private!) function allows construction of a path from a u8
     // slice, which is only safe when it is known to follow the OsStr encoding.
-    unsafe fn from_u8_slice(s: &[u8]) -> &Path {
+    pub(crate) unsafe fn from_u8_slice(s: &[u8]) -> &Path {
         unsafe { Path::new(OsStr::from_encoded_bytes_unchecked(s)) }
     }
     // The following (private!) function reveals the byte encoding used for OsStr.

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1884,80 +1884,91 @@ pub fn set_perm(p: &CStr, perm: FilePermissions) -> io::Result<()> {
     cvt_r(|| unsafe { libc::chmod(p.as_ptr(), perm.mode) }).map(|_| ())
 }
 
+#[cfg(target_os = "android")]
+pub fn set_perm_nofollow(_p: &CStr, _perm: FilePermissions) -> io::Result<()> {
+    // Currently Android seems to be having inconsistent behavior with fchmodat
+    // with `AT_SYMLINK_NOFOLLOW` or openat with `O_NOFOLLOW` + fchmod.
+    // See this issue here mentioning inconsistent behavior on fchmodat:
+    // https://github.com/android/ndk/issues/1258
+    // On the arm-android CI job, using fchmodat with `AT_SYMLINK_NOFOLLOW` +
+    // fallback behavior on a symlink sets the target file's permissions,
+    // which is incorrect behavior.
+    Err(crate::io::ErrorKind::Unsupported.into())
+}
+
+#[cfg(not(target_os = "android"))]
 pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
-    cfg_select! {
-        target_os = "linux" => {
-            let res = cvt_r(|| unsafe {
-                libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
-            })
-            .map(|_| ());
+    #[inline]
+    /// Helper function for fallback open with `O_NOFOLLOW` + `fchmod` behavior
+    fn open_and_set_permissions(p: &CStr, perm: FilePermissions) -> io::Result<()> {
+        use crate::fs::{OpenOptions, Permissions};
 
-            match res {
-                Ok(_) => return Ok(()),
-                Err(err) => {
-                    if err.kind() == crate::io::ErrorKind::Unsupported {
-                        use crate::fs::OpenOptions;
-                        use crate::fs::Permissions;
-                        use crate::os::unix::ffi::OsStrExt;
-                        use crate::os::unix::fs::OpenOptionsExt;
+        let mut options = OpenOptions::new();
 
-                        let mut options = OpenOptions::new();
-                        options.read(true).custom_flags(libc::O_NOFOLLOW);
+        // ESP-IDF and Horizon do not support O_NOFOLLOW, so we skip setting it.
+        // Their filesystems do not have symbolic links, so no special handling is required.
+        #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
+        {
+            #[cfg(not(target_os = "wasi"))]
+            use crate::os::unix::fs::OpenOptionsExt;
+            #[cfg(target_os = "wasi")]
+            use crate::os::wasi::fs::OpenOptionsExt;
+            options.read(true).custom_flags(libc::O_NOFOLLOW);
+        }
 
-                        let os_str = OsStr::from_bytes(p.to_bytes());
-                        let path = Path::new(os_str);
-                        match options.open(path) {
-                            Ok(file) => {
-                                return file.set_permissions(Permissions::from_inner(perm));
-                            },
-                            Err(e) => {
-                                if e.kind() == crate::io::ErrorKind::FilesystemLoop {
-                                    // When O_NOFOLLOW flag is enabled, if the trailing component of
-                                    // a path is a symbolic link, open should fail with ELOOP error
-                                    // For consistency with other Linux distributions, we return
-                                    // `ErrorKind::Unsupported`.
-                                    return Err(err);
-                                }
-                                return Err(e);
-                            }
+        // SAFETY: Since this function is called with `with_native_path`
+        // and that successfully converted the `&Path` to a `CString`,
+        // it should be safe to convert the `&CStr` back to a `Path`.
+        let os_str = unsafe { OsStr::from_encoded_bytes_unchecked(p.to_bytes()) };
+        options.open(Path::new(os_str))?.set_permissions(Permissions::from_inner(perm))
+    }
+
+    // This res value is modified for platforms that support the `fchmodat` syscall.
+    #[allow(unused)]
+    let mut res: Result<(), core::io::Error> = Err(crate::io::ErrorKind::Unsupported.into());
+
+    // These platforms support `fchmodat`, so utilize this syscall over `open` + `fchmod`
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+        target_os = "nto",
+        target_os = "qnx"
+    ))]
+    {
+        res = cvt_r(|| unsafe {
+            libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
+        })
+        .map(|_| ());
+    }
+
+    // If fchmodat fails with `ErrorKind::Unsupported` fallback to using open + fchmod. This is just in case
+    // for older systems like Ubuntu 20.04 where fchmodat fails with EOPNOTSUPP on both regular files and
+    // symlinks when AT_SYMLINK_NOFOLLOW is passed in.
+    match res {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            if err.kind() == crate::io::ErrorKind::Unsupported {
+                match open_and_set_permissions(p, perm) {
+                    Ok(_) => return Ok(()),
+                    Err(e) => {
+                        if e.kind() == crate::io::ErrorKind::FilesystemLoop {
+                            // When open is used with O_NOFOLLOW flag, if the trailing component of
+                            // a path is a symbolic link, it should fail with ELOOP error. Instead of
+                            // returning `FilesystemLoop`, this returns `Unsupported` to keep it consistent
+                            // with what `fchmodat` would return when chmoding a symlink using AT_SYMLINK_NOFOLLOW.
+                            return Err(err);
                         }
+                        return Err(e);
                     }
-
-                    return Err(err);
                 }
             }
-        }
-        any(target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android") => {
-            cvt_r(|| unsafe {
-                libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
-            })
-            .map(|_| ())
-        },
-        // Not all targets support fchmodat, so we fall back to
-        // open + fchmod.
-        _ => {
-            use crate::fs::OpenOptions;
-            use crate::fs::Permissions;
-            let mut options = OpenOptions::new();
-            // ESP-IDF and Horizon do not support O_NOFOLLOW, so we skip setting it.
-            // Their filesystems do not have symbolic links, so no special handling is required.
-            #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
-            {
-                #[cfg(target_os = "wasi")]
-                use crate::os::wasi::fs::OpenOptionsExt;
-                #[cfg(not(target_os = "wasi"))]
-                use crate::os::unix::fs::OpenOptionsExt;
-                options.read(true).custom_flags(libc::O_NOFOLLOW);
-            }
 
-            // SAFETY: Since this function is called with `with_native_path`
-            // and that successfully converted the `&Path` to a `CString`, it
-            // should be safe to slice away the nul byte from `&CStr` and convert
-            // it back to a `&Path`.
-            let path = unsafe { Path::from_u8_slice(p.to_bytes()) };
-            options.open(path)?.set_permissions(Permissions::from_inner(perm))
+            Err(err)
         }
-        _ => cvt_r(|| unsafe { libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, 0) }).map(|_| ()),
     }
 }
 

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1902,9 +1902,17 @@ pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
             let os_str = OsStr::from_bytes(bytes);
             options.open(Path::new(os_str))?.set_permissions(Permissions::from_inner(perm))
         }
-        all(target_os = "linux", not(any(target_os = "espidf", target_os = "horizon"))) => {
+        all(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android"), not(any(target_os = "espidf", target_os = "horizon"))) => {
             cvt_r(|| unsafe {
                 libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
+            })
+            .map(|_| ())
+        },
+        _ => {
+            // These platforms do not have `AT_SYMLINK_NOFOLLOW` but support fchmodat,
+            // so no flag is set for fchmodat.
+            cvt_r(|| unsafe {
+                libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, 0)
             })
             .map(|_| ())
         }

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1885,36 +1885,36 @@ pub fn set_perm(p: &CStr, perm: FilePermissions) -> io::Result<()> {
 }
 
 pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
-    // ESP-IDF and Horizon do not support O_NOFOLLOW, so we skip setting it.
-    // Their filesystems do not have symbolic links, so no special handling is required.
     cfg_select! {
-        // wasm32-wasip1 targets do not support fchmodat, so we fall down to
-        // open + fchmod
-        target_os = "wasi" => {
-            use crate::fs::{OpenOptions, Permissions};
-            use crate::os::wasi::ffi::OsStrExt;
-            use crate::os::wasi::fs::OpenOptionsExt;
-
-            let mut options = OpenOptions::new();
-            options.custom_flags(libc::O_NOFOLLOW);
-
-            let bytes = p.to_bytes();
-            let os_str = OsStr::from_bytes(bytes);
-            options.open(Path::new(os_str))?.set_permissions(Permissions::from_inner(perm))
-        }
-        all(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android"), not(any(target_os = "espidf", target_os = "horizon"))) => {
+        any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android") => {
             cvt_r(|| unsafe {
                 libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
             })
             .map(|_| ())
         },
+        // Not all targets support fchmodat, so we fall back to
+        // open + fchmod.
         _ => {
-            // These platforms do not have `AT_SYMLINK_NOFOLLOW` but support fchmodat,
-            // so no flag is set for fchmodat.
-            cvt_r(|| unsafe {
-                libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, 0)
-            })
-            .map(|_| ())
+            use crate::fs::OpenOptions;
+            use crate::fs::Permissions;
+            let mut options = OpenOptions::new();
+            // ESP-IDF and Horizon do not support O_NOFOLLOW, so we skip setting it.
+            // Their filesystems do not have symbolic links, so no special handling is required.
+            #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
+            {
+                #[cfg(target_os = "wasi")]
+                use crate::os::wasi::fs::OpenOptionsExt;
+                #[cfg(not(target_os = "wasi"))]
+                use crate::os::unix::fs::OpenOptionsExt;
+                options.custom_flags(libc::O_NOFOLLOW);
+            }
+
+            // SAFETY: Since this function is called with `with_native_path`
+            // and that successfully converted the `&Path` to a `CString`, it
+            // should be safe to slice away the nul byte from `&CStr` and convert
+            // it back to a `&Path`.
+            let path = unsafe { Path::from_u8_slice(p.to_bytes()) };
+            options.open(path)?.set_permissions(Permissions::from_inner(perm))
         }
         _ => cvt_r(|| unsafe { libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, 0) }).map(|_| ()),
     }

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1886,7 +1886,48 @@ pub fn set_perm(p: &CStr, perm: FilePermissions) -> io::Result<()> {
 
 pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
     cfg_select! {
-        any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android") => {
+        target_os = "linux" => {
+            let res = cvt_r(|| unsafe {
+                libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
+            })
+            .map(|_| ());
+
+            match res {
+                Ok(_) => return Ok(()),
+                Err(err) => {
+                    if err.kind() == crate::io::ErrorKind::Unsupported {
+                        use crate::fs::OpenOptions;
+                        use crate::fs::Permissions;
+                        use crate::os::unix::ffi::OsStrExt;
+                        use crate::os::unix::fs::OpenOptionsExt;
+
+                        let mut options = OpenOptions::new();
+                        options.read(true).custom_flags(libc::O_NOFOLLOW);
+
+                        let os_str = OsStr::from_bytes(p.to_bytes());
+                        let path = Path::new(os_str);
+                        match options.open(path) {
+                            Ok(file) => {
+                                return file.set_permissions(Permissions::from_inner(perm));
+                            },
+                            Err(e) => {
+                                if e.kind() == crate::io::ErrorKind::FilesystemLoop {
+                                    // When O_NOFOLLOW flag is enabled, if the trailing component of
+                                    // a path is a symbolic link, open should fail with ELOOP error
+                                    // For consistency with other Linux distributions, we return
+                                    // `ErrorKind::Unsupported`.
+                                    return Err(err);
+                                }
+                                return Err(e);
+                            }
+                        }
+                    }
+
+                    return Err(err);
+                }
+            }
+        }
+        any(target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android") => {
             cvt_r(|| unsafe {
                 libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
             })
@@ -1906,7 +1947,7 @@ pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
                 use crate::os::wasi::fs::OpenOptionsExt;
                 #[cfg(not(target_os = "wasi"))]
                 use crate::os::unix::fs::OpenOptionsExt;
-                options.custom_flags(libc::O_NOFOLLOW);
+                options.read(true).custom_flags(libc::O_NOFOLLOW);
             }
 
             // SAFETY: Since this function is called with `with_native_path`

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2054,13 +2054,15 @@ pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
             let os_str = OsStr::from_bytes(bytes);
             options.open(Path::new(os_str))?.set_permissions(Permissions::from_inner(perm))
         }
-        all(target_os = "linux", not(any(target_os = "espidf", target_os = "horizon"))) => {
+        all(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android"), not(any(target_os = "espidf", target_os = "horizon"))) => {
             cvt_r(|| unsafe {
                 libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
             })
             .map(|_| ())
         },
         _ => {
+            // These platforms do not have `AT_SYMLINK_NOFOLLOW` but support fchmodat,
+            // so no flag is set for fchmodat.
             cvt_r(|| unsafe {
                 libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, 0)
             })

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2036,37 +2036,36 @@ pub fn set_perm(p: &CStr, perm: FilePermissions) -> io::Result<()> {
 }
 
 pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
-    // ESP-IDF and Horizon do not support O_NOFOLLOW, so we skip setting it.
-    // Their filesystems do not have symbolic links, so no special handling is required.
     cfg_select! {
-        // wasm32-wasip1 targets do not support fchmodat, so we fall down to
-        // open + fchmod
-        target_os = "wasi" => {
-            use crate::fs::OpenOptions;
-            use crate::fs::Permissions;
-            use crate::os::wasi::ffi::OsStrExt;
-            use crate::os::wasi::fs::OpenOptionsExt;
-
-            let mut options = OpenOptions::new();
-            options.custom_flags(libc::O_NOFOLLOW);
-
-            let bytes = p.to_bytes();
-            let os_str = OsStr::from_bytes(bytes);
-            options.open(Path::new(os_str))?.set_permissions(Permissions::from_inner(perm))
-        }
-        all(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android"), not(any(target_os = "espidf", target_os = "horizon"))) => {
+        any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "android") => {
             cvt_r(|| unsafe {
                 libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, libc::AT_SYMLINK_NOFOLLOW)
             })
             .map(|_| ())
         },
+        // Not all targets support fchmodat, so we fall back to
+        // open + fchmod.
         _ => {
-            // These platforms do not have `AT_SYMLINK_NOFOLLOW` but support fchmodat,
-            // so no flag is set for fchmodat.
-            cvt_r(|| unsafe {
-                libc::fchmodat(libc::AT_FDCWD, p.as_ptr(), perm.mode, 0)
-            })
-            .map(|_| ())
+            use crate::fs::OpenOptions;
+            use crate::fs::Permissions;
+            let mut options = OpenOptions::new();
+            // ESP-IDF and Horizon do not support O_NOFOLLOW, so we skip setting it.
+            // Their filesystems do not have symbolic links, so no special handling is required.
+            #[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
+            {
+                #[cfg(target_os = "wasi")]
+                use crate::os::wasi::fs::OpenOptionsExt;
+                #[cfg(not(target_os = "wasi"))]
+                use crate::os::unix::fs::OpenOptionsExt;
+                options.custom_flags(libc::O_NOFOLLOW);
+            }
+
+            // SAFETY: Since this function is called with `with_native_path`
+            // and that successfully converted the `&Path` to a `CString`, it
+            // should be safe to slice away the nul byte from `&CStr` and convert
+            // it back to a `&Path`.
+            let path = unsafe { Path::from_u8_slice(p.to_bytes()) };
+            options.open(path)?.set_permissions(Permissions::from_inner(perm))
         }
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160170)*
<!-- homu-ignore:end -->

Original Tracking Issue: https://github.com/rust-lang/rust/issues/141607
Fixes mistake made in rust-lang/rust#158168 

This PR refactors documentations for `std::fs::set_permissions_nofollow` and fixes BSD-based systems + Android to use `fchmodat` with `AT_SYMLINK_NOFOLLOW` flag (instead of no flag set) and refactors all other platforms to defer to `OpenOptions` with `O_NOFOLLOW` behavior.

r? @clarfonthey
Since they looked at the original `set_permissions_nofollow` PR I made

cc @RalfJung 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
