### PR TITLE
Mark `Tuple` and `FnPtr` traits `#[fundamental]`

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1069,6 +1069,7 @@ pub const trait Destruct: PointeeSized {}
 #[unstable(feature = "tuple_trait", issue = "157987")]
 #[lang = "tuple_trait"]
 #[diagnostic::on_unimplemented(message = "`{Self}` is not a tuple")]
+#[fundamental]
 #[rustc_deny_explicit_impl]
 #[rustc_dyn_incompatible_trait]
 pub trait Tuple {}
@@ -1145,6 +1146,7 @@ marker_impls! {
     reason = "internal trait for implementing various traits for all function pointers"
 )]
 #[lang = "fn_ptr_trait"]
+#[fundamental]
 #[rustc_deny_explicit_impl]
 #[rustc_dyn_incompatible_trait]
 pub trait FnPtr: Copy + Clone {

--- a/tests/ui/fn/fn-ptr-trait.rs
+++ b/tests/ui/fn/fn-ptr-trait.rs
@@ -4,6 +4,7 @@
 use std::marker::FnPtr;
 
 trait Foo {}
-impl<T> Foo for Vec<T> where T: FnPtr {}
+impl<T> Foo for T where T: FnPtr {}
+impl Foo for i32 {} // works because `FnPtr` is `#[fundamental]`
 
 fn main() {}

--- a/tests/ui/tuple/tuple-trait.rs
+++ b/tests/ui/tuple/tuple-trait.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+
+#![feature(tuple_trait)]
+
+use std::marker::Tuple;
+
+trait Foo {}
+impl<T> Foo for T where T: Tuple {}
+impl Foo for i32 {} // works because `Tuple` is `#[fundamental]`
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This makes it possible to write certain blanket implementations over these traits that would be impossible otherwise, at the cost of making it a breaking change to add new implementations of these traits for existing types. I doubt we plan to convert existing types into function pointers or tuples, so this seems fine.

@rustbot label F-fundamental

