### PR TITLE
Add doc aliases for transpositions `read_exact_buf` and `read_exact_buf_at`

### DIFF
--- a/library/alloc/src/io/read.rs
+++ b/library/alloc/src/io/read.rs
@@ -429,6 +429,7 @@ pub trait Read {
     /// [`ErrorKind::Interrupted`]: crate::io::ErrorKind::Interrupted
     /// [`ErrorKind::UnexpectedEof`]: crate::io::ErrorKind::UnexpectedEof
     #[unstable(feature = "read_buf", issue = "78485")]
+    #[doc(alias("read_exact_buf"))]
     fn read_buf_exact(&mut self, cursor: BorrowedCursor<'_, u8>) -> Result<()> {
         default_read_buf_exact(self, cursor)
     }

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -198,6 +198,7 @@ pub trait FileExt {
     /// }
     /// ```
     #[unstable(feature = "read_buf_at", issue = "140771")]
+    #[doc(alias("read_exact_buf_at"))]
     fn read_buf_exact_at(
         &self,
         mut buf: BorrowedCursor<'_, u8>,


### PR DESCRIPTION
When fingers really want to type `read_exact`, that naturally leads to
the typo `read_exact_buf` instead of `read_buf_exact`, and
`read_exact_buf_at` instead of `read_buf_exact_at`.

Add doc aliases.

These will help people find them in rustdoc, and once
https://github.com/rust-lang/rust/pull/160369 goes in, it'll also help
people find them as rustfix suggestions.
