### PR TITLE
break the dependency from rustc_target -> rustc_fs_util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4805,7 +4805,6 @@ dependencies = [
  "rustc_abi",
  "rustc_data_structures",
  "rustc_error_messages",
- "rustc_fs_util",
  "rustc_macros",
  "rustc_serialize",
  "rustc_span",

--- a/compiler/rustc_target/Cargo.toml
+++ b/compiler/rustc_target/Cargo.toml
@@ -11,7 +11,6 @@ object = { version = "0.37.0", default-features = false, features = ["elf", "mac
 rustc_abi = { path = "../rustc_abi" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_error_messages = { path = "../rustc_error_messages" }
-rustc_fs_util = { path = "../rustc_fs_util" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_span = { path = "../rustc_span" }
@@ -22,4 +21,3 @@ serde_json = "1.0.59"
 serde_path_to_error = "0.1.17"
 tracing = "0.1"
 # tidy-alphabetical-end
-

--- a/compiler/rustc_target/src/spec/tuple.rs
+++ b/compiler/rustc_target/src/spec/tuple.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use std::{fmt, io};
 
 use rustc_error_messages::into_diag_arg_using_display;
-use rustc_fs_util::try_canonicalize;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
 /// Either a target tuple string or a path to a JSON file.
@@ -91,7 +90,8 @@ impl TargetTuple {
 
     /// Creates a target tuple from the passed target path.
     pub fn from_path(path: &Path) -> Result<Self, io::Error> {
-        let canonicalized_path = try_canonicalize(path)?;
+        let canonicalized_path =
+            std::fs::canonicalize(path).or_else(|_| std::path::absolute(path))?;
         let contents = std::fs::read_to_string(&canonicalized_path).map_err(|err| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,


### PR DESCRIPTION
fs_util is now first needed by `rustc_session`, so it's not needed before compiling `rustc_hir`. i haven't yet collected before/after timings, i can do so if you like.

inspired by https://github.com/rust-lang/rust/pull/160336.

before:
<img width="635" height="383" alt="image" src="https://github.com/user-attachments/assets/2e8624a3-149c-40c6-9cdc-3b84287cddea" />

after:
<img width="737" height="383" alt="image" src="https://github.com/user-attachments/assets/5410f33b-03f7-45a6-ab54-b60585b7fd17" />

- [x] I used an LLM to create a change in this PR, and I have explained below how it was used.

disclaimer: this PR was LLM generated. i told it to look at https://github.com/rust-lang/rust/pull/160336 and find similar improvements, and it wrote the code. originally it also tried to break `rustc_feature -> rustc_hir` and `rustc_metadata -> rustc_incremental`, but it turns out i was on an old branch and those had already been split up on main.

r? @jackh726 (not the PR i said you would be reviewing, oops, but still quite small)

@rustbot label llm-assisted

<!-- homu-ignore:start -->
<!-- homu-ignore:end -->
