### PR TITLE
Remove itertools dependency from `rustc_ast_pretty`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3701,7 +3701,6 @@ dependencies = [
 name = "rustc_ast_pretty"
 version = "0.0.0"
 dependencies = [
- "itertools",
  "rustc_ast",
  "rustc_lexer",
  "rustc_span",

--- a/compiler/rustc_ast_pretty/Cargo.toml
+++ b/compiler/rustc_ast_pretty/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-itertools = "0.15"
 rustc_ast = { path = "../rustc_ast" }
 rustc_lexer = { path = "../rustc_lexer" }
 rustc_span = { path = "../rustc_span" }

--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -1,7 +1,6 @@
 use std::fmt::Write;
 
 use ast::{ForLoopKind, MatchKind};
-use itertools::Itertools;
 use rustc_ast::util::classify;
 use rustc_ast::util::literal::escape_byte_str_symbol;
 use rustc_ast::util::parser::{self, ExprPrecedence, Fixity};
@@ -169,9 +168,9 @@ impl<'a> State<'a> {
             return;
         }
         let cb = self.cbox(0);
-        for (pos, field) in fields.iter().with_position() {
-            let is_first = pos.is_first();
-            let is_last = pos.is_last();
+        for (idx, field) in fields.iter().enumerate() {
+            let is_first = idx == 0;
+            let is_last = idx == fields.len() - 1;
             self.maybe_print_comment(field.span.hi());
             self.print_outer_attributes(&field.attrs);
             if is_first {

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -1,5 +1,4 @@
 use ast::StaticItem;
-use itertools::Itertools;
 use rustc_ast::{self as ast, EiiImpl, ModKind, Safety, TraitAlias};
 use rustc_span::Ident;
 
@@ -924,8 +923,8 @@ impl<'a> State<'a> {
                     self.word("{");
                     self.zerobreak();
                     let ib = self.ibox(0);
-                    for (pos, use_tree) in items.iter().with_position() {
-                        let is_last = pos.is_last();
+                    for (idx, use_tree) in items.iter().enumerate() {
+                        let is_last = idx == items.len() - 1;
                         self.print_use_tree(&use_tree.0);
                         if !is_last {
                             self.word(",");


### PR DESCRIPTION
3 Second optimization in the `rustc_ast_pretty` module compiletimes (13.57s -> 10.58s)! Not much, but it's honest work :)
Found by an experiment I'm doing, related with Incremental Systems Rethought project goal.

So, cc https://github.com/rust-lang/rust-project-goals/issues/641

r? @jackh726