### PR TITLE
Box::leak: tell people to avoid unleaking

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1892,12 +1892,12 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// has only static references, or none at all, then this may be chosen to be
     /// `'static`.
     ///
-    /// This function is mainly useful for data that lives for the remainder of
-    /// the program's life. Dropping the returned reference will cause a memory
-    /// leak. If this is not acceptable, the reference should first be wrapped
-    /// with the [`Box::from_raw`] function producing a `Box`. This `Box` can
-    /// then be dropped which will properly destroy `T` and release the
-    /// allocated memory.
+    /// This function is mainly useful for data that lives for the remainder of the program's life,
+    /// i.e., memory that is meant to leak. Reconstructing ("unleaking") a `Box` from the mutable
+    /// reference returned here (e.g. via [`Box::from_raw`]) is a grey area (meaning it is possible
+    /// under specific circumstances but many seemingly harmless ways of doing it are undefined
+    /// behavior) and should be avoided. If the memory should eventually be freed, prefer to use
+    /// [`Box::into_raw`] or [`Box::into_non_null`] instead.
     ///
     /// Note: this is an associated function, which means that you have
     /// to call it as `Box::leak(b)` instead of `b.leak()`. This


### PR DESCRIPTION
r? @nia-e 
Cc @rust-lang/opsem 

Note that this goes against the advice given by clippy in https://github.com/rust-lang/rust-clippy/pull/17336. I think clippy should be adjusted to recommend `Box::into_non_null` instead. @ArhanChaudhary wold be great if you could make a clippy PR for that. :)