### PR TITLE
EverInitializedPlaces: stop growing lattice after a path is ever-init

### DIFF
--- a/compiler/rustc_mir_dataflow/src/impls/initialized.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/initialized.rs
@@ -594,6 +594,37 @@ impl<'tcx> Analysis<'tcx> for MaybeUninitializedPlaces<'_, 'tcx> {
 /// We use a mixed bitset to avoid paying too high a memory footprint.
 pub type EverInitializedPlacesDomain = MixedBitSet<InitIndex>;
 
+impl<'a, 'tcx> EverInitializedPlaces<'a, 'tcx> {
+    /// Insert `init` into the ever-init set only if no initialization of the
+    /// **same move path** is already present.
+    ///
+    /// Borrowck queries only whether a local/path has *any* reaching init
+    /// (`is_local_ever_initialized`), and illegal-reassignment diagnostics need
+    /// *a* prior `InitIndex` for span reconstruction — not every assignment
+    /// site. Recording additional `InitIndex` facts for a path that is already
+    /// ever-initialized grows lattice height and forces extra fixpoint visits
+    /// on cyclic MIR (many sequential `loop`/`await` reassignments) without
+    /// changing the Boolean ever-init predicate.
+    ///
+    /// `StorageDead` still kills all inits of the path, so re-initialization
+    /// after dead storage inserts a fresh first fact as before.
+    #[inline]
+    fn gen_if_path_not_ever_init(
+        &self,
+        state: &mut EverInitializedPlacesDomain,
+        init: InitIndex,
+    ) {
+        let move_data = self.move_data();
+        let path = move_data.inits[init].path;
+        let already = move_data.init_path_map[path]
+            .iter()
+            .any(|&other| state.contains(other));
+        if !already {
+            state.gen_(init);
+        }
+    }
+}
+
 impl<'tcx> Analysis<'tcx> for EverInitializedPlaces<'_, 'tcx> {
     type Domain = EverInitializedPlacesDomain;
 
@@ -623,7 +654,9 @@ impl<'tcx> Analysis<'tcx> for EverInitializedPlaces<'_, 'tcx> {
         let rev_lookup = &move_data.rev_lookup;
 
         debug!("initializes move_indexes {:?}", init_loc_map[location]);
-        state.gen_all(init_loc_map[location].iter().copied());
+        for &init in &init_loc_map[location] {
+            self.gen_if_path_not_ever_init(state, init);
+        }
 
         if let mir::StatementKind::StorageDead(local) = stmt.kind
             // End inits for StorageDead, so that an immutable variable can
@@ -646,14 +679,11 @@ impl<'tcx> Analysis<'tcx> for EverInitializedPlaces<'_, 'tcx> {
         let init_loc_map = &move_data.init_loc_map;
         debug!(?terminator);
         debug!("initializes move_indexes {:?}", init_loc_map[location]);
-        state.gen_all(
-            init_loc_map[location]
-                .iter()
-                .filter(|init_index| {
-                    move_data.inits[**init_index].kind != InitKind::NonPanicPathOnly
-                })
-                .copied(),
-        );
+        for &init_index in &init_loc_map[location] {
+            if move_data.inits[init_index].kind != InitKind::NonPanicPathOnly {
+                self.gen_if_path_not_ever_init(state, init_index);
+            }
+        }
         terminator.edges()
     }
 
@@ -667,8 +697,8 @@ impl<'tcx> Analysis<'tcx> for EverInitializedPlaces<'_, 'tcx> {
         let init_loc_map = &move_data.init_loc_map;
 
         let call_loc = self.body.terminator_loc(block);
-        for init_index in &init_loc_map[call_loc] {
-            state.gen_(*init_index);
+        for &init_index in &init_loc_map[call_loc] {
+            self.gen_if_path_not_ever_init(state, init_index);
         }
     }
 }

--- a/tests/ui/borrowck/ever-init-idempotent-many-inits.rs
+++ b/tests/ui/borrowck/ever-init-idempotent-many-inits.rs
@@ -1,0 +1,34 @@
+//! Many reassignments of the same local must not change borrowck's
+//! Boolean ever-init checks or illegal-reassignment diagnostics.
+//!
+//! Guards the EverInitializedPlaces optimization that omits later InitIndex
+//! facts for a move path that is already ever-initialized in the lattice.
+
+//@ run-rustfix
+
+fn many_mut_ok(mut acc: u64) -> u64 {
+    // Conditional backedges so MIR keeps cycles; each iteration reassigns `acc`.
+    for i in 0..32u64 {
+        if i % 2 == 0 {
+            acc = acc.wrapping_add(i);
+        } else {
+            acc = acc.wrapping_mul(3).wrapping_add(1);
+        }
+    }
+    acc
+}
+
+fn main() {
+    let _ = many_mut_ok(1);
+
+    let v: i32;
+    //~^ HELP consider making this binding mutable
+    //~| SUGGESTION mut
+    v = 1;
+    //~^ NOTE first assignment
+    let _ = v;
+    v = 2;
+    //~^ ERROR cannot assign twice to immutable variable
+    //~| NOTE cannot assign twice to immutable
+    let _ = v;
+}

--- a/tests/ui/borrowck/ever-init-idempotent-many-inits.stderr
+++ b/tests/ui/borrowck/ever-init-idempotent-many-inits.stderr
@@ -1,0 +1,17 @@
+error[E0384]: cannot assign twice to immutable variable `v`
+  --> $DIR/ever-init-idempotent-many-inits.rs:30:5
+   |
+LL |     v = 1;
+   |     ----- first assignment to `v`
+...
+LL |     v = 2;
+   |     ^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut v: i32;
+   |         +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0384`.


### PR DESCRIPTION
## Summary

Borrowck’s `EverInitializedPlaces` analysis currently inserts a new `InitIndex` bit for **every** assignment site. On MIR with many sequential reassignments of the same local (classic pattern: many `.await`s or sequential loops reassigning one accumulator), the lattice height grows with the number of init sites. The fixpoint then revisits blocks repeatedly as each new bit appears, producing superlinear `mir_borrowck` time ([#159944](https://github.com/rust-lang/rust/issues/159944)).

Consumers do **not** need that full set of bits:

1. **Boolean ever-init** (`is_local_ever_initialized`): “is *any* init of this local live?”
2. **Illegal-reassignment diagnostics**: need *a* prior `InitIndex` for the “first assignment” span, not every later site.

This PR makes `gen` **idempotent per move path**: if the state already contains any `InitIndex` of the same path, skip inserting a new one. `StorageDead` still kills all inits of the path, so re-initialization after dead storage records a fresh first fact.

### What this is / is not

| | |
| --- | --- |
| **Is** | Small, self-contained change on `main`: keep `MixedBitSet<InitIndex>`, only stop redundant gens |
| **Is not** | A reimplementation of [#160033](https://github.com/rust-lang/rust/pull/160033) (`DenseBitSet<Local>` + cold `first_reaching_init`) |

If rust-lang/rust#160033 lands first, this PR is largely subsumed and can be closed. Until then it is an independently reviewable mitigation of lattice growth on the existing domain.

### Why this helps

After the first live init of a path, further assignments add no new information to the Boolean ever-init predicate. Omitting them keeps the bitset from accumulating N bits for N reassigns of the same local — the lattice-height explosion behind the await/loop cliff (rust-lang/rust#159944).

### Tests

- New UI test: `ever-init-idempotent-many-inits.rs` — many mutable reassigns OK; illegal second assign still attributes “first assignment”.

### Related

- Issue: https://github.com/rust-lang/rust/issues/159944
- Related architecture draft: https://github.com/rust-lang/rust/pull/160033 (prefer that long-term if it lands; this is a smaller intermediate on the existing domain)

r? borrowck