### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_target/src/asm/x86.rs
+++ b/compiler/rustc_target/src/asm/x86.rs
@@ -105,7 +105,7 @@ impl X86InlineAsmRegClass {
     pub fn supported_types(
         self,
         arch: InlineAsmArch,
-        allow_experimental_reg: bool,
+        _allow_experimental_reg: bool,
     ) -> &'static [(InlineAsmType, Option<Symbol>)] {
         match self {
             Self::reg | Self::reg_abcd => {
@@ -117,48 +117,24 @@ impl X86InlineAsmRegClass {
             }
             Self::reg_byte => types! { _: I8; },
             Self::xmm_reg => {
-                if allow_experimental_reg {
-                    types! {
-                        sse: I32, I64, I128, F16, F32, F64, F128,
-                          VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2);
-                    }
-                } else {
-                    types! {
-                        sse: I32, I64, F16, F32, F64, F128,
-                          VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2);
-                    }
+                types! {
+                    sse: I32, I64, I128, F16, F32, F64, F128,
+                      VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2);
                 }
             }
             Self::ymm_reg => {
-                if allow_experimental_reg {
-                    types! {
-                        avx: I32, I64, I128, F16, F32, F64, F128,
-                            VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2),
-                            VecI8(32), VecI16(16), VecI32(8), VecI64(4), VecF16(16), VecF32(8), VecF64(4);
-                    }
-                } else {
-                    types! {
-                        avx: I32, I64, F16, F32, F64, F128,
-                            VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2),
-                            VecI8(32), VecI16(16), VecI32(8), VecI64(4), VecF16(16), VecF32(8), VecF64(4);
-                    }
+                types! {
+                    avx: I32, I64, I128, F16, F32, F64, F128,
+                        VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2),
+                        VecI8(32), VecI16(16), VecI32(8), VecI64(4), VecF16(16), VecF32(8), VecF64(4);
                 }
             }
             Self::zmm_reg => {
-                if allow_experimental_reg {
-                    types! {
-                        avx512f: I32, I64, I128, F16, F32, F64, F128,
-                            VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2),
-                            VecI8(32), VecI16(16), VecI32(8), VecI64(4), VecF16(16), VecF32(8), VecF64(4),
-                            VecI8(64), VecI16(32), VecI32(16), VecI64(8), VecF16(32), VecF32(16), VecF64(8);
-                    }
-                } else {
-                    types! {
-                    avx512f: I32, I64, F16, F32, F64, F128,
+                types! {
+                    avx512f: I32, I64, I128, F16, F32, F64, F128,
                         VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2),
                         VecI8(32), VecI16(16), VecI32(8), VecI64(4), VecF16(16), VecF32(8), VecF64(4),
                         VecI8(64), VecI16(32), VecI32(16), VecI64(8), VecF16(32), VecF32(16), VecF64(8);
-                    }
                 }
             }
 

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -4,6 +4,7 @@ use crate::iter::adapters::zip::try_get_unchecked;
 use crate::iter::{
     FusedIterator, TrustedFused, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce,
 };
+use crate::num::NonZero;
 use crate::ops::Try;
 
 /// An iterator that yields `None` forever after the underlying iterator
@@ -48,6 +49,10 @@ where
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         FuseImpl::next(self)
+    }
+
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        FuseImpl::advance_by(self, n)
     }
 
     #[inline]
@@ -259,6 +264,7 @@ trait FuseImpl<I> {
 
     // Functions specific to any normal Iterators
     fn next(&mut self) -> Option<Self::Item>;
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>>;
     fn nth(&mut self, n: usize) -> Option<Self::Item>;
     fn try_fold<Acc, Fold, R>(&mut self, acc: Acc, fold: Fold) -> R
     where
@@ -299,6 +305,22 @@ where
     #[inline]
     default fn next(&mut self) -> Option<<I as Iterator>::Item> {
         and_then_or_clear(&mut self.iter, Iterator::next)
+    }
+
+    #[inline]
+    default fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        let Some(iter) = &mut self.iter else {
+            return match NonZero::new(n) {
+                Some(n) => Err(n),
+                None => Ok(()),
+            };
+        };
+
+        let res = iter.advance_by(n);
+        if res.is_err() {
+            self.iter = None;
+        }
+        res
     }
 
     #[inline]
