### PR TITLE
Split `SpannedTypeVisitor` into its own crate, `rustc_ty_walk`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4621,7 +4621,7 @@ dependencies = [
  "rustc_middle",
  "rustc_session",
  "rustc_span",
- "rustc_ty_utils",
+ "rustc_ty_walk",
  "tracing",
 ]
 
@@ -4908,6 +4908,17 @@ dependencies = [
  "rustc_span",
  "rustc_target",
  "rustc_trait_selection",
+ "rustc_ty_walk",
+ "tracing",
+]
+
+[[package]]
+name = "rustc_ty_walk"
+version = "0.0.0"
+dependencies = [
+ "rustc_hir",
+ "rustc_middle",
+ "rustc_span",
  "tracing",
 ]
 

--- a/compiler/rustc_privacy/Cargo.toml
+++ b/compiler/rustc_privacy/Cargo.toml
@@ -13,6 +13,6 @@ rustc_macros = { path = "../rustc_macros" }
 rustc_middle = { path = "../rustc_middle" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
-rustc_ty_utils = { path = "../rustc_ty_utils" }
+rustc_ty_walk = { path = "../rustc_ty_walk" }
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1161,7 +1161,7 @@ impl<'tcx> TypePrivacyVisitor<'tcx> {
     }
 }
 
