### PR TITLE
rustdoc: use anonymous constant for primitives/keywords/attribute docs

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -1132,7 +1132,7 @@ pub(crate) struct RustcDocPrimitiveParser;
 
 impl SingleAttributeParser for RustcDocPrimitiveParser {
     const PATH: &[Symbol] = &[sym::rustc_doc_primitive];
-    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Mod)]);
+    const ALLOWED_TARGETS: AllowedTargets<'_> = AllowedTargets::AllowList(&[Allow(Target::Const)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "primitive name");
     const STABILITY: AttributeStability = unstable!(
         rustc_attrs,

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -44,7 +44,7 @@ use rustc_session::lint::builtin::{
     MALFORMED_DIAGNOSTIC_FORMAT_LITERALS, MISPLACED_DIAGNOSTIC_ATTRIBUTES, UNUSED_ATTRIBUTES,
 };
 use rustc_span::edition::Edition;
-use rustc_span::{DUMMY_SP, Ident, Span, Symbol, sym};
+use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::infer::{TyCtxtInferExt, ValuePairs};
 use rustc_trait_selection::traits::{ObligationCtxt, TraitErrors};
@@ -1024,18 +1024,11 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             hir::Node::Item(item) => Some(&item.kind),
             _ => None,
         };
-        match item_kind {
-            Some(ItemKind::Mod(_, module)) => {
-                if !module.item_ids.is_empty() {
-                    self.dcx()
-                        .emit_err(diagnostics::DocKeywordAttributeEmptyMod { span, attr_name });
-                    return;
-                }
-            }
-            _ => {
-                self.dcx().emit_err(diagnostics::DocKeywordAttributeNotMod { span, attr_name });
-                return;
-            }
+        if let Some(ItemKind::Const(ident, _gen, _ty, _rhs)) = item_kind
+            && ident.name == kw::Underscore
+        {
+        } else {
+            self.dcx().emit_err(diagnostics::DocKeywordAttributeNotAnonConst { span, attr_name });
         }
     }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -43,7 +43,7 @@ use rustc_session::lint::builtin::{
     MALFORMED_DIAGNOSTIC_FORMAT_LITERALS, MISPLACED_DIAGNOSTIC_ATTRIBUTES, UNUSED_ATTRIBUTES,
 };
 use rustc_span::edition::Edition;
-use rustc_span::{DUMMY_SP, Ident, Span, Symbol, sym};
+use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::infer::{TyCtxtInferExt, ValuePairs};
 use rustc_trait_selection::traits::ObligationCtxt;
@@ -975,18 +975,11 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             hir::Node::Item(item) => Some(&item.kind),
             _ => None,
         };
-        match item_kind {
-            Some(ItemKind::Mod(_, module)) => {
-                if !module.item_ids.is_empty() {
-                    self.dcx()
-                        .emit_err(diagnostics::DocKeywordAttributeEmptyMod { span, attr_name });
-                    return;
-                }
-            }
-            _ => {
-                self.dcx().emit_err(diagnostics::DocKeywordAttributeNotMod { span, attr_name });
-                return;
-            }
+        if let Some(ItemKind::Const(ident, _gen, _ty, _rhs)) = item_kind
+            && ident.name == kw::Underscore
+        {
+        } else {
+            self.dcx().emit_err(diagnostics::DocKeywordAttributeNotAnonConst { span, attr_name });
         }
     }
 

--- a/compiler/rustc_passes/src/diagnostics.rs
+++ b/compiler/rustc_passes/src/diagnostics.rs
@@ -73,16 +73,8 @@ pub(crate) struct DocAliasNotAnAlias {
 }
 
 #[derive(Diagnostic)]
