### PR TITLE
bootstrap: Remove method `Subcommand::kind`

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -88,7 +88,7 @@ impl CommandLineStep for Std {
             Mode::Std,
             SourceType::InTree,
             target,
-            builder.config.cmd.kind(),
+            builder.kind,
         );
 
         std_cargo(builder, target, &mut cargo, &self.crates);
@@ -98,7 +98,7 @@ impl CommandLineStep for Std {
         }
 
         let _guard = builder.msg(
-            builder.config.cmd.kind(),
+            builder.kind,
             format_args!("library artifacts{}", crate_description(&self.crates)),
             Mode::Std,
             build_compiler,

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -24,10 +24,9 @@ fn configure_with_args(cmd: &[&str], host: &[&str], target: &[&str]) -> Config {
 }
 
 fn run_build(paths: &[PathBuf], config: Config) -> Cache {
-    let kind = config.cmd.kind();
     let build = Build::new(config);
     let builder = Builder::new(&build);
-    builder.run_step_descriptions(&Builder::get_step_descriptions(kind), paths);
+    builder.run_step_descriptions(&Builder::get_step_descriptions(builder.kind), paths);
     builder.cache
 }
 
@@ -3232,10 +3231,10 @@ impl ConfigBuilder {
     fn run(self) -> Cache {
         let config = self.create_config();
 
-        let kind = config.cmd.kind();
         let build = Build::new(config);
         let builder = Builder::new(&build);
-        builder.run_step_descriptions(&Builder::get_step_descriptions(kind), &builder.paths);
+        builder
+            .run_step_descriptions(&Builder::get_step_descriptions(builder.kind), &builder.paths);
         builder.cache
     }
 

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -549,27 +549,6 @@ impl Default for Subcommand {
 }
 
 impl Subcommand {
-    pub fn kind(&self) -> Kind {
-        match self {
-            Subcommand::Bench { .. } => Kind::Bench,
-            Subcommand::Build { .. } => Kind::Build,
-            Subcommand::Check { .. } => Kind::Check,
-            Subcommand::Clippy { .. } => Kind::Clippy,
-            Subcommand::Doc { .. } => Kind::Doc,
-            Subcommand::Fix => Kind::Fix,
-            Subcommand::Format { .. } => Kind::Format,
-            Subcommand::Test { .. } => Kind::Test,
-            Subcommand::Miri { .. } => Kind::Miri,
-            Subcommand::Clean { .. } => Kind::Clean,
-            Subcommand::Dist => Kind::Dist,
-            Subcommand::Install => Kind::Install,
-            Subcommand::Run { .. } => Kind::Run,
-            Subcommand::Setup { .. } => Kind::Setup,
-            Subcommand::Vendor { .. } => Kind::Vendor,
-            Subcommand::Perf { .. } => Kind::Perf,
-        }
-    }
-
     pub fn compiletest_rustc_args(&self) -> Vec<&str> {
         match *self {
             Subcommand::Test { ref compiletest_rustc_args, .. } => {

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -14,7 +14,7 @@ use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::{env, fs};
 
-use crate::builder::{Builder, Kind};
+use crate::builder::Builder;
 use crate::core::build_steps::tool;
 use crate::core::config::{CompilerBuiltins, DebuggerPath, Target};
 use crate::utils::exec::command;
@@ -80,7 +80,7 @@ pub fn check(build: &mut Build) {
     let mut skip_target_sanity =
         env::var_os("BOOTSTRAP_SKIP_TARGET_SANITY").is_some_and(|s| s == "1" || s == "true");
 
-    skip_target_sanity |= build.config.cmd.kind() == Kind::Check;
+    skip_target_sanity |= matches!(build.config.cmd, Subcommand::Check { .. });
 
     // Skip target sanity checks when we are doing anything with mir-opt tests or Miri
     let skipped_paths = [OsStr::new("mir-opt"), OsStr::new("miri")];


### PR DESCRIPTION
Every caller can either get the kind from `builder.kind`, or directly match against variants of `Subcommand`.

`Builder::new` is now the sole mapping from `Subcommand` to `Kind`.
