### PR TITLE
Add regression test for unused_allocation on boxed comparison

### DIFF
--- a/tests/ui/lint/unused/unused-allocation-box-cmp-issue-134186.rs
+++ b/tests/ui/lint/unused/unused-allocation-box-cmp-issue-134186.rs
@@ -1,0 +1,15 @@
+//@ check-pass
+// Regression test for <https://github.com/rust-lang/rust/issues/134186>.
+// Comparing two `Box` values with `==` autorefs each `Box::new(...)` to `&Box<T>`, so the
+// allocation is necessary and `unused_allocation` must not fire
+
+#![deny(unused_allocation)]
+
+pub fn main() {
+    let a = Box::new(42);
+
+    // `PartialEq for Box<T>` takes the operands by reference, so these allocations are used.
+    let _ = a == Box::new(99);
+    let _ = Box::new(99) == a;
+    let _ = Box::new(1) == Box::new(2);
+}


### PR DESCRIPTION
This issue is fixed by https://github.com/rust-lang/rust/pull/151886

Closes rust-lang/rust#134186.