### PR TITLE
Rename `OutlivesPredicate` to `OutlivesClause`

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -304,7 +304,7 @@ struct CollectRegionConstraintsResult<'tcx> {
     location_map: Rc<DenseLocationMap>,
     universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
     region_bound_pairs: Frozen<RegionBoundPairs<'tcx>>,
-    known_type_outlives_obligations: Frozen<Vec<ty::PolyTypeOutlivesPredicate<'tcx>>>,
+    known_type_outlives_obligations: Frozen<Vec<ty::PolyTypeOutlivesClause<'tcx>>>,
     constraints: MirTypeckRegionConstraints<'tcx>,
     deferred_closure_requirements: DeferredClosureRequirements<'tcx>,
     deferred_opaque_type_errors: Vec<DeferredOpaqueTypeError<'tcx>>,

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
@@ -531,7 +531,7 @@ pub(crate) fn apply_definition_site_hidden_types<'tcx>(
     body: &Body<'tcx>,
     universal_regions: &UniversalRegions<'tcx>,
     region_bound_pairs: &RegionBoundPairs<'tcx>,
-    known_type_outlives_obligations: &[ty::PolyTypeOutlivesPredicate<'tcx>],
+    known_type_outlives_obligations: &[ty::PolyTypeOutlivesClause<'tcx>],
     constraints: &mut MirTypeckRegionConstraints<'tcx>,
     hidden_types: &mut FxIndexMap<LocalDefId, ty::DefinitionSiteHiddenType<'tcx>>,
     opaque_types: &[(OpaqueTypeKey<'tcx>, ProvisionalHiddenType<'tcx>)],

--- a/compiler/rustc_borrowck/src/type_check/canonical.rs
+++ b/compiler/rustc_borrowck/src/type_check/canonical.rs
@@ -24,7 +24,7 @@ pub(crate) fn fully_perform_op_raw<'tcx, R: fmt::Debug, Op>(
     body: &Body<'tcx>,
     universal_regions: &UniversalRegions<'tcx>,
     region_bound_pairs: &RegionBoundPairs<'tcx>,
-    known_type_outlives_obligations: &[ty::PolyTypeOutlivesPredicate<'tcx>],
+    known_type_outlives_obligations: &[ty::PolyTypeOutlivesClause<'tcx>],
     constraints: &mut MirTypeckRegionConstraints<'tcx>,
     locations: Locations,
     category: ConstraintCategory<'tcx>,

--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -34,7 +34,7 @@ pub(crate) struct ConstraintConversion<'a, 'tcx> {
     /// logic expecting to see (e.g.) `ReStatic`, and if we supplied
     /// our special inference variable there, we would mess that up.
     region_bound_pairs: &'a RegionBoundPairs<'tcx>,
-    known_type_outlives_obligations: &'a [ty::PolyTypeOutlivesPredicate<'tcx>],
+    known_type_outlives_obligations: &'a [ty::PolyTypeOutlivesClause<'tcx>],
     locations: Locations,
     span: Span,
     category: ConstraintCategory<'tcx>,
@@ -47,7 +47,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
         infcx: &'a BorrowckInferCtxt<'tcx>,
         universal_regions: &'a UniversalRegions<'tcx>,
         region_bound_pairs: &'a RegionBoundPairs<'tcx>,
-        known_type_outlives_obligations: &'a [ty::PolyTypeOutlivesPredicate<'tcx>],
+        known_type_outlives_obligations: &'a [ty::PolyTypeOutlivesClause<'tcx>],
         locations: Locations,
         span: Span,
         category: ConstraintCategory<'tcx>,
@@ -115,7 +115,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
             self.category = outlives_requirement.category;
             self.span = outlives_requirement.blame_span;
             self.convert(
-                ty::OutlivesPredicate(subject, outlived_region),
+                ty::OutlivesClause(subject, outlived_region),
                 self.category,
                 &Default::default(),
             );
@@ -125,9 +125,9 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
 
     fn convert(
         &mut self,
-        predicate: ty::ArgOutlivesPredicate<'tcx>,
+        clause: ty::ArgOutlivesClause<'tcx>,
         constraint_category: ConstraintCategory<'tcx>,
-        higher_ranked_assumptions: &FxHashSet<ty::ArgOutlivesPredicate<'tcx>>,
+        higher_ranked_assumptions: &FxHashSet<ty::ArgOutlivesClause<'tcx>>,
     ) {
         let tcx = self.infcx.tcx;
         debug!("generate: constraints at: {:#?}", self.locations);
@@ -141,15 +141,14 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
             ..
         } = *self;
 
-        let pred = predicate;
         // Constraint is implied by a coroutine's well-formedness.
         if self.infcx.tcx.sess.opts.unstable_opts.higher_ranked_assumptions
-            && higher_ranked_assumptions.contains(&pred)
+            && higher_ranked_assumptions.contains(&clause)
         {
             return;
         }
 
-        let ty::OutlivesPredicate(k1, r2) = pred;
+        let ty::OutlivesClause(k1, r2) = clause;
         match k1.kind() {
             GenericArgKind::Lifetime(r1) => {
                 let r1_vid = self.to_region_vid(r1);

--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -44,7 +44,7 @@ type NormalizedInputsAndOutput<'tcx> = Vec<Ty<'tcx>>;
 pub(crate) struct CreateResult<'tcx> {
     pub(crate) universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
     pub(crate) region_bound_pairs: Frozen<RegionBoundPairs<'tcx>>,
-    pub(crate) known_type_outlives_obligations: Frozen<Vec<ty::PolyTypeOutlivesPredicate<'tcx>>>,
+    pub(crate) known_type_outlives_obligations: Frozen<Vec<ty::PolyTypeOutlivesClause<'tcx>>>,
     pub(crate) normalized_inputs_and_output: NormalizedInputsAndOutput<'tcx>,
 }
 
@@ -342,9 +342,9 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
 
     fn normalize_and_push_type_outlives_obligation(
         &self,
-        mut outlives: ty::PolyTypeOutlivesPredicate<'tcx>,
+        mut outlives: ty::PolyTypeOutlivesClause<'tcx>,
         span: Span,
-        known_type_outlives_obligations: &mut Vec<ty::PolyTypeOutlivesPredicate<'tcx>>,
+        known_type_outlives_obligations: &mut Vec<ty::PolyTypeOutlivesClause<'tcx>>,
         constraints: &mut Vec<&QueryRegionConstraints<'tcx>>,
     ) {
         // In the new solver, normalize the type-outlives obligation assumptions.
@@ -413,12 +413,12 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
 
                 OutlivesBound::RegionSubParam(r_a, param_b) => {
                     self.region_bound_pairs
-                        .insert(ty::OutlivesPredicate(GenericKind::Param(param_b), r_a));
+                        .insert(ty::OutlivesClause(GenericKind::Param(param_b), r_a));
                 }
 
                 OutlivesBound::RegionSubAlias(r_a, alias_b) => {
                     self.region_bound_pairs
-                        .insert(ty::OutlivesPredicate(GenericKind::Alias(alias_b), r_a));
+                        .insert(ty::OutlivesClause(GenericKind::Alias(alias_b), r_a));
                 }
             }
         }

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -239,7 +239,7 @@ struct TypeChecker<'a, 'tcx> {
     /// all of the promoted items.
     user_type_annotations: &'a CanonicalUserTypeAnnotations<'tcx>,
     region_bound_pairs: &'a RegionBoundPairs<'tcx>,
-    known_type_outlives_obligations: &'a [ty::PolyTypeOutlivesPredicate<'tcx>],
+    known_type_outlives_obligations: &'a [ty::PolyTypeOutlivesClause<'tcx>],
     reported_errors: FxIndexSet<(Ty<'tcx>, Span)>,
     universal_regions: &'a UniversalRegions<'tcx>,
     location_table: &'a PoloniusLocationTable,
@@ -257,7 +257,7 @@ pub(crate) struct MirTypeckResults<'tcx> {
     pub(crate) constraints: MirTypeckRegionConstraints<'tcx>,
     pub(crate) universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
     pub(crate) region_bound_pairs: Frozen<RegionBoundPairs<'tcx>>,
-    pub(crate) known_type_outlives_obligations: Frozen<Vec<ty::PolyTypeOutlivesPredicate<'tcx>>>,
+    pub(crate) known_type_outlives_obligations: Frozen<Vec<ty::PolyTypeOutlivesClause<'tcx>>>,
     pub(crate) deferred_closure_requirements: DeferredClosureRequirements<'tcx>,
     pub(crate) polonius_context: Option<PoloniusContext>,
 }

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -89,7 +89,7 @@ use rustc_middle::query::Providers;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::print::with_types_for_signature;
 use rustc_middle::ty::{
-    self, GenericArgs, GenericArgsRef, OutlivesPredicate, Region, RegionExt, Ty, TyCtxt, TypingMode,
+    self, GenericArgs, GenericArgsRef, OutlivesClause, Region, RegionExt, Ty, TyCtxt, TypingMode,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_session::diagnostics::feature_err;
@@ -413,7 +413,7 @@ fn bounds_from_generic_clauses<'tcx>(
             ty::ClauseKind::Projection(projection_pred) => {
                 projections.push(bound_clause.rebind(projection_pred));
             }
-            ty::ClauseKind::RegionOutlives(OutlivesPredicate(a, b)) => {
+            ty::ClauseKind::RegionOutlives(OutlivesClause(a, b)) => {
                 regions.entry(a).or_default().push(b);
             }
             _ => {}

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -510,7 +510,7 @@ pub(crate) fn check_gat_where_clauses(tcx: TyCtxt<'_>, trait_def_id: LocalDefId)
         let unsatisfied_bounds: Vec<_> = required_bounds
             .into_iter()
             .filter(|clause| match clause.kind().skip_binder() {
-                ty::ClauseKind::RegionOutlives(ty::OutlivesPredicate(a, b)) => {
+                ty::ClauseKind::RegionOutlives(ty::OutlivesClause(a, b)) => {
                     !region_known_to_outlive(
                         tcx,
                         gat_def_id,
@@ -520,7 +520,7 @@ pub(crate) fn check_gat_where_clauses(tcx: TyCtxt<'_>, trait_def_id: LocalDefId)
                         b,
                     )
                 }
-                ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(a, b)) => {
+                ty::ClauseKind::TypeOutlives(ty::OutlivesClause(a, b)) => {
                     !ty_known_to_outlive(tcx, gat_def_id, param_env, &FxIndexSet::default(), a, b)
                 }
                 _ => bug!("Unexpected ClauseKind"),
@@ -642,10 +642,10 @@ fn gather_gat_bounds<'tcx, T: TypeFoldable<TyCtxt<'tcx>>>(
                     tcx,
                     ty::EarlyParamRegion { index: region_param.index, name: region_param.name },
                 );
-                // The predicate we expect to see. (In our example,
+                // The clause we expect to see. (In our example,
                 // `Self: 'me`.)
                 bounds.insert(
-                    ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(ty_param, region_param))
+                    ty::ClauseKind::TypeOutlives(ty::OutlivesClause(ty_param, region_param))
                         .upcast(tcx),
                 );
             }
@@ -677,9 +677,9 @@ fn gather_gat_bounds<'tcx, T: TypeFoldable<TyCtxt<'tcx>>>(
                     tcx,
                     ty::EarlyParamRegion { index: region_b_param.index, name: region_b_param.name },
                 );
-                // The predicate we expect to see.
+                // The clause we expect to see.
                 bounds.insert(
-                    ty::ClauseKind::RegionOutlives(ty::OutlivesPredicate(
+                    ty::ClauseKind::RegionOutlives(ty::OutlivesClause(
                         region_a_param,
                         region_b_param,
                     ))

--- a/compiler/rustc_hir_analysis/src/collect/clauses_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/clauses_of.rs
@@ -319,7 +319,7 @@ fn gather_explicit_clauses_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generi
                         }
                     };
                     let clause =
-                        ty::ClauseKind::RegionOutlives(ty::OutlivesPredicate(r1, r2)).upcast(tcx);
+                        ty::ClauseKind::RegionOutlives(ty::OutlivesClause(r1, r2)).upcast(tcx);
                     (clause, span)
                 }))
             }
@@ -389,12 +389,12 @@ fn compute_bidirectional_outlives_clauses<'tcx>(
             );
             let span = tcx.def_span(param.def_id);
             clauses.push((
-                ty::ClauseKind::RegionOutlives(ty::OutlivesPredicate(orig_lifetime, dup_lifetime))
+                ty::ClauseKind::RegionOutlives(ty::OutlivesClause(orig_lifetime, dup_lifetime))
                     .upcast(tcx),
                 span,
             ));
             clauses.push((
-                ty::ClauseKind::RegionOutlives(ty::OutlivesPredicate(dup_lifetime, orig_lifetime))
+                ty::ClauseKind::RegionOutlives(ty::OutlivesClause(dup_lifetime, orig_lifetime))
                     .upcast(tcx),
                 span,
             ));

--- a/compiler/rustc_hir_analysis/src/collect/clauses_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/clauses_of.rs
@@ -1076,7 +1076,7 @@ pub(super) fn const_conditions<'tcx>(
         },
         // While associated types are not really const, we do allow them to have `[const]`
         // bounds and where clauses. `const_conditions` is responsible for gathering
-        // these up so we can check them in `compare_type_predicate_entailment`, and
+        // these up so we can check them in `compare_type_clause_entailment`, and
         // in `HostEffect` goal computation.
         Node::TraitItem(item) => match item.kind {
             hir::TraitItemKind::Fn(_, _) | hir::TraitItemKind::Type(_, _) => {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -353,7 +353,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
                     let region = self.lower_lifetime(lifetime, RegionInferReason::OutlivesBound);
                     let bound = ty::Binder::bind_with_vars(
-                        ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(param_ty, region)),
+                        ty::ClauseKind::TypeOutlives(ty::OutlivesClause(param_ty, region)),
                         bound_vars,
                     );
                     bounds.push((bound.upcast(self.tcx()), lifetime.ident.span));

--- a/compiler/rustc_hir_analysis/src/outlives/explicit.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/explicit.rs
@@ -1,53 +1,41 @@
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::{self, OutlivesPredicate, TyCtxt};
+use rustc_middle::ty::{self, OutlivesClause, TyCtxt};
 
 use super::utils::*;
 
 #[derive(Debug)]
-pub(crate) struct ExplicitPredicatesMap<'tcx> {
-    map: FxIndexMap<DefId, ty::EarlyBinder<'tcx, RequiredPredicates<'tcx>>>,
+pub(crate) struct ExplicitClausesMap<'tcx> {
+    map: FxIndexMap<DefId, ty::EarlyBinder<'tcx, RequiredClauses<'tcx>>>,
 }
 
