### PR TITLE
Add regression test for unused_parens on contract clauses

### DIFF
--- a/tests/ui/contracts/contract-clause-unused-parens-issue-143754.rs
+++ b/tests/ui/contracts/contract-clause-unused-parens-issue-143754.rs
@@ -1,0 +1,22 @@
+//@ check-pass
+// Regression test for <https://github.com/rust-lang/rust/issues/143754>.
+// The contract macros wrap the clause in braces rather than parentheses, so `unused_parens`
+// must not fire on a contract attribute (and must not emit the attribute-eating suggestion).
+
+#![expect(incomplete_features)]
+#![feature(contracts)]
+#![deny(unused_parens)]
+
+#[core::contracts::requires(x.baz > 0)]
+#[core::contracts::ensures(|ret| *ret > 100)]
+fn nest(x: Baz) -> i32 {
+    loop {
+        return x.baz + 50;
+    }
+}
+
+struct Baz {
+    baz: i32,
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#143754

This issue is fixed by the parens->brace delimiter change in rust-lang/rust#144438