### PR TITLE
Implement `Thread::os_id`

### DIFF
--- a/library/std/src/thread/current.rs
+++ b/library/std/src/thread/current.rs
@@ -246,9 +246,8 @@ pub(crate) fn current_or_unnamed() -> Thread {
             (*current).clone()
         }
     } else if current == DESTROYED {
-        let thread = Thread::new(id::get_or_init(), None);
-        thread.set_os_id_to_current();
-        thread
+        let id = id::get_or_init();
+        Thread::new_current(id, None)
     } else {
         init_current(current)
     }
@@ -293,8 +292,7 @@ fn init_current(current: *mut ()) -> Thread {
         CURRENT.set(BUSY);
         // If the thread ID was initialized already, use it.
         let id = id::get_or_init();
-        let thread = Thread::new(id, None);
-        thread.set_os_id_to_current();
+        let thread = Thread::new_current(id, None);
 
         // Make sure that `crate::rt::thread_cleanup` will be run, which will
         // call `drop_current`.

--- a/library/std/src/thread/current.rs
+++ b/library/std/src/thread/current.rs
@@ -246,7 +246,9 @@ pub(crate) fn current_or_unnamed() -> Thread {
             (*current).clone()
         }
     } else if current == DESTROYED {
-        Thread::new(id::get_or_init(), None)
+        let thread = Thread::new(id::get_or_init(), None);
+        thread.set_os_id_to_current();
+        thread
     } else {
         init_current(current)
     }
@@ -292,6 +294,7 @@ fn init_current(current: *mut ()) -> Thread {
         // If the thread ID was initialized already, use it.
         let id = id::get_or_init();
         let thread = Thread::new(id, None);
+        thread.set_os_id_to_current();
 
         // Make sure that `crate::rt::thread_cleanup` will be run, which will
         // call `drop_current`.

--- a/library/std/src/thread/current.rs
+++ b/library/std/src/thread/current.rs
@@ -247,7 +247,7 @@ pub(crate) fn current_or_unnamed() -> Thread {
         }
     } else if current == DESTROYED {
         let id = id::get_or_init();
-        Thread::new_current(id, None)
+        Thread::new_current(id)
     } else {
         init_current(current)
     }