-impl<'tcx> ExplicitPredicatesMap<'tcx> {
-    pub(crate) fn new() -> ExplicitPredicatesMap<'tcx> {
-        ExplicitPredicatesMap { map: FxIndexMap::default() }
+impl<'tcx> ExplicitClausesMap<'tcx> {
+    pub(crate) fn new() -> ExplicitClausesMap<'tcx> {
+        ExplicitClausesMap { map: FxIndexMap::default() }
     }
 
     pub(crate) fn explicit_clauses_of(
         &mut self,
         tcx: TyCtxt<'tcx>,
         def_id: DefId,
-    ) -> &ty::EarlyBinder<'tcx, RequiredPredicates<'tcx>> {
+    ) -> &ty::EarlyBinder<'tcx, RequiredClauses<'tcx>> {
         self.map.entry(def_id).or_insert_with(|| {
             let gen_clauses = if def_id.is_local() {
                 tcx.explicit_clauses_of(def_id)
             } else {
                 tcx.clauses_of(def_id)
             };
-            let mut required_predicates = RequiredPredicates::default();
+            let mut required_clauses = RequiredClauses::default();
 
-            // Process clauses and convert to `RequiredPredicates` entry, see below.
+            // Process clauses and convert to `RequiredClauses` entry, see below.
             for &(clause, span) in gen_clauses.clauses {
                 match clause.kind().skip_binder() {
-                    ty::ClauseKind::TypeOutlives(OutlivesPredicate(ty, reg)) => {
-                        insert_outlives_predicate(
-                            tcx,
-                            ty.into(),
-                            reg,
-                            span,
-                            &mut required_predicates,
-                        )
+                    ty::ClauseKind::TypeOutlives(OutlivesClause(ty, reg)) => {
+                        insert_outlives_clause(tcx, ty.into(), reg, span, &mut required_clauses)
                     }
 
-                    ty::ClauseKind::RegionOutlives(OutlivesPredicate(reg1, reg2)) => {
-                        insert_outlives_predicate(
-                            tcx,
-                            reg1.into(),
-                            reg2,
-                            span,
-                            &mut required_predicates,
-                        )
+                    ty::ClauseKind::RegionOutlives(OutlivesClause(reg1, reg2)) => {
+                        insert_outlives_clause(tcx, reg1.into(), reg2, span, &mut required_clauses)
                     }
                     ty::ClauseKind::Trait(_)
                     | ty::ClauseKind::Projection(_)
@@ -59,7 +47,7 @@ impl<'tcx> ExplicitPredicatesMap<'tcx> {
                 }
             }
 
-            ty::EarlyBinder::bind_iter(required_predicates)
+            ty::EarlyBinder::bind_iter(required_clauses)
         })
     }
 }

--- a/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
@@ -5,38 +5,38 @@ use rustc_middle::ty::{self, GenericArg, GenericArgKind, Ty, TyCtxt};
 use rustc_span::Span;
 use tracing::debug;
 
-use super::explicit::ExplicitPredicatesMap;
+use super::explicit::ExplicitClausesMap;
 use super::utils::*;
 
-/// Infer outlives-predicates for the items in the local crate.
-pub(super) fn infer_predicates(
+/// Infer outlives-clauses for the items in the local crate.
+pub(super) fn infer_clauses(
     tcx: TyCtxt<'_>,
-) -> FxIndexMap<DefId, ty::EarlyBinder<'_, RequiredPredicates<'_>>> {
-    debug!("infer_predicates");
+) -> FxIndexMap<DefId, ty::EarlyBinder<'_, RequiredClauses<'_>>> {
+    debug!("infer_clauses");
 
-    let mut explicit_map = ExplicitPredicatesMap::new();
+    let mut explicit_map = ExplicitClausesMap::new();
 
     let mut global_inferred_outlives = FxIndexMap::default();
 
-    // If new predicates were added then we need to re-calculate
-    // all crates since there could be new implied predicates.
+    // If new clauses were added then we need to re-calculate
+    // all crates since there could be new implied clauses.
     for i in 0.. {
-        let mut predicates_added = vec![];
+        let mut clauses_added = vec![];
 
-        // Visit all the crates and infer predicates
+        // Visit all the crates and infer clauses
         for id in tcx.hir_free_items() {
             let item_did = id.owner_id;
 
             debug!("InferVisitor::visit_item(item={:?})", item_did);
 
-            let mut item_required_predicates = RequiredPredicates::default();
+            let mut item_required_clauses = RequiredClauses::default();
             match tcx.def_kind(item_did) {
                 DefKind::Union | DefKind::Enum | DefKind::Struct => {
                     let adt_def = tcx.adt_def(item_did.to_def_id());
 
                     // Iterate over all fields in item_did
                     for field_def in adt_def.all_fields() {
-                        // Calculating the predicate requirements necessary
+                        // Calculating the clause requirements necessary
                         // for item_did.
                         //
                         // For field of type &'a T (reference) or Adt
@@ -45,24 +45,24 @@ pub(super) fn infer_predicates(
                         let field_ty =
                             tcx.type_of(field_def.did).instantiate_identity().skip_norm_wip();
                         let field_span = tcx.def_span(field_def.did);
-                        insert_required_predicates_to_be_wf(
+                        insert_required_clauses_to_be_wf(
                             tcx,
                             field_ty,
                             field_span,
                             &global_inferred_outlives,
-                            &mut item_required_predicates,
+                            &mut item_required_clauses,
                             &mut explicit_map,
                         );
                     }
                 }
 
                 DefKind::TyAlias if tcx.type_alias_is_checked(item_did) => {
-                    insert_required_predicates_to_be_wf(
+                    insert_required_clauses_to_be_wf(
                         tcx,
                         tcx.type_of(item_did).instantiate_identity().skip_norm_wip(),
                         tcx.def_span(item_did),
                         &global_inferred_outlives,
-                        &mut item_required_predicates,
+                        &mut item_required_clauses,
                         &mut explicit_map,
                     );
                 }
@@ -70,36 +70,36 @@ pub(super) fn infer_predicates(
                 _ => {}
             };
 
-            // If new predicates were added (`local_predicate_map` has more
-            // predicates than the `global_inferred_outlives`), the new predicates
-            // might result in implied predicates for their parent types.
-            // Therefore mark `predicates_added` as true and which will ensure
-            // we walk the crates again and re-calculate predicates for all
+            // If new clauses were added (`local_clause_map` has more
+            // clauses than the `global_inferred_outlives`), the new clauses
+            // might result in implied clauses for their parent types.
+            // Therefore mark `clauses_added` as true and which will ensure
+            // we walk the crates again and re-calculate clauses for all
             // items.
-            let item_predicates_len: usize = global_inferred_outlives
+            let item_clauses_len: usize = global_inferred_outlives
                 .get(&item_did.to_def_id())
-                .map_or(0, |p| p.as_ref().skip_binder().len());
-            if item_required_predicates.len() > item_predicates_len {
-                predicates_added.push(item_did);
+                .map_or(0, |c| c.as_ref().skip_binder().len());
+            if item_required_clauses.len() > item_clauses_len {
+                clauses_added.push(item_did);
                 global_inferred_outlives.insert(
                     item_did.to_def_id(),
-                    ty::EarlyBinder::bind_iter(item_required_predicates),
+                    ty::EarlyBinder::bind_iter(item_required_clauses),
                 );
             }
         }
 
-        if predicates_added.is_empty() {
+        if clauses_added.is_empty() {
             // We've reached a fixed point.
             break;
         } else if !tcx.recursion_limit().value_within_limit(i) {
-            let msg = if let &[id] = &predicates_added[..] {
+            let msg = if let &[id] = &clauses_added[..] {
                 format!("overflow computing implied lifetime bounds for `{}`", tcx.def_path_str(id),)
             } else {
                 "overflow computing implied lifetime bounds".to_string()
             };
             tcx.dcx()
                 .struct_span_fatal(
-                    predicates_added.iter().map(|id| tcx.def_span(*id)).collect::<Vec<_>>(),
+                    clauses_added.iter().map(|id| tcx.def_span(*id)).collect::<Vec<_>>(),
                     msg,
                 )
                 .emit();
@@ -109,19 +109,19 @@ pub(super) fn infer_predicates(
     global_inferred_outlives
 }
 
-fn insert_required_predicates_to_be_wf<'tcx>(
+fn insert_required_clauses_to_be_wf<'tcx>(
     tcx: TyCtxt<'tcx>,
     ty: Ty<'tcx>,
     span: Span,
-    global_inferred_outlives: &FxIndexMap<DefId, ty::EarlyBinder<'tcx, RequiredPredicates<'tcx>>>,
-    required_predicates: &mut RequiredPredicates<'tcx>,
-    explicit_map: &mut ExplicitPredicatesMap<'tcx>,
+    global_inferred_outlives: &FxIndexMap<DefId, ty::EarlyBinder<'tcx, RequiredClauses<'tcx>>>,
+    required_clauses: &mut RequiredClauses<'tcx>,
+    explicit_map: &mut ExplicitClausesMap<'tcx>,
 ) {
     for arg in ty.walk() {
         let leaf_ty = match arg.kind() {
             GenericArgKind::Type(ty) => ty,
 
-            // No predicates from lifetimes or constants, except potentially
+            // No clauses from lifetimes or constants, except potentially
             // constants' types, but `walk` will get to them as well.
             GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => continue,
         };
@@ -129,65 +129,65 @@ fn insert_required_predicates_to_be_wf<'tcx>(
         match *leaf_ty.kind() {
             ty::Ref(region, rty, _) => {
                 // The type is `&'a T` which means that we will have
-                // a predicate requirement of `T: 'a` (`T` outlives `'a`).
+                // a clause requirement of `T: 'a` (`T` outlives `'a`).
                 //
-                // We also want to calculate potential predicates for the `T`.
+                // We also want to calculate potential clauses for the `T`.
                 debug!("Ref");
-                insert_outlives_predicate(tcx, rty.into(), region, span, required_predicates);
+                insert_outlives_clause(tcx, rty.into(), region, span, required_clauses);
             }
 
             ty::Adt(def, args) => {
-                // For ADTs (structs/enums/unions), we check inferred and explicit predicates.
+                // For ADTs (structs/enums/unions), we check inferred and explicit clauses.
                 debug!("Adt");
-                check_inferred_predicates(
+                check_inferred_clauses(
                     tcx,
                     def.did(),
                     args,
                     global_inferred_outlives,
-                    required_predicates,
+                    required_clauses,
                 );
-                check_explicit_predicates(
+                check_explicit_clauses(
                     tcx,
                     def.did(),
                     args,
-                    required_predicates,
+                    required_clauses,
                     explicit_map,
-                    IgnorePredicatesReferencingSelf::No,
+                    IgnoreClausesReferencingSelf::No,
                 );
             }
 
             ty::Alias(_, ty::AliasTy { kind: ty::Free { def_id }, args, .. }) => {
                 // This corresponds to a type like `Type<'a, T>`.
-                // We check inferred and explicit predicates.
+                // We check inferred and explicit clauses.
                 debug!("Free");
-                check_inferred_predicates(
+                check_inferred_clauses(
                     tcx,
                     def_id,
                     args,
                     global_inferred_outlives,
-                    required_predicates,
+                    required_clauses,
                 );
-                check_explicit_predicates(
+                check_explicit_clauses(
                     tcx,
                     def_id,
                     args,
-                    required_predicates,
+                    required_clauses,
                     explicit_map,
-                    IgnorePredicatesReferencingSelf::No,
+                    IgnoreClausesReferencingSelf::No,
                 );
             }
 
             ty::Dynamic(obj, ..) => {
                 // This corresponds to `dyn Trait<..>`. In this case, we should
-                // use the explicit predicates as well.
+                // use the explicit clauses as well.
                 debug!("Dynamic");
                 if let Some(trait_ref) = obj.principal() {
                     let args = trait_ref
                         .with_self_ty(tcx, tcx.types.trait_object_dummy_self)
                         .skip_binder()
                         .args;
-                    // We skip predicates that reference the `Self` type parameter since we don't
-                    // want to leak the dummy Self to the predicates map.
+                    // We skip clauses that reference the `Self` type parameter since we don't
+                    // want to leak the dummy Self to the clauses map.
                     //
                     // While filtering out bounds like `Self: 'a` as in `trait Trait<'a, T>: 'a {}`
                     // doesn't matter since they can't affect the lifetime / type parameters anyway,
@@ -195,33 +195,33 @@ fn insert_required_predicates_to_be_wf<'tcx>(
                     // (see also #54467) it might conceivably be better to extract the binding
                     // `AssocTy = U` from the trait object type (which must exist) and thus infer
                     // an outlives requirement that `U: 'b`.
-                    check_explicit_predicates(
+                    check_explicit_clauses(
                         tcx,
                         trait_ref.def_id(),
                         args,
-                        required_predicates,
+                        required_clauses,
                         explicit_map,
-                        IgnorePredicatesReferencingSelf::Yes,
+                        IgnoreClausesReferencingSelf::Yes,
                     );
                 }
             }
 
             ty::Alias(_, ty::AliasTy { kind: ty::Projection { def_id }, args, .. }) => {
                 // This corresponds to a type like `<() as Trait<'a, T>>::Type`.
-                // We only use the explicit predicates of the trait but
+                // We only use the explicit clauses of the trait but
                 // not the ones of the associated type itself.
                 debug!("Projection");
-                check_explicit_predicates(
+                check_explicit_clauses(
                     tcx,
                     tcx.parent(def_id),
                     args,
-                    required_predicates,
+                    required_clauses,
                     explicit_map,
-                    IgnorePredicatesReferencingSelf::No,
+                    IgnoreClausesReferencingSelf::No,
                 );
             }
 
-            // FIXME(inherent_associated_types): Use the explicit predicates from the parent impl.
+            // FIXME(inherent_associated_types): Use the explicit clauses from the parent impl.
             ty::Alias(_, ty::AliasTy { kind: ty::Inherent { .. }, .. }) => {}
 
             _ => {}
@@ -229,7 +229,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
     }
 }
 
-/// Check the explicit predicates declared on the type.
+/// Check the explicit clauses declared on the type.
 ///
 /// ### Example
 ///
@@ -242,48 +242,46 @@ fn insert_required_predicates_to_be_wf<'tcx>(
 ///     // ...
 /// }
 /// ```
-/// Here, we should fetch the explicit predicates, which
+/// Here, we should fetch the explicit clauses, which
 /// will give us `U: 'static` and `U: Outer`. The latter we
 /// can ignore, but we will want to process `U: 'static`,
 /// applying the instantiation as above.
-// FIXME: change this function's signature and docs to mention clauses instead of predicates
 #[tracing::instrument(level = "debug", skip(tcx))]
-fn check_explicit_predicates<'tcx>(
+fn check_explicit_clauses<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: DefId,
     args: &[GenericArg<'tcx>],
-    required_predicates: &mut RequiredPredicates<'tcx>,
-    explicit_map: &mut ExplicitPredicatesMap<'tcx>,
-    ignore_preds_refing_self: IgnorePredicatesReferencingSelf,
+    required_clauses: &mut RequiredClauses<'tcx>,
+    explicit_map: &mut ExplicitClausesMap<'tcx>,
+    ignore_clauses_refing_self: IgnoreClausesReferencingSelf,
 ) {
     let explicit_clauses = explicit_map.explicit_clauses_of(tcx, def_id);
 
-    for (&clause @ ty::OutlivesPredicate(arg, _), &span) in explicit_clauses.as_ref().skip_binder()
-    {
+    for (&clause @ ty::OutlivesClause(arg, _), &span) in explicit_clauses.as_ref().skip_binder() {
         debug!(?clause);
 
-        if let IgnorePredicatesReferencingSelf::Yes = ignore_preds_refing_self
+        if let IgnoreClausesReferencingSelf::Yes = ignore_clauses_refing_self
             && arg.walk().any(|arg| arg == tcx.types.self_param.into())
         {
             debug!("ignoring clause since it references `Self`");
             continue;
         }
 
-        let clause @ ty::OutlivesPredicate(arg, region) =
+        let clause @ ty::OutlivesClause(arg, region) =
             explicit_clauses.rebind(clause).instantiate(tcx, args).skip_norm_wip();
         debug!(?clause);
 
-        insert_outlives_predicate(tcx, arg, region, span, required_predicates);
+        insert_outlives_clause(tcx, arg, region, span, required_clauses);
     }
 }
 
 #[derive(Debug)]
-enum IgnorePredicatesReferencingSelf {
+enum IgnoreClausesReferencingSelf {
     Yes,
     No,
 }
 
-/// Check the inferred predicates of the type.
+/// Check the inferred clauses of the type.
 ///
 /// ### Example
 ///
@@ -298,29 +296,29 @@ enum IgnorePredicatesReferencingSelf {
 /// ```
 ///
 /// Here, when processing the type of field `outer`, we would request the
-/// set of implicit predicates computed for `Inner` thus far. This will
+/// set of implicit clauses computed for `Inner` thus far. This will
 /// initially come back empty, but in next round we will get `U: 'b`.
 /// We then apply the instantiation `['b => 'a, U => T]` and thus get the
 /// requirement that `T: 'a` holds for `Outer`.
-fn check_inferred_predicates<'tcx>(
+fn check_inferred_clauses<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: DefId,
     args: ty::GenericArgsRef<'tcx>,
-    global_inferred_outlives: &FxIndexMap<DefId, ty::EarlyBinder<'tcx, RequiredPredicates<'tcx>>>,
-    required_predicates: &mut RequiredPredicates<'tcx>,
+    global_inferred_outlives: &FxIndexMap<DefId, ty::EarlyBinder<'tcx, RequiredClauses<'tcx>>>,
+    required_clauses: &mut RequiredClauses<'tcx>,
 ) {
-    // Load the current set of inferred and explicit predicates from `global_inferred_outlives`
+    // Load the current set of inferred and explicit clauses from `global_inferred_outlives`
     // and filter the ones that are `TypeOutlives`.
 
-    let Some(predicates) = global_inferred_outlives.get(&def_id) else {
+    let Some(clauses) = global_inferred_outlives.get(&def_id) else {
         return;
     };
 
-    for (&predicate, &span) in predicates.as_ref().skip_binder() {
-        // `predicate` is `U: 'b` in the example above.
+    for (&clause, &span) in clauses.as_ref().skip_binder() {
+        // `clause` is `U: 'b` in the example above.
         // So apply the instantiation to get `T: 'a`.
-        let ty::OutlivesPredicate(arg, region) =
-            predicates.rebind(predicate).instantiate(tcx, args).skip_norm_wip();
-        insert_outlives_predicate(tcx, arg, region, span, required_predicates);
+        let ty::OutlivesClause(arg, region) =
+            clauses.rebind(clause).instantiate(tcx, args).skip_norm_wip();
+        insert_outlives_clause(tcx, arg, region, span, required_clauses);
     }
 }

--- a/compiler/rustc_hir_analysis/src/outlives/mod.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/mod.rs
@@ -1,6 +1,6 @@
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;
-use rustc_middle::ty::{self, CratePredicatesMap, GenericArgKind, TyCtxt, Upcast};
+use rustc_middle::ty::{self, CrateClausesMap, GenericArgKind, TyCtxt, Upcast};
 use rustc_span::Span;
 
 pub(crate) mod dump;
@@ -15,17 +15,17 @@ pub(super) fn inferred_outlives_of(
     match tcx.def_kind(item_def_id) {
         DefKind::Struct | DefKind::Enum | DefKind::Union => {
             let crate_map = tcx.inferred_outlives_crate(());
-            crate_map.predicates.get(&item_def_id.to_def_id()).copied().unwrap_or(&[])
+            crate_map.clauses.get(&item_def_id.to_def_id()).copied().unwrap_or(&[])
         }
         DefKind::TyAlias if tcx.type_alias_is_checked(item_def_id) => {
             let crate_map = tcx.inferred_outlives_crate(());
-            crate_map.predicates.get(&item_def_id.to_def_id()).copied().unwrap_or(&[])
+            crate_map.clauses.get(&item_def_id.to_def_id()).copied().unwrap_or(&[])
         }
         DefKind::AnonConst if tcx.features().generic_const_exprs() => {
             let id = tcx.local_def_id_to_hir_id(item_def_id);
             if tcx.hir_opt_const_param_default_param_def_id(id).is_some() {
                 // In `generics_of` we set the generics' parent to be our parent's parent which means that
-                // we lose out on the predicates of our actual parent if we dont return those predicates here.
+                // we lose out on the clauses of our actual parent if we dont return those clauses here.
                 // (See comment in `generics_of` for more information on why the parent shenanigans is necessary)
                 //
                 // struct Foo<'a, 'b, const N: usize = { ... }>(&'a &'b ());
@@ -34,7 +34,7 @@ pub(super) fn inferred_outlives_of(
                 //        parent item we dont have set as the
                 //        parent of generics returned by `generics_of`
                 //
-                // In the above code we want the anon const to have predicates in its param env for `'b: 'a`
+                // In the above code we want the anon const to have clauses in its param env for `'b: 'a`
                 let item_def_id = tcx.hir_get_parent_item(id);
                 // In the above code example we would be calling `inferred_outlives_of(Foo)` here
                 tcx.inferred_outlives_of(item_def_id)
@@ -46,36 +46,36 @@ pub(super) fn inferred_outlives_of(
     }
 }
 
-pub(super) fn inferred_outlives_crate(tcx: TyCtxt<'_>, (): ()) -> CratePredicatesMap<'_> {
+pub(super) fn inferred_outlives_crate(tcx: TyCtxt<'_>, (): ()) -> CrateClausesMap<'_> {
     // Compute a map from each ADT (struct/enum/union) and lazy type alias to
-    // the **explicit** outlives predicates (`T: 'a`, `'a: 'b`) that the user wrote.
+    // the **explicit** outlives clauses (`T: 'a`, `'a: 'b`) that the user wrote.
     // Typically there won't be many of these, except in older code where
     // they were mandatory. Nonetheless, we have to ensure that every such
-    // predicate is satisfied, so they form a kind of base set of requirements
+    // clause is satisfied, so they form a kind of base set of requirements
     // for the type.
 
-    // Compute the inferred predicates
-    let global_inferred_outlives = implicit_infer::infer_predicates(tcx);
+    // Compute the inferred clauses
+    let global_inferred_outlives = implicit_infer::infer_clauses(tcx);
 
-    // Convert the inferred predicates into the "collected" form the
+    // Convert the inferred clauses into the "collected" form the
     // global data structure expects.
     //
     // FIXME -- consider correcting impedance mismatch in some way,
     // probably by updating the global data structure.
-    let predicates = global_inferred_outlives
+    let clauses = global_inferred_outlives
         .iter()
         .map(|(&def_id, set)| {
-            let predicates =
+            let clauses =
                 &*tcx.arena.alloc_from_iter(set.as_ref().skip_binder().iter().filter_map(
-                    |(ty::OutlivesPredicate(arg1, region2), &span)| {
+                    |(ty::OutlivesClause(arg1, region2), &span)| {
                         match arg1.kind() {
                             GenericArgKind::Type(ty1) => Some((
-                                ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(ty1, *region2))
+                                ty::ClauseKind::TypeOutlives(ty::OutlivesClause(ty1, *region2))
                                     .upcast(tcx),
                                 span,
                             )),
                             GenericArgKind::Lifetime(region1) => Some((
-                                ty::ClauseKind::RegionOutlives(ty::OutlivesPredicate(
+                                ty::ClauseKind::RegionOutlives(ty::OutlivesClause(
                                     region1, *region2,
                                 ))
                                 .upcast(tcx),
@@ -88,9 +88,9 @@ pub(super) fn inferred_outlives_crate(tcx: TyCtxt<'_>, (): ()) -> CratePredicate
                         }
                     },
                 ));
-            (def_id, predicates)
+            (def_id, clauses)
         })
         .collect();
 
-    ty::CratePredicatesMap { predicates }
+    ty::CrateClausesMap { clauses }
 }

--- a/compiler/rustc_hir_analysis/src/outlives/utils.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/utils.rs
@@ -5,19 +5,18 @@ use rustc_middle::{bug, span_bug};
 use rustc_span::Span;
 use smallvec::smallvec;
 
-/// Tracks the `T: 'a` or `'a: 'a` predicates that we have inferred
+/// Tracks the `T: 'a` or `'a: 'a` clauses that we have inferred
 /// must be added to the struct header.
-pub(crate) type RequiredPredicates<'tcx> = FxIndexMap<ty::ArgOutlivesPredicate<'tcx>, Span>;
+pub(crate) type RequiredClauses<'tcx> = FxIndexMap<ty::ArgOutlivesClause<'tcx>, Span>;
 
 /// Given a requirement `T: 'a` or `'b: 'a`, deduce the
-/// outlives_component and add it to `required_predicates`
-// FIXME: change this function's signature and docs to mention clauses instead of predicates
-pub(crate) fn insert_outlives_predicate<'tcx>(
+/// outlives_component and add it to `required_clauses`
+pub(crate) fn insert_outlives_clause<'tcx>(
     tcx: TyCtxt<'tcx>,
     arg: GenericArg<'tcx>,
     outlived_region: Region<'tcx>,
     span: Span,
-    required_predicates: &mut RequiredPredicates<'tcx>,
+    required_clauses: &mut RequiredClauses<'tcx>,
 ) {
     // If the `'a` region is bound within the field type itself, we
     // don't want to propagate this constraint to the header.
@@ -51,12 +50,12 @@ pub(crate) fn insert_outlives_predicate<'tcx>(
                         // u32`. Decomposing `&'b u32` into
                         // components would yield `'b`, and we add the
                         // where clause that `'b: 'a`.
-                        insert_outlives_predicate(
+                        insert_outlives_clause(
                             tcx,
                             r.into(),
                             outlived_region,
                             span,
-                            required_predicates,
+                            required_clauses,
                         );
                     }
 
@@ -75,8 +74,8 @@ pub(crate) fn insert_outlives_predicate<'tcx>(
                         // components would yield `U`, and we add the
                         // where clause that `U: 'a`.
                         let ty: Ty<'tcx> = param_ty.to_ty(tcx);
-                        required_predicates
-                            .entry(ty::OutlivesPredicate(ty.into(), outlived_region))
+                        required_clauses
+                            .entry(ty::OutlivesClause(ty.into(), outlived_region))
                             .or_insert(span);
                     }
 
@@ -104,8 +103,8 @@ pub(crate) fn insert_outlives_predicate<'tcx>(
                         // Here we want to add an explicit `where <T as Iterator>::Item: 'a`
                         // or `Opaque<T>: 'a` depending on the alias kind.
                         let ty = alias_ty.to_ty(tcx, is_rigid);
-                        required_predicates
-                            .entry(ty::OutlivesPredicate(ty.into(), outlived_region))
+                        required_clauses
+                            .entry(ty::OutlivesClause(ty.into(), outlived_region))
                             .or_insert(span);
                     }
 
@@ -135,7 +134,7 @@ pub(crate) fn insert_outlives_predicate<'tcx>(
             if !is_free_region(r) {
                 return;
             }
-            required_predicates.entry(ty::OutlivesPredicate(arg, outlived_region)).or_insert(span);
+            required_clauses.entry(ty::OutlivesClause(arg, outlived_region)).or_insert(span);
         }
 
         GenericArgKind::Const(_) => {

--- a/compiler/rustc_hir_analysis/src/variance/mod.rs
+++ b/compiler/rustc_hir_analysis/src/variance/mod.rs
@@ -215,7 +215,7 @@ fn variance_of_opaque(
                 }
                 term.visit_with(&mut collector);
             }
-            ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(_, region)) => {
+            ty::ClauseKind::TypeOutlives(ty::OutlivesClause(_, region)) => {
                 region.visit_with(&mut collector);
             }
             _ => {

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -193,11 +193,11 @@ impl<'tcx> InferCtxt<'tcx> {
         {
             let constraint = instantiate_value(self.tcx, &result_args, *constraint);
             match constraint {
-                ty::RegionConstraint::Outlives(predicate) => {
-                    self.register_outlives_constraint(predicate, *vis, cause);
+                ty::RegionConstraint::Outlives(clause) => {
+                    self.register_outlives_constraint(clause, *vis, cause);
                 }
-                ty::RegionConstraint::Eq(predicate) => {
-                    self.register_region_eq_constraint(predicate, *vis, cause);
+                ty::RegionConstraint::Eq(clause) => {
+                    self.register_region_eq_constraint(clause, *vis, cause);
                 }
             }
         }
@@ -611,7 +611,7 @@ impl<'tcx> InferCtxt<'tcx> {
 pub fn make_query_region_constraints<'tcx>(
     outlives_obligations: Vec<TypeOutlivesConstraint<'tcx>>,
     region_constraints: &RegionConstraintData<'tcx>,
-    assumptions: Vec<ty::ArgOutlivesPredicate<'tcx>>,
+    assumptions: Vec<ty::ArgOutlivesClause<'tcx>>,
 ) -> QueryRegionConstraints<'tcx> {
     let RegionConstraintData { constraints, verifys } = region_constraints;
 
@@ -627,7 +627,7 @@ pub fn make_query_region_constraints<'tcx>(
             | ConstraintKind::VarSubReg
             | ConstraintKind::RegSubReg => {
                 // Swap regions because we are going from sub (<=) to outlives (>=).
-                let constraint = ty::OutlivesPredicate(c.sup.into(), c.sub).into();
+                let constraint = ty::OutlivesClause(c.sup.into(), c.sub).into();
                 QueryRegionConstraint {
                     constraint,
                     category: origin.to_constraint_category(),
@@ -647,7 +647,7 @@ pub fn make_query_region_constraints<'tcx>(
         .chain(outlives_obligations.into_iter().map(
             |TypeOutlivesConstraint { sub_region, sup_type, origin }| {
                 QueryRegionConstraint {
-                    constraint: ty::OutlivesPredicate(sup_type.into(), sub_region).into(),
+                    constraint: ty::OutlivesClause(sup_type.into(), sub_region).into(),
                     category: origin.to_constraint_category(),
                     // We don't do leak checks for type outlives
                     visible_for_leak_check: ty::VisibleForLeakCheck::Unreachable,

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -110,7 +110,7 @@ pub enum RegionResolutionError<'tcx> {
         Region<'tcx>,          // the placeholder `'b`
     ),
 
-    CannotNormalize(ty::PolyTypeOutlivesPredicate<'tcx>, SubregionOrigin<'tcx>),
+    CannotNormalize(ty::PolyTypeOutlivesClause<'tcx>, SubregionOrigin<'tcx>),
 }
 
 impl<'tcx> RegionResolutionError<'tcx> {

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -148,7 +148,7 @@ pub struct InferCtxtInner<'tcx> {
     /// are deduced from the well-formedness of the witness's types, and are
     /// necessary because of the way we anonymize the regions in a coroutine,
     /// which may cause types to no longer be considered well-formed.
-    region_assumptions: Vec<ty::ArgOutlivesPredicate<'tcx>>,
+    region_assumptions: Vec<ty::ArgOutlivesClause<'tcx>>,
 
     /// `-Znext-solver`: Successfully proven goals during HIR typeck which
     /// reference inference variables and get reproven in case MIR type check
@@ -187,7 +187,7 @@ impl<'tcx> InferCtxtInner<'tcx> {
     }
 
     #[inline]
-    pub fn region_assumptions(&self) -> &[ty::ArgOutlivesPredicate<'tcx>] {
+    pub fn region_assumptions(&self) -> &[ty::ArgOutlivesClause<'tcx>] {
         &self.region_assumptions
     }
 

--- a/compiler/rustc_infer/src/infer/outlives/env.rs
+++ b/compiler/rustc_infer/src/infer/outlives/env.rs
@@ -38,24 +38,24 @@ pub struct OutlivesEnvironment<'tcx> {
     /// everywhere is just enough of a perf regression to matter. This can/should be
     /// optimized in the future, though.
     region_bound_pairs: RegionBoundPairs<'tcx>,
-    known_type_outlives: Vec<ty::PolyTypeOutlivesPredicate<'tcx>>,
+    known_type_outlives: Vec<ty::PolyTypeOutlivesClause<'tcx>>,
     /// Assumptions that come from the well-formedness of coroutines that we prove
     /// auto trait bounds for during the type checking of this body.
-    higher_ranked_assumptions: FxHashSet<ty::ArgOutlivesPredicate<'tcx>>,
+    higher_ranked_assumptions: FxHashSet<ty::ArgOutlivesClause<'tcx>>,
 }
 
 /// "Region-bound pairs" tracks outlives relations that are known to
 /// be true, either because of explicit where-clauses like `T: 'a` or
 /// because of implied bounds.
-pub type RegionBoundPairs<'tcx> = FxIndexSet<ty::OutlivesPredicate<'tcx, GenericKind<'tcx>>>;
+pub type RegionBoundPairs<'tcx> = FxIndexSet<ty::OutlivesClause<'tcx, GenericKind<'tcx>>>;
 
 impl<'tcx> OutlivesEnvironment<'tcx> {
     /// Create a new `OutlivesEnvironment` from normalized outlives bounds.
     pub fn from_normalized_bounds(
         param_env: ty::ParamEnv<'tcx>,
-        known_type_outlives: Vec<ty::PolyTypeOutlivesPredicate<'tcx>>,
+        known_type_outlives: Vec<ty::PolyTypeOutlivesClause<'tcx>>,
         extra_bounds: impl IntoIterator<Item = OutlivesBound<'tcx>>,
-        higher_ranked_assumptions: FxHashSet<ty::ArgOutlivesPredicate<'tcx>>,
+        higher_ranked_assumptions: FxHashSet<ty::ArgOutlivesClause<'tcx>>,
     ) -> Self {
         let mut region_relation = TransitiveRelationBuilder::default();
         let mut region_bound_pairs = RegionBoundPairs::default();
@@ -66,12 +66,10 @@ impl<'tcx> OutlivesEnvironment<'tcx> {
             debug!("add_outlives_bounds: outlives_bound={:?}", outlives_bound);
             match outlives_bound {
                 OutlivesBound::RegionSubParam(r_a, param_b) => {
-                    region_bound_pairs
-                        .insert(ty::OutlivesPredicate(GenericKind::Param(param_b), r_a));
+                    region_bound_pairs.insert(ty::OutlivesClause(GenericKind::Param(param_b), r_a));
                 }
                 OutlivesBound::RegionSubAlias(r_a, alias_b) => {
-                    region_bound_pairs
-                        .insert(ty::OutlivesPredicate(GenericKind::Alias(alias_b), r_a));
+                    region_bound_pairs.insert(ty::OutlivesClause(GenericKind::Alias(alias_b), r_a));
                 }
                 OutlivesBound::RegionSubRegion(r_a, r_b) => match (r_a.kind(), r_b.kind()) {
                     (
@@ -104,11 +102,11 @@ impl<'tcx> OutlivesEnvironment<'tcx> {
         &self.region_bound_pairs
     }
 
-    pub fn known_type_outlives(&self) -> &[ty::PolyTypeOutlivesPredicate<'tcx>] {
+    pub fn known_type_outlives(&self) -> &[ty::PolyTypeOutlivesClause<'tcx>] {
         &self.known_type_outlives
     }
 
-    pub fn higher_ranked_assumptions(&self) -> &FxHashSet<ty::ArgOutlivesPredicate<'tcx>> {
+    pub fn higher_ranked_assumptions(&self) -> &FxHashSet<ty::ArgOutlivesClause<'tcx>> {
         &self.higher_ranked_assumptions
     }
 }

--- a/compiler/rustc_infer/src/infer/outlives/mod.rs
+++ b/compiler/rustc_infer/src/infer/outlives/mod.rs
@@ -29,7 +29,7 @@ pub fn explicit_outlives_bounds<'tcx>(
         .into_iter()
         .filter_map(ty::Clause::as_region_outlives_clause)
         .filter_map(ty::Binder::no_bound_vars)
-        .map(|ty::OutlivesPredicate(r_a, r_b)| OutlivesBound::RegionSubRegion(r_b, r_a))
+        .map(|ty::OutlivesClause(r_a, r_b)| OutlivesBound::RegionSubRegion(r_b, r_a))
 }
 
 impl<'tcx> InferCtxt<'tcx> {
@@ -75,7 +75,7 @@ impl<'tcx> InferCtxt<'tcx> {
             storage.data.constraints.retain(|(c, _)| match c.kind {
                 ConstraintKind::RegSubReg => !outlives_env
                     .higher_ranked_assumptions()
-                    .contains(&ty::OutlivesPredicate(c.sup.into(), c.sub)),
+                    .contains(&ty::OutlivesClause(c.sup.into(), c.sub)),
 
                 ConstraintKind::VarSubVar
                 | ConstraintKind::RegSubVar

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -65,8 +65,8 @@ use rustc_middle::bug;
 use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::ty::outlives::{Component, push_outlives_components};
 use rustc_middle::ty::{
-    self, GenericArgKind, GenericArgsRef, PolyTypeOutlivesPredicate, Region, RegionExt, RegionVid,
-    Ty, TyCtxt, TypeVisitableExt, eager_resolve_vars,
+    self, GenericArgKind, GenericArgsRef, PolyTypeOutlivesClause, Region, RegionExt, RegionVid, Ty,
+    TyCtxt, TypeVisitableExt, eager_resolve_vars,
 };
 use rustc_span::Span;
 use smallvec::smallvec;
@@ -84,13 +84,13 @@ use crate::traits::{ObligationCause, ObligationCauseCode};
 impl<'tcx> InferCtxt<'tcx> {
     pub fn register_outlives_constraint(
         &self,
-        ty::OutlivesPredicate(arg, r2): ty::ArgOutlivesPredicate<'tcx>,
+        ty::OutlivesClause(arg, r2): ty::ArgOutlivesClause<'tcx>,
         vis: ty::VisibleForLeakCheck,
         cause: &ObligationCause<'tcx>,
     ) {
         match arg.kind() {
             ty::GenericArgKind::Lifetime(r1) => {
-                self.register_region_outlives_constraint(ty::OutlivesPredicate(r1, r2), vis, cause);
+                self.register_region_outlives_constraint(ty::OutlivesClause(r1, r2), vis, cause);
             }
             ty::GenericArgKind::Type(ty1) => {
                 self.register_type_outlives_constraint(ty1, r2, cause);
@@ -113,7 +113,7 @@ impl<'tcx> InferCtxt<'tcx> {
 
     pub fn register_region_outlives_constraint(
         &self,
-        ty::OutlivesPredicate(r_a, r_b): ty::RegionOutlivesPredicate<'tcx>,
+        ty::OutlivesClause(r_a, r_b): ty::RegionOutlivesClause<'tcx>,
         vis: ty::VisibleForLeakCheck,
         cause: &ObligationCause<'tcx>,
     ) {
@@ -190,13 +190,13 @@ impl<'tcx> InferCtxt<'tcx> {
         self.inner.borrow().region_obligations.clone()
     }
 
-    pub fn register_region_assumption(&self, assumption: ty::ArgOutlivesPredicate<'tcx>) {
+    pub fn register_region_assumption(&self, assumption: ty::ArgOutlivesClause<'tcx>) {
         let mut inner = self.inner.borrow_mut();
         inner.undo_log.push(UndoLog::PushRegionAssumption);
         inner.region_assumptions.push(assumption);
     }
 
-    pub fn take_registered_region_assumptions(&self) -> Vec<ty::ArgOutlivesPredicate<'tcx>> {
+    pub fn take_registered_region_assumptions(&self) -> Vec<ty::ArgOutlivesClause<'tcx>> {
         assert!(!self.in_snapshot(), "cannot take registered region assumptions in a snapshot");
         std::mem::take(&mut self.inner.borrow_mut().region_assumptions)
     }
@@ -217,7 +217,7 @@ impl<'tcx> InferCtxt<'tcx> {
         &self,
         // this is always ConstraintConversion but lol
         conversion: impl TypeOutlivesDelegate<'tcx>,
-        known_type_outlives: &[PolyTypeOutlivesPredicate<'tcx>],
+        known_type_outlives: &[PolyTypeOutlivesClause<'tcx>],
         region_outlives: TransitiveRelation<RegionVid>,
         span: Span,
     ) {
@@ -323,7 +323,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 if self.tcx.sess.opts.unstable_opts.higher_ranked_assumptions
                     && outlives_env
                         .higher_ranked_assumptions()
-                        .contains(&ty::OutlivesPredicate(sup_type.into(), sub_region))
+                        .contains(&ty::OutlivesClause(sup_type.into(), sub_region))
                 {
                     continue;
                 }
@@ -388,7 +388,7 @@ where
         tcx: TyCtxt<'tcx>,
         region_bound_pairs: &'cx RegionBoundPairs<'tcx>,
         implicit_region_bound: Option<ty::Region<'tcx>>,
-        caller_bounds: &'cx [ty::PolyTypeOutlivesPredicate<'tcx>],
+        caller_bounds: &'cx [ty::PolyTypeOutlivesClause<'tcx>],
     ) -> Self {
         Self {
             delegate,

--- a/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
+++ b/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
@@ -77,12 +77,12 @@ pub fn extract_verify_if_eq<'tcx>(
 #[instrument(level = "debug", skip(tcx))]
 pub(super) fn can_match_erased_ty<'tcx>(
     tcx: TyCtxt<'tcx>,
-    outlives_predicate: ty::Binder<'tcx, ty::TypeOutlivesPredicate<'tcx>>,
+    outlives_clause: ty::Binder<'tcx, ty::TypeOutlivesClause<'tcx>>,
     erased_ty: Ty<'tcx>,
 ) -> bool {
-    assert!(!outlives_predicate.has_escaping_bound_vars());
-    let erased_outlives_predicate = tcx.erase_and_anonymize_regions(outlives_predicate);
-    let outlives_ty = erased_outlives_predicate.skip_binder().0;
+    assert!(!outlives_clause.has_escaping_bound_vars());
+    let erased_outlives_clause = tcx.erase_and_anonymize_regions(outlives_clause);
+    let outlives_ty = erased_outlives_clause.skip_binder().0;
     if outlives_ty == erased_ty {
         // pointless micro-optimization
         true

--- a/compiler/rustc_infer/src/infer/outlives/verify.rs
+++ b/compiler/rustc_infer/src/infer/outlives/verify.rs
@@ -1,7 +1,7 @@
 use std::assert_matches;
 
 use rustc_middle::ty::outlives::{Component, compute_alias_components_recursive};
-use rustc_middle::ty::{self, OutlivesPredicate, Ty, TyCtxt};
+use rustc_middle::ty::{self, OutlivesClause, Ty, TyCtxt};
 use smallvec::smallvec;
 use tracing::{debug, instrument};
 
@@ -24,7 +24,7 @@ pub(crate) struct VerifyBoundCx<'cx, 'tcx> {
     /// Outside of borrowck the only way to prove `T: '?0` is by
     /// setting  `'?0` to `'empty`.
     implicit_region_bound: Option<ty::Region<'tcx>>,
-    caller_bounds: &'cx [ty::PolyTypeOutlivesPredicate<'tcx>],
+    caller_bounds: &'cx [ty::PolyTypeOutlivesClause<'tcx>],
 }
 
 impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
@@ -32,7 +32,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
         tcx: TyCtxt<'tcx>,
         region_bound_pairs: &'cx RegionBoundPairs<'tcx>,
         implicit_region_bound: Option<ty::Region<'tcx>>,
-        caller_bounds: &'cx [ty::PolyTypeOutlivesPredicate<'tcx>],
+        caller_bounds: &'cx [ty::PolyTypeOutlivesClause<'tcx>],
     ) -> Self {
         Self { tcx, region_bound_pairs, implicit_region_bound, caller_bounds }
     }
@@ -95,7 +95,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
     pub(crate) fn approx_declared_bounds_from_env(
         &self,
         alias_ty: ty::AliasTy<'tcx>,
-    ) -> Vec<ty::PolyTypeOutlivesPredicate<'tcx>> {
+    ) -> Vec<ty::PolyTypeOutlivesClause<'tcx>> {
         let erased_alias_ty = self.tcx.erase_and_anonymize_regions(
             alias_ty.to_ty(self.tcx, ty::IsRigid::yes_if_next_solver(self.tcx)),
         );
@@ -107,7 +107,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
         // Search the env for where clauses like `P: 'a`.
         let env_bounds = self.approx_declared_bounds_from_env(alias_ty).into_iter().map(|binder| {
             // FIXME(#155345): We probably want to assert the alias is rigid here.
-            if let Some(ty::OutlivesPredicate(ty, r)) = binder.no_bound_vars()
+            if let Some(ty::OutlivesClause(ty, r)) = binder.no_bound_vars()
                 && let ty::Alias(_, alias_ty_from_bound) = *ty.kind()
                 && alias_ty_from_bound == alias_ty
             {
@@ -117,7 +117,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
                 VerifyBound::OutlivedBy(r)
             } else {
                 let verify_if_eq_b =
-                    binder.map_bound(|ty::OutlivesPredicate(ty, bound)| VerifyIfEq { ty, bound });
+                    binder.map_bound(|ty::OutlivesClause(ty, bound)| VerifyIfEq { ty, bound });
                 VerifyBound::IfEq(verify_if_eq_b)
             }
         });
@@ -187,7 +187,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
     fn declared_generic_bounds_from_env(
         &self,
         generic_ty: Ty<'tcx>,
-    ) -> Vec<ty::PolyTypeOutlivesPredicate<'tcx>> {
+    ) -> Vec<ty::PolyTypeOutlivesClause<'tcx>> {
         assert_matches!(generic_ty.kind(), ty::Param(_) | ty::Placeholder(_));
         self.declared_generic_bounds_from_env_for_erased_ty(generic_ty)
     }
@@ -207,15 +207,15 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
     fn declared_generic_bounds_from_env_for_erased_ty(
         &self,
         erased_ty: Ty<'tcx>,
-    ) -> Vec<ty::PolyTypeOutlivesPredicate<'tcx>> {
+    ) -> Vec<ty::PolyTypeOutlivesClause<'tcx>> {
         let tcx = self.tcx;
         let mut bounds = vec![];
 
         // To start, collect bounds from user environment. Note that
         // parameter environments are already elaborated, so we don't
         // have to worry about that.
-        bounds.extend(self.caller_bounds.iter().copied().filter(move |outlives_predicate| {
-            super::test_type_match::can_match_erased_ty(tcx, *outlives_predicate, erased_ty)
+        bounds.extend(self.caller_bounds.iter().copied().filter(move |outlives_clause| {
+            super::test_type_match::can_match_erased_ty(tcx, *outlives_clause, erased_ty)
         }));
 
         // Next, collect regions we scraped from the well-formedness
@@ -229,7 +229,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
         // The problem is that the type of `x` is `&'a A`. To be
         // well-formed, then, A must outlive `'a`, but we don't know that
         // this holds from first principles.
-        bounds.extend(self.region_bound_pairs.iter().filter_map(|&OutlivesPredicate(p, r)| {
+        bounds.extend(self.region_bound_pairs.iter().filter_map(|&OutlivesClause(p, r)| {
             debug!(
                 "declared_generic_bounds_from_env_for_erased_ty: region_bound_pair = {:?}",
                 (r, p)
@@ -248,7 +248,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
 
             let p_ty = p.to_ty(tcx);
             let erased_p_ty = self.tcx.erase_and_anonymize_regions(p_ty);
-            (erased_p_ty == erased_ty).then_some(ty::Binder::dummy(ty::OutlivesPredicate(p_ty, r)))
+            (erased_p_ty == erased_ty).then_some(ty::Binder::dummy(ty::OutlivesClause(p_ty, r)))
         }));
 
         bounds

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1885,7 +1885,7 @@ impl ExplicitOutlivesRequirements {
 
         inferred_outlives
             .filter_map(|(clause, _)| match clause.kind().skip_binder() {
-                ty::ClauseKind::RegionOutlives(ty::OutlivesPredicate(a, b)) => match a.kind() {
+                ty::ClauseKind::RegionOutlives(ty::OutlivesClause(a, b)) => match a.kind() {
                     ty::ReEarlyParam(ebr)
                         if item_generics.region_param(ebr, tcx).def_id == lifetime.to_def_id() =>
                     {
@@ -1904,7 +1904,7 @@ impl ExplicitOutlivesRequirements {
     ) -> Vec<ty::Region<'tcx>> {
         inferred_outlives
             .filter_map(|(clause, _)| match clause.kind().skip_binder() {
-                ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(a, b)) => {
+                ty::ClauseKind::TypeOutlives(ty::OutlivesClause(a, b)) => {
                     a.is_param(index).then_some(b)
                 }
                 _ => None,

--- a/compiler/rustc_middle/src/infer/canonical.rs
+++ b/compiler/rustc_middle/src/infer/canonical.rs
@@ -80,7 +80,7 @@ pub struct QueryResponse<'tcx, R> {
 #[derive(StableHash, TypeFoldable, TypeVisitable)]
 pub struct QueryRegionConstraints<'tcx> {
     pub constraints: Vec<QueryRegionConstraint<'tcx>>,
-    pub assumptions: Vec<ty::ArgOutlivesPredicate<'tcx>>,
+    pub assumptions: Vec<ty::ArgOutlivesClause<'tcx>>,
 }
 
 impl QueryRegionConstraints<'_> {

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -805,14 +805,14 @@ rustc_queries! {
         feedable
     }
 
-    /// Returns the *inferred outlives-predicates* of the item given by `DefId`.
+    /// Returns the *inferred outlives-clauses* of the item given by `DefId`.
     ///
     /// E.g., for `struct Foo<'a, T> { x: &'a T }`, this would return `[T: 'a]`.
     ///
     /// **Tip**: You can use `#[rustc_dump_inferred_outlives]` on an item to basically
     /// print the result of this query for use in UI tests or for debugging purposes.
     query inferred_outlives_of(key: DefId) -> &'tcx [(ty::Clause<'tcx>, Span)] {
-        desc { "computing inferred outlives-predicates of `{}`", tcx.def_path_str(key) }
+        desc { "computing inferred outlives-clauses of `{}`", tcx.def_path_str(key) }
         cache_on_disk
         separate_provide_extern
         feedable
@@ -1026,16 +1026,16 @@ rustc_queries! {
         separate_provide_extern
     }
 
-    /// Gets a map with the inferred outlives-predicates of every item in the local crate.
+    /// Gets a map with the inferred outlives-clauses of every item in the local crate.
     ///
     /// <div class="warning">
     ///
     /// **Do not call this query** directly, use [`Self::inferred_outlives_of`] instead.
     ///
     /// </div>
-    query inferred_outlives_crate(_: ()) -> &'tcx ty::CratePredicatesMap<'tcx> {
+    query inferred_outlives_crate(_: ()) -> &'tcx ty::CrateClausesMap<'tcx> {
         arena_cache
-        desc { "computing the inferred outlives-predicates for items in this crate" }
+        desc { "computing the inferred outlives-clauses for items in this crate" }
     }
 
     /// Maps from an impl/trait or struct/variant `DefId`

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -160,7 +160,7 @@ pub struct CtxtInterners<'tcx> {
     captures: InternedSet<'tcx, List<&'tcx ty::CapturedPlace<'tcx>>>,
     valtree: InternedSet<'tcx, ty::ValTreeKind<TyCtxt<'tcx>>>,
     patterns: InternedSet<'tcx, List<ty::Pattern<'tcx>>>,
-    outlives: InternedSet<'tcx, List<ty::ArgOutlivesPredicate<'tcx>>>,
+    outlives: InternedSet<'tcx, List<ty::ArgOutlivesClause<'tcx>>>,
 }
 
 impl<'tcx> CtxtInterners<'tcx> {
@@ -1727,9 +1727,7 @@ nop_list_lift! {
 }
 nop_list_lift! { bound_variable_kinds; ty::BoundVariableKind<'a> => ty::BoundVariableKind<'tcx> }
 nop_list_lift! { patterns; Pattern<'a> => Pattern<'tcx> }
-nop_list_lift! {
-    outlives; ty::ArgOutlivesPredicate<'a> => ty::ArgOutlivesPredicate<'tcx>
-}
+nop_list_lift! { outlives; ty::ArgOutlivesClause<'a> => ty::ArgOutlivesClause<'tcx> }
 
 // This is the impl for `&'a GenericArgs<'a>`.
 nop_list_lift! { args; GenericArg<'a> => GenericArg<'tcx> }
@@ -2019,7 +2017,7 @@ slice_interners!(
     local_def_ids: intern_local_def_ids(LocalDefId),
     captures: intern_captures(&'tcx ty::CapturedPlace<'tcx>),
     patterns: pub mk_patterns(Pattern<'tcx>),
-    outlives: pub mk_outlives(ty::ArgOutlivesPredicate<'tcx>),
+    outlives: pub mk_outlives(ty::ArgOutlivesClause<'tcx>),
     predefined_opaques_in_body: pub mk_predefined_opaques_in_body((ty::OpaqueTypeKey<'tcx>, Ty<'tcx>)),
 );
 
@@ -2487,8 +2485,8 @@ impl<'tcx> TyCtxt<'tcx> {
     where
         I: Iterator<Item = T>,
         T: CollectAndApply<
-                ty::ArgOutlivesPredicate<'tcx>,
-                &'tcx ty::List<ty::ArgOutlivesPredicate<'tcx>>,
+                ty::ArgOutlivesClause<'tcx>,
+                &'tcx ty::List<ty::ArgOutlivesClause<'tcx>>,
             >,
     {
         T::collect_and_apply(iter, |xs| self.mk_outlives(xs))

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -123,7 +123,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     type EarlyParamRegion = ty::EarlyParamRegion;
     type LateParamRegion = ty::LateParamRegion;
 
-    type RegionAssumptions = &'tcx ty::List<ty::ArgOutlivesPredicate<'tcx>>;
+    type RegionAssumptions = &'tcx ty::List<ty::ArgOutlivesClause<'tcx>>;
 
     type ParamEnv = ty::ParamEnv<'tcx>;
     type Predicate = Predicate<'tcx>;

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -533,7 +533,7 @@ impl<'tcx> GenericClauses<'tcx> {
 /// `[const]` bounds for a given item. This is represented using a struct much like
 /// `GenericClauses`, where you can either choose to only instantiate the "own"
 /// bounds or all of the bounds including those from the parent. This distinction
-/// is necessary for code like `compare_method_predicate_entailment`.
+/// is necessary for code like `compare_method_clause_entailment`.
 #[derive(Copy, Clone, Default, Debug, TyEncodable, TyDecodable, StableHash)]
 pub struct ConstConditions<'tcx> {
     pub parent: Option<DefId>,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -84,14 +84,14 @@ pub use self::list::{List, ListWithCachedTypeInfo};
 pub use self::opaque_types::OpaqueTypeKey;
 pub use self::pattern::{Pattern, PatternKind};
 pub use self::predicate::{
-    AliasTerm, AliasTermKind, ArgOutlivesPredicate, Clause, ClauseKind, CoercePredicate,
+    AliasTerm, AliasTermKind, ArgOutlivesClause, Clause, ClauseKind, CoercePredicate,
     ExistentialPredicate, ExistentialPredicateStableCmpExt, ExistentialProjection,
-    ExistentialTraitRef, HostEffectPredicate, NormalizesTo, OutlivesPredicate, PolyCoercePredicate,
+    ExistentialTraitRef, HostEffectPredicate, NormalizesTo, OutlivesClause, PolyCoercePredicate,
     PolyExistentialPredicate, PolyExistentialProjection, PolyExistentialTraitRef,
-    PolyProjectionPredicate, PolyRegionOutlivesPredicate, PolySubtypePredicate, PolyTraitPredicate,
-    PolyTraitRef, PolyTypeOutlivesPredicate, Predicate, PredicateKind, ProjectionPredicate,
-    RegionConstraint, RegionEqPredicate, RegionOutlivesPredicate, SubtypePredicate, TraitPredicate,
-    TraitRef, TypeOutlivesPredicate,
+    PolyProjectionPredicate, PolyRegionOutlivesClause, PolySubtypePredicate, PolyTraitPredicate,
+    PolyTraitRef, PolyTypeOutlivesClause, Predicate, PredicateKind, ProjectionPredicate,
+    RegionConstraint, RegionEqPredicate, RegionOutlivesClause, SubtypePredicate, TraitPredicate,
+    TraitRef, TypeOutlivesClause,
 };
 pub use self::region::{
     EarlyParamRegion, LateParamRegion, LateParamRegionKind, Region, RegionExt, RegionKind,
@@ -670,11 +670,11 @@ impl<'tcx> rustc_type_ir::Flags for Ty<'tcx> {
 /// `tcx.inferred_outlives_of()` to get the outlives for a *particular*
 /// item.
 #[derive(StableHash, Debug)]
-pub struct CratePredicatesMap<'tcx> {
+pub struct CrateClausesMap<'tcx> {
     /// For each struct with outlive bounds, maps to a vector of the
-    /// predicate of its outlive bounds. If an item has no outlives
+    /// clause of its outlive bounds. If an item has no outlives
     /// bounds, it will have no entry.
-    pub predicates: DefIdMap<&'tcx [(Clause<'tcx>, Span)]>,
+    pub clauses: DefIdMap<&'tcx [(Clause<'tcx>, Span)]>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/compiler/rustc_middle/src/ty/predicate.rs
+++ b/compiler/rustc_middle/src/ty/predicate.rs
@@ -21,15 +21,15 @@ pub type PredicateKind<'tcx> = ir::PredicateKind<TyCtxt<'tcx>>;
 pub type NormalizesTo<'tcx> = ir::NormalizesTo<TyCtxt<'tcx>>;
 pub type CoercePredicate<'tcx> = ir::CoercePredicate<TyCtxt<'tcx>>;
 pub type SubtypePredicate<'tcx> = ir::SubtypePredicate<TyCtxt<'tcx>>;
-pub type OutlivesPredicate<'tcx, T> = ir::OutlivesPredicate<TyCtxt<'tcx>, T>;
-pub type RegionOutlivesPredicate<'tcx> = OutlivesPredicate<'tcx, ty::Region<'tcx>>;
-pub type TypeOutlivesPredicate<'tcx> = OutlivesPredicate<'tcx, Ty<'tcx>>;
-pub type ArgOutlivesPredicate<'tcx> = OutlivesPredicate<'tcx, ty::GenericArg<'tcx>>;
+pub type OutlivesClause<'tcx, T> = ir::OutlivesClause<TyCtxt<'tcx>, T>;
+pub type RegionOutlivesClause<'tcx> = OutlivesClause<'tcx, ty::Region<'tcx>>;
+pub type TypeOutlivesClause<'tcx> = OutlivesClause<'tcx, Ty<'tcx>>;
+pub type ArgOutlivesClause<'tcx> = OutlivesClause<'tcx, ty::GenericArg<'tcx>>;
 pub type RegionEqPredicate<'tcx> = ir::RegionEqPredicate<TyCtxt<'tcx>>;
 pub type RegionConstraint<'tcx> = ir::RegionConstraint<TyCtxt<'tcx>>;
 pub type PolyTraitPredicate<'tcx> = ty::Binder<'tcx, TraitPredicate<'tcx>>;
-pub type PolyRegionOutlivesPredicate<'tcx> = ty::Binder<'tcx, RegionOutlivesPredicate<'tcx>>;
-pub type PolyTypeOutlivesPredicate<'tcx> = ty::Binder<'tcx, TypeOutlivesPredicate<'tcx>>;
+pub type PolyRegionOutlivesClause<'tcx> = ty::Binder<'tcx, RegionOutlivesClause<'tcx>>;
+pub type PolyTypeOutlivesClause<'tcx> = ty::Binder<'tcx, TypeOutlivesClause<'tcx>>;
 pub type PolySubtypePredicate<'tcx> = ty::Binder<'tcx, SubtypePredicate<'tcx>>;
 pub type PolyCoercePredicate<'tcx> = ty::Binder<'tcx, CoercePredicate<'tcx>>;
 pub type PolyProjectionPredicate<'tcx> = ty::Binder<'tcx, ProjectionPredicate<'tcx>>;
@@ -195,7 +195,7 @@ impl<'tcx> Clause<'tcx> {
         }
     }
 
-    pub fn as_type_outlives_clause(self) -> Option<ty::Binder<'tcx, TypeOutlivesPredicate<'tcx>>> {
+    pub fn as_type_outlives_clause(self) -> Option<ty::Binder<'tcx, TypeOutlivesClause<'tcx>>> {
         let clause = self.kind();
         if let ty::ClauseKind::TypeOutlives(o) = clause.skip_binder() {
             Some(clause.rebind(o))
@@ -204,9 +204,7 @@ impl<'tcx> Clause<'tcx> {
         }
     }
 
-    pub fn as_region_outlives_clause(
-        self,
-    ) -> Option<ty::Binder<'tcx, RegionOutlivesPredicate<'tcx>>> {
+    pub fn as_region_outlives_clause(self) -> Option<ty::Binder<'tcx, RegionOutlivesClause<'tcx>>> {
         let clause = self.kind();
         if let ty::ClauseKind::RegionOutlives(o) = clause.skip_binder() {
             Some(clause.rebind(o))
@@ -540,20 +538,20 @@ impl<'tcx> UpcastFrom<TyCtxt<'tcx>, PolyTraitPredicate<'tcx>> for Clause<'tcx> {
     }
 }
 
-impl<'tcx> UpcastFrom<TyCtxt<'tcx>, RegionOutlivesPredicate<'tcx>> for Predicate<'tcx> {
-    fn upcast_from(from: RegionOutlivesPredicate<'tcx>, tcx: TyCtxt<'tcx>) -> Self {
+impl<'tcx> UpcastFrom<TyCtxt<'tcx>, RegionOutlivesClause<'tcx>> for Predicate<'tcx> {
+    fn upcast_from(from: RegionOutlivesClause<'tcx>, tcx: TyCtxt<'tcx>) -> Self {
         ty::Binder::dummy(PredicateKind::Clause(ClauseKind::RegionOutlives(from))).upcast(tcx)
     }
 }
 
-impl<'tcx> UpcastFrom<TyCtxt<'tcx>, PolyRegionOutlivesPredicate<'tcx>> for Predicate<'tcx> {
-    fn upcast_from(from: PolyRegionOutlivesPredicate<'tcx>, tcx: TyCtxt<'tcx>) -> Self {
-        from.map_bound(|p| PredicateKind::Clause(ClauseKind::RegionOutlives(p))).upcast(tcx)
+impl<'tcx> UpcastFrom<TyCtxt<'tcx>, PolyRegionOutlivesClause<'tcx>> for Predicate<'tcx> {
+    fn upcast_from(from: PolyRegionOutlivesClause<'tcx>, tcx: TyCtxt<'tcx>) -> Self {
+        from.map_bound(|c| PredicateKind::Clause(ClauseKind::RegionOutlives(c))).upcast(tcx)
     }
 }
 
-impl<'tcx> UpcastFrom<TyCtxt<'tcx>, TypeOutlivesPredicate<'tcx>> for Predicate<'tcx> {
-    fn upcast_from(from: TypeOutlivesPredicate<'tcx>, tcx: TyCtxt<'tcx>) -> Self {
+impl<'tcx> UpcastFrom<TyCtxt<'tcx>, TypeOutlivesClause<'tcx>> for Predicate<'tcx> {
+    fn upcast_from(from: TypeOutlivesClause<'tcx>, tcx: TyCtxt<'tcx>) -> Self {
         ty::Binder::dummy(PredicateKind::Clause(ClauseKind::TypeOutlives(from))).upcast(tcx)
     }
 }

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2984,7 +2984,7 @@ where
     }
 }
 
-impl<'tcx, T, P: PrettyPrinter<'tcx>> Print<P> for ty::OutlivesPredicate<'tcx, T>
+impl<'tcx, T, P: PrettyPrinter<'tcx>> Print<P> for ty::OutlivesClause<'tcx, T>
 where
     T: Print<P>,
 {

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -788,6 +788,6 @@ list_fold! {
     &'tcx ty::List<(ty::OpaqueTypeKey<'tcx>, Ty<'tcx>)>: mk_predefined_opaques_in_body,
     &'tcx ty::List<PlaceElem<'tcx>> : mk_place_elems,
     &'tcx ty::List<ty::Pattern<'tcx>> : mk_patterns,
-    &'tcx ty::List<ty::ArgOutlivesPredicate<'tcx>> : mk_outlives,
+    &'tcx ty::List<ty::ArgOutlivesClause<'tcx>> : mk_outlives,
     &'tcx ty::List<ty::Const<'tcx>> : mk_const_list,
 }

--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -481,7 +481,7 @@ fn register_region_constraints<D, I>(
 {
     for (constraint, vis) in constraints {
         match constraint {
-            ty::RegionConstraint::Outlives(ty::OutlivesPredicate(lhs, rhs)) => match lhs.kind() {
+            ty::RegionConstraint::Outlives(ty::OutlivesClause(lhs, rhs)) => match lhs.kind() {
                 ty::GenericArgKind::Lifetime(lhs) => delegate.sub_regions(rhs, lhs, vis, span),
                 ty::GenericArgKind::Type(lhs) => delegate.register_ty_outlives(lhs, rhs, span),
                 ty::GenericArgKind::Const(_) => panic!("const outlives: {lhs:?}: {rhs:?}"),

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
@@ -11,7 +11,7 @@ use rustc_type_ir::region_constraint::{
     Assumptions, RegionConstraint, eagerly_handle_placeholders_in_universe,
 };
 use rustc_type_ir::{
-    AliasTy, Binder, ClauseKind, InferCtxtLike, Interner, OutlivesPredicate, Region, TypeVisitable,
+    AliasTy, Binder, ClauseKind, InferCtxtLike, Interner, OutlivesClause, Region, TypeVisitable,
     TypeVisitableExt, TypeVisitor, UniverseIndex, max_universe,
 };
 use tracing::{debug, instrument};
@@ -108,7 +108,7 @@ where
 
         clauses.filter(move |clause| max_universe(&**self.delegate, *clause) == u).for_each(
             |clause| match clause.kind().skip_binder() {
-                RegionOutlives(OutlivesPredicate(r1, r2)) => {
+                RegionOutlives(OutlivesClause(r1, r2)) => {
                     assert!(clause.kind().no_bound_vars().is_some());
                     region_outlives_builder.add(r1, r2);
                 }

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -87,9 +87,9 @@ where
     #[instrument(level = "trace", skip(self))]
     fn compute_type_outlives_goal(
         &mut self,
-        goal: Goal<I, ty::OutlivesPredicate<I, I::Ty>>,
+        goal: Goal<I, ty::OutlivesClause<I, I::Ty>>,
     ) -> QueryResultOrRerunNonErased<I> {
-        let ty::OutlivesPredicate(ty, lt) = goal.predicate;
+        let ty::OutlivesClause(ty, lt) = goal.predicate;
         let ty = self.normalize(GoalSource::Misc, goal.param_env, ty::Unnormalized::new_wip(ty))?;
 
         if self.cx().assumptions_on_binders() {
@@ -114,9 +114,9 @@ where
     #[instrument(level = "trace", skip(self))]
     fn compute_region_outlives_goal(
         &mut self,
-        goal: Goal<I, ty::OutlivesPredicate<I, Region<I>>>,
+        goal: Goal<I, ty::OutlivesClause<I, Region<I>>>,
     ) -> QueryResultOrRerunNonErased<I> {
-        let ty::OutlivesPredicate(a, b) = goal.predicate;
+        let ty::OutlivesClause(a, b) = goal.predicate;
 
         if self.cx().assumptions_on_binders() {
             let constraint =

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -899,7 +899,7 @@ where
                     }
                     ecx.add_goal(
                         GoalSource::Misc,
-                        goal.with(cx, ty::OutlivesPredicate(ty_lifetime, lifetime)),
+                        goal.with(cx, ty::OutlivesClause(ty_lifetime, lifetime)),
                     )?;
                     ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
                 }
@@ -1084,7 +1084,7 @@ where
             )?;
 
             // The type must outlive the lifetime of the `dyn` we're unsizing into.
-            ecx.add_goal(GoalSource::Misc, goal.with(cx, ty::OutlivesPredicate(a_ty, b_region)))?;
+            ecx.add_goal(GoalSource::Misc, goal.with(cx, ty::OutlivesClause(a_ty, b_region)))?;
             ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
         })
     }
@@ -1200,7 +1200,7 @@ where
             // Also require that a_ty's lifetime outlives b_ty's lifetime.
             ecx.add_goal(
                 GoalSource::ImplWhereBound,
-                Goal::new(ecx.cx(), param_env, ty::OutlivesPredicate(a_region, b_region)),
+                Goal::new(ecx.cx(), param_env, ty::OutlivesClause(a_region, b_region)),
             )?;
 
             ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -144,7 +144,7 @@ where
                 try_visit!(term.visit_with(self));
                 self.visit_projection_term(projection_ty)
             }
-            ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(ty, _region)) => ty.visit_with(self),
+            ty::ClauseKind::TypeOutlives(ty::OutlivesClause(ty, _region)) => ty.visit_with(self),
             ty::ClauseKind::RegionOutlives(..) => V::Result::output(),
             ty::ClauseKind::ConstArgHasType(ct, ty) => {
                 try_visit!(ct.visit_with(self));

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -1568,8 +1568,8 @@ pub enum PredicateKind {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum ClauseKind {
     Trait(TraitPredicate),
-    RegionOutlives(RegionOutlivesPredicate),
-    TypeOutlives(TypeOutlivesPredicate),
+    RegionOutlives(RegionOutlivesClause),
+    TypeOutlives(TypeOutlivesClause),
     Projection(ProjectionPredicate),
     ConstArgHasType(TyConst, Ty),
     WellFormed(TermKind),
@@ -1602,10 +1602,17 @@ pub struct TraitPredicate {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-pub struct OutlivesPredicate<A, B>(pub A, pub B);
+pub struct OutlivesClause<A, B>(pub A, pub B);
 
-pub type RegionOutlivesPredicate = OutlivesPredicate<Region, Region>;
-pub type TypeOutlivesPredicate = OutlivesPredicate<Ty, Region>;
+pub type RegionOutlivesClause = OutlivesClause<Region, Region>;
+pub type TypeOutlivesClause = OutlivesClause<Ty, Region>;
+
+#[deprecated = "renamed to [`OutlivesClause`]"]
+pub type OutlivesPredicate<A, B> = OutlivesClause<A, B>;
+#[deprecated = "renamed to [`RegionOutlivesClause`]"]
+pub type RegionOutlivesPredicate = RegionOutlivesClause;
+#[deprecated = "renamed to [`TypeOutlivesClause`]"]
+pub type TypeOutlivesPredicate = TypeOutlivesClause;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ProjectionPredicate {

--- a/compiler/rustc_public/src/unstable/convert/stable/ty.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/ty.rs
@@ -772,8 +772,8 @@ impl<'tcx> Stable<'tcx> for ty::ClauseKind<'tcx> {
                 crate::ty::ClauseKind::RegionOutlives(region_outlives.stable(tables, cx))
             }
             ClauseKind::TypeOutlives(type_outlives) => {
-                let ty::OutlivesPredicate::<_, _>(a, b) = type_outlives;
-                crate::ty::ClauseKind::TypeOutlives(crate::ty::OutlivesPredicate(
+                let ty::OutlivesClause::<_, _>(a, b) = type_outlives;
+                crate::ty::ClauseKind::TypeOutlives(crate::ty::OutlivesClause(
                     a.stable(tables, cx),
                     b.stable(tables, cx),
                 ))
@@ -856,19 +856,19 @@ impl<'tcx> Stable<'tcx> for ty::TraitPredicate<'tcx> {
     }
 }
 
-impl<'tcx, T> Stable<'tcx> for ty::OutlivesPredicate<'tcx, T>
+impl<'tcx, T> Stable<'tcx> for ty::OutlivesClause<'tcx, T>
 where
     T: Stable<'tcx>,
 {
-    type T = crate::ty::OutlivesPredicate<T::T, Region>;
+    type T = crate::ty::OutlivesClause<T::T, Region>;
 
     fn stable<'cx>(
         &self,
         tables: &mut Tables<'cx, BridgeTys>,
         cx: &CompilerCtxt<'cx, BridgeTys>,
     ) -> Self::T {
-        let ty::OutlivesPredicate(a, b) = self;
-        crate::ty::OutlivesPredicate(a.stable(tables, cx), b.stable(tables, cx))
+        let ty::OutlivesClause(a, b) = self;
+        crate::ty::OutlivesClause(a.stable(tables, cx), b.stable(tables, cx))
     }
 }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -452,7 +452,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     for (clause, span) in
                         self.tcx.clauses_of(def_id).instantiate_identity(self.tcx).into_iter()
                     {
-                        if let ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(a, b)) =
+                        if let ty::ClauseKind::TypeOutlives(ty::OutlivesClause(a, b)) =
                             clause.kind().skip_binder()
                             && let ty::Param(param) = a.kind()
                             && param.name == kw::SelfUpper

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -4565,7 +4565,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     )
                 });
             }
-            // Suppress `compare_type_predicate_entailment` errors for RPITITs, since they
+            // Suppress `compare_type_clause_entailment` errors for RPITITs, since they
             // should be implied by the parent method.
             ObligationCauseCode::CompareImplItem { trait_item_def_id, .. }
                 if tcx.is_impl_trait_in_trait(trait_item_def_id) => {}

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -844,7 +844,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                                 &dummy_cause,
                             );
                         }
-                        (Some(ty::OutlivesPredicate(t_a, r_b)), _) => {
+                        (Some(ty::OutlivesClause(t_a, r_b)), _) => {
                             selcx.infcx.register_type_outlives_constraint(t_a, r_b, &dummy_cause);
                         }
                         _ => {}

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -499,7 +499,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                     ProcessResult::Changed(Default::default())
                 }
 
-                ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(
+                ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(ty::OutlivesClause(
                     t_a,
                     r_b,
                 ))) => {

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -334,13 +334,13 @@ fn do_normalize_clauses<'tcx>(
     //
     // FIXME: It's very weird that we ignore region obligations but apparently
     // still need to use `resolve_regions` as we need the resolved regions in
-    // the normalized predicates.
+    // the normalized clauses.
     //
     // FIXME(-Zhigher-ranked-assumptions): We're ignoring region errors for now.
     // There're placeholder constraints `leaking` out. This is a hack to work around
     // the fact that we don't support placeholder assumptions right now and is necessary
-    // for `compare_method_predicate_entailment`. We should remove this once we
-    // have proper support for implied bounds on binders.
+    // for `compare_method_clause_entailment`. We should remove this once we have proper
+    // support for implied bounds on binders.
     //
     // This is required by trait-system-refactor-initiative#166. The new solver encounters
     // this more frequently as we entirely ignore outlives predicates with the old solver.

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -343,7 +343,7 @@ fn do_normalize_clauses<'tcx>(
     // support for implied bounds on binders.
     //
     // This is required by trait-system-refactor-initiative#166. The new solver encounters
-    // this more frequently as we entirely ignore outlives predicates with the old solver.
+    // this more frequently as we entirely ignore outlives clauses with the old solver.
     let _errors = infcx.resolve_regions(cause.body_def_id, elaborated_env, []);
     match infcx.fully_resolve(clauses) {
         Ok(clauses) => Ok(clauses),

--- a/compiler/rustc_trait_selection/src/traits/outlives_for_liveness.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_for_liveness.rs
@@ -55,8 +55,7 @@ pub(crate) fn live_args_for_alias_from_outlives_bounds<'tcx>(
             } else {
                 test_type_match::extract_verify_if_eq(
                     tcx,
-                    &outlives
-                        .map_bound(|ty::OutlivesPredicate(ty, bound)| VerifyIfEq { ty, bound }),
+                    &outlives.map_bound(|ty::OutlivesClause(ty, bound)| VerifyIfEq { ty, bound }),
                     // FIXME(#155345): Region handling should generally only
                     // deal with rigid aliases, making sure we do so correctly
                     // everywhere is effort, so we're just using `No` everywhere
@@ -345,7 +344,7 @@ fn live_args_for_outlives_clause<'tcx>(
     tcx: TyCtxt<'tcx>,
     alias_def_id: DefId,
     ty: Ty<'tcx>,
-    outlives: ty::Binder<'tcx, ty::TypeOutlivesPredicate<'tcx>>,
+    outlives: ty::Binder<'tcx, ty::TypeOutlivesClause<'tcx>>,
 ) -> Option<FxIndexSet<ty::EarlyBinder<'tcx, ty::GenericArg<'tcx>>>> {
     // N.B. it's okay to skip the binder here (and in the rest of the function),
     // because all variables under binders do not escape
@@ -370,7 +369,7 @@ fn live_args_for_outlives_clause<'tcx>(
     // we want *all* the identity regions in `ty` that match the outlives bound.
     test_type_match::extract_verify_if_eq(
         tcx,
-        &outlives.map_bound(|ty::OutlivesPredicate(ty, bound)| VerifyIfEq { ty, bound }),
+        &outlives.map_bound(|ty::OutlivesClause(ty, bound)| VerifyIfEq { ty, bound }),
         ty,
     )?;
 

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
@@ -135,11 +135,12 @@ pub fn compute_implied_outlives_bounds_inner<'tcx>(
                 }
 
                 // We need to register region relationships
-                ty::PredicateKind::Clause(ty::ClauseKind::RegionOutlives(
-                    ty::OutlivesPredicate(r_a, r_b),
-                )) => outlives_bounds.push(OutlivesBound::RegionSubRegion(r_b, r_a)),
+                ty::PredicateKind::Clause(ty::ClauseKind::RegionOutlives(ty::OutlivesClause(
+                    r_a,
+                    r_b,
+                ))) => outlives_bounds.push(OutlivesBound::RegionSubRegion(r_b, r_a)),
 
-                ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(
+                ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(ty::OutlivesClause(
                     ty_a,
                     r_b,
                 ))) => {

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/normalize.rs
@@ -89,13 +89,13 @@ impl<'tcx> Normalizable<'tcx> for ty::FnSig<'tcx> {
     }
 }
 
-/// This impl is not needed, since we never normalize type outlives predicates
+/// This impl is not needed, since we never normalize type outlives clauses
 /// in the old solver, but is required by trait bounds to be happy.
-impl<'tcx> Normalizable<'tcx> for ty::PolyTypeOutlivesPredicate<'tcx> {
+impl<'tcx> Normalizable<'tcx> for ty::PolyTypeOutlivesClause<'tcx> {
     fn type_op_method(
         _tcx: TyCtxt<'tcx>,
         _canonicalized: CanonicalQueryInput<'tcx, ParamEnvAnd<'tcx, Normalize<'tcx, Self>>>,
     ) -> Result<CanonicalQueryResponse<'tcx, Self>, NoSolution> {
-        unreachable!("we never normalize PolyTypeOutlivesPredicate")
+        unreachable!("we never normalize PolyTypeOutlivesClause")
     }
 }

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -318,7 +318,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     )]
                 }
                 Condition::Outlives { long, short } => {
-                    let outlives = ty::OutlivesPredicate(long, short);
+                    let outlives = ty::OutlivesClause(long, short);
                     thin_vec![Obligation::with_depth(
                         tcx,
                         obligation.cause.clone(),
@@ -1096,7 +1096,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     .map_err(|_| SelectionError::Unimplemented)?;
 
                 // Register one obligation for 'a: 'b.
-                let outlives = ty::OutlivesPredicate(r_a, r_b);
+                let outlives = ty::OutlivesClause(r_a, r_b);
                 obligations.push(Obligation::with_depth(
                     tcx,
                     obligation.cause.clone(),
@@ -1146,7 +1146,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
                 // If the type is `Foo + 'a`, ensure that the type
                 // being cast to `Foo + 'a` outlives `'a`:
-                let outlives = ty::OutlivesPredicate(source, r);
+                let outlives = ty::OutlivesClause(source, r);
                 nested.push(predicate_to_obligation(
                     ty::ClauseKind::TypeOutlives(outlives).upcast(tcx),
                 ));
@@ -1331,13 +1331,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         match *self_ty.skip_binder().kind() {
             ty::Dynamic(_bounds, lifetime) => {
-                obligations.push(
-                    obligation.with(
-                        tcx,
-                        ty_lifetime
-                            .map_bound(|ty_lifetime| ty::OutlivesPredicate(ty_lifetime, lifetime)),
-                    ),
-                );
+                obligations.push(obligation.with(
+                    tcx,
+                    ty_lifetime.map_bound(|ty_lifetime| ty::OutlivesClause(ty_lifetime, lifetime)),
+                ));
             }
 
             ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2764,7 +2764,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
             obligation.cause.clone(),
             obligation.recursion_depth + 1,
             obligation.param_env,
-            ty::Binder::dummy(ty::OutlivesPredicate(a_region, b_region)),
+            ty::Binder::dummy(ty::OutlivesClause(a_region, b_region)),
         ));
 
         Ok(Some(nested))
@@ -3267,5 +3267,5 @@ pub(crate) enum ProjectionMatchesProjection {
 #[derive(Clone, Debug, TypeFoldable, TypeVisitable)]
 pub(crate) struct AutoImplConstituents<'tcx> {
     pub types: Vec<Ty<'tcx>>,
-    pub assumptions: Vec<ty::ArgOutlivesPredicate<'tcx>>,
+    pub assumptions: Vec<ty::ArgOutlivesClause<'tcx>>,
 }

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -178,7 +178,7 @@ pub fn clause_obligations<'tcx>(
             // the corresponding trait predicate it should've been generated beside.
         }
         ty::ClauseKind::RegionOutlives(..) => {}
-        ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(ty, _reg)) => {
+        ty::ClauseKind::TypeOutlives(ty::OutlivesClause(ty, _reg)) => {
             wf.add_wf_preds_for_term(ty.into());
         }
         ty::ClauseKind::Projection(t) => {
@@ -653,7 +653,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
             for implicit_bound in implicit_bounds {
                 let cause = self.cause(ObligationCauseCode::ObjectTypeBound(ty, explicit_bound));
                 let outlives =
-                    ty::Binder::dummy(ty::OutlivesPredicate(explicit_bound, implicit_bound));
+                    ty::Binder::dummy(ty::OutlivesClause(explicit_bound, implicit_bound));
                 self.out.push(traits::Obligation::with_depth(
                     self.tcx(),
                     cause,
@@ -847,7 +847,7 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
                         self.recursion_depth,
                         self.param_env,
                         ty::Binder::dummy(ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(
-                            ty::OutlivesPredicate(rty, r),
+                            ty::OutlivesClause(rty, r),
                         ))),
                     ));
                 }
@@ -1235,14 +1235,14 @@ pub fn object_region_bounds<'tcx>(
 ) -> Vec<ty::Region<'tcx>> {
     let erased_self_ty = tcx.types.trait_object_dummy_self;
 
-    let predicates =
+    let clauses =
         existential_predicates.iter().map(|predicate| predicate.with_self_ty(tcx, erased_self_ty));
 
-    traits::elaborate(tcx, predicates)
-        .filter_map(|pred| {
-            debug!(?pred);
-            match pred.kind().skip_binder() {
-                ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(ref t, ref r)) => {
+    traits::elaborate(tcx, clauses)
+        .filter_map(|clause| {
+            debug!(?clause);
+            match clause.kind().skip_binder() {
+                ty::ClauseKind::TypeOutlives(ty::OutlivesClause(ref t, ref r)) => {
                     // Search for a bound of the form `erased_self_ty
                     // : 'a`, but be wary of something like `for<'a>
                     // erased_self_ty : 'a` (we interpret a

--- a/compiler/rustc_traits/src/coroutine_witnesses.rs
+++ b/compiler/rustc_traits/src/coroutine_witnesses.rs
@@ -54,7 +54,7 @@ fn compute_assumptions<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: DefId,
     bound_tys: &'tcx ty::List<Ty<'tcx>>,
-) -> &'tcx ty::List<ty::ArgOutlivesPredicate<'tcx>> {
+) -> &'tcx ty::List<ty::ArgOutlivesClause<'tcx>> {
     if tcx.next_trait_solver_globally() || !tcx.sess.opts.unstable_opts.higher_ranked_assumptions {
         return &ty::List::empty();
     }

--- a/compiler/rustc_ty_utils/src/implied_bounds.rs
+++ b/compiler/rustc_ty_utils/src/implied_bounds.rs
@@ -66,7 +66,7 @@ fn assumed_wf_types<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> &'tcx [(Ty<'
                     //
                     // Side-note: We don't really need to do this remapping for early-bound
                     // lifetimes because they're already "linked" by the bidirectional outlives
-                    // predicates we insert in the `explicit_clauses_of` query for RPITITs.
+                    // clauses we insert in the `explicit_clauses_of` query for RPITITs.
                     let mut mapping = FxHashMap::default();
                     let generics = tcx.generics_of(def_id);
 

--- a/compiler/rustc_type_ir/src/elaborate.rs
+++ b/compiler/rustc_type_ir/src/elaborate.rs
@@ -197,7 +197,7 @@ impl<I: Interner, O: Elaboratable<I>> Elaborator<I, O> {
                     },
                 ),
             ),
-            ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(ty_max, r_min)) => {
+            ty::ClauseKind::TypeOutlives(ty::OutlivesClause(ty_max, r_min)) => {
                 // We know that `T: 'a` for some type `T`. We can
                 // often elaborate this. For example, if we know that
                 // `[U]: 'a`, that implies that `U: 'a`. Similarly, if
@@ -259,18 +259,18 @@ fn elaborate_component_to_clause<I: Interner>(
             if r.is_bound() {
                 None
             } else {
-                Some(ty::ClauseKind::RegionOutlives(ty::OutlivesPredicate(r, outlives_region)))
+                Some(ty::ClauseKind::RegionOutlives(ty::OutlivesClause(r, outlives_region)))
             }
         }
 
         Component::Param(p) => {
             let ty = Ty::new_param(cx, p);
-            Some(ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(ty, outlives_region)))
+            Some(ty::ClauseKind::TypeOutlives(ty::OutlivesClause(ty, outlives_region)))
         }
 
         Component::Placeholder(p) => {
             let ty = Ty::new_placeholder(cx, p);
-            Some(ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(ty, outlives_region)))
+            Some(ty::ClauseKind::TypeOutlives(ty::OutlivesClause(ty, outlives_region)))
         }
 
         Component::UnresolvedInferenceVariable(_) => None,
@@ -278,7 +278,7 @@ fn elaborate_component_to_clause<I: Interner>(
         Component::Alias(is_rigid, alias_ty) => {
             // We might end up here if we have `Foo<<Bar as Baz>::Assoc>: 'a`.
             // With this, we can deduce that `<Bar as Baz>::Assoc: 'a`.
-            Some(ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(
+            Some(ty::ClauseKind::TypeOutlives(ty::OutlivesClause(
                 alias_ty.to_ty(cx, is_rigid),
                 outlives_region,
             )))
@@ -386,12 +386,12 @@ impl<I: Interner, It: Iterator<Item = I::Clause>> Iterator for FilterToTraits<I,
 
 pub fn elaborate_outlives_assumptions<I: Interner>(
     cx: I,
-    assumptions: impl IntoIterator<Item = ty::OutlivesPredicate<I, I::GenericArg>>,
-) -> HashSet<ty::OutlivesPredicate<I, I::GenericArg>> {
+    assumptions: impl IntoIterator<Item = ty::OutlivesClause<I, I::GenericArg>>,
+) -> HashSet<ty::OutlivesClause<I, I::GenericArg>> {
     let mut collected = HashSet::default();
 
-    for ty::OutlivesPredicate(arg1, r2) in assumptions {
-        collected.insert(ty::OutlivesPredicate(arg1, r2));
+    for ty::OutlivesClause(arg1, r2) in assumptions {
+        collected.insert(ty::OutlivesClause(arg1, r2));
         match arg1.kind() {
             // Elaborate the components of an type, since we may have substituted a
             // generic coroutine with a more specific type.
@@ -402,22 +402,22 @@ pub fn elaborate_outlives_assumptions<I: Interner>(
                     match c {
                         Component::Region(r1) => {
                             if !r1.is_bound() {
-                                collected.insert(ty::OutlivesPredicate(r1.into(), r2));
+                                collected.insert(ty::OutlivesClause(r1.into(), r2));
                             }
                         }
 
                         Component::Param(p) => {
                             let ty = Ty::new_param(cx, p);
-                            collected.insert(ty::OutlivesPredicate(ty.into(), r2));
+                            collected.insert(ty::OutlivesClause(ty.into(), r2));
                         }
 
                         Component::Placeholder(p) => {
                             let ty = Ty::new_placeholder(cx, p);
-                            collected.insert(ty::OutlivesPredicate(ty.into(), r2));
+                            collected.insert(ty::OutlivesClause(ty.into(), r2));
                         }
 
                         Component::Alias(is_rigid, alias_ty) => {
-                            collected.insert(ty::OutlivesPredicate(
+                            collected.insert(ty::OutlivesClause(
                                 alias_ty.to_ty(cx, is_rigid).into(),
                                 r2,
                             ));

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -395,14 +395,11 @@ impl<I: Interner> FlagComputation<I> {
             })) => {
                 self.add_args(trait_ref.args.as_slice());
             }
-            ty::PredicateKind::Clause(ty::ClauseKind::RegionOutlives(ty::OutlivesPredicate(
-                a,
-                b,
-            ))) => {
+            ty::PredicateKind::Clause(ty::ClauseKind::RegionOutlives(ty::OutlivesClause(a, b))) => {
                 self.add_region(a);
                 self.add_region(b);
             }
-            ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(
+            ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(ty::OutlivesClause(
                 ty,
                 region,
             ))) => {

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -463,8 +463,8 @@ pub trait Predicate<I: Interner<Predicate = Self>>:
     + UpcastFrom<I, ty::Binder<I, ty::TraitRef<I>>>
     + UpcastFrom<I, ty::TraitPredicate<I>>
     + UpcastFrom<I, ty::ProjectionPredicate<I>>
-    + UpcastFrom<I, ty::OutlivesPredicate<I, I::Ty>>
-    + UpcastFrom<I, ty::OutlivesPredicate<I, Region<I>>>
+    + UpcastFrom<I, ty::OutlivesClause<I, I::Ty>>
+    + UpcastFrom<I, ty::OutlivesClause<I, Region<I>>>
     + IntoKind<Kind = ty::Binder<I, ty::PredicateKind<I>>>
     + Elaboratable<I>
 {
@@ -511,7 +511,7 @@ pub trait Clause<I: Interner<Clause = Self>>:
 {
     fn as_predicate(self) -> I::Predicate;
 
-    fn as_type_outlives_clause(self) -> Option<ty::Binder<I, ty::OutlivesPredicate<I, I::Ty>>> {
+    fn as_type_outlives_clause(self) -> Option<ty::Binder<I, ty::OutlivesClause<I, I::Ty>>> {
         self.kind()
             .map_bound(|clause| {
                 if let ty::ClauseKind::TypeOutlives(outlives) = clause {

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -193,7 +193,7 @@ pub trait Interner:
         + Debug
         + Hash
         + Eq
-        + SliceLike<Item = ty::OutlivesPredicate<Self, Self::GenericArg>>
+        + SliceLike<Item = ty::OutlivesClause<Self, Self::GenericArg>>
         + TypeFoldable<Self>;
 
     // Predicates
@@ -340,8 +340,8 @@ pub trait Interner:
         def_id: Self::DefId,
     ) -> ty::EarlyBinder<Self, impl IntoIterator<Item = (Self::Clause, Self::Span)>>;
 
-    /// This is equivalent to computing the super-predicates of the trait for this impl
-    /// and filtering them to the outlives predicates. This is purely for performance.
+    /// This is equivalent to computing the super-clauses of the trait for this impl
+    /// and filtering them to the outlives clauses. This is purely for performance.
     fn impl_super_outlives(
         self,
         impl_def_id: Self::ImplId,

--- a/compiler/rustc_type_ir/src/ir_print.rs
+++ b/compiler/rustc_type_ir/src/ir_print.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use crate::{AliasConst, ClosureKind};
 use crate::{
     AliasTerm, AliasTy, Binder, CoercePredicate, ExistentialProjection, ExistentialTraitRef, FnSig,
-    HostEffectPredicate, Interner, NormalizesTo, OutlivesPredicate, PatternKind, Placeholder,
+    HostEffectPredicate, Interner, NormalizesTo, OutlivesClause, PatternKind, Placeholder,
     ProjectionPredicate, Region, SubtypePredicate, TraitPredicate, TraitRef,
 };
 
@@ -64,12 +64,12 @@ where
     }
 }
 
-impl<I: Interner, T> fmt::Display for OutlivesPredicate<I, T>
+impl<I: Interner, T> fmt::Display for OutlivesClause<I, T>
 where
-    I: IrPrint<OutlivesPredicate<I, T>>,
+    I: IrPrint<OutlivesClause<I, T>>,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        <I as IrPrint<OutlivesPredicate<I, T>>>::print(self, fmt)
+        <I as IrPrint<OutlivesClause<I, T>>>::print(self, fmt)
     }
 }
 

--- a/compiler/rustc_type_ir/src/outlives.rs
+++ b/compiler/rustc_type_ir/src/outlives.rs
@@ -8,7 +8,7 @@ use smallvec::{SmallVec, smallvec};
 use crate::data_structures::SsoHashSet;
 use crate::inherent::*;
 use crate::visit::{TypeSuperVisitable, TypeVisitable, TypeVisitableExt as _, TypeVisitor};
-use crate::{self as ty, AliasTy, Interner, OutlivesPredicate, Region, Unnormalized};
+use crate::{self as ty, AliasTy, Interner, OutlivesClause, Region, Unnormalized};
 
 #[derive_where(Debug; I: Interner)]
 pub enum Component<I: Interner> {
@@ -279,7 +279,7 @@ pub fn declared_bounds_from_definition<I: Interner>(
     bounds
         .iter_instantiated(cx, alias_ty.args)
         .map(Unnormalized::skip_norm_wip)
-        .filter_map(|p| p.as_type_outlives_clause())
-        .filter_map(|p| p.no_bound_vars())
-        .map(|OutlivesPredicate(_, r)| r)
+        .filter_map(|c| c.as_type_outlives_clause())
+        .filter_map(|c| c.no_bound_vars())
+        .map(|OutlivesClause(_, r)| r)
 }

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -21,9 +21,9 @@ use crate::{self as ty, Alias, Interner, Region};
     feature = "nightly",
     derive(Decodable_NoContext, Encodable_NoContext, StableHash_NoContext)
 )]
-pub struct OutlivesPredicate<I: Interner, A>(pub A, pub Region<I>);
+pub struct OutlivesClause<I: Interner, A>(pub A, pub Region<I>);
 
-impl<I: Interner, A: Eq> Eq for OutlivesPredicate<I, A> {}
+impl<I: Interner, A: Eq> Eq for OutlivesClause<I, A> {}
 
 /// `'a == 'b`.
 /// For the rationale behind having this instead of a pair of bidirectional
@@ -39,8 +39,8 @@ pub struct RegionEqPredicate<I: Interner>(pub Region<I>, pub Region<I>);
 
 impl<I: Interner> RegionEqPredicate<I> {
     /// Decompose `'a == 'b` into `['a: 'b, 'b: 'a]`
-    pub fn into_bidirectional_outlives(self) -> [OutlivesPredicate<I, I::GenericArg>; 2] {
-        [OutlivesPredicate(self.0.into(), self.1), OutlivesPredicate(self.1.into(), self.0)]
+    pub fn into_bidirectional_outlives(self) -> [OutlivesClause<I, I::GenericArg>; 2] {
+        [OutlivesClause(self.0.into(), self.1), OutlivesClause(self.1.into(), self.0)]
     }
 }
 
@@ -51,12 +51,12 @@ impl<I: Interner> RegionEqPredicate<I> {
     derive(Decodable_NoContext, Encodable_NoContext, StableHash_NoContext)
 )]
 pub enum RegionConstraint<I: Interner> {
-    Outlives(OutlivesPredicate<I, I::GenericArg>),
+    Outlives(OutlivesClause<I, I::GenericArg>),
     Eq(RegionEqPredicate<I>),
 }
 
-impl<I: Interner> From<OutlivesPredicate<I, I::GenericArg>> for RegionConstraint<I> {
-    fn from(value: OutlivesPredicate<I, I::GenericArg>) -> Self {
+impl<I: Interner> From<OutlivesClause<I, I::GenericArg>> for RegionConstraint<I> {
+    fn from(value: OutlivesClause<I, I::GenericArg>) -> Self {
         RegionConstraint::Outlives(value)
     }
 }
@@ -80,7 +80,7 @@ impl<I: Interner> RegionConstraint<I> {
 
     /// If `self` is an eq constraint, iterate through its decomposed bidirectional outlives
     /// bounds and if not, just iterate once for the outlives bound itself.
-    pub fn iter_outlives(self) -> impl Iterator<Item = OutlivesPredicate<I, I::GenericArg>> {
+    pub fn iter_outlives(self) -> impl Iterator<Item = OutlivesClause<I, I::GenericArg>> {
         match self {
             RegionConstraint::Outlives(outlives) => iter::once(outlives).chain(None),
             RegionConstraint::Eq(eq) => {

--- a/compiler/rustc_type_ir/src/predicate_kind.rs
+++ b/compiler/rustc_type_ir/src/predicate_kind.rs
@@ -22,10 +22,10 @@ pub enum ClauseKind<I: Interner> {
     Trait(ty::TraitPredicate<I>),
 
     /// `where 'a: 'r`
-    RegionOutlives(ty::OutlivesPredicate<I, Region<I>>),
+    RegionOutlives(ty::OutlivesClause<I, Region<I>>),
 
     /// `where T: 'r`
-    TypeOutlives(ty::OutlivesPredicate<I, I::Ty>),
+    TypeOutlives(ty::OutlivesClause<I, I::Ty>),
 
     /// `where <T as TraitRef>::Name == X`, approximately.
     /// See the `ProjectionPredicate` struct for details.

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -51,7 +51,7 @@ use crate::inherent::*;
 use crate::relate::{Relate, RelateResult, TypeRelation, VarianceDiagInfo};
 use crate::{
     AliasTy, Binder, BoundRegion, BoundVar, BoundVariableKind, DebruijnIndex, FallibleTypeFolder,
-    GenericTypeVisitable, InferCtxtLike, Interner, IsRigid, OutlivesPredicate, Region, RegionKind,
+    GenericTypeVisitable, InferCtxtLike, Interner, IsRigid, OutlivesClause, Region, RegionKind,
     TyKind, TypeFoldable, TypeFolder, TypeVisitable, TypeVisitor, TypingMode, UniverseIndex,
     Variance, VisitorResult, max_universe, set_aliases_to_non_rigid, try_visit,
     walk_visitable_list,
@@ -59,7 +59,7 @@ use crate::{
 
 #[derive_where(Clone, Debug; I: Interner)]
 pub struct Assumptions<I: Interner> {
-    pub type_outlives: Vec<Binder<I, OutlivesPredicate<I, I::Ty>>>,
+    pub type_outlives: Vec<Binder<I, OutlivesClause<I, I::Ty>>>,
     pub region_outlives: TransitiveRelation<Region<I>>,
     pub inverse_region_outlives: TransitiveRelation<Region<I>>,
 }
@@ -74,7 +74,7 @@ impl<I: Interner> Assumptions<I> {
     }
 
     pub fn new(
-        type_outlives: Vec<Binder<I, OutlivesPredicate<I, I::Ty>>>,
+        type_outlives: Vec<Binder<I, OutlivesClause<I, I::Ty>>>,
         region_outlives: TransitiveRelation<Region<I>>,
     ) -> Self {
         Self {
@@ -969,7 +969,7 @@ pub fn regions_outlived_by_placeholder<I: Interner>(
     }
 
     assumptions.type_outlives.iter().flat_map(move |binder| match binder.no_bound_vars() {
-        Some(OutlivesPredicate(ty, r)) => (ty == t).then_some(r),
+        Some(OutlivesClause(ty, r)) => (ty == t).then_some(r),
         None => Some(Region::new_static(cx)),
     })
 }
@@ -1026,7 +1026,7 @@ fn alias_outlives_candidates_from_assumptions<Infcx: InferCtxtLike<Interner = I>
 
     infcx.enter_forall_with_empty_assumptions(bound_outlives, |(alias, r)| {
         for bound_type_outlives in assumptions.type_outlives.iter() {
-            let OutlivesPredicate(alias2, r2) =
+            let OutlivesClause(alias2, r2) =
                 infcx.instantiate_binder_with_infer(*bound_type_outlives);
 
             let mut relation = HigherRankedAliasMatcher {

--- a/src/doc/rustc-dev-guide/src/effects.md
+++ b/src/doc/rustc-dev-guide/src/effects.md
@@ -97,16 +97,16 @@ impl<T: [const] Clone> Foo for Vec<T> {
 }
 ```
 
-These checks are done in [`compare_method_predicate_entailment`].
+These checks are done in [`compare_method_clause_entailment`].
 A similar function that does the same check for associated types is called
-[`compare_type_predicate_entailment`].
+[`compare_type_clause_entailment`].
 Both of these need to consider `const_conditions` when in const contexts.
 
 In MIR, as part of const checking, `const_conditions` of items that are called
 are revalidated again in [`Checker::revalidate_conditional_constness`].
 
-[`compare_method_predicate_entailment`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/check/compare_impl_item/fn.compare_method_predicate_entailment.html
-[`compare_type_predicate_entailment`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/check/compare_impl_item/fn.compare_type_predicate_entailment.html
+[`compare_method_clause_entailment`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/check/compare_impl_item/fn.compare_method_clause_entailment.html
+[`compare_type_clause_entailment`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/check/compare_impl_item/fn.compare_type_clause_entailment.html
 [`FnCtxt::enforce_context_effects`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_typeck/fn_ctxt/struct.FnCtxt.html#method.enforce_context_effects
 [`wfcheck::check_impl`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/check/wfcheck/fn.check_impl.html
 [`Checker::revalidate_conditional_constness`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_const_eval/check_consts/check/struct.Checker.html#method.revalidate_conditional_constness

--- a/src/doc/rustc-dev-guide/src/return-position-impl-trait-in-trait.md
+++ b/src/doc/rustc-dev-guide/src/return-position-impl-trait-in-trait.md
@@ -198,7 +198,7 @@ RPITITs begin by copying the predicates of the method that defined it,
 both on the trait and impl side.
 
 Additionally, we install "bidirectional outlives" predicates.
-Specifically, we add region-outlives predicates in both directions for
+Specifically, we add region-outlives clauses in both directions for
 each captured early-bound lifetime that constrains it to be equal to the
 duplicated early-bound lifetime that results from lowering. This is best
 illustrated in an example:

--- a/src/doc/rustc-dev-guide/src/return-position-impl-trait-in-trait.md
+++ b/src/doc/rustc-dev-guide/src/return-position-impl-trait-in-trait.md
@@ -306,7 +306,7 @@ come after the `=` in `type Assoc = ...` for each RPITIT.
 Since `collect_return_position_impl_trait_in_trait_tys` does fulfillment and
 region resolution, we must provide it `assumed_wf_types` so that we can prove
 region obligations with the same expected implied bounds as
-`compare_method_predicate_entailment` does.
+`compare_method_clause_entailment` does.
 
 Since the return type of a method is understood to be one of the assumed WF
 types, and we eagerly fold the return type with inference variables to do

--- a/src/doc/rustc-dev-guide/src/traits/implied-bounds.md
+++ b/src/doc/rustc-dev-guide/src/traits/implied-bounds.md
@@ -13,23 +13,24 @@ The explicit implied bounds are computed in [`fn inferred_outlives_of`]. Only AD
 lazy type aliases have explicit implied bounds which are computed via a fixpoint algorithm
 in the [`fn inferred_outlives_crate`] query.
 
-We use [`fn insert_required_predicates_to_be_wf`] on all fields of all ADTs in the crate.
+We use [`fn insert_required_clauses_to_be_wf`] on all fields of all ADTs in the crate.
 This function computes the outlives bounds for each component of the field using a
 separate implementation.
 
-For ADTs, trait objects, and associated types the initially required predicates are
-computed in [`fn check_explicit_predicates`]. This simply uses `fn explicit_clauses_of`
+For ADTs, trait objects, and associated types the initially required clauses are
+computed in [`fn check_explicit_clauses`]. This simply uses `fn explicit_clauses_of`
 without elaborating them.
 
-Region predicates are added via [`fn insert_outlives_predicate`]. This function takes
-an outlives predicate, decomposes it and adds the components as explicit predicates only
+Region clauses are added via [`fn insert_outlives_clause`]. This function takes
+an outlives clause, decomposes it and adds the components as explicit clauses only
 if the outlived region is a region parameter. [It does not add `'static` requirements][nostatic].
 
+<!-- FIXME: update the links to point at the version of the repo with the renamed functions after #160343 lands -->
  [`fn inferred_outlives_of`]: https://github.com/rust-lang/rust/blob/5b8bc568d28b2e922290c9a966b3231d0ce9398b/compiler/rustc_hir_analysis/src/outlives/mod.rs#L20
  [`fn inferred_outlives_crate`]: https://github.com/rust-lang/rust/blob/5b8bc568d28b2e922290c9a966b3231d0ce9398b/compiler/rustc_hir_analysis/src/outlives/mod.rs#L83
- [`fn insert_required_predicates_to_be_wf`]: https://github.com/rust-lang/rust/blob/5b8bc568d28b2e922290c9a966b3231d0ce9398b/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs#L89
- [`fn check_explicit_predicates`]: https://github.com/rust-lang/rust/blob/5b8bc568d28b2e922290c9a966b3231d0ce9398b/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs#L238
- [`fn insert_outlives_predicate`]: https://github.com/rust-lang/rust/blob/5b8bc568d28b2e922290c9a966b3231d0ce9398b/compiler/rustc_hir_analysis/src/outlives/utils.rs#L15
+ [`fn insert_required_clauses_to_be_wf`]: https://github.com/rust-lang/rust/blob/5b8bc568d28b2e922290c9a966b3231d0ce9398b/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs#L89
+ [`fn check_explicit_clauses`]: https://github.com/rust-lang/rust/blob/5b8bc568d28b2e922290c9a966b3231d0ce9398b/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs#L238
+ [`fn insert_outlives_clause`]: https://github.com/rust-lang/rust/blob/5b8bc568d28b2e922290c9a966b3231d0ce9398b/compiler/rustc_hir_analysis/src/outlives/utils.rs#L15
  [nostatic]: https://github.com/rust-lang/rust/blob/5b8bc568d28b2e922290c9a966b3231d0ce9398b/compiler/rustc_hir_analysis/src/outlives/utils.rs#L159-L165
 
 ## implicit implied bounds

--- a/src/doc/rustc-dev-guide/src/typing-parameter-envs.md
+++ b/src/doc/rustc-dev-guide/src/typing-parameter-envs.md
@@ -25,7 +25,7 @@ such as `ConstArgHasType` or (some) implied bounds.
 
 In most cases `ParamEnv`s are initially created via the [`param_env` query][query] which returns a `ParamEnv` derived from the provided item's where clauses.
 A `ParamEnv` can also be created with arbitrary sets of clauses that are not derived from a specific item,
-such as in [`compare_method_predicate_entailment`][method_pred_entailment] where we create a hybrid `ParamEnv` consisting of the impl's where clauses and the trait definition's function's where clauses.
+such as in [`compare_method_clause_entailment`][method_clause_entailment] where we create a hybrid `ParamEnv` consisting of the impl's where clauses and the trait definition's function's where clauses.
 
 ---
 
@@ -76,7 +76,7 @@ fn foo2<T>(a: T) {
 ```
 
 [clauses_of]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/collect/clauses_of/fn.clauses_of.html
-[method_pred_entailment]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/check/compare_impl_item/fn.compare_method_predicate_entailment.html
+[method_clause_entailment]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/check/compare_impl_item/fn.compare_method_clause_entailment.html
 [query]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/context/struct.TyCtxt.html#method.param_env
 [normalization]: normalization.md
 
@@ -111,7 +111,7 @@ Creating an empty environment with `ParamEnv::empty` is typically only done eith
 or as part of some analysis that do not expect to ever encounter generic parameters
 (e.g. various parts of coherence/orphan check).
 
-Creating an env from an arbitrary set of where clauses is usually unnecessary and should only be done if the environment you need does not correspond to an actual item in the source code (e.g. [`compare_method_predicate_entailment`][method_pred_entailment]).
+Creating an env from an arbitrary set of where clauses is usually unnecessary and should only be done if the environment you need does not correspond to an actual item in the source code (e.g. [`compare_method_clause_entailment`][method_clause_entailment]).
 
 [param_env_new]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.ParamEnv.html#method.new
 [normalize_env_or_error]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_trait_selection/traits/fn.normalize_param_env_or_error.html
@@ -124,7 +124,7 @@ Creating an env from an arbitrary set of where clauses is usually unnecessary an
 [mirtypeck_param_env]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_borrowck/type_check/struct.TypeChecker.html#structfield.param_env
 [env_empty]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.ParamEnv.html#method.empty
 [param_env_query]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_typeck/fn_ctxt/struct.FnCtxt.html#structfield.param_env
-[method_pred_entailment]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/check/compare_impl_item/fn.compare_method_predicate_entailment.html
+[method_clause_entailment]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/check/compare_impl_item/fn.compare_method_clause_entailment.html
 [predicate_emitting_relation]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/relate/combine/trait.PredicateEmittingRelation.html
 [tenv_mono]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.TypingEnv.html#method.fully_monomorphized
 [compiler_help]: https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -432,9 +432,9 @@ pub(crate) fn clean_clause<'tcx>(
     let bound_clause = clause.kind();
     match bound_clause.skip_binder() {
         ty::ClauseKind::Trait(pred) => clean_poly_trait_predicate(bound_clause.rebind(pred), cx),
-        ty::ClauseKind::RegionOutlives(pred) => Some(clean_region_outlives_predicate(pred, cx.tcx)),
+        ty::ClauseKind::RegionOutlives(pred) => Some(clean_region_outlives_clause(pred, cx.tcx)),
         ty::ClauseKind::TypeOutlives(pred) => {
-            Some(clean_type_outlives_predicate(bound_clause.rebind(pred), cx))
+            Some(clean_type_outlives_clause(bound_clause.rebind(pred), cx))
         }
         ty::ClauseKind::Projection(pred) => {
             Some(clean_projection_predicate(bound_clause.rebind(pred), cx))
@@ -467,11 +467,11 @@ fn clean_poly_trait_predicate<'tcx>(
     })
 }
 
-fn clean_region_outlives_predicate<'tcx>(
-    pred: ty::RegionOutlivesPredicate<'tcx>,
+fn clean_region_outlives_clause<'tcx>(
+    clause: ty::RegionOutlivesClause<'tcx>,
     tcx: TyCtxt<'tcx>,
 ) -> WherePredicate {
-    let ty::OutlivesPredicate(a, b) = pred;
+    let ty::OutlivesClause(a, b) = clause;
 
     WherePredicate::RegionPredicate {
         lifetime: clean_middle_region(a, tcx).expect("failed to clean lifetime"),
@@ -481,14 +481,14 @@ fn clean_region_outlives_predicate<'tcx>(
     }
 }
 
-fn clean_type_outlives_predicate<'tcx>(
-    pred: ty::Binder<'tcx, ty::TypeOutlivesPredicate<'tcx>>,
+fn clean_type_outlives_clause<'tcx>(
+    clause: ty::Binder<'tcx, ty::TypeOutlivesClause<'tcx>>,
     cx: &mut DocContext<'tcx>,
 ) -> WherePredicate {
-    let ty::OutlivesPredicate(ty, lt) = pred.skip_binder();
+    let ty::OutlivesClause(ty, lt) = clause.skip_binder();
 
     WherePredicate::BoundPredicate {
-        ty: clean_middle_ty(pred.rebind(ty), cx, None, None),
+        ty: clean_middle_ty(clause.rebind(ty), cx, None, None),
         bounds: vec![GenericBound::Outlives(
             clean_middle_region(lt, cx.tcx).expect("failed to clean lifetimes"),
         )],
@@ -903,7 +903,7 @@ fn clean_ty_generics_inner<'tcx>(
                     ty::ClauseKind::Trait(pred) if let ty::Param(param) = pred.self_ty().kind() => {
                         Some(param.index)
                     }
-                    ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(ty, _reg))
+                    ty::ClauseKind::TypeOutlives(ty::OutlivesClause(ty, _reg))
                         if let ty::Param(param) = ty.kind() =>
                     {
                         Some(param.index)
@@ -2401,7 +2401,7 @@ fn clean_middle_opaque_bounds<'tcx>(
             let bound_predicate = bound.kind();
             let trait_ref = match bound_predicate.skip_binder() {
                 ty::ClauseKind::Trait(tr) => bound_predicate.rebind(tr.trait_ref),
-                ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(_ty, reg)) => {
+                ty::ClauseKind::TypeOutlives(ty::OutlivesClause(_ty, reg)) => {
                     return clean_middle_region(reg, cx.tcx).map(GenericBound::Outlives);
                 }
                 _ => return None,

--- a/tests/rustdoc-js/auxiliary/interner.rs
+++ b/tests/rustdoc-js/auxiliary/interner.rs
@@ -68,8 +68,8 @@ pub trait Interner: Sized {
     type PlaceholderRegion: Copy + Debug + Hash + Ord + PlaceholderLike;
     type Predicate: Copy + Debug + Hash + Eq + TypeSuperVisitable<Self> + Flags;
     type TraitPredicate: Copy + Debug + Hash + Eq;
-    type RegionOutlivesPredicate: Copy + Debug + Hash + Eq;
-    type TypeOutlivesPredicate: Copy + Debug + Hash + Eq;
+    type RegionOutlivesClause: Copy + Debug + Hash + Eq;
+    type TypeOutlivesClause: Copy + Debug + Hash + Eq;
     type ProjectionPredicate: Copy + Debug + Hash + Eq;
     type NormalizesTo: Copy + Debug + Hash + Eq;
     type SubtypePredicate: Copy + Debug + Hash + Eq;

--- a/tests/ui/associated-types/normalization-generality-2.rs
+++ b/tests/ui/associated-types/normalization-generality-2.rs
@@ -5,7 +5,7 @@
 
 // Ensures that we don't regress on "implementation is not general enough" when
 // normalizating under binders. Unlike `normalization-generality.rs`, this also produces
-// type outlives predicates that we must ignore.
+// type outlives clauses that we must ignore.
 
 pub unsafe trait Yokeable<'a> {
     type Output: 'a;

--- a/tests/ui/traits/next-solver/global-where-bound-normalization.rs
+++ b/tests/ui/traits/next-solver/global-where-bound-normalization.rs
@@ -20,7 +20,7 @@ impl Proj for MyField {
     type Assoc = u8;
 }
 
-// While wf-checking the global bounds of `fn foo`, elaborating this outlives predicate triggered a
+// While wf-checking the global bounds of `fn foo`, elaborating this outlives clause triggered a
 // cycle in the search graph along a particular probe path, which was not an actual solution.
 // That cycle then resulted in a forced false-positive ambiguity due to a performance hack in the
 // search graph and then ended up floundering the root goal evaluation.


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/107250 / Follow-up to https://github.com/rust-lang/rust/pull/160177

This is motivated by `OutlivesPredicate` being the inner type of `ClauseKind::TypeOutlives` and `ClauseKind::RegionOutlives`, and the "outlives clause" terminology already being used in a few places across the codebase.

One thing worth noting: `OutlivesPredicate` and its derivatives are duplicated in `rustc_public`. I chose to rename them, but leave the old names available as deprecated type aliases -- this should hopefully be semver-compatible?

r? @oli-obk
cc @nnethercote