### PR TITLE
`Iterator::{min,max}(_by_key)` should use overridden `min`/`max`/`lt`

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -743,6 +743,54 @@ impl<T: Clone> Clone for Reverse<T> {
     }
 }
 
+/// A pair where ordering and equality work on only the `key`, ignoring the `value`.
+///
+/// Used to implement `Iterator::min_by_key` as `map`+`min`, for example.
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct KeyAndValue<K, V> {
+    pub key: K,
+    pub value: V,
+}
+impl<K: PartialEq, V> PartialEq for KeyAndValue<K, V> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+    #[inline]
+    fn ne(&self, other: &Self) -> bool {
+        self.key != other.key
+    }
+}
+impl<K: Eq, V> Eq for KeyAndValue<K, V> {}
+impl<K: PartialOrd, V> PartialOrd for KeyAndValue<K, V> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        PartialOrd::partial_cmp(&self.key, &other.key)
+    }
+    #[inline]
+    fn lt(&self, other: &Self) -> bool {
+        self.key < other.key
+    }
+    #[inline]
+    fn le(&self, other: &Self) -> bool {
+        self.key <= other.key
+    }
+    #[inline]
+    fn gt(&self, other: &Self) -> bool {
+        self.key > other.key
+    }
+    #[inline]
+    fn ge(&self, other: &Self) -> bool {
+        self.key >= other.key
+    }
+}
+impl<K: Ord, V> Ord for KeyAndValue<K, V> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        Ord::cmp(&self.key, &other.key)
+    }
+}
+
 /// Trait for types that form a [total order](https://en.wikipedia.org/wiki/Total_order).
 ///
 /// Implementations must be consistent with the [`PartialOrd`] implementation, and ensure `max`,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -6,7 +6,7 @@ use super::super::{
 };
 use super::TrustedLen;
 use crate::array;
-use crate::cmp::{self, Ordering};
+use crate::cmp::{self, KeyAndValue, Ordering};
 use crate::marker::Destruct;
 use crate::num::NonZero;
 use crate::ops::{ChangeOutputType, ControlFlow, FromResidual, Residual, Try};
