### PR TITLE
Replace unsafe usage of `NonNull::new_unchecked` with `Box::into_non_null`

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1493,6 +1493,10 @@ impl<T: ?Sized> Box<T> {
     #[stable(feature = "box_vec_non_null", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub fn into_non_null(b: Self) -> NonNull<T> {
+        // As of August 2026, we cannot utilize `Box::leak`
+        // because whether or not you can reconstruct the `Box`
+        // later using `Box::from_raw` or `Box::from_non_null` is
+        // an open question.
         // SAFETY: `Box` is guaranteed to be non-null.
         unsafe { NonNull::new_unchecked(Self::into_raw(b)) }
     }

--- a/library/alloc/src/io/error.rs
+++ b/library/alloc/src/io/error.rs
@@ -259,8 +259,7 @@ fn custom_owner_from_box(
         drop(unsafe { Box::from_raw(ptr) })
     }
 
-    // SAFETY: the pointer returned by Box::into_raw is non-null.
-    let error = unsafe { core::ptr::NonNull::new_unchecked(Box::into_raw(error)) };
+    let error = Box::into_non_null(error);
 
     // SAFETY:
     // * `error` is valid up to a static lifetime, and owns its pointee.
@@ -269,8 +268,7 @@ fn custom_owner_from_box(
     //   and will be stored in a `CustomOwner`.
     let custom = unsafe { Custom::from_raw(kind, error, drop_box_raw, drop_box_raw) };
 
-    // SAFETY: the pointer returned by Box::into_raw is non-null.
-    let custom = unsafe { core::ptr::NonNull::new_unchecked(Box::into_raw(Box::new(custom))) };
+    let custom = Box::into_non_null(Box::new(custom));
 
     // SAFETY: the `outer_drop` provided to `custom` is valid for itself.
     unsafe { CustomOwner::from_raw(custom) }

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -207,6 +207,10 @@ impl<T: Sized> NonNull<T> {
 impl<T: PointeeSized> NonNull<T> {
     /// Creates a new `NonNull`.
     ///
+    /// Note that if you have an `&mut`, you can use the safe [`from_mut`] instead.
+    ///
+    /// [`from_mut`]: NonNull::from_mut
+    ///
     /// # Safety
     ///
     /// `ptr` must be non-null.
@@ -245,6 +249,10 @@ impl<T: PointeeSized> NonNull<T> {
     }
 
     /// Creates a new `NonNull` if `ptr` is non-null.
+    ///
+    /// Note that if you have an `&mut`, you can use [`from_mut`] instead to avoid the `Option`.
+    ///
+    /// [`from_mut`]: NonNull::from_mut
     ///
     /// # Panics during const evaluation
     ///

--- a/library/std/src/sys/thread/solid.rs
+++ b/library/std/src/sys/thread/solid.rs
@@ -169,8 +169,7 @@ impl Thread {
             }
         }
 
-        // Safety: `Box::into_raw` returns a non-null pointer
-        let p_inner = unsafe { NonNull::new_unchecked(Box::into_raw(inner)) };
+        let p_inner = Box::into_non_null(inner);
 
         let new_task = ItronError::err_if_negative(unsafe {
             abi::acre_tsk(&abi::T_CTSK {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160251)*
<!-- homu-ignore:end -->

~~We can avoid unsafe by replacing `unsafe { NonNull::new_unchecked(Box::into_raw(..)) }` with `NonNull::from_mut(Self::leak(..))`. A simple test to demonstrate the code generation is equivalent: https://godbolt.org/z/P5q9bzPPK~~

We can avoid unsafe by replacing `unsafe { NonNull::new_unchecked(Box::into_raw(..)) }` with the (soon-to-be-stable) `Box::into_non_null(..)`

Additionally, slightly tweak documentation.