### PR TITLE
Always use short ty path for call with missing arguments suggestion

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -18,6 +18,7 @@ use rustc_index::IndexVec;
 use rustc_infer::infer::{BoundRegionConversionTime, DefineOpaqueTypes, InferOk, TypeTrace};
 use rustc_middle::ty::adjustment::AllowTwoPhase;
 use rustc_middle::ty::error::TypeError;
+use rustc_middle::ty::print::with_forced_trimmed_paths;
 use rustc_middle::ty::{self, IsSuggestable, Ty, TyCtxt, TypeVisitableExt, Unnormalized};
 use rustc_middle::{bug, span_bug};
 use rustc_session::Session;
@@ -3489,7 +3490,7 @@ impl<'a, 'tcx> CallCtxt<'a, 'tcx> {
         if ty.is_unit() {
             "()".to_string()
         } else if ty.is_suggestable(self.tcx, false) {
-            format!("/* {ty} */")
+            with_forced_trimmed_paths!(format!("/* {ty} */"))
         } else if let Some(fn_def_id) = self.fn_def_id
             && self.tcx.def_kind(fn_def_id).is_fn_like()
             && let self_implicit =

--- a/tests/ui/argument-suggestions/display-is-suggestable.stderr
+++ b/tests/ui/argument-suggestions/display-is-suggestable.stderr
@@ -11,8 +11,8 @@ LL | fn foo(x: &(dyn Display + Send)) {}
    |    ^^^ ------------------------
 help: provide the argument
    |
-LL |     foo(/* &dyn std::fmt::Display + Send */);
-   |         +++++++++++++++++++++++++++++++++++
+LL |     foo(/* &dyn Display + Send */);
+   |         +++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/next-solver/deferred-closure-call-recovery-issue-157951.stderr
+++ b/tests/ui/traits/next-solver/deferred-closure-call-recovery-issue-157951.stderr
@@ -30,8 +30,8 @@ LL |     let f = |f: dyn Fn()| f;
    |             ^^^^^^^^^^^^^
 help: provide the argument
    |
-LL |     f(/* (dyn Fn() + 'static) */);
-   |       ++++++++++++++++++++++++++
+LL |     f(/* dyn Fn() */);
+   |       ++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/type/verbose-suggestion-for-missing-fn-args.rs
+++ b/tests/ui/type/verbose-suggestion-for-missing-fn-args.rs
@@ -1,0 +1,15 @@
+use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+fn main() {
+    my_very_long_function_name_with_lots_of_args(); //~ ERROR E0061
+}
+
+fn my_very_long_function_name_with_lots_of_args(
+    _first_long_param: bool,
+    _second_long_param: HashMap<Arc<String>, Vec<BTreeSet<usize>>>,
+    _third_long_param: usize,
+    _fourth_long_param: String,
+    _fifth_long_param: Mutex<Option<VecDeque<Arc<String>>>>,
+) {
+}

--- a/tests/ui/type/verbose-suggestion-for-missing-fn-args.stderr
+++ b/tests/ui/type/verbose-suggestion-for-missing-fn-args.stderr
@@ -1,0 +1,29 @@
+error[E0061]: this function takes 5 arguments but 0 arguments were supplied
+  --> $DIR/verbose-suggestion-for-missing-fn-args.rs:5:5
+   |
+LL |     my_very_long_function_name_with_lots_of_args();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- multiple arguments are missing
+   |
+note: function defined here
+  --> $DIR/verbose-suggestion-for-missing-fn-args.rs:8:4
+   |
+LL | fn my_very_long_function_name_with_lots_of_args(
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     _first_long_param: bool,
+   |     -----------------------
+LL |     _second_long_param: HashMap<Arc<String>, Vec<BTreeSet<usize>>>,
+   |     --------------------------------------------------------------
+LL |     _third_long_param: usize,
+   |     ------------------------
+LL |     _fourth_long_param: String,
+   |     --------------------------
+LL |     _fifth_long_param: Mutex<Option<VecDeque<Arc<String>>>>,
+   |     -------------------------------------------------------
+help: provide the arguments
+   |
+LL |     my_very_long_function_name_with_lots_of_args(/* bool */, /* HashMap<Arc<String>, Vec<BTreeSet<usize>>> */, /* usize */, /* String */, /* Mutex<Option<VecDeque<Arc<String>>>> */);
+   |                                                  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
Mitigate having too long of a suggestion when there are many arguments missing by not printing the full path of the expected types.

```
error[E0061]: this function takes 5 arguments but 0 arguments were supplied
  --> $DIR/verbose-suggestion-for-missing-fn-args.rs:5:5
   |
LL |     my_very_long_function_name_with_lots_of_args();
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- multiple arguments are missing
   |
note: function defined here
  --> $DIR/verbose-suggestion-for-missing-fn-args.rs:8:4
   |
LL | fn my_very_long_function_name_with_lots_of_args(
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
LL |     _first_long_param: bool,
   |     -----------------------
LL |     _second_long_param: HashMap<Arc<String>, Vec<BTreeSet<usize>>>,
   |     --------------------------------------------------------------
LL |     _third_long_param: usize,
   |     ------------------------
LL |     _fourth_long_param: String,
   |     --------------------------
LL |     _fifth_long_param: Mutex<Option<VecDeque<Arc<String>>>>,
   |     -------------------------------------------------------
help: provide the arguments
   |
LL |     my_very_long_function_name_with_lots_of_args(/* bool */, /* HashMap<Arc<String>, Vec<BTreeSet<usize>>> */, /* usize */, /* String */, /* Mutex<Option<VecDeque<Arc<String>>>> */);
   |                                                  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
```

Partially address rust-lang/rust#101242. More work is needed to close that ticket, but this is an easy stop gap.