### PR TITLE
Configure backport nominations for rustfmt

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -939,6 +939,60 @@ topic = "#{number}: stable-nominated"
 message_on_add = "PR #{number} has been **accepted** for **stable** backport."
 
 
+# --- rustfmt ------------------------------------------------------------------
+
+[notify-zulip."beta-nominated".rustfmt]
+required_labels = ["T-rustfmt"]
+zulip_stream = 621384 # #t-rustfmt/backports
+topic = "#{number}: beta-nominated"
+message_on_add = [
+    """\
+@*T-rustfmt* @*T-rustfmt-contributors* PR #{number} "{title}" has been nominated
+for beta backport.
+""",
+    """\
+/poll Approve beta backport of #{number}?
+approve
+decline
+don't know
+""",
+]
+message_on_remove = "PR #{number}'s beta-nomination has been removed."
+
+[notify-zulip."beta-accepted".rustfmt]
+required_labels = ["T-rustfmt"]
+zulip_stream = 621384 # #t-rustfmt/backports
+# Put it in the same thread as beta-nominated.
+topic = "#{number}: beta-nominated"
+message_on_add = "PR #{number} has been **accepted** for **beta** backport."
+
+[notify-zulip."stable-nominated".rustfmt]
+required_labels = ["T-rustfmt"]
+zulip_stream = 621384 # #t-rustfmt/backports
+topic = "#{number}: stable-nominated"
+message_on_add = [
+    """\
+@*T-rustfmt* @*T-rustfmt-contributors* PR #{number} "{title}" has been nominated
+for stable backport.
+""",
+    """\
+/poll Approve stable backport of #{number}?
+approve
+approve (but does not justify new dot release on its own)
+decline
+don't know
+""",
+]
+message_on_remove = "PR #{number}'s stable-nomination has been removed."
+
+[notify-zulip."stable-accepted".rustfmt]
+required_labels = ["T-rustfmt"]
+zulip_stream = 621384 # #t-rustfmt/backports
+# Put it in the same thread as stable-nominated.
+topic = "#{number}: stable-nominated"
+message_on_add = "PR #{number} has been **accepted** for **stable** backport."
+
+
 [notify-zulip."A-edition-2021"]
 required_labels = ["C-bug"]
 zulip_stream = 268952 # #edition

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -704,6 +704,9 @@ message_on_reopen = "Issue #{number} has been reopened. Pinging @*T-types*."
 # Zulip notifications
 # ------------------------------------------------------------------------------
 
+
+# --- rustdoc-------------------------------------------------------------------
+
 [notify-zulip."beta-nominated".rustdoc]
 required_labels = ["T-rustdoc"]
 zulip_stream = 266220 # #t-rustdoc
@@ -768,6 +771,8 @@ message_on_close = "PR #{number} has been closed. Thanks for participating!"
 message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
 
 
+# --- compiler -----------------------------------------------------------------
+
 [notify-zulip."beta-nominated".compiler]
 required_labels = ["T-compiler"]
 zulip_stream = 474880 # #t-compiler/backports
@@ -829,6 +834,9 @@ zulip_stream = 474880 # #t-compiler/backports
 topic = "#{number}: stable-nominated"
 message_on_add = "PR #{number} has been **accepted** for **stable** backport."
 
+
+# --- libs ---------------------------------------------------------------------
+
 [notify-zulip."beta-nominated".libs]
 required_labels = ["T-libs"]
 zulip_stream = 542373 # #t-libs/backports
@@ -878,6 +886,8 @@ zulip_stream = 542373 # #t-libs/backports
 topic = "#{number}: stable-nominated"
 message_on_add = "PR #{number} has been **accepted** for **stable** backport."
 
+
+# --- bootstrap ----------------------------------------------------------------
 
 [notify-zulip."beta-nominated".bootstrap]
 required_labels = ["T-bootstrap"]


### PR DESCRIPTION
## Summary

As discussed in [#t-rustfmt > Backport channel](https://rust-lang.zulipchat.com/#narrow/channel/357797-t-rustfmt/topic/Backport.20channel/with/613788070), configure triagebot backport nominations (rust-lang/rust) against [#t-rustfmt/backports](https://rust-lang.zulipchat.com/#narrow/channel/621384-t-rustfmt.2Fbackports) so it's less likely for backport nominations involving rustfmt to get lost.

The rustfmt backport channel number is `621384`, since the URL is

```
https://rust-lang.zulipchat.com/#narrow/channel/621384-t-rustfmt.2Fbackports
```

cc @ytmimi 