### PR TITLE
rustdoc: fix ICE when a grapheme cluster joins a Prepend-class character to `_` or `:`

### DIFF
--- a/src/librustdoc/html/escape.rs
+++ b/src/librustdoc/html/escape.rs
@@ -79,9 +79,12 @@ impl fmt::Display for EscapeBodyTextWithWbr<'_> {
             } else if (s.contains(':') && !next_is_colon())
                 || (s.contains('_') && !next_is_underscore())
             {
-                EscapeBodyText(&text[last..i + 1]).fmt(fmt)?;
+                // `i + s.len()`, not `i + 1`: a cluster containing `_` or `:` can still be
+                // several bytes long, because UAX#29 GB9b joins a `Prepend` character to the
+                // one that follows it.
+                EscapeBodyText(&text[last..i + s.len()]).fmt(fmt)?;
                 fmt.write_str("<wbr>")?;
-                last = i + 1;
+                last = i + s.len();
             }
         }
         if last < text.len() {

--- a/src/librustdoc/html/escape/tests.rs
+++ b/src/librustdoc/html/escape/tests.rs
@@ -40,6 +40,10 @@ fn escape_body_text_with_wbr() {
     assert_eq!(&E("ṼẽçÑñéå").to_string(), "Ṽẽç<wbr>Ññéå");
     assert_eq!(&E("V\u{0300}e\u{0300}c\u{0300}D\u{0300}e\u{0300}q\u{0300}u\u{0300}e\u{0300}u\u{0300}e\u{0300}").to_string(), "V\u{0300}e\u{0300}c\u{0300}<wbr>D\u{0300}e\u{0300}q\u{0300}u\u{0300}e\u{0300}u\u{0300}e\u{0300}");
     assert_eq!(&E("LPFNACCESSIBLEOBJECTFROMWINDOW").to_string(), "LPFNACCESSIBLEOBJECTFROMWINDOW");
+    // clusters where the `_` or `:` is not the first byte (UAX#29 GB9b `Prepend`)
+    assert_eq!(&E("abc\u{0D4E}_defgh").to_string(), "abc\u{0D4E}_<wbr>defgh");
+    assert_eq!(&E("abc\u{0605}:defgh").to_string(), "abc\u{0605}:<wbr>defgh");
+    assert_eq!(&E("first_\u{0300}second").to_string(), "first_\u{0300}<wbr>second");
 }
 // property test
 #[test]

--- a/tests/rustdoc-html/item-name-grapheme-cluster-wbr.rs
+++ b/tests/rustdoc-html/item-name-grapheme-cluster-wbr.rs
@@ -1,0 +1,8 @@
+// Regression test for #160231: `<wbr>` insertion sliced mid-character on an item name whose
+// grapheme cluster starts with a `Prepend` character and contains `_`.
+
+#![crate_name = "foo"]
+#![allow(mixed_script_confusables, non_camel_case_types)]
+
+//@ hasraw foo/index.html 'abcൎ_<wbr>defgh'
+pub struct abcൎ_defgh;


### PR DESCRIPTION
Fixes rust-lang/rust#160231

`EscapeBodyTextWithWbr` iterates `text.grapheme_indices(true)`, so `i` is the start of a grapheme cluster, but the `_`/`:` word-break arm sliced at `i + 1` — hard-coding the assumption that a cluster containing `_` or `:` is exactly one byte long.

UAX#29 GB9b joins a `Prepend`-class character (`U+0600`–`U+0605`, `U+0D4E`, `U+111C2`, …) with the character that follows it, so a cluster can start with a multi-byte character and still contain `_`. `i + 1` then lands inside that character and `str` indexing panics. `U+0D4E` is `XID_Continue`, so this is reachable from an ordinary item name that rustc accepts:

```rust
pub struct abcൎ_defgh;
```

rustdoc ICEs on that with `end byte index 4 is not a char boundary; it is inside 'ൎ' (bytes 3..6 of string)`, which means `cargo doc` cannot document the crate at all.

Break after the whole cluster (`i + s.len()`) instead. The adjacent CamelCase arm already slices at `i`, which is always a cluster boundary, so it needed no change.

The `i + 1` dates to 3bf8bcfbe0e (which added the `:` arm) and was extended to `_` by ac303df4e21, both in rust-lang/rust#126247.

This also fixes a smaller, non-panicking case: when a combining mark trails the `_` (`first_◌̀second`), the old code inserted the `<wbr>` between `_` and its combining mark, splitting a grapheme cluster.

Tests: unit cases in `src/librustdoc/html/escape/tests.rs` covering a `Prepend`+`_` cluster, a `Prepend`+`:` cluster, and the trailing-combining-mark case; plus an end-to-end regression test in `tests/rustdoc-html/` so the ICE itself stays fixed.

The existing tests missed this because they only cover `Extend`-class clusters, which join backwards onto an ASCII base character and so keep `i + 1` on a boundary (`E("ṼẽçÑñéå")`, `E("V\u{0300}e\u{0300}…")`). `Prepend` is the one class that joins forwards. The property test `escape_body_text_with_wbr_makes_sense` can't reach it either — its alphabet is `[b'a', b'A', b'_']`.

r? rustdoc