@@ -3248,7 +3248,7 @@ pub const trait Iterator {
         Self: Sized,
         Self::Item: Ord,
     {
-        self.max_by(Ord::cmp)
+        self.reduce(Ord::max)
     }
 
     /// Returns the minimum element of an iterator.
@@ -3285,7 +3285,7 @@ pub const trait Iterator {
         Self: Sized,
         Self::Item: Ord,
     {
-        self.min_by(Ord::cmp)
+        self.reduce(Ord::min)
     }
 
     /// Returns the element that gives the maximum value from the
@@ -3308,18 +3308,17 @@ pub const trait Iterator {
         Self: Sized,
         F: FnMut(&Self::Item) -> B,
     {
-        #[inline]
-        fn key<T, B>(mut f: impl FnMut(&T) -> B) -> impl FnMut(T) -> (B, T) {
-            move |x| (f(&x), x)
-        }
+        // If we implemented this via `max_by` that would force it to use `B::cmp`.
+        // By using `max` over `KeyAndValue`, it instead ends up calling `B::lt`
+        // (via `KeyAndValue::max`), which is often overridden more efficiently.
 
         #[inline]
-        fn compare<T, B: Ord>((x_p, _): &(B, T), (y_p, _): &(B, T)) -> Ordering {
-            x_p.cmp(y_p)
+        fn key<T, B>(mut f: impl FnMut(&T) -> B) -> impl FnMut(T) -> KeyAndValue<B, T> {
+            move |value| KeyAndValue { key: f(&value), value }
         }
 
-        let (_, x) = self.map(key(f)).max_by(compare)?;
-        Some(x)
+        let KeyAndValue { value, .. } = self.map(key(f)).max()?;
+        Some(value)
     }
 
     /// Returns the element that gives the maximum value with respect to the
@@ -3370,18 +3369,17 @@ pub const trait Iterator {
         Self: Sized,
         F: FnMut(&Self::Item) -> B,
     {
-        #[inline]
-        fn key<T, B>(mut f: impl FnMut(&T) -> B) -> impl FnMut(T) -> (B, T) {
-            move |x| (f(&x), x)
-        }
+        // If we implemented this via `min_by` that would force it to use `B::cmp`.
+        // By using `min` over `KeyAndValue`, it instead ends up calling `B::lt`
+        // (via `KeyAndValue::min`), which is often overridden more efficiently.
 
         #[inline]
-        fn compare<T, B: Ord>((x_p, _): &(B, T), (y_p, _): &(B, T)) -> Ordering {
-            x_p.cmp(y_p)
+        fn key<T, B>(mut f: impl FnMut(&T) -> B) -> impl FnMut(T) -> KeyAndValue<B, T> {
+            move |value| KeyAndValue { key: f(&value), value }
         }
 
-        let (_, x) = self.map(key(f)).min_by(compare)?;
-        Some(x)
+        let KeyAndValue { value, .. } = self.map(key(f)).min()?;
+        Some(value)
     }
 
     /// Returns the element that gives the minimum value with respect to the

--- a/library/coretests/tests/iter/traits/iterator.rs
+++ b/library/coretests/tests/iter/traits/iterator.rs
@@ -1,4 +1,5 @@
 use core::cell::RefCell;
+use core::cmp::Ordering;
 use core::iter::zip;
 use core::num::NonZero;
 
@@ -17,13 +18,13 @@ impl PartialEq for Mod3 {
 impl Eq for Mod3 {}
 
 impl PartialOrd for Mod3 {
-    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Ord for Mod3 {
-    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> Ordering {
         (self.0 % 3).cmp(&(other.0 % 3))
     }
 }
@@ -75,8 +76,6 @@ fn test_lt() {
 
 #[test]
 fn test_cmp_by() {
-    use core::cmp::Ordering;
-
     let f = |x: i32, y: i32| (x * x).cmp(&y);
     let xs = || [1, 2, 3, 4].iter().copied();
     let ys = || [1, 4, 16].iter().copied();
@@ -91,8 +90,6 @@ fn test_cmp_by() {
 
 #[test]
 fn test_partial_cmp_by() {
-    use core::cmp::Ordering;
-
     let f = |x: i32, y: i32| (x * x).partial_cmp(&y);
     let xs = || [1, 2, 3, 4].iter().copied();
     let ys = || [1, 4, 16].iter().copied();
@@ -721,4 +718,63 @@ fn _empty_impl_all_auto_traits<T>() {
     fn all_auto_traits<T: Send + Sync + Unpin + UnwindSafe + RefUnwindSafe>() {}
 
     all_auto_traits::<std::iter::Empty<T>>();
+}
+
+#[test]
+fn test_iterator_min_max_use_ord_min_max() {
+    // There's no stable guarantee that the iterator methods use these, but they were added
+    // on `Ord` (as opposed to just the functions in `cmp`) so that they could be overridden
+    // when a more efficient implementation is available, so we should probably use them.
+
+    let a = [OnlyMinMax(3), OnlyMinMax(1), OnlyMinMax(5), OnlyMinMax(9), OnlyMinMax(7)];
+    assert_eq!(a.iter().copied().min(), Some(OnlyMinMax(1)));
+    assert_eq!(a.iter().copied().max(), Some(OnlyMinMax(9)));
+
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+    struct OnlyMinMax(i32);
+    impl PartialOrd for OnlyMinMax {
+        fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
+            unimplemented!()
+        }
+    }
+    impl Ord for OnlyMinMax {
+        fn cmp(&self, _other: &Self) -> Ordering {
+            unimplemented!()
+        }
+        fn min(self, other: Self) -> Self {
+            Self(Ord::min(self.0, other.0))
+        }
+        fn max(self, other: Self) -> Self {
+            Self(Ord::max(self.0, other.0))
+        }
+    }
+}
+
+#[test]
+fn test_iterator_min_max_by_key_use_lt() {
+    // The exact method is certainly not a stable guarantee. The important part
+    // is that they use a simple `-> bool` method as opposed to three-way `cmp`.
+    // If they used `gt` instead, or something, that wouldn't be the end of the world,
+    // but `lt` tends to be best optimized because that's the one that C++ has
+    // traditionally used in standard library templates.
+
+    let a = [3, 1, 5, 9, 7];
+    assert_eq!(a.iter().copied().min_by_key(|x| OnlyLt(*x)), Some(1));
+    assert_eq!(a.iter().copied().max_by_key(|x| OnlyLt(*x)), Some(9));
+
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+    struct OnlyLt(i32);
+    impl PartialOrd for OnlyLt {
+        fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
+            unimplemented!()
+        }
+        fn lt(&self, other: &Self) -> bool {
+            self.0 < other.0
+        }
+    }
+    impl Ord for OnlyLt {
+        fn cmp(&self, _other: &Self) -> Ordering {
+            unimplemented!()
+        }
+    }
 }


### PR DESCRIPTION
Two related changes to provided Iterator implementations:
- `Iterator::min` and `Iterator::max` are currently implemented via `min_by` and `max_by`, which means they don't use `Ord::{min,max}` despite those being overridable to do something more efficient.  Move these to just being `.reduce(Ord::min)` and `.reduce(Ord::max)` to take advantage of potential overrides.
- `Iterator::min_by_key` and `Iterator::max_by_key` are implemented by mapping to a tuple then using `min_by`/`max_by` with a comparator that only looks at one field in the tuple.  That means they end up doing things like `a.cmp(b).is_le()`, which is wasteful if there an overloaded `-> bool` method it could use instead.  So rephrase these two to work as `.map(…).min()`/`.map(…).max()` by mapping to a type that's *not* a tuple and which can thus override more things instead of just passing a `Fn(…) -> Ordering`.