### PR TITLE
Make the noundef-on-Cast size guard explicit

### DIFF
--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -529,6 +529,26 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
             PassMode::Cast { cast: Box::new(target.into().with_attrs(attrs)), pad_i32: false };
     }
 
+    /// Cast to `target`, forwarding `NoUndef` only when the layout provably has no uninit
+    /// bytes *and* the cast exactly covers the layout (`target.size(cx) == self.layout.size`).
+    /// A wider cast (e.g. `Uniform::new` rounding a 3-byte aggregate up to an `i32`) covers
+    /// undef padding bytes that must not be marked `noundef`; a narrower cast does not occur,
+    /// since a `PassMode::Cast` target always covers the whole value.
+    pub fn cast_to_maybe_noundef<T, C>(&mut self, target: T, cx: &C)
+    where
+        T: Into<CastTarget>,
+        Ty: TyAbiInterface<'a, C> + Copy,
+        C: HasDataLayout,
+    {
+        let target = target.into();
+        let attr = if layout_is_noundef(self.layout, cx) && target.size(cx) == self.layout.size {
+            ArgAttribute::NoUndef
+        } else {
+            ArgAttribute::default()
+        };
+        self.cast_to_with_attrs(target, attr.into());
+    }
+
     pub fn cast_to_and_pad_i32<T: Into<CastTarget>>(&mut self, target: T, pad_i32: bool) {
         self.mode = PassMode::Cast { cast: Box::new(target.into()), pad_i32 };
     }
@@ -837,12 +857,7 @@ impl<'a, Ty> FnAbi<'a, Ty> {
                         // We want to pass small aggregates as immediates, but using
                         // an LLVM aggregate type for this leads to bad optimizations,
                         // so we pick an appropriately sized integer type instead.
-                        let attr = if layout_is_noundef(arg.layout, cx) {
-                            ArgAttribute::NoUndef
-                        } else {
-                            ArgAttribute::default()
-                        };
-                        arg.cast_to_with_attrs(Reg { kind: RegKind::Integer, size }, attr.into());
+                        arg.cast_to_maybe_noundef(Reg { kind: RegKind::Integer, size }, cx);
                     } else if self.conv == CanonAbi::RustTail {
                         assert!(arg.layout.is_sized(), "extern \"tail\" arguments must be sized");
                         arg.pass_by_stack_offset(None);


### PR DESCRIPTION
`ArgAbi::cast_to` drops the argument's `ArgAttributes`. rust-lang/rust#152864 restored `noundef` on `PassMode::Cast` for the Rust ABI by re-adding it via `cast_to_with_attrs` when `layout_is_noundef` is true.

This works today because `adjust_for_rust_abi` constructs a `Reg { Integer, size }` with `size == layout.size`. However, this assumption isn't guarded anywhere - if this pattern gets reused where a cast is wider than the layout (like foreign ABIs using `Uniform::new` rounding up), padding bytes would be incorrectly marked as `noundef`.

This PR adds an explicit size check via a new `ArgAbi::cast_to_maybe_noundef` helper, which only emits `NoUndef` if `layout_is_noundef(layout)` and `cast.size(cx) <= layout.size`.

No functional change intended. Existing tests (like `abi-noundef-cast`) continue to pass.

Split out from the foreign-ABI work per the Zulip thread; foreign `Reg::iN` sites will reuse this helper in a follow-up PR.

r? @RalfJung