### PR TITLE
Remove an outdated FIXME

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1174,8 +1174,6 @@ impl LinkCollector<'_, '_> {
     }
 
     /// This is the entry point for resolving an intra-doc link.
-    ///
-    /// FIXME(jynelson): this is way too many arguments
     fn resolve_link(
         &mut self,
         dox: &str,


### PR DESCRIPTION
This FIXME was added in https://github.com/rust-lang/rust/pull/78923, at which point there were 8 arguments. Now there are only 5, which is much more reasonable.

This commit was brought to you by https://oli-obk.github.io/fixmeh/.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
