### PR TITLE
perf: Store small bitsets inline in DenseBitSet

### DIFF
--- a/compiler/rustc_index/Cargo.toml
+++ b/compiler/rustc_index/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 rustc_index_macros = { path = "../rustc_index_macros" }
 rustc_macros = { path = "../rustc_macros", optional = true }
 rustc_serialize = { path = "../rustc_serialize", optional = true }
-smallvec = { version = "1.8.1", optional = true }
+smallvec = "1.8.1"
 # tidy-alphabetical-end
 
 [features]
@@ -17,7 +17,6 @@ default = ["nightly"]
 nightly = [
     "dep:rustc_macros",
     "dep:rustc_serialize",
-    "dep:smallvec",
     "rustc_index_macros/nightly",
 ]
 rustc_randomized_layouts = []

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -6,6 +6,7 @@ use std::{fmt, iter, slice};
 use Chunk::*;
 #[cfg(feature = "nightly")]
 use rustc_macros::{Decodable_NoContext, Encodable_NoContext};
+use smallvec::{SmallVec, smallvec};
 
 use crate::{Idx, IndexVec};
 
@@ -115,7 +116,7 @@ macro_rules! bit_relations_inherent_impls {
 #[derive(Eq, PartialEq, Hash)]
 pub struct DenseBitSet<T> {
     domain_size: usize,
-    words: Vec<Word>,
+    words: SmallVec<[Word; 2]>,
     marker: PhantomData<T>,
 }
 
@@ -131,7 +132,7 @@ impl<T: Idx> DenseBitSet<T> {
     #[inline]
     pub fn new_empty(domain_size: usize) -> DenseBitSet<T> {
         let num_words = num_words(domain_size);
-        DenseBitSet { domain_size, words: vec![0; num_words], marker: PhantomData }
+        DenseBitSet { domain_size, words: smallvec![0; num_words], marker: PhantomData }
     }
 
     /// Creates a new, filled bitset with a given `domain_size`.
@@ -139,7 +140,7 @@ impl<T: Idx> DenseBitSet<T> {
     pub fn new_filled(domain_size: usize) -> DenseBitSet<T> {
         let num_words = num_words(domain_size);
         let mut result =
-            DenseBitSet { domain_size, words: vec![!0; num_words], marker: PhantomData };
+            DenseBitSet { domain_size, words: smallvec![!0; num_words], marker: PhantomData };
         result.clear_excess_bits();
         result
     }


### PR DESCRIPTION
`DenseBitSet` heap-allocated its words even for a tiny domain, and dataflow allocates one per basic block. Storing the words in a `SmallVec<[Word; 2]>` keeps bitsets up to 128 bits inline, so small ones no longer allocate.