@@ -292,7 +292,7 @@ fn init_current(current: *mut ()) -> Thread {
         CURRENT.set(BUSY);
         // If the thread ID was initialized already, use it.
         let id = id::get_or_init();
-        let thread = Thread::new_current(id, None);
+        let thread = Thread::new_current(id);
 
         // Make sure that `crate::rt::thread_cleanup` will be run, which will
         // call `drop_current`.

--- a/library/std/src/thread/lifecycle.rs
+++ b/library/std/src/thread/lifecycle.rs
@@ -141,6 +141,10 @@ impl ThreadInit {
             rtabort!("current thread handle already set during thread spawn");
         }
 
+        // The handle was created by the spawning thread, so only now that we are
+        // running can the OS id be filled in.
+        self.handle.set_os_id_to_current();
+
         if let Some(name) = self.handle.cname() {
             imp::set_name(name);
         }

--- a/library/std/src/thread/tests.rs
+++ b/library/std/src/thread/tests.rs
@@ -365,8 +365,8 @@ fn test_thread_os_id_matches_current() {
 fn test_thread_os_id_of_spawned_thread() {
     let spawned = thread::spawn(|| thread::current().os_id());
     let handle = spawned.thread().clone();
-    let seen_by_the_thread_itself = spawned.join().unwrap();
-    assert_eq!(handle.os_id(), seen_by_the_thread_itself);
+    let spawned_id = spawned.join().unwrap();
+    assert_eq!(handle.os_id(), spawned_id);
 }
 
 #[test]

--- a/library/std/src/thread/tests.rs
+++ b/library/std/src/thread/tests.rs
@@ -357,6 +357,19 @@ fn test_thread_os_id_not_equal() {
 }
 
 #[test]
+fn test_thread_os_id_matches_current() {
+    assert_eq!(thread::current().os_id(), crate::sys::thread::current_os_id());
+}
+
+#[test]
+fn test_thread_os_id_of_spawned_thread() {
+    let spawned = thread::spawn(|| thread::current().os_id());
+    let handle = spawned.thread().clone();
+    let seen_by_the_thread_itself = spawned.join().unwrap();
+    assert_eq!(handle.os_id(), seen_by_the_thread_itself);
+}
+
+#[test]
 fn test_scoped_threads_drop_result_before_join() {
     let actually_finished = &AtomicBool::new(false);
     struct X<'scope, 'env>(&'scope Scope<'scope, 'env>, &'env AtomicBool);

--- a/library/std/src/thread/thread.rs
+++ b/library/std/src/thread/thread.rs
@@ -116,8 +116,11 @@ impl Thread {
     /// Creates a handle for the calling thread, recording its OS id.
     ///
     /// `id` must be the `ThreadId` of the calling thread.
-    pub(crate) fn new_current(id: ThreadId, name: Option<String>) -> Thread {
-        let thread = Thread::new(id, name);
+    ///
+    /// Takes no name because passing one into `Thread::new` allocates with the
+    /// global allocator, which `thread::current` is documented never to use.
+    pub(crate) fn new_current(id: ThreadId) -> Thread {
+        let thread = Thread::new(id, None);
         thread.set_os_id_to_current();
         thread
     }
@@ -127,9 +130,14 @@ impl Thread {
     /// May only be called from the thread to which this handle belongs. A
     /// spawned thread does this itself once it starts running, since its handle
     /// already exists by then.
+    ///
+    /// `imp::current_os_id` must not allocate with the global allocator or call
+    /// `thread::current`.
     pub(crate) fn set_os_id_to_current(&self) {
         if let Some(os_id) = imp::current_os_id() {
-            let _ = self.inner.os_id.set(os_id);
+            if self.inner.os_id.set(os_id).is_err() {
+                rtabort!("thread OS id already set");
+            }
         }
     }
 
@@ -235,12 +243,9 @@ impl Thread {
     /// it. `None` means the platform has no such id, the thread has not started
     /// running yet, or the id could not be read.
     ///
-    /// Ids are unique among threads running at the same moment, but the
-    /// operating system may reuse the id of a thread that has exited, and a
-    /// `Thread` handle can outlive the thread it refers to. As long as you know
-    /// the thread is running, the id still refers to that thread; for the
-    /// current thread you always know. When you do not, use the id only where a
-    /// repeated id is harmless, such as logging.
+    /// The operating system may reuse the id of a thread that has exited, and a
+    /// `Thread` handle can outlive the thread it refers to. Use the id only
+    /// where a reused id is harmless, such as logging.
     ///
     /// # Examples
     ///

--- a/library/std/src/thread/thread.rs
+++ b/library/std/src/thread/thread.rs
@@ -232,14 +232,15 @@ impl Thread {
     ///
     /// This is the id that shows up in tools like `ps` and `top`, debuggers and
     /// crash logs, unlike [`ThreadId`], which has no guaranteed relationship to
-    /// it. `None` means the platform has no such id or offers no way to read it,
-    /// or that the thread has not started running yet.
+    /// it. `None` means the platform has no such id, the thread has not started
+    /// running yet, or the id could not be read.
     ///
-    /// The operating system may hand the same id to a later thread once this one
-    /// exits, so it does not name a thread uniquely over the life of the
-    /// process. It may also no longer refer to this thread at all, since any
-    /// thread but the current one can exit at any point. For anything other than
-    /// the current thread, logging is the only safe use.
+    /// Ids are unique among threads running at the same moment, but the
+    /// operating system may reuse the id of a thread that has exited, and a
+    /// `Thread` handle can outlive the thread it refers to. As long as you know
+    /// the thread is running, the id still refers to that thread; for the
+    /// current thread you always know. When you do not, use the id only where a
+    /// repeated id is harmless, such as logging.
     ///
     /// # Examples
     ///
@@ -247,8 +248,10 @@ impl Thread {
     /// #![feature(thread_os_id)]
     /// use std::thread;
     ///
-    /// let spawned = thread::spawn(|| thread::current().os_id());
-    /// println!("spawned thread ran as {:?}", spawned.join().unwrap());
+    /// let spawned = thread::spawn(|| thread::current().os_id()).join().unwrap();
+    /// if spawned.is_some() {
+    ///     assert_ne!(spawned, thread::current().os_id());
+    /// }
     /// ```
     #[unstable(feature = "thread_os_id", issue = "160215")]
     #[must_use]

--- a/library/std/src/thread/thread.rs
+++ b/library/std/src/thread/thread.rs
@@ -113,6 +113,15 @@ impl Thread {
         Thread { inner }
     }
 
+    /// Creates a handle for the calling thread, recording its OS id.
+    ///
+    /// `id` must be the `ThreadId` of the calling thread.
+    pub(crate) fn new_current(id: ThreadId, name: Option<String>) -> Thread {
+        let thread = Thread::new(id, name);
+        thread.set_os_id_to_current();
+        thread
+    }
+
     /// Records the OS id of the calling thread in this handle.
     ///
     /// May only be called from the thread to which this handle belongs. A

--- a/library/std/src/thread/thread.rs
+++ b/library/std/src/thread/thread.rs
@@ -6,6 +6,7 @@ use crate::fmt;
 use crate::pin::Pin;
 use crate::sync::Arc;
 use crate::sys::sync::Parker;
+use crate::sys::thread as imp;
 use crate::time::Duration;
 
 // This module ensures private fields are kept private, which is necessary to enforce the safety requirements.
@@ -40,6 +41,59 @@ mod thread_name_string {
 
 use thread_name_string::ThreadNameString;
 
+// The handle of a spawned thread exists before the thread does, so the thread
+// stores its own id once it starts running, hence the atomic. 0 means "not known".
+//
+// Of the platform calls behind `current_os_id`, only Apple's yields a `uint64_t`,
+// and every Apple target has 64-bit atomics, so `usize` loses nothing on the
+// second arm.
+cfg_select! {
+    target_has_atomic = "64" => {
+        use crate::sync::atomic::{Atomic, AtomicU64, Ordering::Relaxed};
+
+        struct OsId(Atomic<u64>);
+
+        impl OsId {
+            const fn unknown() -> Self {
+                Self(AtomicU64::new(0))
+            }
+
+            fn get(&self) -> Option<u64> {
+                match self.0.load(Relaxed) {
+                    0 => None,
+                    id => Some(id),
+                }
+            }
+
+            fn set(&self, id: u64) {
+                self.0.store(id, Relaxed);
+            }
+        }
+    }
+    _ => {
+        use crate::sync::atomic::{Atomic, AtomicUsize, Ordering::Relaxed};
+
+        struct OsId(Atomic<usize>);
+
+        impl OsId {
+            const fn unknown() -> Self {
+                Self(AtomicUsize::new(0))
+            }
+
+            fn get(&self) -> Option<u64> {
+                match self.0.load(Relaxed) {
+                    0 => None,
+                    id => Some(id as u64),
+                }
+            }
+
+            fn set(&self, id: u64) {
+                self.0.store(id as usize, Relaxed);
+            }
+        }
+    }
+}
+
 /// The internal representation of a `Thread` handle
 ///
 /// We explicitly set the alignment for our guarantee in Thread::into_raw. This
@@ -49,6 +103,7 @@ use thread_name_string::ThreadNameString;
 struct Inner {
     name: Option<ThreadNameString>,
     id: ThreadId,
+    os_id: OsId,
     parker: Parker,
 }
 
@@ -103,11 +158,23 @@ impl Thread {
             let ptr = Arc::get_mut_unchecked(&mut arc).as_mut_ptr();
             (&raw mut (*ptr).name).write(name);
             (&raw mut (*ptr).id).write(id);
+            (&raw mut (*ptr).os_id).write(OsId::unknown());
             Parker::new_in_place(&raw mut (*ptr).parker);
             Pin::new_unchecked(arc.assume_init())
         };
 
         Thread { inner }
+    }
+
+    /// Records the OS id of the calling thread in this handle.
+    ///
+    /// May only be called from the thread to which this handle belongs. A
+    /// spawned thread does this itself once it starts running, since its handle
+    /// already exists by then.
+    pub(crate) fn set_os_id_to_current(&self) {
+        if let Some(os_id) = imp::current_os_id() {
+            self.inner.os_id.set(os_id);
+        }
     }
 
     /// Like the public [`park`], but callable on any handle. This is used to
@@ -202,6 +269,35 @@ impl Thread {
     #[must_use]
     pub fn id(&self) -> ThreadId {
         self.inner.id
+    }
+
+    /// Gets the id the operating system gave this thread, if it has one that can
+    /// be read.
+    ///
+    /// This is the id `ps`, `top`, a debugger or a crash log shows, unlike
+    /// [`ThreadId`], which is internal to Rust and unrelated to it. `None` means
+    /// the platform has no such id or offers no way to read it, or that the
+    /// thread has not started running yet.
+    ///
+    /// The operating system may hand the same id to a later thread once this one
+    /// exits, so it does not name a thread uniquely over the life of the
+    /// process. It may also no longer refer to this thread at all, since any
+    /// thread but the current one can exit at any point. For anything other than
+    /// the current thread, logging is the only safe use.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(thread_os_id)]
+    /// use std::thread;
+    ///
+    /// let spawned = thread::spawn(|| thread::current().os_id());
+    /// println!("spawned thread ran as {:?}", spawned.join().unwrap());
+    /// ```
+    #[unstable(feature = "thread_os_id", issue = "160215")]
+    #[must_use]
+    pub fn os_id(&self) -> Option<u64> {
+        self.inner.os_id.get()
     }
 
     /// Gets the thread's name.

--- a/library/std/src/thread/thread.rs
+++ b/library/std/src/thread/thread.rs
@@ -4,7 +4,7 @@ use crate::alloc::System;
 use crate::ffi::CStr;
 use crate::fmt;
 use crate::pin::Pin;
-use crate::sync::Arc;
+use crate::sync::{Arc, OnceLock};
 use crate::sys::sync::Parker;
 use crate::sys::thread as imp;
 use crate::time::Duration;
@@ -41,59 +41,6 @@ mod thread_name_string {
 
 use thread_name_string::ThreadNameString;
 
-// The handle of a spawned thread exists before the thread does, so the thread
-// stores its own id once it starts running, hence the atomic. 0 means "not known".
-//
-// Of the platform calls behind `current_os_id`, only Apple's yields a `uint64_t`,
-// and every Apple target has 64-bit atomics, so `usize` loses nothing on the
-// second arm.
-cfg_select! {
-    target_has_atomic = "64" => {
-        use crate::sync::atomic::{Atomic, AtomicU64, Ordering::Relaxed};
-
-        struct OsId(Atomic<u64>);
-
-        impl OsId {
-            const fn unknown() -> Self {
-                Self(AtomicU64::new(0))
-            }
-
-            fn get(&self) -> Option<u64> {
-                match self.0.load(Relaxed) {
-                    0 => None,
-                    id => Some(id),
-                }
-            }
-
-            fn set(&self, id: u64) {
-                self.0.store(id, Relaxed);
-            }
-        }
-    }
-    _ => {
-        use crate::sync::atomic::{Atomic, AtomicUsize, Ordering::Relaxed};
-
-        struct OsId(Atomic<usize>);
-
-        impl OsId {
-            const fn unknown() -> Self {
-                Self(AtomicUsize::new(0))
-            }
-
-            fn get(&self) -> Option<u64> {
-                match self.0.load(Relaxed) {
-                    0 => None,
-                    id => Some(id as u64),
-                }
-            }
-
-            fn set(&self, id: u64) {
-                self.0.store(id as usize, Relaxed);
-            }
-        }
-    }
-}
-
 /// The internal representation of a `Thread` handle
 ///
 /// We explicitly set the alignment for our guarantee in Thread::into_raw. This
@@ -103,7 +50,7 @@ cfg_select! {
 struct Inner {
     name: Option<ThreadNameString>,
     id: ThreadId,
-    os_id: OsId,
+    os_id: OnceLock<u64>,
     parker: Parker,
 }
 
@@ -158,7 +105,7 @@ impl Thread {
             let ptr = Arc::get_mut_unchecked(&mut arc).as_mut_ptr();
             (&raw mut (*ptr).name).write(name);
             (&raw mut (*ptr).id).write(id);
-            (&raw mut (*ptr).os_id).write(OsId::unknown());
+            (&raw mut (*ptr).os_id).write(OnceLock::new());
             Parker::new_in_place(&raw mut (*ptr).parker);
             Pin::new_unchecked(arc.assume_init())
         };
@@ -173,7 +120,7 @@ impl Thread {
     /// already exists by then.
     pub(crate) fn set_os_id_to_current(&self) {
         if let Some(os_id) = imp::current_os_id() {
-            self.inner.os_id.set(os_id);
+            let _ = self.inner.os_id.set(os_id);
         }
     }
 
@@ -274,10 +221,10 @@ impl Thread {
     /// Gets the id the operating system gave this thread, if it has one that can
     /// be read.
     ///
-    /// This is the id `ps`, `top`, a debugger or a crash log shows, unlike
-    /// [`ThreadId`], which is internal to Rust and unrelated to it. `None` means
-    /// the platform has no such id or offers no way to read it, or that the
-    /// thread has not started running yet.
+    /// This is the id that shows up in tools like `ps` and `top`, debuggers and
+    /// crash logs, unlike [`ThreadId`], which has no guaranteed relationship to
+    /// it. `None` means the platform has no such id or offers no way to read it,
+    /// or that the thread has not started running yet.
     ///
     /// The operating system may hand the same id to a later thread once this one
     /// exits, so it does not name a thread uniquely over the life of the
@@ -297,7 +244,7 @@ impl Thread {
     #[unstable(feature = "thread_os_id", issue = "160215")]
     #[must_use]
     pub fn os_id(&self) -> Option<u64> {
-        self.inner.os_id.get()
+        self.inner.os_id.get().copied()
     }
 
     /// Gets the thread's name.

--- a/library/std/src/thread/thread.rs
+++ b/library/std/src/thread/thread.rs
@@ -125,7 +125,8 @@ impl Thread {
         thread
     }
 
-    /// Records the OS id of the calling thread in this handle.
+    /// Records the calling thread's OS id, as reported by
+    /// `imp::current_os_id`, in this handle.
     ///
     /// May only be called from the thread to which this handle belongs. A
     /// spawned thread does this itself once it starts running, since its handle
@@ -240,12 +241,17 @@ impl Thread {
     ///
     /// This is the id that shows up in tools like `ps` and `top`, debuggers and
     /// crash logs, unlike [`ThreadId`], which has no guaranteed relationship to
-    /// it. `None` means the platform has no such id, the thread has not started
-    /// running yet, or the id could not be read.
+    /// it. On a platform with no OS-visible thread id, such as SGX, the value
+    /// may be some other per-thread value (there, the thread's address), which
+    /// such tools will not recognize. `None` means no id could be recorded: the
+    /// thread has not started running yet, or the platform has no way to read
+    /// one.
     ///
     /// The operating system may reuse the id of a thread that has exited, and a
-    /// `Thread` handle can outlive the thread it refers to. Use the id only
-    /// where a reused id is harmless, such as logging.
+    /// `Thread` handle can outlive the thread it refers to. After a `fork`, the
+    /// id recorded in the child process still refers to the parent's thread; it
+    /// is not re-read. Use the id only where a reused or stale id is harmless,
+    /// such as logging.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160219)*
<!-- homu-ignore:end -->

Implements `Thread::os_id` as an unstable feature, per the accepted ACP rust-lang/libs-team#635.

Tracking issue: rust-lang/rust#160215

`os_id` returns the OS-level thread id, so Rust programs can tie their own logs to system-level logs (the ACP's stated motivation).

- Using the existing `current_os_id` is much simpler than pulling the id off `imp::Thread` in `spawn_unchecked`. That needs a per-platform arm, and the child still has to fill it in on platforms without a by handle query, so it'd be extra on top of this rather than instead of it.
- `Thread` is handed to user code by spawn hooks before the native thread exists, so the id can only be filled in later. There's no spare `u64` value to mean "not set yet", so a OnceLock is chosen as a simple primitive to use for this purpose.
  
r? libs