@@ -379,6 +401,17 @@ where
     #[inline]
     fn next(&mut self) -> Option<<I as Iterator>::Item> {
         self.iter.as_mut()?.next()
+    }
+
+    #[inline]
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        match &mut self.iter {
+            Some(iter) => iter.advance_by(n),
+            None => match NonZero::new(n) {
+                Some(n) => Err(n),
+                None => Ok(()),
+            },
+        }
     }
 
     #[inline]

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -145,6 +145,13 @@
 //!   the allocation), `base + o` will not wrap around the address space (in
 //!   other words, will not overflow `usize`)
 //!
+//! Allocations typically have a fixed size that cannot change. However, allocations created by
+//! directly invoking page table operations of the operating system, e.g. via `mmap`, are allowed to
+//! grow by adding more pages to them at the end. Unmapping parts of an allocation (i.e., shrinking
+//! it or punching holes into it) is currently not supported. Allocations created via
+//! "compiler-recognized" operations, such as `std::alloc` methods or `libc::malloc`, can never
+//! change their size, even if they use `mmap` under the hood.
+//!
 //! [`null()`]: null
 //!
 //! # Provenance

--- a/src/doc/unstable-book/src/language-features/asm-experimental-reg.md
+++ b/src/doc/unstable-book/src/language-features/asm-experimental-reg.md
@@ -19,9 +19,6 @@ This tracks support for additional registers in architectures where inline assem
 
 | Architecture | Register class | Target feature | Allowed types |
 | ------------ | -------------- | -------------- | ------------- |
-| x86 | `xmm_reg` | `sse` | `i128` |
-| x86 | `ymm_reg` | `avx` | `i128` |
-| x86 | `zmm_reg` | `avx512f` | `i128` |
 | LoongArch | `vreg` | `lsx` | `f32`, `f64`, <br> `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2` |
 | LoongArch | `xreg` | `lasx` | `f32`, `f64`, <br> `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2`, <br> `i8x32`, `i16x16`, `i32x8`, `i64x4`, `f32x8`, `f64x4` |
 

--- a/tests/ui/asm/x86_64/bad-reg.experimental_reg.stderr
+++ b/tests/ui/asm/x86_64/bad-reg.experimental_reg.stderr
@@ -1,5 +1,5 @@
 error: invalid register class `foo`: unknown register class
-  --> $DIR/bad-reg.rs:20:20
+  --> $DIR/bad-reg.rs:19:20
    |
 LL |         asm!("{}", in(foo) foo);
    |                    ^^^^^^^^^^^
@@ -7,13 +7,13 @@ LL |         asm!("{}", in(foo) foo);
    = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register `foo`: unknown register