-impl<'tcx> rustc_ty_utils::sig_types::SpannedTypeVisitor<'tcx> for TypePrivacyVisitor<'tcx> {
+impl<'tcx> rustc_ty_walk::SpannedTypeVisitor<'tcx> for TypePrivacyVisitor<'tcx> {
     type Result = ControlFlow<()>;
     fn visit(&mut self, span: Span, value: impl TypeVisitable<TyCtxt<'tcx>>) -> Self::Result {
         self.span = span;
@@ -1754,7 +1754,7 @@ fn check_mod_privacy(tcx: TyCtxt<'_>, mod_id: LocalModId) {
 
     let module = tcx.hir_module_items(mod_id);
     for def_id in module.definitions() {
-        let _ = rustc_ty_utils::sig_types::walk_types(tcx, def_id, &mut visitor);
+        let _ = rustc_ty_walk::walk_types(tcx, def_id, &mut visitor);
 
         if let Some(body_id) = tcx.hir_maybe_body_owned_by(def_id) {
             visitor.visit_nested_body(body_id.id());

--- a/compiler/rustc_ty_utils/Cargo.toml
+++ b/compiler/rustc_ty_utils/Cargo.toml
@@ -19,5 +19,6 @@ rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
 rustc_trait_selection = { path = "../rustc_trait_selection" }
+rustc_ty_walk = { path = "../rustc_ty_walk" }
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_ty_utils/src/lib.rs
+++ b/compiler/rustc_ty_utils/src/lib.rs
@@ -5,7 +5,6 @@
 //! This API is completely unstable and subject to change.
 
 // tidy-alphabetical-start
-#![feature(associated_type_defaults)]
 #![feature(deref_patterns)]
 #![feature(iterator_try_collect)]
 #![feature(never_type)]
@@ -26,7 +25,6 @@ mod needs_drop;
 mod nested_bodies;
 mod opaque_types;
 mod representability;
-pub mod sig_types;
 mod structural_match;
 mod ty;
 

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -186,7 +186,7 @@ impl<'tcx> OpaqueTypeCollector<'tcx> {
             trace!(?define);
             let mode = std::mem::replace(&mut self.mode, CollectionMode::Taits);
             let n = self.opaques.len();
-            super::sig_types::walk_types(self.tcx, define, self);
+            rustc_ty_walk::walk_types(self.tcx, define, self);
             if n == self.opaques.len() {
                 self.tcx.dcx().span_err(span, "item does not contain any opaque types");
             }
@@ -198,7 +198,7 @@ impl<'tcx> OpaqueTypeCollector<'tcx> {
     }
 }
 
-impl<'tcx> super::sig_types::SpannedTypeVisitor<'tcx> for OpaqueTypeCollector<'tcx> {
+impl<'tcx> rustc_ty_walk::SpannedTypeVisitor<'tcx> for OpaqueTypeCollector<'tcx> {
     #[instrument(skip(self), ret, level = "trace")]
     fn visit(&mut self, span: Span, value: impl TypeVisitable<TyCtxt<'tcx>>) {
         self.visit_spanned(span, value);
@@ -328,7 +328,7 @@ fn opaque_types_defined_by<'tcx>(
     trace!(?kind);
     let mut collector = OpaqueTypeCollector::new(tcx, item);
     collector.collect_taits_from_defines_attr();
-    super::sig_types::walk_types(tcx, item, &mut collector);
+    rustc_ty_walk::walk_types(tcx, item, &mut collector);
 
     match kind {
         DefKind::AssocFn

--- a/compiler/rustc_ty_walk/Cargo.toml
+++ b/compiler/rustc_ty_walk/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rustc_ty_walk"
+version = "0.0.0"
+edition = "2024"
+
+[dependencies]
+# tidy-alphabetical-start
+rustc_hir = { path = "../rustc_hir" }
+rustc_middle = { path = "../rustc_middle" }
+rustc_span = { path = "../rustc_span" }
+tracing = "0.1"
+# tidy-alphabetical-end

--- a/compiler/rustc_ty_walk/src/lib.rs
+++ b/compiler/rustc_ty_walk/src/lib.rs
@@ -1,5 +1,9 @@
-//! This module contains helpers for walking all types of
-//! a signature, while preserving spans as much as possible
+//! This crate contains a helper for walking all types of a signature, while preserving spans as
+//! much as possible
+
+// tidy-alphabetical-start
+#![feature(associated_type_defaults)]
+// tidy-alphabetical-end
 
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_bench.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_bench.snap
@@ -91,6 +91,7 @@ expression: bench
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_compiler.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_compiler.snap
@@ -73,6 +73,7 @@ expression: build compiler
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check.snap
@@ -75,6 +75,7 @@ expression: check
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_compiler.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_compiler.snap
@@ -75,6 +75,7 @@ expression: check compiler
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_compiletest_include_default_paths.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_compiletest_include_default_paths.snap
@@ -75,6 +75,7 @@ expression: check compiletest --include-default-paths
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_clippy.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_clippy.snap
@@ -90,6 +90,7 @@ expression: clippy
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_fix.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_fix.snap
@@ -75,6 +75,7 @@ expression: fix
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
@@ -139,6 +139,7 @@ expression: test
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
@@ -136,6 +136,7 @@ expression: test --skip=coverage
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_map.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_map.snap
@@ -139,6 +139,7 @@ expression: test --skip=coverage-map
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_run.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_run.snap
@@ -139,6 +139,7 @@ expression: test --skip=coverage-run
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
@@ -100,6 +100,7 @@ expression: test --skip=tests
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_coverage.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_coverage.snap
@@ -136,6 +136,7 @@ expression: test --skip=tests/coverage
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_etc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_etc.snap
@@ -84,6 +84,7 @@ expression: test --skip=tests --skip=library --skip=tidyselftest
     - Set({compiler/rustc_traits})
     - Set({compiler/rustc_transmute})
     - Set({compiler/rustc_ty_utils})
+    - Set({compiler/rustc_ty_walk})
     - Set({compiler/rustc_type_ir})
     - Set({compiler/rustc_type_ir_macros})
     - Set({compiler/rustc_windows_rc})

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -1775,7 +1775,7 @@ mod snapshot {
         insta::assert_snapshot!(
             ctx.config("check")
                 .path("compiler")
-                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (73 crates)");
+                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (74 crates)");
     }
 
     #[test]
@@ -1801,7 +1801,7 @@ mod snapshot {
             ctx.config("check")
                 .path("compiler")
                 .stage(1)
-                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (73 crates)");
+                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (74 crates)");
     }
 
     #[test]
@@ -1815,7 +1815,7 @@ mod snapshot {
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
-        [check] rustc 1 <host> -> rustc 2 <host> (73 crates)
+        [check] rustc 1 <host> -> rustc 2 <host> (74 crates)
         ");
     }
 
@@ -1831,7 +1831,7 @@ mod snapshot {
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
         [check] rustc 1 <host> -> std 1 <target1>
-        [check] rustc 1 <host> -> rustc 2 <target1> (73 crates)
+        [check] rustc 1 <host> -> rustc 2 <target1> (74 crates)
         [check] rustc 1 <host> -> rustc 2 <target1>
         [check] rustc 1 <host> -> Rustdoc 2 <target1>
         [check] rustc 1 <host> -> rustc_codegen_cranelift 2 <target1>
@@ -1927,7 +1927,7 @@ mod snapshot {
             ctx.config("check")
                 .paths(&["library", "compiler"])
                 .args(&args)
-                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (73 crates)");
+                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (74 crates)");
     }
 
     #[test]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160362)*
<!-- homu-ignore:end -->

`rustc_privacy` pulls in all of `rustc_ty_utils`, but only wants `SpannedTypeVisitor` and `walk_types`. Move those to a small `rustc_ty_walk` crate.

This allows `rustc_privacy` to start building much sooner.
