### PR TITLE
interpret: rename validate_operand → validate_place

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -484,7 +484,7 @@ fn const_validate_mplace<'tcx>(
                 CtfeValidationMode::Const { allow_immutable_unsafe_cell: !inner }
             }
         };
-        ecx.const_validate_operand(&mplace.into(), path, &mut ref_tracking, mode)
+        ecx.const_validate_place(&mplace.into(), path, &mut ref_tracking, mode)
             .report_err()
             // Instead of just reporting the `InterpError` via the usual machinery, we give a more targeted
             // error about the validation failure.

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -1117,7 +1117,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // ourselves. This value is now in `left.` The one that started out in `left` already got
         // validated by the copy above.
         if M::enforce_validity(self, left.layout) {
-            self.validate_operand(
+            self.validate_place(
                 &left.clone().into(),
                 M::enforce_validity_recursively(self, left.layout),
                 /*reset_provenance_and_padding*/ true,

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -626,7 +626,7 @@ where
         if M::enforce_validity(self, dest.layout()) {
             // Data got changed, better make sure it matches the type!
             // Also needed to reset padding.
-            self.validate_operand(
+            self.validate_place(
                 &dest.to_place(),
                 M::enforce_validity_recursively(self, dest.layout()),
                 /*reset_provenance_and_padding*/ true,
@@ -858,13 +858,13 @@ where
             // shared reference.
             // But if the types are identical, that is strictly redundant so we only do one pass.
             if src.layout().ty != dest.layout().ty {
-                self.validate_operand(
+                self.validate_place(
                     &dest.transmute(src.layout(), self)?,
                     M::enforce_validity_recursively(self, src.layout()),
                     /*reset_provenance_and_padding*/ true,
                 )?;
             }
-            self.validate_operand(
+            self.validate_place(
                 &dest,
                 M::enforce_validity_recursively(self, dest.layout()),
                 /*reset_provenance_and_padding*/ true,

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -342,7 +342,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // Validate that the entire thing is valid, and reset padding that might be in between the
         // fields.
         if M::enforce_validity(self, dest.layout()) {
-            self.validate_operand(
+            self.validate_place(
                 dest,
                 M::enforce_validity_recursively(self, dest.layout()),
                 /*reset_provenance_and_padding*/ true,

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -363,7 +363,7 @@ struct ValidityVisitor<'rt, 'tcx, M: Machine<'tcx>> {
     /// we only store a (range) set of offsets -- the base pointer is the same throughout the entire
     /// visit, after all.
     /// If this is `Some`, then `reset_provenance_and_padding` must be true (but not vice versa:
-    /// we might not track data vs padding bytes if the operand isn't stored in memory anyway).
+    /// we might not track data vs padding bytes if the place isn't stored in memory anyway).
     data_bytes: Option<RangeSet>,
     /// True if we are inside of `MaybeDangling`. This disables pointer access checks.
     may_dangle: bool,
@@ -1573,7 +1573,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
 
 impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     /// The internal core entry point for all validation operations.
-    fn validate_operand_internal(
+    fn validate_place_internal(
         &mut self,
         val: &PlaceTy<'tcx, M::Provenance>,
         path: Path<'tcx>,
@@ -1582,7 +1582,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         reset_provenance_and_padding: bool,
         start_in_may_dangle: bool,
     ) -> InterpResult<'tcx> {
-        trace!("validate_operand_internal: {:?}, {:?}", *val, val.layout.ty);
+        trace!("validate_place_internal: {:?}, {:?}", *val, val.layout.ty);
 
         // Run the visitor.
         self.run_for_validation_mut(|ecx| {
@@ -1621,7 +1621,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     }
 
     /// This function checks the data at `val` to be const-valid.
-    /// `val` is assumed to cover valid memory if it is an indirect operand.
+    /// `val` is assumed to cover valid memory.
     /// It will error if the bits at the destination do not match the ones described by the layout.
     ///
     /// `ref_tracking` is used to record references that we encounter so that they
@@ -1631,14 +1631,14 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     /// - no pointers to statics.
     /// - no `UnsafeCell` or non-ZST `&mut`.
     #[inline(always)]
-    pub(crate) fn const_validate_operand(
+    pub(crate) fn const_validate_place(
         &mut self,
         val: &PlaceTy<'tcx, M::Provenance>,
         path: Path<'tcx>,
         ref_tracking: &mut RefTracking<MPlaceTy<'tcx, M::Provenance>, Path<'tcx>>,
         ctfe_mode: CtfeValidationMode,
     ) -> InterpResult<'tcx> {
-        self.validate_operand_internal(
+        self.validate_place_internal(
             val,
             path,
             Some(ref_tracking),
@@ -1649,27 +1649,22 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     }
 
     /// This function checks the data at `val` to be runtime-valid.
-    /// `val` is assumed to cover valid memory if it is an indirect operand.
+    /// `val` is assumed to cover valid memory.
     /// It will error if the bits at the destination do not match the ones described by the layout.
     #[inline(always)]
-    pub fn validate_operand(
+    pub fn validate_place(
         &mut self,
         val: &PlaceTy<'tcx, M::Provenance>,
         recursive: bool,
         reset_provenance_and_padding: bool,
     ) -> InterpResult<'tcx> {
-        let _trace = enter_trace_span!(
-            M,
-            "validate_operand",
-            recursive,
-            reset_provenance_and_padding,
-            ?val,
-        );
+        let _trace =
+            enter_trace_span!(M, "validate_place", recursive, reset_provenance_and_padding, ?val,);
         // Note that we *could* actually be in CTFE here with `-Zextra-const-ub-checks`, but it's
         // still correct to not use `ctfe_mode`: that mode is for validation of the final constant
         // value, it rules out things like `UnsafeCell` in awkward places.
         if !recursive {
-            return self.validate_operand_internal(
+            return self.validate_place_internal(
                 val,
                 Path::new(val.layout.ty),
                 None,
@@ -1680,7 +1675,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         }
         // Do a recursive check.
         let mut ref_tracking = RefTracking::empty();
-        self.validate_operand_internal(
+        self.validate_place_internal(
             val,
             Path::new(val.layout.ty),
             Some(&mut ref_tracking),
@@ -1692,7 +1687,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             // Things behind reference do *not* have the provenance reset. In fact
             // we treat the entire thing as being inside MaybeDangling, i.e., references
             // do not have to be dereferenceable.
-            self.validate_operand_internal(
+            self.validate_place_internal(
                 &mplace.into(),
                 path,
                 None, // no further recursion

--- a/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
+++ b/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
@@ -76,7 +76,7 @@ fn check_validity_requirement_strict<'tcx>(
     // option this is fine, but if this is ever meant to be stable we should probably add
     // a "fast mode" to validation.
     with_no_trimmed_paths!(
-        cx.validate_operand(
+        cx.validate_place(
             &allocated.into(),
             /*recursive*/ false,
             /*reset_provenance_and_padding*/ false,
@@ -200,7 +200,7 @@ pub(crate) fn validate_scalar_in_layout<'tcx>(
 
     cx.write_scalar(scalar, &allocated).unwrap();
 
-    cx.validate_operand(
+    cx.validate_place(
         &allocated.into(),
         /*recursive*/ false,
         /*reset_provenance_and_padding*/ false,

--- a/src/tools/miri/src/shims/native_lib/mod.rs
+++ b/src/tools/miri/src/shims/native_lib/mod.rs
@@ -354,7 +354,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // Run the validation that would usually be part of `return`, also to reset
         // any provenance and padding that would not survive the return.
         if MiriMachine::enforce_validity(this, dest.layout) {
-            this.validate_operand(
+            this.validate_place(
                 &dest.clone().into(),
                 MiriMachine::enforce_validity_recursively(this, dest.layout),
                 /*reset_provenance_and_padding*/ true,


### PR DESCRIPTION
A long time ago this worked on `OpTy`, but it got changed to `PlaceTy` at some point. Let's update the method names to match their signature.

r? @oli-obk 