### PR TITLE
Try to recover less from incorrectly parsed const arg

### DIFF
--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -902,13 +902,13 @@ impl<'a> Parser<'a> {
                 err
             })?;
         if !self.expr_is_valid_const_arg(&expr) {
-            self.dcx().emit_err(ConstGenericWithoutBraces {
+            return Err(self.dcx().create_err(ConstGenericWithoutBraces {
                 span: expr.span,
                 sugg: ConstGenericWithoutBracesSugg {
                     left: expr.span.shrink_to_lo(),
                     right: expr.span.shrink_to_hi(),
                 },
-            });
+            }));
         }
 
         Ok(expr)

--- a/tests/ui/const-generics/early/closing-args-token.rs
+++ b/tests/ui/const-generics/early/closing-args-token.rs
@@ -4,7 +4,6 @@ struct T<const X: bool>;
 fn bad_args_1() {
     S::<5 + 2 >> 7>;
     //~^ ERROR expressions must be enclosed in braces to be used as const generic arguments
-    //~| ERROR comparison operators cannot be chained
 }
 
 fn bad_args_2() {

--- a/tests/ui/const-generics/early/closing-args-token.stderr
+++ b/tests/ui/const-generics/early/closing-args-token.stderr
@@ -10,18 +10,7 @@ LL |     S::<{ 5 + 2 } >> 7>;
    |         +       +
 
 error: comparison operators cannot be chained
-  --> $DIR/closing-args-token.rs:5:16
-   |
-LL |     S::<5 + 2 >> 7>;
-   |                ^  ^
-   |
-help: split the comparison into two
-   |
-LL |     S::<5 + 2 >> 7 && 7>;
-   |                    ++++
-
-error: comparison operators cannot be chained
-  --> $DIR/closing-args-token.rs:11:20
+  --> $DIR/closing-args-token.rs:10:20
    |
 LL |     S::<{ 5 + 2 } >> 7>;
    |                    ^  ^
@@ -32,13 +21,13 @@ LL |     S::<{ 5 + 2 } >> 7 && 7>;
    |                        ++++
 
 error: expected expression, found `;`
-  --> $DIR/closing-args-token.rs:16:16
+  --> $DIR/closing-args-token.rs:15:16
    |
 LL |     T::<0 >= 3>;
    |                ^ expected expression
 
 error: comparison operators cannot be chained
-  --> $DIR/closing-args-token.rs:22:12
+  --> $DIR/closing-args-token.rs:21:12
    |
 LL |     T::<x >>= 2 > 0>;
    |            ^^   ^
@@ -48,5 +37,5 @@ help: split the comparison into two
 LL |     T::<x >>= 2 && 2 > 0>;
    |                 ++++
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/early/macro_rules-braces.stderr
+++ b/tests/ui/const-generics/early/macro_rules-braces.stderr
@@ -2,7 +2,7 @@ error: expressions must be enclosed in braces to be used as const generic argume
   --> $DIR/macro_rules-braces.rs:44:17
    |
 LL |     let _: baz!(m::P);
-   |                 ^^^^
+   |            -----^^^^- this macro call doesn't expand to a type
    |
 help: enclose the `const` expression in braces
    |
@@ -13,7 +13,7 @@ error: expressions must be enclosed in braces to be used as const generic argume
   --> $DIR/macro_rules-braces.rs:64:17
    |
 LL |     let _: baz!(10 + 7);
-   |                 ^^^^^^
+   |            -----^^^^^^- this macro call doesn't expand to a type
    |
 help: enclose the `const` expression in braces
    |

--- a/tests/ui/parser/cast-angle-bracket-precedence.rs
+++ b/tests/ui/parser/cast-angle-bracket-precedence.rs
@@ -27,3 +27,8 @@ fn main() {
 
     println!("{}", a as usize << long_name); //~ ERROR `<<` is interpreted as a start of generic
 }
+
+fn foo() {
+    if 1 as f64 < 0.0 && 1 >= 0 {}
+    //~^ ERROR `<` is interpreted as a start of generic arguments for `f64`, not a compariso
+}

--- a/tests/ui/parser/cast-angle-bracket-precedence.stderr
+++ b/tests/ui/parser/cast-angle-bracket-precedence.stderr
@@ -1,3 +1,16 @@
+error: `<` is interpreted as a start of generic arguments for `f64`, not a comparison
+  --> $DIR/cast-angle-bracket-precedence.rs:32:17
+   |
+LL |     if 1 as f64 < 0.0 && 1 >= 0 {}
+   |                 ^ ----------- interpreted as generic arguments
+   |                 |
+   |                 not interpreted as comparison
+   |
+help: try comparing the cast value
+   |
+LL |     if (1 as f64) < 0.0 && 1 >= 0 {}
+   |        +        +
+
 error: `<` is interpreted as a start of generic arguments for `usize`, not a comparison
   --> $DIR/cast-angle-bracket-precedence.rs:8:31
    |
@@ -82,5 +95,5 @@ help: try shifting the cast value
 LL |     println!("{}", (a as usize) << long_name);
    |                    +          +
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
The error recovery can cause a cascade of irrelevant errors, so instead return the `PResult::Err` and let the parser fail further up in the logic.

Fix rust-lang/rust#88416.