### PR TITLE
rustdoc: preserve existing output for invalid Markdown

### DIFF
--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -69,14 +69,14 @@ pub(crate) fn render_and_write(
     let playground_url = options.markdown_playground_url.or(options.playground_url);
     let playground = playground_url.map(|url| markdown::Playground { crate_name: None, url });
 
-    let mut out =
-        File::create(&output).map_err(|e| format!("{output}: {e}", output = output.display()))?;
-
     let (metadata, text) = extract_leading_metadata(&input_str);
     if metadata.is_empty() {
         return Err("invalid markdown file: no initial lines starting with `# ` or `%`".to_owned());
     }
     let title = metadata[0];
+
+    let mut out =
+        File::create(&output).map_err(|e| format!("{output}: {e}", output = output.display()))?;
 
     let error_codes = ErrorCodes::from(options.unstable_features.is_nightly_build());
     let text = fmt::from_fn(|f| {

--- a/tests/run-make/rustdoc/invalid-markdown-preserves-output/missing-title.md
+++ b/tests/run-make/rustdoc/invalid-markdown-preserves-output/missing-title.md
@@ -1,0 +1,1 @@
+Standalone Markdown requires an initial title.

--- a/tests/run-make/rustdoc/invalid-markdown-preserves-output/rmake.rs
+++ b/tests/run-make/rustdoc/invalid-markdown-preserves-output/rmake.rs
@@ -1,0 +1,26 @@
+// Check that rejecting malformed standalone Markdown does not truncate an existing output file.
+
+//@ needs-target-std
+
+use run_make_support::{path, rfs, rustdoc};
+
+const SENTINEL: &str = "existing output";
+
+fn main() {
+    let out_dir = path("out");
+    rfs::create_dir(&out_dir);
+
+    let output = out_dir.join("missing-title.html");
+    rfs::write(&output, SENTINEL);
+
+    rustdoc()
+        .input("missing-title.md")
+        .out_dir(&out_dir)
+        .run_fail()
+        .assert_exit_code(1)
+        .assert_stderr_contains(
+            "error: invalid markdown file: no initial lines starting with `# ` or `%`",
+        );
+
+    assert_eq!(rfs::read_to_string(output), SENTINEL);
+}


### PR DESCRIPTION
Standalone Markdown without an initial title is rejected, but rustdoc opened and truncated the destination before performing that validation. As a result, a failed invocation could destroy a previously generated page.

Validate the metadata before creating the destination file. Add a run-make regression test that seeds an existing output and verifies it remains unchanged after the expected error.

The change is limited to the invalid-input path; rendering valid Markdown is unchanged.

Tests:

- `./x test --force-rerun tests/run-make/rustdoc/invalid-markdown-preserves-output`
- `./x fmt --check`
- `git diff --check`
