### PR TITLE
perf: store the fulfillment engine inline in ObligationCtxt

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -23,8 +23,9 @@ use rustc_span::{BytePos, DUMMY_SP, Span};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_trait_selection::regions::InferCtxtRegionExt;
+use rustc_trait_selection::solve::NextSolverError;
 use rustc_trait_selection::traits::{
-    self, FulfillmentError, ObligationCause, ObligationCauseCode, ObligationCtxt,
+    self, FromSolverError, FulfillmentError, ObligationCause, ObligationCauseCode, ObligationCtxt,
 };
 use tracing::{debug, instrument};
 
@@ -802,7 +803,8 @@ struct ImplTraitInTraitCollector<'a, 'tcx, E> {
 
 impl<'a, 'tcx, E> ImplTraitInTraitCollector<'a, 'tcx, E>
 where
-    E: 'tcx,
+    E: FromSolverError<'tcx, NextSolverError<'tcx>>
+        + FromSolverError<'tcx, traits::OldSolverError<'tcx>>,
 {
     fn new(
         ocx: &'a ObligationCtxt<'a, 'tcx, E>,
@@ -816,7 +818,8 @@ where
 
 impl<'tcx, E> TypeFolder<TyCtxt<'tcx>> for ImplTraitInTraitCollector<'_, 'tcx, E>
 where
-    E: 'tcx,
+    E: FromSolverError<'tcx, NextSolverError<'tcx>>
+        + FromSolverError<'tcx, traits::OldSolverError<'tcx>>,
 {
     fn cx(&self) -> TyCtxt<'tcx> {
         self.ocx.infcx.tcx

--- a/compiler/rustc_hir_typeck/src/fallback.rs
+++ b/compiler/rustc_hir_typeck/src/fallback.rs
@@ -15,7 +15,7 @@ use rustc_middle::ty::{self, FloatVid, Ty, TyCtxt, TypeSuperVisitable, TypeVisit
 use rustc_session::lint;
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{DUMMY_SP, Span};
-use rustc_trait_selection::traits::{ObligationCause, ObligationCtxt};
+use rustc_trait_selection::traits::{ObligationCause, ObligationCtxt, TraitEngine};
 use tracing::debug;
 
 use crate::{FnCtxt, diagnostics};

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -37,7 +37,7 @@ use rustc_span::def_id::LocalDefId;
 use rustc_span::hygiene::DesugaringKind;
 use rustc_trait_selection::error_reporting::infer::need_type_info::TypeAnnotationNeeded;
 use rustc_trait_selection::traits::{
-    self, NormalizeExt, ObligationCauseCode, StructurallyNormalizeExt,
+    self, NormalizeExt, ObligationCauseCode, StructurallyNormalizeExt, TraitEngine,
 };
 use tracing::{debug, instrument};
 
@@ -1498,7 +1498,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // in a reentrant borrow, causing an ICE.
             let result = self.at(&self.misc(sp), self.param_env).structurally_normalize_const(
                 Unnormalized::new_wip(ct),
-                &mut **self.fulfillment_cx.borrow_mut(),
+                &mut *self.fulfillment_cx.borrow_mut(),
             );
             match result {
                 Ok(normalized_ct) => normalized_ct,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
@@ -2,7 +2,7 @@
 
 use rustc_data_structures::unord::UnordSet;
 use rustc_hir::def_id::DefId;
-use rustc_infer::traits::{self, ObligationCause, PredicateObligations};
+use rustc_infer::traits::{self, ObligationCause, PredicateObligations, TraitEngine};
 use rustc_middle::ty::{self, Ty, TypeVisitableExt};
 use rustc_span::Span;
 use rustc_trait_selection::solve::Certainty;

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -49,7 +49,7 @@ use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{HirId, HirIdMap, Node};
 use rustc_hir_analysis::check::{check_abi, check_custom_abi};
 use rustc_hir_analysis::hir_ty_lowering::HirTyLowerer;
-use rustc_infer::traits::{ObligationCauseCode, ObligationInspector, WellFormedLoc};
+use rustc_infer::traits::{ObligationCauseCode, ObligationInspector, TraitEngine, WellFormedLoc};
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::{self, FnSigKind, Ty, TyCtxt, Unnormalized};

--- a/compiler/rustc_hir_typeck/src/typeck_root_ctxt.rs
+++ b/compiler/rustc_hir_typeck/src/typeck_root_ctxt.rs
@@ -8,7 +8,7 @@ use rustc_middle::span_bug;
 use rustc_middle::ty::{self, Ty, TyCtxt, TyVid, TypeVisitableExt, TypingMode};
 use rustc_span::Span;
 use rustc_span::def_id::LocalDefIdMap;
-use rustc_trait_selection::traits::{self, FulfillmentError, TraitEngine, TraitEngineExt as _};
+use rustc_trait_selection::traits::{self, FulfillmentEngine, FulfillmentError, TraitEngine};
 use tracing::instrument;
 
 use super::callee::DeferredCallResolution;
@@ -31,7 +31,7 @@ pub(crate) struct TypeckRootCtxt<'tcx> {
 
     pub(super) locals: RefCell<HirIdMap<Ty<'tcx>>>,
 
-    pub(super) fulfillment_cx: RefCell<Box<dyn TraitEngine<'tcx, FulfillmentError<'tcx>>>>,
+    pub(super) fulfillment_cx: RefCell<FulfillmentEngine<'tcx, FulfillmentError<'tcx>>>,
 
     // Used to detect opaque types uses added after we've already checked them.
     //
@@ -87,7 +87,7 @@ impl<'tcx> TypeckRootCtxt<'tcx> {
             .in_hir_typeck()
             .build(TypingMode::typeck_for_body(tcx, def_id));
         let typeck_results = RefCell::new(ty::TypeckResults::new(hir_owner));
-        let fulfillment_cx = RefCell::new(<dyn TraitEngine<'_, _>>::new(&infcx));
+        let fulfillment_cx = RefCell::new(FulfillmentEngine::new(&infcx));
 
         TypeckRootCtxt {
             infcx,

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -10,7 +10,6 @@ use rustc_infer::infer::canonical::{
 };
 use rustc_infer::infer::{DefineOpaqueTypes, InferCtxt, InferOk, RegionResolutionError, TypeTrace};
 use rustc_infer::traits::PredicateObligations;
-use rustc_macros::extension;
 use rustc_middle::arena::ArenaAllocatable;
 use rustc_middle::traits::query::NoSolution;
 use rustc_middle::ty::error::TypeError;
@@ -27,29 +26,11 @@ use crate::traits::{
     StructurallyNormalizeExt,
 };
 
-#[extension(pub trait TraitEngineExt<'tcx, E>)]
-impl<'tcx, E> dyn TraitEngine<'tcx, E>
-where
-    E: FromSolverError<'tcx, NextSolverError<'tcx>> + FromSolverError<'tcx, OldSolverError<'tcx>>,
-{
-    fn new(infcx: &InferCtxt<'tcx>) -> Box<Self> {
-        if infcx.next_trait_solver() {
-            Box::new(NextFulfillmentCtxt::new(infcx))
-        } else {
-            assert!(
-                !infcx.tcx.next_trait_solver_globally(),
-                "using old solver even though new solver is enabled globally"
-            );
-            Box::new(FulfillmentContext::new(infcx))
-        }
-    }
-}
-
-/// The fulfillment engine of an [`ObligationCtxt`]. It is stored inline
-/// rather than boxed as a `dyn TraitEngine` because `ObligationCtxt`s are
-/// created very often (e.g. once per candidate probe during method
+/// A fulfillment engine, stored inline rather than boxed as a
+/// `dyn TraitEngine` because some of its holders (e.g. [`ObligationCtxt`])
+/// are created very often (once per candidate probe during method
 /// resolution), so the heap allocation would be expensive.
-enum FulfillmentEngine<'tcx, E> {
+pub enum FulfillmentEngine<'tcx, E> {
     Old(FulfillmentContext<'tcx, E>),
     Next(NextFulfillmentCtxt<'tcx, E>),
 }
@@ -58,7 +39,7 @@ impl<'tcx, E> FulfillmentEngine<'tcx, E>
 where
     E: FromSolverError<'tcx, NextSolverError<'tcx>> + FromSolverError<'tcx, OldSolverError<'tcx>>,
 {
-    fn new(infcx: &InferCtxt<'tcx>) -> Self {
+    pub fn new(infcx: &InferCtxt<'tcx>) -> Self {
         if infcx.next_trait_solver() {
             FulfillmentEngine::Next(NextFulfillmentCtxt::new(infcx))
         } else {

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -45,28 +45,146 @@ where
     }
 }
 
+/// The fulfillment engine of an [`ObligationCtxt`]. It is stored inline
+/// rather than boxed as a `dyn TraitEngine` because `ObligationCtxt`s are
+/// created very often (e.g. once per candidate probe during method
+/// resolution), so the heap allocation would be expensive.
+enum FulfillmentEngine<'tcx, E> {
+    Old(FulfillmentContext<'tcx, E>),
+    Next(NextFulfillmentCtxt<'tcx, E>),
+}
+
+impl<'tcx, E> FulfillmentEngine<'tcx, E>
+where
+    E: FromSolverError<'tcx, NextSolverError<'tcx>> + FromSolverError<'tcx, OldSolverError<'tcx>>,
+{
+    fn new(infcx: &InferCtxt<'tcx>) -> Self {
+        if infcx.next_trait_solver() {
+            FulfillmentEngine::Next(NextFulfillmentCtxt::new(infcx))
+        } else {
+            assert!(
+                !infcx.tcx.next_trait_solver_globally(),
+                "using old solver even though new solver is enabled globally"
+            );
+            FulfillmentEngine::Old(FulfillmentContext::new(infcx))
+        }
+    }
+}
+
+impl<'tcx, E> TraitEngine<'tcx, E> for FulfillmentEngine<'tcx, E>
+where
+    E: FromSolverError<'tcx, NextSolverError<'tcx>> + FromSolverError<'tcx, OldSolverError<'tcx>>,
+{
+    fn register_predicate_obligation(
+        &mut self,
+        infcx: &InferCtxt<'tcx>,
+        obligation: PredicateObligation<'tcx>,
+    ) {
+        match self {
+            FulfillmentEngine::Old(engine) => {
+                engine.register_predicate_obligation(infcx, obligation)
+            }
+            FulfillmentEngine::Next(engine) => {
+                engine.register_predicate_obligation(infcx, obligation)
+            }
+        }
+    }
+
+    fn register_predicate_obligations(
+        &mut self,
+        infcx: &InferCtxt<'tcx>,
+        obligations: PredicateObligations<'tcx>,
+    ) {
+        match self {
+            FulfillmentEngine::Old(engine) => {
+                engine.register_predicate_obligations(infcx, obligations)
+            }
+            FulfillmentEngine::Next(engine) => {
+                engine.register_predicate_obligations(infcx, obligations)
+            }
+        }
+    }
+
+    fn try_evaluate_obligations(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<E> {
+        match self {
+            FulfillmentEngine::Old(engine) => engine.try_evaluate_obligations(infcx),
+            FulfillmentEngine::Next(engine) => engine.try_evaluate_obligations(infcx),
+        }
+    }
+
+    fn collect_remaining_errors(&mut self, infcx: &InferCtxt<'tcx>) -> Vec<E> {
+        match self {
+            FulfillmentEngine::Old(engine) => engine.collect_remaining_errors(infcx),
+            FulfillmentEngine::Next(engine) => engine.collect_remaining_errors(infcx),
+        }
+    }
+
+    fn has_pending_obligations(&self) -> bool {
+        match self {
+            FulfillmentEngine::Old(engine) => engine.has_pending_obligations(),
+            FulfillmentEngine::Next(engine) => engine.has_pending_obligations(),
+        }
+    }
+
+    fn pending_obligations(&self) -> PredicateObligations<'tcx> {
+        match self {
+            FulfillmentEngine::Old(engine) => engine.pending_obligations(),
+            FulfillmentEngine::Next(engine) => engine.pending_obligations(),
+        }
+    }
+
+    fn pending_obligations_potentially_referencing_sub_root(
+        &self,
+        infcx: &InferCtxt<'tcx>,
+        sub_root: ty::TyVid,
+    ) -> PredicateObligations<'tcx> {
+        match self {
+            FulfillmentEngine::Old(engine) => {
+                engine.pending_obligations_potentially_referencing_sub_root(infcx, sub_root)
+            }
+            FulfillmentEngine::Next(engine) => {
+                engine.pending_obligations_potentially_referencing_sub_root(infcx, sub_root)
+            }
+        }
+    }
+
+    fn drain_stalled_obligations_for_coroutines(
+        &mut self,
+        infcx: &InferCtxt<'tcx>,
+    ) -> PredicateObligations<'tcx> {
+        match self {
+            FulfillmentEngine::Old(engine) => {
+                engine.drain_stalled_obligations_for_coroutines(infcx)
+            }
+            FulfillmentEngine::Next(engine) => {
+                engine.drain_stalled_obligations_for_coroutines(infcx)
+            }
+        }
+    }
+}
+
 /// Used if you want to have pleasant experience when dealing
 /// with obligations outside of hir or mir typeck.
 pub struct ObligationCtxt<'a, 'tcx, E = ScrubbedTraitError<'tcx>> {
     pub infcx: &'a InferCtxt<'tcx>,
-    engine: RefCell<Box<dyn TraitEngine<'tcx, E>>>,
+    engine: RefCell<FulfillmentEngine<'tcx, E>>,
 }
 
 impl<'a, 'tcx> ObligationCtxt<'a, 'tcx, FulfillmentError<'tcx>> {
     pub fn new_with_diagnostics(infcx: &'a InferCtxt<'tcx>) -> Self {
-        Self { infcx, engine: RefCell::new(<dyn TraitEngine<'tcx, _>>::new(infcx)) }
+        Self { infcx, engine: RefCell::new(FulfillmentEngine::new(infcx)) }
     }
 }
 
 impl<'a, 'tcx> ObligationCtxt<'a, 'tcx, ScrubbedTraitError<'tcx>> {
     pub fn new(infcx: &'a InferCtxt<'tcx>) -> Self {
-        Self { infcx, engine: RefCell::new(<dyn TraitEngine<'tcx, _>>::new(infcx)) }
+        Self { infcx, engine: RefCell::new(FulfillmentEngine::new(infcx)) }
     }
 }
 
 impl<'a, 'tcx, E> ObligationCtxt<'a, 'tcx, E>
 where
-    E: 'tcx,
+    E: FromSolverError<'tcx, NextSolverError<'tcx>> + FromSolverError<'tcx, OldSolverError<'tcx>>,
 {
     pub fn register_obligation(&self, obligation: PredicateObligation<'tcx>) {
         self.engine.borrow_mut().register_predicate_obligation(self.infcx, obligation);
@@ -297,14 +415,14 @@ impl<'tcx> ObligationCtxt<'_, 'tcx, ScrubbedTraitError<'tcx>> {
         self.infcx.make_canonicalized_query_response(
             inference_vars,
             answer,
-            &mut **self.engine.borrow_mut(),
+            &mut *self.engine.borrow_mut(),
         )
     }
 }
 
 impl<'tcx, E> ObligationCtxt<'_, 'tcx, E>
 where
-    E: FromSolverError<'tcx, NextSolverError<'tcx>>,
+    E: FromSolverError<'tcx, NextSolverError<'tcx>> + FromSolverError<'tcx, OldSolverError<'tcx>>,
 {
     pub fn assumed_wf_types(
         &self,
@@ -331,7 +449,7 @@ where
             match self
                 .infcx
                 .at(&cause, param_env)
-                .deeply_normalize(Unnormalized::new_wip(ty), &mut **self.engine.borrow_mut())
+                .deeply_normalize(Unnormalized::new_wip(ty), &mut *self.engine.borrow_mut())
             {
                 // Insert well-formed types, ignoring duplicates.
                 Ok(normalized) => drop(implied_bounds.insert(normalized)),
@@ -348,7 +466,7 @@ where
         param_env: ty::ParamEnv<'tcx>,
         value: Unnormalized<'tcx, T>,
     ) -> Result<T, Vec<E>> {
-        self.infcx.at(cause, param_env).deeply_normalize(value, &mut **self.engine.borrow_mut())
+        self.infcx.at(cause, param_env).deeply_normalize(value, &mut *self.engine.borrow_mut())
     }
 
     pub fn structurally_normalize_ty(
@@ -359,7 +477,7 @@ where
     ) -> Result<Ty<'tcx>, Vec<E>> {
         self.infcx
             .at(cause, param_env)
-            .structurally_normalize_ty(value, &mut **self.engine.borrow_mut())
+            .structurally_normalize_ty(value, &mut *self.engine.borrow_mut())
     }
 
     pub fn structurally_normalize_const(
@@ -370,7 +488,7 @@ where
     ) -> Result<ty::Const<'tcx>, Vec<E>> {
         self.infcx
             .at(cause, param_env)
-            .structurally_normalize_const(value, &mut **self.engine.borrow_mut())
+            .structurally_normalize_const(value, &mut *self.engine.borrow_mut())
     }
 
     pub fn structurally_normalize_term(
@@ -381,6 +499,6 @@ where
     ) -> Result<ty::Term<'tcx>, Vec<E>> {
         self.infcx
             .at(cause, param_env)
-            .structurally_normalize_term(value, &mut **self.engine.borrow_mut())
+            .structurally_normalize_term(value, &mut *self.engine.borrow_mut())
     }
 }

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -50,7 +50,7 @@ pub use self::dyn_compatibility::{
     DynCompatibilityViolation, dyn_compatibility_violations_for_assoc_item,
     hir_ty_lowering_dyn_compatibility_violations, is_vtable_safe_method,
 };
-pub use self::engine::{ObligationCtxt, TraitEngineExt};
+pub use self::engine::{FulfillmentEngine, ObligationCtxt};
 pub use self::fulfill::{FulfillmentContext, OldSolverError, PendingPredicateObligation};
 pub use self::normalize::NormalizeExt;
 pub use self::project::{normalize_inherent_projection, normalize_projection_term};

--- a/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
@@ -8,7 +8,7 @@ use tracing::{debug, instrument};
 use crate::solve::NextSolverError;
 use crate::traits::query::NoSolution;
 use crate::traits::query::normalize::QueryNormalizeExt;
-use crate::traits::{FromSolverError, Normalized, ObligationCause, ObligationCtxt};
+use crate::traits::{FromSolverError, Normalized, ObligationCause, ObligationCtxt, OldSolverError};
 
 /// This returns true if the type `ty` is "trivial" for
 /// dropck-outlives -- that is, if it doesn't require any types to
@@ -106,7 +106,7 @@ pub fn compute_dropck_outlives_with_errors<'tcx, E>(
     span: Span,
 ) -> Result<DropckOutlivesResult<'tcx>, Vec<E>>
 where
-    E: FromSolverError<'tcx, NextSolverError<'tcx>>,
+    E: FromSolverError<'tcx, NextSolverError<'tcx>> + FromSolverError<'tcx, OldSolverError<'tcx>>,
 {
     let tcx = ocx.infcx.tcx;
     let ParamEnvAnd { param_env, value: DropckOutlives { dropped_ty } } = goal;


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160268)*
<!-- homu-ignore:end -->

Every `ObligationCtxt` allocated its fulfillment engine on the heap as a `Box<dyn TraitEngine>`. This was the single largest allocation site in the compiler: 161k allocations on a `syn` check build (measured with DHAT). `ObligationCtxt`s are created in hot paths, for example once per candidate probe during method resolution.

The allocation is easy to avoid. Which solver is used never changes during a compilation session, and both engine types are small (the obligation forest allocates its own storage separately). So this PR stores the engine directly inside `ObligationCtxt`, in a two-variant enum. Calls now go through a match on that enum instead of virtual dispatch.

The enum's `TraitEngine` impl needs both `FromSolverError` bounds, so a few generic impl blocks and two generic users now need both bounds as well. The concrete error types used in practice already implement both, so nothing else changes for callers. The typeck root fulfillment context keeps the boxed engine; it is created once per function body, so the allocation does not matter there.
