### PR TITLE
Remove `Copy` supertrait from `VaList`

### DIFF
--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -313,7 +313,7 @@ const impl<'f> Drop for VaList<'f> {
 // meantime.
 #[lang = "va_arg_safe"]
 #[stable(feature = "c_variadic", since = "CURRENT_RUSTC_VERSION")]
-pub impl(self) unsafe trait VaArgSafe: Copy {}
+pub impl(self) unsafe trait VaArgSafe {}
 
 crate::cfg_select! {
     any(target_arch = "avr", target_arch = "msp430") => {
@@ -458,6 +458,10 @@ impl<'f> VaList<'f> {
     /// - The actual type of the argument `U` is compatible with `T` (as defined below).
     /// - If `U` and `T` are both integer types, then the value passed by the caller must be
     /// representable in both types.
+    /// - If `T` is not [`Copy`], then it must not have already been read using `next_arg`
+    /// on a [`clone`][VaList::clone]d copy of this `VaList`.
+    /// (Currently, all types implementing [`VaArgSafe`] also implement [`Copy`],
+    /// but this may change in the future.)
     ///
     /// Types `T` and `U` are compatible when:
     ///


### PR DESCRIPTION
… And adjust `next_arg`'s safety comment accordingly. This leaves us more flexibility for the future.

Zulip discussion: https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/.60.3A.20Copy.60.20bound.20on.20.60VaArgSafe.60

@rustbot label T-libs-api

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
