### PR TITLE
Fix `Path::with_extension` dropping the file name for `..X`

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -372,12 +372,10 @@ fn split_file_at_dot(file: &OsStr) -> (&OsStr, Option<&OsStr>) {
     let slice = file.as_encoded_bytes();
     let start = stem_start(slice);
 
-    let Some(i) = slice[start..].iter().position(|b| *b == b'.') else {
-        return (file, None),
+    let Some(dot) = slice[start..].iter().position(|b| *b == b'.') else {
+        return (file, None);
     };
-    let i = start + i;
-    let before = &slice[..i];
-    let after = &slice[i + 1..];
+    let dot = start + dot;
 
     // The unsafety here stems from converting between &OsStr and &[u8]
     // and back. This is safe to do because (1) we only look at ASCII
@@ -385,8 +383,8 @@ fn split_file_at_dot(file: &OsStr) -> (&OsStr, Option<&OsStr>) {
     // only from ASCII-bounded slices of existing &OsStr values.
     unsafe {
         (
-            OsStr::from_encoded_bytes_unchecked(before),
-            Some(OsStr::from_encoded_bytes_unchecked(after)),
+            OsStr::from_encoded_bytes_unchecked(&slice[..dot]),
+            Some(OsStr::from_encoded_bytes_unchecked(&slice[dot + 1..])),
         )
     }
 }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2979,6 +2979,7 @@ impl Path {
     /// assert_eq!("gz", Path::new("foo.tar.gz").extension().unwrap());
     /// assert_eq!(None, Path::new(".gitignore").extension());
     /// assert_eq!(None, Path::new("..gitignore").extension());
+    /// assert_eq!(None, Path::new("...gitignore").extension());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2945,6 +2945,7 @@ impl Path {
     /// assert_eq!(".config", Path::new(".config").file_prefix().unwrap());
     /// assert_eq!(".config", Path::new(".config.toml").file_prefix().unwrap());
     /// assert_eq!("..config", Path::new("..config.toml").file_prefix().unwrap());
+    /// assert_eq!("...config", Path::new("...config.toml").file_prefix().unwrap());
     /// ```
     ///
     /// # See Also

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -372,10 +372,10 @@ fn split_file_at_dot(file: &OsStr) -> (&OsStr, Option<&OsStr>) {
     let slice = file.as_encoded_bytes();
     let start = stem_start(slice);
 
-    let i = match slice[start..].iter().position(|b| *b == b'.') {
-        Some(i) => start + i,
-        None => return (file, None),
+    let Some(i) = slice[start..].iter().position(|b| *b == b'.') else {
+        return (file, None),
     };
+    let i = start + i;
     let before = &slice[..i];
     let after = &slice[i + 1..];
 

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -329,28 +329,42 @@ fn has_physical_root(s: &[u8], prefix: Option<Prefix<'_>>) -> bool {
     !path.is_empty() && is_sep_byte(path[0])
 }
 
+/// How many leading `.`s of a file name are held back from the stem/extension split.
+///
+/// Splitting inside them could leave a stem of `.` or `..`, which names a directory rather than
+/// a file. Three is enough to rule that out while still letting `...` — a file name in its own
+/// right — carry an extension.
+const MAX_LEADING_DOTS: usize = 3;
+
+/// Where the stem/extension split may start: after the leading run of `.`s, capped at
+/// [`MAX_LEADING_DOTS`].
+fn stem_start(slice: &[u8]) -> usize {
+    slice
+        .iter()
+        .take(MAX_LEADING_DOTS)
+        .position(|b| *b != b'.')
+        .unwrap_or(slice.len().min(MAX_LEADING_DOTS))
+}
+
 // basic workhorse for splitting stem and extension
 fn rsplit_file_at_dot(file: &OsStr) -> (Option<&OsStr>, Option<&OsStr>) {
-    if file.as_encoded_bytes() == b".." {
+    let slice = file.as_encoded_bytes();
+    let start = stem_start(slice);
+
+    let Some(dot) = slice[start..].iter().rposition(|b| *b == b'.') else {
         return (Some(file), None);
-    }
+    };
+    let dot = start + dot;
 
     // The unsafety here stems from converting between &OsStr and &[u8]
     // and back. This is safe to do because (1) we only look at ASCII
     // contents of the encoding and (2) new &OsStr values are produced
     // only from ASCII-bounded slices of existing &OsStr values.
-    let mut iter = file.as_encoded_bytes().rsplitn(2, |b| *b == b'.');
-    let after = iter.next();
-    let before = iter.next();
-    if before == Some(b"") {
-        (Some(file), None)
-    } else {
-        unsafe {
-            (
-                before.map(|s| OsStr::from_encoded_bytes_unchecked(s)),
-                after.map(|s| OsStr::from_encoded_bytes_unchecked(s)),
-            )
-        }
+    unsafe {
+        (
+            Some(OsStr::from_encoded_bytes_unchecked(&slice[..dot])),
+            Some(OsStr::from_encoded_bytes_unchecked(&slice[dot + 1..])),
+        )
     }
 }
 
@@ -2877,8 +2891,12 @@ impl Path {
     ///
     /// * [`None`], if there is no file name;
     /// * The entire file name if there is no embedded `.`;
-    /// * The entire file name if the file name begins with `.` and has no other `.`s within;
+    /// * The entire file name if the file name begins with up to three `.` and has no other `.`s
+    ///   within;
     /// * Otherwise, the portion of the file name before the final `.`
+    ///
+    /// Up to three leading `.`s are held back from the split, so the stem is itself always a file
+    /// name — never `.` or `..`.
     ///
     /// # Examples
     ///
@@ -2887,6 +2905,8 @@ impl Path {
     ///
     /// assert_eq!("foo", Path::new("foo.rs").file_stem().unwrap());
     /// assert_eq!("foo.tar", Path::new("foo.tar.gz").file_stem().unwrap());
+    /// assert_eq!(".gitignore", Path::new(".gitignore").file_stem().unwrap());
+    /// assert_eq!("..gitignore", Path::new("..gitignore").file_stem().unwrap());
     /// ```
     ///
     /// # See Also
@@ -2942,7 +2962,7 @@ impl Path {
     ///
     /// * [`None`], if there is no file name;
     /// * [`None`], if there is no embedded `.`;
-    /// * [`None`], if the file name begins with `.` and has no other `.`s within;
+    /// * [`None`], if the file name begins with up to three `.` and has no other `.`s within;
     /// * Otherwise, the portion of the file name after the final `.`
     ///
     /// [`self.file_name`]: Path::file_name
@@ -2954,6 +2974,8 @@ impl Path {
     ///
     /// assert_eq!("rs", Path::new("foo.rs").extension().unwrap());
     /// assert_eq!("gz", Path::new("foo.tar.gz").extension().unwrap());
+    /// assert_eq!(None, Path::new(".gitignore").extension());
+    /// assert_eq!(None, Path::new("..gitignore").extension());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3150,27 +3150,38 @@ impl Path {
     }
 
     fn _with_extension(&self, extension: &OsStr) -> PathBuf {
-        let self_len = self.as_os_str().len();
+        validate_extension(extension);
+
         let self_bytes = self.as_os_str().as_encoded_bytes();
 
-        let (new_capacity, slice_to_copy) = match self.extension() {
-            None => {
-                // Enough capacity for the extension and the dot
-                let capacity = self_len + extension.len() + 1;
-                let whole_path = self_bytes;
-                (capacity, whole_path)
-            }
-            Some(previous_extension) => {
-                let capacity = self_len + extension.len() - previous_extension.len();
-                let path_till_dot = &self_bytes[..self_len - previous_extension.len()];
-                (capacity, path_till_dot)
+        // Like `set_extension`, keep everything up to and including the file
+        // stem and replace the rest. A path with no file stem has no extension
+        // to set, and is copied unchanged.
+        let (slice_to_copy, set_extension) = match self.file_stem() {
+            None => (self_bytes, false),
+            Some(file_stem) => {
+                let file_stem = file_stem.as_encoded_bytes();
+                let end_file_stem = file_stem[file_stem.len()..].as_ptr().addr();
+                let start = self_bytes.as_ptr().addr();
+                (&self_bytes[..end_file_stem.wrapping_sub(start)], true)
             }
         };
+
+        let add_dot_and_extension = set_extension && !extension.is_empty();
+        let new_capacity =
+            slice_to_copy.len() + if add_dot_and_extension { extension.len() + 1 } else { 0 };
 
         let mut new_path = PathBuf::with_capacity(new_capacity);
         // SAFETY: The path is empty, so cannot have surrogate halves.
         unsafe { new_path.inner.extend_from_slice_unchecked(slice_to_copy) };
-        new_path.set_extension(extension);
+
+        if add_dot_and_extension {
+            new_path.inner.push(".");
+            // SAFETY: Since a UTF-8 string was just pushed, it is not possible
+            // for the buffer to end with a surrogate half.
+            unsafe { new_path.inner.extend_from_slice_unchecked(extension.as_encoded_bytes()) };
+        }
+
         new_path
     }
 

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -370,20 +370,19 @@ fn rsplit_file_at_dot(file: &OsStr) -> (Option<&OsStr>, Option<&OsStr>) {
 
 fn split_file_at_dot(file: &OsStr) -> (&OsStr, Option<&OsStr>) {
     let slice = file.as_encoded_bytes();
-    if slice == b".." {
-        return (file, None);
-    }
+    let start = stem_start(slice);
+
+    let i = match slice[start..].iter().position(|b| *b == b'.') {
+        Some(i) => start + i,
+        None => return (file, None),
+    };
+    let before = &slice[..i];
+    let after = &slice[i + 1..];
 
     // The unsafety here stems from converting between &OsStr and &[u8]
     // and back. This is safe to do because (1) we only look at ASCII
     // contents of the encoding and (2) new &OsStr values are produced
     // only from ASCII-bounded slices of existing &OsStr values.
-    let i = match slice[1..].iter().position(|b| *b == b'.') {
-        Some(i) => i + 1,
-        None => return (file, None),
-    };
-    let before = &slice[..i];
-    let after = &slice[i + 1..];
     unsafe {
         (
             OsStr::from_encoded_bytes_unchecked(before),
@@ -2927,9 +2926,12 @@ impl Path {
     ///
     /// * [`None`], if there is no file name;
     /// * The entire file name if there is no embedded `.`;
-    /// * The portion of the file name before the first non-beginning `.`;
-    /// * The entire file name if the file name begins with `.` and has no other `.`s within;
-    /// * The portion of the file name before the second `.` if the file name begins with `.`
+    /// * The entire file name if the file name begins with up to three `.` and has no other `.`s
+    ///   within;
+    /// * Otherwise, the portion of the file name before the first `.` that does not begin it
+    ///
+    /// As with [`Path::file_stem`], up to three leading `.`s are held back from the split, so the
+    /// prefix is itself always a file name — never `.` or `..`.
     ///
     /// [`self.file_name`]: Path::file_name
     ///
@@ -2942,6 +2944,7 @@ impl Path {
     /// assert_eq!("foo", Path::new("foo.tar.gz").file_prefix().unwrap());
     /// assert_eq!(".config", Path::new(".config").file_prefix().unwrap());
     /// assert_eq!(".config", Path::new(".config.toml").file_prefix().unwrap());
+    /// assert_eq!("..config", Path::new("..config.toml").file_prefix().unwrap());
     /// ```
     ///
     /// # See Also

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -2024,6 +2024,7 @@ pub fn test_with_extension() {
     twe!("....", "txt", "....txt");
 
     // dots after the start of the file name split as they always have
+    twe!("foo.bar.baz", "txt", "foo.bar.txt");
     twe!("foo..bar", "txt", "foo..txt");
     twe!("foo..bar", "", "foo.");
     twe!(".foo..bar", "txt", ".foo..txt");

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -1617,6 +1617,37 @@ pub fn test_stem_ext() {
 
     t!("..x.y.z", file_stem: Some("..x.y"), extension: Some("z"));
 
+    // up to three leading dots are part of the stem
+    t!(".x", file_stem: Some(".x"), extension: None);
+
+    t!("..x", file_stem: Some("..x"), extension: None);
+
+    t!("...x", file_stem: Some("...x"), extension: None);
+
+    t!("...", file_stem: Some("..."), extension: None);
+
+    t!("..x.y", file_stem: Some("..x"), extension: Some("y"));
+
+    // past three, `...` is a file name that can carry an extension
+    t!("....x", file_stem: Some("..."), extension: Some("x"));
+
+    t!("....", file_stem: Some("..."), extension: Some(""));
+
+    t!(".....x", file_stem: Some("...."), extension: Some("x"));
+
+    // dots after the start of the file name split as they always have
+    t!("x.y", file_stem: Some("x"), extension: Some("y"));
+
+    t!("x..y", file_stem: Some("x."), extension: Some("y"));
+
+    t!("x...y", file_stem: Some("x.."), extension: Some("y"));
+
+    t!(".x..y", file_stem: Some(".x."), extension: Some("y"));
+
+    t!("..x..y", file_stem: Some("..x."), extension: Some("y"));
+
+    t!("...x...y", file_stem: Some("...x.."), extension: Some("y"));
+
     t!("", file_stem: None, extension: None);
 }
 
@@ -1887,12 +1918,23 @@ pub fn test_set_extension() {
     tfe!("foo/..", "bar", "foo/..", false);
     tfe!("/", "foo", "/", false);
 
-    // file names with leading dots keep them
-    tfe!("..foo", "txt", "..txt", true);
-    tfe!("..foo", "", ".", true);
-    tfe!("...foo", "txt", "...txt", true);
-    tfe!("bar/..foo", "txt", "bar/..txt", true);
-    tfe!("/bar/..foo", "txt", "/bar/..txt", true);
+    // up to three leading dots are part of the stem, so they are kept along with the file name
+    tfe!("..foo", "txt", "..foo.txt", true);
+    tfe!("..foo", "", "..foo", true);
+    tfe!("...foo", "txt", "...foo.txt", true);
+    tfe!("bar/..foo", "txt", "bar/..foo.txt", true);
+    tfe!("/bar/..foo", "txt", "/bar/..foo.txt", true);
+    tfe!("..foo.bar", "txt", "..foo.txt", true);
+    tfe!("...", "txt", "....txt", true);
+    tfe!("....foo", "txt", "....txt", true);
+    tfe!("....", "txt", "....txt", true);
+
+    // dots after the start of the file name split as they always have
+    tfe!("foo.bar.baz", "txt", "foo.bar.txt", true);
+    tfe!("foo..bar", "txt", "foo..txt", true);
+    tfe!("foo..bar", "", "foo.", true);
+    tfe!(".foo..bar", "txt", ".foo..txt", true);
+    tfe!("bar/foo..baz", "txt", "bar/foo..txt", true);
 }
 
 #[test]
@@ -1955,12 +1997,22 @@ pub fn test_with_extension() {
     twe!("foo/..", "bar", "foo/..");
     twe!("/", "foo", "/");
 
-    // file names with leading dots keep them
-    twe!("..foo", "txt", "..txt");
-    twe!("..foo", "", ".");
-    twe!("...foo", "txt", "...txt");
-    twe!("bar/..foo", "txt", "bar/..txt");
-    twe!("/bar/..foo", "txt", "/bar/..txt");
+    // up to three leading dots are part of the stem, so they are kept along with the file name
+    twe!("..foo", "txt", "..foo.txt");
+    twe!("..foo", "", "..foo");
+    twe!("...foo", "txt", "...foo.txt");
+    twe!("bar/..foo", "txt", "bar/..foo.txt");
+    twe!("/bar/..foo", "txt", "/bar/..foo.txt");
+    twe!("..foo.bar", "txt", "..foo.txt");
+    twe!("...", "txt", "....txt");
+    twe!("....foo", "txt", "....txt");
+    twe!("....", "txt", "....txt");
+
+    // dots after the start of the file name split as they always have
+    twe!("foo..bar", "txt", "foo..txt");
+    twe!("foo..bar", "", "foo.");
+    twe!(".foo..bar", "txt", ".foo..txt");
+    twe!("bar/foo..baz", "txt", "bar/foo..txt");
 
     // New extension is smaller than file name
     twe!("aaa_aaa_aaa", "bbb_bbb", "aaa_aaa_aaa.bbb_bbb");

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -1886,6 +1886,13 @@ pub fn test_set_extension() {
     tfe!("..", "foo", "..", false);
     tfe!("foo/..", "bar", "foo/..", false);
     tfe!("/", "foo", "/", false);
+
+    // file names with leading dots keep them
+    tfe!("..foo", "txt", "..txt", true);
+    tfe!("..foo", "", ".", true);
+    tfe!("...foo", "txt", "...txt", true);
+    tfe!("bar/..foo", "txt", "bar/..txt", true);
+    tfe!("/bar/..foo", "txt", "/bar/..txt", true);
 }
 
 #[test]
@@ -1947,6 +1954,13 @@ pub fn test_with_extension() {
     twe!("..", "foo", "..");
     twe!("foo/..", "bar", "foo/..");
     twe!("/", "foo", "/");
+
+    // file names with leading dots keep them
+    twe!("..foo", "txt", "..txt");
+    twe!("..foo", "", ".");
+    twe!("...foo", "txt", "...txt");
+    twe!("bar/..foo", "txt", "bar/..txt");
+    twe!("/bar/..foo", "txt", "/bar/..txt");
 
     // New extension is smaller than file name
     twe!("aaa_aaa_aaa", "bbb_bbb", "aaa_aaa_aaa.bbb_bbb");

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -1689,7 +1689,22 @@ pub fn test_prefix_ext() {
 
     t!(".x.y.z", file_prefix: Some(".x"), extension: Some("z"));
 
-    t!("..x.y.z", file_prefix: Some("."), extension: Some("z"));
+    t!("..x.y.z", file_prefix: Some("..x"), extension: Some("z"));
+
+    // up to three leading dots are part of the prefix
+    t!("..x", file_prefix: Some("..x"), extension: None);
+
+    t!("...x.y", file_prefix: Some("...x"), extension: Some("y"));
+
+    t!("...", file_prefix: Some("..."), extension: None);
+
+    // past three, `...` is a file name that can carry an extension
+    t!("....x", file_prefix: Some("..."), extension: Some("x"));
+
+    // dots after the start of the file name split as they always have
+    t!("x..y.z", file_prefix: Some("x"), extension: Some("z"));
+
+    t!("..x..y.z", file_prefix: Some("..x"), extension: Some("z"));
 
     t!("", file_prefix: None, extension: None);
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160240)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#160239.

Two changes. The first is the reported bug; the second is the spec change approved at the 2026-08-04 libs-api meeting.

## 1. `with_extension` dropped the file name after `..`

`Path::new("a/..foo").with_extension("txt")` returned `a/..` — a parent directory — where `set_extension` returned `a/..txt`. `with_extension` is documented purely as "See [`PathBuf::set_extension`] for more details", so the two should agree.

`_with_extension` chopped only the previous extension off the byte slice, leaving the trailing dot in place, then called `set_extension` on that intermediate. For `..foo` the intermediate ends in `..`, which has no `file_name()`, so `set_extension` returned `false` and did nothing — and its return value was discarded, so the file name was silently dropped. Regression from rust-lang/rust#113106, first released in 1.73.0.

The fix copies up to the end of the file stem — the boundary `set_extension` truncates to — and appends the dot and extension directly, keeping the single exact-capacity allocation.

## 2. Up to three leading dots are part of the file stem

`file_stem` and `extension` held back only the *first* `.` of a file name, so a name of nothing but dots could become the stem: `...foo` had stem `..`, and `set_extension("")` on it produced a parent directory. `file_prefix` had the matching defect — `..config.toml` had prefix `.`.

Both now hold back up to three leading dots (`MAX_LEADING_DOTS`, shared by `rsplit_file_at_dot` and `split_file_at_dot` so the two cannot drift). The cap is what keeps the stem a file name in its own right — never `.` or `..` — while still letting `...`, itself a legal file name, carry an extension: `....foo` splits as stem `...` and extension `foo`.

Three is the least cap that achieves this: over the 9841 file names of length ≤ 8 over `{. a b}`, a cap of 1 leaves 189 names with a stem of `.` or `..`, a cap of 2 leaves 63, and a cap of 3 leaves none. Caps above 3 are behaviourally identical to 3.

Behaviour changes are limited to file names whose stem was previously made up only of dots. Full before/after matrix in @clarfonthey's comment: https://github.com/rust-lang/rust/pull/160240#issuecomment-5149419408

## Tests

Tests were added to `test_with_extension` and `test_set_extension`, which already mirror each other case for case, and to `test_stem_ext` / `test_prefix_ext`. They cover the cap boundary (`....x`, `....`, `.....x`) and, per @nia-e's request, pin that dots after the start of a file name still split as they always have (`x..y`, `x...y`, `.x..y`, `..x..y`, `foo..bar`, `bar/foo..baz`).

`./x test library/std` is green and `./x fmt --check` is clean. Reverting the source change while keeping the tests fails all four of `test_stem_ext`, `test_prefix_ext`, `test_set_extension` and `test_with_extension`.
