### PR TITLE
Fix(lib/fs/tests): Avoid permission denials when cleaning up TempDirs in `set_get_permissions_nofollows*`

### DIFF
--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -629,6 +629,16 @@ fn set_get_permissions_nofollows() {
             assert_eq!(result.unwrap(), ());
             let metadata0 = check!(fs::metadata(&filename));
             assert!(metadata0.permissions().readonly());
+
+            // Reset the read-only bit under Windows 7: avoids the
+            // `TempDir::drop` from crashing on a permission denial when
+            // trying to delete the file that has it.
+            #[cfg(all(windows, target_vendor = "win7"))]
+            {
+                let mut permission_bits = metadata0.permissions();
+                permission_bits.set_readonly(false);
+                check!(fs::set_permissions_nofollow(&filename, permission_bits));
+            }
         },
         _ => {
             let error_kind = result.unwrap_err().kind();
@@ -669,6 +679,16 @@ fn set_get_permissions_nofollows_symlink() {
             assert!(metadata0.permissions().readonly());
             #[cfg(not(windows))]
             assert!(!metadata0.permissions().readonly());
+
+            // Reset the read-only bit under Windows 7: avoids the
+            // `TempDir::drop` from crashing on a permission denial when
+            // trying to delete the file that has it.
+            #[cfg(all(windows, target_vendor = "win7"))]
+            {
+                let mut permission_bits = metadata0.permissions();
+                permission_bits.set_readonly(false);
+                check!(fs::set_permissions_nofollow(&symlink_name, permission_bits));
+            }
         },
         _ => {
             let error_kind = result.unwrap_err().kind();


### PR DESCRIPTION
At least under Windows 7, the `set_get_permissions_nofollows` and `set_get_permissions_nofollows_symlink` FS tests currently fail on:

```
---- fs::tests::set_get_permissions_nofollows stdout ----
thread 'fs::tests::set_get_permissions_nofollows' (2308) panicked at library/std/src/test_helpers.rs:53:20:
called `Result::unwrap()` on an `Err` value: Os { code: 5, kind: PermissionDenied, message: "Access is denied." }
---- fs::tests::set_get_permissions_nofollows stdout end ----
---- fs::tests::set_get_permissions_nofollows_symlink stdout ----
thread 'fs::tests::set_get_permissions_nofollows_symlink' (1108) panicked at library/std/src/test_helpers.rs:53:20:
called `Result::unwrap()` on an `Err` value: Os { code: 5, kind: PermissionDenied, message: "Access is denied." }
---- fs::tests::set_get_permissions_nofollows_symlink stdout end ----
```

The panic clearly occurs in `TempDir::drop` that calls `fs::remove_dir_all`. This is consistent with the fact that `FILE_ATTRIBUTE_READONLY` is set on the file:

> Applications can read the file, but cannot write to it or delete it.

from [the attribute's documentation].

This therefore fixes these tests by resetting the attribute before letting the drop guard run.

[the attribute's documentation]: https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants

cc rust-lang/rust#141607 @roblabla 

@rustbot label T-libs A-io O-windows-7