-  --> $DIR/bad-reg.rs:22:18
+  --> $DIR/bad-reg.rs:21:18
    |
 LL |         asm!("", in("foo") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid asm template modifier `z` for this register class
-  --> $DIR/bad-reg.rs:24:15
+  --> $DIR/bad-reg.rs:23:15
    |
 LL |         asm!("{:z}", in(reg) foo);
    |               ^^^^   ----------- argument
@@ -23,7 +23,7 @@ LL |         asm!("{:z}", in(reg) foo);
    = note: the `reg` register class supports the following template modifiers: `l`, `x`, `e`, and `r`
 
 error: invalid asm template modifier `r` for this register class
-  --> $DIR/bad-reg.rs:26:15
+  --> $DIR/bad-reg.rs:25:15
    |
 LL |         asm!("{:r}", in(xmm_reg) foo);
    |               ^^^^   --------------- argument
@@ -33,7 +33,7 @@ LL |         asm!("{:r}", in(xmm_reg) foo);
    = note: the `xmm_reg` register class supports the following template modifiers: `x`, `y`, and `z`
 
 error: asm template modifiers are not allowed for `const` arguments
-  --> $DIR/bad-reg.rs:28:15
+  --> $DIR/bad-reg.rs:27:15
    |
 LL |         asm!("{:a}", const 0);
    |               ^^^^   ------- argument
@@ -41,7 +41,7 @@ LL |         asm!("{:a}", const 0);
    |               template modifier
 
 error: asm template modifiers are not allowed for `sym` arguments
-  --> $DIR/bad-reg.rs:30:15
+  --> $DIR/bad-reg.rs:29:15
    |
 LL |         asm!("{:a}", sym main);
    |               ^^^^   -------- argument
@@ -49,67 +49,67 @@ LL |         asm!("{:a}", sym main);
    |               template modifier
 
 error: invalid register `ebp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", in("ebp") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `rsp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", in("rsp") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `ip`: the instruction pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", in("ip") foo);
    |                  ^^^^^^^^^^^^
 
 error: register class `x87_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", in("st(2)") foo);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `mmx_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", in("mm0") foo);
    |                  ^^^^^^^^^^^^^
 
 error: register class `kreg0` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:49:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", in("k0") foo);
    |                  ^^^^^^^^^^^^
 
 error: register class `x87_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:54:20
+  --> $DIR/bad-reg.rs:53:20
    |
 LL |         asm!("{}", in(x87_reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: register class `mmx_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:57:20
