### PR TITLE
Rename splat to rustc_splat in error messages

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -750,7 +750,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         spans,
                         // FIXME(splat): add a new error code before stabilization
                         E0277,
-                        "cannot use splat attribute; the splatted argument type \
+                        "cannot use `rustc_splat` attribute; the splatted argument type \
                         must be a tuple or unit, not a {:?} ({:?})",
                         tuple_type.kind(),
                         self.structurally_resolve_type(

--- a/tests/ui/splat/splat-async-fn-tuple-fail.rs
+++ b/tests/ui/splat/splat-async-fn-tuple-fail.rs
@@ -5,7 +5,7 @@
 #![feature(splat)]
 
 async fn async_wrong_type(#[rustc_splat] _x: u32) {}
-//~^ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32
+//~^ ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a u32
 
 async fn async_multi_splat(
     #[rustc_splat] (_a, _b): (u32, i8),

--- a/tests/ui/splat/splat-async-fn-tuple-fail.stderr
+++ b/tests/ui/splat/splat-async-fn-tuple-fail.stderr
@@ -9,7 +9,7 @@ LL |     #[rustc_splat] (_c, _d): (u32, i8),
    |
    = help: remove `#[rustc_splat]` from all but one argument
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32 (u32)
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a u32 (u32)
   --> $DIR/splat-async-fn-tuple-fail.rs:7:46
    |
 LL | async fn async_wrong_type(#[rustc_splat] _x: u32) {}

--- a/tests/ui/splat/splat-cannot-resolve.rs
+++ b/tests/ui/splat/splat-cannot-resolve.rs
@@ -22,14 +22,14 @@ trait Trait {
 
 fn ambig(#[rustc_splat] t: Trait::MaybeTup) {}
 //~^ ERROR ambiguous associated type
-//~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
-//~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
-//~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
+//~| ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a
+//~| ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a
+//~| ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a
 fn ambig_tup(#[rustc_splat] t: Trait::Tup) {}
 //~^ ERROR ambiguous associated type
-//~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
-//~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
-//~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
+//~| ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a
+//~| ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a
+//~| ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a
 
 fn main() {
     tuple();

--- a/tests/ui/splat/splat-cannot-resolve.stderr
+++ b/tests/ui/splat/splat-cannot-resolve.stderr
@@ -34,7 +34,7 @@ error[E0720]: cannot resolve opaque type
 LL | fn tuple_trait(#[rustc_splat] t: impl std::marker::Tuple) -> impl std::marker::Tuple {
    |                                                              ^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
   --> $DIR/splat-cannot-resolve.rs:23:28
    |
 LL | fn ambig(#[rustc_splat] t: Trait::MaybeTup) {}
@@ -43,7 +43,7 @@ LL | fn ambig(#[rustc_splat] t: Trait::MaybeTup) {}
 LL |     ambig();
    |     ^^^^^^^
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
   --> $DIR/splat-cannot-resolve.rs:28:32
    |
 LL | fn ambig_tup(#[rustc_splat] t: Trait::Tup) {}
@@ -52,7 +52,7 @@ LL | fn ambig_tup(#[rustc_splat] t: Trait::Tup) {}
 LL |     ambig_tup();
    |     ^^^^^^^^^^^
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
   --> $DIR/splat-cannot-resolve.rs:23:28
    |
 LL | fn ambig(#[rustc_splat] t: Trait::MaybeTup) {}
@@ -61,7 +61,7 @@ LL | fn ambig(#[rustc_splat] t: Trait::MaybeTup) {}
 LL |     ambig(1);
    |     ^^^^^^^^
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
   --> $DIR/splat-cannot-resolve.rs:28:32
    |
 LL | fn ambig_tup(#[rustc_splat] t: Trait::Tup) {}
@@ -70,7 +70,7 @@ LL | fn ambig_tup(#[rustc_splat] t: Trait::Tup) {}
 LL |     ambig_tup(1);
    |     ^^^^^^^^^^^^
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
   --> $DIR/splat-cannot-resolve.rs:23:28
    |
 LL | fn ambig(#[rustc_splat] t: Trait::MaybeTup) {}
@@ -79,7 +79,7 @@ LL | fn ambig(#[rustc_splat] t: Trait::MaybeTup) {}
 LL |     ambig(1, 2.0);
    |     ^^^^^^^^^^^^^
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a {type error} ({type error})
   --> $DIR/splat-cannot-resolve.rs:28:32
    |
 LL | fn ambig_tup(#[rustc_splat] t: Trait::Tup) {}

--- a/tests/ui/splat/splat-dyn-asref-tuple-fail.rs
+++ b/tests/ui/splat/splat-dyn-asref-tuple-fail.rs
@@ -10,10 +10,10 @@
 // FIXME(splat): Some errors are reported on the callee, but they would be more ergonomic on the
 // caller as well
 fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)
-//~^ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
-//~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
-//~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
-//~| ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a
+//~^ ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a
+//~| ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a
+//~| ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a
+//~| ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a
 where
     T: std::marker::Tuple,
 {

--- a/tests/ui/splat/splat-dyn-asref-tuple-fail.stderr
+++ b/tests/ui/splat/splat-dyn-asref-tuple-fail.stderr
@@ -1,4 +1,4 @@
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Trait(std::convert::AsRef<std::string::String>)
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a Trait(std::convert::AsRef<std::string::String>)
   --> $DIR/splat-dyn-asref-tuple-fail.rs:12:42
    |
 LL | fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)
@@ -22,7 +22,7 @@ LL | fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)
 LL |     T: std::marker::Tuple,
    |        ^^^^^^^^^^^^^^^^^^ required by this bound in `dyn_asref_splat`
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Trait(std::convert::AsRef<_>)
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a Trait(std::convert::AsRef<_>)
   --> $DIR/splat-dyn-asref-tuple-fail.rs:12:42
    |
 LL | fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)
@@ -31,7 +31,7 @@ LL | fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)
 LL |     dyn_asref_splat(&s);
    |     ^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Trait(std::convert::AsRef<(u8, f32)>)
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a Trait(std::convert::AsRef<(u8, f32)>)
   --> $DIR/splat-dyn-asref-tuple-fail.rs:12:42
    |
 LL | fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)
@@ -40,7 +40,7 @@ LL | fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)
 LL |     dyn_asref_splat::<(u8, f32)>(&t);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Trait(std::convert::AsRef<_>)
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a Trait(std::convert::AsRef<_>)
   --> $DIR/splat-dyn-asref-tuple-fail.rs:12:42
    |
 LL | fn dyn_asref_splat<T>(#[rustc_splat] _t: &dyn AsRef<T>)

--- a/tests/ui/splat/splat-maybe-tuple.rs
+++ b/tests/ui/splat/splat-maybe-tuple.rs
@@ -5,7 +5,7 @@
 #![feature(splat)]
 #![expect(unused)]
 
-fn unbound_generic_arg<T>(#[rustc_splat] t: T) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32
+fn unbound_generic_arg<T>(#[rustc_splat] t: T) {} //~ ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a u32
 
 fn main() {
     unbound_generic_arg();

--- a/tests/ui/splat/splat-maybe-tuple.stderr
+++ b/tests/ui/splat/splat-maybe-tuple.stderr
@@ -1,4 +1,4 @@
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32 (u32)
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a u32 (u32)
   --> $DIR/splat-maybe-tuple.rs:8:45
    |
 LL | fn unbound_generic_arg<T>(#[rustc_splat] t: T) {}

--- a/tests/ui/splat/splat-non-tuple.rs
+++ b/tests/ui/splat/splat-non-tuple.rs
@@ -25,8 +25,9 @@ struct Foo;
 fn struct_arg(#[rustc_splat] z: Foo) {} //~ ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a Foo
 
 impl Foo {
-    // FIXME(splat): ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple
     fn tuple_2_self(
+        // FIXME(splat): ERROR cannot use `rustc_splat` attribute; the splatted argument type...
+        // must be a tuple
         #[rustc_splat] self,
         (a, b): (u32, i8),
     ) -> u32 {
@@ -41,8 +42,9 @@ impl FooTrait for Foo {
     //~| NOTE expected signature `fn(#[rustc_splat] (_,))`
     //~| NOTE found signature `fn((_,))`
 
-    // FIXME(splat): ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple
     fn tuple_4(
+        // FIXME(splat): ERROR cannot use `rustc_splat` attribute; the splatted argument type...
+        // must be a tuple
         #[rustc_splat] self,
         _: (u32, i8, (), f32),
     ) {
@@ -54,8 +56,9 @@ struct TupleStruct(u32, i8);
 fn tuple_struct_arg(#[rustc_splat] z: TupleStruct) {} //~ ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a TupleStruct
 
 impl TupleStruct {
-    // FIXME(splat): ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple
     fn tuple_2(
+        // FIXME(splat): ERROR cannot use `rustc_splat` attribute; the splatted argument type...
+        // must be a tuple
         #[rustc_splat] self,
         (a, b): (f32, f64),
     ) -> f32 {
@@ -66,8 +69,9 @@ impl TupleStruct {
 impl FooTrait for TupleStruct {
     fn tuple_1(#[rustc_splat] _: (u32,)) {}
 
-    // FIXME(splat): ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple
     fn tuple_4(
+        // FIXME(splat): ERROR cannot use `rustc_splat` attribute; the splatted argument type...
+        // must be a tuple
         #[rustc_splat] self,
         _: (u32, i8, (), f32),
     ) {

--- a/tests/ui/splat/splat-non-tuple.rs
+++ b/tests/ui/splat/splat-non-tuple.rs
@@ -4,14 +4,14 @@
 #![feature(splat)]
 #![expect(unused)]
 
-fn primitive_arg(#[rustc_splat] x: u32) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32
+fn primitive_arg(#[rustc_splat] x: u32) {} //~ ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a u32
 
 enum NotATuple {
     A(u32),
     B(i8),
 }
 
-fn enum_arg(#[rustc_splat] y: NotATuple) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a NotATuple
+fn enum_arg(#[rustc_splat] y: NotATuple) {} //~ ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a NotATuple
 
 trait FooTrait {
     fn tuple_1(#[rustc_splat] _: (u32,)); //~ NOTE type in trait
@@ -22,10 +22,10 @@ trait FooTrait {
 
 struct Foo;
 
-fn struct_arg(#[rustc_splat] z: Foo) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Foo
+fn struct_arg(#[rustc_splat] z: Foo) {} //~ ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a Foo
 
 impl Foo {
-    // FIXME(splat): ERROR cannot use splat attribute; the splatted argument type must be a tuple
+    // FIXME(splat): ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple
     fn tuple_2_self(
         #[rustc_splat] self,
         (a, b): (u32, i8),
@@ -41,7 +41,7 @@ impl FooTrait for Foo {
     //~| NOTE expected signature `fn(#[rustc_splat] (_,))`
     //~| NOTE found signature `fn((_,))`
 
-    // FIXME(splat): ERROR cannot use splat attribute; the splatted argument type must be a tuple
+    // FIXME(splat): ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple
     fn tuple_4(
         #[rustc_splat] self,
         _: (u32, i8, (), f32),
@@ -51,10 +51,10 @@ impl FooTrait for Foo {
 
 struct TupleStruct(u32, i8);
 
-fn tuple_struct_arg(#[rustc_splat] z: TupleStruct) {} //~ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a TupleStruct
+fn tuple_struct_arg(#[rustc_splat] z: TupleStruct) {} //~ ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a TupleStruct
 
 impl TupleStruct {
-    // FIXME(splat): ERROR cannot use splat attribute; the splatted argument type must be a tuple
+    // FIXME(splat): ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple
     fn tuple_2(
         #[rustc_splat] self,
         (a, b): (f32, f64),
@@ -66,7 +66,7 @@ impl TupleStruct {
 impl FooTrait for TupleStruct {
     fn tuple_1(#[rustc_splat] _: (u32,)) {}
 
-    // FIXME(splat): ERROR cannot use splat attribute; the splatted argument type must be a tuple
+    // FIXME(splat): ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple
     fn tuple_4(
         #[rustc_splat] self,
         _: (u32, i8, (), f32),

--- a/tests/ui/splat/splat-non-tuple.stderr
+++ b/tests/ui/splat/splat-non-tuple.stderr
@@ -1,5 +1,5 @@
 error[E0053]: method `tuple_1` has an incompatible type for trait
-  --> $DIR/splat-non-tuple.rs:38:5
+  --> $DIR/splat-non-tuple.rs:39:5
    |
 LL |     fn tuple_1(_: (u32,)) {}
    |     ^^^^^^^^^^^^^^^^^^^^^ expected fn with arg 0 splatted, found fn with no splatted arg
@@ -40,7 +40,7 @@ LL |     struct_arg(foo);
    |     ^^^^^^^^^^^^^^^
 
 error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a TupleStruct (TupleStruct)
-  --> $DIR/splat-non-tuple.rs:54:39
+  --> $DIR/splat-non-tuple.rs:56:39
    |
 LL | fn tuple_struct_arg(#[rustc_splat] z: TupleStruct) {}
    |                                       ^^^^^^^^^^^

--- a/tests/ui/splat/splat-non-tuple.stderr
+++ b/tests/ui/splat/splat-non-tuple.stderr
@@ -12,7 +12,7 @@ LL |     fn tuple_1(#[rustc_splat] _: (u32,));
    = note: expected signature `fn(#[rustc_splat] (_,))`
               found signature `fn((_,))`
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32 (u32)
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a u32 (u32)
   --> $DIR/splat-non-tuple.rs:7:36
    |
 LL | fn primitive_arg(#[rustc_splat] x: u32) {}
@@ -21,7 +21,7 @@ LL | fn primitive_arg(#[rustc_splat] x: u32) {}
 LL |     primitive_arg(1u32);
    |     ^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a NotATuple (NotATuple)
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a NotATuple (NotATuple)
   --> $DIR/splat-non-tuple.rs:14:31
    |
 LL | fn enum_arg(#[rustc_splat] y: NotATuple) {}
@@ -30,7 +30,7 @@ LL | fn enum_arg(#[rustc_splat] y: NotATuple) {}
 LL |     enum_arg(NotATuple::A(1u32));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a Foo (Foo)
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a Foo (Foo)
   --> $DIR/splat-non-tuple.rs:25:33
    |
 LL | fn struct_arg(#[rustc_splat] z: Foo) {}
@@ -39,7 +39,7 @@ LL | fn struct_arg(#[rustc_splat] z: Foo) {}
 LL |     struct_arg(foo);
    |     ^^^^^^^^^^^^^^^
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a TupleStruct (TupleStruct)
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a TupleStruct (TupleStruct)
   --> $DIR/splat-non-tuple.rs:54:39
    |
 LL | fn tuple_struct_arg(#[rustc_splat] z: TupleStruct) {}

--- a/tests/ui/splat/splat-trait-tuple.rs
+++ b/tests/ui/splat/splat-trait-tuple.rs
@@ -13,7 +13,7 @@ trait FooTrait {
 struct Foo;
 
 impl FooTrait for Foo {
-    // Currently, splat attributes on impls must match traits. This provides better UX.
+    // Currently, `rustc_splat` attributes on impls must match traits. This provides better UX.
     fn tuple_1_trait(#[rustc_splat] _: (u32,)) {}
 
     fn tuple_2_trait(&self, #[rustc_splat] _: (u32, f32)) {}

--- a/tests/ui/splat/splat-unsafe-fn-tuple-fail.rs
+++ b/tests/ui/splat/splat-unsafe-fn-tuple-fail.rs
@@ -4,7 +4,7 @@
 #![feature(splat)]
 
 unsafe fn unsafe_wrong_type(#[rustc_splat] _x: u32) {}
-//~^ ERROR cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32
+//~^ ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a u32
 
 unsafe fn unsafe_multi_splat(
     #[rustc_splat] (_a, _b): (u32, i8),

--- a/tests/ui/splat/splat-unsafe-fn-tuple-fail.stderr
+++ b/tests/ui/splat/splat-unsafe-fn-tuple-fail.stderr
@@ -9,7 +9,7 @@ LL |     #[rustc_splat] (_c, _d): (u32, i8),
    |
    = help: remove `#[rustc_splat]` from all but one argument
 
-error[E0277]: cannot use splat attribute; the splatted argument type must be a tuple or unit, not a u32 (u32)
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a u32 (u32)
   --> $DIR/splat-unsafe-fn-tuple-fail.rs:6:48
    |
 LL | unsafe fn unsafe_wrong_type(#[rustc_splat] _x: u32) {}


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/153629

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR renames "splat attribute" to "\`rustc_splat\` attribute" in error messages (and some comments).
It was meant to be part of rust-lang/rust#159817 but I missed it.

The search and replace command I used was:
```sh
fastmod --extensions rs --fixed-strings 'splat attribute' '`rustc_splat` attribute'
```

This doesn't need to be backported, because those error messages only appear on nightly.

Part of rust-lang/rust#159428