### PR TITLE
Update `minifier` version to `0.4.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1261,7 +1261,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1388,7 +1388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2166,7 +2166,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2515,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "minifier"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f1541610994bba178cb36757e102d06a52a2d9612aa6d34c64b3b377c5d943"
+checksum = "245c950e30794ed20f72ff60c85ae1cddb0ba54fda4623017a678943f98f636c"
 
 [[package]]
 name = "minimal-lexical"
@@ -2653,7 +2653,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5085,7 +5085,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5517,7 +5517,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5536,7 +5536,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6514,7 +6514,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -14,7 +14,7 @@ askama = { version = "0.16.0", default-features = false, features = ["alloc", "c
 base64 = "0.21.7"
 indexmap = { version = "2", features = ["serde"] }
 itertools = "0.15"
-minifier = { version = "0.3.5", default-features = false }
+minifier = { version = "0.4.0", default-features = false }
 proc-macro2 = "1.0.103"
 pulldown-cmark-escape = { version = "0.11.0", features = ["simd"] }
 regex = "1"
@@ -37,7 +37,7 @@ features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"]
 
 [build-dependencies]
 sha2 = "0.10.8"
-minifier = { version = "0.3.2", default-features = false }
+minifier = { version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 expect-test = "1.4.0"

--- a/src/librustdoc/build.rs
+++ b/src/librustdoc/build.rs
@@ -57,7 +57,7 @@ fn main() {
             let minified: String = if path.ends_with(".css") {
                 minifier::css::minify(str::from_utf8(&data_bytes).unwrap()).unwrap().to_string()
             } else {
-                minifier::js::minify(str::from_utf8(&data_bytes).unwrap()).to_string()
+                minifier::js::minify(str::from_utf8(&data_bytes).unwrap()).unwrap().to_string()
             };
             std::fs::write(&minified_path, minified.as_bytes()).expect("write to out_dir");
         } else {


### PR DESCRIPTION
Contains security fix added by @Eh2406 done in https://github.com/GuillaumeGomez/minifier-rs/pull/130.

r? ghost