### PR TITLE
target_features: sse (or at least avx2) is incompatible with soft-float ABI

### DIFF
--- a/compiler/rustc_codegen_ssa/src/diagnostics.rs
+++ b/compiler/rustc_codegen_ssa/src/diagnostics.rs
@@ -1194,6 +1194,12 @@ pub(crate) struct XcrunSdkPathWarning {
 pub(crate) struct Aarch64SoftfloatNeon;
 
 #[derive(Diagnostic)]
+#[diag(
+    "enabling the `sse` target feature on the current target is unsupported due to LLVM backend issues"
+)]
+pub(crate) struct X86SoftfloatSse;
+
+#[derive(Diagnostic)]
 #[diag("ignoring feature with missing prefix in `-Ctarget-feature`: `{$feature}`")]
 #[note("features must begin with a `+` to enable or `-` to disable it")]
 pub(crate) struct UnknownCTargetFeaturePrefix<'a> {

--- a/compiler/rustc_codegen_ssa/src/diagnostics.rs
+++ b/compiler/rustc_codegen_ssa/src/diagnostics.rs
@@ -1198,6 +1198,12 @@ pub(crate) struct XcrunSdkPathWarning {
 pub(crate) struct Aarch64SoftfloatNeon;
 
 #[derive(Diagnostic)]
+#[diag(
+    "enabling the `sse` target feature on the current target is unsupported due to LLVM backend issues"
+)]
+pub(crate) struct X86SoftfloatSse;
+
+#[derive(Diagnostic)]
 #[diag("ignoring feature with missing prefix in `-Ctarget-feature`: `{$feature}`")]
 #[note("features must begin with a `+` to enable or `-` to disable it")]
 pub(crate) struct UnknownCTargetFeaturePrefix<'a> {

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -3,7 +3,7 @@ use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_hir::attrs::InstructionSetAttr;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
-use rustc_lint_defs::builtin::AARCH64_SOFTFLOAT_NEON;
+use rustc_lint_defs::builtin::{AARCH64_SOFTFLOAT_NEON, X86_SOFTFLOAT_SSE};
 use rustc_middle::middle::codegen_fn_attrs::{TargetFeature, TargetFeatureKind};
 use rustc_middle::query::Providers;
 use rustc_middle::ty::TyCtxt;
