### PR TITLE
dont fire `unused_mut` on `&pin mut self`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3008,7 +3008,7 @@ impl Param {
                 }),
             ),
             SelfKind::Pinned(lt, mutbl) => (
-                mutbl,
+                Mutability::Not,
                 Box::new(Ty {
                     id: DUMMY_NODE_ID,
                     kind: TyKind::PinnedRef(lt, MutTy { ty: infer_ty, mutbl }),

--- a/tests/ui/pin-ergonomics/unused-mut.rs
+++ b/tests/ui/pin-ergonomics/unused-mut.rs
@@ -1,0 +1,21 @@
+//@ check-pass
+//@ compile-flags: --force-warn unused-mut
+
+#![feature(pin_ergonomics)]
+#![allow(dead_code, incomplete_features)]
+
+// `&pin mut self` should not trigger `unused_mut`: the `mut` qualifies the pin
+// reference (like `&mut self`), not the binding. See https://github.com/rust-lang/rust/issues/142077.
+
+struct Foo;
+
+impl Foo {
+    fn baz(&pin mut self) {}
+    fn baz_const(&pin const self) {}
+    fn baz_lt<'a>(&'a pin mut self) {}
+    fn baz_const_lt(&'_ pin const self) {}
+}
+
+fn foo(_: &pin mut Foo) {}
+
+fn main() {}


### PR DESCRIPTION
`SelfKind::Pinned` in `Param::from_self` was setting the binding mutability to `mutbl`, so `&pin mut self` produced a mutable binding and triggered `unused_mut` spuriously. the `mut` qualifies the pin reference, not the binding. same as `SelfKind::Region` which uses `Mutability::Not`.

fixes https://github.com/rust-lang/rust/issues/142077

r? @petrochenkov