-#[diag("`#[doc({$attr_name} = \"...\")]` should be used on empty modules")]
-pub(crate) struct DocKeywordAttributeEmptyMod {
-    #[primary_span]
-    pub span: Span,
-    pub attr_name: &'static str,
-}
-
-#[derive(Diagnostic)]
-#[diag("`#[doc({$attr_name} = \"...\")]` should be used on modules")]
-pub(crate) struct DocKeywordAttributeNotMod {
+#[diag("`#[doc({$attr_name} = \"...\")]` should be used on anonymous constants")]
+pub(crate) struct DocKeywordAttributeNotAnonConst {
     #[primary_span]
     pub span: Span,
     pub attr_name: &'static str,

--- a/library/core/src/attribute_docs.rs
+++ b/library/core/src/attribute_docs.rs
@@ -82,7 +82,7 @@
 ///
 /// [`unused_must_use`]: ../rustc/lints/listing/warn-by-default.html#unused-must-use
 /// [the `must_use` attribute]: ../reference/attributes/diagnostics.html#the-must_use-attribute
-mod must_use_attribute {}
+const _: () = ();
 
 #[doc(attribute = "allow")]
 //
@@ -144,7 +144,7 @@ mod must_use_attribute {}
 /// [`forbid`]: ./attribute.forbid.html
 /// [`warn`]: ./attribute.warn.html
 /// [`deny`]: ./attribute.deny.html
-mod allow_attribute {}
+const _: () = ();
 
 #[doc(attribute = "cfg")]
 //
@@ -192,7 +192,7 @@ mod allow_attribute {}
 /// [`cfg_attr`]: ../reference/conditional-compilation.html#the-cfg_attr-attribute
 /// [the `cfg` attribute]: ../reference/conditional-compilation.html#the-cfg-attribute
 /// [`if`]: ./keyword.if.html
-mod cfg_attribute {}
+const _: () = ();
 
 #[doc(attribute = "deny")]
 //
@@ -240,7 +240,7 @@ mod cfg_attribute {}
 /// [`allow`]: ./attribute.allow.html
 /// [`warn`]: ./attribute.warn.html
 /// [`deny`]: ./attribute.deny.html
-mod deny_attribute {}
+const _: () = ();
 
 #[doc(attribute = "forbid")]
 //
@@ -276,7 +276,7 @@ mod deny_attribute {}
 /// [the `forbid` attribute]: ../reference/attributes/diagnostics.html#lint-check-attributes
 /// [`allow`]: ./attribute.allow.html
 /// [`warn`]: ./attribute.warn.html
-mod forbid_attribute {}
+const _: () = ();
 
 #[doc(attribute = "deprecated")]
 //
@@ -302,7 +302,7 @@ mod forbid_attribute {}
 /// For more information, see the Reference on [the `deprecated` attribute].
 ///
 /// [the `deprecated` attribute]: ../reference/attributes/diagnostics.html#the-deprecated-attribute
-mod deprecated_attribute {}
+const _: () = ();
 
 #[doc(attribute = "warn")]
 //
@@ -348,7 +348,7 @@ mod deprecated_attribute {}
 /// [`allow`]: ./attribute.allow.html
 /// [`deny`]: ./attribute.deny.html
 /// [`forbid`]: ./attribute.forbid.html
-mod warn_attribute {}
+const _: () = ();
 
 #[doc(attribute = "no_std")]
 //
@@ -404,7 +404,7 @@ mod warn_attribute {}
 /// [`Option`]: option::Option
 /// [`Result`]: result::Result
 /// [the `no_std` attribute]: ../reference/names/preludes.html#the-no_std-attribute
-mod no_std_attribute {}
+const _: () = ();
 
 #[doc(attribute = "inline")]
 //
@@ -444,7 +444,7 @@ mod no_std_attribute {}
 /// For more information, see the Reference on [the `inline` attribute].
 ///
 /// [the `inline` attribute]: ../reference/attributes/codegen.html#the-inline-attribute
-mod inline_attribute {}
+const _: () = ();
 
 #[doc(attribute = "cold")]
 //
@@ -474,7 +474,7 @@ mod inline_attribute {}
 /// For more information, see the Reference on [the `cold` attribute].
 ///
 /// [the `cold` attribute]: ../reference/attributes/codegen.html#the-cold-attribute
-mod cold_attribute {}
+const _: () = ();
 
 #[doc(attribute = "track_caller")]
 //
@@ -505,7 +505,7 @@ mod cold_attribute {}
 /// [`Location::caller`]: panic::Location::caller
 /// [`Option::unwrap`]: Option::unwrap
 /// [the `track_caller` attribute]: ../reference/attributes/codegen.html#the-track_caller-attribute
-mod track_caller_attribute {}
+const _: () = ();
 
 #[doc(attribute = "proc_macro")]
 //
@@ -554,7 +554,7 @@ mod track_caller_attribute {}
 /// [`TokenStream`]: ../proc_macro/struct.TokenStream.html
 /// [function-like procedural macros]: ../reference/procedural-macros.html#the-proc_macro-attribute
 /// [`proc_macro`]: ../proc_macro/index.html
-mod proc_macro_attribute {}
+const _: () = ();
 
 #[doc(attribute = "link_section")]
 //
@@ -580,7 +580,7 @@ mod proc_macro_attribute {}
 /// For more information, see the Reference on [the `link_section` attribute].
 ///
 /// [the `link_section` attribute]: ../reference/abi.html#the-link_section-attribute
-mod link_section_attribute {}
+const _: () = ();
 
 #[doc(attribute = "non_exhaustive")]
 //
@@ -632,4 +632,4 @@ mod link_section_attribute {}
 /// For more information, see the Reference on [the `non_exhaustive` attribute].
 ///
 /// [the `non_exhaustive` attribute]: ../reference/attributes/type_system.html#the-non_exhaustive-attribute
-mod non_exhaustive_attribute {}
+const _: () = ();

--- a/library/core/src/keyword_docs.rs
+++ b/library/core/src/keyword_docs.rs
@@ -73,7 +73,7 @@
 /// [`use`]: keyword.use.html
 /// [const-cast]: pointer::cast
 /// [mut-cast]: primitive.pointer.html#method.cast-1
-mod as_keyword {}
+const _: () = ();
 
 #[doc(keyword = "break")]
 //
@@ -171,7 +171,7 @@ mod as_keyword {}
 /// [Reference on "break expression"]: ../reference/expressions/loop-expr.html#break-expressions
 /// [Reference on "break and loop values"]:
 /// ../reference/expressions/loop-expr.html#break-and-loop-values
-mod break_keyword {}
+const _: () = ();
 
 #[doc(keyword = "const")]
 //
@@ -248,7 +248,7 @@ mod break_keyword {}
 /// [Reference]: ../reference/items/constant-items.html
 /// [const-blocks]: ../reference/expressions/block-expr.html#const-blocks
 /// [const-eval]: ../reference/const_eval.html
-mod const_keyword {}
+const _: () = ();
 
 #[doc(keyword = "continue")]
 //
@@ -288,7 +288,7 @@ mod const_keyword {}
 /// See [continue expressions] from the reference for more details.
 ///
 /// [continue expressions]: ../reference/expressions/loop-expr.html#continue-expressions
-mod continue_keyword {}
+const _: () = ();
 
 #[doc(keyword = "crate")]
 //
@@ -325,7 +325,7 @@ mod continue_keyword {}
 /// module `foo`, from anywhere else in the same crate.
 ///
 /// [Reference]: ../reference/items/extern-crates.html
-mod crate_keyword {}
+const _: () = ();
 
 #[doc(keyword = "else")]
 //
@@ -378,7 +378,7 @@ mod crate_keyword {}
 /// [`match`]: keyword.match.html
 /// [`false`]: keyword.false.html
 /// [`if`]: keyword.if.html
-mod else_keyword {}
+const _: () = ();
 
 #[doc(keyword = "enum")]
 //
@@ -433,7 +433,7 @@ mod else_keyword {}
 /// [ADT]: https://en.wikipedia.org/wiki/Algebraic_data_type
 /// [Rust Book]: ../book/ch06-01-defining-an-enum.html
 /// [Reference]: ../reference/items/enumerations.html
-mod enum_keyword {}
+const _: () = ();
 
 #[doc(keyword = "extern")]
 //
@@ -480,7 +480,7 @@ mod enum_keyword {}
 /// ../book/ch19-01-unsafe-rust.html#using-extern-functions-to-call-external-code
 /// [Reference]: ../reference/items/external-blocks.html
 /// [`crate`]: keyword.crate.html
-mod extern_keyword {}
+const _: () = ();
 
 #[doc(keyword = "false")]
 //
@@ -491,7 +491,7 @@ mod extern_keyword {}
 /// See the documentation for [`true`] for more information.
 ///
 /// [`true`]: keyword.true.html
-mod false_keyword {}
+const _: () = ();
 
 #[doc(keyword = "fn")]
 //
@@ -558,7 +558,7 @@ mod false_keyword {}
 /// [`extern`]: keyword.extern.html
 /// [Rust book]: ../book/ch03-03-how-functions-work.html
 /// [Reference]: ../reference/items/functions.html
-mod fn_keyword {}
+const _: () = ();
 
 #[doc(keyword = "for")]
 //
@@ -640,7 +640,7 @@ mod fn_keyword {}
 /// [Rust book]:
 /// ../book/ch03-05-control-flow.html#looping-through-a-collection-with-for
 /// [Reference]: ../reference/expressions/loop-expr.html#iterator-loops
-mod for_keyword {}
+const _: () = ();
 
 #[doc(keyword = "if")]
 //
@@ -714,7 +714,7 @@ mod for_keyword {}
 ///
 /// [Rust book]: ../book/ch03-05-control-flow.html#if-expressions
 /// [Reference]: ../reference/expressions/if-expr.html
-mod if_keyword {}
+const _: () = ();
 
 #[doc(keyword = "impl")]
 //
@@ -804,7 +804,7 @@ mod if_keyword {}
 /// [book1]: ../book/ch05-03-method-syntax.html
 /// [Reference]: ../reference/items/implementations.html
 /// [book2]: ../book/ch10-02-traits.html#returning-types-that-implement-traits
-mod impl_keyword {}
+const _: () = ();
 
 #[doc(keyword = "in")]
 //
@@ -836,7 +836,7 @@ mod impl_keyword {}
 /// For more information, see the [Reference].
 ///
 /// [Reference]: ../reference/visibility-and-privacy.html#pubin-path-pubcrate-pubsuper-and-pubself
-mod in_keyword {}
+const _: () = ();
 
 #[doc(keyword = "let")]
 //
@@ -899,7 +899,7 @@ mod in_keyword {}
 /// [`if`]: keyword.if.html
 /// [book2]: ../book/ch18-01-all-the-places-for-patterns.html#let-statements
 /// [Reference]: ../reference/statements.html#let-statements
-mod let_keyword {}
+const _: () = ();
 
 #[doc(keyword = "loop")]
 //
@@ -949,7 +949,7 @@ mod let_keyword {}
 /// [`for`]: keyword.for.html
 /// [`while`]: keyword.while.html
 /// [Reference]: ../reference/expressions/loop-expr.html
-mod loop_keyword {}
+const _: () = ();
 
 #[doc(keyword = "match")]
 //
@@ -999,7 +999,7 @@ mod loop_keyword {}
 /// For more information on `match` and matching in general, see the [Reference].
 ///
 /// [Reference]: ../reference/expressions/match-expr.html
-mod match_keyword {}
+const _: () = ();
 
 #[doc(keyword = "mod")]
 //
@@ -1027,7 +1027,7 @@ mod match_keyword {}
 /// [`pub`]: keyword.pub.html
 /// [`struct`]: keyword.struct.html
 /// [modules]: ../reference/items/modules.html
-mod mod_keyword {}
+const _: () = ();
 
 #[doc(keyword = "move")]
 //
@@ -1085,7 +1085,7 @@ mod mod_keyword {}
 ///
 /// [closure]: ../book/ch13-01-closures.html
 /// [threads]: ../book/ch16-01-threads.html#using-move-closures-with-threads
-mod move_keyword {}
+const _: () = ();
 
 #[doc(keyword = "mut")]
 //
@@ -1143,7 +1143,7 @@ mod move_keyword {}
 /// More information on mutable references and pointers can be found in the [Reference].
 ///
 /// [Reference]: ../reference/types/pointer.html#mutable-references-mut
-mod mut_keyword {}
+const _: () = ();
 
 #[doc(keyword = "pub")]
 //
@@ -1158,7 +1158,7 @@ mod mut_keyword {}
 ///
 /// [reference]:../reference/visibility-and-privacy.html?highlight=pub#visibility-and-privacy
 /// [Rust by Example]:../rust-by-example/mod/visibility.html
-mod pub_keyword {}
+const _: () = ();
 
 #[doc(keyword = "ref")]
 //
@@ -1208,7 +1208,7 @@ mod pub_keyword {}
 ///
 /// [`match`]: keyword.match.html
 /// [Reference]: ../reference/patterns.html#identifier-patterns
-mod ref_keyword {}
+const _: () = ();
 
 #[doc(keyword = "return")]
 //
@@ -1272,7 +1272,7 @@ mod ref_keyword {}
 ///
 /// [closures]: ../book/ch13-01-closures.html
 /// [`async`]: ../std/keyword.async.html
-mod return_keyword {}
+const _: () = ();
 
 #[doc(keyword = "become")]
 //
@@ -1376,7 +1376,7 @@ mod return_keyword {}
 /// let program = &[Inst::Inc, Inst::Inc, Inst::Dec, Inst::Inc];
 /// assert_eq!(dispatch(program, 0), 2);
 /// ```
-mod become_keyword {}
+const _: () = ();
 
 #[doc(keyword = "self")]
 //
@@ -1469,7 +1469,7 @@ mod become_keyword {}
 ///
 /// [`use`]: keyword.use.html
 /// [Reference]: ../reference/items/associated-items.html#methods
-mod self_keyword {}
+const _: () = ();
 
 // FIXME: Once rustdoc can handle URL conflicts on case insensitive file systems, we can replace
 // these two lines with `#[doc(keyword = "Self")]` and update `is_doc_keyword` in
@@ -1540,7 +1540,7 @@ mod self_keyword {}
 ///
 /// [`impl`]: keyword.impl.html
 /// [`trait`]: keyword.trait.html
-mod self_upper_keyword {}
+const _: () = ();
 
 #[doc(keyword = "static")]
 //
@@ -1626,7 +1626,7 @@ mod self_upper_keyword {}
 /// [`RefCell`]: cell::RefCell
 /// [atomic]: sync::atomic
 /// [Reference]: ../reference/items/static-items.html
-mod static_keyword {}
+const _: () = ();
 
 #[doc(keyword = "struct")]
 //
@@ -1734,7 +1734,7 @@ mod static_keyword {}
 /// [`PhantomData`]: marker::PhantomData
 /// [book]: ../book/ch05-01-defining-structs.html
 /// [reference]: ../reference/items/structs.html
-mod struct_keyword {}
+const _: () = ();
 
 #[doc(keyword = "super")]
 //
@@ -1760,7 +1760,7 @@ mod struct_keyword {}
 ///
 /// [module]: ../reference/items/modules.html
 /// [Reference]: ../reference/paths.html#super
-mod super_keyword {}
+const _: () = ();
 
 #[doc(keyword = "trait")]
 //
@@ -1945,7 +1945,7 @@ mod super_keyword {}
 /// [`unsafe`]: keyword.unsafe.html
 /// [Ref-Traits]: ../reference/items/traits.html
 /// [Ref-Trait-Objects]: ../reference/types/trait-object.html
-mod trait_keyword {}
+const _: () = ();
 
 #[doc(keyword = "true")]
 //
@@ -1972,7 +1972,7 @@ mod trait_keyword {}
 /// [`while`]: keyword.while.html
 /// [`match`]: ../reference/expressions/match-expr.html#match-guards
 /// [`false`]: keyword.false.html
-mod true_keyword {}
+const _: () = ();
 
 #[doc(keyword = "type")]
 //
@@ -2024,7 +2024,7 @@ mod true_keyword {}
 /// [`trait`]: keyword.trait.html
 /// [associated type]: ../reference/items/associated-items.html#associated-types
 /// [alias]: ../reference/items/type-aliases.html
-mod type_keyword {}
+const _: () = ();
 
 #[doc(keyword = "unsafe")]
 //
@@ -2310,7 +2310,7 @@ mod type_keyword {}
 /// [soundness]: https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#soundness-of-code--of-a-library
 /// [Reference]: ../reference/unsafety.html
 /// [discussion on Rust Internals]: https://internals.rust-lang.org/t/what-does-unsafe-mean/6696
-mod unsafe_keyword {}
+const _: () = ();
 
 #[doc(keyword = "use")]
 //
@@ -2408,7 +2408,7 @@ mod unsafe_keyword {}
 /// [`super`]: keyword.super.html
 /// [ref-use-decls]: ../reference/items/use-declarations.html
 /// [ref-impl-trait]: ../reference/types/impl-trait.html
-mod use_keyword {}
+const _: () = ();
 
 #[doc(keyword = "where")]
 //
@@ -2508,7 +2508,7 @@ mod use_keyword {}
 /// ```
 ///
 /// [RFC]: https://github.com/rust-lang/rfcs/blob/master/text/0135-where.md
-mod where_keyword {}
+const _: () = ();
 
 #[doc(keyword = "while")]
 //
@@ -2566,7 +2566,7 @@ mod where_keyword {}
 /// [`for`]: keyword.for.html
 /// [`loop`]: keyword.loop.html
 /// [reference]: ../reference/expressions/loop-expr.html#predicate-loops
-mod while_keyword {}
+const _: () = ();
 
 // 2018 Edition keywords
 
@@ -2628,7 +2628,7 @@ mod while_keyword {}
 /// [never type]: ../reference/types/never.html
 /// [`Result`]: result::Result
 /// [async book blocks]: https://rust-lang.github.io/async-book/part-guide/more-async-await.html#async-blocks
-mod async_keyword {}
+const _: () = ();
 
 #[doc(keyword = "await")]
 //
@@ -2648,7 +2648,7 @@ mod async_keyword {}
 /// [`Future`]: future::Future
 /// [async book]: https://rust-lang.github.io/async-book/
 /// [`async`]: ../std/keyword.async.html
-mod await_keyword {}
+const _: () = ();
 
 #[doc(keyword = "dyn")]
 //
@@ -2684,7 +2684,7 @@ mod await_keyword {}
 /// [ref-dyn-compat]: ../reference/items/traits.html#dyn-compatibility
 /// [erased]: https://en.wikipedia.org/wiki/Type_erasure
 /// [^1]: Formerly known as *object safe*.
-mod dyn_keyword {}
+const _: () = ();
 
 #[doc(keyword = "union")]
 //
@@ -2758,4 +2758,4 @@ mod dyn_keyword {}
 ///
 /// [`struct`]: keyword.struct.html
 /// [union]: ../reference/items/unions.html
-mod union_keyword {}
+const _: () = ();

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -58,7 +58,7 @@
 /// assert_eq!(false as i32, 0);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_bool {}
+const _: () = ();
 
 #[rustc_doc_primitive = "never"]
 #[doc(alias = "!")]
@@ -312,7 +312,7 @@ mod prim_bool {}
 /// [2024 edition]: <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
 ///
 #[unstable(feature = "never_type", issue = "35121")]
-mod prim_never {}
+const _: () = ();
 
 // Required to make auto trait impls render.
 // See src/librustdoc/passes/collect_trait_impls.rs:collect_trait_impls
@@ -448,7 +448,7 @@ impl ! {}
 /// assert_eq!(32, size_of_val(&v[..]));
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_char {}
+const _: () = ();
 
 #[rustc_doc_primitive = "unit"]
 #[doc(alias = "(")]
@@ -489,7 +489,7 @@ mod prim_char {}
 /// ```
 ///
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_unit {}
+const _: () = ();
 
 // Required to make auto trait impls render.
 // See src/librustdoc/passes/collect_trait_impls.rs:collect_trait_impls
@@ -616,7 +616,7 @@ impl () {}
 /// [`write`]: ptr::write
 /// [valid]: ptr#safety
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_pointer {}
+const _: () = ();
 
 #[rustc_doc_primitive = "array"]
 #[doc(alias = "[]")]
@@ -828,7 +828,7 @@ mod prim_pointer {}
 /// [slice pattern]: ../reference/patterns.html#slice-patterns
 /// [`From<Tuple>`]: convert::From
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_array {}
+const _: () = ();
 
 #[rustc_doc_primitive = "slice"]
 #[doc(alias = "[")]
@@ -942,7 +942,7 @@ mod prim_array {}
 /// [`.chunks`]: slice::chunks
 /// [`.windows`]: slice::windows
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_slice {}
+const _: () = ();
 
 #[rustc_doc_primitive = "str"]
 /// String slices.
@@ -1015,7 +1015,7 @@ mod prim_slice {}
 /// called on a string slice may assume that it is valid UTF-8, which means that a non-UTF-8 string
 /// slice can lead to undefined behavior down the road.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_str {}
+const _: () = ();
 
 #[rustc_doc_primitive = "tuple"]
 #[doc(alias = "(")]
@@ -1142,7 +1142,7 @@ mod prim_str {}
 /// ```
 ///
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_tuple {}
+const _: () = ();
 
 // Required to make auto trait impls render.
 // See src/librustdoc/passes/collect_trait_impls.rs:collect_trait_impls
@@ -1167,7 +1167,7 @@ impl<T> (T,) {}
 ///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Half-precision_floating-point_format
 #[unstable(feature = "f16", issue = "116909")]
-mod prim_f16 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "f32"]
 #[doc(alias = "single")]
@@ -1380,7 +1380,7 @@ mod prim_f16 {}
 /// # }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_f32 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "f64"]
 #[doc(alias = "double")]
@@ -1394,7 +1394,7 @@ mod prim_f32 {}
 ///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Double-precision_floating-point_format
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_f64 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "f128"]
 #[doc(alias = "quad")]
