### PR TITLE
Provide more context when an expected type was a type parameter

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1001,6 +1001,9 @@ fn report_trait_method_mismatch<'tcx>(
     impl_trait_ref: ty::TraitRef<'tcx>,
 ) -> ErrorGuaranteed {
     let tcx = infcx.tcx;
+    let x = cause.code();
+    let y = trait_sig.output();
+    tracing::info!(?cause, ?x, ?terr, ?trait_m, ?trait_sig, ?y);
     let (impl_err_span, trait_err_span) =
         extract_spans_for_error_reporting(infcx, terr, &cause, impl_m, trait_m);
 
@@ -1088,6 +1091,19 @@ fn report_trait_method_mismatch<'tcx>(
         false,
         None,
     );
+
+    if let TypeError::ArgumentSorts(_, i) = &terr
+        && let Some(ty) =
+            tcx.fn_sig(trait_m.def_id).skip_binder().inputs_and_output().skip_binder().get(*i)
+        && let ty::Param(param) = ty.kind()
+    {
+        // The expected type corresponds to a type parameter, which migh thave a default type or
+        // have been explicitly set in the `impl` with a different type.
+        let generics = tcx.generics_of(trait_m.def_id);
+        let param = generics.type_param(*param, tcx);
+        let span = tcx.def_span(param.def_id);
+        diag.span_note(span, format!("expected to match this type parameter"));
+    }
 
     diag.emit()
 }

--- a/tests/ui/compare-method/bad-self-type.stderr
+++ b/tests/ui/compare-method/bad-self-type.stderr
@@ -24,6 +24,11 @@ LL |     fn foo(self);
    |            ^^^^
    = note: expected signature `fn(MyFuture)`
               found signature `fn(Box<MyFuture>)`
