### PR TITLE
borrowck: Simplify deps to build compiler 30s faster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3760,7 +3760,6 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_trait_selection",
- "rustc_traits",
  "smallvec",
  "tracing",
 ]

--- a/compiler/rustc_borrowck/Cargo.toml
+++ b/compiler/rustc_borrowck/Cargo.toml
@@ -22,7 +22,6 @@ rustc_mir_dataflow = { path = "../rustc_mir_dataflow" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_trait_selection = { path = "../rustc_trait_selection" }
-rustc_traits = { path = "../rustc_traits" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -20,7 +20,8 @@ use rustc_span::Span;
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::error_reporting::infer::nice_region_error::NiceRegionError;
 use rustc_trait_selection::traits::ObligationCtxt;
-use rustc_traits::{type_op_ascribe_user_type_with_span, type_op_prove_predicate_with_cause};
+use rustc_trait_selection::traits::query::type_op::prove_predicate::type_op_prove_predicate_with_cause;
+use rustc_traits::type_op_ascribe_user_type_with_span;
 use tracing::{debug, instrument};
 
 use crate::MirBorrowckCtxt;

--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -20,8 +20,8 @@ use rustc_span::Span;
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::error_reporting::infer::nice_region_error::NiceRegionError;
 use rustc_trait_selection::traits::ObligationCtxt;
+use rustc_trait_selection::traits::query::type_op::ascribe_user_type::type_op_ascribe_user_type_with_span;
 use rustc_trait_selection::traits::query::type_op::prove_predicate::type_op_prove_predicate_with_cause;
-use rustc_traits::type_op_ascribe_user_type_with_span;
 use tracing::{debug, instrument};
 
 use crate::MirBorrowckCtxt;

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/prove_predicate.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/prove_predicate.rs
@@ -50,3 +50,15 @@ impl<'tcx> super::QueryTypeOp<'tcx> for ProvePredicate<'tcx> {
         Ok(())
     }
 }
+
+/// The core of the `type_op_prove_predicate` query: for diagnostics purposes in NLL HRTB errors,
+/// this query can be re-run to better track the span of the obligation cause, and improve the error
+/// message. Do not call directly unless you're in that very specific context.
+pub fn type_op_prove_predicate_with_cause<'tcx>(
+    ocx: &ObligationCtxt<'_, 'tcx>,
+    key: ParamEnvAnd<'tcx, ProvePredicate<'tcx>>,
+    cause: ObligationCause<'tcx>,
+) {
+    let ParamEnvAnd { param_env, value: ProvePredicate { predicate } } = key;
+    ocx.register_obligation(Obligation::new(ocx.infcx.tcx, cause, param_env, predicate));
+}

--- a/compiler/rustc_traits/src/lib.rs
+++ b/compiler/rustc_traits/src/lib.rs
@@ -15,7 +15,6 @@ mod type_op;
 
 use rustc_middle::query::Providers;
 pub use rustc_trait_selection::traits::query::type_op::ascribe_user_type::type_op_ascribe_user_type_with_span;
-pub use type_op::type_op_prove_predicate_with_cause;
 
 pub fn provide(p: &mut Providers) {
     dropck_outlives::provide(p);

--- a/compiler/rustc_traits/src/lib.rs
+++ b/compiler/rustc_traits/src/lib.rs
@@ -14,7 +14,6 @@ mod normalize_projection_ty;
 mod type_op;
 
 use rustc_middle::query::Providers;
-pub use rustc_trait_selection::traits::query::type_op::ascribe_user_type::type_op_ascribe_user_type_with_span;
 
 pub fn provide(p: &mut Providers) {
     dropck_outlives::provide(p);

--- a/compiler/rustc_traits/src/type_op.rs
+++ b/compiler/rustc_traits/src/type_op.rs
@@ -12,8 +12,10 @@ use rustc_trait_selection::traits::query::type_op::ascribe_user_type::{
     AscribeUserType, type_op_ascribe_user_type_with_span,
 };
 use rustc_trait_selection::traits::query::type_op::normalize::Normalize;
-use rustc_trait_selection::traits::query::type_op::prove_predicate::ProvePredicate;
-use rustc_trait_selection::traits::{Normalized, Obligation, ObligationCause, ObligationCtxt};
+use rustc_trait_selection::traits::query::type_op::prove_predicate::{
+    ProvePredicate, type_op_prove_predicate_with_cause,
+};
+use rustc_trait_selection::traits::{Normalized, ObligationCause, ObligationCtxt};
 
 pub(crate) fn provide(p: &mut Providers) {
     *p = Providers {
@@ -88,16 +90,4 @@ fn type_op_prove_predicate<'tcx>(
         type_op_prove_predicate_with_cause(ocx, key, ObligationCause::dummy());
         Ok(())
     })
-}
-
-/// The core of the `type_op_prove_predicate` query: for diagnostics purposes in NLL HRTB errors,
-/// this query can be re-run to better track the span of the obligation cause, and improve the error
-/// message. Do not call directly unless you're in that very specific context.
-pub fn type_op_prove_predicate_with_cause<'tcx>(
-    ocx: &ObligationCtxt<'_, 'tcx>,
-    key: ParamEnvAnd<'tcx, ProvePredicate<'tcx>>,
-    cause: ObligationCause<'tcx>,
-) {
-    let ParamEnvAnd { param_env, value: ProvePredicate { predicate } } = key;
-    ocx.register_obligation(Obligation::new(ocx.infcx.tcx, cause, param_env, predicate));
 }


### PR DESCRIPTION
`rustc_borrowck` uses two helpers from `rustc_traits`. One of them is re-exported from `rustc_trait_selection`, and the other can easily move to `rustc_trait_selection`.

Making `rustc_borrowck` use these helpers from `rustc_trait_selection` directly, and eliminating the `rustc_traits` dependency, allows starting to build `rustc_borrowck` earlier, which substantially speeds up building the compiler because `rustc_borrowck` is one of the last things to build.

On my system, this speeds up the rustc build by a little over 30s.
