### PR TITLE
Fix duplicate lifetime parameter

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics/mod.rs
+++ b/compiler/rustc_resolve/src/diagnostics/mod.rs
@@ -1010,8 +1010,6 @@ pub(crate) struct ElidedAnonymousLifetimeReportError {
     #[primary_span]
     #[label("explicit lifetime name needed here")]
     pub(crate) span: Span,
-    #[subdiagnostic]
-    pub(crate) suggestion: Option<ElidedAnonymousLifetimeReportErrorSuggestion>,
 }
 
 #[derive(Diagnostic)]
@@ -1037,18 +1035,6 @@ pub(crate) struct AnonymousLifetimeNonGatReportError {
         "in the trait the associated type is declared without lifetime parameters, so using a borrowed type for them requires that lifetime to come from the implemented type"
     )]
     pub(crate) decl: MultiSpan,
-}
-
-#[derive(Subdiagnostic)]
-#[multipart_suggestion(
-    "consider introducing a higher-ranked lifetime here",
-    applicability = "machine-applicable"
-)]
-pub(crate) struct ElidedAnonymousLifetimeReportErrorSuggestion {
-    #[suggestion_part(code = "for<'a> ")]
-    pub(crate) lo: Span,
-    #[suggestion_part(code = "'a ")]
-    pub(crate) hi: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1906,35 +1906,6 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 }
                 LifetimeRibKind::AnonymousReportError => {
                     let guar = if elided {
-                        let suggestion = if self.diag_metadata.in_assoc_ty_binding {
-                            // In an associated type binding like `I: IntoIterator<Item = &T>`,
-                            // introducing the lifetime on the trait ref would produce
-                            // `I: for<'a> IntoIterator<Item = &'a T>`. Prefer a named lifetime
-                            // from an enclosing item instead, so the assoc-ty-binding-specific path
-                            // below builds that suggestion.
-                            None
-                        } else {
-                            self.lifetime_ribs[i..].iter().rev().find_map(|rib| {
-                                // Look for a `Generics` rib that represents a trait or where-bound
-                                // binder (`T: Trait<&U>` or `where T: Trait<&U>`), since that is
-                                // where the generic E0637 diagnostic can insert `for<'a>`.
-                                if let LifetimeRibKind::Generics {
-                                    span,
-                                    kind:
-                                        LifetimeBinderKind::PolyTrait
-                                        | LifetimeBinderKind::WhereBound,
-                                    ..
-                                } = rib.kind
-                                {
-                                    Some(crate::diagnostics::ElidedAnonymousLifetimeReportErrorSuggestion {
-                                        lo: span.shrink_to_lo(),
-                                        hi: lifetime.ident.span.shrink_to_hi(),
-                                    })
-                                } else {
-                                    None
-                                }
-                            })
-                        };
                         // are we trying to use an anonymous lifetime
                         // on a non GAT associated trait type?
                         if !self.in_func_body
@@ -1986,29 +1957,8 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                                 self.point_at_impl_lifetimes(&mut err, i, lifetime.ident.span);
                                 err.emit()
                             }
-                        } else if self.diag_metadata.in_assoc_ty_binding {
-                            // For associated type bindings, e.g.
-                            // `fn f<I: IntoIterator<Item = &T>>()`, introduce a named lifetime
-                            // on an enclosing generics binder instead:
-                            // `fn f<'a, I: IntoIterator<Item = &'a T>>()`.
-                            let mut err = self.r.dcx().create_err(
-                                crate::diagnostics::ElidedAnonymousLifetimeReportError {
-                                    span: lifetime.ident.span,
-                                    suggestion,
-                                },
-                            );
-                            self.suggest_introducing_lifetime_for_assoc_ty_binding(
-                                &mut err,
-                                lifetime.ident.span,
-                            );
-                            err.emit()
                         } else {
-                            self.r.dcx().emit_err(
-                                crate::diagnostics::ElidedAnonymousLifetimeReportError {
-                                    span: lifetime.ident.span,
-                                    suggestion,
-                                },
-                            )
+                            self.report_missing_lifetime_is_banned(&missing_lifetime)
                         }
                     } else {
                         self.r.dcx().emit_err(

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -173,7 +173,10 @@ enum TypoCandidate {
     Shadowed(Res, Option<Span>),
     None,
 }
-
+enum SuggestMode {
+    E0106,
+    E0637,
+}
 impl TypoCandidate {
     fn to_opt_suggestion(self) -> Option<TypoSuggestion> {
         match self {
@@ -3821,33 +3824,6 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         self.suggest_introducing_lifetime_filtered(err, name, |_| true, suggest);
     }
 
-    pub(crate) fn suggest_introducing_lifetime_for_assoc_ty_binding(
-        &self,
-        err: &mut Diag<'_>,
-        lifetime: Span,
-    ) {
-        self.suggest_introducing_lifetime_filtered(
-            err,
-            None,
-            |kind| {
-                !matches!(
-                    kind,
-                    LifetimeBinderKind::FnPtrType
-                        | LifetimeBinderKind::PolyTrait
-                        | LifetimeBinderKind::WhereBound
-                )
-            },
-            |err, _higher_ranked, span, message, intro_sugg, _| {
-                err.multipart_suggestion(
-                    message,
-                    vec![(span, intro_sugg), (lifetime.shrink_to_hi(), "'a ".to_string())],
-                    Applicability::MaybeIncorrect,
-                );
-                false
-            },
-        );
-    }
-
     fn suggest_introducing_lifetime_filtered(
         &self,
         err: &mut Diag<'_>,
@@ -4070,6 +4046,23 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             &mut err,
             lifetime_refs,
             function_param_lifetimes,
+            SuggestMode::E0106,
+        );
+        err.emit()
+    }
+    pub(crate) fn report_missing_lifetime_is_banned<'a>(
+        &mut self,
+        lifetime_refs: &'a MissingLifetime,
+    ) -> ErrorGuaranteed {
+        let mut err =
+            self.r.dcx().create_err(crate::diagnostics::ElidedAnonymousLifetimeReportError {
+                span: lifetime_refs.span,
+            });
+        self.add_missing_lifetime_specifiers_label(
+            &mut err,
+            [lifetime_refs],
+            None,
+            SuggestMode::E0637,
         );
         err.emit()
     }
@@ -4079,16 +4072,20 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         err: &mut Diag<'_>,
         lifetime_refs: impl Clone + IntoIterator<Item = &'a MissingLifetime>,
         function_param_lifetimes: Option<(Vec<MissingLifetime>, Vec<ElisionFnParameter>)>,
+        suggest_mode: SuggestMode,
     ) {
-        for &lt in lifetime_refs.clone() {
-            err.span_label(
-                lt.span,
-                format!(
-                    "expected {} lifetime parameter{}",
-                    if lt.count == 1 { "named".to_string() } else { lt.count.to_string() },
-                    pluralize!(lt.count),
-                ),
-            );
+        // E0637 already labels the lifetime itself, so only add labels to E0106
+        if matches!(suggest_mode, SuggestMode::E0106) {
+            for &lt in lifetime_refs.clone() {
+                err.span_label(
+                    lt.span,
+                    format!(
+                        "expected {} lifetime parameter{}",
+                        if lt.count == 1 { "named".to_string() } else { lt.count.to_string() },
+                        pluralize!(lt.count),
+                    ),
+                );
+            }
         }
 
         let mut in_scope_lifetimes: Vec<_> = self
@@ -4184,59 +4181,107 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             [(existing, _)] => existing.name,
             _ => Symbol::intern("'lifetime"),
         };
-
+        // A lifetime name that doesn't clash with the existing lifetimes
+        #[allow(rustc::symbol_intern_string_literal)]
+        let available_lifetime_name = ('a'..='z')
+            .map(|c| Symbol::intern(&format!("'{c}")))
+            .find(|candidate| !in_scope_lifetimes.iter().any(|(ident, _)| ident.name == *candidate))
+            .unwrap_or(Symbol::intern("'lifetime"));
         let mut spans_suggs: Vec<_> = Vec::new();
         let source_map = self.r.tcx.sess.source_map();
-        let build_sugg = |lt: MissingLifetime| match lt.kind {
+        let build_sugg = |lt: MissingLifetime, to: Symbol| match lt.kind {
             MissingLifetimeKind::Underscore => {
                 debug_assert_eq!(lt.count, 1);
-                (lt.span, existing_name.to_string())
+                (lt.span, to.to_string())
             }
             MissingLifetimeKind::Ampersand => {
                 debug_assert_eq!(lt.count, 1);
-                (lt.span.shrink_to_hi(), format!("{existing_name} "))
+                (lt.span.shrink_to_hi(), format!("{to} "))
             }
             MissingLifetimeKind::Comma => {
-                let sugg: String = std::iter::repeat_n(existing_name.as_str(), lt.count)
-                    .intersperse(", ")
-                    .collect();
+                let sugg: String =
+                    std::iter::repeat_n(to.as_str(), lt.count).intersperse(", ").collect();
                 let is_empty_brackets = source_map.span_followed_by(lt.span, ">").is_some();
                 let sugg = if is_empty_brackets { sugg } else { format!("{sugg}, ") };
                 (lt.span.shrink_to_hi(), sugg)
             }
             MissingLifetimeKind::Brackets => {
                 let sugg: String = std::iter::once("<")
-                    .chain(std::iter::repeat_n(existing_name.as_str(), lt.count).intersperse(", "))
+                    .chain(std::iter::repeat_n(to.as_str(), lt.count).intersperse(", "))
                     .chain([">"])
                     .collect();
                 (lt.span.shrink_to_hi(), sugg)
             }
         };
         for &lt in lifetime_refs.clone() {
-            spans_suggs.push(build_sugg(lt));
+            spans_suggs.push(build_sugg(lt, existing_name));
         }
         debug!(?spans_suggs);
         match in_scope_lifetimes.len() {
             0 => {
                 if let Some((param_lifetimes, _)) = function_param_lifetimes {
                     for lt in param_lifetimes {
-                        spans_suggs.push(build_sugg(lt))
+                        spans_suggs.push(build_sugg(lt, existing_name))
                     }
                 }
-                self.suggest_introducing_lifetime(
-                    err,
-                    None,
-                    |err, higher_ranked, span, message, intro_sugg, _| {
-                        err.multipart_suggestion(
-                            message,
-                            std::iter::once((span, intro_sugg))
-                                .chain(spans_suggs.clone())
-                                .collect(),
-                            Applicability::MaybeIncorrect,
-                        );
-                        higher_ranked
-                    },
-                );
+                // For associated type bindings, e.g.
+                // `fn f<I: IntoIterator<Item = &T>>()`, introduce a named lifetime
+                // on an enclosing generics binder instead:
+                // `fn f<'a, I: IntoIterator<Item = &'a T>>()`.
+                if matches!(suggest_mode, SuggestMode::E0637)
+                    && self.diag_metadata.in_assoc_ty_binding
+                {
+                    // Skip HRTB binders
+                    self.suggest_introducing_lifetime_filtered(
+                        err,
+                        None,
+                        |kind| {
+                            !matches!(
+                                kind,
+                                LifetimeBinderKind::FnPtrType
+                                    | LifetimeBinderKind::PolyTrait
+                                    | LifetimeBinderKind::WhereBound
+                            )
+                        },
+                        |err, _, span, message, intro_sugg, _| {
+                            err.multipart_suggestion(
+                                message,
+                                std::iter::once((span, intro_sugg))
+                                    .chain(spans_suggs.clone())
+                                    .collect(),
+                                Applicability::MaybeIncorrect,
+                            );
+                            false
+                        },
+                    );
+                } else {
+                    self.suggest_introducing_lifetime_filtered(
+                        err,
+                        None,
+                        // E0637 should only use HRTB binder, E0106 may use any binder.
+                        |kind| {
+                            matches!(suggest_mode, SuggestMode::E0106)
+                                || matches!(
+                                    kind,
+                                    LifetimeBinderKind::PolyTrait | LifetimeBinderKind::WhereBound,
+                                )
+                        },
+                        |err, higher_ranked, span, message, intro_sugg, _| {
+                            err.multipart_suggestion(
+                                message,
+                                std::iter::once((span, intro_sugg))
+                                    .chain(spans_suggs.clone())
+                                    .collect(),
+                                Applicability::MaybeIncorrect,
+                            );
+                            if matches!(suggest_mode, SuggestMode::E0637) {
+                                false
+                            } else {
+                                higher_ranked
+                            }
+                        },
+                    );
+                }
             }
             1 => {
                 let post = if maybe_static {
@@ -4261,6 +4306,35 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                     spans_suggs,
                     Applicability::MaybeIncorrect,
                 );
+                if matches!(suggest_mode, SuggestMode::E0637)
+                    && !self.diag_metadata.in_assoc_ty_binding
+                {
+                    // Also suggest introducing an HRTB for E0637 errors.
+                    let mut new_lifetime_suggs = Vec::new();
+                    for lt in lifetime_refs.clone() {
+                        new_lifetime_suggs.push(build_sugg(*lt, available_lifetime_name));
+                    }
+                    self.suggest_introducing_lifetime_filtered(
+                        err,
+                        Some(Ident::new(available_lifetime_name, DUMMY_SP)),
+                        |kind| {
+                            matches!(
+                                kind,
+                                LifetimeBinderKind::PolyTrait | LifetimeBinderKind::WhereBound,
+                            )
+                        },
+                        |err, _, span, message, intro_sugg, _| {
+                            err.multipart_suggestion(
+                                message,
+                                std::iter::once((span, intro_sugg))
+                                    .chain(new_lifetime_suggs.clone())
+                                    .collect(),
+                                Applicability::MaybeIncorrect,
+                            );
+                            false
+                        },
+                    );
+                }
                 if maybe_static {
                     // FIXME: what follows are general suggestions, but we'd want to perform some
                     // minimal flow analysis to provide more accurate suggestions. For example, if
@@ -4509,6 +4583,35 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                         "consider using one of the available lifetimes here",
                         spans_suggs,
                         Applicability::HasPlaceholders,
+                    );
+                }
+                if matches!(suggest_mode, SuggestMode::E0637)
+                    && !self.diag_metadata.in_assoc_ty_binding
+                {
+                    // Also suggest introducing an HRTB for E0637 errors.
+                    let mut new_lifetime_suggs = Vec::new();
+                    for lt in lifetime_refs.clone() {
+                        new_lifetime_suggs.push(build_sugg(*lt, available_lifetime_name));
+                    }
+                    self.suggest_introducing_lifetime_filtered(
+                        err,
+                        Some(Ident::new(available_lifetime_name, DUMMY_SP)),
+                        |kind| {
+                            matches!(
+                                kind,
+                                LifetimeBinderKind::PolyTrait | LifetimeBinderKind::WhereBound,
+                            )
+                        },
+                        |err, _, span, message, intro_sugg, _| {
+                            err.multipart_suggestion(
+                                message,
+                                std::iter::once((span, intro_sugg))
+                                    .chain(new_lifetime_suggs.clone())
+                                    .collect(),
+                                Applicability::MaybeIncorrect,
+                            );
+                            false
+                        },
                     );
                 }
             }

--- a/tests/ui/closures/binder/implicit-stuff.stderr
+++ b/tests/ui/closures/binder/implicit-stuff.stderr
@@ -33,12 +33,22 @@ error[E0637]: `&` without an explicit lifetime name cannot be used here
    |
 LL |     let _ = for<'a> |x: &()| -> &'a () { x };
    |                         ^ explicit lifetime name needed here
+   |
+help: consider using the `'a` lifetime
+   |
+LL |     let _ = for<'a> |x: &'a ()| -> &'a () { x };
+   |                          ++
 
 error[E0637]: `&` without an explicit lifetime name cannot be used here
   --> $DIR/implicit-stuff.rs:26:36
    |
 LL |     let _ = for<'a> |x: &'a ()| -> &() { x };
    |                                    ^ explicit lifetime name needed here
+   |
+help: consider using the `'a` lifetime
+   |
+LL |     let _ = for<'a> |x: &'a ()| -> &'a () { x };
+   |                                     ++
 
 error: implicit types in closure signatures are forbidden when `for<...>` is present
   --> $DIR/implicit-stuff.rs:5:21

--- a/tests/ui/error-codes/E0637.rs
+++ b/tests/ui/error-codes/E0637.rs
@@ -26,4 +26,15 @@ trait T {
 fn foo<F>(t: F) where F: T<Assoc=&str> {}
 //~^ ERROR: `&` without an explicit lifetime name cannot be used here [E0637]
 
+// Regression test for https://github.com/rust-lang/rust/issues/123713.
+fn one_assoc<'a,F>(t: &'a F) where &'a F: T<Assoc=&str> {}// suggest &'a str
+//~^ ERROR E0637
+fn one<'a,F>(t: &'a F) where F:Into<&u32> {}// suggest to use 'a or for<'b>
+//~^ ERROR E0637
+fn multiple_assoc<'a,'b,F>(t: &'a F) where &'a F: T<Assoc=&str>{}
+//~^ ERROR E0637
+// suggest the user to choose one of the available lifetimes
+fn multiple<'a,'b,F>(t: &'a F) where F:Into<&u32>{}
+//~^ ERROR E0637
+// suggest the user to choose one of the available lifetimes or for<'c>
 fn main() {}

--- a/tests/ui/error-codes/E0637.stderr
+++ b/tests/ui/error-codes/E0637.stderr
@@ -25,7 +25,8 @@ error[E0637]: `&` without an explicit lifetime name cannot be used here
 LL |     T: Into<&u32>,
    |             ^ explicit lifetime name needed here
    |
-help: consider introducing a higher-ranked lifetime here
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
 LL |     T: for<'a> Into<&'a u32>,
    |        +++++++       ++
@@ -52,7 +53,69 @@ help: consider introducing a named lifetime parameter
 LL | fn foo<'a, F>(t: F) where F: T<Assoc=&'a str> {}
    |        +++                            ++
 
-error: aborting due to 5 previous errors
+error[E0637]: `&` without an explicit lifetime name cannot be used here
+  --> $DIR/E0637.rs:30:51
+   |
+LL | fn one_assoc<'a,F>(t: &'a F) where &'a F: T<Assoc=&str> {}// suggest &'a str
+   |                                                   ^ explicit lifetime name needed here
+   |
+help: consider using the `'a` lifetime
+   |
+LL | fn one_assoc<'a,F>(t: &'a F) where &'a F: T<Assoc=&'a str> {}// suggest &'a str
+   |                                                    ++
+
+error[E0637]: `&` without an explicit lifetime name cannot be used here
+  --> $DIR/E0637.rs:32:37
+   |
+LL | fn one<'a,F>(t: &'a F) where F:Into<&u32> {}// suggest to use 'a or for<'b>
+   |                                     ^ explicit lifetime name needed here
+   |
+help: consider using the `'a` lifetime
+   |
+LL | fn one<'a,F>(t: &'a F) where F:Into<&'a u32> {}// suggest to use 'a or for<'b>
+   |                                      ++
+help: consider making the bound lifetime-generic with a new `'b` lifetime
+   |
+LL | fn one<'a,F>(t: &'a F) where F:for<'b> Into<&'b u32> {}// suggest to use 'a or for<'b>
+   |                                +++++++       ++
+
+error[E0637]: `&` without an explicit lifetime name cannot be used here
+  --> $DIR/E0637.rs:34:59
+   |
+LL | fn multiple_assoc<'a,'b,F>(t: &'a F) where &'a F: T<Assoc=&str>{}
+   |                                                           ^ explicit lifetime name needed here
+   |
+note: these named lifetimes are available to use
+  --> $DIR/E0637.rs:34:19
+   |
+LL | fn multiple_assoc<'a,'b,F>(t: &'a F) where &'a F: T<Assoc=&str>{}
+   |                   ^^ ^^
+help: consider using one of the available lifetimes here
+   |
+LL | fn multiple_assoc<'a,'b,F>(t: &'a F) where &'a F: T<Assoc=&'lifetime str>{}
+   |                                                            +++++++++
+
+error[E0637]: `&` without an explicit lifetime name cannot be used here
+  --> $DIR/E0637.rs:37:45
+   |
+LL | fn multiple<'a,'b,F>(t: &'a F) where F:Into<&u32>{}
+   |                                             ^ explicit lifetime name needed here
+   |
+note: these named lifetimes are available to use
+  --> $DIR/E0637.rs:37:13
+   |
+LL | fn multiple<'a,'b,F>(t: &'a F) where F:Into<&u32>{}
+   |             ^^ ^^
+help: consider using one of the available lifetimes here
+   |
+LL | fn multiple<'a,'b,F>(t: &'a F) where F:Into<&'lifetime u32>{}
+   |                                              +++++++++
+help: consider making the bound lifetime-generic with a new `'c` lifetime
+   |
+LL | fn multiple<'a,'b,F>(t: &'a F) where F:for<'c> Into<&'c u32>{}
+   |                                        +++++++       ++
+
+error: aborting due to 9 previous errors
 
 Some errors have detailed explanations: E0106, E0637.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/generic-const-items/elided-lifetimes.stderr
+++ b/tests/ui/generic-const-items/elided-lifetimes.stderr
@@ -4,7 +4,8 @@ error[E0637]: `&` without an explicit lifetime name cannot be used here
 LL |     &T: Copy;
    |     ^ explicit lifetime name needed here
    |
-help: consider introducing a higher-ranked lifetime here
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
 LL |     for<'a> &'a T: Copy;
    |     +++++++  ++

--- a/tests/ui/generics/issue-65285-incorrect-explicit-lifetime-name-needed.stderr
+++ b/tests/ui/generics/issue-65285-incorrect-explicit-lifetime-name-needed.stderr
@@ -4,7 +4,8 @@ error[E0637]: `&` without an explicit lifetime name cannot be used here
 LL | fn should_error<T>() where T : Into<&u32> {}
    |                                     ^ explicit lifetime name needed here
    |
-help: consider introducing a higher-ranked lifetime here
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
 LL | fn should_error<T>() where T : for<'a> Into<&'a u32> {}
    |                                +++++++       ++

--- a/tests/ui/pattern/const-error-ice-issue-148542.stderr
+++ b/tests/ui/pattern/const-error-ice-issue-148542.stderr
@@ -4,7 +4,8 @@ error[E0637]: `&` without an explicit lifetime name cannot be used here
 LL | fn foo() where &str:, {
    |                ^ explicit lifetime name needed here
    |
-help: consider introducing a higher-ranked lifetime here
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
 LL | fn foo() where for<'a> &'a str:, {
    |                +++++++  ++

--- a/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2015.stderr
+++ b/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2015.stderr
@@ -4,7 +4,8 @@ error[E0637]: `&` without an explicit lifetime name cannot be used here
 LL |     T: WithType<&u32>
    |                 ^ explicit lifetime name needed here
    |
-help: consider introducing a higher-ranked lifetime here
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
 LL |     T: for<'a> WithType<&'a u32>
    |        +++++++           ++

--- a/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2018.stderr
+++ b/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2018.stderr
@@ -4,7 +4,8 @@ error[E0637]: `&` without an explicit lifetime name cannot be used here
 LL |     T: WithType<&u32>
    |                 ^ explicit lifetime name needed here
    |
-help: consider introducing a higher-ranked lifetime here
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
 LL |     T: for<'a> WithType<&'a u32>
    |        +++++++           ++

--- a/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2015.stderr
+++ b/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2015.stderr
@@ -4,7 +4,8 @@ error[E0637]: `&` without an explicit lifetime name cannot be used here
 LL |     T: WithType<&u32>
    |                 ^ explicit lifetime name needed here
    |
-help: consider introducing a higher-ranked lifetime here
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
 LL |     T: for<'a> WithType<&'a u32>
    |        +++++++           ++

--- a/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2018.stderr
+++ b/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2018.stderr
@@ -4,7 +4,8 @@ error[E0637]: `&` without an explicit lifetime name cannot be used here
 LL |     T: WithType<&u32>
    |                 ^ explicit lifetime name needed here
    |
-help: consider introducing a higher-ranked lifetime here
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
 LL |     T: for<'a> WithType<&'a u32>
    |        +++++++           ++


### PR DESCRIPTION
Closes rust-lang/rust#123713

The previous code suggest adding a higher-ranked lifetime `for<'a>` for regular case and explicit lifetime `'a` for associated type. But it didn't check whether the lifetime `'a` is already occupied and it never suggest the user to use the existing lifetime.

I think that it might be better if we put the diagnostics code for error `E0637`  together with `E0106` in the same function `add_missing_lifetime_specifiers_label`, since they share some same logic. 

The current code behaves differently when there are lifetimes in scope:
- 0 lifetime available: same behaviour, suggest `for<'a>` (regular case) or `'a` (associated type)
- 1 lifetime available: suggest using this lifetime or create a new higher-ranked lifetime with a fresh name (for regular case)
- multiple lifetime available: suggest using one of the lifetime or create a new higher-ranked lifetime with a fresh name (for regular case)

The help message of introducing HRTB changed to the same with `E0106`.