@@ -1417,31 +1417,31 @@ mod prim_f64 {}
 ///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Quadruple-precision_floating-point_format
 #[unstable(feature = "f128", issue = "116909")]
-mod prim_f128 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "i8"]
 //
 /// The 8-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_i8 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "i16"]
 //
 /// The 16-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_i16 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "i32"]
 //
 /// The 32-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_i32 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "i64"]
 //
 /// The 64-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_i64 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "i128"]
 //
@@ -1459,31 +1459,31 @@ mod prim_i64 {}
 /// do not use the same alignment. `i128` is intended to always match `__int128` and does not
 /// attempt to match `_BitInt(128)` on platforms without `__int128`.
 #[stable(feature = "i128", since = "1.26.0")]
-mod prim_i128 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "u8"]
 //
 /// The 8-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_u8 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "u16"]
 //
 /// The 16-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_u16 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "u32"]
 //
 /// The 32-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_u32 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "u64"]
 //
 /// The 64-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_u64 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "u128"]
 //
@@ -1491,7 +1491,7 @@ mod prim_u64 {}
 ///
 /// Please see [the documentation for `i128`](prim@i128) for information on ABI compatibility.
 #[stable(feature = "i128", since = "1.26.0")]
-mod prim_u128 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "isize"]
 //
@@ -1501,7 +1501,7 @@ mod prim_u128 {}
 /// location in memory. For example, on a 32 bit target, this is 4 bytes
 /// and on a 64 bit target, this is 8 bytes.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_isize {}
