### PR TITLE
Rework `smallest_range_containing` to handle duplicates

### DIFF
--- a/compiler/rustc_abi/src/tests.rs
+++ b/compiler/rustc_abi/src/tests.rs
@@ -7,6 +7,68 @@ fn align_constants() {
 }
 
 #[test]
+#[should_panic(expected = "Value 299 is too big for Size(1 bytes)")]
+fn wrapping_range_smallest_range_containing_size_mismatch() {
+    WrappingRange::smallest_range_containing(200..300, Size::from_bytes(1));
+}
+
+#[test]
+fn wrapping_range_smallest_range_containing() {
+    #[track_caller]
+    fn check(x: impl IntoIterator<Item = u128>, bytes: u64, start: u128, end: u128) {
+        assert_eq!(
+            WrappingRange::smallest_range_containing(x, Size::from_bytes(bytes)),
+            Some(WrappingRange { start, end }),
+        );
+    }
+
+    assert_eq!(WrappingRange::smallest_range_containing([], Size::from_bytes(1)), None);
+
+    check([7], 1, 7, 7);
+    check([7, 7, 7], 1, 7, 7);
+
+    check(0..=127, 1, 0, 127);
+    check((0..=127).chain([255]), 1, 255, 127);
+
+    check((-100..=100_i128).map(i128::cast_unsigned), 16, (-100_i128).cast_unsigned(), 100);
+
+    // A wraparound case that's not just "sort them as signed"
+    check([10, 100, 160, 220], 1, 100, 10);
+
+    check([0, 0xFF], 1, 0xFF, 0);
+    check([0, 0xFF], 2, 0, 0xFF);
+    check([0, 0xFFFF], 2, 0xFFFF, 0);
+    check([0, 0xFFFF], 4, 0, 0xFFFF);
+    check([0, 0xFFFFFFFF], 4, 0xFFFFFFFF, 0);
+    check([0, 0xFFFFFFFF], 8, 0, 0xFFFFFFFF);
+
+    check([100, 200], 1, 100, 200);
+    check([100, 200, 50], 1, 50, 200);
+    check([100, 200, 250], 1, 100, 250);
+    check([100, 200, 250, 50], 1, 200, 100);
+
+    check([200, 50], 1, 200, 50);
+    check([200, 50, 190], 1, 190, 50);
+    check([200, 50, 60], 1, 200, 60);
+    check([200, 50, 125], 1, 50, 200);
+
+    // The mem::Alignment case
+    check((0..64).map(|n| 1 << n), 8, 1, i64::MIN.cast_unsigned().into());
+
+    // Both `100..=228` and `..=228 | 100..` are the same size, but we pick the one without zero.
+    check([100, 228], 1, 100, 228);
+
+    // The wraparound one here is slightly smaller, so we pick it despite including zero.
+    // (The distance 10→96 is 86, compared to 85 for 96→181 and 181→10.)
+    check([10, 96, 181], 1, 96, 10);
+
+    // These 4 values are evenly spaced so all 4 candidate ranges have length 193:
+    // `(..=32) | (96..)`, `(..=96) | (160..)`, `(..=160) | (224..)`, and `32..=224`.
+    // We pick the last one as the only one that doesn't contain zero.
+    check([0xA0, 0xE0, 0x20, 0x60], 1, 0x20, 0xE0);
+}
+
+#[test]
 fn wrapping_range_contains_range() {
     let size16 = Size::from_bytes(16);
 

--- a/compiler/rustc_abi/src/wrapping_range.rs
+++ b/compiler/rustc_abi/src/wrapping_range.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use std::ops::RangeFull;
+use std::{fmt, iter};
 
 use crate::Size;
 #[cfg(feature = "nightly")]
@@ -149,51 +149,49 @@ impl WrappingRange {
     ///
     /// # Examples
     ///
-    ///
     /// ```
     /// use rustc_abi::{Size, WrappingRange};
     ///
-    /// let range = WrappingRange::smallest_range_containing([2, 6, 12, 4], Size::from_bytes(2));
-    /// assert_eq!(range.unwrap(), WrappingRange { start: 2, end: 12 });
+    /// let chain = std::iter::chain(10..20, 30..40);
+    /// let range = WrappingRange::smallest_range_containing(chain, Size::from_bytes(2));
+    /// assert_eq!(range.unwrap(), WrappingRange { start: 10, end: 39 });
     ///
-    /// let range = WrappingRange::smallest_range_containing(0..=127, Size::from_bytes(1));
-    /// assert_eq!(range.unwrap(), WrappingRange { start: 0, end: 127 });
-    /// let range = WrappingRange::smallest_range_containing([129, 128, 127], Size::from_bytes(1));
-    /// assert_eq!(range.unwrap(), WrappingRange { start: 127, end: 129 });
+    /// // Values don't need to be sorted nor unique
+    /// let range = WrappingRange::smallest_range_containing([3, 5, 3, 1, 3], Size::from_bytes(2));
+    /// assert_eq!(range.unwrap(), WrappingRange { start: 1, end: 5 });
     ///
     /// // The size matters because it changes where the wrapping can happen:
     /// let range = WrappingRange::smallest_range_containing([1, 254], Size::from_bytes(1));
     /// assert_eq!(range.unwrap(), WrappingRange { start: 254, end: 1 });
     /// let range = WrappingRange::smallest_range_containing([1, 254], Size::from_bytes(4));
     /// assert_eq!(range.unwrap(), WrappingRange { start: 1, end: 254 });
-    ///
-    /// // Both `100..=228` and `..=228 | 100..` are the same size, but we pick the one without zero.
-    /// let range = WrappingRange::smallest_range_containing([100, 228], Size::from_bytes(1));
-    /// assert_eq!(range.unwrap(), WrappingRange { start: 100, end: 228 });
-    /// // These 4 values are evenly spaced so all 4 candidate ranges have length 193:
-    /// // `(..=32) | (96..)`, `(..=96) | (160..)`, `(..=160) | (224..)`, and `32..=224`.
-    /// // We pick the last one as the only one that doesn't contain zero.
-    /// let range = WrappingRange::smallest_range_containing([0xA0, 0xE0, 0x20, 0x60], Size::from_bytes(1));
-    /// assert_eq!(range.unwrap(), WrappingRange { start: 0x20, end: 0xE0 });
     /// ```
     pub fn smallest_range_containing(
         values: impl IntoIterator<Item = u128>,
         size: Size,
     ) -> Option<Self> {
         let mut values: Vec<_> = values.into_iter().collect();
-        let umax = size.unsigned_int_max();
-        for value in &values {
-            debug_assert!(*value <= umax, "Value {value:?} is too big for {size:?}");
-        }
         values.sort_unstable();
 
-        // Having sorted all the values, every element is a possible start point for the
-        // range of values, up to the previous element (wrapping around the end of the vec).
-        // Look at all those candidates and pick the one that's as narrow as possible.
-        let pairs = std::iter::zip(values.iter().copied(), values.iter().copied().cycle().skip(1));
-        let ranges = pairs.map(|(end, start)| WrappingRange { start, end });
-        let smallest_range = ranges.min_by_key(|r| (r.width(size), r.start));
-        smallest_range
+        // The simple answer is the non-wraparound range `min..=max`.
+        let obvious_range = WrappingRange { start: *values.first()?, end: *values.last()? };
+
+        // Having sorted the inputs, one test is enough to double-check they all fit in `size`.
+        let max_input = obvious_range.end;
+        assert!(
+            max_input <= size.unsigned_int_max(),
+            "Value {max_input:?} is too big for {size:?}",
+        );
+
+        // But every `[.., end, start, ..]` is also a potential candidate for a wraparound
+        // range `(..=end) | (start..)`, so long as `start` and `end` aren't duplicates.
+        let wraparound_ranges = values
+            .array_windows::<2>()
+            .filter_map(|&[end, start]| (start != end).then_some(WrappingRange { start, end }));
+
+        // Pick whichever range is smallest. By putting the non-wraparound range first,
+        // it'll be preferred over a wraparound range with the same width.
+        iter::chain(iter::once(obvious_range), wraparound_ranges).min_by_key(|r| r.width(size))
     }
 }
 


### PR DESCRIPTION
@theemathas [pointed out](https://github.com/rust-lang/rust/issues/159438#issuecomment-5125473820) that this method I added in https://github.com/rust-lang/rust/pull/159509 is implicitly assuming that there are no duplicates in the input.  That's not a problem for its one use today -- an enum whose layout matters can't have duplicate discriminants -- but it could be a sharp edge in future, so this PR reworks it to handle duplicate values fine.

As a bonus, as I tried a couple different approaches (from just asserting to deduping to more) I found this rephrasing that I think is clearer.  In particular, while the `.iter().copied().cycle().skip(1)` I'd written *works*, it's definitely not something that you look at and think "oh, obviously".  I think this version using `.array_windows::<2>()` is easier to follow and splitting the wraparound and non-wraparound cases also simplifies the `min_by_key` lambda.

No changes to any layouts from this -- it just refactors this function.