### PR TITLE
Add PR body notes for Cargo lock file maintenance

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,11 +35,16 @@
       "dependencyDashboardApproval": false
     },
     {
-      // Update all Cargo.lock files except library/Cargo.lock in one PR.
+      // Set defaults for all Cargo.lock files.
+      // library/Cargo.lock is grouped into a dedicated PR by the more
+      // specific rule below.
       "matchManagers": ["cargo"],
       "matchUpdateTypes": ["lockFileMaintenance"],
       "groupName": "Cargo lock file maintenance",
-      "commitMessageAction": "Cargo lock file maintenance"
+      "commitMessageAction": "Compiler and tools lock file update",
+      // Renovate merges all matching rules, so the lockfiles rules below
+      // also inherits this note and asks Triagebot for a dep-bumps reviewer.
+      "prBodyNotes": ["r? dep-bumps"]
     },
     {
       // Update library/Cargo.lock in a dedicated PR.
@@ -47,7 +52,7 @@
       "matchUpdateTypes": ["lockFileMaintenance"],
       "matchFileNames": ["library/Cargo.lock"],
       "groupName": "library lock file maintenance",
-      "commitMessageAction": "Library lock file maintenance"
+      "commitMessageAction": "Library lock file update"
     },
     {
       // These packages don't have a committed Cargo.lock file.
@@ -63,7 +68,7 @@
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["lockFileMaintenance"],
       "groupName": "Yarn lock file maintenance",
-      "commitMessageAction": "Yarn lock file maintenance"
+      "commitMessageAction": "Yarn lock file update"
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Same as https://github.com/rust-lang/rust/blob/8c3a200b704adb5f110249b68daa4ff386b36e29/.github/workflows/dependencies.yml#L22
Docs: https://docs.renovatebot.com/configuration-options/#prbodynotes
<!-- homu-ignore:end -->
r? @Kobzol 