### PR TITLE
Add documentation for the `target_feature` attribute

### DIFF
--- a/library/core/src/attribute_docs.rs
+++ b/library/core/src/attribute_docs.rs
@@ -633,3 +633,64 @@ const _: () = ();
 ///
 /// [the `non_exhaustive` attribute]: ../reference/attributes/type_system.html#the-non_exhaustive-attribute
 const _: () = ();
+
+#[doc(attribute = "target_feature")]
+//
+/// Enables extra CPU instructions for a single function.
+///
+/// Newer CPUs support instructions that older ones may lack. AVX2, for example, processes 32
+/// bytes in a single instruction, but a program using it everywhere cannot run on older machines.
+/// By default the compiler stays within a baseline that the compilation target defines.
+/// `#[target_feature(enable = "...")]` enables the named features for one function, so a portable
+/// binary can use faster instructions on CPUs that support them, and fall back otherwise:
+///
+/// ```
+/// # #[cfg(target_arch = "x86_64")] {
+/// #[target_feature(enable = "avx2")]
+/// fn increment_avx2(data: &mut [u8]) {
+///     // The compiler may use AVX2 instructions to process many bytes at once.
+///     for byte in data {
+///         *byte = byte.wrapping_add(1);
+///     }
+/// }
+///
+/// fn increment(data: &mut [u8]) {
+///     if is_x86_feature_detected!("avx2") {
+///         // SAFETY: the CPU was just confirmed to support AVX2.
+///         unsafe { increment_avx2(data) }
+///     } else {
+///         // Fallback that runs on every x86-64 CPU.
+///         for byte in data {
+///             *byte = byte.wrapping_add(1);
+///         }
+///     }
+/// }
+/// # }
+/// ```
+///
+/// Calling a `#[target_feature]` function on a CPU that lacks the features is undefined
+/// behavior, unless the platform explicitly documents it to be safe. That is why the call
+/// needs `unsafe`: the caller must verify that the features are present. Even in a crate built
+/// with `-C target-feature=+avx2`, calling `increment_avx2` still needs `unsafe`; only a
+/// caller that enables the same features through its own `#[target_feature]` attribute may
+/// call it without.
+///
+/// The value of `enable` is one or more comma-separated feature names, and the names are
+/// architecture-specific: `avx2` belongs to x86, `neon` to ARM. The `-C target-feature` flag
+/// accepts the same names crate-wide, and run-time detection has per-architecture macros such
+/// as [`is_x86_feature_detected`] and [`is_aarch64_feature_detected`], which callers use to
+/// confirm the running CPU has a feature before the call.
+///
+/// Inlining would copy the function's extra instructions into code that runs on any CPU, so
+/// the function is never inlined into callers that lack its features and does not combine with
+/// [`inline(always)`]. Every dispatched call is a real call, so put a whole loop behind it,
+/// not a few instructions. It also does not implement the `Fn` traits, so wrap the checked call
+/// in a closure instead.
+///
+/// For more information, see the Reference on [the `target_feature` attribute].
+///
+/// [`is_x86_feature_detected`]: ../std/arch/macro.is_x86_feature_detected.html
+/// [`is_aarch64_feature_detected`]: ../std/arch/macro.is_aarch64_feature_detected.html
+/// [`inline(always)`]: ./attribute.inline.html
+/// [the `target_feature` attribute]: ../reference/attributes/codegen.html#the-target_feature-attribute
+const _: () = ();

--- a/library/core/src/attribute_docs.rs
+++ b/library/core/src/attribute_docs.rs
@@ -581,3 +581,62 @@ mod proc_macro_attribute {}
 ///
 /// [the `link_section` attribute]: ../reference/abi.html#the-link_section-attribute
 mod link_section_attribute {}
