### PR TITLE
Improve the test for patterns in fn pointers

### DIFF
--- a/tests/ui/fn/fn-ptr-pattern.rs
+++ b/tests/ui/fn/fn-ptr-pattern.rs
@@ -1,23 +1,46 @@
-fn patterns<F>(
-    pat1: fn(true: bool),
+fn allowed<F>(
+    data: &str,
+    f1: fn(msg: String),
+    f2: fn(_: String),
+    f3: fn(String, msg: String),
+    f4: fn(msg: String, String),
+    f5: fn(duplicate_name: bool, duplicate_name: bool),
+) { }
+
+
+// Patterns are semantically rejected
+fn semantics<F>(
+    pat1: fn(1..3: bool),
     //~^ ERROR patterns aren't allowed in function pointer types
-    pat2: fn(1..3: bool),
+    pat2: fn((x, y): (bool, bool)),
     //~^ ERROR patterns aren't allowed in function pointer types
-    pat3: fn((x, y): (bool, bool)),
+    pat3: fn(Thing { a, b }: Thing),
     //~^ ERROR patterns aren't allowed in function pointer types
-    pat4: fn(self),
-    //~^ ERROR `self` parameter is only allowed in associated functions
-    pat5: fn(self, self),
-    //~^ ERROR `self` parameter is only allowed in associated functions
-    //~| ERROR unexpected `self` parameter in function
-    pat6: fn(bool, self),
-    //~^ ERROR unexpected `self` parameter in function
-    pat7: fn(Thing { a, b }: Thing),
-    //~^ ERROR patterns aren't allowed in function pointer types
-    pat8: fn(NoThing { a, b }: NoThing),
+    pat4: fn(NoThing { a, b }: NoThing),
     //~^ ERROR patterns aren't allowed in function pointer types
     //~| ERROR cannot find type `NoThing` in this scope
-    pat9: fn((((((x))))): bool),
+    pat5: fn((((((x))))): bool),
+    //~^ ERROR patterns aren't allowed in function pointer types
+
+    self1: fn(self),
+    //~^ ERROR `self` parameter is only allowed in associated functions
+    self2: fn(self, self),
+    //~^ ERROR `self` parameter is only allowed in associated functions
+    //~| ERROR unexpected `self` parameter in function
+    self3: fn(bool, self),
+    //~^ ERROR unexpected `self` parameter in function
+
+    restricted_pat1: fn(mut x: ()),
+    //~^ ERROR patterns aren't allowed in function pointer types
+    restricted_pat2: fn(&x: ()),
+    //~^ ERROR patterns aren't allowed in function pointer types
+    restricted_pat3: fn(&&x: ()),
+    //~^ ERROR patterns aren't allowed in function pointer types
+    restricted_pat4: fn(false: ()),
+    //~^ ERROR patterns aren't allowed in function pointer types
+    restricted_pat5: fn(&_: ()),
+    //~^ ERROR patterns aren't allowed in function pointer types
+    restricted_pat6: fn(&true: ()),
     //~^ ERROR patterns aren't allowed in function pointer types
 ) { }
 

--- a/tests/ui/fn/fn-ptr-pattern.rs
+++ b/tests/ui/fn/fn-ptr-pattern.rs
@@ -44,6 +44,34 @@ fn semantics<F>(
     //~^ ERROR patterns aren't allowed in function pointer types
 ) { }
 
+// Patterns are also syntactically rejected, but restricted patterns are not
+#[cfg(false)]
+fn syntax<F>(
+    pat1: fn(1..3: bool),
+    //~^ ERROR patterns aren't allowed in function pointer types
+    pat2: fn((x, y): (bool, bool)),
+    //~^ ERROR patterns aren't allowed in function pointer types
+    pat3: fn(Thing { a, b }: Thing),
+    //~^ ERROR patterns aren't allowed in function pointer types
+    pat4: fn(NoThing { a, b }: NoThing),
+    //~^ ERROR patterns aren't allowed in function pointer types
+    pat5: fn((((((x))))): bool),
+    //~^ ERROR patterns aren't allowed in function pointer types
+
+    self1: fn(self),
+    self2: fn(self, self),
+    //~^ ERROR unexpected `self` parameter in function
+    self3: fn(bool, self),
+    //~^ ERROR unexpected `self` parameter in function
+
+    restricted_pat1: fn(mut x: ()),
+    restricted_pat2: fn(&x: ()),
+    restricted_pat3: fn(&&x: ()),
+    restricted_pat4: fn(false: ()),
+    restricted_pat5: fn(&_: ()),
+    restricted_pat6: fn(&true: ()),
+) { }
+
 struct Thing { a: bool, b: bool }
 
 fn main() {

--- a/tests/ui/fn/fn-ptr-pattern.stderr
+++ b/tests/ui/fn/fn-ptr-pattern.stderr
@@ -1,101 +1,131 @@
 error[E0642]: patterns aren't allowed in function pointer types
-  --> $DIR/fn-ptr-pattern.rs:4:14
+  --> $DIR/fn-ptr-pattern.rs:13:14
    |
-LL |     pat2: fn(1..3: bool),
+LL |     pat1: fn(1..3: bool),
    |              ^^^^
    |
 help: give this argument a name or use an underscore to ignore it
    |
-LL -     pat2: fn(1..3: bool),
-LL +     pat2: fn(_: bool),
+LL -     pat1: fn(1..3: bool),
+LL +     pat1: fn(_: bool),
    |
-
-error[E0642]: patterns aren't allowed in function pointer types
-  --> $DIR/fn-ptr-pattern.rs:6:14
-   |
-LL |     pat3: fn((x, y): (bool, bool)),
-   |              ^^^^^^
-   |
-help: give this argument a name or use an underscore to ignore it
-   |
-LL -     pat3: fn((x, y): (bool, bool)),
-LL +     pat3: fn(_: (bool, bool)),
-   |
-
-error: unexpected `self` parameter in function
-  --> $DIR/fn-ptr-pattern.rs:10:20
-   |
-LL |     pat5: fn(self, self),
-   |                    ^^^^ must be the first parameter of an associated function
-
-error: unexpected `self` parameter in function
-  --> $DIR/fn-ptr-pattern.rs:13:20
-   |
-LL |     pat6: fn(bool, self),
-   |                    ^^^^ must be the first parameter of an associated function
 
 error[E0642]: patterns aren't allowed in function pointer types
   --> $DIR/fn-ptr-pattern.rs:15:14
    |
-LL |     pat7: fn(Thing { a, b }: Thing),
-   |              ^^^^^^^^^^^^^^
+LL |     pat2: fn((x, y): (bool, bool)),
+   |              ^^^^^^
    |
 help: give this argument a name or use an underscore to ignore it
    |
-LL -     pat7: fn(Thing { a, b }: Thing),
-LL +     pat7: fn(_: Thing),
+LL -     pat2: fn((x, y): (bool, bool)),
+LL +     pat2: fn(_: (bool, bool)),
    |
 
 error[E0642]: patterns aren't allowed in function pointer types
   --> $DIR/fn-ptr-pattern.rs:17:14
    |
-LL |     pat8: fn(NoThing { a, b }: NoThing),
+LL |     pat3: fn(Thing { a, b }: Thing),
+   |              ^^^^^^^^^^^^^^
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL -     pat3: fn(Thing { a, b }: Thing),
+LL +     pat3: fn(_: Thing),
+   |
+
+error[E0642]: patterns aren't allowed in function pointer types
+  --> $DIR/fn-ptr-pattern.rs:19:14
+   |
+LL |     pat4: fn(NoThing { a, b }: NoThing),
    |              ^^^^^^^^^^^^^^^^
    |
 help: give this argument a name or use an underscore to ignore it
    |
-LL -     pat8: fn(NoThing { a, b }: NoThing),
-LL +     pat8: fn(_: NoThing),
+LL -     pat4: fn(NoThing { a, b }: NoThing),
+LL +     pat4: fn(_: NoThing),
    |
 
 error[E0642]: patterns aren't allowed in function pointer types
-  --> $DIR/fn-ptr-pattern.rs:20:14
+  --> $DIR/fn-ptr-pattern.rs:22:14
    |
-LL |     pat9: fn((((((x))))): bool),
+LL |     pat5: fn((((((x))))): bool),
    |              ^^^^^^^^^^^
    |
 help: give this argument a name or use an underscore to ignore it
    |
-LL -     pat9: fn((((((x))))): bool),
-LL +     pat9: fn(_: bool),
+LL -     pat5: fn((((((x))))): bool),
+LL +     pat5: fn(_: bool),
    |
+
+error: unexpected `self` parameter in function
+  --> $DIR/fn-ptr-pattern.rs:27:21
+   |
+LL |     self2: fn(self, self),
+   |                     ^^^^ must be the first parameter of an associated function
+
+error: unexpected `self` parameter in function
+  --> $DIR/fn-ptr-pattern.rs:30:21
+   |
+LL |     self3: fn(bool, self),
+   |                     ^^^^ must be the first parameter of an associated function
+
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/fn-ptr-pattern.rs:25:15
+   |
+LL |     self1: fn(self),
+   |               ^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/fn-ptr-pattern.rs:27:15
+   |
+LL |     self2: fn(self, self),
+   |               ^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
 
 error[E0561]: patterns aren't allowed in function pointer types
-  --> $DIR/fn-ptr-pattern.rs:2:14
+  --> $DIR/fn-ptr-pattern.rs:33:25
    |
-LL |     pat1: fn(true: bool),
-   |              ^^^^
+LL |     restricted_pat1: fn(mut x: ()),
+   |                         ^^^^^
 
-error: `self` parameter is only allowed in associated functions
-  --> $DIR/fn-ptr-pattern.rs:8:14
+error[E0561]: patterns aren't allowed in function pointer types
+  --> $DIR/fn-ptr-pattern.rs:35:25
    |
-LL |     pat4: fn(self),
-   |              ^^^^ not semantically valid as function parameter
-   |
-   = note: associated functions are those in `impl` or `trait` definitions
+LL |     restricted_pat2: fn(&x: ()),
+   |                         ^^
 
-error: `self` parameter is only allowed in associated functions
-  --> $DIR/fn-ptr-pattern.rs:10:14
+error[E0561]: patterns aren't allowed in function pointer types
+  --> $DIR/fn-ptr-pattern.rs:37:25
    |
-LL |     pat5: fn(self, self),
-   |              ^^^^ not semantically valid as function parameter
+LL |     restricted_pat3: fn(&&x: ()),
+   |                         ^^^
+
+error[E0561]: patterns aren't allowed in function pointer types
+  --> $DIR/fn-ptr-pattern.rs:39:25
    |
-   = note: associated functions are those in `impl` or `trait` definitions
+LL |     restricted_pat4: fn(false: ()),
+   |                         ^^^^^
+
+error[E0561]: patterns aren't allowed in function pointer types
+  --> $DIR/fn-ptr-pattern.rs:41:25
+   |
+LL |     restricted_pat5: fn(&_: ()),
+   |                         ^^
+
+error[E0561]: patterns aren't allowed in function pointer types
+  --> $DIR/fn-ptr-pattern.rs:43:25
+   |
+LL |     restricted_pat6: fn(&true: ()),
+   |                         ^^^^^
 
 error[E0425]: cannot find type `NoThing` in this scope
-  --> $DIR/fn-ptr-pattern.rs:17:32
+  --> $DIR/fn-ptr-pattern.rs:19:32
    |
-LL |     pat8: fn(NoThing { a, b }: NoThing),
+LL |     pat4: fn(NoThing { a, b }: NoThing),
    |                                ^^^^^^^
 ...
 LL | struct Thing { a: bool, b: bool }
@@ -103,11 +133,11 @@ LL | struct Thing { a: bool, b: bool }
    |
 help: a struct with a similar name exists
    |
-LL -     pat8: fn(NoThing { a, b }: NoThing),
-LL +     pat8: fn(NoThing { a, b }: Thing),
+LL -     pat4: fn(NoThing { a, b }: NoThing),
+LL +     pat4: fn(NoThing { a, b }: Thing),
    |
 
-error: aborting due to 11 previous errors
+error: aborting due to 16 previous errors
 
 Some errors have detailed explanations: E0425, E0561, E0642.
 For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/fn/fn-ptr-pattern.stderr
+++ b/tests/ui/fn/fn-ptr-pattern.stderr
@@ -70,6 +70,78 @@ error: unexpected `self` parameter in function
 LL |     self3: fn(bool, self),
    |                     ^^^^ must be the first parameter of an associated function
 
+error[E0642]: patterns aren't allowed in function pointer types
+  --> $DIR/fn-ptr-pattern.rs:50:14
+   |
+LL |     pat1: fn(1..3: bool),
+   |              ^^^^
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL -     pat1: fn(1..3: bool),
+LL +     pat1: fn(_: bool),
+   |
+
+error[E0642]: patterns aren't allowed in function pointer types
+  --> $DIR/fn-ptr-pattern.rs:52:14
+   |
+LL |     pat2: fn((x, y): (bool, bool)),
+   |              ^^^^^^
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL -     pat2: fn((x, y): (bool, bool)),
+LL +     pat2: fn(_: (bool, bool)),
+   |
+
+error[E0642]: patterns aren't allowed in function pointer types
+  --> $DIR/fn-ptr-pattern.rs:54:14
+   |
+LL |     pat3: fn(Thing { a, b }: Thing),
+   |              ^^^^^^^^^^^^^^
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL -     pat3: fn(Thing { a, b }: Thing),
+LL +     pat3: fn(_: Thing),
+   |
+
+error[E0642]: patterns aren't allowed in function pointer types
+  --> $DIR/fn-ptr-pattern.rs:56:14
+   |
+LL |     pat4: fn(NoThing { a, b }: NoThing),
+   |              ^^^^^^^^^^^^^^^^
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL -     pat4: fn(NoThing { a, b }: NoThing),
+LL +     pat4: fn(_: NoThing),
+   |
+
+error[E0642]: patterns aren't allowed in function pointer types
+  --> $DIR/fn-ptr-pattern.rs:58:14
+   |
+LL |     pat5: fn((((((x))))): bool),
+   |              ^^^^^^^^^^^
+   |
+help: give this argument a name or use an underscore to ignore it
+   |
+LL -     pat5: fn((((((x))))): bool),
+LL +     pat5: fn(_: bool),
+   |
+
+error: unexpected `self` parameter in function
+  --> $DIR/fn-ptr-pattern.rs:62:21
+   |
+LL |     self2: fn(self, self),
+   |                     ^^^^ must be the first parameter of an associated function
+
+error: unexpected `self` parameter in function
+  --> $DIR/fn-ptr-pattern.rs:64:21
+   |
+LL |     self3: fn(bool, self),
+   |                     ^^^^ must be the first parameter of an associated function
+
 error: `self` parameter is only allowed in associated functions
   --> $DIR/fn-ptr-pattern.rs:25:15
    |
@@ -137,7 +209,7 @@ LL -     pat4: fn(NoThing { a, b }: NoThing),
 LL +     pat4: fn(NoThing { a, b }: Thing),
    |
 
-error: aborting due to 16 previous errors
+error: aborting due to 23 previous errors
 
 Some errors have detailed explanations: E0425, E0561, E0642.
 For more information about an error, try `rustc --explain E0425`.


### PR DESCRIPTION
Follow up of https://github.com/rust-lang/rust/pull/160282
The goal is to cover more cases of the behaviour of patterns in fn pointers.