+const _: () = ();
 
 #[rustc_doc_primitive = "usize"]
 //
@@ -1511,7 +1511,7 @@ mod prim_isize {}
 /// location in memory. For example, on a 32 bit target, this is 4 bytes
 /// and on a 64 bit target, this is 8 bytes.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_usize {}
+const _: () = ();
 
 #[rustc_doc_primitive = "reference"]
 #[doc(alias = "&")]
@@ -1672,7 +1672,7 @@ mod prim_usize {}
 ///
 /// [allocation]: ptr#allocation
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_ref {}
+const _: () = ();
 
 #[rustc_doc_primitive = "fn"]
 //
@@ -1947,7 +1947,7 @@ mod prim_ref {}
 /// In addition, all *safe* function pointers implement [`Fn`], [`FnMut`], and [`FnOnce`], because
 /// these traits are specially known to the compiler.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_fn {}
+const _: () = ();
 
 // Required to make auto trait impls render.
 // See src/librustdoc/passes/collect_trait_impls.rs:collect_trait_impls

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -58,7 +58,7 @@
 /// assert_eq!(false as i32, 0);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_bool {}
+const _: () = ();
 
 #[rustc_doc_primitive = "never"]
 #[doc(alias = "!")]
@@ -312,7 +312,7 @@ mod prim_bool {}
 /// [2024 edition]: <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
 ///
 #[unstable(feature = "never_type", issue = "35121")]
-mod prim_never {}
+const _: () = ();
 
 // Required to make auto trait impls render.
 // See src/librustdoc/passes/collect_trait_impls.rs:collect_trait_impls
@@ -448,7 +448,7 @@ impl ! {}
 /// assert_eq!(32, size_of_val(&v[..]));
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_char {}
+const _: () = ();
 
 #[rustc_doc_primitive = "unit"]
 #[doc(alias = "(")]
@@ -489,7 +489,7 @@ mod prim_char {}
 /// ```
 ///
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_unit {}
+const _: () = ();
 
 // Required to make auto trait impls render.
 // See src/librustdoc/passes/collect_trait_impls.rs:collect_trait_impls
@@ -616,7 +616,7 @@ impl () {}
 /// [`write`]: ptr::write
 /// [valid]: ptr#safety
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_pointer {}
+const _: () = ();
 
 #[rustc_doc_primitive = "array"]
 #[doc(alias = "[]")]
@@ -828,7 +828,7 @@ mod prim_pointer {}
 /// [slice pattern]: ../reference/patterns.html#slice-patterns
 /// [`From<Tuple>`]: convert::From
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_array {}
+const _: () = ();
 
 #[rustc_doc_primitive = "slice"]
 #[doc(alias = "[")]
@@ -942,7 +942,7 @@ mod prim_array {}
 /// [`.chunks`]: slice::chunks
 /// [`.windows`]: slice::windows
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_slice {}
+const _: () = ();
 
 #[rustc_doc_primitive = "str"]
 /// String slices.
@@ -1015,7 +1015,7 @@ mod prim_slice {}
 /// called on a string slice may assume that it is valid UTF-8, which means that a non-UTF-8 string
 /// slice can lead to undefined behavior down the road.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_str {}
+const _: () = ();
 
 #[rustc_doc_primitive = "tuple"]
 #[doc(alias = "(")]
@@ -1142,7 +1142,7 @@ mod prim_str {}
 /// ```
 ///
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_tuple {}
+const _: () = ();
 
 // Required to make auto trait impls render.
 // See src/librustdoc/passes/collect_trait_impls.rs:collect_trait_impls
@@ -1167,7 +1167,7 @@ impl<T> (T,) {}
 ///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Half-precision_floating-point_format
 #[unstable(feature = "f16", issue = "116909")]
-mod prim_f16 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "f32"]
 #[doc(alias = "single")]
@@ -1363,7 +1363,7 @@ mod prim_f16 {}
 /// x = (a + c) + (b + d); // Reordered to shorten critical path and enable vectorization
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_f32 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "f64"]
 #[doc(alias = "double")]
@@ -1377,7 +1377,7 @@ mod prim_f32 {}
 ///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Double-precision_floating-point_format
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_f64 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "f128"]
 #[doc(alias = "quad")]
@@ -1400,31 +1400,31 @@ mod prim_f64 {}
 ///
 /// [wikipedia]: https://en.wikipedia.org/wiki/Quadruple-precision_floating-point_format
 #[unstable(feature = "f128", issue = "116909")]
-mod prim_f128 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "i8"]
 //
 /// The 8-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_i8 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "i16"]
 //
 /// The 16-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_i16 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "i32"]
 //
 /// The 32-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_i32 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "i64"]
 //
 /// The 64-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_i64 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "i128"]
 //
@@ -1442,31 +1442,31 @@ mod prim_i64 {}
 /// do not use the same alignment. `i128` is intended to always match `__int128` and does not
 /// attempt to match `_BitInt(128)` on platforms without `__int128`.
 #[stable(feature = "i128", since = "1.26.0")]
-mod prim_i128 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "u8"]
 //
 /// The 8-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_u8 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "u16"]
 //
 /// The 16-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_u16 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "u32"]
 //
 /// The 32-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_u32 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "u64"]
 //
 /// The 64-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_u64 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "u128"]
 //
@@ -1474,7 +1474,7 @@ mod prim_u64 {}
 ///
 /// Please see [the documentation for `i128`](prim@i128) for information on ABI compatibility.
 #[stable(feature = "i128", since = "1.26.0")]
-mod prim_u128 {}
+const _: () = ();
 
 #[rustc_doc_primitive = "isize"]
 //
@@ -1484,7 +1484,7 @@ mod prim_u128 {}
 /// location in memory. For example, on a 32 bit target, this is 4 bytes
 /// and on a 64 bit target, this is 8 bytes.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_isize {}
+const _: () = ();
 
 #[rustc_doc_primitive = "usize"]
 //
@@ -1494,7 +1494,7 @@ mod prim_isize {}
 /// location in memory. For example, on a 32 bit target, this is 4 bytes
 /// and on a 64 bit target, this is 8 bytes.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_usize {}
+const _: () = ();
 
 #[rustc_doc_primitive = "reference"]
 #[doc(alias = "&")]
