### PR TITLE
renovate: update lock files weekly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,9 +5,8 @@
     "github>rust-lang/renovate:actions",
     // Open a PR to migrate the config when Renovate deprecates syntax
     ":configMigration",
-    // Refresh lock files on the first day of each month
-    // (still gated by dashboard approval for now)
-    ":maintainLockFilesMonthly",
+    // Refresh lock files weekly
+    ":maintainLockFilesWeekly",
   ],
   // Cargo manifests in this repository use unstable features.
   "env": {
@@ -28,6 +27,11 @@
     {
       // No dashboard approval necessary for GitHub Actions updates
       "matchManagers": ["github-actions"],
+      "dependencyDashboardApproval": false
+    },
+    {
+      // No dashboard approval necessary for lock file maintenance
+      "matchUpdateTypes": ["lockFileMaintenance"],
       "dependencyDashboardApproval": false
     },
     {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Discussed in [#t-infra > renovate for rust-lang/rust @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/renovate.20for.20rust-lang.2Frust/near/613816527).
Log file updates work correctly, so we want to open them automatically every week. Similar to how [dependencies.yml](https://github.com/rust-lang/rust/blob/922325bb13bfea5b41454318563f2a65e83c2336/.github/workflows/dependencies.yml#L7) was working before.
The goal is to delete `dependencies.yml` later.
<!-- homu-ignore:end -->
r? @Kobzol 