### PR TITLE
Bubble bad path error while parsing field to avoid unecessary second error

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2386,15 +2386,15 @@ impl<'a> Parser<'a> {
         self.expect_field_ty_separator()?;
         let ty = self.parse_ty()?;
         if self.token == token::Colon && self.look_ahead(1, |&t| t != token::Colon) {
-            self.dcx()
+            return Err(self
+                .dcx()
                 .struct_span_err(self.token.span, "found single colon in a struct field type path")
                 .with_span_suggestion_verbose(
                     self.token.span,
                     "write a path separator here",
                     "::",
                     Applicability::MaybeIncorrect,
-                )
-                .emit();
+                ));
         }
         let default = if self.token == token::Eq {
             self.bump();

--- a/tests/ui/suggestions/struct-field-type-including-single-colon.rs
+++ b/tests/ui/suggestions/struct-field-type-including-single-colon.rs
@@ -8,13 +8,19 @@ mod foo {
 struct Foo {
     a: foo:A,
     //~^ ERROR found single colon in a struct field type path
-    //~| ERROR expected `,`, or `}`, found `:`
 }
 
 struct Bar {
     b: foo::bar:B,
     //~^ ERROR found single colon in a struct field type path
-    //~| ERROR expected `,`, or `}`, found `:`
+}
+
+// Issue #92685.
+struct Qux {
+    c: Vec<foo:A>,
+    //~^ ERROR: struct takes at least 1 generic argument but 0 generic arguments were supplied
+    //~| ERROR: associated item constraints are not allowed here
+    //~| ERROR: cannot find trait `A` in this scope
 }
 
 fn main() {}

--- a/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
+++ b/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
@@ -1,6 +1,8 @@
 error: found single colon in a struct field type path
   --> $DIR/struct-field-type-including-single-colon.rs:9:11
    |
+LL | struct Foo {
+   |        --- while parsing this struct
 LL |     a: foo:A,
    |           ^
    |
@@ -9,17 +11,11 @@ help: write a path separator here
 LL |     a: foo::A,
    |            +
 
-error: expected `,`, or `}`, found `:`
-  --> $DIR/struct-field-type-including-single-colon.rs:9:11
-   |
-LL | struct Foo {
-   |        --- while parsing this struct
-LL |     a: foo:A,
-   |           ^
-
 error: found single colon in a struct field type path
-  --> $DIR/struct-field-type-including-single-colon.rs:15:16
+  --> $DIR/struct-field-type-including-single-colon.rs:14:16
    |
+LL | struct Bar {
+   |        --- while parsing this struct
 LL |     b: foo::bar:B,
    |                ^
    |
@@ -28,13 +24,41 @@ help: write a path separator here
 LL |     b: foo::bar::B,
    |                 +
 
-error: expected `,`, or `}`, found `:`
-  --> $DIR/struct-field-type-including-single-colon.rs:15:16
+error[E0405]: cannot find trait `A` in this scope
+  --> $DIR/struct-field-type-including-single-colon.rs:20:16
    |
-LL | struct Bar {
-   |        --- while parsing this struct
-LL |     b: foo::bar:B,
-   |                ^
+LL |     c: Vec<foo:A>,
+   |                ^ not found in this scope
+   |
+help: you might have meant to write a path instead of an associated type bound
+   |
+LL |     c: Vec<foo::A>,
+   |                +
 
-error: aborting due to 4 previous errors
+error[E0107]: struct takes at least 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/struct-field-type-including-single-colon.rs:20:8
+   |
+LL |     c: Vec<foo:A>,
+   |        ^^^ expected at least 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL |     c: Vec<T, foo:A>,
+   |            ++
 
+error[E0229]: associated item constraints are not allowed here
+  --> $DIR/struct-field-type-including-single-colon.rs:20:12
+   |
+LL |     c: Vec<foo:A>,
+   |            ^^^^^ associated item constraint not allowed here
+   |
+help: consider removing this associated item constraint
+   |
+LL -     c: Vec<foo:A>,
+LL +     c: Vec,
+   |
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0107, E0229, E0405.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
Noticed while looking at rust-lang/rust#92685. Add test for the case in that ticket.