@@ -1655,7 +1655,7 @@ mod prim_usize {}
 ///
 /// [allocation]: ptr#allocation
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_ref {}
+const _: () = ();
 
 #[rustc_doc_primitive = "fn"]
 //
@@ -1930,7 +1930,7 @@ mod prim_ref {}
 /// In addition, all *safe* function pointers implement [`Fn`], [`FnMut`], and [`FnOnce`], because
 /// these traits are specially known to the compiler.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_fn {}
+const _: () = ();
 
 // Required to make auto trait impls render.
 // See src/librustdoc/passes/collect_trait_impls.rs:collect_trait_impls

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -130,7 +130,7 @@ To do so, the `#[doc(keyword = "...")]` attribute is used. Example:
 
 /// Some documentation about the keyword.
 #[doc(keyword = "break")]
-mod empty_mod {}
+const _: () = ();
 ```
 
 ### Document builtin attributes
@@ -147,7 +147,7 @@ To do so, the `#[doc(attribute = "...")]` attribute is used. Example:
 
 /// Some documentation about the attribute.
 #[doc(attribute = "repr")]
-mod empty_mod {}
+const _: () = ();
 ```
 
 ### Use the Rust logo as the crate logo

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -236,7 +236,7 @@ impl ExternalCrate {
             .unwrap_or(Unknown) // Well, at least we tried.
     }
 
-    fn mapped_root_modules<T>(
+    fn mapped_root_anon_consts<T>(
         &self,
         tcx: TyCtxt<'_>,
         f: impl Fn(DefId, TyCtxt<'_>) -> Option<(DefId, T)>,
@@ -248,7 +248,7 @@ impl ExternalCrate {
                 tcx.hir_root_module()
                     .item_ids
                     .iter()
-                    .filter(move |&&id| matches!(tcx.hir_item(id).kind, hir::ItemKind::Mod(..)))
+                    .filter(move |&&id| matches!(tcx.hir_item(id).kind, hir::ItemKind::Const(..)))
                     .filter_map(move |&id| f(id.owner_id.into(), tcx)),
             )
         } else {
@@ -256,7 +256,11 @@ impl ExternalCrate {
                 tcx.module_children(root)
                     .iter()
                     .filter_map(|item| {
-                        if let Res::Def(DefKind::Mod, did) = item.res { Some(did) } else { None }
+                        if let Res::Def(DefKind::Const { is_type_const: false }, did) = item.res {
+                            Some(did)
+                        } else {
+                            None
+                        }
                     })
                     .filter_map(move |did| f(did, tcx)),
             )
@@ -281,7 +285,7 @@ impl ExternalCrate {
         let as_target = move |did: DefId, tcx: TyCtxt<'_>| -> Option<(DefId, Symbol)> {
             find_attr!(tcx, did, Doc(d) => callback(d)).flatten().map(|value| (did, value))
         };
-        self.mapped_root_modules(tcx, as_target)
+        self.mapped_root_anon_consts(tcx, as_target)
     }
 
     pub(crate) fn primitives(
@@ -316,7 +320,7 @@ impl ExternalCrate {
             Some((def_id, prim))
         }
 
-        self.mapped_root_modules(tcx, as_primitive)
+        self.mapped_root_anon_consts(tcx, as_primitive)
     }
 }
 
@@ -984,10 +988,10 @@ pub(crate) enum ItemKind {
     AssocTypeItem(Box<TypeAlias>, Vec<GenericBound>),
     /// An item that has been stripped by a rustdoc pass
     StrippedItem(Box<ItemKind>),
-    /// This item represents a module with a `#[doc(keyword = "...")]` attribute which is used
+    /// This item represents an anonymous constant with a `#[doc(keyword = "...")]` attribute which is used
     /// to generate documentation for Rust keywords.
     KeywordItem,
-    /// This item represents a module with a `#[doc(attribute = "...")]` attribute which is used
+    /// This item represents an anonymous constant with a `#[doc(attribute = "...")]` attribute which is used
     /// to generate documentation for Rust builtin attributes.
     AttributeItem,
 }

--- a/tests/run-make/rustdoc/search-load-itemtype/foo.rs
+++ b/tests/run-make/rustdoc/search-load-itemtype/foo.rs
@@ -4,15 +4,13 @@
 
 //@ has foo/keyword.while.html
 //@ hasraw search.index/name/*.js while
-//@ !hasraw search.index/name/*.js w_keyword
 #[doc(keyword = "while")]
-mod w_keyword {}
+const _: () = ();
 
 //@ has foo/primitive.u32.html
 //@ hasraw search.index/name/*.js u32
-//@ !hasraw search.index/name/*.js u_primitive
 #[rustc_doc_primitive = "u32"]
-mod u_primitive {}
+const _: () = ();
 
 //@ has foo/x_mod/index.html
 //@ hasraw search.index/name/*.js x_mod
@@ -114,6 +112,5 @@ pub trait ATraitAlias = ATrait;
 
 //@ has foo/attribute.doc.html
 //@ hasraw search.index/name/*.js doc
-//@ !hasraw search.index/name/*.js aa_mod
 #[doc(attribute = "doc")]
