### PR TITLE
Stabilize `bool::toggle`

### DIFF
--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -140,7 +140,6 @@ impl bool {
     /// # Examples
     ///
     /// ```
-    /// #![feature(bool_toggle)]
     /// let mut boolean = false;
     ///
     /// boolean.toggle();
@@ -152,7 +151,7 @@ impl bool {
     ///
     /// [`true`]: ../std/keyword.true.html
     /// [`false`]: ../std/keyword.false.html
-    #[unstable(feature = "bool_toggle", issue = "159298")]
+    #[stable(feature = "bool_toggle", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub const fn toggle(&mut self) {
         *self = !*self;

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -152,6 +152,7 @@ impl bool {
     /// [`true`]: ../std/keyword.true.html
     /// [`false`]: ../std/keyword.false.html
     #[stable(feature = "bool_toggle", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "bool_toggle", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub const fn toggle(&mut self) {
         *self = !*self;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Hooray, my first stabilization! (It's not much, but it's a start!)

As mentioned in https://github.com/rust-lang/rust/issues/159298#issuecomment-5036515342 this should probably not be merged before 1.100 to give it time to simmer in nightly-only for a release.

@rustbot modify labels: +T-libs-api
Closes rust-lang/rust#159298