### PR TITLE
Avoid region checking with unnormalized param env

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -185,6 +185,24 @@ where
     let assumed_wf_types = wfcx.ocx.assumed_wf_types_and_report_errors(param_env, body_def_id)?;
     debug!(?assumed_wf_types);
 
+    // Parameter environment normalization reports an error and falls back to the
+    // unnormalized environment when normalization fails. Do not pass such an
+    // environment to region checking with the next trait solver.
+    if infcx.next_trait_solver()
+        && param_env.caller_bounds().iter().any(|clause| {
+            clause
+                .as_type_outlives_clause()
+                .is_some_and(|type_outlives| type_outlives.has_non_rigid_aliases())
+        })
+    {
+        return Err(tcx.dcx().has_errors().unwrap_or_else(|| {
+            tcx.dcx().span_delayed_bug(
+                tcx.def_span(body_def_id),
+                "unnormalized type-outlives predicate in parameter environment",
+            )
+        }));
+    }
+
     let infcx_compat = infcx.fork();
 
     // We specifically want to *disable* the implied bounds hack, first,

--- a/tests/ui/traits/next-solver/normalize/unnormalized-param-env-issue-160196.rs
+++ b/tests/ui/traits/next-solver/normalize/unnormalized-param-env-issue-160196.rs
@@ -1,0 +1,28 @@
+//@ compile-flags: -Znext-solver
+//@ check-fail
+
+trait Trait1 {
+    type Assoc1;
+}
+
+struct Indir;
+
+trait Trait2 {
+    type Assoc2;
+}
+
+impl<T> Trait2 for T
+//~^ ERROR the trait bound `Indir: Trait1` is not satisfied
+//~| ERROR the trait bound `T: Trait2` is not satisfied
+where
+    T: Trait1,
+    T::Assoc1: 'static,
+    T: Trait1<Assoc1 = <Indir as Trait1>::Assoc1>,
+    //~^ ERROR the trait bound `Indir: Trait1` is not satisfied
+{
+    type Assoc2 = ();
+    //~^ ERROR the trait bound `Indir: Trait1` is not satisfied
+    //~| ERROR the trait bound `T: Trait2` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/normalize/unnormalized-param-env-issue-160196.stderr
+++ b/tests/ui/traits/next-solver/normalize/unnormalized-param-env-issue-160196.stderr
@@ -1,0 +1,82 @@
+error[E0277]: the trait bound `Indir: Trait1` is not satisfied
+  --> $DIR/unnormalized-param-env-issue-160196.rs:14:1
+   |
+LL | / impl<T> Trait2 for T
+LL | |
+LL | |
+LL | | where
+LL | |     T: Trait1,
+LL | |     T::Assoc1: 'static,
+LL | |     T: Trait1<Assoc1 = <Indir as Trait1>::Assoc1>,
+   | |__________________________________________________^ unsatisfied trait bound
+   |
+help: the trait `Trait1` is not implemented for `Indir`
+  --> $DIR/unnormalized-param-env-issue-160196.rs:8:1
+   |
+LL | struct Indir;
+   | ^^^^^^^^^^^^
+help: this trait has no implementations, consider adding one
+  --> $DIR/unnormalized-param-env-issue-160196.rs:4:1
+   |
+LL | trait Trait1 {
+   | ^^^^^^^^^^^^
+
+error[E0277]: the trait bound `Indir: Trait1` is not satisfied
+  --> $DIR/unnormalized-param-env-issue-160196.rs:23:5
+   |
+LL |     type Assoc2 = ();
+   |     ^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `Trait1` is not implemented for `Indir`
+  --> $DIR/unnormalized-param-env-issue-160196.rs:8:1
+   |
+LL | struct Indir;
+   | ^^^^^^^^^^^^
+help: this trait has no implementations, consider adding one
+  --> $DIR/unnormalized-param-env-issue-160196.rs:4:1
+   |
+LL | trait Trait1 {
+   | ^^^^^^^^^^^^
+
+error[E0277]: the trait bound `T: Trait2` is not satisfied
+  --> $DIR/unnormalized-param-env-issue-160196.rs:23:19
+   |
+LL |     type Assoc2 = ();
+   |                   ^^ the trait `Trait2` is not implemented for `T`
+   |
+help: consider further restricting type parameter `T` with trait `Trait2`
+   |
+LL |     T: Trait1 + Trait2,
+   |               ++++++++
+
+error[E0277]: the trait bound `T: Trait2` is not satisfied
+  --> $DIR/unnormalized-param-env-issue-160196.rs:14:20
+   |
+LL | impl<T> Trait2 for T
+   |                    ^ the trait `Trait2` is not implemented for `T`
+   |
+help: consider further restricting type parameter `T` with trait `Trait2`
+   |
+LL |     T: Trait1 + Trait2,
+   |               ++++++++
+
+error[E0277]: the trait bound `Indir: Trait1` is not satisfied
+  --> $DIR/unnormalized-param-env-issue-160196.rs:20:15
+   |
+LL |     T: Trait1<Assoc1 = <Indir as Trait1>::Assoc1>,
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `Trait1` is not implemented for `Indir`
+  --> $DIR/unnormalized-param-env-issue-160196.rs:8:1
+   |
+LL | struct Indir;
+   | ^^^^^^^^^^^^
+help: this trait has no implementations, consider adding one
+  --> $DIR/unnormalized-param-env-issue-160196.rs:4:1
+   |
+LL | trait Trait1 {
+   | ^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
fixes rust-lang/rust#160196