### PR TITLE
std: Update `wasip3` crate dependency

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "wasip3"
-version = "0.6.0+wasi-0.3.0-rc-2026-03-15"
+version = "0.7.0+wasi-0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed83456dd6a0b8581998c0365e4651fa2997e5093b49243b7f35391afaa7a3d9"
+checksum = "07aa681120704bf09828d1f7cf7e763666c1dc6a36e5096efd0ad9aadfb302d3"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -89,7 +89,7 @@ wasip2 = { version = '1.0.3', features = [
 ], default-features = false }
 
 [target.'cfg(all(target_os = "wasi", target_env = "p3"))'.dependencies]
-wasip3 = { version = '0.6.0', features = [
+wasip3 = { version = '0.7.0', features = [
     'rustc-dep-of-std',
 ], default-features = false }
 


### PR DESCRIPTION
This updates the crate to a version where the imported APIs use officially released/defined versions of interfaces. For the `wasm32-wasip3` target this is WASI 0.3.0. Note that `wasm32-wasip3` is still a tier 3 target, so this isn't expected to have much practical effect until it's upgraded to tier 2.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
