### PR TITLE
Fix ICE for parsing issue with a closing brace

### DIFF
--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -168,10 +168,11 @@ impl<'a> Parser<'a> {
             // Do not attempt to parse an expression if we're done here.
             self.error_outer_attrs(attrs)?;
             self.mk_stmt(lo, StmtKind::Empty)
-        } else if self.token == token::CloseBrace {
-            self.error_outer_attrs(attrs)?;
-            self.dcx().span_bug(self.token.span, "don't parse a statement if you see `}`");
         } else {
+            if self.token == token::CloseBrace {
+                self.error_outer_attrs(attrs.clone())?;
+            }
+
             // Remainder are line-expr stmts. This is similar to the `parse_stmt_path_start` case
             // above.
             let restrictions =

--- a/tests/ui/parser/visibility-before-close-brace-issue-160171.rs
+++ b/tests/ui/parser/visibility-before-close-brace-issue-160171.rs
@@ -1,0 +1,7 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/160171.
+//! A misplaced `pub` before a block's closing brace must not ICE.
+
+fn main() {
+    pub
+    //~^ ERROR visibility `pub` is not followed by an item
+} //~ ERROR expected expression, found `}`

--- a/tests/ui/parser/visibility-before-close-brace-issue-160171.stderr
+++ b/tests/ui/parser/visibility-before-close-brace-issue-160171.stderr
@@ -1,0 +1,16 @@
+error: visibility `pub` is not followed by an item
+  --> $DIR/visibility-before-close-brace-issue-160171.rs:5:5
+   |
+LL |     pub
+   |     ^^^ the visibility
+   |
+   = help: you likely meant to define an item, e.g., `pub fn foo() {}`
+
+error: expected expression, found `}`
+  --> $DIR/visibility-before-close-brace-issue-160171.rs:7:1
+   |
+LL | }
+   | ^ expected expression
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust#160171


r? @petrochenkov 