### PR TITLE
When suggesting method names, prefer *exact* doc aliases over similar names

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -2526,23 +2526,21 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             if applicable_close_candidates.is_empty() {
                 Ok(None)
             } else {
-                let best_name = {
-                    let names = applicable_close_candidates
-                        .iter()
-                        .map(|cand| cand.name())
-                        .collect::<Vec<Symbol>>();
-                    find_best_match_for_name_with_substrings(
-                        &names,
-                        self.method_name.unwrap().name,
-                        None,
-                    )
-                }
-                .or_else(|| {
-                    applicable_close_candidates
-                        .iter()
-                        .find(|cand| self.matches_by_doc_alias(cand.def_id))
-                        .map(|cand| cand.name())
-                });
+                let best_name = applicable_close_candidates
+                    .iter()
+                    .find(|cand| self.matches_by_doc_alias(cand.def_id))
+                    .map(|cand| cand.name())
+                    .or_else(|| {
+                        let names = applicable_close_candidates
+                            .iter()
+                            .map(|cand| cand.name())
+                            .collect::<Vec<Symbol>>();
+                        find_best_match_for_name_with_substrings(
+                            &names,
+                            self.method_name.unwrap().name,
+                            None,
+                        )
+                    });
                 Ok(best_name.and_then(|best_name| {
                     applicable_close_candidates
                         .into_iter()

--- a/tests/ui/attributes/rustc_confusables_std_cases.rs
+++ b/tests/ui/attributes/rustc_confusables_std_cases.rs
@@ -16,7 +16,6 @@ fn main() {
     //~^ HELP you might have meant to use `len`
     x.size(); //~ ERROR E0599
     //~^ HELP you might have meant to use `len`
-    //~| HELP there is a method `resize` with a similar name
     x.append(42); //~ ERROR E0308
     //~^ HELP you might have meant to use `push`
     String::new().push(""); //~ ERROR E0308

--- a/tests/ui/attributes/rustc_confusables_std_cases.stderr
+++ b/tests/ui/attributes/rustc_confusables_std_cases.stderr
@@ -59,8 +59,6 @@ error[E0599]: no method named `size` found for struct `Vec<{integer}>` in the cu
 LL |     x.size();
    |       ^^^^
    |
-help: there is a method `resize` with a similar name, but with different arguments
-  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 help: you might have meant to use `len`
    |
 LL -     x.size();
@@ -68,7 +66,7 @@ LL +     x.len();
    |
 
 error[E0308]: mismatched types
-  --> $DIR/rustc_confusables_std_cases.rs:20:14
+  --> $DIR/rustc_confusables_std_cases.rs:19:14
    |
 LL |     x.append(42);
    |       ------ ^^ expected `&mut Vec<{integer}>`, found integer
@@ -86,7 +84,7 @@ LL +     x.push(42);
    |
 
 error[E0308]: mismatched types
-  --> $DIR/rustc_confusables_std_cases.rs:22:24
+  --> $DIR/rustc_confusables_std_cases.rs:21:24
    |
 LL |     String::new().push("");
    |                   ---- ^^ expected `char`, found `&str`
@@ -101,7 +99,7 @@ LL |     String::new().push_str("");
    |                       ++++
 
 error[E0599]: no method named `append` found for struct `String` in the current scope
-  --> $DIR/rustc_confusables_std_cases.rs:24:19
+  --> $DIR/rustc_confusables_std_cases.rs:23:19
    |
 LL |     String::new().append("");
    |                   ^^^^^^
@@ -113,7 +111,7 @@ LL +     String::new().push_str("");
    |
 
 error[E0599]: no method named `get_line` found for struct `Stdin` in the current scope
-  --> $DIR/rustc_confusables_std_cases.rs:28:11
+  --> $DIR/rustc_confusables_std_cases.rs:27:11
    |
 LL |     stdin.get_line(&mut buffer).unwrap();
    |           ^^^^^^^^

--- a/tests/ui/suggestions/suggest-exact-alias-before-similar-name.rs
+++ b/tests/ui/suggestions/suggest-exact-alias-before-similar-name.rs
@@ -1,0 +1,15 @@
+struct Reader;
+//~^ NOTE method `read_exact_buf` not found for this struct
+
+impl Reader {
+    fn read_exact(&self) {}
+
+    #[doc(alias("read_exact_buf"))]
+    fn read_buf_exact(&self) {}
+}
+
+fn main() {
+    Reader.read_exact_buf();
+    //~^ ERROR no method named `read_exact_buf` found for struct `Reader` in the current scope
+    //~^^ HELP there is a method `read_exact` with a similar name
+}

--- a/tests/ui/suggestions/suggest-exact-alias-before-similar-name.rs
+++ b/tests/ui/suggestions/suggest-exact-alias-before-similar-name.rs
@@ -11,5 +11,5 @@ impl Reader {
 fn main() {
     Reader.read_exact_buf();
     //~^ ERROR no method named `read_exact_buf` found for struct `Reader` in the current scope
-    //~^^ HELP there is a method `read_exact` with a similar name
+    //~^^ HELP there is a method `read_buf_exact` with a similar name
 }

--- a/tests/ui/suggestions/suggest-exact-alias-before-similar-name.stderr
+++ b/tests/ui/suggestions/suggest-exact-alias-before-similar-name.stderr
@@ -7,10 +7,10 @@ LL | struct Reader;
 LL |     Reader.read_exact_buf();
    |            ^^^^^^^^^^^^^^
    |
-help: there is a method `read_exact` with a similar name
+help: there is a method `read_buf_exact` with a similar name
    |
 LL -     Reader.read_exact_buf();
-LL +     Reader.read_exact();
+LL +     Reader.read_buf_exact();
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/suggestions/suggest-exact-alias-before-similar-name.stderr
+++ b/tests/ui/suggestions/suggest-exact-alias-before-similar-name.stderr
@@ -1,0 +1,18 @@
+error[E0599]: no method named `read_exact_buf` found for struct `Reader` in the current scope
+  --> $DIR/suggest-exact-alias-before-similar-name.rs:12:12
+   |
+LL | struct Reader;
+   | ------------- method `read_exact_buf` not found for this struct
+...
+LL |     Reader.read_exact_buf();
+   |            ^^^^^^^^^^^^^^
+   |
+help: there is a method `read_exact` with a similar name
+   |
+LL -     Reader.read_exact_buf();
+LL +     Reader.read_exact();
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
We currently prefer candidates from a similarity search over doc aliases or `rustc_confusables`, even though the latter requires an *exact* match. Reverse this order, so that an exactly matching doc alias or `rustc_confusables` entry will take precedence.

The net result of this is that `read_exact_buf` will now produce a suggestion for `read_buf_exact`, not `read_exact`, if both exist and the former has a doc alias for `read_exact_buf`.

Note that this makes method searches consistent with standalone function searches, because for the latter we already prefer doc aliases over similarity searches.