### PR TITLE
Add -Zinstrument-mcount={fentry-nop-record,fentry-record}

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -8,7 +8,8 @@ use rustc_middle::middle::codegen_fn_attrs::{
 };
 use rustc_middle::ty::{self, Instance, TyCtxt};
 use rustc_session::config::{
-    BranchProtection, FunctionReturn, InstrumentMcount, OptLevel, PAuthKey, PacRet,
+    BranchProtection, FunctionReturn, InstrumentMcount, InstrumentMcountOpts, OptLevel, PAuthKey,
+    PacRet,
 };
 use rustc_span::sym;
 use rustc_symbol_mangling::mangle_internal_symbol;
@@ -201,7 +202,7 @@ pub(crate) fn frame_pointer(sess: &Session) -> FramePointer {
     let opts = &sess.opts;
     // "mcount" function relies on stack pointer.
     // See <https://sourceware.org/binutils/docs/gprof/Implementation.html>.
-    if opts.unstable_opts.instrument_mcount == InstrumentMcount::Mcount {
+    if let InstrumentMcount::Mcount(_) = opts.unstable_opts.instrument_mcount {
         fp.ratchet(FramePointer::Always);
     }
     fp.ratchet(opts.cg.force_frame_pointers);
@@ -248,8 +249,9 @@ fn instrument_function_attr<'ll>(
         };
 
         if instrument_entry {
+            let mut opts = InstrumentMcountOpts::default();
             match sess.opts.unstable_opts.instrument_mcount {
-                InstrumentMcount::Mcount => {
+                InstrumentMcount::Mcount(mopts) => {
                     // The function name varies on platforms.
                     // See test/CodeGen/mcount.c in clang.
                     let mcount_name = match &sess.target.llvm_mcount_intrinsic {
@@ -262,11 +264,19 @@ fn instrument_function_attr<'ll>(
                         "instrument-function-entry-inlined",
                         mcount_name,
                     ));
+                    opts = mopts;
                 }
-                InstrumentMcount::Fentry => {
+                InstrumentMcount::Fentry(fopts) => {
                     attrs.push(llvm::CreateAttrStringValue(cx.llcx, "fentry-call", "true"));
+                    opts = fopts;
                 }
                 InstrumentMcount::Disabled => {}
+            }
+            if opts.no_call {
+                attrs.push(llvm::CreateAttrString(cx.llcx, "mnop-mcount"));
+            }
+            if opts.record {
+                attrs.push(llvm::CreateAttrString(cx.llcx, "mrecord-mcount"));
             }
         }
     }

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -13,11 +13,11 @@ use rustc_session::config::{
     AnnotateMoves, AutoDiff, BranchProtection, CFGuard, Cfg, CodegenRetagOptions, CoverageLevel,
     CoverageOptions, DebugInfo, DumpMonoStatsFormat, ErrorOutputType, ExternEntry, ExternLocation,
     Externs, FmtDebug, FunctionReturn, IncrementalStateAssertion, InliningThreshold, Input,
-    InstrumentCoverage, InstrumentMcount, InstrumentXRay, LinkSelfContained, LinkerPluginLto,
-    LocationDetail, LtoCli, MirIncludeSpans, NextSolverConfig, Offload, Options, OutFileName,
-    OutputType, OutputTypes, PAuthKey, PacRet, Passes, PatchableFunctionEntry, Polonius,
-    ProcMacroExecutionStrategy, Strip, SwitchWithOptPath, SymbolManglingVersion, WasiExecModel,
-    build_configuration, build_session_options, rustc_optgroups,
+    InstrumentCoverage, InstrumentMcount, InstrumentMcountOpts, InstrumentXRay, LinkSelfContained,
+    LinkerPluginLto, LocationDetail, LtoCli, MirIncludeSpans, NextSolverConfig, Offload, Options,
+    OutFileName, OutputType, OutputTypes, PAuthKey, PacRet, Passes, PatchableFunctionEntry,
+    Polonius, ProcMacroExecutionStrategy, Strip, SwitchWithOptPath, SymbolManglingVersion,
+    WasiExecModel, build_configuration, build_session_options, rustc_optgroups,
 };
 use rustc_session::lint::Level;
 use rustc_session::search_paths::SearchPath;
@@ -833,7 +833,7 @@ fn test_unstable_options_tracking_hash() {
     tracked!(inline_mir, Some(true));
     tracked!(inline_mir_hint_threshold, Some(123));
     tracked!(inline_mir_threshold, Some(123));
-    tracked!(instrument_mcount, InstrumentMcount::Mcount);
+    tracked!(instrument_mcount, InstrumentMcount::Mcount(InstrumentMcountOpts::default()));
     tracked!(instrument_xray, Some(InstrumentXRay::default()));
     tracked!(link_directives, false);
     tracked!(link_only, true);

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -258,15 +258,23 @@ pub enum AnnotateMoves {
     Enabled(Option<u64>),
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct InstrumentMcountOpts {
+    // Insert a nop which could be replaced by an mcount call.
+    pub no_call: bool,
+    // Record the location of the call instrument in a special linker section.
+    pub record: bool,
+}
+
 /// The different settings that the `-Z Instrument-mcount` flag can have.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum InstrumentMcount {
     /// `-Z instrument-mcount=no`
     Disabled,
     /// `-Z instrument-mcount=yes`
-    Mcount,
+    Mcount(InstrumentMcountOpts),
     /// `-Z instrument-mcount=fentry`
-    Fentry,
+    Fentry(InstrumentMcountOpts),
 }
 
 /// Settings for `-Z instrument-xray` flag.
@@ -3141,11 +3149,12 @@ pub(crate) mod dep_tracking {
     use super::{
         AnnotateMoves, AutoDiff, BranchProtection, CFGuard, CFProtection, CodegenRetagOptions,
         CoverageOptions, CrateType, DebugInfo, DebugInfoCompression, ErrorOutputType, FmtDebug,
-        FunctionReturn, InliningThreshold, InstrumentCoverage, InstrumentMcount, InstrumentXRay,
-        LinkerPluginLto, LocationDetail, LtoCli, MirStripDebugInfo, NextSolverConfig, Offload,
-        OptLevel, OutFileName, OutputType, OutputTypes, PatchableFunctionEntry, PointerAuthOption,
-        Polonius, ResolveDocLinks, SourceFileHashAlgorithm, SplitDwarfKind, SwitchWithOptPath,
-        SymbolManglingVersion, WasiExecModel,
+        FunctionReturn, InliningThreshold, InstrumentCoverage, InstrumentMcount,
+        InstrumentMcountOpts, InstrumentXRay, LinkerPluginLto, LocationDetail, LtoCli,
+        MirStripDebugInfo, NextSolverConfig, Offload, OptLevel, OutFileName, OutputType,
+        OutputTypes, PatchableFunctionEntry, PointerAuthOption, Polonius, ResolveDocLinks,
+        SourceFileHashAlgorithm, SplitDwarfKind, SwitchWithOptPath, SymbolManglingVersion,
+        WasiExecModel,
     };
     use crate::lint;
     use crate::utils::NativeLib;
@@ -3208,6 +3217,7 @@ pub(crate) mod dep_tracking {
         InstrumentCoverage,
         CoverageOptions,
         InstrumentMcount,
+        InstrumentMcountOpts,
         InstrumentXRay,
         CrateType,
         MergeFunctions,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -852,8 +852,7 @@ mod desc {
     pub(crate) const parse_coverage_options: &str = "`block` | `branch` | `condition`";
     pub(crate) const parse_codegen_retag_options: &str =
         "either no value or a comma-separated list of settings: `no-precise-im`, `no-precise-pin`";
-    pub(crate) const parse_instrument_mcount: &str =
-        "either a boolean (`yes`, `no`, `on`, `off`, etc), or `fentry` on supported targets.";
+    pub(crate) const parse_instrument_mcount: &str = "either a boolean (`yes`, `no`, `on`, `off`, etc), or `fentry`, `fentry-record`, `fentry-nop-record` on supported targets";
     pub(crate) const parse_instrument_xray: &str = "either a boolean (`yes`, `no`, `on`, `off`, etc), or a comma separated list of settings: `always` or `never` (mutually exclusive), `ignore-loops`, `instruction-threshold=N`, `skip-entry`, `skip-exit`";
     pub(crate) const parse_unpretty: &str = "`string` or `string=string`";
     pub(crate) const parse_treat_err_as_bug: &str = "either no value or a non-negative number";
@@ -1670,15 +1669,33 @@ pub mod parse {
 
     pub(crate) fn parse_instrument_mcount(slot: &mut InstrumentMcount, v: Option<&str>) -> bool {
         let mut use_mcount = false;
+        let mut opts = InstrumentMcountOpts::default();
         if parse_bool(&mut use_mcount, v) {
-            *slot = if use_mcount { InstrumentMcount::Mcount } else { InstrumentMcount::Disabled };
-            true
-        } else if let Some("fentry") = v {
-            *slot = InstrumentMcount::Fentry;
-            true
-        } else {
-            false
+            *slot = if use_mcount {
+                InstrumentMcount::Mcount(opts)
+            } else {
+                InstrumentMcount::Disabled
+            };
+            return true;
         }
+        match v {
+            Some("fentry") => {
+                *slot = InstrumentMcount::Fentry(opts);
+            }
+            Some("fentry-record") => {
+                opts.record = true;
+                *slot = InstrumentMcount::Fentry(opts);
+            }
+            Some("fentry-nop-record") => {
+                opts.record = true;
+                opts.no_call = true;
+                *slot = InstrumentMcount::Fentry(opts);
+            }
+            _ => {
+                return false;
+            }
+        }
+        true
     }
 
     pub(crate) fn parse_instrument_xray(

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1612,10 +1612,15 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
         }
     }
 
-    if sess.opts.unstable_opts.instrument_mcount == InstrumentMcount::Fentry
-        && !sess.target.options.supports_fentry
-    {
-        sess.dcx().emit_err(diagnostics::InstrumentationNotSupported { us: "fentry".to_string() });
+    if let InstrumentMcount::Fentry(opts) = sess.opts.unstable_opts.instrument_mcount {
+        if !sess.target.options.supports_fentry {
+            sess.dcx()
+                .emit_err(diagnostics::InstrumentationNotSupported { us: "fentry".to_string() });
+        }
+        if (opts.no_call || opts.record) && sess.target.arch != Arch::S390x {
+            sess.dcx()
+                .emit_err(diagnostics::InstrumentationNotSupported { us: "fentry-*".to_string() });
+        }
     }
 
     if sess.opts.unstable_opts.instrument_xray.is_some() && !sess.target.options.supports_xray {

--- a/src/doc/unstable-book/src/compiler-flags/instrument-mcount.md
+++ b/src/doc/unstable-book/src/compiler-flags/instrument-mcount.md
@@ -12,17 +12,19 @@ Supported options:
  - `no`, `n`, `off`: Do no enable instrumentation. The default option. This requires, and enables frame pointer generation.
  - `yes`, `y`, `on`: Enable mcount based function instrumentation.
  - `fentry`: Enable fentry based function instrument, where supported. The calling conventions for this are different than mcount, with less overhead, and no frame pointer requirements. This counting function is always named `__fentry__`. This is only available on x86 and s390x targets.
+ - `fentry-nop-record` and `fentry-record`: These options extend the `fentry` option by recording each call site into a section named `__mcount_loc` in the output object file, and optionally replacing the call to `__fentry__` with a nop. These options are not implemented for all targets. Support is noted the supports fentry recording column below.
 
-|target                   |mcount function|supports fentry|ABI notes|
-|---                      |---            |---            |---      |
-|aarch64-apple-darwin     | `\u{1}mcount` |               |         |
-|aarch64-pc-windows-msvc  | `mcount`      |               |         |
-|aarch64-unknown-linux-gnu| `_mcount`     |               |         |
-|i686-pc-windows-msvc     | `mcount`      |              x|         |
-|i686-unknown-linux-gnu   | `mcount`      |              x|         |
-|x86_64-pc-windows-gnu    | `_mcount`     |              x|         |
-|x86_64-pc-windows-msvc   | `mcount`      |              x|         |
-|x86_64-unknown-linux-gnu | `mcount`      |              x|        1|
+|target                   |mcount function|supports fentry|supports fentry recording|ABI notes|
+|---                      |---            |---            |----                     |--      |
+|aarch64-apple-darwin     | `\u{1}mcount` |               |                         |        |
+|aarch64-pc-windows-msvc  | `mcount`      |               |                         |        |
+|aarch64-unknown-linux-gnu| `_mcount`     |               |                         |        |
+|i686-pc-windows-msvc     | `mcount`      |              x|                         |        |
+|i686-unknown-linux-gnu   | `mcount`      |              x|                         |        |
+|x86_64-pc-windows-gnu    | `_mcount`     |              x|                         |        |
+|x86_64-pc-windows-msvc   | `mcount`      |              x|                         |        |
+|x86_64-unknown-linux-gnu | `mcount`      |              x|                         |       1|
+|s390x-unknown-linux-gnu  | `mcount`      |              x|                        x|        |
 
 On arm eabi targets, the mcount function is usually named `__gnu_mcount_nc`, though some targets may use different names. Implementers of counting function should consult the target specific documentation for quirks of each ABI function.
 

--- a/tests/codegen-llvm/instrument-mcount-opts.rs
+++ b/tests/codegen-llvm/instrument-mcount-opts.rs
@@ -1,0 +1,26 @@
+//@ revisions: ncyr ycyr ycnr
+//@ add-minicore
+//@ needs-llvm-components: systemz
+//@ compile-flags: -Copt-level=0 --target=s390x-unknown-linux-gnu
+//@[ncyr] compile-flags: -Zinstrument-mcount=fentry-nop-record
+//@[ycyr] compile-flags: -Zinstrument-mcount=fentry-record
+//@[ycnr] compile-flags: -Zinstrument-mcount=fentry
+#![feature(no_core)]
+#![crate_type = "rlib"]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+// ncyr: attributes #{{.*}} {{.*}} "fentry-call"="true" "mnop-mcount" "mrecord-mcount"
+//
+// ncnr: attributes #{{.*}} {{.*}} "fentry-call"="true" "mnop-mcount"
+// ncnr-NOT: attributes #{{.*}} {{.*}} "mrecord-mcount"
+//
+// ycnr: attributes #{{.*}} {{.*}} "fentry-call"="true"
+// ycnr-NOT: attributes #{{.*}} {{.*}} "mnop-mcount"
+// ycnr-NOT: attributes #{{.*}} {{.*}} "mrecord-mcount"
+//
+// ycyr: attributes #{{.*}} {{.*}} "fentry-call"="true" "mrecord-mcount"
+// ycyr-NOT: attributes #{{.*}} {{.*}} "mnop-mcount"
+pub fn foo() {}


### PR DESCRIPTION
The linux kernel still uses fentry for x86 and s390x arches. s390x depends entirely on the compiler to record and nop these sections.

This facilitates support for inserting nop's and/or recording the location of each mcount call in a special section named `__mcount_loc`.

These attributes are currently only supported with fentry on the s390x target, otherwise they are quietly ignored (except on s390x).
