### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,7 +31,7 @@ or reading the [rustc dev guide][rustcguidebuild].
 
 Make sure you have installed the dependencies:
 
-* `python` 3 or 2.7
+* `python` 3 
 * `git`
 * A C compiler (when building for the host, `cc` is enough; cross-compiling may
   need additional compilers)


### PR DESCRIPTION
Python 2.7 reached End of Life on January 1, 2020. Removing it from the build dependencies to avoid confusion. Python 3 is the only supported version.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