+  --> $DIR/bad-reg.rs:56:20
    |
 LL |         asm!("{}", in(mmx_reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: register class `x87_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:60:20
+  --> $DIR/bad-reg.rs:59:20
    |
 LL |         asm!("{}", out(x87_reg) _);
    |                    ^^^^^^^^^^^^^^
 
 error: register class `mmx_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:62:20
+  --> $DIR/bad-reg.rs:61:20
    |
 LL |         asm!("{}", out(mmx_reg) _);
    |                    ^^^^^^^^^^^^^^
 
 error: register `al` conflicts with register `eax`
-  --> $DIR/bad-reg.rs:68:33
+  --> $DIR/bad-reg.rs:67:33
    |
 LL |         asm!("", in("eax") foo, in("al") bar);
    |                  -------------  ^^^^^^^^^^^^ register `al`
@@ -117,7 +117,7 @@ LL |         asm!("", in("eax") foo, in("al") bar);
    |                  register `eax`
 
 error: register `rax` conflicts with register `rax`
-  --> $DIR/bad-reg.rs:71:33
+  --> $DIR/bad-reg.rs:70:33
    |
 LL |         asm!("", in("rax") foo, out("rax") bar);
    |                  -------------  ^^^^^^^^^^^^^^ register `rax`
@@ -125,13 +125,13 @@ LL |         asm!("", in("rax") foo, out("rax") bar);
    |                  register `rax`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:71:18
+  --> $DIR/bad-reg.rs:70:18
    |
 LL |         asm!("", in("rax") foo, out("rax") bar);
    |                  ^^^^^^^^^^^^^
 
 error: register `ymm0` conflicts with register `xmm0`
-  --> $DIR/bad-reg.rs:76:34
+  --> $DIR/bad-reg.rs:75:34
    |
 LL |         asm!("", in("xmm0") foo, in("ymm0") bar);
    |                  --------------  ^^^^^^^^^^^^^^ register `ymm0`
@@ -139,7 +139,7 @@ LL |         asm!("", in("xmm0") foo, in("ymm0") bar);
    |                  register `xmm0`
 
 error: register `ymm0` conflicts with register `xmm0`
-  --> $DIR/bad-reg.rs:78:34
+  --> $DIR/bad-reg.rs:77:34
    |
 LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
    |                  --------------  ^^^^^^^^^^^^^^^ register `ymm0`
@@ -147,25 +147,25 @@ LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
    |                  register `xmm0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:78:18
+  --> $DIR/bad-reg.rs:77:18
    |
 LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
    |                  ^^^^^^^^^^^^^^
 
 error: cannot use register `bl`: rbx is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", in("bl") foo);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `bh`: rbx is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", in("bh") foo);
    |                  ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:43:30
+  --> $DIR/bad-reg.rs:42:30
    |
 LL |         asm!("", in("st(2)") foo);
    |                              ^^^
@@ -173,7 +173,7 @@ LL |         asm!("", in("st(2)") foo);
    = note: register class `x87_reg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:46:28
+  --> $DIR/bad-reg.rs:45:28
    |
 LL |         asm!("", in("mm0") foo);
    |                            ^^^
@@ -181,7 +181,7 @@ LL |         asm!("", in("mm0") foo);
    = note: register class `mmx_reg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:49:27
+  --> $DIR/bad-reg.rs:48:27
    |
 LL |         asm!("", in("k0") foo);
    |                           ^^^
@@ -189,7 +189,7 @@ LL |         asm!("", in("k0") foo);
    = note: register class `kreg0` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:54:32
+  --> $DIR/bad-reg.rs:53:32
    |
 LL |         asm!("{}", in(x87_reg) foo);
    |                                ^^^
@@ -197,7 +197,7 @@ LL |         asm!("{}", in(x87_reg) foo);
    = note: register class `x87_reg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:57:32
+  --> $DIR/bad-reg.rs:56:32
    |
 LL |         asm!("{}", in(mmx_reg) foo);
    |                                ^^^
@@ -205,7 +205,7 @@ LL |         asm!("{}", in(mmx_reg) foo);
    = note: register class `mmx_reg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:68:42
+  --> $DIR/bad-reg.rs:67:42
    |
 LL |         asm!("", in("eax") foo, in("al") bar);
    |                                          ^^^
@@ -213,7 +213,7 @@ LL |         asm!("", in("eax") foo, in("al") bar);
    = note: register class `reg_byte` supports these types: i8
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:73:27
+  --> $DIR/bad-reg.rs:72:27
    |
 LL |         asm!("", in("al") foo, lateout("al") bar);
    |                           ^^^
@@ -221,7 +221,7 @@ LL |         asm!("", in("al") foo, lateout("al") bar);
    = note: register class `reg_byte` supports these types: i8
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:73:46
+  --> $DIR/bad-reg.rs:72:46
    |
 LL |         asm!("", in("al") foo, lateout("al") bar);
    |                                              ^^^

--- a/tests/ui/asm/x86_64/bad-reg.rs
+++ b/tests/ui/asm/x86_64/bad-reg.rs
@@ -3,7 +3,6 @@
 //@ compile-flags: --target x86_64-unknown-linux-gnu -C target-feature=+avx2,+avx512f
 //@ needs-llvm-components: x86
 #![cfg_attr(experimental_reg, feature(asm_experimental_reg))]
-
 #![crate_type = "lib"]
 #![feature(no_core)]
 #![no_core]
@@ -79,22 +78,16 @@ fn main() {
         //~^ ERROR register `ymm0` conflicts with register `xmm0`
         asm!("", in("xmm0") foo, lateout("ymm0") bar);
 
-        // Passing u128/i128 is currently experimental.
+        // Use 128-bit integers with vector registers.
         let mut xmmword = 0u128;
 
-        asm!("/* {:x} */", in(xmm_reg) xmmword); // requires asm_experimental_reg
-        //[stable]~^ ERROR type `u128` cannot be used with this register class in stable
-        asm!("/* {:x} */", out(xmm_reg) xmmword); // requires asm_experimental_reg
-        //[stable]~^ ERROR type `u128` cannot be used with this register class in stable
+        asm!("/* {:x} */", in(xmm_reg) xmmword);
+        asm!("/* {:x} */", out(xmm_reg) xmmword);
 
-        asm!("/* {:y} */", in(ymm_reg) xmmword); // requires asm_experimental_reg
-        //[stable]~^ ERROR type `u128` cannot be used with this register class in stable
-        asm!("/* {:y} */", out(ymm_reg) xmmword); // requires asm_experimental_reg
-        //[stable]~^ ERROR type `u128` cannot be used with this register class in stable
+        asm!("/* {:y} */", in(ymm_reg) xmmword);
+        asm!("/* {:y} */", out(ymm_reg) xmmword);
 
-        asm!("/* {:z} */", in(zmm_reg) xmmword); // requires asm_experimental_reg
-        //[stable]~^ ERROR type `u128` cannot be used with this register class in stable
-        asm!("/* {:z} */", out(zmm_reg) xmmword); // requires asm_experimental_reg
-        //[stable]~^ ERROR type `u128` cannot be used with this register class in stable
+        asm!("/* {:z} */", in(zmm_reg) xmmword);
+        asm!("/* {:z} */", out(zmm_reg) xmmword);
     }
 }

--- a/tests/ui/asm/x86_64/bad-reg.stable.stderr
+++ b/tests/ui/asm/x86_64/bad-reg.stable.stderr
@@ -1,5 +1,5 @@
 error: invalid register class `foo`: unknown register class
-  --> $DIR/bad-reg.rs:20:20
+  --> $DIR/bad-reg.rs:19:20
    |
 LL |         asm!("{}", in(foo) foo);
    |                    ^^^^^^^^^^^
@@ -7,13 +7,13 @@ LL |         asm!("{}", in(foo) foo);
    = note: the following register classes are supported on this target: `reg`, `reg_abcd`, `reg_byte`, `xmm_reg`, `ymm_reg`, `zmm_reg`, `kreg`, `kreg0`, `mmx_reg`, `x87_reg`, and `tmm_reg`
 
 error: invalid register `foo`: unknown register
-  --> $DIR/bad-reg.rs:22:18
+  --> $DIR/bad-reg.rs:21:18
    |
 LL |         asm!("", in("foo") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid asm template modifier `z` for this register class
-  --> $DIR/bad-reg.rs:24:15
+  --> $DIR/bad-reg.rs:23:15
    |
 LL |         asm!("{:z}", in(reg) foo);
    |               ^^^^   ----------- argument
@@ -23,7 +23,7 @@ LL |         asm!("{:z}", in(reg) foo);
    = note: the `reg` register class supports the following template modifiers: `l`, `x`, `e`, and `r`
 
 error: invalid asm template modifier `r` for this register class
-  --> $DIR/bad-reg.rs:26:15
+  --> $DIR/bad-reg.rs:25:15
    |
 LL |         asm!("{:r}", in(xmm_reg) foo);
    |               ^^^^   --------------- argument
@@ -33,7 +33,7 @@ LL |         asm!("{:r}", in(xmm_reg) foo);
    = note: the `xmm_reg` register class supports the following template modifiers: `x`, `y`, and `z`
 
 error: asm template modifiers are not allowed for `const` arguments
-  --> $DIR/bad-reg.rs:28:15
+  --> $DIR/bad-reg.rs:27:15
    |
 LL |         asm!("{:a}", const 0);
    |               ^^^^   ------- argument
@@ -41,7 +41,7 @@ LL |         asm!("{:a}", const 0);
    |               template modifier
 
 error: asm template modifiers are not allowed for `sym` arguments
-  --> $DIR/bad-reg.rs:30:15
+  --> $DIR/bad-reg.rs:29:15
    |
 LL |         asm!("{:a}", sym main);
    |               ^^^^   -------- argument
@@ -49,67 +49,67 @@ LL |         asm!("{:a}", sym main);
    |               template modifier
 
 error: invalid register `ebp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", in("ebp") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `rsp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", in("rsp") foo);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `ip`: the instruction pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", in("ip") foo);
    |                  ^^^^^^^^^^^^
 
 error: register class `x87_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", in("st(2)") foo);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `mmx_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", in("mm0") foo);
    |                  ^^^^^^^^^^^^^
 
 error: register class `kreg0` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:49:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", in("k0") foo);
    |                  ^^^^^^^^^^^^
 
 error: register class `x87_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:54:20
+  --> $DIR/bad-reg.rs:53:20
    |
 LL |         asm!("{}", in(x87_reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: register class `mmx_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:57:20
+  --> $DIR/bad-reg.rs:56:20
    |
 LL |         asm!("{}", in(mmx_reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: register class `x87_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:60:20
+  --> $DIR/bad-reg.rs:59:20
    |
 LL |         asm!("{}", out(x87_reg) _);
    |                    ^^^^^^^^^^^^^^
 
 error: register class `mmx_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:62:20
+  --> $DIR/bad-reg.rs:61:20
    |
 LL |         asm!("{}", out(mmx_reg) _);
    |                    ^^^^^^^^^^^^^^
 
 error: register `al` conflicts with register `eax`
-  --> $DIR/bad-reg.rs:68:33
+  --> $DIR/bad-reg.rs:67:33
    |
 LL |         asm!("", in("eax") foo, in("al") bar);
    |                  -------------  ^^^^^^^^^^^^ register `al`
@@ -117,7 +117,7 @@ LL |         asm!("", in("eax") foo, in("al") bar);
    |                  register `eax`
 
 error: register `rax` conflicts with register `rax`
-  --> $DIR/bad-reg.rs:71:33
+  --> $DIR/bad-reg.rs:70:33
    |
 LL |         asm!("", in("rax") foo, out("rax") bar);
    |                  -------------  ^^^^^^^^^^^^^^ register `rax`
@@ -125,13 +125,13 @@ LL |         asm!("", in("rax") foo, out("rax") bar);
    |                  register `rax`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:71:18
+  --> $DIR/bad-reg.rs:70:18
    |
 LL |         asm!("", in("rax") foo, out("rax") bar);
    |                  ^^^^^^^^^^^^^
 
 error: register `ymm0` conflicts with register `xmm0`
-  --> $DIR/bad-reg.rs:76:34
+  --> $DIR/bad-reg.rs:75:34
    |
 LL |         asm!("", in("xmm0") foo, in("ymm0") bar);
    |                  --------------  ^^^^^^^^^^^^^^ register `ymm0`
@@ -139,7 +139,7 @@ LL |         asm!("", in("xmm0") foo, in("ymm0") bar);
    |                  register `xmm0`
 
 error: register `ymm0` conflicts with register `xmm0`
-  --> $DIR/bad-reg.rs:78:34
+  --> $DIR/bad-reg.rs:77:34
    |
 LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
    |                  --------------  ^^^^^^^^^^^^^^^ register `ymm0`
@@ -147,25 +147,25 @@ LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
    |                  register `xmm0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:78:18
+  --> $DIR/bad-reg.rs:77:18
    |
 LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
    |                  ^^^^^^^^^^^^^^
 
 error: cannot use register `bl`: rbx is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", in("bl") foo);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `bh`: rbx is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", in("bh") foo);
    |                  ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:43:30
+  --> $DIR/bad-reg.rs:42:30
    |
 LL |         asm!("", in("st(2)") foo);
    |                              ^^^
@@ -173,7 +173,7 @@ LL |         asm!("", in("st(2)") foo);
    = note: register class `x87_reg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:46:28
+  --> $DIR/bad-reg.rs:45:28
    |
 LL |         asm!("", in("mm0") foo);
    |                            ^^^
@@ -181,7 +181,7 @@ LL |         asm!("", in("mm0") foo);
    = note: register class `mmx_reg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:49:27
+  --> $DIR/bad-reg.rs:48:27
    |
 LL |         asm!("", in("k0") foo);
    |                           ^^^
@@ -189,7 +189,7 @@ LL |         asm!("", in("k0") foo);
    = note: register class `kreg0` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:54:32
+  --> $DIR/bad-reg.rs:53:32
    |
 LL |         asm!("{}", in(x87_reg) foo);
    |                                ^^^
@@ -197,7 +197,7 @@ LL |         asm!("{}", in(x87_reg) foo);
    = note: register class `x87_reg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:57:32
+  --> $DIR/bad-reg.rs:56:32
    |
 LL |         asm!("{}", in(mmx_reg) foo);
    |                                ^^^
@@ -205,7 +205,7 @@ LL |         asm!("{}", in(mmx_reg) foo);
    = note: register class `mmx_reg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:68:42
+  --> $DIR/bad-reg.rs:67:42
    |
 LL |         asm!("", in("eax") foo, in("al") bar);
    |                                          ^^^
@@ -213,7 +213,7 @@ LL |         asm!("", in("eax") foo, in("al") bar);
    = note: register class `reg_byte` supports these types: i8
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:73:27
+  --> $DIR/bad-reg.rs:72:27
    |
 LL |         asm!("", in("al") foo, lateout("al") bar);
    |                           ^^^
@@ -221,73 +221,12 @@ LL |         asm!("", in("al") foo, lateout("al") bar);
    = note: register class `reg_byte` supports these types: i8
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:73:46
+  --> $DIR/bad-reg.rs:72:46
    |
 LL |         asm!("", in("al") foo, lateout("al") bar);
    |                                              ^^^
    |
    = note: register class `reg_byte` supports these types: i8
 
-error[E0658]: type `u128` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:85:40
-   |
-LL |         asm!("/* {:x} */", in(xmm_reg) xmmword); // requires asm_experimental_reg
-   |                                        ^^^^^^^
-   |
-   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
-   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+error: aborting due to 30 previous errors
 
-error[E0658]: type `u128` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:87:41
-   |
-LL |         asm!("/* {:x} */", out(xmm_reg) xmmword); // requires asm_experimental_reg
-   |                                         ^^^^^^^
-   |
-   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
-   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: type `u128` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:90:40
-   |
-LL |         asm!("/* {:y} */", in(ymm_reg) xmmword); // requires asm_experimental_reg
-   |                                        ^^^^^^^
-   |
-   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
-   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: type `u128` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:92:41
-   |
-LL |         asm!("/* {:y} */", out(ymm_reg) xmmword); // requires asm_experimental_reg
-   |                                         ^^^^^^^
-   |
-   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
-   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: type `u128` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:95:40
-   |
-LL |         asm!("/* {:z} */", in(zmm_reg) xmmword); // requires asm_experimental_reg
-   |                                        ^^^^^^^
-   |
-   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
-   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: type `u128` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:97:41
-   |
-LL |         asm!("/* {:z} */", out(zmm_reg) xmmword); // requires asm_experimental_reg
-   |                                         ^^^^^^^
-   |
-   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
-   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error: aborting due to 36 previous errors
-
-For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/asm/x86_64/type-check-3.stderr
+++ b/tests/ui/asm/x86_64/type-check-3.stderr
@@ -28,7 +28,7 @@ error: type `u8` cannot be used with this register class
 LL |         asm!("{}", in(xmm_reg) 0u8);
    |                                ^^^
    |
-   = note: register class `xmm_reg` supports these types: i32, i64, f16, f32, f64, f128, i8x16, i16x8, i32x4, i64x2, f16x8, f32x4, f64x2
+   = note: register class `xmm_reg` supports these types: i32, i64, i128, f16, f32, f64, f128, i8x16, i16x8, i32x4, i64x2, f16x8, f32x4, f64x2
 
 error: `avx512bw` target feature is not enabled
   --> $DIR/type-check-3.rs:27:29

--- a/tests/ui/feature-gates/feature-gate-asm_experimental_reg.rs
+++ b/tests/ui/feature-gates/feature-gate-asm_experimental_reg.rs
@@ -1,16 +1,27 @@
 //@ add-minicore
-//@ compile-flags: --target x86_64-unknown-linux-gnu
-//@ needs-llvm-components: x86
+//@ compile-flags: --target loongarch64-unknown-none
+//@ needs-llvm-components: loongarch
 //@ ignore-backends: gcc
 
-#![feature(no_core, lang_items, rustc_attrs)]
+#![feature(no_core, lang_items, rustc_attrs, repr_simd)]
 #![crate_type = "rlib"]
 #![no_core]
+#![allow(non_camel_case_types)]
 
 extern crate minicore;
 use minicore::*;
 
-unsafe fn main() {
-    asm!("{:x}", in(xmm_reg) 0u128);
-    //~^ ERROR type `u128` cannot be used with this register class in stable
+#[repr(simd)]
+pub struct i8x16([i8; 16]);
+
+impl Copy for i8x16 {}
+
+unsafe fn main(x: i8x16) -> i8x16 {
+    let y;
+    asm!("xvadd.h {1:u}, {0:u}, {0:u}", out(vreg) y, in(vreg) x);
+    //~^ ERROR register class `vreg` can only be used as a clobber in stable
+    //~| ERROR register class `vreg` can only be used as a clobber in stable
+    //~| ERROR type `i8x16` cannot be used with this register class in stable
+    //~| ERROR type `i8x16` cannot be used with this register class in stable
+    y
 }

--- a/tests/ui/feature-gates/feature-gate-asm_experimental_reg.stderr
+++ b/tests/ui/feature-gates/feature-gate-asm_experimental_reg.stderr
@@ -1,13 +1,43 @@
-error[E0658]: type `u128` cannot be used with this register class in stable
-  --> $DIR/feature-gate-asm_experimental_reg.rs:14:30
+error[E0658]: register class `vreg` can only be used as a clobber in stable
+  --> $DIR/feature-gate-asm_experimental_reg.rs:21:41
    |
-LL |     asm!("{:x}", in(xmm_reg) 0u128);
-   |                              ^^^^^
+LL |     asm!("xvadd.h {1:u}, {0:u}, {0:u}", out(vreg) y, in(vreg) x);
+   |                                         ^^^^^^^^^^^
    |
    = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
    = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0658]: register class `vreg` can only be used as a clobber in stable
+  --> $DIR/feature-gate-asm_experimental_reg.rs:21:54
+   |
+LL |     asm!("xvadd.h {1:u}, {0:u}, {0:u}", out(vreg) y, in(vreg) x);
+   |                                                      ^^^^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: type `i8x16` cannot be used with this register class in stable
+  --> $DIR/feature-gate-asm_experimental_reg.rs:21:51
+   |
+LL |     asm!("xvadd.h {1:u}, {0:u}, {0:u}", out(vreg) y, in(vreg) x);
+   |                                                   ^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: type `i8x16` cannot be used with this register class in stable
+  --> $DIR/feature-gate-asm_experimental_reg.rs:21:63
+   |
+LL |     asm!("xvadd.h {1:u}, {0:u}, {0:u}", out(vreg) y, in(vreg) x);
+   |                                                               ^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#159525 (Stabilize passing 128-bit integers via vector registers with `asm!` on x86)
 - rust-lang/rust#160342 (Specialize `advance_by` method of `Fuse`)
 - rust-lang/rust#159729 (allocations are allowed to grow (but not shrink))

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=159525,160342,159729)
<!-- homu-ignore:end -->