+
+#[doc(attribute = "target_feature")]
+//
+/// Enables extra CPU instructions for a single function.
+///
+/// A program is compiled for a baseline CPU, so instructions that only newer CPUs support go
+/// unused even when the machine running the program has them. `#[target_feature(enable = "...")]`
+/// compiles one function with extra features turned on while the rest of the crate keeps the
+/// baseline. The `-C target-feature` and `-C target-cpu` compiler flags enable features for the
+/// whole crate instead, which raises the minimum CPU the binary runs on.
+///
+/// The usual shape is to ask the CPU what it supports at run time, dispatch into the specialized
+/// function, and keep a fallback for everything else:
+///
+/// ```
+/// # #[cfg(target_arch = "x86_64")] {
+/// #[target_feature(enable = "avx2")]
+/// fn sum_avx2(xs: &[u32]) -> u32 {
+///     // The compiler may use AVX2 instructions in here.
+///     xs.iter().sum()
+/// }
+///
+/// fn sum(xs: &[u32]) -> u32 {
+///     if is_x86_feature_detected!("avx2") {
+///         // SAFETY: the CPU was just checked for AVX2 support.
+///         unsafe { sum_avx2(xs) }
+///     } else {
+///         xs.iter().sum()
+///     }
+/// }
+///
+/// assert_eq!(sum(&[1, 2, 3]), 6);
+/// # }
+/// ```
+///
+/// The standard library provides a detection macro for each architecture, such as
+/// [`is_x86_feature_detected`] and [`is_aarch64_feature_detected`].
+///
+/// Calling a `#[target_feature]` function on a CPU without the features is undefined behavior, so
+/// the call needs an `unsafe` block. The exception is a caller that enables the same features
+/// itself: there the compiler already knows the instructions are available, so the call is safe.
+/// Closures written inside such a function inherit its features.
+///
+/// The attribute does not combine with [`inline(always)`], since inlining the body into a caller
+/// that lacks the features would be unsound. The function does not implement the `Fn` traits and
+/// only coerces to an `unsafe fn` pointer, so pass a closure that calls it instead. It is also not
+/// allowed on `main` or on a safe trait method.
+///
+/// The value of `enable` is a comma-separated list of feature names. Names are specific to an
+/// architecture, and one that is not valid for the target is an error. Some are still unstable and
+/// need a nightly feature gate.
+///
+/// For more information, see the Reference on [the `target_feature` attribute].
+///
+/// [`is_x86_feature_detected`]: ../std/arch/macro.is_x86_feature_detected.html
+/// [`is_aarch64_feature_detected`]: ../std/arch/macro.is_aarch64_feature_detected.html
+/// [`inline(always)`]: ./attribute.inline.html
+/// [the `target_feature` attribute]: ../reference/attributes/codegen.html#the-target_feature-attribute
+mod target_feature_attribute {}

--- a/library/core/src/attribute_docs.rs
+++ b/library/core/src/attribute_docs.rs
@@ -626,8 +626,7 @@ mod link_section_attribute {}
 ///
 /// The attribute does not combine with [`inline(always)`], since inlining the body into a caller
 /// that lacks the features would be unsound. The function does not implement the `Fn` traits and
-/// only coerces to an `unsafe fn` pointer, so pass a closure that calls it instead. It is also not
-/// allowed on `main` or on a safe trait method.
+/// only coerces to an `unsafe fn` pointer, so pass a closure that calls it instead.
 ///
 /// The value of `enable` is a comma-separated list of feature names. Names are specific to an
 /// architecture, and one that is not valid for the target is an error. Some are still unstable and


### PR DESCRIPTION
Documents the `target_feature` attribute, aiming at the guide level and beginner friendly. Low level details and per-architecture feature table stay out in the Reference. 

The example is wrapped in a hidden `#[cfg(target_arch = "x86_64")]` block to make the example compile everywhere the doctests run.

Part of rust-lang/rust#157604

r? @GuillaumeGomez

Tested with `./x test library/core --doc --test-args attribute_docs` and the same for `library/std`.