### PR TITLE
Fix #160217: Do not materialize Wild let bindings with type annotations

### DIFF
--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -575,6 +575,36 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         initializer_id: ExprId,
     ) -> BlockAnd<()> {
         match irrefutable_pat.kind {
+            // Optimize `let _ = ...` to peel off side-effect-free coercions.
+            PatKind::Wild => {
+                let mut initializer_id = initializer_id;
+                // Peel off reborrows (Borrow(Deref(arg))) and Use/Scope coercions that don't have side effects.
+                loop {
+                    let init = &self.thir[initializer_id];
+                    match init.kind {
+                        ExprKind::Borrow { arg: deref_arg, .. } => {
+                            let deref_init = &self.thir[deref_arg];
+                            if let ExprKind::Deref { arg: inner_arg } = deref_init.kind {
+                                initializer_id = inner_arg;
+                            } else {
+                                break;
+                            }
+                        }
+                        ExprKind::Cast { source: arg } | ExprKind::Use { source: arg } => {
+                            initializer_id = arg;
+                        }
+                        ExprKind::Scope { value, .. } => {
+                            initializer_id = value;
+                        }
+                        _ => break,
+                    }
+                }
+                let initializer = &self.thir[initializer_id];
+                let place_builder =
+                    unpack!(block = self.lower_scrutinee(block, initializer_id, initializer.span));
+                self.place_into_pattern(block, irrefutable_pat, place_builder, true)
+            }
+
             // Optimize `let x = ...` and `let x: T = ...` to write directly into `x`,
             // and then require that `T == typeof(x)` if present.
             PatKind::Binding { mode: BindingMode(ByRef::No, _), var, subpattern: None, .. } => {


### PR DESCRIPTION
Fix rust-lang/rust#160217.

This PR fixes an inconsistency where a type-annotated wildcard binding (e.g., `let _: &_ = x;`) inappropriately materializes its value and triggers UB in Miri, whereas `let _ = x;` safely mentions the place without loading.

The issue occurs because type checking implicitly inserts coercions (like a reborrow `&*x`) to satisfy the type annotation. In MIR building, these coercions force an evaluation that loads the value from memory. 

To fix this, we updated `expr_into_pattern` in `compiler/rustc_mir_build/src/builder/matches/mod.rs` to intercept `PatKind::Wild`. It actively traverses the initializer's THIR to peel off compiler-inserted, side-effect-free coercions (such as `Borrow`, `Deref`, `Cast`, `Use`, and `Scope`). This allows the MIR builder to accurately lower the binding to a safe `PlaceMention`, resolving the UB without altering language semantics.

Co-authored-by: Jibin Jose <jibinjose884@gmail.com>