@@ -99,12 +99,23 @@ pub(crate) fn from_target_feature_attr(
                     if abi_feature_constraints.incompatible.contains(&name.as_str()) {
                         // For "neon" specifically, we emit an FCW instead of a hard error.
                         // See <https://github.com/rust-lang/rust/issues/134375>.
+                        // Similar for "sse" on x86.
+                        // See <https://github.com/rust-lang/rust/issues/117938>.
                         if tcx.sess.target.arch == Arch::AArch64 && name.as_str() == "neon" {
                             tcx.emit_node_span_lint(
                                 AARCH64_SOFTFLOAT_NEON,
                                 tcx.local_def_id_to_hir_id(did),
                                 feature_span,
                                 diagnostics::Aarch64SoftfloatNeon,
+                            );
+                        } else if matches!(tcx.sess.target.arch, Arch::X86 | Arch::X86_64)
+                            && name.as_str() == "sse"
+                        {
+                            tcx.emit_node_span_lint(
+                                X86_SOFTFLOAT_SSE,
+                                tcx.local_def_id_to_hir_id(did),
+                                feature_span,
+                                diagnostics::X86SoftfloatSse,
                             );
                         } else {
                             tcx.dcx().emit_err(diagnostics::InternalOnlyTargetFeatureAttr {

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -8,7 +8,7 @@ use rustc_middle::query::Providers;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_session::diagnostics::feature_err;
-use rustc_session::lint::builtin::AARCH64_SOFTFLOAT_NEON;
+use rustc_session::lint::builtin::{AARCH64_SOFTFLOAT_NEON, X86_SOFTFLOAT_SSE};
 use rustc_span::{Span, Symbol, edit_distance, sym};
 use rustc_target::spec::{Arch, SanitizerSet};
 use rustc_target::target_features::{RUSTC_SPECIFIC_FEATURES, Stability};
@@ -99,12 +99,23 @@ pub(crate) fn from_target_feature_attr(
                     if abi_feature_constraints.incompatible.contains(&name.as_str()) {
                         // For "neon" specifically, we emit an FCW instead of a hard error.
                         // See <https://github.com/rust-lang/rust/issues/134375>.
+                        // Similar for "sse" on x86.
+                        // See <https://github.com/rust-lang/rust/issues/117938>.
                         if tcx.sess.target.arch == Arch::AArch64 && name.as_str() == "neon" {
                             tcx.emit_node_span_lint(
                                 AARCH64_SOFTFLOAT_NEON,
                                 tcx.local_def_id_to_hir_id(did),
                                 feature_span,
                                 diagnostics::Aarch64SoftfloatNeon,
+                            );
+                        } else if matches!(tcx.sess.target.arch, Arch::X86 | Arch::X86_64)
+                            && name.as_str() == "sse"
+                        {
+                            tcx.emit_node_span_lint(
+                                X86_SOFTFLOAT_SSE,
+                                tcx.local_def_id_to_hir_id(did),
+                                feature_span,
+                                diagnostics::X86SoftfloatSse,
                             );
                         } else {
                             tcx.dcx().emit_err(diagnostics::ForbiddenTargetFeatureAttr {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -157,6 +157,7 @@ pub mod hardwired {
             USELESS_DEPRECATED,
             VARARGS_WITHOUT_PATTERN,
             WARNINGS,
+            X86_SOFTFLOAT_SSE,
             // tidy-alphabetical-end
         ]
     }
@@ -5371,6 +5372,45 @@ declare_lint! {
     "detects code that could be affected by ABI issues on aarch64 softfloat targets",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #134375),
+        report_in_deps: true,
+    };
+}
+
+declare_lint! {
+    /// The `x86_softfloat_sse` lint detects usage of `#[target_feature(enable = "sse")]` or target
+    /// features that imply SSE on softfloat x86 and x86-64 targets. Enabling this target feature
+    /// in a soft-float configuration is not supported by LLVM and can lead to crashes.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore (needs x86_64-unknown-none)
+    /// #[target_feature(enable = "avx")]
+    /// fn with_avx() {}
+    /// ```
+    ///
+    /// This will produce:
+    ///
+    /// ```text
+    /// error: enabling the `sse` target feature on the current target is unsupported due to LLVM backend issues
+    ///   --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:11:18
+    ///    |
+    ///    | #[target_feature(enable = "avx")]
+    ///    |                  ^^^^^^^^^^^^^^^
+    ///    |
+    ///    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    ///    = note: for more information, see issue #117938 <https://github.com/rust-lang/rust/issues/117938>
+    /// ```
+    ///
+    /// ### Explanation
+    ///
+    /// LLVM does not support combining the `soft-float` target feature (which is implicitly enabled
+    /// on these targets) with `sse`. This can lead to crashes of the backend. To prevent that,
+    /// Rust is turning that combination into an error.
+    pub X86_SOFTFLOAT_SSE,
+    Warn,
+    "detects code that could be affected by LLVM backend issues on x86 softfloat targets",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: fcw!(FutureReleaseError #117938),
         report_in_deps: true,
     };
 }

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -5368,7 +5368,7 @@ declare_lint! {
     /// on this target due to this issue, but the problem was not known at the time of
     /// stabilization.
     pub AARCH64_SOFTFLOAT_NEON,
-    Warn,
+    Deny,
     "detects code that could be affected by ABI issues on aarch64 softfloat targets",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #134375),
@@ -5407,7 +5407,7 @@ declare_lint! {
     /// on these targets) with `sse`. This can lead to crashes of the backend. To prevent that,
     /// Rust is turning that combination into an error.
     pub X86_SOFTFLOAT_SSE,
-    Warn,
+    Deny,
     "detects code that could be affected by LLVM backend issues on x86 softfloat targets",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #117938),

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -157,6 +157,7 @@ pub mod hardwired {
             USELESS_DEPRECATED,
             VARARGS_WITHOUT_PATTERN,
             WARNINGS,
+            X86_SOFTFLOAT_SSE,
             // tidy-alphabetical-end
         ]
     }
@@ -5374,6 +5375,45 @@ declare_lint! {
     "detects code that could be affected by ABI issues on aarch64 softfloat targets",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #134375),
+        report_in_deps: true,
+    };
+}
+
+declare_lint! {
+    /// The `x86_softfloat_sse` lint detects usage of `#[target_feature(enable = "sse")]` or target
+    /// features that imply SSE on softfloat x86 and x86-64 targets. Enabling this target feature
+    /// in a soft-float configuration is not supported by LLVM and can lead to crashes.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore (needs x86_64-unknown-none)
+    /// #[target_feature(enable = "avx")]
+    /// fn with_avx() {}
+    /// ```
+    ///
+    /// This will produce:
+    ///
+    /// ```text
+    /// error: enabling the `sse` target feature on the current target is unsupported due to LLVM backend issues
+    ///   --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:11:18
+    ///    |
+    ///    | #[target_feature(enable = "avx")]
+    ///    |                  ^^^^^^^^^^^^^^^
+    ///    |
+    ///    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    ///    = note: for more information, see issue #117938 <https://github.com/rust-lang/rust/issues/117938>
+    /// ```
+    ///
+    /// ### Explanation
+    ///
+    /// LLVM does not support combining the `soft-float` target feature (which is implicitly enabled
+    /// on these targets) with `sse`. This can lead to crashes of the backend. To prevent that,
+    /// Rust is turning that combination into an error.
+    pub X86_SOFTFLOAT_SSE,
+    Warn,
+    "detects code that could be affected by LLVM backend issues on x86 softfloat targets",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: fcw!(FutureReleaseError #117938),
         report_in_deps: true,
     };
 }

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -5371,7 +5371,7 @@ declare_lint! {
     /// on this target due to this issue, but the problem was not known at the time of
     /// stabilization.
     pub AARCH64_SOFTFLOAT_NEON,
-    Warn,
+    Deny,
     "detects code that could be affected by ABI issues on aarch64 softfloat targets",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #134375),
@@ -5410,7 +5410,7 @@ declare_lint! {
     /// on these targets) with `sse`. This can lead to crashes of the backend. To prevent that,
     /// Rust is turning that combination into an error.
     pub X86_SOFTFLOAT_SSE,
-    Warn,
+    Deny,
     "detects code that could be affected by LLVM backend issues on x86 softfloat targets",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #117938),

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -1293,7 +1293,9 @@ impl Target {
                         // `x87` and all other FPU features so those do not matter.
                         // Note that this one requirement is the entire implementation of the ABI!
                         // LLVM handles the rest.
-                        FeatureConstraints { required: &["soft-float"], incompatible: &[] }
+                        // We mark "sse" as incompatible since LLVM likes to crash when both
+                        // "soft-float" and "sse" are enabled.
+                        FeatureConstraints { required: &["soft-float"], incompatible: &["sse"] }
                     }
                     _ => unreachable!(),
                 }
@@ -1314,7 +1316,9 @@ impl Target {
                         // `x87` and all other FPU features so those do not matter.
                         // Note that this one requirement is the entire implementation of the ABI!
                         // LLVM handles the rest.
-                        FeatureConstraints { required: &["soft-float"], incompatible: &[] }
+                        // We mark "sse" as incompatible since LLVM likes to crash when both
+                        // "soft-float" and "sse" are enabled.
+                        FeatureConstraints { required: &["soft-float"], incompatible: &["sse"] }
                     }
                     _ => unreachable!(),
                 }

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -1250,7 +1250,9 @@ impl Target {
                         // `x87` and all other FPU features so those do not matter.
                         // Note that this one requirement is the entire implementation of the ABI!
                         // LLVM handles the rest.
-                        FeatureConstraints { required: &["soft-float"], incompatible: &[] }
+                        // We mark "sse" as incompatible since LLVM likes to crash when both
+                        // "soft-float" and "sse" are enabled.
+                        FeatureConstraints { required: &["soft-float"], incompatible: &["sse"] }
                     }
                     _ => unreachable!(),
                 }
@@ -1271,7 +1273,9 @@ impl Target {
                         // `x87` and all other FPU features so those do not matter.
                         // Note that this one requirement is the entire implementation of the ABI!
                         // LLVM handles the rest.
-                        FeatureConstraints { required: &["soft-float"], incompatible: &[] }
+                        // We mark "sse" as incompatible since LLVM likes to crash when both
+                        // "soft-float" and "sse" are enabled.
+                        FeatureConstraints { required: &["soft-float"], incompatible: &["sse"] }
                     }
                     _ => unreachable!(),
                 }

--- a/library/portable-simd/crates/core_simd/src/swizzle_dyn.rs
+++ b/library/portable-simd/crates/core_simd/src/swizzle_dyn.rs
@@ -1,3 +1,7 @@
+// Allow these FCW: anyone soundly using the intrinsics has to enable
+// the target feature, and that will generate a warning for them.
+#![allow(aarch64_softfloat_neon, x86_softfloat_sse)]
+
 use crate::simd::Simd;
 use core::mem;
 

--- a/library/stdarch/crates/core_arch/src/aarch64/mod.rs
+++ b/library/stdarch/crates/core_arch/src/aarch64/mod.rs
@@ -6,13 +6,6 @@
 //! [arm_ref]: http://infocenter.arm.com/help/topic/com.arm.doc.ihi0073a/IHI0073A_arm_neon_intrinsics_ref.pdf
 //! [arm_dat]: https://developer.arm.com/technologies/neon/intrinsics
 
-#![cfg_attr(
-    all(target_arch = "aarch64", target_abi = "softfloat"),
-    // Just allow the warning: anyone soundly using the intrinsics has to enable
-    // the target feature, and that will generate a warning for them.
-    allow(aarch64_softfloat_neon)
-)]
-
 mod mte;
 #[unstable(feature = "stdarch_aarch64_mte", issue = "129010")]
 pub use self::mte::*;

--- a/library/stdarch/crates/core_arch/src/arm_shared/mod.rs
+++ b/library/stdarch/crates/core_arch/src/arm_shared/mod.rs
@@ -47,12 +47,6 @@
 //!
 //! - [ACLE Q2 2018](https://developer.arm.com/docs/101028/latest)
 
-#![cfg_attr(
-    all(target_arch = "aarch64", target_abi = "softfloat"),
-    // Just allow the warning: anyone soundly using the intrinsics has to enable
-    // the target feature, and that will generate a warning for them.
-    allow(aarch64_softfloat_neon)
-)]
 // Only for 'neon' submodule
 #![allow(non_camel_case_types)]
 

--- a/library/stdarch/crates/core_arch/src/mod.rs
+++ b/library/stdarch/crates/core_arch/src/mod.rs
@@ -1,6 +1,9 @@
 //! `core_arch`
 
 #![allow(unknown_lints, unnecessary_transmutes)]
+// Allow these FCW: anyone soundly using the intrinsics has to enable
+// the target feature, and that will generate a warning for them.
+#![allow(aarch64_softfloat_neon, x86_softfloat_sse)]
 
 #[macro_use]
 mod macros;

--- a/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.aarch64.stderr
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.aarch64.stderr
@@ -1,31 +1,31 @@
 error: enabling the `neon` target feature on the current target is unsound due to ABI issues
-  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:13:18
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:16:36
    |
-LL | #[target_feature(enable = "neon")]
-   |                  ^^^^^^^^^^^^^^^
+LL | #[cfg_attr(aarch64, target_feature(enable = "neon"))]
+   |                                    ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #134375 <https://github.com/rust-lang/rust/issues/134375>
 note: the lint level is defined here
-  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:8:9
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:11:9
    |
-LL | #![deny(aarch64_softfloat_neon)]
+LL | #![deny(aarch64_softfloat_neon, x86_softfloat_sse)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
 error: enabling the `neon` target feature on the current target is unsound due to ABI issues
-  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:13:18
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:16:36
    |
-LL | #[target_feature(enable = "neon")]
-   |                  ^^^^^^^^^^^^^^^
+LL | #[cfg_attr(aarch64, target_feature(enable = "neon"))]
+   |                                    ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #134375 <https://github.com/rust-lang/rust/issues/134375>
 note: the lint level is defined here
-  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:8:9
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:11:9
    |
-LL | #![deny(aarch64_softfloat_neon)]
+LL | #![deny(aarch64_softfloat_neon, x86_softfloat_sse)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.rs
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.rs
@@ -1,16 +1,22 @@
 //@ compile-flags: --crate-type=lib
-//@ compile-flags: --target=aarch64-unknown-none-softfloat
-//@ needs-llvm-components: aarch64
+//@ revisions: aarch64 x86_64
+//@[aarch64] compile-flags: --target=aarch64-unknown-none-softfloat
+//@[aarch64] needs-llvm-components: aarch64
+//@[x86_64] compile-flags: --target=x86_64-unknown-none
+//@[x86_64] needs-llvm-components: x86
 //@ add-minicore
 //@ ignore-backends: gcc
 #![feature(no_core)]
 #![no_core]
-#![deny(aarch64_softfloat_neon)]
+#![deny(aarch64_softfloat_neon, x86_softfloat_sse)]
 
 extern crate minicore;
 use minicore::*;
 
-#[target_feature(enable = "neon")]
-//~^ERROR: enabling the `neon` target feature on the current target is unsound
-//~|WARN: previously accepted
+#[cfg_attr(aarch64, target_feature(enable = "neon"))]
+//[aarch64]~^ERROR: enabling the `neon` target feature on the current target is unsound
+//[aarch64]~|WARN: previously accepted
+#[cfg_attr(x86_64, target_feature(enable = "avx"))]
+//[x86_64]~^ERROR: enabling the `sse` target feature on the current target is unsupported
+//[x86_64]~|WARN: previously accepted
 pub unsafe fn my_fun() {}

--- a/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.x86_64.stderr
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-attribute-fcw.x86_64.stderr
@@ -1,0 +1,31 @@
+error: enabling the `sse` target feature on the current target is unsupported due to LLVM backend issues
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:19:35
+   |
+LL | #[cfg_attr(x86_64, target_feature(enable = "avx"))]
+   |                                   ^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #117938 <https://github.com/rust-lang/rust/issues/117938>
+note: the lint level is defined here
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:11:33
+   |
+LL | #![deny(aarch64_softfloat_neon, x86_softfloat_sse)]
+   |                                 ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: enabling the `sse` target feature on the current target is unsupported due to LLVM backend issues
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:19:35
+   |
+LL | #[cfg_attr(x86_64, target_feature(enable = "avx"))]
+   |                                   ^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #117938 <https://github.com/rust-lang/rust/issues/117938>
+note: the lint level is defined here
+  --> $DIR/abi-incompatible-target-feature-attribute-fcw.rs:11:33
+   |
+LL | #![deny(aarch64_softfloat_neon, x86_softfloat_sse)]
+   |                                 ^^^^^^^^^^^^^^^^^
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160302)*
<!-- homu-ignore:end -->

Fixes https://github.com/rust-lang/rust/issues/117938

Enabling both the avx2 and soft-float target features is [not supported by LLVM](https://github.com/rust-lang/rust/issues/117938#issuecomment-1812742490) and can crash the backend. Let's preempt that with rust-level checks. (I still think there's also an LLVM bug here, it shouldn't just SIGILL on unexpected target feature configurations, but that's a different discussion.)


What is not clear to me is whether this just affects just avx2 or also avx or even sse (we don't support mmx/3dnow separately).  @dianqk do you know more about this? To be safe, let's reject "sse" and therefore by implication also all other x86 vector target features.

This PR turns `#[target_feature(enable = "sse")]` on a softfloat target into an FCW similar to what we do on aarch64 (see https://github.com/rust-lang/rust/pull/135160). The FCW only affects people building for soft-float targets which is a fairly small percentage of our overall users (and which means we cannot meaningfully crater this). I hence went for "report in deps" immediately so that the people building the actual binaries see these warnings that their upstreams probably will never see.