-mod aa_mod {}
+const _: () = ();

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -179,11 +179,11 @@ pub enum AnEnum {
 
 #[doc(keyword = "for")]
 /// Some keyword.
-pub mod keyword {}
+const _: () = ();
 
 #[doc(attribute = "forbid")]
 /// Some attribute.
-pub mod repr {}
+const _: () = ();
 
 /// Just some type alias.
 pub type SomeType = u32;

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -178,11 +178,11 @@ pub enum AnEnum {
 
 #[doc(keyword = "for")]
 /// Some keyword.
-pub mod keyword {}
+const _: () = ();
 
 #[doc(attribute = "forbid")]
 /// Some attribute.
-pub mod repr {}
+const _: () = ();
 
 /// Just some type alias.
 pub type SomeType = u32;

--- a/tests/rustdoc-html/auto/auto-impl-primitive.rs
+++ b/tests/rustdoc-html/auto/auto-impl-primitive.rs
@@ -7,4 +7,4 @@ pub use std::fs::File;
 //@ has 'foo/primitive.i16.html' '//h2[@id="synthetic-implementations"]' 'Auto Trait Implementation'
 #[rustc_doc_primitive = "i16"]
 /// I love poneys!
-mod prim {}
+const _: () = ();

--- a/tests/rustdoc-html/doc-attribute.rs
+++ b/tests/rustdoc-html/doc-attribute.rs
@@ -11,14 +11,12 @@
 //@ has foo/attribute.no_mangle.html '//h1' 'Attribute no_mangle'
 //@ has foo/attribute.no_mangle.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 //@ has foo/index.html '//a/@href' '../foo/index.html'
-//@ !has foo/foo/index.html
-//@ !has-dir foo/foo
 //@ !has foo/index.html '//span' '🔒'
 #[doc(attribute = "no_mangle")]
 /// this is a test!
-mod foo{}
+const _: () = ();
 
 //@ has foo/attribute.repr.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'hello'
 #[doc(attribute = "repr")]
 /// hello
-mod bar {}
+const _: () = ();

--- a/tests/rustdoc-html/doc-on-keyword.rs
+++ b/tests/rustdoc-html/doc-on-keyword.rs
@@ -10,4 +10,4 @@
 #[doc(keyword = "trait")]
 //
 /// [`Send`] and [Sync]
-mod bar {}
+const _: () = ();

--- a/tests/rustdoc-html/fake-items-doc-private-items.rs
+++ b/tests/rustdoc-html/fake-items-doc-private-items.rs
@@ -1,0 +1,37 @@
+//! Test checking that these `_` constants don't show up
+//@ compile-flags: --document-private-items
+
+//@ !has foo/constant._.html
+
+// both PUB_CONST and PRIV_CONST should show up, but not the anon consts
+//@ count foo/index.html '//*[@class="constant"]' 2
+#![crate_name = "foo"]
+
+#![feature(rustdoc_internals)]
+#![feature(rustc_attrs)]
+
+//@ has foo/attribute.no_mangle.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'hello attr'
+#[doc(attribute = "no_mangle")]
+/// hello attr
+const _: () = ();
+
+//@ has foo/keyword.match.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'hello kw'
+#[doc(keyword = "match")]
+/// hello kw
+const _: () = ();
+
+//@ has foo/primitive.i128.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'hello prim'
+#[rustc_doc_primitive = "i128"]
+/// hello prim
+const _: () = ();
+
+/// regular anon const
+const _: () = ();
+
+//@ has foo/constant.PUB_CONST.html
+/// woop
+pub const PUB_CONST: i32 = 42;
+
+//@ has foo/constant.PRIV_CONST.html
+/// woop2
+const PRIV_CONST: i32 = 42;

--- a/tests/rustdoc-html/intra-doc/auxiliary/my-core.rs
+++ b/tests/rustdoc-html/intra-doc/auxiliary/my-core.rs
@@ -5,7 +5,7 @@
 
 #[rustc_doc_primitive = "char"]
 /// Some char docs
-mod char {}
+const _: () = ();
 
 impl char {
     pub fn len_utf8(self) -> usize {

--- a/tests/rustdoc-html/intra-doc/prim-methods-local.rs
+++ b/tests/rustdoc-html/intra-doc/prim-methods-local.rs
@@ -11,7 +11,7 @@
 //! A [prim@`char`] and its [`char::len_utf8`].
 
 #[rustc_doc_primitive = "char"]
-mod char {}
+const _: () = ();
 
 impl char {
     pub fn len_utf8(self) -> usize {

--- a/tests/rustdoc-html/intra-doc/prim-self.rs
+++ b/tests/rustdoc-html/intra-doc/prim-self.rs
@@ -27,7 +27,7 @@ impl usize {
 
 #[rustc_doc_primitive = "usize"]
 /// This has some docs.
-mod usize {}
+const _: () = ();
 
 /// [S::f]
 /// [Self::f]

--- a/tests/rustdoc-html/keyword.rs
+++ b/tests/rustdoc-html/keyword.rs
@@ -9,14 +9,12 @@
 //@ has foo/keyword.match.html '//h1' 'Keyword match'
 //@ has foo/keyword.match.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
 //@ has foo/index.html '//a/@href' '../foo/index.html'
-//@ !has foo/foo/index.html
-//@ !has-dir foo/foo
 //@ !has foo/index.html '//span' '🔒'
 #[doc(keyword = "match")]
 /// this is a test!
-mod foo{}
+const _: () = ();
 
 //@ has foo/keyword.break.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'hello'
 #[doc(keyword = "break")]
 /// hello
-mod bar {}
+const _: () = ();

--- a/tests/rustdoc-html/notable-trait/doc-notable_trait-mut_t_is_not_an_iterator.rs
+++ b/tests/rustdoc-html/notable-trait/doc-notable_trait-mut_t_is_not_an_iterator.rs
@@ -14,7 +14,7 @@
 ///
 /// We need to put this in here, because notable traits
 /// that are implemented on foreign types don't show up.
-mod reference {}
+const _: () = ();
 
 //@ has doc_notable_trait_mut_t_is_not_an_iterator/fn.fn_no_matches.html
 //@ !has - '//code[@class="content"]' 'Iterator'

--- a/tests/rustdoc-html/notable-trait/doc-notable_trait-mut_t_is_not_ref_t.rs
+++ b/tests/rustdoc-html/notable-trait/doc-notable_trait-mut_t_is_not_ref_t.rs
@@ -12,7 +12,7 @@
 ///
 /// We need to put this in here, because notable traits
 /// that are implemented on foreign types don't show up.
-mod reference {}
+const _: () = ();
 
 //@ has doc_notable_trait_mut_t_is_not_ref_t/fn.fn_no_matches.html
 //@ !has - '//code[@class="content"]' "impl<'_, I> Iterator for &'_ mut I"

--- a/tests/rustdoc-html/primitive/auxiliary/issue-15318.rs
+++ b/tests/rustdoc-html/primitive/auxiliary/issue-15318.rs
@@ -14,4 +14,4 @@ fn bar(_: &core::panic::PanicInfo) -> ! { loop {} }
 
 /// dox
 #[rustc_doc_primitive = "pointer"]
-pub mod ptr {}
+const _: () = ();

--- a/tests/rustdoc-html/primitive/auxiliary/primitive-doc.rs
+++ b/tests/rustdoc-html/primitive/auxiliary/primitive-doc.rs
@@ -2,10 +2,18 @@
 //@ edition: 2018
 
 #![feature(rustc_attrs)]
-#![feature(no_core)]
+#![feature(no_core, lang_items)]
 #![no_core]
+
+#[lang = "pointee_sized"]
+pub trait PointeeSized {}
+
+#[lang = "meta_sized"]
+pub trait MetaSized: PointeeSized {}
+
+#[lang = "sized"]
+pub trait Sized: MetaSized {}
 
 #[rustc_doc_primitive = "usize"]
 /// This is the built-in type `usize`.
-mod usize {
-}
+const _: () = ();

--- a/tests/rustdoc-html/primitive/cross-crate-primitive-doc.rs
+++ b/tests/rustdoc-html/primitive/cross-crate-primitive-doc.rs
@@ -2,17 +2,8 @@
 //@ compile-flags: --extern-html-root-url=primitive_doc=../ -Z unstable-options
 //@ only-linux
 
-#![feature(no_core, lang_items)]
+#![feature(no_core)]
 #![no_core]
-
-#[lang = "pointee_sized"]
-pub trait PointeeSized {}
-
-#[lang = "meta_sized"]
-pub trait MetaSized: PointeeSized {}
-
-#[lang = "sized"]
-pub trait Sized: MetaSized {}
 
 extern crate primitive_doc;
 

--- a/tests/rustdoc-html/primitive/primitive-generic-impl.rs
+++ b/tests/rustdoc-html/primitive/primitive-generic-impl.rs
@@ -5,4 +5,4 @@
 
 #[rustc_doc_primitive = "i32"]
 /// Some useless docs, wouhou!
-mod i32 {}
+const _: () = ();

--- a/tests/rustdoc-html/primitive/primitive-raw-pointer-dox-15318-3.rs
+++ b/tests/rustdoc-html/primitive/primitive-raw-pointer-dox-15318-3.rs
@@ -6,4 +6,4 @@
 
 /// dox
 #[rustc_doc_primitive = "pointer"]
-pub mod ptr {}
+const _: () = ();

--- a/tests/rustdoc-html/primitive/primitive-raw-pointer-link-no-inlined-15318-2.rs
+++ b/tests/rustdoc-html/primitive/primitive-raw-pointer-link-no-inlined-15318-2.rs
@@ -7,8 +7,6 @@
 
 extern crate issue_15318;
 
-pub use issue_15318::ptr;
-
 //@ !has issue_15318_2/fn.bar.html \
 //          '//*[@href="primitive.pointer.html"]' \
 //          '*mut T'

--- a/tests/rustdoc-html/primitive/primitive-reference.rs
+++ b/tests/rustdoc-html/primitive/primitive-reference.rs
@@ -17,7 +17,7 @@
 //        'impl<A, B> Foo<&A> for &B'
 #[rustc_doc_primitive = "reference"]
 /// this is a test!
-mod reference {}
+const _: () = ();
 
 pub struct Bar;
 

--- a/tests/rustdoc-html/primitive/primitive-slice-auto-trait.rs
+++ b/tests/rustdoc-html/primitive/primitive-slice-auto-trait.rs
@@ -11,4 +11,4 @@
 //@ has - '//div[@id="synthetic-implementations-list"]//h3' 'impl<T> Sync for [T]where T: Sync'
 #[rustc_doc_primitive = "slice"]
 /// this is a test!
-mod slice_prim {}
+const _: () = ();

--- a/tests/rustdoc-html/primitive/primitive-tuple-auto-trait.rs
+++ b/tests/rustdoc-html/primitive/primitive-tuple-auto-trait.rs
@@ -19,4 +19,4 @@
 /// This header is hard-coded in the HTML format linking for `#[doc(fake_variadics)]`.
 /// To make sure it gets linked correctly, we need to make sure the hardcoded anchor
 /// in the code matches what rustdoc generates for the header.
-mod tuple_prim {}
+const _: () = ();

--- a/tests/rustdoc-html/primitive/primitive-unit-auto-trait.rs
+++ b/tests/rustdoc-html/primitive/primitive-unit-auto-trait.rs
@@ -11,4 +11,4 @@
 //@ has - '//div[@id="synthetic-implementations-list"]//h3' 'impl Sync for ()'
 #[rustc_doc_primitive = "unit"]
 /// this is a test!
-mod unit_prim {}
+const _: () = ();

--- a/tests/rustdoc-html/primitive/primitive.rs
+++ b/tests/rustdoc-html/primitive/primitive.rs
@@ -15,19 +15,19 @@
 //@ !has foo/index.html '//span' '🔒'
 #[rustc_doc_primitive = "i32"]
 /// this is a test!
-mod i32 {}
+const _: () = ();
 
 //@ has foo/primitive.bool.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'hello'
 #[rustc_doc_primitive = "bool"]
 /// hello
-mod bool {}
+const _: () = ();
 
 //@ has foo/primitive.f16.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'hello'
 #[rustc_doc_primitive = "f16"]
 /// hello
-mod f16 {}
+const _: () = ();
 
 //@ has foo/primitive.f128.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'hello'
 #[rustc_doc_primitive = "f128"]
 /// hello
-mod f128 {}
+const _: () = ();

--- a/tests/rustdoc-html/primitive/search-index-primitive-inherent-method-23511.rs
+++ b/tests/rustdoc-html/primitive/search-index-primitive-inherent-method-23511.rs
@@ -5,12 +5,11 @@
 // https://github.com/rust-lang/rust/issues/23511
 #![crate_name="issue_23511"]
 
-pub mod str {
-    #![rustc_doc_primitive = "str"]
+#[rustc_doc_primitive = "str"]
+const _: () = ();
 
-    impl str {
-        //@ hasraw search.index/name/*.js foo
-        #[rustc_allow_incoherent_impl]
-        pub fn foo(&self) {}
-    }
+impl str {
+    //@ hasraw search.index/name/*.js foo
+    #[rustc_allow_incoherent_impl]
+    pub fn foo(&self) {}
 }

--- a/tests/rustdoc-html/sidebar/sidebar-all-page.rs
+++ b/tests/rustdoc-html/sidebar/sidebar-all-page.rs
@@ -31,4 +31,4 @@ pub type Type = u8;
 pub const FOO: u8 = 0;
 pub static BAR: u8 = 0;
 #[rustc_doc_primitive = "u8"]
-mod u8 {}
+const _: () = ();

--- a/tests/rustdoc-html/source-code-pages/check-source-code-urls-to-def.rs
+++ b/tests/rustdoc-html/source-code-pages/check-source-code-urls-to-def.rs
@@ -68,4 +68,4 @@ pub fn foo4() {
 
 //@ has - '//pre[@class="rust"]//a[@href="../../foo/primitive.bool.html"]' 'bool'
 #[rustc_doc_primitive = "bool"]
-mod whatever {}
+const _: () = ();

--- a/tests/rustdoc-html/stability.rs
+++ b/tests/rustdoc-html/stability.rs
@@ -160,7 +160,7 @@ pub trait UnstableTraitWithStableMethod {
 //
 /// `i32` is always stable in 1.0, even if you look at it from core.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod prim_i32 {}
+const _: () = ();
 
 //@ has stability/keyword.if.html \
 //      '//div[@class="main-heading"]//span[@class="since"]' '1.0.0'
@@ -168,4 +168,4 @@ mod prim_i32 {}
 //
 /// We currently don't document stability for keywords, but let's test it anyway.
 #[stable(feature = "rust1", since = "1.0.0")]
-mod if_keyword {}
+const _: () = ();

--- a/tests/rustdoc-html/tab_title.rs
+++ b/tests/rustdoc-html/tab_title.rs
@@ -36,10 +36,10 @@ pub mod blah {
 
 //@ has foo/keyword.continue.html '//head/title' 'continue - Rust'
 #[doc(keyword = "continue")]
-mod continue_keyword {}
+const _: () = ();
 
 //@ has foo/primitive.u8.html '//head/title' 'u8 - Rust'
 //@ !has - '//head/title' 'foo'
 #[rustc_doc_primitive = "u8"]
 /// `u8` docs
-mod u8 {}
+const _: () = ();

--- a/tests/rustdoc-html/titles.rs
+++ b/tests/rustdoc-html/titles.rs
@@ -52,7 +52,7 @@ macro_rules! foo_macro {
 //@ matches 'foo/primitive.bool.html' '//h1' 'Primitive Type bool'
 //@ count - '//*[@class="rustdoc-breadcrumbs"]' 0
 #[rustc_doc_primitive = "bool"]
-mod bool {}
+const _: () = ();
 
 //@ matches 'foo/static.FOO_STATIC.html' '//h1' 'Static FOO_STATIC'
 //@ matches - '//*[@class="rustdoc-breadcrumbs"]' 'foo'

--- a/tests/rustdoc-html/type-alias/primitive-local-link-121106.rs
+++ b/tests/rustdoc-html/type-alias/primitive-local-link-121106.rs
@@ -5,7 +5,7 @@
 //@ has foo/primitive.i32.html '//h1' 'Primitive Type i32'
 //@ has foo/index.html '//a/@href' '../foo/index.html'
 #[rustc_doc_primitive = "i32"]
-mod i32 {}
+const _: () = ();
 
 //@ has foo/struct.Node.html '//a/@href' 'primitive.i32.html'
 pub struct Node;

--- a/tests/rustdoc-json/doc_attribute.rs
+++ b/tests/rustdoc-json/doc_attribute.rs
@@ -5,14 +5,11 @@
 #![no_std]
 
 //@ !has "$.index[?(@.name=='repr')]"
-//@ has "$.index[?(@.name=='foo')]"
-
 #[doc(attribute = "repr")]
 /// this is a test!
-pub mod foo {}
+const _: () = ();
 
 //@ !has "$.index[?(@.name=='forbid')]"
-//@ !has "$.index[?(@.name=='bar')]"
 #[doc(attribute = "forbid")]
 /// hello
-mod bar {}
+const _: () = ();

--- a/tests/rustdoc-json/impls/local_for_local_primitive.rs
+++ b/tests/rustdoc-json/impls/local_for_local_primitive.rs
@@ -15,4 +15,4 @@ impl Local for bool {}
 //@ has "$.index[?(@.name=='bool')]"
 #[rustc_doc_primitive = "bool"]
 /// Boolean docs
-mod prim_bool {}
+const _: () = ();

--- a/tests/rustdoc-json/keyword.rs
+++ b/tests/rustdoc-json/keyword.rs
@@ -1,20 +1,17 @@
-// Regression test for <https://github.com/rust-lang/rust/issues/98002>.
-
-// Keywords should not be generated in rustdoc JSON output and this test
-// ensures it.
+//! Regression test for <https://github.com/rust-lang/rust/issues/98002>.
+//!
+//! Keywords should not be generated in rustdoc JSON output and this test
+//! ensures it.
 
 #![feature(rustdoc_internals)]
 #![no_std]
 
 //@ !has "$.index[?(@.name=='match')]"
-//@ has "$.index[?(@.name=='foo')]"
-
 #[doc(keyword = "match")]
 /// this is a test!
-pub mod foo {}
+const _: () = ();
 
 //@ !has "$.index[?(@.name=='break')]"
-//@ !has "$.index[?(@.name=='bar')]"
 #[doc(keyword = "break")]
 /// hello
-mod bar {}
+const _: () = ();

--- a/tests/rustdoc-json/keyword_private.rs
+++ b/tests/rustdoc-json/keyword_private.rs
@@ -1,20 +1,19 @@
-// Ensure keyword docs are present with --document-private-items
+//! Regression test for <https://github.com/rust-lang/rust/issues/98002>.
+//!
+//! Keywords should not be generated in rustdoc JSON output and this test
+//! ensures it.
 
-//@ compile-flags: --document-private-items
+//@compile-flags: --document-private-items
+
 #![feature(rustdoc_internals)]
+#![no_std]
 
 //@ !has "$.index[?(@.name=='match')]"
-//@ has  "$.index[?(@.name=='foo')]"
-//@ is   "$.index[?(@.name=='foo')].attrs[*].other" '"#[doc(keyword = \"match\")]"'
-//@ is   "$.index[?(@.name=='foo')].docs" '"this is a test!"'
 #[doc(keyword = "match")]
 /// this is a test!
-pub mod foo {}
+const _: () = ();
 
 //@ !has "$.index[?(@.name=='break')]"
-//@ has "$.index[?(@.name=='bar')]"
-//@ is   "$.index[?(@.name=='bar')].attrs[*].other" '"#[doc(keyword = \"break\")]"'
-//@ is   "$.index[?(@.name=='bar')].docs" '"hello"'
 #[doc(keyword = "break")]
 /// hello
-mod bar {}
+const _: () = ();

--- a/tests/rustdoc-json/primitives/local_primitive.rs
+++ b/tests/rustdoc-json/primitives/local_primitive.rs
@@ -3,19 +3,25 @@
 #![feature(no_core)]
 #![feature(rustc_attrs)]
 #![feature(rustdoc_internals)]
+#![feature(lang_items)]
 #![no_core]
 #![rustc_coherence_is_core]
 
 //! Link to [i32][prim@i32] [i64][prim@i64]
 
+#[lang = "pointee_sized"]
+pub trait PointeeSized {}
+
+#[lang = "meta_sized"]
+pub trait MetaSized: PointeeSized {}
+
+#[lang = "sized"]
+pub trait Sized: MetaSized {}
+
 #[rustc_doc_primitive = "i32"]
-mod prim_i32 {}
+const _: () = ();
 
 //@ set local_i32 = "$.index[?(@.name=='i32')].id"
 
 //@ has "$.index[?(@.name=='local_primitive')]"
-//@ ismany "$.index[?(@.name=='local_primitive')].inner.module.items[*]" $local_i32
 //@ is "$.index[?(@.name=='local_primitive')].links['prim@i32']" $local_i32
-
-// Let's ensure the `prim_i32` module isn't present in the output JSON:
-//@ !has "$.index[?(@.name=='prim_i32')]"

--- a/tests/rustdoc-json/primitives/primitive_impls.rs
+++ b/tests/rustdoc-json/primitives/primitive_impls.rs
@@ -35,7 +35,7 @@ impl Trait for i32 {}
 
 /// i32
 #[rustc_doc_primitive = "i32"]
-mod prim_i32 {}
+const _: () = ();
 
 //@ set i32 = "$.index[?(@.docs=='i32')].id"
 //@ is "$.index[?(@.docs=='i32')].name" '"i32"'

--- a/tests/rustdoc-json/primitives/primitive_overloading.rs
+++ b/tests/rustdoc-json/primitives/primitive_overloading.rs
@@ -5,8 +5,7 @@
 #![feature(rustc_attrs)]
 
 //@ has "$.index[?(@.name=='usize')]"
-//@ has "$.index[?(@.name=='prim')]"
 
 #[rustc_doc_primitive = "usize"]
 /// This is the built-in type `usize`.
-mod prim {}
+const _: () = ();

--- a/tests/rustdoc-json/primitives/use_primitive.rs
+++ b/tests/rustdoc-json/primitives/use_primitive.rs
@@ -3,8 +3,7 @@
 #![feature(rustc_attrs)]
 
 #[rustc_doc_primitive = "usize"]
-mod usize {}
-
+const _: () = ();
 //@ set local_crate_id = "$.index[?(@.name=='use_primitive')].crate_id"
 
 //@ has "$.index[?(@.name=='ilog10')]"

--- a/tests/rustdoc-ui/coverage/exotic.rs
+++ b/tests/rustdoc-ui/coverage/exotic.rs
@@ -9,8 +9,8 @@
 
 /// woo, check it out, we can write our own primitive docs lol
 #[rustc_doc_primitive = "unit"]
-mod prim_unit {}
+const _: () = ();
 
 /// keywords? sure, pile them on
 #[doc(keyword="where")]
-mod where_keyword {}
+const _: () = ();

--- a/tests/rustdoc-ui/doc-attribute-unsupported.rs
+++ b/tests/rustdoc-ui/doc-attribute-unsupported.rs
@@ -4,4 +4,4 @@
 
 #[doc(attribute = "diagnostic::do_not_recommend")] //~ ERROR
 /// bla
-mod yup {}
+const _: () = ();

--- a/tests/rustdoc-ui/invalid-attribute.rs
+++ b/tests/rustdoc-ui/invalid-attribute.rs
@@ -4,7 +4,7 @@
 #![feature(rustdoc_internals)]
 
 #[doc(attribute = "foo df")] //~ ERROR
-mod foo {}
+const _: () = ();
 
 #[doc(attribute = "fooyi")] //~ ERROR
-mod foo2 {}
+const _: () = ();

--- a/tests/rustdoc-ui/invalid-keyword.rs
+++ b/tests/rustdoc-ui/invalid-keyword.rs
@@ -1,4 +1,4 @@
 #![feature(rustdoc_internals)]
 
 #[doc(keyword = "foo df")] //~ ERROR
-mod foo {}
+const _: () = ();

--- a/tests/ui/feature-gates/feature-gate-rustdoc_internals.rs
+++ b/tests/ui/feature-gates/feature-gate-rustdoc_internals.rs
@@ -1,10 +1,10 @@
 #[doc(keyword = "match")] //~ ERROR: `#[doc(keyword)]` is meant for internal use only
 /// wonderful
-mod foo {}
+const _: () = ();
 
 #[doc(attribute = "repr")] //~ ERROR: `#[doc(attribute)]` is meant for internal use only
 /// wonderful
-mod foo2 {}
+const _: () = ();
 
 trait Mine {}
 

--- a/tests/ui/rustdoc/doc_keyword.rs
+++ b/tests/ui/rustdoc/doc_keyword.rs
@@ -3,21 +3,17 @@
 
 #![doc(keyword = "match")]
 //~^ ERROR `#![doc(keyword = "...")]` isn't allowed as a crate-level attribute
-#[doc(keyword = "match")] //~ ERROR `#[doc(keyword = "...")]` should be used on empty modules
-mod foo {
-    fn hell() {}
-}
 
-#[doc(keyword = "match")] //~ ERROR `#[doc(keyword = "...")]` should be used on modules
+#[doc(keyword = "match")] //~ ERROR `#[doc(keyword = "...")]` should be used on anonymous constants
 fn foo() {}
 
 
 // Regression test for the ICE described in #83512.
 trait Foo {
     #[doc(keyword = "match")]
-    //~^ ERROR: `#[doc(keyword = "...")]` should be used on modules
+    //~^ ERROR: `#[doc(keyword = "...")]` should be used on anonymous constants
     fn quux() {}
 }
 
 #[doc(keyword = "tadam")] //~ ERROR nonexistent keyword `tadam`
-mod tadam {}
+const _: () = ();

--- a/tests/ui/rustdoc/doc_keyword.stderr
+++ b/tests/ui/rustdoc/doc_keyword.stderr
@@ -5,30 +5,24 @@ LL | #![doc(keyword = "match")]
    |        ^^^^^^^
 
 error: nonexistent keyword `tadam` used in `#[doc(keyword = "...")]`
-  --> $DIR/doc_keyword.rs:22:17
+  --> $DIR/doc_keyword.rs:18:17
    |
 LL | #[doc(keyword = "tadam")]
    |                 ^^^^^^^
    |
    = help: only existing keywords are allowed in core/std
 
-error: `#[doc(keyword = "...")]` should be used on empty modules
-  --> $DIR/doc_keyword.rs:6:7
+error: `#[doc(keyword = "...")]` should be used on anonymous constants
+  --> $DIR/doc_keyword.rs:7:7
    |
 LL | #[doc(keyword = "match")]
    |       ^^^^^^^
 
-error: `#[doc(keyword = "...")]` should be used on modules
-  --> $DIR/doc_keyword.rs:11:7
-   |
-LL | #[doc(keyword = "match")]
-   |       ^^^^^^^
-
-error: `#[doc(keyword = "...")]` should be used on modules
-  --> $DIR/doc_keyword.rs:17:11
+error: `#[doc(keyword = "...")]` should be used on anonymous constants
+  --> $DIR/doc_keyword.rs:13:11
    |
 LL |     #[doc(keyword = "match")]
    |           ^^^^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/rustdoc/feature-gate-doc_primitive.rs
+++ b/tests/ui/rustdoc/feature-gate-doc_primitive.rs
@@ -3,6 +3,6 @@
 //~| NOTE the `rustc_doc_primitive` attribute is an internal implementation detail that will never be stable
 //~| NOTE the `rustc_doc_primitive` attribute is used by the standard library to provide a way to generate documentation for primitive types
 /// Some docs
-mod usize {}
+const _: () = ();
 
 fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160288)*
<!-- homu-ignore:end -->

For context: [#t-rustdoc > hiding fake_item modules. @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/266220-t-rustdoc/topic/hiding.20fake_item.20modules.2E/near/612115954)

r? @GuillaumeGomez 

I've rendered the standard library docs and prims/kws/attrs all show up as normal.

However I could not figure out how to run some of the tests, so this may be a bit of CI-debugging for me :(