### PR TITLE
Rerun the goal with doubled recursion limit even if the goal has ty vars

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -338,18 +338,6 @@ fn maybe_evaluate_root_goal_with_higher_recursion_limit<D, I>(
         Ok(goal_evaluation) => goal_evaluation.goal.predicate,
     };
 
-    // Some goals no longer overflow after the stalled infers are resolved.
-    // Thus we don't have to rerun eagerly here.
-    let has_stalled_infers = match predicate.kind().skip_binder() {
-        ty::PredicateKind::Clause(ty::ClauseKind::Projection(projection)) => {
-            projection.projection_term.has_non_region_infer()
-        }
-        _ => predicate.has_non_region_infer(),
-    };
-    if has_stalled_infers {
-        return;
-    }
-
     let rerun_result = delegate.commit_if_ok(|| {
         let rerun_result =
             EvalCtxt::enter_root(delegate, delegate.cx().recursion_limit() * 2, span, |ecx| {
@@ -397,19 +385,6 @@ fn maybe_evaluate_root_goal_for_proof_tree_with_higher_recursion_limit<D, I>(
         Ok(_) => {}
     }
 
-    // Some goals no longer overflow after the stalled infers are resolved.
-    // Thus we don't have to rerun eagerly here.
-    let predicate: I::Predicate = goal_evaluation.uncanonicalized_goal.predicate;
-    let has_stalled_infers = match predicate.kind().skip_binder() {
-        ty::PredicateKind::Clause(ty::ClauseKind::Projection(projection)) => {
-            projection.projection_term.has_non_region_infer()
-        }
-        _ => predicate.has_non_region_infer(),
-    };
-    if has_stalled_infers {
-        return;
-    }
-
     let rerun_result = delegate.commit_if_ok(|| {
         let (new_result, new_goal_evaluation) = evaluate_root_goal_for_proof_tree(
             delegate,
@@ -426,6 +401,7 @@ fn maybe_evaluate_root_goal_for_proof_tree_with_higher_recursion_limit<D, I>(
         }
     });
     if let Ok(rerun_result) = rerun_result {
+        let predicate: I::Predicate = goal_evaluation.uncanonicalized_goal.predicate;
         delegate.cx().emit_next_solver_overflow_fcw(predicate, span);
         *initial_result = rerun_result;
     }

--- a/tests/ui/traits/next-solver/overflow-discards-constraints.rs
+++ b/tests/ui/traits/next-solver/overflow-discards-constraints.rs
@@ -1,0 +1,75 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// Previously we didn't rerun the goal with doubled recursion limit if the goal contained ty vars.
+// This is to avoid futile evaluation. However, sometimes the type inference progress relies on
+// successful trait solving response. If we don't evaluate with higher recursion limit, the type
+// inference would fail eventually.
+//
+// See the `recursion_depth_exceeding_limit` FCW for why we need the doubled recursion limit.
+
+// Setting it to 12 would make it compile.
+#![recursion_limit = "6"]
+
+trait Trait<T> {}
+
+struct W1<T>(T);
+struct W2<T>(T);
+struct W3<T>(T);
+struct W4<T>(T);
+struct W5<T>(T);
+struct W6<T>(T);
+struct W7<T>(T);
+
+
+impl<T> Trait<T> for ()
+    where
+    W1<T>: Trait<T>,
+{}
+
+impl<T> Trait<T> for W1<T>
+where
+    W2<T>: Trait<T>,
+{}
+
+impl<T> Trait<T> for W2<T>
+where
+    W3<T>: Trait<T>,
+{}
+
+impl<T> Trait<T> for W3<T>
+where
+    W4<T>: Trait<T>,
+{}
+
+impl<T> Trait<T> for W4<T>
+where
+    W5<T>: Trait<T>,
+{}
+
+impl<T> Trait<T> for W5<T>
+where
+    W6<T>: Trait<T>,
+{}
+
+impl<T> Trait<T> for W6<T>
+where
+    W7<T>: Trait<T>,
+{}
+
+impl Trait<i32> for W7<i32> {}
+
+fn foo<T>()
+    where
+        (): Trait<T>,
+{
+}
+
+fn main() {
+    foo(); // register a `(): Trait<?t>` obligation
+    //~^ WARN: overflow evaluating the requirement `(): Trait<_>` [recursion_depth_exceeding_limit]
+    //~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //~| WARN: overflow evaluating the requirement `(): Trait<i32>` [recursion_depth_exceeding_limit]
+    //~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+}

--- a/tests/ui/traits/next-solver/overflow-discards-constraints.stderr
+++ b/tests/ui/traits/next-solver/overflow-discards-constraints.stderr
@@ -1,0 +1,27 @@
+warning: overflow evaluating the requirement `(): Trait<_>`
+  --> $DIR/overflow-discards-constraints.rs:69:5
+   |
+LL |     foo(); // register a `(): Trait<?t>` obligation
+   |     ^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "12"]` attribute to your crate (`overflow_discards_constraints`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+   = note: `#[warn(recursion_depth_exceeding_limit)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: overflow evaluating the requirement `(): Trait<i32>`
+  --> $DIR/overflow-discards-constraints.rs:69:5
+   |
+LL |     foo(); // register a `(): Trait<?t>` obligation
+   |     ^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "12"]` attribute to your crate (`overflow_discards_constraints`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fix the `bevy_render` regression and more in the next solver crater run.

The problem is that we don't rerun the root goal with doubled recursion limit if it contains ty vars.
But we actually need the evaluation response to resolve the ty vars. So the type inference fails.

cc rust-lang/rust#159224 rust-lang/rust#159228