### PR TITLE
Fix rustdoc ICE when checking if a generic arg can be elided

### DIFF
--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -117,6 +117,8 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
     };
 
     let mut elision_has_failed_once_before = false;
+
+    // Calculates where the parent trait's generic parameters end
     let index_offset = generics.count() - args.len();
     let clean_arg = |(index, &arg): (usize, &ty::GenericArg<'tcx>)| {
         // Elide the self type.
@@ -124,6 +126,7 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
             return None;
         }
 
+        // Skips over the parent trait's generic parameters
         let param = generics.param_at(index + index_offset, cx.tcx);
         let arg = ty::Binder::bind_with_vars(arg, bound_vars);
 

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -117,18 +117,19 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
     };
 
     let mut elision_has_failed_once_before = false;
+    let index_offset = generics.count() - args.len();
     let clean_arg = |(index, &arg): (usize, &ty::GenericArg<'tcx>)| {
         // Elide the self type.
         if has_self && index == 0 {
             return None;
         }
 
-        let param = generics.param_at(index, cx.tcx);
+        let param = generics.param_at(index + index_offset, cx.tcx);
         let arg = ty::Binder::bind_with_vars(arg, bound_vars);
 
         // Elide arguments that coincide with their default.
         if !elision_has_failed_once_before && let Some(default) = param.default_value(cx.tcx) {
-            let default = default.instantiate(cx.tcx, args.as_ref()).skip_norm_wip();
+            let default = default.instantiate(cx.tcx, args.as_ref()).skip_normalization();
             if can_elide_generic_arg(arg, arg.rebind(default)) {
                 return None;
             }

--- a/tests/rustdoc-ui/ice-clean-generic-args-133637.rs
+++ b/tests/rustdoc-ui/ice-clean-generic-args-133637.rs
@@ -5,14 +5,8 @@
 // Regression test for issue #133637. Previously we would index into the flattened generics list
 // with the children generic indexes. This resulted in an ICE when debug assertions were on.
 
-struct SomeDefault;
-
-trait SomeTrait<Default = SomeDefault> {
+trait Trait<Default = ()> {
     type Type<'a, 'b>;
 }
 
-impl<B, T> SomeTrait<B> for T {
-    type Type<'a, 'b> = (&'a u8, &'b u8);
-}
-
-type SomeType<'a, 'b, T, Gen = SomeDefault> = <T as SomeTrait<Gen>>::Type<'a, 'b>;
+type Type<T> = <T as Trait>::Type<'static, 'static>;

--- a/tests/rustdoc-ui/ice-clean-generic-args-133637.rs
+++ b/tests/rustdoc-ui/ice-clean-generic-args-133637.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+// https://github.com/rust-lang/rust/issues/133637
+#![crate_name="foo"]
+
+// Regression test for issue #133637. Previously we would index into the flattened generics list
+// with the children generic indexes. This resulted in an ICE when debug assertions were on.
+
+struct SomeDefault;
+
+trait SomeTrait<Default = SomeDefault> {
+    type Type<'a, 'b>;
+}
+
+impl<B, T> SomeTrait<B> for T {
+    type Type<'a, 'b> = (&'a u8, &'b u8);
+}
+
+type SomeType<'a, 'b, T, Gen = SomeDefault> = <T as SomeTrait<Gen>>::Type<'a, 'b>;


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160295)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#133637

The `param_at` call expects a index into the full generics list, while index is generated only from the children.

I also noticed a call to `skip_norm_wip` so I replaced that with `skip_normalization`

I have one question about adding the regression test, should it live under rustdoc-ui or rustdoc-ui/issue. I will add it later today. 

@fmease