### PR TITLE
New solver: fix infinite loop in the higher-ranked free type alias 

### DIFF
--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -698,7 +698,8 @@ impl<'tcx> UniversalRegionsBuilder<'_, 'tcx> {
         let inputs_and_output = match defining_ty {
             DefiningTy::Closure(def_id, args) => {
                 assert_eq!(self.mir_def.to_def_id(), def_id);
-                let closure_sig = args.as_closure().sig();
+                let closure_args = args.as_closure();
+                let closure_sig = closure_args.sig();
                 let inputs_and_output = closure_sig.inputs_and_output();
                 let bound_vars = tcx.mk_bound_variable_kinds_from_iter(
                     inputs_and_output.bound_vars().iter().chain(iter::once(
@@ -710,9 +711,28 @@ impl<'tcx> UniversalRegionsBuilder<'_, 'tcx> {
                     kind: ty::BoundRegionKind::ClosureEnv,
                 };
                 let env_region = ty::Region::new_bound(tcx, ty::INNERMOST, br);
+                // The closure self type contains a redundant copy of the signature: the actual
+                // inputs and output are added separately below. Do not reveal opaques in this
+                // copy, as doing so under the signature binder would create fresh placeholder
+                // instantiations which do not match the closure type in the MIR.
+                let closure_sig_as_fn_ptr_ty = closure_args.sig_as_fn_ptr_ty();
+                let closure_sig_as_fn_ptr_ty = if self.infcx.next_trait_solver() {
+                    ty::set_opaques_to_rigid(tcx, closure_sig_as_fn_ptr_ty)
+                } else {
+                    closure_sig_as_fn_ptr_ty
+                };
+                let closure_args = ty::ClosureArgs::new(
+                    tcx,
+                    ty::ClosureArgsParts {
+                        parent_args: closure_args.parent_args(),
+                        closure_kind_ty: closure_args.kind_ty(),
+                        closure_sig_as_fn_ptr_ty,
+                        tupled_upvars_ty: closure_args.tupled_upvars_ty(),
+                    },
+                );
                 let closure_ty = tcx.closure_env_ty(
-                    Ty::new_closure(tcx, def_id, args),
-                    args.as_closure().kind(),
+                    Ty::new_closure(tcx, def_id, closure_args.args),
+                    closure_args.kind(),
                     env_region,
                 );
 

--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -1114,6 +1114,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.tcx().liberate_late_bound_regions(expr_def_id.to_def_id(), bound_sig);
         let liberated_sig =
             self.normalize(self.tcx.def_span(expr_def_id), Unnormalized::new_wip(liberated_sig));
+        // Higher-ranked normalization keeps opaque types rigid. The liberated signature is used
+        // to check the closure body, so defining opaques is allowed again at this point.
+        let liberated_sig = if self.next_trait_solver() {
+            ty::set_opaques_to_non_rigid(self.tcx, liberated_sig).skip_norm_wip()
+        } else {
+            liberated_sig
+        };
         ClosureSignatures { bound_sig, liberated_sig }
     }
 }

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -754,7 +754,7 @@ where
         candidates: &mut Vec<Candidate<I>>,
         consider_self_bounds: AliasBoundKind,
     ) -> Result<(), RerunNonErased> {
-        let (alias_ty, def_id) = match self_ty.kind() {
+        let (alias_ty, def_id, rigid_opaque) = match self_ty.kind() {
             ty::Bool
             | ty::Char
             | ty::Int(_)
@@ -805,10 +805,10 @@ where
             ty::Alias(
                 ty::IsRigid::Yes,
                 alias_ty @ AliasTy { kind: ty::Projection { def_id }, .. },
-            ) => (alias_ty, def_id.into()),
+            ) => (alias_ty, def_id.into(), false),
 
             ty::Alias(ty::IsRigid::Yes, alias_ty @ AliasTy { kind: ty::Opaque { def_id }, .. }) => {
-                (alias_ty, def_id.into())
+                (alias_ty, def_id.into(), true)
             }
 
             ty::Alias(ty::IsRigid::No, _) => unreachable!("non-rigid self type: {self_ty:?}"),
@@ -830,6 +830,14 @@ where
                     .iter_instantiated(self.cx(), alias_ty.args)
                     .map(Unnormalized::skip_norm_wip)
                 {
+                    // Instantiating the bounds loses the rigidness of opaque aliases. Preserve it
+                    // when the self type is rigid so matching the assumption does not reveal the
+                    // opaque which caused us to consider its bounds in the first place.
+                    let assumption = if rigid_opaque {
+                        ty::set_opaques_to_rigid(self.cx(), assumption)
+                    } else {
+                        assumption
+                    };
                     candidates.extend(G::probe_and_consider_implied_clause(
                         self,
                         CandidateSource::AliasBound(consider_self_bounds),

--- a/compiler/rustc_next_trait_solver/src/solve/project_goals/free_alias.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/project_goals/free_alias.rs
@@ -4,6 +4,7 @@
 //! Since a free alias is never ambiguous, this just computes the `type_of` of
 //! the alias and registers the where-clauses of the type alias.
 
+use rustc_type_ir::inherent::*;
 use rustc_type_ir::solve::QueryResultOrRerunNonErased;
 use rustc_type_ir::{self as ty, Interner, Unnormalized};
 
@@ -34,7 +35,19 @@ where
         let actual = match free_alias.kind {
             ty::AliasTermKind::FreeTy { def_id } => {
                 let free = cx.type_of(def_id.into()).instantiate(cx, free_alias.args);
-                let free = self.normalize(GoalSource::Misc, goal.param_env, free)?;
+                let free = free.skip_norm_wip();
+                let rigid_free = ty::set_opaques_to_rigid(cx, free);
+                // A higher-ranked normalizer may explicitly request an expansion with its opaques
+                // made rigid. The alias bounds have already been registered above. Preserve those
+                // opaques while still recursively normalizing the rest of the expansion.
+                let free =
+                    if rigid_free != free && goal.predicate.term.as_type() == Some(rigid_free) {
+                        rigid_free
+                    } else {
+                        free
+                    };
+                let free =
+                    self.normalize(GoalSource::Misc, goal.param_env, Unnormalized::new_wip(free))?;
                 free.into()
             }
             ty::AliasTermKind::FreeConst { def_id } if cx.is_type_const(def_id.into()) => {

--- a/compiler/rustc_trait_selection/src/solve/normalize.rs
+++ b/compiler/rustc_trait_selection/src/solve/normalize.rs
@@ -51,14 +51,33 @@ where
     let mut stalled_goals = vec![];
     let mut folder = NormalizationFolder::new(infcx, universes.clone(), |alias_term| {
         let delegate = <&SolverDelegate<'tcx>>::from(infcx);
+        // Normalizing an alias under a binder must not define any opaques in its expansion. Ask
+        // the free-alias goal for that expansion with its opaques made rigid so it still registers
+        // the alias bounds and normalizes the rest of the expansion.
+        let rigid_expansion = match alias_term.kind {
+            ty::AliasTermKind::FreeTy { def_id } if alias_term.has_placeholders() => {
+                let expansion = infcx
+                    .tcx
+                    .type_of(def_id)
+                    .instantiate(infcx.tcx, alias_term.args)
+                    .skip_norm_wip();
+                let rigid_expansion = ty::set_opaques_to_rigid(infcx.tcx, expansion);
+                (rigid_expansion != expansion).then_some(rigid_expansion.into())
+            }
+            _ => None,
+        };
         let infer_term = delegate.next_term_var_of_alias_kind(alias_term, at.cause.span);
-        let predicate = ty::ProjectionPredicate { projection_term: alias_term, term: infer_term };
+        let predicate = ty::ProjectionPredicate {
+            projection_term: alias_term,
+            term: rigid_expansion.unwrap_or(infer_term),
+        };
         let goal = Goal::new(infcx.tcx, at.param_env, predicate);
         let result = match delegate.evaluate_root_goal(goal, at.cause.span, None) {
             Ok(result) => result,
             Err(err) => return Err(err),
         };
-        let normalized = infcx.resolve_vars_if_possible(infer_term);
+        let normalized =
+            rigid_expansion.unwrap_or_else(|| infcx.resolve_vars_if_possible(infer_term));
         let normalization_was_ambiguous = match result.certainty {
             Certainty::Yes => NormalizationWasAmbiguous::No,
             Certainty::Maybe { .. } => {

--- a/compiler/rustc_type_ir/src/fold.rs
+++ b/compiler/rustc_type_ir/src/fold.rs
@@ -577,6 +577,13 @@ where
     ty::Unnormalized::new(folded)
 }
 
+pub fn set_opaques_to_rigid<I: Interner, T>(cx: I, value: T) -> T
+where
+    T: TypeFoldable<I>,
+{
+    set_aliases_rigidness_with_mode(cx, value, RigidnessFoldMode::OpaqueToRigid)
+}
+
 pub fn set_aliases_to_rigid<I: Interner, T>(cx: I, value: T) -> T
 where
     T: TypeFoldable<I>,
@@ -607,6 +614,7 @@ enum RigidnessFoldMode {
     AllToRigid,
     AllToNonRigid,
     TypeToRigid,
+    OpaqueToRigid,
     OpaqueToNonRigid,
 }
 
@@ -619,6 +627,7 @@ impl RigidnessFoldMode {
                 v.has_non_rigid_aliases()
                     && v.has_type_flags(ty::TypeFlags::HAS_ALIAS - ty::TypeFlags::HAS_CONST_ALIAS)
             }
+            RigidnessFoldMode::OpaqueToRigid => v.has_non_rigid_aliases() && v.has_opaque_types(),
             RigidnessFoldMode::OpaqueToNonRigid => v.has_rigid_aliases() && v.has_opaque_types(),
         }
     }
@@ -655,6 +664,13 @@ impl<I: Interner> TypeFolder<I> for RigidnessFolder<I> {
                     RigidnessFoldMode::AllToNonRigid => {
                         I::Ty::new_alias(self.cx(), ty::IsRigid::No, alias_ty)
                     }
+                    RigidnessFoldMode::OpaqueToRigid => {
+                        if let ty::AliasTyKind::Opaque { .. } = alias_ty.kind {
+                            I::Ty::new_alias(self.cx(), ty::IsRigid::Yes, alias_ty)
+                        } else {
+                            I::Ty::new_alias(self.cx(), is_rigid, alias_ty)
+                        }
+                    }
                     RigidnessFoldMode::OpaqueToNonRigid => {
                         if let ty::AliasTyKind::Opaque { .. } = alias_ty.kind {
                             I::Ty::new_alias(self.cx(), ty::IsRigid::No, alias_ty)
@@ -683,7 +699,9 @@ impl<I: Interner> TypeFolder<I> for RigidnessFolder<I> {
                     RigidnessFoldMode::AllToNonRigid => {
                         I::Const::new_alias(self.cx(), ty::IsRigid::No, alias_const)
                     }
-                    RigidnessFoldMode::OpaqueToNonRigid | RigidnessFoldMode::TypeToRigid => {
+                    RigidnessFoldMode::OpaqueToRigid
+                    | RigidnessFoldMode::OpaqueToNonRigid
+                    | RigidnessFoldMode::TypeToRigid => {
                         I::Const::new_alias(self.cx(), is_rigid, alias_const)
                     }
                 }

--- a/tests/ui/closures/supertrait-hint-cycle-nested-opaque.rs
+++ b/tests/ui/closures/supertrait-hint-cycle-nested-opaque.rs
@@ -8,6 +8,7 @@
 #![feature(closure_lifetime_binder)]
 
 use std::future::Future;
+use std::pin::Pin;
 
 trait AsyncFn<I, R>: FnMut(I) -> Self::Fut {
     type Fut: Future<Output = R>;
@@ -36,32 +37,20 @@ where
 trait Cap<'a> {}
 impl<T> Cap<'_> for T {}
 
-fn works(ctx: &mut usize) {
+fn check(ctx: &mut usize) {
     let mut inner = 0;
 
-    type Ret<'a, 'b: 'a> = impl Future<Output = Result<usize, ()>> + 'a + Cap<'b>;
-
-    let callback = for<'a, 'b> |c: &'a mut &'b mut usize| -> Ret<'a, 'b> {
-        inner += 1;
-        async move {
-            let _c = c;
-            Ok(1usize)
-        }
-    };
-    call(ctx, callback);
-}
-
-fn doesnt_work_but_should(ctx: &mut usize) {
-    let mut inner = 0;
-
-    type Ret<'a, 'b: 'a> = impl Future<Output = Result<usize, ()>> + 'a + Cap<'b>;
+    // Ensure that normalization preserves an opaque nested inside a structural type, not only an
+    // opaque which is itself the direct expansion of the free alias.
+    type Ret<'a, 'b: 'a> =
+        Pin<Box<impl Future<Output = Result<usize, ()>> + 'a + Cap<'b>>>;
 
     call(ctx, for<'a, 'b> |c: &'a mut &'b mut usize| -> Ret<'a, 'b> {
         inner += 1;
-        async move {
+        Box::pin(async move {
             let _c = c;
             Ok(1usize)
-        }
+        })
     });
 }
 


### PR DESCRIPTION
### Problem

The next trait solver eagerly normalized a higher-ranked free type alias into its underlying TAIT while inferring a closure signature. This incorrectly treated the opaque as a defining use and caused a cycle through the opaque bounds, closure output, and AsyncFn supertrait. The old solver keeps opaques hidden during type checking and accepts this code.

  ### Solution

Keep opaques rigid while normalizing higher-ranked signatures, while still checking the free alias’s where-clauses and normalizing the surrounding type. Once the binder is liberated for closure-body checking, make the opaque non-rigid again so the body can define its hidden type.

The change also preserves this rigidity in borrowck’s redundant closure-signature copy and when instantiating bounds for rigid opaques. 

r? @lcnr