+note: expected to match this type parameter
+  --> $DIR/bad-self-type.rs:16:1
+   |
+LL | trait T {
+   | ^^^^^^^
 help: change the self-receiver type to match the trait
    |
 LL -     fn foo(self: Box<Self>) {}

--- a/tests/ui/compare-method/default-type-parameter.rs
+++ b/tests/ui/compare-method/default-type-parameter.rs
@@ -1,0 +1,14 @@
+trait Trait<T = ()> {
+    fn foo() -> T;
+}
+
+struct S;
+
+impl Trait for S {
+    fn foo() -> u32 { 0 } //~ ERROR
+}
+impl Trait<i32> for () {
+    fn foo() -> u32 { 0 } //~ ERROR
+}
+
+fn main() {}

--- a/tests/ui/compare-method/default-type-parameter.stderr
+++ b/tests/ui/compare-method/default-type-parameter.stderr
@@ -1,0 +1,51 @@
+error[E0053]: method `foo` has an incompatible type for trait
+  --> $DIR/default-type-parameter.rs:8:17
+   |
+LL |     fn foo() -> u32 { 0 }
+   |                 ^^^ expected `()`, found `u32`
+   |
+note: type in trait
+  --> $DIR/default-type-parameter.rs:2:17
+   |
+LL |     fn foo() -> T;
+   |                 ^
+   = note: expected signature `fn() -> ()`
+              found signature `fn() -> u32`
+note: expected to match this type parameter
+  --> $DIR/default-type-parameter.rs:1:13
+   |
+LL | trait Trait<T = ()> {
+   |             ^^^^^^
+help: change the output type to match the trait
+   |
+LL -     fn foo() -> u32 { 0 }
+LL +     fn foo() -> () { 0 }
+   |
+
+error[E0053]: method `foo` has an incompatible type for trait
+  --> $DIR/default-type-parameter.rs:11:17
+   |
+LL |     fn foo() -> u32 { 0 }
+   |                 ^^^ expected `i32`, found `u32`
+   |
+note: type in trait
+  --> $DIR/default-type-parameter.rs:2:17
+   |
+LL |     fn foo() -> T;
+   |                 ^
+   = note: expected signature `fn() -> i32`
+              found signature `fn() -> u32`
+note: expected to match this type parameter
+  --> $DIR/default-type-parameter.rs:1:13
+   |
+LL | trait Trait<T = ()> {
+   |             ^^^^^^
+help: change the output type to match the trait
+   |
+LL -     fn foo() -> u32 { 0 }
+LL +     fn foo() -> i32 { 0 }
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0053`.

--- a/tests/ui/compare-method/issue-90444.stderr
+++ b/tests/ui/compare-method/issue-90444.stderr
@@ -20,6 +20,8 @@ LL |     fn from(_: fn((), (), u64)) -> Self {
    |
    = note: expected signature `fn(fn((), (), u32)) -> B`
               found signature `fn(fn((), (), u64)) -> B`
+note: expected to match this type parameter
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
 help: change the parameter type to match the trait
    |
 LL -     fn from(_: fn((), (), u64)) -> Self {

--- a/tests/ui/compare-method/reordered-type-param.stderr
+++ b/tests/ui/compare-method/reordered-type-param.stderr
@@ -16,6 +16,11 @@ LL |   fn b<C:Clone,D>(&self, x: C) -> C;
               found signature `fn(&E, G) -> G`
    = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
    = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+note: expected to match this type parameter
+  --> $DIR/reordered-type-param.rs:7:8
+   |
+LL |   fn b<C:Clone,D>(&self, x: C) -> C;
+   |        ^
 help: change the parameter type to match the trait
    |
 LL -   fn b<F:Clone,G>(&self, _x: G) -> G { panic!() }

--- a/tests/ui/fn_traits/fn-impl-mismatched-param-type.stderr
+++ b/tests/ui/fn_traits/fn-impl-mismatched-param-type.stderr
@@ -8,6 +8,8 @@ LL |   extern "rust-call" fn call(&self, (_,): (T,)) {}
    |
    = note: expected signature `extern "rust-call" fn(&Foo, (&'a _,))`
               found signature `extern "rust-call" fn(&Foo, (_,))`
+note: expected to match this type parameter
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 help: change the parameter type to match the trait
    |
 LL |   extern "rust-call" fn call(&self, (_,): (&'a T,)) {}
@@ -23,6 +25,8 @@ LL |   extern "rust-call" fn call_mut(&mut self, (_,): (T,)) {}
    |
    = note: expected signature `extern "rust-call" fn(&mut Foo, (&'a _,))`
               found signature `extern "rust-call" fn(&mut Foo, (_,))`
+note: expected to match this type parameter
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 help: change the parameter type to match the trait
    |
 LL |   extern "rust-call" fn call_mut(&mut self, (_,): (&'a T,)) {}
@@ -39,6 +43,8 @@ LL |   extern "rust-call" fn call_once(self, (_,): (T,)) {}
    |
    = note: expected signature `extern "rust-call" fn(Foo, (&'a _,))`
               found signature `extern "rust-call" fn(Foo, (_,))`
+note: expected to match this type parameter
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 help: change the parameter type to match the trait
    |
 LL |   extern "rust-call" fn call_once(self, (_,): (&'a T,)) {}

--- a/tests/ui/traits/wrong-mul-method-signature.stderr
+++ b/tests/ui/traits/wrong-mul-method-signature.stderr
@@ -6,6 +6,8 @@ LL |     fn mul(self, s: &f64) -> Vec1 {
    |
    = note: expected signature `fn(Vec1, _) -> Vec1`
               found signature `fn(Vec1, &_) -> Vec1`
+note: expected to match this type parameter
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 help: change the parameter type to match the trait
    |
 LL -     fn mul(self, s: &f64) -> Vec1 {
@@ -20,6 +22,8 @@ LL |     fn mul(self, s: f64) -> Vec2 {
    |
    = note: expected signature `fn(Vec2, Vec2) -> f64`
               found signature `fn(Vec2, f64) -> Vec2`
+note: expected to match this type parameter
+  --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 help: change the parameter type to match the trait
    |
 LL -     fn mul(self, s: f64) -> Vec2 {


### PR DESCRIPTION
This becomes particularly confusing when a type parameter has a default.

```
  --> $DIR/default-type-parameter.rs:8:17
   |
LL |     fn foo() -> u32 { 0 }
   |                 ^^^ expected `()`, found `u32`
   |
note: type in trait
  --> $DIR/default-type-parameter.rs:2:17
   |
LL |     fn foo() -> T;
   |                 ^
   = note: expected signature `fn() -> ()`
              found signature `fn() -> u32`
note: expected to match this type parameter
  --> $DIR/default-type-parameter.rs:1:13
   |
LL | trait Trait<T = ()> {
   |             ^^^^^^
help: change the output type to match the trait
   |
LL -     fn foo() -> u32 { 0 }
LL +     fn foo() -> () { 0 }
```
Fix rust-lang/rust#67991.