### PR TITLE
Remove unused `va_start` intrinsic

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -161,12 +161,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 location.val
             }
 
-            // va_end uses the fallback body (a no-op).
-            sym::va_start => {
-                bx.va_start(args[0].immediate());
-                OperandValue::ZeroSized
-            }
-
             sym::size_of_val => {
                 let tp_ty = fn_args.type_at(0);
                 let (_, meta) = args[0].val.pointer_parts();

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -659,9 +659,7 @@ pub(crate) fn check_intrinsic_type(
             (0, 0, vec![va_list_ref_ty], va_list_ty)
         }
 
-        sym::va_start | sym::va_end => {
-            (0, 0, vec![mk_va_list_ty(hir::Mutability::Mut).0], tcx.types.unit)
-        }
+        sym::va_end => (0, 0, vec![mk_va_list_ty(hir::Mutability::Mut).0], tcx.types.unit),
 
         sym::va_arg => (1, 0, vec![mk_va_list_ty(hir::Mutability::Mut).0], param(0)),
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2300,7 +2300,6 @@ symbols! {
         va_copy,
         va_end,
         va_list,
-        va_start,
         val,
         validity,
         value,


### PR DESCRIPTION
The `va_start` intrinsic isn't declared in `core::intrinsics` or used to implement Rust `VaList` support ([the compiler calls `bx.va_start` directly in `rustc_codegen_ssa`](https://github.com/rust-lang/rust/blob/b5be620d5ac9824c4a6030df9fb72644ef4f459b/compiler/rustc_codegen_ssa/src/mir/mod.rs#L523)), therefore this PR removes it.