### PR TITLE
perf: Avoid a heap allocation per basic block in MoveData's location maps

### DIFF
--- a/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
@@ -205,21 +205,39 @@ pub trait HasMoveData<'tcx> {
 
 #[derive(Debug)]
 pub struct LocationMap<T> {
-    /// Location-indexed (BasicBlock for outer index, index within BB
-    /// for inner index) map.
-    pub(crate) map: IndexVec<BasicBlock, Vec<T>>,
+    /// All per-location entries live in the single flat `data` vector.
+    /// `block_starts[bb]` gives the index in `data` where block `bb`'s entries
+    /// start; each block has one entry per statement plus one for its terminator.
+    data: Vec<T>,
+    block_starts: IndexVec<BasicBlock, usize>,
+}
+
+impl<T> LocationMap<T> {
+    #[inline]
+    fn offset(&self, loc: Location) -> usize {
+        let offset = self.block_starts[loc.block] + loc.statement_index;
+        if cfg!(debug_assertions) {
+            // A block's entries run until the next block's start, or the end of
+            // `data` for the last block.
+            let next = loc.block.as_usize() + 1;
+            let block_end = self.block_starts.raw.get(next).copied().unwrap_or(self.data.len());
+            assert!(offset < block_end, "{loc:?} is out of range for its block");
+        }
+        offset
+    }
 }
 
 impl<T> Index<Location> for LocationMap<T> {
     type Output = T;
     fn index(&self, index: Location) -> &Self::Output {
-        &self.map[index.block][index.statement_index]
+        &self.data[self.offset(index)]
     }
 }
 
 impl<T> IndexMut<Location> for LocationMap<T> {
     fn index_mut(&mut self, index: Location) -> &mut Self::Output {
-        &mut self.map[index.block][index.statement_index]
+        let offset = self.offset(index);
+        &mut self.data[offset]
     }
 }
 
@@ -228,13 +246,13 @@ where
     T: Default + Clone,
 {
     fn new(body: &Body<'_>) -> Self {
-        LocationMap {
-            map: body
-                .basic_blocks
-                .iter()
-                .map(|block| vec![T::default(); block.statements.len() + 1])
-                .collect(),
+        let mut block_starts = IndexVec::with_capacity(body.basic_blocks.len());
+        let mut total = 0;
+        for block in body.basic_blocks.iter() {
+            block_starts.push(total);
+            total += block.statements.len() + 1;
         }
+        LocationMap { data: vec![T::default(); total], block_starts }
     }
 }
 


### PR DESCRIPTION
`MoveData` holds two `LocationMap`s, and each was an `IndexVec<BasicBlock, Vec<T>>` that heap-allocated one `Vec` per basic block. Building the move data for a body allocated a small vector for every block, twice over. Store the entries in one flat buffer indexed by a per-block start offset, so each map is two allocations regardless of block count.
