### PR TITLE
fix borrowck ICE for consts with fn pointer type

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -4277,7 +4277,8 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
     ) -> Option<AnnotatedBorrowFnSignature<'tcx>> {
         // Define a fallback for when we can't match a closure.
         let fallback = || {
-            let is_closure = self.infcx.tcx.is_closure_like(self.mir_def_id().to_def_id());
+            let tcx = self.infcx.tcx;
+            let is_closure = tcx.is_closure_like(self.mir_def_id().to_def_id());
             if is_closure {
                 None
             } else {
@@ -4288,7 +4289,7 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
                     .instantiate_identity()
                     .skip_norm_wip();
                 match ty.kind() {
-                    ty::FnDef(_, _) | ty::FnPtr(..) => self.annotate_fn_sig(
+                    ty::FnDef(_, _) => self.annotate_fn_sig(
                         self.mir_def_id(),
                         self.infcx
                             .tcx
@@ -4296,6 +4297,8 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
                             .instantiate_identity()
                             .skip_norm_wip(),
                     ),
+                    // a const/static can have a fn ptr type, take the sig from the type instead.
+                    ty::FnPtr(_, _) => self.annotate_fn_sig(self.mir_def_id(), ty.fn_sig(tcx)),
                     _ => None,
                 }
             }

--- a/tests/ui/borrowck/const-fn-ptr-borrow-annotation.rs
+++ b/tests/ui/borrowck/const-fn-ptr-borrow-annotation.rs
@@ -1,0 +1,16 @@
+// Regression test for https://github.com/rust-lang/rust/issues/160255.
+
+use std::mem;
+
+const A: fn() = unsafe {
+    mem::transmute({
+        fn fun() {}
+        let _ = fun as fn();
+        {
+            let s = [0; 10];
+            &s //~ ERROR: `s` does not live long enough [E0597]
+        }
+    })
+};
+
+fn main() {}

--- a/tests/ui/borrowck/const-fn-ptr-borrow-annotation.stderr
+++ b/tests/ui/borrowck/const-fn-ptr-borrow-annotation.stderr
@@ -1,0 +1,16 @@
+error[E0597]: `s` does not live long enough
+  --> $DIR/const-fn-ptr-borrow-annotation.rs:11:13
+   |
+LL |     mem::transmute({
+   |     -------------- borrow later used by call
+...
+LL |             let s = [0; 10];
+   |                 - binding `s` declared here
+LL |             &s
+   |             ^^ borrowed value does not live long enough
+LL |         }
+   |         - `s` dropped here while still borrowed
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
`borrowck`'s `annotate_argument_and_return_for_borrow` called `tcx.fn_sig` on the item being checked whenever its type was a `fn def` or `fn ptr`. For a const like `const A: fn()`, that asks for the signature of the const itself, which is not a function item, so we ICE'd with `"unexpected sort of node in fn_sig"`.

Now we take the signature from the `fn ptr` type instead and skip the annotation when there's no `fn decl` to annotate.

also added a regression test under `tests/ui/borrowck`.

fixes: rust-lang/rust#160255