### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1261,7 +1261,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1388,7 +1388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1410,12 +1410,6 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -1630,19 +1624,15 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-dependencies = [
- "fallible-iterator",
- "indexmap",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "gimli"
-version = "0.32.3"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
- "fallible-iterator",
+ "fnv",
+ "hashbrown 0.16.1",
  "indexmap",
  "stable_deref_trait",
 ]
@@ -1696,9 +1686,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.1.5",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2166,7 +2165,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2653,7 +2652,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2779,12 +2778,7 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
- "crc32fast",
- "flate2",
- "hashbrown 0.15.5",
- "indexmap",
  "memchr",
- "ruzstd 0.7.3",
 ]
 
 [[package]]
@@ -2793,13 +2787,22 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
+dependencies = [
  "crc32fast",
  "flate2",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "memchr",
- "ruzstd 0.8.2",
- "wasmparser 0.236.1",
+ "ruzstd",
+ "wasmparser 0.243.0",
 ]
 
 [[package]]
@@ -3506,15 +3509,15 @@ version = "0.0.0"
 dependencies = [
  "bstr",
  "build_helper",
- "gimli 0.32.3",
+ "gimli 0.33.0",
  "libc",
- "object 0.37.3",
+ "object 0.38.1",
  "regex",
  "rustdoc-json-types",
  "serde_json",
  "similar",
  "tempfile",
- "wasmparser 0.236.1",
+ "wasmparser 0.243.0",
 ]
 
 [[package]]
@@ -3798,12 +3801,12 @@ name = "rustc_codegen_llvm"
 version = "0.0.0"
 dependencies = [
  "bitflags",
- "gimli 0.31.1",
+ "gimli 0.33.0",
  "itertools",
  "libc",
  "libloading 0.9.0",
  "measureme",
- "object 0.37.3",
+ "object 0.38.1",
  "rustc-demangle",
  "rustc_abi",
  "rustc_ast",
@@ -3837,7 +3840,7 @@ dependencies = [
  "find-msvc-tools",
  "itertools",
  "libc",
- "object 0.37.3",
+ "object 0.38.1",
  "pathdiff",
  "regex",
  "rustc_abi",
@@ -4802,7 +4805,7 @@ version = "0.0.0"
 dependencies = [
  "arrayvec",
  "bitflags",
- "object 0.37.3",
+ "object 0.38.1",
  "rustc_abi",
  "rustc_data_structures",
  "rustc_error_messages",
@@ -5085,7 +5088,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5093,15 +5096,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ruzstd"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
-dependencies = [
- "twox-hash 1.6.3",
-]
 
 [[package]]
 name = "ruzstd"
@@ -5517,7 +5511,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5536,7 +5530,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5623,13 +5617,13 @@ dependencies = [
 
 [[package]]
 name = "thorin-dwp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9c1e705f82a260173f3eec93f2ff6d7807f23ad5a8cc2e7316a891733ea7a1"
+checksum = "6ce6b46108e50803d2c10216929e49fa3eda07ee3dc246310c18c4a1e3b1fa58"
 dependencies = [
- "gimli 0.31.1",
- "hashbrown 0.15.5",
- "object 0.36.7",
+ "gimli 0.33.0",
+ "hashbrown 0.16.1",
+ "object 0.38.1",
  "tracing",
 ]
 
@@ -6431,9 +6425,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.236.1"
+version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
+checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
 dependencies = [
  "bitflags",
  "indexmap",
@@ -6514,7 +6508,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -11,12 +11,12 @@ test = false
 bitflags = "2.4.1"
 # To avoid duplicate dependencies, this should match the version of gimli used
 # by `rustc_codegen_ssa` via its `thorin-dwp` dependency.
-gimli = "0.31"
+gimli = "0.33"
 itertools = "0.15"
 libc = "0.2"
 libloading = { version = "0.9.0" }
 measureme = "12.0.1"
-object = { version = "0.37.0", default-features = false, features = ["std", "read"] }
+object = { version = "0.38.1", default-features = false, features = ["std", "read"] }
 rustc-demangle = "0.1.28"
 rustc_abi = { path = "../rustc_abi" }
 rustc_ast = { path = "../rustc_ast" }

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -37,7 +37,7 @@ rustc_trait_selection = { path = "../rustc_trait_selection" }
 serde_json = "1.0.59"
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
 tempfile = "3.2"
-thorin-dwp = "0.9"
+thorin-dwp = "0.10"
 tracing = "0.1"
 wasm-encoder = "0.219"
 # tidy-alphabetical-end
@@ -48,7 +48,7 @@ libc = "0.2.50"
 # tidy-alphabetical-end
 
 [dependencies.object]
-version = "0.37.0"
+version = "0.38.1"
 default-features = false
 features = ["read_core", "elf", "macho", "pe", "xcoff", "unaligned", "archive", "write", "wasm"]
 

--- a/compiler/rustc_codegen_ssa/src/diagnostics.rs
+++ b/compiler/rustc_codegen_ssa/src/diagnostics.rs
@@ -261,9 +261,6 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for ThorinErrorWrapper {
             thorin::Error::ParseUnitAbbreviations(_) => {
                 build(msg!("failed to parse unit abbreviations"))
             }
-            thorin::Error::ParseUnitAttribute(_) => {
-                build(msg!("failed to parse unit attribute"))
-            }
             thorin::Error::ParseUnitHeader(_) => {
                 build(msg!("failed to parse unit header"))
             }

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -11,6 +11,7 @@ use rustc_middle::ty::adjustment::PointerCoercion;
 use rustc_middle::ty::util::{Discr, IntTypeExt};
 use rustc_middle::ty::{self, GenericArgsRef, Ty, TyCtxt};
 use rustc_middle::{bug, span_bug};
+use rustc_mir_dataflow::DropFlagState;
 use rustc_span::{DUMMY_SP, dummy_spanned};
 use tracing::{debug, instrument};
 
@@ -107,11 +108,10 @@ pub(crate) trait DropElaborator<'a, 'tcx>: fmt::Debug {
     /// Returns the drop flag of `path` as a MIR `Operand` (or `None` if `path` has no drop flag).
     fn get_drop_flag(&mut self, path: Self::Path) -> Option<Operand<'tcx>>;
 
-    /// Modifies the MIR patch so that the drop flag of `path` (if any) is cleared at `location`.
+    /// Return the drop flag of `path`, if any.
     ///
-    /// If `mode` is deep, drop flags of all child paths should also be cleared by inserting
-    /// additional statements.
-    fn clear_drop_flag(&mut self, location: Location, path: Self::Path, mode: DropFlagMode);
+    /// If `mode` is deep, drop flags of all child paths should be returned.
+    fn drop_flags_for(&mut self, path: Self::Path, mode: DropFlagMode) -> Vec<Place<'tcx>>;
 
     // Subpaths
 
@@ -1568,10 +1568,20 @@ where
             // bother setting it.
             return succ;
         }
-        let block = self.new_block(unwind, TerminatorKind::Goto { target: succ });
-        let block_start = Location { block, statement_index: 0 };
-        self.elaborator.clear_drop_flag(block_start, self.path, mode);
-        block
+        let flags = self.elaborator.drop_flags_for(self.path, mode);
+        let statements: Vec<_> = flags
+            .into_iter()
+            .map(|flag| {
+                self.assign(
+                    flag,
+                    Rvalue::Use(self.constant_bool(DropFlagState::Absent.value()), WithRetag::Yes),
+                )
+            })
+            .collect();
+        if statements.is_empty() {
+            return succ;
+        }
+        self.new_block_with_statements(unwind, statements, TerminatorKind::Goto { target: succ })
     }
 
     #[instrument(level = "debug", skip(self), ret)]
@@ -1663,6 +1673,14 @@ where
             span: self.source_info.span,
             user_ty: None,
             const_: Const::from_usize(self.tcx(), val.into()),
+        }))
+    }
+
+    fn constant_bool(&self, val: bool) -> Operand<'tcx> {
+        Operand::Constant(Box::new(ConstOperand {
+            span: self.source_info.span,
+            user_ty: None,
+            const_: Const::from_bool(self.tcx(), val),
         }))
     }
 

--- a/compiler/rustc_mir_transform/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drops.rs
@@ -189,17 +189,23 @@ impl<'a, 'tcx> DropElaborator<'a, 'tcx> for ElaborateDropsCtxt<'a, 'tcx> {
         }
     }
 
-    fn clear_drop_flag(&mut self, loc: Location, path: Self::Path, mode: DropFlagMode) {
+    fn drop_flags_for(&mut self, path: Self::Path, mode: DropFlagMode) -> Vec<Place<'tcx>> {
+        let mut flags = vec![];
         match mode {
             DropFlagMode::Shallow => {
-                self.set_drop_flag(loc, path, DropFlagState::Absent);
+                if let Some(flag) = self.drop_flags[path] {
+                    flags.push(flag.into());
+                }
             }
             DropFlagMode::Deep => {
                 on_all_children_bits(self.move_data(), path, |child| {
-                    self.set_drop_flag(loc, child, DropFlagState::Absent)
+                    if let Some(flag) = self.drop_flags[child] {
+                        flags.push(flag.into());
+                    }
                 });
             }
         }
+        flags
     }
 
     fn field_subpath(&self, path: Self::Path, field: FieldIdx) -> Option<Self::Path> {

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -460,7 +460,9 @@ impl<'a, 'tcx> DropElaborator<'a, 'tcx> for DropShimElaborator<'a, 'tcx> {
         None
     }
 
-    fn clear_drop_flag(&mut self, _location: Location, _path: Self::Path, _mode: DropFlagMode) {}
+    fn drop_flags_for(&mut self, _path: Self::Path, _mode: DropFlagMode) -> Vec<Place<'tcx>> {
+        Vec::new()
+    }
 
     fn field_subpath(&self, _path: Self::Path, _field: FieldIdx) -> Option<Self::Path> {
         None

--- a/compiler/rustc_target/Cargo.toml
+++ b/compiler/rustc_target/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 # tidy-alphabetical-start
 arrayvec = { version = "0.7", default-features = false }
 bitflags = "2.4.1"
-object = { version = "0.37.0", default-features = false, features = ["elf", "macho"] }
+object = { version = "0.38.1", default-features = false, features = ["elf", "macho"] }
 rustc_abi = { path = "../rustc_abi" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_error_messages = { path = "../rustc_error_messages" }

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
 dependencies = [
  "memchr",
 ]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -41,7 +41,7 @@ clap_complete = "4.4"
 home = "0.5"
 ignore = "0.4"
 libc = "0.2"
-object = { version = "0.37", default-features = false, features = ["archive", "coff", "read_core", "std", "unaligned"] }
+object = { version = "0.38.1", default-features = false, features = ["archive", "coff", "read_core", "std", "unaligned"] }
 opener = "0.8"
 semver = "1.0"
 serde = "1.0"

--- a/src/bootstrap/src/utils/proc_macro_deps.rs
+++ b/src/bootstrap/src/utils/proc_macro_deps.rs
@@ -3,7 +3,6 @@
 /// See <https://github.com/rust-lang/rust/issues/134863>
 pub static CRATES: &[&str] = &[
     // tidy-alphabetical-start
-    "allocator-api2",
     "anyhow",
     "askama_derive",
     "askama_parser",

--- a/src/tools/run-make-support/Cargo.toml
+++ b/src/tools/run-make-support/Cargo.toml
@@ -11,14 +11,14 @@ edition = "2024"
 
 # tidy-alphabetical-start
 bstr = "1.12"
-gimli = "0.32"
+gimli = "0.33"
 libc = "0.2"
-object = { version = "0.37", features = ["wasm"] }
+object = { version = "0.38.1", features = ["wasm"] }
 regex = "1.11"
 serde_json = "1.0"
 similar = "2.7"
 tempfile = "3"
-wasmparser = { version = "0.236", default-features = false, features = ["std", "features", "validate"] }
+wasmparser = { version = "0.243", default-features = false, features = ["std", "features", "validate"] }
 # tidy-alphabetical-end
 
 # Shared with bootstrap and compiletest

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -340,7 +340,6 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "equivalent",
     "errno",
     "expect-test",
-    "fallible-iterator", // dependency of `thorin`
     "fastrand",
     "find-msvc-tools",
     "flate2",

--- a/tests/mir-opt/box_partial_move.maybe_move.ElaborateDrops.diff
+++ b/tests/mir-opt/box_partial_move.maybe_move.ElaborateDrops.diff
@@ -44,7 +44,7 @@
       bb4: {
           StorageDead(_3);
 -         drop(_2) -> [return: bb5, unwind continue];
-+         goto -> bb14;
++         goto -> bb13;
       }
   
       bb5: {
@@ -61,34 +61,30 @@
 +     }
 + 
 +     bb8: {
-+         goto -> bb5;
-+     }
-+ 
-+     bb9: {
 +         _6 = &mut _2;
-+         _7 = <Box<String> as Drop>::drop(move _6) -> [return: bb8, unwind: bb7];
++         _7 = <Box<String> as Drop>::drop(move _6) -> [return: bb5, unwind: bb7];
 +     }
 + 
-+     bb10 (cleanup): {
++     bb9 (cleanup): {
 +         _8 = &mut _2;
 +         _9 = <Box<String> as Drop>::drop(move _8) -> [return: bb7, unwind terminate(cleanup)];
 +     }
 + 
++     bb10: {
++         goto -> bb12;
++     }
++ 
 +     bb11: {
-+         goto -> bb13;
++         drop((*_10)) -> [return: bb8, unwind: bb9];
 +     }
 + 
 +     bb12: {
-+         drop((*_10)) -> [return: bb9, unwind: bb10];
++         switchInt(copy _5) -> [0: bb8, otherwise: bb11];
 +     }
 + 
 +     bb13: {
-+         switchInt(copy _5) -> [0: bb9, otherwise: bb12];
-+     }
-+ 
-+     bb14: {
 +         _10 = copy ((_2.0: std::ptr::Unique<std::string::String>).0: std::ptr::NonNull<std::string::String>) as *const std::string::String (Transmute);
-+         goto -> bb11;
++         goto -> bb10;
       }
   }
   

--- a/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
+++ b/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
@@ -404,34 +404,34 @@
       bb37: {
           StorageDead(_2);
 -         drop(_44) -> [return: bb38, unwind: bb78];
-+         goto -> bb93;
++         goto -> bb38;
       }
   
       bb38: {
           StorageDead(_44);
 -         drop(_34) -> [return: bb39, unwind: bb83];
-+         goto -> bb94;
++         goto -> bb39;
       }
   
       bb39: {
 +         _53 = const false;
           StorageDead(_34);
 -         drop(_24) -> [return: bb40, unwind: bb87];
-+         goto -> bb95;
++         goto -> bb40;
       }
   
       bb40: {
 +         _54 = const false;
           StorageDead(_24);
 -         drop(_14) -> [return: bb41, unwind: bb90];
-+         goto -> bb96;
++         goto -> bb41;
       }
   
       bb41: {
 +         _55 = const false;
           StorageDead(_14);
 -         drop(_4) -> [return: bb42, unwind continue];
-+         goto -> bb97;
++         goto -> bb42;
       }
   
       bb42: {
@@ -459,7 +459,7 @@
           StorageDead(_3);
           StorageDead(_2);
 -         drop(_44) -> [return: bb47, unwind: bb78];
-+         goto -> bb98;
++         goto -> bb47;
       }
   
       bb47: {
@@ -485,7 +485,7 @@
   
       bb51: {
 -         drop(_34) -> [return: bb52, unwind: bb83];
-+         goto -> bb99;
++         goto -> bb52;
       }
   
       bb52: {
@@ -507,7 +507,7 @@
   
       bb55: {
 -         drop(_24) -> [return: bb56, unwind: bb87];
-+         goto -> bb100;
++         goto -> bb56;
       }
   
       bb56: {
@@ -524,7 +524,7 @@
   
       bb58: {
 -         drop(_14) -> [return: bb59, unwind: bb90];
-+         goto -> bb101;
++         goto -> bb59;
       }
   
       bb59: {
@@ -535,7 +535,7 @@
   
       bb60: {
 -         drop(_4) -> [return: bb61, unwind continue];
-+         goto -> bb102;
++         goto -> bb61;
       }
   
       bb61: {
@@ -681,46 +681,6 @@
   
       bb92 (cleanup): {
           resume;
-+     }
-+ 
-+     bb93: {
-+         goto -> bb38;
-+     }
-+ 
-+     bb94: {
-+         goto -> bb39;
-+     }
-+ 
-+     bb95: {
-+         goto -> bb40;
-+     }
-+ 
-+     bb96: {
-+         goto -> bb41;
-+     }
-+ 
-+     bb97: {
-+         goto -> bb42;
-+     }
-+ 
-+     bb98: {
-+         goto -> bb47;
-+     }
-+ 
-+     bb99: {
-+         goto -> bb52;
-+     }
-+ 
-+     bb100: {
-+         goto -> bb56;
-+     }
-+ 
-+     bb101: {
-+         goto -> bb59;
-+     }
-+ 
-+     bb102: {
-+         goto -> bb61;
       }
   }
   

--- a/tests/mir-opt/coroutine/async_await.a-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_await.a-{closure#0}.StateTransform.diff
@@ -30,7 +30,7 @@
 +         _6 = std::future::ResumeTy(move _7);
 +         _5 = copy (_1.0: &mut {async fn body of a()});
 +         _4 = discriminant((*_5));
-+         switchInt(move _4) -> [0: bb5, 1: bb3, otherwise: bb4];
++         switchInt(move _4) -> [0: bb4, 1: bb2, otherwise: bb3];
       }
   
       bb1: {
@@ -42,20 +42,16 @@
 -     bb2 (cleanup): {
 -         resume;
 +     bb2: {
-+         goto -> bb1;
++         assert(const false, "`async fn` resumed after completion") -> [success: bb2, unwind continue];
 +     }
 + 
 +     bb3: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb3, unwind continue];
-+     }
-+ 
-+     bb4: {
 +         unreachable;
 +     }
 + 
-+     bb5: {
++     bb4: {
 +         _3 = const ();
-+         goto -> bb2;
++         goto -> bb1;
       }
   }
   

--- a/tests/mir-opt/coroutine/async_await.b-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_await.b-{closure#0}.StateTransform.diff
@@ -86,7 +86,7 @@
 +         _40 = std::future::ResumeTy(move _41);
 +         _39 = copy (_1.0: &mut {async fn body of b()});
 +         _38 = discriminant((*_39));
-+         switchInt(move _38) -> [0: bb47, 1: bb46, 2: bb45, 3: bb43, 4: bb44, otherwise: bb7];
++         switchInt(move _38) -> [0: bb46, 1: bb45, 2: bb44, 3: bb42, 4: bb43, otherwise: bb7];
       }
   
       bb1: {
@@ -309,7 +309,7 @@
       bb23: {
           StorageDead(_21);
 -         drop(_1) -> [return: bb24, unwind: bb50];
-+         goto -> bb41;
++         goto -> bb24;
       }
   
       bb24: {
@@ -486,14 +486,10 @@
   
 -     bb50 (cleanup): {
 +     bb40 (cleanup): {
-+         goto -> bb42;
++         goto -> bb41;
 +     }
 + 
-+     bb41: {
-+         goto -> bb24;
-+     }
-+ 
-+     bb42 (cleanup): {
++     bb41 (cleanup): {
 +         discriminant((*_39)) = 2;
           resume;
       }
@@ -501,7 +497,7 @@
 -     bb51 (cleanup): {
 -         StorageDead(_23);
 -         goto -> bb52;
-+     bb43: {
++     bb42: {
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         StorageLive(_19);
@@ -513,7 +509,7 @@
 -     bb52 (cleanup): {
 -         StorageDead(_21);
 -         goto -> bb55;
-+     bb44: {
++     bb43: {
 +         StorageLive(_21);
 +         StorageLive(_35);
 +         StorageLive(_36);
@@ -524,21 +520,21 @@
 -     bb53 (cleanup): {
 -         StorageDead(_6);
 -         goto -> bb54;
-+     bb45: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb45, unwind continue];
++     bb44: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb44, unwind continue];
       }
   
 -     bb54 (cleanup): {
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         goto -> bb55;
-+     bb46: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb46, unwind continue];
++     bb45: {
++         assert(const false, "`async fn` resumed after completion") -> [success: bb45, unwind continue];
       }
   
 -     bb55 (cleanup): {
 -         drop(_1) -> [return: bb50, unwind terminate(cleanup)];
-+     bb47: {
++     bb46: {
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         StorageLive(_5);

--- a/tests/mir-opt/coroutine/async_drop.array-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.array-{closure#0}.StateTransform.diff
@@ -65,7 +65,7 @@
 +         _26 = std::future::ResumeTy(move _27);
 +         _25 = copy (_1.0: &mut {async fn body of array()});
 +         _24 = discriminant((*_25));
-+         switchInt(move _24) -> [0: bb26, 1: bb25, 2: bb24, 3: bb22, 4: bb23, otherwise: bb11];
++         switchInt(move _24) -> [0: bb25, 1: bb24, 2: bb23, 3: bb21, 4: bb22, otherwise: bb11];
       }
   
       bb1: {
@@ -85,7 +85,7 @@
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb4, unwind: bb8];
 +         nop;
-+         goto -> bb20;
++         goto -> bb4;
       }
   
       bb4: {
@@ -104,7 +104,7 @@
 -     bb6: {
 -         coroutine_drop;
 +     bb6 (cleanup): {
-+         goto -> bb21;
++         goto -> bb20;
       }
   
 -     bb7 (cleanup): {
@@ -201,49 +201,49 @@
 +         _21 = Pin::<&mut [AsyncInt; 2]>::new_unchecked(move _22) -> [return: bb18, unwind: bb5];
       }
   
-      bb20: {
+-     bb20: {
 -         _13 = &mut _6;
 -         _10 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _13) -> [return: bb19, unwind: bb11];
-+         goto -> bb4;
++     bb20 (cleanup): {
++         discriminant((*_25)) = 2;
++         resume;
       }
   
--     bb21: {
+      bb21: {
 -         _2 = move _14;
 -         StorageDead(_14);
 -         goto -> bb27;
-+     bb21 (cleanup): {
-+         discriminant((*_25)) = 2;
-+         resume;
++         StorageLive(_7);
++         _7 = move _26;
++         goto -> bb10;
       }
   
       bb22: {
 -         _2 = move _14;
 -         StorageDead(_14);
 -         goto -> bb20;
-+         StorageLive(_7);
-+         _7 = move _26;
-+         goto -> bb10;
++         StorageLive(_14);
++         _14 = move _26;
++         goto -> bb12;
       }
   
       bb23: {
-          StorageLive(_14);
+-         StorageLive(_14);
 -         _14 = yield(const ()) -> [resume: bb21, drop: bb22];
-+         _14 = move _26;
-+         goto -> bb12;
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb23, unwind continue];
       }
   
       bb24: {
 -         _16 = discriminant(_15);
 -         switchInt(move _16) -> [0: bb9, 1: bb23, otherwise: bb16];
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb24, unwind continue];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb24, unwind continue];
       }
   
       bb25: {
 -         _15 = <impl Future<Output = ()> as Future>::poll(move _17, move _18) -> [return: bb24, unwind: bb11];
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb25, unwind continue];
-      }
-  
-      bb26: {
+-     }
+- 
+-     bb26: {
 -         _19 = move _2;
 -         _18 = std::future::get_context::<'_, '_>(move _19) -> [return: bb25, unwind: bb11];
 -     }

--- a/tests/mir-opt/coroutine/async_drop.array-{closure#0}.coroutine_drop_async.0.mir
+++ b/tests/mir-opt/coroutine/async_drop.array-{closure#0}.coroutine_drop_async.0.mir
@@ -37,7 +37,7 @@ fn array::{closure#0}(_1: Pin<&mut {async fn body of array()}>, _2: &mut Context
         _26 = std::future::ResumeTy(move _27);
         _25 = copy (_1.0: &mut {async fn body of array()});
         _24 = discriminant((*_25));
-        switchInt(move _24) -> [0: bb16, 2: bb21, 3: bb19, 4: bb20, otherwise: bb22];
+        switchInt(move _24) -> [0: bb16, 2: bb20, 3: bb18, 4: bb19, otherwise: bb21];
     }
 
     bb1: {
@@ -56,7 +56,7 @@ fn array::{closure#0}(_1: Pin<&mut {async fn body of array()}>, _2: &mut Context
     }
 
     bb4 (cleanup): {
-        goto -> bb18;
+        goto -> bb17;
     }
 
     bb5: {
@@ -119,35 +119,31 @@ fn array::{closure#0}(_1: Pin<&mut {async fn body of array()}>, _2: &mut Context
     }
 
     bb16: {
-        goto -> bb17;
-    }
-
-    bb17: {
         goto -> bb15;
     }
 
-    bb18 (cleanup): {
+    bb17 (cleanup): {
         discriminant((*_25)) = 2;
         resume;
     }
 
-    bb19: {
+    bb18: {
         StorageLive(_7);
         _7 = move _26;
         goto -> bb7;
     }
 
-    bb20: {
+    bb19: {
         StorageLive(_14);
         _14 = move _26;
         goto -> bb14;
     }
 
-    bb21: {
-        assert(const false, "`async fn` resumed after panicking") -> [success: bb21, unwind continue];
+    bb20: {
+        assert(const false, "`async fn` resumed after panicking") -> [success: bb20, unwind continue];
     }
 
-    bb22: {
+    bb21: {
         _0 = Poll::<()>::Ready(const ());
         return;
     }

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncEnum.MentionedItems.after.mir
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncEnum.MentionedItems.after.mir
@@ -55,7 +55,7 @@ yields ()
 
     bb0: {
         _3 = move (_1.0: &mut AsyncEnum);
-        goto -> bb65;
+        goto -> bb64;
     }
 
     bb1: {
@@ -66,189 +66,189 @@ yields ()
         resume;
     }
 
-    bb3: {
-        goto -> bb1;
+    bb3 (cleanup): {
+        drop((((*_3) as A).0: AsyncInt)) -> [return: bb2, unwind terminate(cleanup)];
     }
 
     bb4 (cleanup): {
         drop((((*_3) as A).0: AsyncInt)) -> [return: bb2, unwind terminate(cleanup)];
     }
 
-    bb5 (cleanup): {
-        drop((((*_3) as A).0: AsyncInt)) -> [return: bb2, unwind terminate(cleanup)];
-    }
-
-    bb6: {
+    bb5: {
         StorageDead(_4);
         goto -> bb1;
     }
 
-    bb7 (cleanup): {
+    bb6 (cleanup): {
         StorageDead(_4);
         goto -> bb2;
     }
 
+    bb7: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb7, unwind: bb6];
+    }
+
     bb8: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb8, unwind: bb7];
+        _2 = move _5;
+        StorageDead(_5);
+        goto -> bb7;
     }
 
     bb9: {
         _2 = move _5;
         StorageDead(_5);
-        goto -> bb8;
+        goto -> bb15;
     }
 
     bb10: {
-        _2 = move _5;
-        StorageDead(_5);
-        goto -> bb16;
+        StorageLive(_5);
+        _5 = yield(const ()) -> [resume: bb8, drop: bb9];
     }
 
     bb11: {
-        StorageLive(_5);
-        _5 = yield(const ()) -> [resume: bb9, drop: bb10];
-    }
-
-    bb12: {
         unreachable;
     }
 
-    bb13: {
+    bb12: {
         _7 = discriminant(_6);
-        switchInt(move _7) -> [0: bb6, 1: bb11, otherwise: bb12];
+        switchInt(move _7) -> [0: bb5, 1: bb10, otherwise: bb11];
+    }
+
+    bb13: {
+        _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb12, unwind: bb6];
     }
 
     bb14: {
-        _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb13, unwind: bb7];
+        _10 = move _2;
+        _9 = std::future::get_context::<'_, '_>(move _10) -> [return: bb13, unwind: bb6];
     }
 
     bb15: {
-        _10 = move _2;
-        _9 = std::future::get_context::<'_, '_>(move _10) -> [return: bb14, unwind: bb7];
+        _11 = &mut _4;
+        _8 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _11) -> [return: bb14, unwind: bb6];
     }
 
     bb16: {
-        _11 = &mut _4;
-        _8 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _11) -> [return: bb15, unwind: bb7];
+        StorageLive(_4);
+        _4 = async_drop_in_place::<AsyncInt>(copy (_12.0: &mut AsyncInt)) -> [return: bb15, unwind: bb6];
     }
 
     bb17: {
-        StorageLive(_4);
-        _4 = async_drop_in_place::<AsyncInt>(copy (_12.0: &mut AsyncInt)) -> [return: bb16, unwind: bb7];
+        _13 = &mut (((*_3) as A).0: AsyncInt);
+        _12 = Pin::<&mut AsyncInt>::new_unchecked(move _13) -> [return: bb16, unwind: bb2];
     }
 
     bb18: {
-        _13 = &mut (((*_3) as A).0: AsyncInt);
-        _12 = Pin::<&mut AsyncInt>::new_unchecked(move _13) -> [return: bb17, unwind: bb2];
-    }
-
-    bb19: {
-        StorageDead(_14);
-        goto -> bb3;
-    }
-
-    bb20: {
         StorageDead(_14);
         goto -> bb1;
     }
 
-    bb21 (cleanup): {
+    bb19: {
+        StorageDead(_14);
+        goto -> bb1;
+    }
+
+    bb20 (cleanup): {
         StorageDead(_14);
         goto -> bb2;
     }
 
+    bb21: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb21, unwind: bb20];
+    }
+
     bb22: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb22, unwind: bb21];
+        _2 = move _15;
+        StorageDead(_15);
+        goto -> bb21;
     }
 
     bb23: {
         _2 = move _15;
         StorageDead(_15);
-        goto -> bb22;
+        goto -> bb28;
     }
 
     bb24: {
-        _2 = move _15;
-        StorageDead(_15);
-        goto -> bb29;
+        StorageLive(_15);
+        _15 = yield(const ()) -> [resume: bb22, drop: bb23];
     }
 
     bb25: {
-        StorageLive(_15);
-        _15 = yield(const ()) -> [resume: bb23, drop: bb24];
+        _17 = discriminant(_16);
+        switchInt(move _17) -> [0: bb19, 1: bb24, otherwise: bb11];
     }
 
     bb26: {
-        _17 = discriminant(_16);
-        switchInt(move _17) -> [0: bb20, 1: bb25, otherwise: bb12];
+        _16 = <impl Future<Output = ()> as Future>::poll(move _18, move _19) -> [return: bb25, unwind: bb20];
     }
 
     bb27: {
-        _16 = <impl Future<Output = ()> as Future>::poll(move _18, move _19) -> [return: bb26, unwind: bb21];
+        _20 = move _2;
+        _19 = std::future::get_context::<'_, '_>(move _20) -> [return: bb26, unwind: bb20];
     }
 
     bb28: {
-        _20 = move _2;
-        _19 = std::future::get_context::<'_, '_>(move _20) -> [return: bb27, unwind: bb21];
+        _21 = &mut _14;
+        _18 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _21) -> [return: bb27, unwind: bb20];
     }
 
     bb29: {
-        _21 = &mut _14;
-        _18 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _21) -> [return: bb28, unwind: bb21];
+        _2 = move _22;
+        StorageDead(_22);
+        goto -> bb35;
     }
 
     bb30: {
         _2 = move _22;
         StorageDead(_22);
-        goto -> bb36;
+        goto -> bb28;
     }
 
     bb31: {
-        _2 = move _22;
-        StorageDead(_22);
-        goto -> bb29;
+        StorageLive(_22);
+        _22 = yield(const ()) -> [resume: bb29, drop: bb30];
     }
 
     bb32: {
-        StorageLive(_22);
-        _22 = yield(const ()) -> [resume: bb30, drop: bb31];
+        _24 = discriminant(_23);
+        switchInt(move _24) -> [0: bb18, 1: bb31, otherwise: bb11];
     }
 
     bb33: {
-        _24 = discriminant(_23);
-        switchInt(move _24) -> [0: bb19, 1: bb32, otherwise: bb12];
+        _23 = <impl Future<Output = ()> as Future>::poll(move _25, move _26) -> [return: bb32, unwind: bb20];
     }
 
     bb34: {
-        _23 = <impl Future<Output = ()> as Future>::poll(move _25, move _26) -> [return: bb33, unwind: bb21];
+        _27 = move _2;
+        _26 = std::future::get_context::<'_, '_>(move _27) -> [return: bb33, unwind: bb20];
     }
 
     bb35: {
-        _27 = move _2;
-        _26 = std::future::get_context::<'_, '_>(move _27) -> [return: bb34, unwind: bb21];
+        _28 = &mut _14;
+        _25 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _28) -> [return: bb34, unwind: bb20];
     }
 
     bb36: {
-        _28 = &mut _14;
-        _25 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _28) -> [return: bb35, unwind: bb21];
+        StorageLive(_14);
+        _14 = async_drop_in_place::<AsyncInt>(copy (_29.0: &mut AsyncInt)) -> [return: bb35, unwind: bb20];
     }
 
     bb37: {
-        StorageLive(_14);
-        _14 = async_drop_in_place::<AsyncInt>(copy (_29.0: &mut AsyncInt)) -> [return: bb36, unwind: bb21];
+        _30 = &mut (((*_3) as A).0: AsyncInt);
+        _29 = Pin::<&mut AsyncInt>::new_unchecked(move _30) -> [return: bb36, unwind: bb2];
     }
 
-    bb38: {
-        _30 = &mut (((*_3) as A).0: AsyncInt);
-        _29 = Pin::<&mut AsyncInt>::new_unchecked(move _30) -> [return: bb37, unwind: bb2];
+    bb38 (cleanup): {
+        drop((((*_3) as B).0: SyncInt)) -> [return: bb2, unwind terminate(cleanup)];
     }
 
     bb39 (cleanup): {
         drop((((*_3) as B).0: SyncInt)) -> [return: bb2, unwind terminate(cleanup)];
     }
 
-    bb40 (cleanup): {
-        drop((((*_3) as B).0: SyncInt)) -> [return: bb2, unwind terminate(cleanup)];
+    bb40: {
+        drop((((*_3) as B).0: SyncInt)) -> [return: bb1, unwind: bb2];
     }
 
     bb41: {
@@ -256,122 +256,118 @@ yields ()
     }
 
     bb42: {
-        drop((((*_3) as B).0: SyncInt)) -> [return: bb3, unwind: bb2];
-    }
-
-    bb43: {
         _31 = discriminant((*_3));
-        switchInt(move _31) -> [0: bb38, otherwise: bb42];
+        switchInt(move _31) -> [0: bb37, otherwise: bb41];
     }
 
-    bb44 (cleanup): {
+    bb43 (cleanup): {
         _32 = discriminant((*_3));
-        switchInt(move _32) -> [0: bb4, otherwise: bb39];
+        switchInt(move _32) -> [0: bb3, otherwise: bb38];
+    }
+
+    bb44: {
+        _33 = discriminant((*_3));
+        switchInt(move _33) -> [0: bb17, otherwise: bb40];
     }
 
     bb45: {
-        _33 = discriminant((*_3));
-        switchInt(move _33) -> [0: bb18, otherwise: bb41];
+        StorageDead(_34);
+        goto -> bb42;
     }
 
     bb46: {
         StorageDead(_34);
-        goto -> bb43;
-    }
-
-    bb47: {
-        StorageDead(_34);
-        goto -> bb45;
-    }
-
-    bb48 (cleanup): {
-        StorageDead(_34);
         goto -> bb44;
     }
 
+    bb47 (cleanup): {
+        StorageDead(_34);
+        goto -> bb43;
+    }
+
+    bb48: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb48, unwind: bb47];
+    }
+
     bb49: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb49, unwind: bb48];
+        _2 = move _35;
+        StorageDead(_35);
+        goto -> bb48;
     }
 
     bb50: {
         _2 = move _35;
         StorageDead(_35);
-        goto -> bb49;
+        goto -> bb55;
     }
 
     bb51: {
-        _2 = move _35;
-        StorageDead(_35);
-        goto -> bb56;
+        StorageLive(_35);
+        _35 = yield(const ()) -> [resume: bb49, drop: bb50];
     }
 
     bb52: {
-        StorageLive(_35);
-        _35 = yield(const ()) -> [resume: bb50, drop: bb51];
+        _37 = discriminant(_36);
+        switchInt(move _37) -> [0: bb46, 1: bb51, otherwise: bb11];
     }
 
     bb53: {
-        _37 = discriminant(_36);
-        switchInt(move _37) -> [0: bb47, 1: bb52, otherwise: bb12];
+        _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb52, unwind: bb47];
     }
 
     bb54: {
-        _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb53, unwind: bb48];
+        _40 = move _2;
+        _39 = std::future::get_context::<'_, '_>(move _40) -> [return: bb53, unwind: bb47];
     }
 
     bb55: {
-        _40 = move _2;
-        _39 = std::future::get_context::<'_, '_>(move _40) -> [return: bb54, unwind: bb48];
+        _41 = &mut _34;
+        _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb54, unwind: bb47];
     }
 
     bb56: {
-        _41 = &mut _34;
-        _38 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _41) -> [return: bb55, unwind: bb48];
+        _2 = move _42;
+        StorageDead(_42);
+        goto -> bb62;
     }
 
     bb57: {
         _2 = move _42;
         StorageDead(_42);
-        goto -> bb63;
+        goto -> bb55;
     }
 
     bb58: {
-        _2 = move _42;
-        StorageDead(_42);
-        goto -> bb56;
+        StorageLive(_42);
+        _42 = yield(const ()) -> [resume: bb56, drop: bb57];
     }
 
     bb59: {
-        StorageLive(_42);
-        _42 = yield(const ()) -> [resume: bb57, drop: bb58];
+        _44 = discriminant(_43);
+        switchInt(move _44) -> [0: bb45, 1: bb58, otherwise: bb11];
     }
 
     bb60: {
-        _44 = discriminant(_43);
-        switchInt(move _44) -> [0: bb46, 1: bb59, otherwise: bb12];
+        _43 = <impl Future<Output = ()> as Future>::poll(move _45, move _46) -> [return: bb59, unwind: bb47];
     }
 
     bb61: {
-        _43 = <impl Future<Output = ()> as Future>::poll(move _45, move _46) -> [return: bb60, unwind: bb48];
+        _47 = move _2;
+        _46 = std::future::get_context::<'_, '_>(move _47) -> [return: bb60, unwind: bb47];
     }
 
     bb62: {
-        _47 = move _2;
-        _46 = std::future::get_context::<'_, '_>(move _47) -> [return: bb61, unwind: bb48];
+        _48 = &mut _34;
+        _45 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _48) -> [return: bb61, unwind: bb47];
     }
 
     bb63: {
-        _48 = &mut _34;
-        _45 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _48) -> [return: bb62, unwind: bb48];
+        StorageLive(_34);
+        _34 = <AsyncEnum as AsyncDrop>::drop(move _49) -> [return: bb62, unwind: bb47];
     }
 
     bb64: {
-        StorageLive(_34);
-        _34 = <AsyncEnum as AsyncDrop>::drop(move _49) -> [return: bb63, unwind: bb48];
-    }
-
-    bb65: {
         _50 = &mut (*_3);
-        _49 = Pin::<&mut AsyncEnum>::new_unchecked(move _50) -> [return: bb64, unwind: bb44];
+        _49 = Pin::<&mut AsyncEnum>::new_unchecked(move _50) -> [return: bb63, unwind: bb43];
     }
 }

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncInt.MentionedItems.after.mir
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncInt.MentionedItems.after.mir
@@ -25,7 +25,7 @@ yields ()
 
     bb0: {
         _3 = move (_1.0: &mut AsyncInt);
-        goto -> bb24;
+        goto -> bb23;
     }
 
     bb1: {
@@ -37,111 +37,107 @@ yields ()
     }
 
     bb3: {
+        StorageDead(_4);
         goto -> bb1;
     }
 
     bb4: {
         StorageDead(_4);
-        goto -> bb3;
-    }
-
-    bb5: {
-        StorageDead(_4);
         goto -> bb1;
     }
 
-    bb6 (cleanup): {
+    bb5 (cleanup): {
         StorageDead(_4);
         goto -> bb2;
     }
 
+    bb6: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb6, unwind: bb5];
+    }
+
     bb7: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb7, unwind: bb6];
+        _2 = move _5;
+        StorageDead(_5);
+        goto -> bb6;
     }
 
     bb8: {
         _2 = move _5;
         StorageDead(_5);
-        goto -> bb7;
+        goto -> bb14;
     }
 
     bb9: {
-        _2 = move _5;
-        StorageDead(_5);
-        goto -> bb15;
+        StorageLive(_5);
+        _5 = yield(const ()) -> [resume: bb7, drop: bb8];
     }
 
     bb10: {
-        StorageLive(_5);
-        _5 = yield(const ()) -> [resume: bb8, drop: bb9];
-    }
-
-    bb11: {
         unreachable;
     }
 
-    bb12: {
+    bb11: {
         _7 = discriminant(_6);
-        switchInt(move _7) -> [0: bb5, 1: bb10, otherwise: bb11];
+        switchInt(move _7) -> [0: bb4, 1: bb9, otherwise: bb10];
+    }
+
+    bb12: {
+        _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb11, unwind: bb5];
     }
 
     bb13: {
-        _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb12, unwind: bb6];
+        _10 = move _2;
+        _9 = std::future::get_context::<'_, '_>(move _10) -> [return: bb12, unwind: bb5];
     }
 
     bb14: {
-        _10 = move _2;
-        _9 = std::future::get_context::<'_, '_>(move _10) -> [return: bb13, unwind: bb6];
+        _11 = &mut _4;
+        _8 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _11) -> [return: bb13, unwind: bb5];
     }
 
     bb15: {
-        _11 = &mut _4;
-        _8 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _11) -> [return: bb14, unwind: bb6];
+        _2 = move _12;
+        StorageDead(_12);
+        goto -> bb21;
     }
 
     bb16: {
         _2 = move _12;
         StorageDead(_12);
-        goto -> bb22;
+        goto -> bb14;
     }
 
     bb17: {
-        _2 = move _12;
-        StorageDead(_12);
-        goto -> bb15;
+        StorageLive(_12);
+        _12 = yield(const ()) -> [resume: bb15, drop: bb16];
     }
 
     bb18: {
-        StorageLive(_12);
-        _12 = yield(const ()) -> [resume: bb16, drop: bb17];
+        _14 = discriminant(_13);
+        switchInt(move _14) -> [0: bb3, 1: bb17, otherwise: bb10];
     }
 
     bb19: {
-        _14 = discriminant(_13);
-        switchInt(move _14) -> [0: bb4, 1: bb18, otherwise: bb11];
+        _13 = <impl Future<Output = ()> as Future>::poll(move _15, move _16) -> [return: bb18, unwind: bb5];
     }
 
     bb20: {
-        _13 = <impl Future<Output = ()> as Future>::poll(move _15, move _16) -> [return: bb19, unwind: bb6];
+        _17 = move _2;
+        _16 = std::future::get_context::<'_, '_>(move _17) -> [return: bb19, unwind: bb5];
     }
 
     bb21: {
-        _17 = move _2;
-        _16 = std::future::get_context::<'_, '_>(move _17) -> [return: bb20, unwind: bb6];
+        _18 = &mut _4;
+        _15 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _18) -> [return: bb20, unwind: bb5];
     }
 
     bb22: {
-        _18 = &mut _4;
-        _15 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _18) -> [return: bb21, unwind: bb6];
+        StorageLive(_4);
+        _4 = <AsyncInt as AsyncDrop>::drop(move _19) -> [return: bb21, unwind: bb5];
     }
 
     bb23: {
-        StorageLive(_4);
-        _4 = <AsyncInt as AsyncDrop>::drop(move _19) -> [return: bb22, unwind: bb6];
-    }
-
-    bb24: {
         _20 = &mut (*_3);
-        _19 = Pin::<&mut AsyncInt>::new_unchecked(move _20) -> [return: bb23, unwind: bb2];
+        _19 = Pin::<&mut AsyncInt>::new_unchecked(move _20) -> [return: bb22, unwind: bb2];
     }
 }

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncReference_'__.MentionedItems.after.mir
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncReference_'__.MentionedItems.after.mir
@@ -25,7 +25,7 @@ yields ()
 
     bb0: {
         _3 = move (_1.0: &mut AsyncReference<'_>);
-        goto -> bb24;
+        goto -> bb23;
     }
 
     bb1: {
@@ -37,111 +37,107 @@ yields ()
     }
 
     bb3: {
+        StorageDead(_4);
         goto -> bb1;
     }
 
     bb4: {
         StorageDead(_4);
-        goto -> bb3;
-    }
-
-    bb5: {
-        StorageDead(_4);
         goto -> bb1;
     }
 
-    bb6 (cleanup): {
+    bb5 (cleanup): {
         StorageDead(_4);
         goto -> bb2;
     }
 
+    bb6: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb6, unwind: bb5];
+    }
+
     bb7: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb7, unwind: bb6];
+        _2 = move _5;
+        StorageDead(_5);
+        goto -> bb6;
     }
 
     bb8: {
         _2 = move _5;
         StorageDead(_5);
-        goto -> bb7;
+        goto -> bb14;
     }
 
     bb9: {
-        _2 = move _5;
-        StorageDead(_5);
-        goto -> bb15;
+        StorageLive(_5);
+        _5 = yield(const ()) -> [resume: bb7, drop: bb8];
     }
 
     bb10: {
-        StorageLive(_5);
-        _5 = yield(const ()) -> [resume: bb8, drop: bb9];
-    }
-
-    bb11: {
         unreachable;
     }
 
-    bb12: {
+    bb11: {
         _7 = discriminant(_6);
-        switchInt(move _7) -> [0: bb5, 1: bb10, otherwise: bb11];
+        switchInt(move _7) -> [0: bb4, 1: bb9, otherwise: bb10];
+    }
+
+    bb12: {
+        _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb11, unwind: bb5];
     }
 
     bb13: {
-        _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb12, unwind: bb6];
+        _10 = move _2;
+        _9 = std::future::get_context::<'_, '_>(move _10) -> [return: bb12, unwind: bb5];
     }
 
     bb14: {
-        _10 = move _2;
-        _9 = std::future::get_context::<'_, '_>(move _10) -> [return: bb13, unwind: bb6];
+        _11 = &mut _4;
+        _8 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _11) -> [return: bb13, unwind: bb5];
     }
 
     bb15: {
-        _11 = &mut _4;
-        _8 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _11) -> [return: bb14, unwind: bb6];
+        _2 = move _12;
+        StorageDead(_12);
+        goto -> bb21;
     }
 
     bb16: {
         _2 = move _12;
         StorageDead(_12);
-        goto -> bb22;
+        goto -> bb14;
     }
 
     bb17: {
-        _2 = move _12;
-        StorageDead(_12);
-        goto -> bb15;
+        StorageLive(_12);
+        _12 = yield(const ()) -> [resume: bb15, drop: bb16];
     }
 
     bb18: {
-        StorageLive(_12);
-        _12 = yield(const ()) -> [resume: bb16, drop: bb17];
+        _14 = discriminant(_13);
+        switchInt(move _14) -> [0: bb3, 1: bb17, otherwise: bb10];
     }
 
     bb19: {
-        _14 = discriminant(_13);
-        switchInt(move _14) -> [0: bb4, 1: bb18, otherwise: bb11];
+        _13 = <impl Future<Output = ()> as Future>::poll(move _15, move _16) -> [return: bb18, unwind: bb5];
     }
 
     bb20: {
-        _13 = <impl Future<Output = ()> as Future>::poll(move _15, move _16) -> [return: bb19, unwind: bb6];
+        _17 = move _2;
+        _16 = std::future::get_context::<'_, '_>(move _17) -> [return: bb19, unwind: bb5];
     }
 
     bb21: {
-        _17 = move _2;
-        _16 = std::future::get_context::<'_, '_>(move _17) -> [return: bb20, unwind: bb6];
+        _18 = &mut _4;
+        _15 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _18) -> [return: bb20, unwind: bb5];
     }
 
     bb22: {
-        _18 = &mut _4;
-        _15 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _18) -> [return: bb21, unwind: bb6];
+        StorageLive(_4);
+        _4 = <AsyncReference<'_> as AsyncDrop>::drop(move _19) -> [return: bb21, unwind: bb5];
     }
 
     bb23: {
-        StorageLive(_4);
-        _4 = <AsyncReference<'_> as AsyncDrop>::drop(move _19) -> [return: bb22, unwind: bb6];
-    }
-
-    bb24: {
         _20 = &mut (*_3);
-        _19 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _20) -> [return: bb23, unwind: bb2];
+        _19 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _20) -> [return: bb22, unwind: bb2];
     }
 }

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncStruct.MentionedItems.after.mir
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncStruct.MentionedItems.after.mir
@@ -79,7 +79,7 @@ yields ()
 
     bb0: {
         _3 = move (_1.0: &mut AsyncStruct);
-        goto -> bb90;
+        goto -> bb89;
     }
 
     bb1: {
@@ -90,442 +90,438 @@ yields ()
         resume;
     }
 
-    bb3: {
-        goto -> bb1;
-    }
-
-    bb4 (cleanup): {
+    bb3 (cleanup): {
         drop(((*_3).2: AsyncInt)) -> [return: bb2, unwind terminate(cleanup)];
     }
 
-    bb5 (cleanup): {
-        drop(((*_3).1: AsyncInt)) -> [return: bb4, unwind terminate(cleanup)];
+    bb4 (cleanup): {
+        drop(((*_3).1: AsyncInt)) -> [return: bb3, unwind terminate(cleanup)];
     }
 
-    bb6: {
+    bb5: {
         StorageDead(_4);
         goto -> bb1;
     }
 
-    bb7 (cleanup): {
+    bb6 (cleanup): {
         StorageDead(_4);
         goto -> bb2;
     }
 
+    bb7: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb7, unwind: bb6];
+    }
+
     bb8: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb8, unwind: bb7];
+        _2 = move _5;
+        StorageDead(_5);
+        goto -> bb7;
     }
 
     bb9: {
         _2 = move _5;
         StorageDead(_5);
-        goto -> bb8;
+        goto -> bb15;
     }
 
     bb10: {
-        _2 = move _5;
-        StorageDead(_5);
-        goto -> bb16;
+        StorageLive(_5);
+        _5 = yield(const ()) -> [resume: bb8, drop: bb9];
     }
 
     bb11: {
-        StorageLive(_5);
-        _5 = yield(const ()) -> [resume: bb9, drop: bb10];
-    }
-
-    bb12: {
         unreachable;
     }
 
-    bb13: {
+    bb12: {
         _7 = discriminant(_6);
-        switchInt(move _7) -> [0: bb6, 1: bb11, otherwise: bb12];
+        switchInt(move _7) -> [0: bb5, 1: bb10, otherwise: bb11];
+    }
+
+    bb13: {
+        _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb12, unwind: bb6];
     }
 
     bb14: {
-        _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb13, unwind: bb7];
+        _10 = move _2;
+        _9 = std::future::get_context::<'_, '_>(move _10) -> [return: bb13, unwind: bb6];
     }
 
     bb15: {
-        _10 = move _2;
-        _9 = std::future::get_context::<'_, '_>(move _10) -> [return: bb14, unwind: bb7];
+        _11 = &mut _4;
+        _8 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _11) -> [return: bb14, unwind: bb6];
     }
 
     bb16: {
-        _11 = &mut _4;
-        _8 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _11) -> [return: bb15, unwind: bb7];
+        StorageLive(_4);
+        _4 = async_drop_in_place::<AsyncInt>(copy (_12.0: &mut AsyncInt)) -> [return: bb15, unwind: bb6];
     }
 
     bb17: {
-        StorageLive(_4);
-        _4 = async_drop_in_place::<AsyncInt>(copy (_12.0: &mut AsyncInt)) -> [return: bb16, unwind: bb7];
+        _13 = &mut ((*_3).2: AsyncInt);
+        _12 = Pin::<&mut AsyncInt>::new_unchecked(move _13) -> [return: bb16, unwind: bb2];
     }
 
     bb18: {
-        _13 = &mut ((*_3).2: AsyncInt);
-        _12 = Pin::<&mut AsyncInt>::new_unchecked(move _13) -> [return: bb17, unwind: bb2];
+        StorageDead(_14);
+        goto -> bb17;
     }
 
-    bb19: {
+    bb19 (cleanup): {
         StorageDead(_14);
-        goto -> bb18;
+        goto -> bb3;
     }
 
-    bb20 (cleanup): {
-        StorageDead(_14);
-        goto -> bb4;
+    bb20: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb20, unwind: bb19];
     }
 
     bb21: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb21, unwind: bb20];
+        _2 = move _15;
+        StorageDead(_15);
+        goto -> bb20;
     }
 
     bb22: {
         _2 = move _15;
         StorageDead(_15);
-        goto -> bb21;
+        goto -> bb27;
     }
 
     bb23: {
-        _2 = move _15;
-        StorageDead(_15);
-        goto -> bb28;
+        StorageLive(_15);
+        _15 = yield(const ()) -> [resume: bb21, drop: bb22];
     }
 
     bb24: {
-        StorageLive(_15);
-        _15 = yield(const ()) -> [resume: bb22, drop: bb23];
+        _17 = discriminant(_16);
+        switchInt(move _17) -> [0: bb18, 1: bb23, otherwise: bb11];
     }
 
     bb25: {
-        _17 = discriminant(_16);
-        switchInt(move _17) -> [0: bb19, 1: bb24, otherwise: bb12];
+        _16 = <impl Future<Output = ()> as Future>::poll(move _18, move _19) -> [return: bb24, unwind: bb19];
     }
 
     bb26: {
-        _16 = <impl Future<Output = ()> as Future>::poll(move _18, move _19) -> [return: bb25, unwind: bb20];
+        _20 = move _2;
+        _19 = std::future::get_context::<'_, '_>(move _20) -> [return: bb25, unwind: bb19];
     }
 
     bb27: {
-        _20 = move _2;
-        _19 = std::future::get_context::<'_, '_>(move _20) -> [return: bb26, unwind: bb20];
+        _21 = &mut _14;
+        _18 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _21) -> [return: bb26, unwind: bb19];
     }
 
     bb28: {
-        _21 = &mut _14;
-        _18 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _21) -> [return: bb27, unwind: bb20];
+        StorageLive(_14);
+        _14 = async_drop_in_place::<AsyncInt>(copy (_22.0: &mut AsyncInt)) -> [return: bb27, unwind: bb19];
     }
 
     bb29: {
-        StorageLive(_14);
-        _14 = async_drop_in_place::<AsyncInt>(copy (_22.0: &mut AsyncInt)) -> [return: bb28, unwind: bb20];
+        _23 = &mut ((*_3).1: AsyncInt);
+        _22 = Pin::<&mut AsyncInt>::new_unchecked(move _23) -> [return: bb28, unwind: bb3];
     }
 
     bb30: {
-        _23 = &mut ((*_3).1: AsyncInt);
-        _22 = Pin::<&mut AsyncInt>::new_unchecked(move _23) -> [return: bb29, unwind: bb4];
-    }
-
-    bb31: {
-        StorageDead(_24);
-        goto -> bb3;
-    }
-
-    bb32: {
         StorageDead(_24);
         goto -> bb1;
     }
 
-    bb33 (cleanup): {
+    bb31: {
+        StorageDead(_24);
+        goto -> bb1;
+    }
+
+    bb32 (cleanup): {
         StorageDead(_24);
         goto -> bb2;
     }
 
+    bb33: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb33, unwind: bb32];
+    }
+
     bb34: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb34, unwind: bb33];
+        _2 = move _25;
+        StorageDead(_25);
+        goto -> bb33;
     }
 
     bb35: {
         _2 = move _25;
         StorageDead(_25);
-        goto -> bb34;
+        goto -> bb40;
     }
 
     bb36: {
-        _2 = move _25;
-        StorageDead(_25);
-        goto -> bb41;
+        StorageLive(_25);
+        _25 = yield(const ()) -> [resume: bb34, drop: bb35];
     }
 
     bb37: {
-        StorageLive(_25);
-        _25 = yield(const ()) -> [resume: bb35, drop: bb36];
+        _27 = discriminant(_26);
+        switchInt(move _27) -> [0: bb31, 1: bb36, otherwise: bb11];
     }
 
     bb38: {
-        _27 = discriminant(_26);
-        switchInt(move _27) -> [0: bb32, 1: bb37, otherwise: bb12];
+        _26 = <impl Future<Output = ()> as Future>::poll(move _28, move _29) -> [return: bb37, unwind: bb32];
     }
 
     bb39: {
-        _26 = <impl Future<Output = ()> as Future>::poll(move _28, move _29) -> [return: bb38, unwind: bb33];
+        _30 = move _2;
+        _29 = std::future::get_context::<'_, '_>(move _30) -> [return: bb38, unwind: bb32];
     }
 
     bb40: {
-        _30 = move _2;
-        _29 = std::future::get_context::<'_, '_>(move _30) -> [return: bb39, unwind: bb33];
+        _31 = &mut _24;
+        _28 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _31) -> [return: bb39, unwind: bb32];
     }
 
     bb41: {
-        _31 = &mut _24;
-        _28 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _31) -> [return: bb40, unwind: bb33];
+        _2 = move _32;
+        StorageDead(_32);
+        goto -> bb47;
     }
 
     bb42: {
         _2 = move _32;
         StorageDead(_32);
-        goto -> bb48;
+        goto -> bb40;
     }
 
     bb43: {
-        _2 = move _32;
-        StorageDead(_32);
-        goto -> bb41;
+        StorageLive(_32);
+        _32 = yield(const ()) -> [resume: bb41, drop: bb42];
     }
 
     bb44: {
-        StorageLive(_32);
-        _32 = yield(const ()) -> [resume: bb42, drop: bb43];
+        _34 = discriminant(_33);
+        switchInt(move _34) -> [0: bb30, 1: bb43, otherwise: bb11];
     }
 
     bb45: {
-        _34 = discriminant(_33);
-        switchInt(move _34) -> [0: bb31, 1: bb44, otherwise: bb12];
+        _33 = <impl Future<Output = ()> as Future>::poll(move _35, move _36) -> [return: bb44, unwind: bb32];
     }
 
     bb46: {
-        _33 = <impl Future<Output = ()> as Future>::poll(move _35, move _36) -> [return: bb45, unwind: bb33];
+        _37 = move _2;
+        _36 = std::future::get_context::<'_, '_>(move _37) -> [return: bb45, unwind: bb32];
     }
 
     bb47: {
-        _37 = move _2;
-        _36 = std::future::get_context::<'_, '_>(move _37) -> [return: bb46, unwind: bb33];
+        _38 = &mut _24;
+        _35 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _38) -> [return: bb46, unwind: bb32];
     }
 
     bb48: {
-        _38 = &mut _24;
-        _35 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _38) -> [return: bb47, unwind: bb33];
+        StorageLive(_24);
+        _24 = async_drop_in_place::<AsyncInt>(copy (_39.0: &mut AsyncInt)) -> [return: bb47, unwind: bb32];
     }
 
     bb49: {
-        StorageLive(_24);
-        _24 = async_drop_in_place::<AsyncInt>(copy (_39.0: &mut AsyncInt)) -> [return: bb48, unwind: bb33];
+        _40 = &mut ((*_3).2: AsyncInt);
+        _39 = Pin::<&mut AsyncInt>::new_unchecked(move _40) -> [return: bb48, unwind: bb2];
     }
 
     bb50: {
-        _40 = &mut ((*_3).2: AsyncInt);
-        _39 = Pin::<&mut AsyncInt>::new_unchecked(move _40) -> [return: bb49, unwind: bb2];
+        StorageDead(_41);
+        goto -> bb49;
     }
 
     bb51: {
         StorageDead(_41);
-        goto -> bb50;
+        goto -> bb17;
     }
 
-    bb52: {
+    bb52 (cleanup): {
         StorageDead(_41);
-        goto -> bb18;
+        goto -> bb3;
     }
 
-    bb53 (cleanup): {
-        StorageDead(_41);
-        goto -> bb4;
+    bb53: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb53, unwind: bb52];
     }
 
     bb54: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb54, unwind: bb53];
+        _2 = move _42;
+        StorageDead(_42);
+        goto -> bb53;
     }
 
     bb55: {
         _2 = move _42;
         StorageDead(_42);
-        goto -> bb54;
+        goto -> bb60;
     }
 
     bb56: {
-        _2 = move _42;
-        StorageDead(_42);
-        goto -> bb61;
+        StorageLive(_42);
+        _42 = yield(const ()) -> [resume: bb54, drop: bb55];
     }
 
     bb57: {
-        StorageLive(_42);
-        _42 = yield(const ()) -> [resume: bb55, drop: bb56];
+        _44 = discriminant(_43);
+        switchInt(move _44) -> [0: bb51, 1: bb56, otherwise: bb11];
     }
 
     bb58: {
-        _44 = discriminant(_43);
-        switchInt(move _44) -> [0: bb52, 1: bb57, otherwise: bb12];
+        _43 = <impl Future<Output = ()> as Future>::poll(move _45, move _46) -> [return: bb57, unwind: bb52];
     }
 
     bb59: {
-        _43 = <impl Future<Output = ()> as Future>::poll(move _45, move _46) -> [return: bb58, unwind: bb53];
+        _47 = move _2;
+        _46 = std::future::get_context::<'_, '_>(move _47) -> [return: bb58, unwind: bb52];
     }
 
     bb60: {
-        _47 = move _2;
-        _46 = std::future::get_context::<'_, '_>(move _47) -> [return: bb59, unwind: bb53];
+        _48 = &mut _41;
+        _45 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _48) -> [return: bb59, unwind: bb52];
     }
 
     bb61: {
-        _48 = &mut _41;
-        _45 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _48) -> [return: bb60, unwind: bb53];
+        _2 = move _49;
+        StorageDead(_49);
+        goto -> bb67;
     }
 
     bb62: {
         _2 = move _49;
         StorageDead(_49);
-        goto -> bb68;
+        goto -> bb60;
     }
 
     bb63: {
-        _2 = move _49;
-        StorageDead(_49);
-        goto -> bb61;
+        StorageLive(_49);
+        _49 = yield(const ()) -> [resume: bb61, drop: bb62];
     }
 
     bb64: {
-        StorageLive(_49);
-        _49 = yield(const ()) -> [resume: bb62, drop: bb63];
+        _51 = discriminant(_50);
+        switchInt(move _51) -> [0: bb50, 1: bb63, otherwise: bb11];
     }
 
     bb65: {
-        _51 = discriminant(_50);
-        switchInt(move _51) -> [0: bb51, 1: bb64, otherwise: bb12];
+        _50 = <impl Future<Output = ()> as Future>::poll(move _52, move _53) -> [return: bb64, unwind: bb52];
     }
 
     bb66: {
-        _50 = <impl Future<Output = ()> as Future>::poll(move _52, move _53) -> [return: bb65, unwind: bb53];
+        _54 = move _2;
+        _53 = std::future::get_context::<'_, '_>(move _54) -> [return: bb65, unwind: bb52];
     }
 
     bb67: {
-        _54 = move _2;
-        _53 = std::future::get_context::<'_, '_>(move _54) -> [return: bb66, unwind: bb53];
+        _55 = &mut _41;
+        _52 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _55) -> [return: bb66, unwind: bb52];
     }
 
     bb68: {
-        _55 = &mut _41;
-        _52 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _55) -> [return: bb67, unwind: bb53];
+        StorageLive(_41);
+        _41 = async_drop_in_place::<AsyncInt>(copy (_56.0: &mut AsyncInt)) -> [return: bb67, unwind: bb52];
     }
 
     bb69: {
-        StorageLive(_41);
-        _41 = async_drop_in_place::<AsyncInt>(copy (_56.0: &mut AsyncInt)) -> [return: bb68, unwind: bb53];
+        _57 = &mut ((*_3).1: AsyncInt);
+        _56 = Pin::<&mut AsyncInt>::new_unchecked(move _57) -> [return: bb68, unwind: bb3];
     }
 
     bb70: {
-        _57 = &mut ((*_3).1: AsyncInt);
-        _56 = Pin::<&mut AsyncInt>::new_unchecked(move _57) -> [return: bb69, unwind: bb4];
+        StorageDead(_58);
+        goto -> bb69;
     }
 
     bb71: {
         StorageDead(_58);
-        goto -> bb70;
+        goto -> bb29;
     }
 
-    bb72: {
+    bb72 (cleanup): {
         StorageDead(_58);
-        goto -> bb30;
+        goto -> bb4;
     }
 
-    bb73 (cleanup): {
-        StorageDead(_58);
-        goto -> bb5;
+    bb73: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb73, unwind: bb72];
     }
 
     bb74: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb74, unwind: bb73];
+        _2 = move _59;
+        StorageDead(_59);
+        goto -> bb73;
     }
 
     bb75: {
         _2 = move _59;
         StorageDead(_59);
-        goto -> bb74;
+        goto -> bb80;
     }
 
     bb76: {
-        _2 = move _59;
-        StorageDead(_59);
-        goto -> bb81;
+        StorageLive(_59);
+        _59 = yield(const ()) -> [resume: bb74, drop: bb75];
     }
 
     bb77: {
-        StorageLive(_59);
-        _59 = yield(const ()) -> [resume: bb75, drop: bb76];
+        _61 = discriminant(_60);
+        switchInt(move _61) -> [0: bb71, 1: bb76, otherwise: bb11];
     }
 
     bb78: {
-        _61 = discriminant(_60);
-        switchInt(move _61) -> [0: bb72, 1: bb77, otherwise: bb12];
+        _60 = <impl Future<Output = ()> as Future>::poll(move _62, move _63) -> [return: bb77, unwind: bb72];
     }
 
     bb79: {
-        _60 = <impl Future<Output = ()> as Future>::poll(move _62, move _63) -> [return: bb78, unwind: bb73];
+        _64 = move _2;
+        _63 = std::future::get_context::<'_, '_>(move _64) -> [return: bb78, unwind: bb72];
     }
 
     bb80: {
-        _64 = move _2;
-        _63 = std::future::get_context::<'_, '_>(move _64) -> [return: bb79, unwind: bb73];
+        _65 = &mut _58;
+        _62 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _65) -> [return: bb79, unwind: bb72];
     }
 
     bb81: {
-        _65 = &mut _58;
-        _62 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _65) -> [return: bb80, unwind: bb73];
+        _2 = move _66;
+        StorageDead(_66);
+        goto -> bb87;
     }
 
     bb82: {
         _2 = move _66;
         StorageDead(_66);
-        goto -> bb88;
+        goto -> bb80;
     }
 
     bb83: {
-        _2 = move _66;
-        StorageDead(_66);
-        goto -> bb81;
+        StorageLive(_66);
+        _66 = yield(const ()) -> [resume: bb81, drop: bb82];
     }
 
     bb84: {
-        StorageLive(_66);
-        _66 = yield(const ()) -> [resume: bb82, drop: bb83];
+        _68 = discriminant(_67);
+        switchInt(move _68) -> [0: bb70, 1: bb83, otherwise: bb11];
     }
 
     bb85: {
-        _68 = discriminant(_67);
-        switchInt(move _68) -> [0: bb71, 1: bb84, otherwise: bb12];
+        _67 = <impl Future<Output = ()> as Future>::poll(move _69, move _70) -> [return: bb84, unwind: bb72];
     }
 
     bb86: {
-        _67 = <impl Future<Output = ()> as Future>::poll(move _69, move _70) -> [return: bb85, unwind: bb73];
+        _71 = move _2;
+        _70 = std::future::get_context::<'_, '_>(move _71) -> [return: bb85, unwind: bb72];
     }
 
     bb87: {
-        _71 = move _2;
-        _70 = std::future::get_context::<'_, '_>(move _71) -> [return: bb86, unwind: bb73];
+        _72 = &mut _58;
+        _69 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _72) -> [return: bb86, unwind: bb72];
     }
 
     bb88: {
-        _72 = &mut _58;
-        _69 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _72) -> [return: bb87, unwind: bb73];
+        StorageLive(_58);
+        _58 = <AsyncStruct as AsyncDrop>::drop(move _73) -> [return: bb87, unwind: bb72];
     }
 
     bb89: {
-        StorageLive(_58);
-        _58 = <AsyncStruct as AsyncDrop>::drop(move _73) -> [return: bb88, unwind: bb73];
-    }
-
-    bb90: {
         _74 = &mut (*_3);
-        _73 = Pin::<&mut AsyncStruct>::new_unchecked(move _74) -> [return: bb89, unwind: bb5];
+        _73 = Pin::<&mut AsyncStruct>::new_unchecked(move _74) -> [return: bb88, unwind: bb4];
     }
 }

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.SyncThenAsync.MentionedItems.after.mir
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.SyncThenAsync.MentionedItems.after.mir
@@ -64,7 +64,7 @@ yields ()
 
     bb0: {
         _3 = move (_1.0: &mut SyncThenAsync);
-        goto -> bb74;
+        goto -> bb73;
     }
 
     bb1: {
@@ -75,358 +75,354 @@ yields ()
         resume;
     }
 
-    bb3: {
-        goto -> bb1;
-    }
-
-    bb4 (cleanup): {
+    bb3 (cleanup): {
         drop(((*_3).3: AsyncInt)) -> [return: bb2, unwind terminate(cleanup)];
     }
 
+    bb4 (cleanup): {
+        drop(((*_3).2: SyncInt)) -> [return: bb3, unwind terminate(cleanup)];
+    }
+
     bb5 (cleanup): {
-        drop(((*_3).2: SyncInt)) -> [return: bb4, unwind terminate(cleanup)];
+        drop(((*_3).1: AsyncInt)) -> [return: bb4, unwind terminate(cleanup)];
     }
 
-    bb6 (cleanup): {
-        drop(((*_3).1: AsyncInt)) -> [return: bb5, unwind terminate(cleanup)];
-    }
-
-    bb7: {
+    bb6: {
         StorageDead(_4);
         goto -> bb1;
     }
 
-    bb8 (cleanup): {
+    bb7 (cleanup): {
         StorageDead(_4);
         goto -> bb2;
     }
 
+    bb8: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb8, unwind: bb7];
+    }
+
     bb9: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb9, unwind: bb8];
+        _2 = move _5;
+        StorageDead(_5);
+        goto -> bb8;
     }
 
     bb10: {
         _2 = move _5;
         StorageDead(_5);
-        goto -> bb9;
+        goto -> bb16;
     }
 
     bb11: {
-        _2 = move _5;
-        StorageDead(_5);
-        goto -> bb17;
+        StorageLive(_5);
+        _5 = yield(const ()) -> [resume: bb9, drop: bb10];
     }
 
     bb12: {
-        StorageLive(_5);
-        _5 = yield(const ()) -> [resume: bb10, drop: bb11];
-    }
-
-    bb13: {
         unreachable;
     }
 
-    bb14: {
+    bb13: {
         _7 = discriminant(_6);
-        switchInt(move _7) -> [0: bb7, 1: bb12, otherwise: bb13];
+        switchInt(move _7) -> [0: bb6, 1: bb11, otherwise: bb12];
+    }
+
+    bb14: {
+        _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb13, unwind: bb7];
     }
 
     bb15: {
-        _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb14, unwind: bb8];
+        _10 = move _2;
+        _9 = std::future::get_context::<'_, '_>(move _10) -> [return: bb14, unwind: bb7];
     }
 
     bb16: {
-        _10 = move _2;
-        _9 = std::future::get_context::<'_, '_>(move _10) -> [return: bb15, unwind: bb8];
+        _11 = &mut _4;
+        _8 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _11) -> [return: bb15, unwind: bb7];
     }
 
     bb17: {
-        _11 = &mut _4;
-        _8 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _11) -> [return: bb16, unwind: bb8];
+        StorageLive(_4);
+        _4 = async_drop_in_place::<AsyncInt>(copy (_12.0: &mut AsyncInt)) -> [return: bb16, unwind: bb7];
     }
 
     bb18: {
-        StorageLive(_4);
-        _4 = async_drop_in_place::<AsyncInt>(copy (_12.0: &mut AsyncInt)) -> [return: bb17, unwind: bb8];
+        _13 = &mut ((*_3).3: AsyncInt);
+        _12 = Pin::<&mut AsyncInt>::new_unchecked(move _13) -> [return: bb17, unwind: bb2];
     }
 
     bb19: {
-        _13 = &mut ((*_3).3: AsyncInt);
-        _12 = Pin::<&mut AsyncInt>::new_unchecked(move _13) -> [return: bb18, unwind: bb2];
+        drop(((*_3).2: SyncInt)) -> [return: bb18, unwind: bb3];
     }
 
     bb20: {
-        drop(((*_3).2: SyncInt)) -> [return: bb19, unwind: bb4];
+        StorageDead(_14);
+        goto -> bb19;
     }
 
-    bb21: {
+    bb21 (cleanup): {
         StorageDead(_14);
-        goto -> bb20;
+        goto -> bb4;
     }
 
-    bb22 (cleanup): {
-        StorageDead(_14);
-        goto -> bb5;
+    bb22: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb22, unwind: bb21];
     }
 
     bb23: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb23, unwind: bb22];
+        _2 = move _15;
+        StorageDead(_15);
+        goto -> bb22;
     }
 
     bb24: {
         _2 = move _15;
         StorageDead(_15);
-        goto -> bb23;
+        goto -> bb29;
     }
 
     bb25: {
-        _2 = move _15;
-        StorageDead(_15);
-        goto -> bb30;
+        StorageLive(_15);
+        _15 = yield(const ()) -> [resume: bb23, drop: bb24];
     }
 
     bb26: {
-        StorageLive(_15);
-        _15 = yield(const ()) -> [resume: bb24, drop: bb25];
+        _17 = discriminant(_16);
+        switchInt(move _17) -> [0: bb20, 1: bb25, otherwise: bb12];
     }
 
     bb27: {
-        _17 = discriminant(_16);
-        switchInt(move _17) -> [0: bb21, 1: bb26, otherwise: bb13];
+        _16 = <impl Future<Output = ()> as Future>::poll(move _18, move _19) -> [return: bb26, unwind: bb21];
     }
 
     bb28: {
-        _16 = <impl Future<Output = ()> as Future>::poll(move _18, move _19) -> [return: bb27, unwind: bb22];
+        _20 = move _2;
+        _19 = std::future::get_context::<'_, '_>(move _20) -> [return: bb27, unwind: bb21];
     }
 
     bb29: {
-        _20 = move _2;
-        _19 = std::future::get_context::<'_, '_>(move _20) -> [return: bb28, unwind: bb22];
+        _21 = &mut _14;
+        _18 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _21) -> [return: bb28, unwind: bb21];
     }
 
     bb30: {
-        _21 = &mut _14;
-        _18 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _21) -> [return: bb29, unwind: bb22];
+        StorageLive(_14);
+        _14 = async_drop_in_place::<AsyncInt>(copy (_22.0: &mut AsyncInt)) -> [return: bb29, unwind: bb21];
     }
 
     bb31: {
-        StorageLive(_14);
-        _14 = async_drop_in_place::<AsyncInt>(copy (_22.0: &mut AsyncInt)) -> [return: bb30, unwind: bb22];
+        _23 = &mut ((*_3).1: AsyncInt);
+        _22 = Pin::<&mut AsyncInt>::new_unchecked(move _23) -> [return: bb30, unwind: bb4];
     }
 
     bb32: {
-        _23 = &mut ((*_3).1: AsyncInt);
-        _22 = Pin::<&mut AsyncInt>::new_unchecked(move _23) -> [return: bb31, unwind: bb5];
-    }
-
-    bb33: {
-        StorageDead(_24);
-        goto -> bb3;
-    }
-
-    bb34: {
         StorageDead(_24);
         goto -> bb1;
     }
 
-    bb35 (cleanup): {
+    bb33: {
+        StorageDead(_24);
+        goto -> bb1;
+    }
+
+    bb34 (cleanup): {
         StorageDead(_24);
         goto -> bb2;
     }
 
+    bb35: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb35, unwind: bb34];
+    }
+
     bb36: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb36, unwind: bb35];
+        _2 = move _25;
+        StorageDead(_25);
+        goto -> bb35;
     }
 
     bb37: {
         _2 = move _25;
         StorageDead(_25);
-        goto -> bb36;
+        goto -> bb42;
     }
 
     bb38: {
-        _2 = move _25;
-        StorageDead(_25);
-        goto -> bb43;
+        StorageLive(_25);
+        _25 = yield(const ()) -> [resume: bb36, drop: bb37];
     }
 
     bb39: {
-        StorageLive(_25);
-        _25 = yield(const ()) -> [resume: bb37, drop: bb38];
+        _27 = discriminant(_26);
+        switchInt(move _27) -> [0: bb33, 1: bb38, otherwise: bb12];
     }
 
     bb40: {
-        _27 = discriminant(_26);
-        switchInt(move _27) -> [0: bb34, 1: bb39, otherwise: bb13];
+        _26 = <impl Future<Output = ()> as Future>::poll(move _28, move _29) -> [return: bb39, unwind: bb34];
     }
 
     bb41: {
-        _26 = <impl Future<Output = ()> as Future>::poll(move _28, move _29) -> [return: bb40, unwind: bb35];
+        _30 = move _2;
+        _29 = std::future::get_context::<'_, '_>(move _30) -> [return: bb40, unwind: bb34];
     }
 
     bb42: {
-        _30 = move _2;
-        _29 = std::future::get_context::<'_, '_>(move _30) -> [return: bb41, unwind: bb35];
+        _31 = &mut _24;
+        _28 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _31) -> [return: bb41, unwind: bb34];
     }
 
     bb43: {
-        _31 = &mut _24;
-        _28 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _31) -> [return: bb42, unwind: bb35];
+        _2 = move _32;
+        StorageDead(_32);
+        goto -> bb49;
     }
 
     bb44: {
         _2 = move _32;
         StorageDead(_32);
-        goto -> bb50;
+        goto -> bb42;
     }
 
     bb45: {
-        _2 = move _32;
-        StorageDead(_32);
-        goto -> bb43;
+        StorageLive(_32);
+        _32 = yield(const ()) -> [resume: bb43, drop: bb44];
     }
 
     bb46: {
-        StorageLive(_32);
-        _32 = yield(const ()) -> [resume: bb44, drop: bb45];
+        _34 = discriminant(_33);
+        switchInt(move _34) -> [0: bb32, 1: bb45, otherwise: bb12];
     }
 
     bb47: {
-        _34 = discriminant(_33);
-        switchInt(move _34) -> [0: bb33, 1: bb46, otherwise: bb13];
+        _33 = <impl Future<Output = ()> as Future>::poll(move _35, move _36) -> [return: bb46, unwind: bb34];
     }
 
     bb48: {
-        _33 = <impl Future<Output = ()> as Future>::poll(move _35, move _36) -> [return: bb47, unwind: bb35];
+        _37 = move _2;
+        _36 = std::future::get_context::<'_, '_>(move _37) -> [return: bb47, unwind: bb34];
     }
 
     bb49: {
-        _37 = move _2;
-        _36 = std::future::get_context::<'_, '_>(move _37) -> [return: bb48, unwind: bb35];
+        _38 = &mut _24;
+        _35 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _38) -> [return: bb48, unwind: bb34];
     }
 
     bb50: {
-        _38 = &mut _24;
-        _35 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _38) -> [return: bb49, unwind: bb35];
+        StorageLive(_24);
+        _24 = async_drop_in_place::<AsyncInt>(copy (_39.0: &mut AsyncInt)) -> [return: bb49, unwind: bb34];
     }
 
     bb51: {
-        StorageLive(_24);
-        _24 = async_drop_in_place::<AsyncInt>(copy (_39.0: &mut AsyncInt)) -> [return: bb50, unwind: bb35];
+        _40 = &mut ((*_3).3: AsyncInt);
+        _39 = Pin::<&mut AsyncInt>::new_unchecked(move _40) -> [return: bb50, unwind: bb2];
     }
 
     bb52: {
-        _40 = &mut ((*_3).3: AsyncInt);
-        _39 = Pin::<&mut AsyncInt>::new_unchecked(move _40) -> [return: bb51, unwind: bb2];
+        drop(((*_3).2: SyncInt)) -> [return: bb51, unwind: bb3];
     }
 
     bb53: {
-        drop(((*_3).2: SyncInt)) -> [return: bb52, unwind: bb4];
+        StorageDead(_41);
+        goto -> bb52;
     }
 
     bb54: {
         StorageDead(_41);
-        goto -> bb53;
+        goto -> bb19;
     }
 
-    bb55: {
+    bb55 (cleanup): {
         StorageDead(_41);
-        goto -> bb20;
+        goto -> bb4;
     }
 
-    bb56 (cleanup): {
-        StorageDead(_41);
-        goto -> bb5;
+    bb56: {
+        assert(const false, "`async fn` resumed after async drop") -> [success: bb56, unwind: bb55];
     }
 
     bb57: {
-        assert(const false, "`async fn` resumed after async drop") -> [success: bb57, unwind: bb56];
+        _2 = move _42;
+        StorageDead(_42);
+        goto -> bb56;
     }
 
     bb58: {
         _2 = move _42;
         StorageDead(_42);
-        goto -> bb57;
+        goto -> bb63;
     }
 
     bb59: {
-        _2 = move _42;
-        StorageDead(_42);
-        goto -> bb64;
+        StorageLive(_42);
+        _42 = yield(const ()) -> [resume: bb57, drop: bb58];
     }
 
     bb60: {
-        StorageLive(_42);
-        _42 = yield(const ()) -> [resume: bb58, drop: bb59];
+        _44 = discriminant(_43);
+        switchInt(move _44) -> [0: bb54, 1: bb59, otherwise: bb12];
     }
 
     bb61: {
-        _44 = discriminant(_43);
-        switchInt(move _44) -> [0: bb55, 1: bb60, otherwise: bb13];
+        _43 = <impl Future<Output = ()> as Future>::poll(move _45, move _46) -> [return: bb60, unwind: bb55];
     }
 
     bb62: {
-        _43 = <impl Future<Output = ()> as Future>::poll(move _45, move _46) -> [return: bb61, unwind: bb56];
+        _47 = move _2;
+        _46 = std::future::get_context::<'_, '_>(move _47) -> [return: bb61, unwind: bb55];
     }
 
     bb63: {
-        _47 = move _2;
-        _46 = std::future::get_context::<'_, '_>(move _47) -> [return: bb62, unwind: bb56];
+        _48 = &mut _41;
+        _45 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _48) -> [return: bb62, unwind: bb55];
     }
 
     bb64: {
-        _48 = &mut _41;
-        _45 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _48) -> [return: bb63, unwind: bb56];
+        _2 = move _49;
+        StorageDead(_49);
+        goto -> bb70;
     }
 
     bb65: {
         _2 = move _49;
         StorageDead(_49);
-        goto -> bb71;
+        goto -> bb63;
     }
 
     bb66: {
-        _2 = move _49;
-        StorageDead(_49);
-        goto -> bb64;
+        StorageLive(_49);
+        _49 = yield(const ()) -> [resume: bb64, drop: bb65];
     }
 
     bb67: {
-        StorageLive(_49);
-        _49 = yield(const ()) -> [resume: bb65, drop: bb66];
+        _51 = discriminant(_50);
+        switchInt(move _51) -> [0: bb53, 1: bb66, otherwise: bb12];
     }
 
     bb68: {
-        _51 = discriminant(_50);
-        switchInt(move _51) -> [0: bb54, 1: bb67, otherwise: bb13];
+        _50 = <impl Future<Output = ()> as Future>::poll(move _52, move _53) -> [return: bb67, unwind: bb55];
     }
 
     bb69: {
-        _50 = <impl Future<Output = ()> as Future>::poll(move _52, move _53) -> [return: bb68, unwind: bb56];
+        _54 = move _2;
+        _53 = std::future::get_context::<'_, '_>(move _54) -> [return: bb68, unwind: bb55];
     }
 
     bb70: {
-        _54 = move _2;
-        _53 = std::future::get_context::<'_, '_>(move _54) -> [return: bb69, unwind: bb56];
+        _55 = &mut _41;
+        _52 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _55) -> [return: bb69, unwind: bb55];
     }
 
     bb71: {
-        _55 = &mut _41;
-        _52 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _55) -> [return: bb70, unwind: bb56];
+        StorageLive(_41);
+        _41 = async_drop_in_place::<AsyncInt>(copy (_56.0: &mut AsyncInt)) -> [return: bb70, unwind: bb55];
     }
 
     bb72: {
-        StorageLive(_41);
-        _41 = async_drop_in_place::<AsyncInt>(copy (_56.0: &mut AsyncInt)) -> [return: bb71, unwind: bb56];
+        _57 = &mut ((*_3).1: AsyncInt);
+        _56 = Pin::<&mut AsyncInt>::new_unchecked(move _57) -> [return: bb71, unwind: bb4];
     }
 
     bb73: {
-        _57 = &mut ((*_3).1: AsyncInt);
-        _56 = Pin::<&mut AsyncInt>::new_unchecked(move _57) -> [return: bb72, unwind: bb5];
-    }
-
-    bb74: {
         _58 = &mut (*_3);
-        _59 = <SyncThenAsync as Drop>::drop(move _58) -> [return: bb73, unwind: bb6];
+        _59 = <SyncThenAsync as Drop>::drop(move _58) -> [return: bb72, unwind: bb5];
     }
 }

--- a/tests/mir-opt/coroutine/async_drop.double-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.double-{closure#0}.StateTransform.diff
@@ -98,7 +98,7 @@
 +         _43 = std::future::ResumeTy(move _44);
 +         _42 = copy (_1.0: &mut {async fn body of double()});
 +         _41 = discriminant((*_42));
-+         switchInt(move _41) -> [0: bb42, 1: bb41, 2: bb40, 3: bb36, 4: bb37, 5: bb38, 6: bb39, otherwise: bb13];
++         switchInt(move _41) -> [0: bb41, 1: bb40, 2: bb39, 3: bb35, 4: bb36, 5: bb37, 6: bb38, otherwise: bb13];
       }
   
       bb1: {
@@ -119,7 +119,7 @@
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb4, unwind: bb12];
 +         nop;
-+         goto -> bb34;
++         goto -> bb4;
       }
   
       bb4: {
@@ -154,7 +154,7 @@
 -     bb8: {
 -         coroutine_drop;
 +     bb8 (cleanup): {
-+         goto -> bb35;
++         goto -> bb34;
       }
   
 -     bb9 (cleanup): {
@@ -343,67 +343,66 @@
 +         _38 = Pin::<&mut AsyncInt>::new_unchecked(move _39) -> [return: bb32, unwind: bb6];
       }
   
-      bb34: {
+-     bb34: {
 -         StorageDead(_23);
 -         goto -> bb2;
-+         goto -> bb4;
-      }
-  
--     bb35: {
--         StorageDead(_23);
--         goto -> bb6;
-+     bb35 (cleanup): {
++     bb34 (cleanup): {
 +         discriminant((*_42)) = 2;
 +         resume;
+      }
+  
+      bb35: {
+-         StorageDead(_23);
+-         goto -> bb6;
++         StorageLive(_7);
++         _7 = move _43;
++         goto -> bb12;
       }
   
 -     bb36 (cleanup): {
 -         StorageDead(_23);
 -         goto -> bb10;
 +     bb36: {
-+         StorageLive(_7);
-+         _7 = move _43;
-+         goto -> bb12;
++         StorageLive(_14);
++         _14 = move _43;
++         goto -> bb14;
       }
   
       bb37: {
 -         assert(const false, "`async fn` resumed after async drop") -> [success: bb37, unwind: bb36];
-+         StorageLive(_14);
-+         _14 = move _43;
-+         goto -> bb14;
++         StorageLive(_24);
++         _24 = move _43;
++         goto -> bb25;
       }
   
       bb38: {
 -         _2 = move _24;
 -         StorageDead(_24);
 -         goto -> bb37;
-+         StorageLive(_24);
-+         _24 = move _43;
-+         goto -> bb25;
++         StorageLive(_31);
++         _31 = move _43;
++         goto -> bb26;
       }
   
       bb39: {
 -         _2 = move _24;
 -         StorageDead(_24);
 -         goto -> bb44;
-+         StorageLive(_31);
-+         _31 = move _43;
-+         goto -> bb26;
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb39, unwind continue];
       }
   
       bb40: {
 -         StorageLive(_24);
 -         _24 = yield(const ()) -> [resume: bb38, drop: bb39];
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb40, unwind continue];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb40, unwind continue];
       }
   
       bb41: {
 -         _26 = discriminant(_25);
 -         switchInt(move _26) -> [0: bb35, 1: bb40, otherwise: bb20];
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb41, unwind continue];
-      }
-  
-      bb42: {
+-     }
+- 
+-     bb42: {
 -         _25 = <impl Future<Output = ()> as Future>::poll(move _27, move _28) -> [return: bb41, unwind: bb36];
 -     }
 - 

--- a/tests/mir-opt/coroutine/async_drop.double-{closure#0}.coroutine_drop_async.0.mir
+++ b/tests/mir-opt/coroutine/async_drop.double-{closure#0}.coroutine_drop_async.0.mir
@@ -60,7 +60,7 @@ fn double::{closure#0}(_1: Pin<&mut {async fn body of double()}>, _2: &mut Conte
         _43 = std::future::ResumeTy(move _44);
         _42 = copy (_1.0: &mut {async fn body of double()});
         _41 = discriminant((*_42));
-        switchInt(move _41) -> [0: bb29, 2: bb36, 3: bb32, 4: bb33, 5: bb34, 6: bb35, otherwise: bb37];
+        switchInt(move _41) -> [0: bb29, 2: bb35, 3: bb31, 4: bb32, 5: bb33, 6: bb34, otherwise: bb36];
     }
 
     bb1: {
@@ -99,7 +99,7 @@ fn double::{closure#0}(_1: Pin<&mut {async fn body of double()}>, _2: &mut Conte
     }
 
     bb8 (cleanup): {
-        goto -> bb31;
+        goto -> bb30;
     }
 
     bb9: {
@@ -212,47 +212,43 @@ fn double::{closure#0}(_1: Pin<&mut {async fn body of double()}>, _2: &mut Conte
     }
 
     bb29: {
-        goto -> bb30;
-    }
-
-    bb30: {
         goto -> bb28;
     }
 
-    bb31 (cleanup): {
+    bb30 (cleanup): {
         discriminant((*_42)) = 2;
         resume;
     }
 
-    bb32: {
+    bb31: {
         StorageLive(_7);
         _7 = move _43;
         goto -> bb11;
     }
 
-    bb33: {
+    bb32: {
         StorageLive(_14);
         _14 = move _43;
         goto -> bb18;
     }
 
-    bb34: {
+    bb33: {
         StorageLive(_24);
         _24 = move _43;
         goto -> bb21;
     }
 
-    bb35: {
+    bb34: {
         StorageLive(_31);
         _31 = move _43;
         goto -> bb27;
     }
 
-    bb36: {
-        assert(const false, "`async fn` resumed after panicking") -> [success: bb36, unwind continue];
+    bb35: {
+        assert(const false, "`async fn` resumed after panicking") -> [success: bb35, unwind continue];
     }
 
-    bb37: {
+    bb36: {
         _0 = Poll::<()>::Ready(const ());
         return;
     }

--- a/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.StateTransform.diff
@@ -313,7 +313,7 @@
 +         _183 = std::future::ResumeTy(move _184);
 +         _182 = copy (_1.0: &mut {async fn body of elaborate_drops()});
 +         _181 = discriminant((*_182));
-+         switchInt(move _181) -> [0: bb170, 1: bb169, 2: bb168, 3: bb150, 4: bb151, 5: bb152, 6: bb153, 7: bb154, 8: bb155, 9: bb156, 10: bb157, 11: bb158, 12: bb159, 13: bb160, 14: bb161, 15: bb162, 16: bb163, 17: bb164, 18: bb165, 19: bb166, 20: bb167, otherwise: bb43];
++         switchInt(move _181) -> [0: bb169, 1: bb168, 2: bb167, 3: bb149, 4: bb150, 5: bb151, 6: bb152, 7: bb153, 8: bb154, 9: bb155, 10: bb156, 11: bb157, 12: bb158, 13: bb159, 14: bb160, 15: bb161, 16: bb162, 17: bb163, 18: bb164, 19: bb165, 20: bb166, otherwise: bb43];
       }
   
       bb1: {
@@ -497,7 +497,7 @@
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb22, unwind: bb51];
 +         nop;
-+         goto -> bb148;
++         goto -> bb22;
       }
   
       bb22: {
@@ -620,7 +620,7 @@
       bb38 (cleanup): {
 -         StorageDead(_24);
 -         goto -> bb39;
-+         goto -> bb149;
++         goto -> bb148;
       }
   
 -     bb39 (cleanup): {
@@ -1456,22 +1456,16 @@
 +         _178 = Pin::<&mut AsyncInt>::new_unchecked(move _179) -> [return: bb146, unwind: bb36];
       }
   
-      bb148: {
+-     bb148: {
 -         _104 = <impl Future<Output = ()> as Future>::poll(move _106, move _107) -> [return: bb147, unwind: bb135];
-+         goto -> bb22;
-      }
-  
--     bb149: {
--         _108 = move _2;
--         _107 = std::future::get_context::<'_, '_>(move _108) -> [return: bb148, unwind: bb135];
-+     bb149 (cleanup): {
++     bb148 (cleanup): {
 +         discriminant((*_182)) = 2;
 +         resume;
       }
   
-      bb150: {
--         _109 = &mut _95;
--         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb149, unwind: bb135];
+      bb149: {
+-         _108 = move _2;
+-         _107 = std::future::get_context::<'_, '_>(move _108) -> [return: bb148, unwind: bb135];
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_25);
@@ -1480,9 +1474,9 @@
 +         goto -> bb42;
       }
   
-      bb151: {
--         StorageLive(_95);
--         _95 = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb150, unwind: bb135];
+      bb150: {
+-         _109 = &mut _95;
+-         _106 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _109) -> [return: bb149, unwind: bb135];
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_25);
@@ -1491,9 +1485,9 @@
 +         goto -> bb44;
       }
   
-      bb152: {
--         _111 = &mut _15;
--         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb151, unwind: bb45];
+      bb151: {
+-         StorageLive(_95);
+-         _95 = async_drop_in_place::<AsyncEnum>(copy (_110.0: &mut AsyncEnum)) -> [return: bb150, unwind: bb135];
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_45);
@@ -1501,9 +1495,9 @@
 +         goto -> bb55;
       }
   
-      bb153: {
--         StorageDead(_112);
--         goto -> bb17;
+      bb152: {
+-         _111 = &mut _15;
+-         _110 = Pin::<&mut AsyncEnum>::new_unchecked(move _111) -> [return: bb151, unwind: bb45];
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_52);
@@ -1511,13 +1505,22 @@
 +         goto -> bb56;
       }
   
-      bb154: {
+      bb153: {
 -         StorageDead(_112);
--         goto -> bb30;
+-         goto -> bb17;
 +         StorageLive(_17);
 +         StorageLive(_62);
 +         _62 = move _183;
 +         goto -> bb67;
+      }
+  
+      bb154: {
+-         StorageDead(_112);
+-         goto -> bb30;
++         StorageLive(_17);
++         StorageLive(_69);
++         _69 = move _183;
++         goto -> bb68;
       }
   
 -     bb155 (cleanup): {
@@ -1525,123 +1528,118 @@
 -         goto -> bb46;
 +     bb155: {
 +         StorageLive(_17);
-+         StorageLive(_69);
-+         _69 = move _183;
-+         goto -> bb68;
-      }
-  
-      bb156: {
--         assert(const false, "`async fn` resumed after async drop") -> [success: bb156, unwind: bb155];
-+         StorageLive(_17);
 +         StorageLive(_79);
 +         _79 = move _183;
 +         goto -> bb79;
       }
   
-      bb157: {
--         _2 = move _113;
--         StorageDead(_113);
--         goto -> bb156;
+      bb156: {
+-         assert(const false, "`async fn` resumed after async drop") -> [success: bb156, unwind: bb155];
 +         StorageLive(_17);
 +         StorageLive(_86);
 +         _86 = move _183;
 +         goto -> bb80;
       }
   
-      bb158: {
+      bb157: {
 -         _2 = move _113;
 -         StorageDead(_113);
--         goto -> bb163;
+-         goto -> bb156;
 +         StorageLive(_96);
 +         _96 = move _183;
 +         goto -> bb91;
       }
   
-      bb159: {
--         StorageLive(_113);
--         _113 = yield(const ()) -> [resume: bb157, drop: bb158];
+      bb158: {
+-         _2 = move _113;
+-         StorageDead(_113);
+-         goto -> bb163;
 +         StorageLive(_103);
 +         _103 = move _183;
 +         goto -> bb92;
       }
   
-      bb160: {
--         _115 = discriminant(_114);
--         switchInt(move _115) -> [0: bb154, 1: bb159, otherwise: bb59];
-+         StorageLive(_113);
+      bb159: {
+          StorageLive(_113);
+-         _113 = yield(const ()) -> [resume: bb157, drop: bb158];
 +         _113 = move _183;
 +         goto -> bb103;
       }
   
-      bb161: {
--         _114 = <impl Future<Output = ()> as Future>::poll(move _116, move _117) -> [return: bb160, unwind: bb155];
+      bb160: {
+-         _115 = discriminant(_114);
+-         switchInt(move _115) -> [0: bb154, 1: bb159, otherwise: bb59];
 +         StorageLive(_120);
 +         _120 = move _183;
 +         goto -> bb104;
       }
   
-      bb162: {
--         _118 = move _2;
--         _117 = std::future::get_context::<'_, '_>(move _118) -> [return: bb161, unwind: bb155];
+      bb161: {
+-         _114 = <impl Future<Output = ()> as Future>::poll(move _116, move _117) -> [return: bb160, unwind: bb155];
 +         StorageLive(_130);
 +         _130 = move _183;
 +         goto -> bb115;
       }
   
-      bb163: {
--         _119 = &mut _112;
--         _116 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _119) -> [return: bb162, unwind: bb155];
+      bb162: {
+-         _118 = move _2;
+-         _117 = std::future::get_context::<'_, '_>(move _118) -> [return: bb161, unwind: bb155];
 +         StorageLive(_137);
 +         _137 = move _183;
 +         goto -> bb116;
+      }
+  
+      bb163: {
+-         _119 = &mut _112;
+-         _116 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _119) -> [return: bb162, unwind: bb155];
++         StorageLive(_147);
++         _147 = move _183;
++         goto -> bb127;
       }
   
       bb164: {
 -         _2 = move _120;
 -         StorageDead(_120);
 -         goto -> bb170;
-+         StorageLive(_147);
-+         _147 = move _183;
-+         goto -> bb127;
++         StorageLive(_154);
++         _154 = move _183;
++         goto -> bb128;
       }
   
       bb165: {
 -         _2 = move _120;
 -         StorageDead(_120);
 -         goto -> bb163;
-+         StorageLive(_154);
-+         _154 = move _183;
-+         goto -> bb128;
-      }
-  
-      bb166: {
--         StorageLive(_120);
--         _120 = yield(const ()) -> [resume: bb164, drop: bb165];
 +         StorageLive(_164);
 +         _164 = move _183;
 +         goto -> bb139;
       }
   
-      bb167: {
--         _122 = discriminant(_121);
--         switchInt(move _122) -> [0: bb153, 1: bb166, otherwise: bb59];
+      bb166: {
+-         StorageLive(_120);
+-         _120 = yield(const ()) -> [resume: bb164, drop: bb165];
 +         StorageLive(_171);
 +         _171 = move _183;
 +         goto -> bb140;
       }
   
+      bb167: {
+-         _122 = discriminant(_121);
+-         switchInt(move _122) -> [0: bb153, 1: bb166, otherwise: bb59];
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb167, unwind continue];
+      }
+  
       bb168: {
 -         _121 = <impl Future<Output = ()> as Future>::poll(move _123, move _124) -> [return: bb167, unwind: bb155];
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb168, unwind continue];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb168, unwind continue];
       }
   
       bb169: {
 -         _125 = move _2;
 -         _124 = std::future::get_context::<'_, '_>(move _125) -> [return: bb168, unwind: bb155];
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb169, unwind continue];
-      }
-  
-      bb170: {
+-     }
+- 
+-     bb170: {
 -         _126 = &mut _112;
 -         _123 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _126) -> [return: bb169, unwind: bb155];
 -     }

--- a/tests/mir-opt/coroutine/async_drop.simple-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.simple-{closure#0}.StateTransform.diff
@@ -69,7 +69,7 @@
 +         _25 = std::future::ResumeTy(move _26);
 +         _24 = copy (_1.0: &mut {async fn body of simple()});
 +         _23 = discriminant((*_24));
-+         switchInt(move _23) -> [0: bb26, 1: bb25, 2: bb24, 3: bb22, 4: bb23, otherwise: bb11];
++         switchInt(move _23) -> [0: bb25, 1: bb24, 2: bb23, 3: bb21, 4: bb22, otherwise: bb11];
       }
   
       bb1: {
@@ -83,7 +83,7 @@
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb3, unwind: bb9];
 +         nop;
-+         goto -> bb20;
++         goto -> bb3;
       }
   
       bb3: {
@@ -110,7 +110,7 @@
 -     bb6: {
 -         coroutine_drop;
 +     bb6 (cleanup): {
-+         goto -> bb21;
++         goto -> bb20;
       }
   
 -     bb7 (cleanup): {
@@ -208,51 +208,50 @@
 +         _20 = Pin::<&mut AsyncInt>::new_unchecked(move _21) -> [return: bb18, unwind: bb4];
       }
   
-      bb20: {
+-     bb20: {
 -         _11 = move _2;
 -         _10 = std::future::get_context::<'_, '_>(move _11) -> [return: bb19, unwind: bb12];
-+         goto -> bb3;
-      }
-  
--     bb21: {
--         _12 = &mut _5;
--         _9 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _12) -> [return: bb20, unwind: bb12];
-+     bb21 (cleanup): {
++     bb20 (cleanup): {
 +         discriminant((*_24)) = 2;
 +         resume;
+      }
+  
+      bb21: {
+-         _12 = &mut _5;
+-         _9 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _12) -> [return: bb20, unwind: bb12];
++         StorageLive(_6);
++         _6 = move _25;
++         goto -> bb10;
       }
   
       bb22: {
 -         _2 = move _13;
 -         StorageDead(_13);
 -         goto -> bb28;
-+         StorageLive(_6);
-+         _6 = move _25;
-+         goto -> bb10;
++         StorageLive(_13);
++         _13 = move _25;
++         goto -> bb12;
       }
   
       bb23: {
 -         _2 = move _13;
 -         StorageDead(_13);
 -         goto -> bb21;
-+         StorageLive(_13);
-+         _13 = move _25;
-+         goto -> bb12;
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb23, unwind continue];
       }
   
       bb24: {
 -         StorageLive(_13);
 -         _13 = yield(const ()) -> [resume: bb22, drop: bb23];
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb24, unwind continue];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb24, unwind continue];
       }
   
       bb25: {
 -         _15 = discriminant(_14);
 -         switchInt(move _15) -> [0: bb10, 1: bb24, otherwise: bb17];
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb25, unwind continue];
-      }
-  
-      bb26: {
+-     }
+- 
+-     bb26: {
 -         _14 = <impl Future<Output = ()> as Future>::poll(move _16, move _17) -> [return: bb25, unwind: bb12];
 -     }
 - 

--- a/tests/mir-opt/coroutine/async_drop.simple-{closure#0}.coroutine_drop_async.0.mir
+++ b/tests/mir-opt/coroutine/async_drop.simple-{closure#0}.coroutine_drop_async.0.mir
@@ -39,7 +39,7 @@ fn simple::{closure#0}(_1: Pin<&mut {async fn body of simple()}>, _2: &mut Conte
         _25 = std::future::ResumeTy(move _26);
         _24 = copy (_1.0: &mut {async fn body of simple()});
         _23 = discriminant((*_24));
-        switchInt(move _23) -> [0: bb18, 2: bb23, 3: bb21, 4: bb22, otherwise: bb24];
+        switchInt(move _23) -> [0: bb18, 2: bb22, 3: bb20, 4: bb21, otherwise: bb23];
     }
 
     bb1: {
@@ -68,7 +68,7 @@ fn simple::{closure#0}(_1: Pin<&mut {async fn body of simple()}>, _2: &mut Conte
     }
 
     bb6 (cleanup): {
-        goto -> bb20;
+        goto -> bb19;
     }
 
     bb7: {
@@ -131,35 +131,31 @@ fn simple::{closure#0}(_1: Pin<&mut {async fn body of simple()}>, _2: &mut Conte
     }
 
     bb18: {
-        goto -> bb19;
-    }
-
-    bb19: {
         goto -> bb17;
     }
 
-    bb20 (cleanup): {
+    bb19 (cleanup): {
         discriminant((*_24)) = 2;
         resume;
     }
 
-    bb21: {
+    bb20: {
         StorageLive(_6);
         _6 = move _25;
         goto -> bb9;
     }
 
-    bb22: {
+    bb21: {
         StorageLive(_13);
         _13 = move _25;
         goto -> bb16;
     }
 
-    bb23: {
-        assert(const false, "`async fn` resumed after panicking") -> [success: bb23, unwind continue];
+    bb22: {
+        assert(const false, "`async fn` resumed after panicking") -> [success: bb22, unwind continue];
     }
 
-    bb24: {
+    bb23: {
         _0 = Poll::<()>::Ready(const ());
         return;
     }

--- a/tests/mir-opt/coroutine/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-abort.mir
+++ b/tests/mir-opt/coroutine/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-abort.mir
@@ -36,7 +36,7 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
         _24 = std::future::ResumeTy(move _25);
         _23 = copy (_1.0: &mut {async fn body of a<T>()});
         _22 = discriminant((*_23));
-        switchInt(move _22) -> [0: bb13, 3: bb16, 4: bb17, otherwise: bb18];
+        switchInt(move _22) -> [0: bb13, 3: bb15, 4: bb16, otherwise: bb17];
     }
 
     bb1: {
@@ -104,30 +104,26 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb13: {
-        goto -> bb15;
+        goto -> bb14;
     }
 
     bb14: {
-        goto -> bb12;
+        drop(((*_23).0: T)) -> [return: bb12, unwind unreachable];
     }
 
     bb15: {
-        drop(((*_23).0: T)) -> [return: bb14, unwind unreachable];
-    }
-
-    bb16: {
         StorageLive(_5);
         _5 = move _24;
         goto -> bb4;
     }
 
-    bb17: {
+    bb16: {
         StorageLive(_12);
         _12 = move _24;
         goto -> bb11;
     }
 
-    bb18: {
+    bb17: {
         _0 = Poll::<()>::Ready(const ());
         return;
     }

--- a/tests/mir-opt/coroutine/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-unwind.mir
+++ b/tests/mir-opt/coroutine/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-unwind.mir
@@ -36,7 +36,7 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
         _24 = std::future::ResumeTy(move _25);
         _23 = copy (_1.0: &mut {async fn body of a<T>()});
         _22 = discriminant((*_23));
-        switchInt(move _22) -> [0: bb16, 2: bb22, 3: bb20, 4: bb21, otherwise: bb23];
+        switchInt(move _22) -> [0: bb16, 2: bb21, 3: bb19, 4: bb20, otherwise: bb22];
     }
 
     bb1: {
@@ -55,7 +55,7 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb4 (cleanup): {
-        goto -> bb19;
+        goto -> bb18;
     }
 
     bb5: {
@@ -118,39 +118,35 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb16: {
-        goto -> bb18;
+        goto -> bb17;
     }
 
     bb17: {
-        goto -> bb15;
+        drop(((*_23).0: T)) -> [return: bb15, unwind: bb4];
     }
 
-    bb18: {
-        drop(((*_23).0: T)) -> [return: bb17, unwind: bb4];
-    }
-
-    bb19 (cleanup): {
+    bb18 (cleanup): {
         discriminant((*_23)) = 2;
         resume;
     }
 
-    bb20: {
+    bb19: {
         StorageLive(_5);
         _5 = move _24;
         goto -> bb7;
     }
 
-    bb21: {
+    bb20: {
         StorageLive(_12);
         _12 = move _24;
         goto -> bb14;
     }
 
-    bb22: {
-        assert(const false, "`async fn` resumed after panicking") -> [success: bb22, unwind continue];
+    bb21: {
+        assert(const false, "`async fn` resumed after panicking") -> [success: bb21, unwind continue];
     }
 
-    bb23: {
+    bb22: {
         _0 = Poll::<()>::Ready(const ());
         return;
     }

--- a/tests/mir-opt/coroutine/async_drop_mir_pin.core.future-async_drop-async_drop_in_place-{closure#0}.[Foo;1].MentionedItems.after.mir
+++ b/tests/mir-opt/coroutine/async_drop_mir_pin.core.future-async_drop-async_drop_in_place-{closure#0}.[Foo;1].MentionedItems.after.mir
@@ -45,7 +45,7 @@ yields ()
 
     bb0: {
         _3 = move (_1.0: &mut [Foo; 1]);
-        goto -> bb44;
+        goto -> bb43;
     }
 
     bb1: {
@@ -261,12 +261,8 @@ yields ()
     }
 
     bb43: {
-        goto -> bb42;
-    }
-
-    bb44: {
         _4 = &raw mut (*_3);
         _5 = move _4 as *mut [Foo] (PointerCoercion(Unsize, Implicit));
-        goto -> bb43;
+        goto -> bb42;
     }
 }

--- a/tests/mir-opt/coroutine/async_fn.add-{closure#0}-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.add-{closure#0}-{closure#0}.StateTransform.diff
@@ -46,7 +46,7 @@
 +         _10 = std::future::ResumeTy(move _11);
 +         _9 = copy (_1.0: &mut {async block@$DIR/async_fn.rs:34:13: 34:18});
 +         _8 = discriminant((*_9));
-+         switchInt(move _8) -> [0: bb5, 1: bb3, otherwise: bb4];
++         switchInt(move _8) -> [0: bb4, 1: bb2, otherwise: bb3];
       }
   
       bb1: {
@@ -58,18 +58,14 @@
 -     bb2 (cleanup): {
 -         resume;
 +     bb2: {
-+         goto -> bb1;
++         assert(const false, "`async fn` resumed after completion") -> [success: bb2, unwind continue];
 +     }
 + 
 +     bb3: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb3, unwind continue];
-+     }
-+ 
-+     bb4: {
 +         unreachable;
 +     }
 + 
-+     bb5: {
++     bb4: {
 +         StorageLive(_3);
 +         _5 = no_retag copy ((*_9).0: &u32);
 +         _3 = copy (*_5);
@@ -79,7 +75,7 @@
 +         _7 = Add(move _3, move _4);
 +         StorageDead(_4);
 +         StorageDead(_3);
-+         goto -> bb2;
++         goto -> bb1;
       }
   }
   

--- a/tests/mir-opt/coroutine/async_fn.add-{closure#0}-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.add-{closure#0}-{closure#0}.coroutine_drop.0.mir
@@ -15,7 +15,7 @@ fn add::{closure#0}::{closure#0}(_1: &mut {async block@$DIR/async_fn.rs:34:13: 3
 
     bb0: {
         _8 = discriminant((*_1));
-        switchInt(move _8) -> [0: bb2, otherwise: bb4];
+        switchInt(move _8) -> [0: bb2, otherwise: bb3];
     }
 
     bb1: {
@@ -23,14 +23,10 @@ fn add::{closure#0}::{closure#0}(_1: &mut {async block@$DIR/async_fn.rs:34:13: 3
     }
 
     bb2: {
-        goto -> bb3;
-    }
-
-    bb3: {
         goto -> bb1;
     }
 
-    bb4: {
+    bb3: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/async_fn.add-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.add-{closure#0}.StateTransform.diff
@@ -95,7 +95,7 @@
 +         _28 = std::future::ResumeTy(move _29);
 +         _27 = copy (_1.0: &mut {async fn body of add()});
 +         _26 = discriminant((*_27));
-+         switchInt(move _26) -> [0: bb28, 1: bb27, 2: bb26, 3: bb25, otherwise: bb6];
++         switchInt(move _26) -> [0: bb27, 1: bb26, 2: bb25, 3: bb24, otherwise: bb6];
       }
   
       bb1: {
@@ -210,7 +210,7 @@
 -         drop(_1) -> [return: bb13, unwind: bb28];
 +         nop;
 +         nop;
-+         goto -> bb23;
++         goto -> bb13;
       }
   
       bb13: {
@@ -291,26 +291,19 @@
 -         StorageDead(_13);
 -         StorageDead(_12);
 -         drop(_10) -> [return: bb23, unwind terminate(cleanup)];
-+         goto -> bb24;
++         goto -> bb23;
       }
   
--     bb23 (cleanup): {
+      bb23 (cleanup): {
 -         StorageDead(_10);
 -         goto -> bb26;
-+     bb23: {
-+         goto -> bb13;
-      }
-  
-      bb24 (cleanup): {
--         goto -> bb25;
 +         discriminant((*_27)) = 2;
 +         resume;
       }
   
--     bb25 (cleanup): {
--         StorageDead(_9);
--         goto -> bb26;
-+     bb25: {
+-     bb24 (cleanup): {
+-         goto -> bb25;
++     bb24: {
 +         StorageLive(_5);
 +         StorageLive(_8);
 +         StorageLive(_23);
@@ -319,11 +312,18 @@
 +         goto -> bb9;
       }
   
+-     bb25 (cleanup): {
+-         StorageDead(_9);
+-         goto -> bb26;
++     bb25: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb25, unwind continue];
+      }
+  
 -     bb26 (cleanup): {
 -         StorageDead(_8);
 -         goto -> bb27;
 +     bb26: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb26, unwind continue];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb26, unwind continue];
       }
   
 -     bb27 (cleanup): {
@@ -331,10 +331,8 @@
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb28, unwind terminate(cleanup)];
-+     bb27: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb27, unwind continue];
-      }
-  
+-     }
+- 
 -     bb28 (cleanup): {
 -         resume;
 -     }
@@ -354,7 +352,7 @@
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb28, unwind terminate(cleanup)];
-+     bb28: {
++     bb27: {
 +         nop;
 +         (((*_27) as variant#3).0: u32) = copy ((*_27).0: u32);
 +         nop;

--- a/tests/mir-opt/coroutine/async_fn.add-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.add-{closure#0}.coroutine_drop.0.mir
@@ -48,7 +48,7 @@ fn add::{closure#0}(_1: &mut {async fn body of add()}) -> () {
 
     bb0: {
         _26 = discriminant((*_1));
-        switchInt(move _26) -> [0: bb11, 3: bb14, otherwise: bb15];
+        switchInt(move _26) -> [0: bb11, 3: bb12, otherwise: bb13];
     }
 
     bb1: {
@@ -71,7 +71,7 @@ fn add::{closure#0}(_1: &mut {async fn body of add()}) -> () {
         StorageDead(_5);
         nop;
         nop;
-        goto -> bb12;
+        goto -> bb5;
     }
 
     bb5: {
@@ -104,18 +104,10 @@ fn add::{closure#0}(_1: &mut {async fn body of add()}) -> () {
     }
 
     bb11: {
-        goto -> bb13;
-    }
-
-    bb12: {
-        goto -> bb5;
-    }
-
-    bb13: {
         goto -> bb10;
     }
 
-    bb14: {
+    bb12: {
         StorageLive(_5);
         StorageLive(_8);
         StorageLive(_23);
@@ -123,7 +115,7 @@ fn add::{closure#0}(_1: &mut {async fn body of add()}) -> () {
         goto -> bb1;
     }
 
-    bb15: {
+    bb13: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/async_fn.build_aggregate-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.build_aggregate-{closure#0}.StateTransform.diff
@@ -141,7 +141,7 @@
 +         _52 = std::future::ResumeTy(move _53);
 +         _51 = copy (_1.0: &mut {async fn body of build_aggregate()});
 +         _50 = discriminant((*_51));
-+         switchInt(move _50) -> [0: bb49, 1: bb48, 2: bb47, 3: bb45, 4: bb46, otherwise: bb7];
++         switchInt(move _50) -> [0: bb48, 1: bb47, 2: bb46, 3: bb44, 4: bb45, otherwise: bb7];
       }
   
       bb1: {
@@ -397,7 +397,7 @@
           StorageDead(_4);
           StorageDead(_3);
 -         drop(_1) -> [return: bb24, unwind: bb52];
-+         goto -> bb43;
++         goto -> bb24;
       }
   
       bb24: {
@@ -611,14 +611,10 @@
   
 -     bb52 (cleanup): {
 +     bb42 (cleanup): {
-+         goto -> bb44;
++         goto -> bb43;
 +     }
 + 
-+     bb43: {
-+         goto -> bb24;
-+     }
-+ 
-+     bb44 (cleanup): {
++     bb43 (cleanup): {
 +         discriminant((*_51)) = 2;
           resume;
       }
@@ -628,7 +624,7 @@
 -         StorageDead(_28);
 -         StorageDead(_8);
 -         goto -> bb54;
-+     bb45: {
++     bb44: {
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         StorageLive(_7);
@@ -642,7 +638,7 @@
 -     bb54 (cleanup): {
 -         StorageDead(_29);
 -         goto -> bb56;
-+     bb46: {
++     bb45: {
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         StorageLive(_7);
@@ -659,14 +655,14 @@
 -         StorageDead(_13);
 -         StorageDead(_8);
 -         goto -> bb56;
-+     bb47: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb47, unwind continue];
++     bb46: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb46, unwind continue];
       }
   
 -     bb56 (cleanup): {
 -         goto -> bb57;
-+     bb48: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb48, unwind continue];
++     bb47: {
++         assert(const false, "`async fn` resumed after completion") -> [success: bb47, unwind continue];
       }
   
 -     bb57 (cleanup): {
@@ -677,7 +673,7 @@
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb52, unwind terminate(cleanup)];
-+     bb49: {
++     bb48: {
 +         StorageLive(_3);
 +         _3 = copy ((*_51).0: u32);
 +         StorageLive(_4);

--- a/tests/mir-opt/coroutine/async_fn.build_aggregate-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.build_aggregate-{closure#0}.coroutine_drop.0.mir
@@ -86,7 +86,7 @@ fn build_aggregate::{closure#0}(_1: &mut {async fn body of build_aggregate()}) -
 
     bb0: {
         _50 = discriminant((*_1));
-        switchInt(move _50) -> [0: bb16, 3: bb19, 4: bb20, otherwise: bb21];
+        switchInt(move _50) -> [0: bb16, 3: bb17, 4: bb18, otherwise: bb19];
     }
 
     bb1: {
@@ -130,7 +130,7 @@ fn build_aggregate::{closure#0}(_1: &mut {async fn body of build_aggregate()}) -
         nop;
         StorageDead(_4);
         StorageDead(_3);
-        goto -> bb17;
+        goto -> bb8;
     }
 
     bb8: {
@@ -178,18 +178,10 @@ fn build_aggregate::{closure#0}(_1: &mut {async fn body of build_aggregate()}) -
     }
 
     bb16: {
-        goto -> bb18;
-    }
-
-    bb17: {
-        goto -> bb8;
-    }
-
-    bb18: {
         goto -> bb15;
     }
 
-    bb19: {
+    bb17: {
         StorageLive(_3);
         StorageLive(_4);
         StorageLive(_7);
@@ -199,7 +191,7 @@ fn build_aggregate::{closure#0}(_1: &mut {async fn body of build_aggregate()}) -
         goto -> bb4;
     }
 
-    bb20: {
+    bb18: {
         StorageLive(_3);
         StorageLive(_4);
         StorageLive(_7);
@@ -211,7 +203,7 @@ fn build_aggregate::{closure#0}(_1: &mut {async fn body of build_aggregate()}) -
         goto -> bb1;
     }
 
-    bb21: {
+    bb19: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/async_fn.foo-{closure#0}-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.foo-{closure#0}-{closure#0}.StateTransform.diff
@@ -46,7 +46,7 @@
 +         _10 = std::future::ResumeTy(move _11);
 +         _9 = copy (_1.0: &mut {async block@$DIR/async_fn.rs:21:13: 21:18});
 +         _8 = discriminant((*_9));
-+         switchInt(move _8) -> [0: bb5, 1: bb3, otherwise: bb4];
++         switchInt(move _8) -> [0: bb4, 1: bb2, otherwise: bb3];
       }
   
       bb1: {
@@ -58,18 +58,14 @@
 -     bb2 (cleanup): {
 -         resume;
 +     bb2: {
-+         goto -> bb1;
++         assert(const false, "`async fn` resumed after completion") -> [success: bb2, unwind continue];
 +     }
 + 
 +     bb3: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb3, unwind continue];
-+     }
-+ 
-+     bb4: {
 +         unreachable;
 +     }
 + 
-+     bb5: {
++     bb4: {
 +         StorageLive(_3);
 +         _5 = no_retag copy ((*_9).0: &u32);
 +         _3 = copy (*_5);
@@ -79,7 +75,7 @@
 +         _7 = Add(move _3, move _4);
 +         StorageDead(_4);
 +         StorageDead(_3);
-+         goto -> bb2;
++         goto -> bb1;
       }
   }
   

--- a/tests/mir-opt/coroutine/async_fn.foo-{closure#0}-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.foo-{closure#0}-{closure#0}.coroutine_drop.0.mir
@@ -15,7 +15,7 @@ fn foo::{closure#0}::{closure#0}(_1: &mut {async block@$DIR/async_fn.rs:21:13: 2
 
     bb0: {
         _8 = discriminant((*_1));
-        switchInt(move _8) -> [0: bb2, otherwise: bb4];
+        switchInt(move _8) -> [0: bb2, otherwise: bb3];
     }
 
     bb1: {
@@ -23,14 +23,10 @@ fn foo::{closure#0}::{closure#0}(_1: &mut {async block@$DIR/async_fn.rs:21:13: 2
     }
 
     bb2: {
-        goto -> bb3;
-    }
-
-    bb3: {
         goto -> bb1;
     }
 
-    bb4: {
+    bb3: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/async_fn.foo-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.foo-{closure#0}.StateTransform.diff
@@ -128,7 +128,7 @@
 +         _38 = std::future::ResumeTy(move _39);
 +         _36 = copy (_1.0: &mut {async fn body of foo()});
 +         _35 = discriminant((*_36));
-+         switchInt(move _35) -> [0: bb26, 1: bb25, 2: bb24, 3: bb23, otherwise: bb6];
++         switchInt(move _35) -> [0: bb25, 1: bb24, 2: bb23, 3: bb22, otherwise: bb6];
       }
   
       bb1: {
@@ -266,7 +266,7 @@
 -         drop(_1) -> [return: bb12, unwind: bb25];
 +         nop;
 +         nop;
-+         goto -> bb21;
++         goto -> bb12;
       }
   
       bb12: {
@@ -347,26 +347,19 @@
 -         StorageDead(_16);
 -         StorageDead(_15);
 -         drop(_13) -> [return: bb21, unwind terminate(cleanup)];
-+         goto -> bb22;
++         goto -> bb21;
       }
   
--     bb21 (cleanup): {
+      bb21 (cleanup): {
 -         StorageDead(_13);
 -         goto -> bb24;
-+     bb21: {
-+         goto -> bb12;
-      }
-  
-      bb22 (cleanup): {
--         goto -> bb23;
 +         discriminant((*_36)) = 2;
 +         resume;
       }
   
--     bb23 (cleanup): {
--         StorageDead(_10);
--         goto -> bb24;
-+     bb23: {
+-     bb22 (cleanup): {
+-         goto -> bb23;
++     bb22: {
 +         StorageLive(_5);
 +         StorageLive(_7);
 +         StorageLive(_8);
@@ -375,6 +368,13 @@
 +         StorageLive(_27);
 +         _26 = move _38;
 +         goto -> bb9;
+      }
+  
+-     bb23 (cleanup): {
+-         StorageDead(_10);
+-         goto -> bb24;
++     bb23: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb23, unwind continue];
       }
   
 -     bb24 (cleanup): {
@@ -387,15 +387,13 @@
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb25, unwind terminate(cleanup)];
 +     bb24: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb24, unwind continue];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb24, unwind continue];
       }
   
 -     bb25 (cleanup): {
 -         resume;
-+     bb25: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb25, unwind continue];
-      }
-  
+-     }
+- 
 -     bb26 (cleanup): {
 -         StorageDead(_13);
 -         goto -> bb27;
@@ -410,7 +408,7 @@
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb25, unwind terminate(cleanup)];
-+     bb26: {
++     bb25: {
 +         nop;
 +         (((*_36) as variant#3).0: &u32) = copy ((*_36).0: &u32);
 +         nop;

--- a/tests/mir-opt/coroutine/async_fn.foo-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.foo-{closure#0}.coroutine_drop.0.mir
@@ -72,7 +72,7 @@ fn foo::{closure#0}(_1: &mut {async fn body of foo()}) -> () {
 
     bb0: {
         _35 = discriminant((*_1));
-        switchInt(move _35) -> [0: bb9, 3: bb12, otherwise: bb13];
+        switchInt(move _35) -> [0: bb9, 3: bb10, otherwise: bb11];
     }
 
     bb1: {
@@ -94,7 +94,7 @@ fn foo::{closure#0}(_1: &mut {async fn body of foo()}) -> () {
         StorageDead(_5);
         nop;
         nop;
-        goto -> bb10;
+        goto -> bb4;
     }
 
     bb4: {
@@ -126,18 +126,10 @@ fn foo::{closure#0}(_1: &mut {async fn body of foo()}) -> () {
     }
 
     bb9: {
-        goto -> bb11;
-    }
-
-    bb10: {
-        goto -> bb4;
-    }
-
-    bb11: {
         goto -> bb8;
     }
 
-    bb12: {
+    bb10: {
         StorageLive(_5);
         StorageLive(_7);
         StorageLive(_8);
@@ -147,7 +139,7 @@ fn foo::{closure#0}(_1: &mut {async fn body of foo()}) -> () {
         goto -> bb1;
     }
 
-    bb13: {
+    bb11: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/async_fn.hello_world-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.hello_world-{closure#0}.StateTransform.diff
@@ -95,7 +95,7 @@
 +         _36 = std::future::ResumeTy(move _37);
 +         _35 = copy (_1.0: &mut {async fn body of hello_world()});
 +         _34 = discriminant((*_35));
-+         switchInt(move _34) -> [0: bb33, 1: bb32, 2: bb31, 3: bb30, otherwise: bb8];
++         switchInt(move _34) -> [0: bb32, 1: bb31, 2: bb30, 3: bb29, otherwise: bb8];
       }
   
       bb1: {
@@ -259,7 +259,7 @@
 -         drop(_1) -> [return: bb15, unwind: bb32];
 +         nop;
 +         nop;
-+         goto -> bb28;
++         goto -> bb15;
       }
   
       bb15: {
@@ -396,14 +396,10 @@
   
 -     bb32 (cleanup): {
 +     bb27 (cleanup): {
-+         goto -> bb29;
++         goto -> bb28;
 +     }
 + 
-+     bb28: {
-+         goto -> bb15;
-+     }
-+ 
-+     bb29 (cleanup): {
++     bb28 (cleanup): {
 +         discriminant((*_35)) = 2;
           resume;
       }
@@ -412,7 +408,7 @@
 -         StorageDead(_18);
 -         StorageDead(_10);
 -         goto -> bb34;
-+     bb30: {
++     bb29: {
 +         StorageLive(_5);
 +         StorageLive(_9);
 +         StorageLive(_10);
@@ -435,15 +431,15 @@
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb32, unwind terminate(cleanup)];
++     bb30: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb30, unwind continue];
++     }
++ 
 +     bb31: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb31, unwind continue];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb31, unwind continue];
 +     }
 + 
 +     bb32: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb32, unwind continue];
-+     }
-+ 
-+     bb33: {
 +         nop;
 +         (((*_35) as variant#3).0: [u8; 1]) = [const 0_u8; 1];
 +         nop;

--- a/tests/mir-opt/coroutine/async_fn.hello_world-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.hello_world-{closure#0}.coroutine_drop.0.mir
@@ -54,7 +54,7 @@ fn hello_world::{closure#0}(_1: &mut {async fn body of hello_world()}) -> () {
 
     bb0: {
         _34 = discriminant((*_1));
-        switchInt(move _34) -> [0: bb9, 3: bb12, otherwise: bb13];
+        switchInt(move _34) -> [0: bb9, 3: bb10, otherwise: bb11];
     }
 
     bb1: {
@@ -78,7 +78,7 @@ fn hello_world::{closure#0}(_1: &mut {async fn body of hello_world()}) -> () {
         StorageDead(_5);
         nop;
         nop;
-        goto -> bb10;
+        goto -> bb4;
     }
 
     bb4: {
@@ -112,18 +112,10 @@ fn hello_world::{closure#0}(_1: &mut {async fn body of hello_world()}) -> () {
     }
 
     bb9: {
-        goto -> bb11;
-    }
-
-    bb10: {
-        goto -> bb4;
-    }
-
-    bb11: {
         goto -> bb8;
     }
 
-    bb12: {
+    bb10: {
         StorageLive(_5);
         StorageLive(_9);
         StorageLive(_10);
@@ -135,7 +127,7 @@ fn hello_world::{closure#0}(_1: &mut {async fn body of hello_world()}) -> () {
         goto -> bb1;
     }
 
-    bb13: {
+    bb11: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#0}.StateTransform.diff
@@ -44,7 +44,7 @@
 +         _10 = std::future::ResumeTy(move _11);
 +         _9 = copy (_1.0: &mut {async block@$DIR/async_fn.rs:61:18: 61:23});
 +         _8 = discriminant((*_9));
-+         switchInt(move _8) -> [0: bb5, 1: bb3, otherwise: bb4];
++         switchInt(move _8) -> [0: bb4, 1: bb2, otherwise: bb3];
       }
   
       bb1: {
@@ -56,18 +56,14 @@
 -     bb2 (cleanup): {
 -         resume;
 +     bb2: {
-+         goto -> bb1;
++         assert(const false, "`async fn` resumed after completion") -> [success: bb2, unwind continue];
 +     }
 + 
 +     bb3: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb3, unwind continue];
-+     }
-+ 
-+     bb4: {
 +         unreachable;
 +     }
 + 
-+     bb5: {
++     bb4: {
 +         StorageLive(_3);
 +         _5 = no_retag copy ((*_9).0: &u32);
 +         _3 = copy (*_5);
@@ -77,7 +73,7 @@
 +         _7 = Mul(move _3, move _4);
 +         StorageDead(_4);
 +         StorageDead(_3);
-+         goto -> bb2;
++         goto -> bb1;
       }
   }
   

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#0}.coroutine_drop.0.mir
@@ -14,7 +14,7 @@ fn includes_never::{closure#0}::{closure#0}(_1: &mut {async block@$DIR/async_fn.
 
     bb0: {
         _8 = discriminant((*_1));
-        switchInt(move _8) -> [0: bb2, otherwise: bb4];
+        switchInt(move _8) -> [0: bb2, otherwise: bb3];
     }
 
     bb1: {
@@ -22,14 +22,10 @@ fn includes_never::{closure#0}::{closure#0}(_1: &mut {async block@$DIR/async_fn.
     }
 
     bb2: {
-        goto -> bb3;
-    }
-
-    bb3: {
         goto -> bb1;
     }
 
-    bb4: {
+    bb3: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#1}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#1}.StateTransform.diff
@@ -44,7 +44,7 @@
 +         _10 = std::future::ResumeTy(move _11);
 +         _9 = copy (_1.0: &mut {async block@$DIR/async_fn.rs:67:15: 67:20});
 +         _8 = discriminant((*_9));
-+         switchInt(move _8) -> [0: bb5, 1: bb3, otherwise: bb4];
++         switchInt(move _8) -> [0: bb4, 1: bb2, otherwise: bb3];
       }
   
       bb1: {
@@ -56,18 +56,14 @@
 -     bb2 (cleanup): {
 -         resume;
 +     bb2: {
-+         goto -> bb1;
++         assert(const false, "`async fn` resumed after completion") -> [success: bb2, unwind continue];
 +     }
 + 
 +     bb3: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb3, unwind continue];
-+     }
-+ 
-+     bb4: {
 +         unreachable;
 +     }
 + 
-+     bb5: {
++     bb4: {
 +         StorageLive(_3);
 +         _5 = no_retag copy ((*_9).0: &u32);
 +         _3 = copy (*_5);
@@ -77,7 +73,7 @@
 +         _7 = Add(move _3, move _4);
 +         StorageDead(_4);
 +         StorageDead(_3);
-+         goto -> bb2;
++         goto -> bb1;
       }
   }
   

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#1}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#1}.coroutine_drop.0.mir
@@ -14,7 +14,7 @@ fn includes_never::{closure#0}::{closure#1}(_1: &mut {async block@$DIR/async_fn.
 
     bb0: {
         _8 = discriminant((*_1));
-        switchInt(move _8) -> [0: bb2, otherwise: bb4];
+        switchInt(move _8) -> [0: bb2, otherwise: bb3];
     }
 
     bb1: {
@@ -22,14 +22,10 @@ fn includes_never::{closure#0}::{closure#1}(_1: &mut {async block@$DIR/async_fn.
     }
 
     bb2: {
-        goto -> bb3;
-    }
-
-    bb3: {
         goto -> bb1;
     }
 
-    bb4: {
+    bb3: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}.StateTransform.diff
@@ -125,7 +125,7 @@
 +         _51 = std::future::ResumeTy(move _52);
 +         _50 = copy (_1.0: &mut {async fn body of includes_never()});
 +         _49 = discriminant((*_50));
-+         switchInt(move _49) -> [0: bb30, 1: bb29, 2: bb28, 3: bb27, otherwise: bb6];
++         switchInt(move _49) -> [0: bb29, 1: bb28, 2: bb27, 3: bb26, otherwise: bb6];
       }
   
       bb1: {
@@ -247,7 +247,7 @@
 -         drop(_1) -> [return: bb14, unwind: bb29];
 +         nop;
 +         nop;
-+         goto -> bb25;
++         goto -> bb14;
       }
   
       bb13: {
@@ -345,26 +345,19 @@
       bb24 (cleanup): {
 -         StorageDead(_9);
 -         goto -> bb27;
-+         goto -> bb26;
++         goto -> bb25;
       }
   
--     bb25 (cleanup): {
+      bb25 (cleanup): {
 -         goto -> bb26;
-+     bb25: {
-+         goto -> bb14;
-      }
-  
-      bb26 (cleanup): {
--         StorageDead(_7);
--         goto -> bb27;
 +         discriminant((*_50)) = 2;
 +         resume;
       }
   
--     bb27 (cleanup): {
--         StorageDead(_6);
--         goto -> bb28;
-+     bb27: {
+-     bb26 (cleanup): {
+-         StorageDead(_7);
+-         goto -> bb27;
++     bb26: {
 +         StorageLive(_5);
 +         StorageLive(_6);
 +         StorageLive(_22);
@@ -373,21 +366,26 @@
 +         goto -> bb9;
       }
   
+-     bb27 (cleanup): {
+-         StorageDead(_6);
+-         goto -> bb28;
++     bb27: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb27, unwind continue];
+      }
+  
 -     bb28 (cleanup): {
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb29, unwind terminate(cleanup)];
 +     bb28: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb28, unwind continue];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb28, unwind continue];
       }
   
 -     bb29 (cleanup): {
 -         resume;
-+     bb29: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb29, unwind continue];
-      }
-  
+-     }
+- 
 -     bb30 (cleanup): {
 -         StorageDead(_9);
 -         goto -> bb31;
@@ -399,7 +397,7 @@
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb29, unwind terminate(cleanup)];
-+     bb30: {
++     bb29: {
 +         nop;
 +         (((*_50) as variant#3).0: bool) = copy ((*_50).0: bool);
 +         nop;

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}.coroutine_drop.0.mir
@@ -82,7 +82,7 @@ fn includes_never::{closure#0}(_1: &mut {async fn body of includes_never()}) -> 
 
     bb0: {
         _49 = discriminant((*_1));
-        switchInt(move _49) -> [0: bb9, 3: bb12, otherwise: bb13];
+        switchInt(move _49) -> [0: bb9, 3: bb10, otherwise: bb11];
     }
 
     bb1: {
@@ -101,7 +101,7 @@ fn includes_never::{closure#0}(_1: &mut {async fn body of includes_never()}) -> 
         StorageDead(_5);
         nop;
         nop;
-        goto -> bb10;
+        goto -> bb4;
     }
 
     bb4: {
@@ -130,18 +130,10 @@ fn includes_never::{closure#0}(_1: &mut {async fn body of includes_never()}) -> 
     }
 
     bb9: {
-        goto -> bb11;
-    }
-
-    bb10: {
-        goto -> bb4;
-    }
-
-    bb11: {
         goto -> bb8;
     }
 
-    bb12: {
+    bb10: {
         StorageLive(_5);
         StorageLive(_6);
         StorageLive(_22);
@@ -149,7 +141,7 @@ fn includes_never::{closure#0}(_1: &mut {async fn body of includes_never()}) -> 
         goto -> bb1;
     }
 
-    bb13: {
+    bb11: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}-{closure#0}.StateTransform.diff
@@ -44,7 +44,7 @@
 +         _10 = std::future::ResumeTy(move _11);
 +         _9 = copy (_1.0: &mut {async block@$DIR/async_fn.rs:80:50: 80:55});
 +         _8 = discriminant((*_9));
-+         switchInt(move _8) -> [0: bb5, 1: bb3, otherwise: bb4];
++         switchInt(move _8) -> [0: bb4, 1: bb2, otherwise: bb3];
       }
   
       bb1: {
@@ -56,18 +56,14 @@
 -     bb2 (cleanup): {
 -         resume;
 +     bb2: {
-+         goto -> bb1;
++         assert(const false, "`async fn` resumed after completion") -> [success: bb2, unwind continue];
 +     }
 + 
 +     bb3: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb3, unwind continue];
-+     }
-+ 
-+     bb4: {
 +         unreachable;
 +     }
 + 
-+     bb5: {
++     bb4: {
 +         StorageLive(_3);
 +         _5 = no_retag copy ((*_9).0: &u32);
 +         _3 = copy (*_5);
@@ -77,7 +73,7 @@
 +         _7 = Add(move _3, move _4);
 +         StorageDead(_4);
 +         StorageDead(_3);
-+         goto -> bb2;
++         goto -> bb1;
       }
   }
   

--- a/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}-{closure#0}.coroutine_drop.0.mir
@@ -14,7 +14,7 @@ fn partial_init::{closure#0}::{closure#0}(_1: &mut {async block@$DIR/async_fn.rs
 
     bb0: {
         _8 = discriminant((*_1));
-        switchInt(move _8) -> [0: bb2, otherwise: bb4];
+        switchInt(move _8) -> [0: bb2, otherwise: bb3];
     }
 
     bb1: {
@@ -22,14 +22,10 @@ fn partial_init::{closure#0}::{closure#0}(_1: &mut {async block@$DIR/async_fn.rs
     }
 
     bb2: {
-        goto -> bb3;
-    }
-
-    bb3: {
         goto -> bb1;
     }
 
-    bb4: {
+    bb3: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}.StateTransform.diff
@@ -81,7 +81,7 @@
 +         _29 = std::future::ResumeTy(move _30);
 +         _28 = copy (_1.0: &mut {async fn body of partial_init()});
 +         _27 = discriminant((*_28));
-+         switchInt(move _27) -> [0: bb32, 1: bb31, 2: bb30, 3: bb29, otherwise: bb7];
++         switchInt(move _27) -> [0: bb31, 1: bb30, 2: bb29, 3: bb28, otherwise: bb7];
       }
   
       bb1: {
@@ -211,7 +211,7 @@
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb14, unwind: bb32];
 +         nop;
-+         goto -> bb27;
++         goto -> bb14;
       }
   
       bb14: {
@@ -313,28 +313,20 @@
       }
   
       bb26 (cleanup): {
--         goto -> bb27;
-+         goto -> bb28;
+          goto -> bb27;
       }
   
--     bb27 (cleanup): {
+      bb27 (cleanup): {
 -         StorageDead(_9);
 -         drop(_6) -> [return: bb28, unwind terminate(cleanup)];
-+     bb27: {
-+         goto -> bb14;
-      }
-  
-      bb28 (cleanup): {
--         StorageDead(_6);
--         goto -> bb29;
 +         discriminant((*_28)) = 2;
 +         resume;
       }
   
--     bb29 (cleanup): {
--         StorageDead(_8);
--         goto -> bb31;
-+     bb29: {
+-     bb28 (cleanup): {
+-         StorageDead(_6);
+-         goto -> bb29;
++     bb28: {
 +         StorageLive(_4);
 +         StorageLive(_5);
 +         StorageLive(_8);
@@ -344,11 +336,18 @@
 +         goto -> bb10;
       }
   
+-     bb29 (cleanup): {
+-         StorageDead(_8);
+-         goto -> bb31;
++     bb29: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb29, unwind continue];
+      }
+  
 -     bb30 (cleanup): {
 -         StorageDead(_6);
 -         goto -> bb31;
 +     bb30: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb30, unwind continue];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb30, unwind continue];
       }
   
 -     bb31 (cleanup): {
@@ -356,10 +355,8 @@
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb32, unwind terminate(cleanup)];
-+     bb31: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb31, unwind continue];
-      }
-  
+-     }
+- 
 -     bb32 (cleanup): {
 -         resume;
 -     }
@@ -380,7 +377,7 @@
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb32, unwind terminate(cleanup)];
-+     bb32: {
++     bb31: {
 +         nop;
 +         (((*_28) as variant#3).0: u32) = copy ((*_28).0: u32);
 +         StorageLive(_4);

--- a/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}.coroutine_drop.0.mir
@@ -47,7 +47,7 @@ fn partial_init::{closure#0}(_1: &mut {async fn body of partial_init()}) -> () {
 
     bb0: {
         _27 = discriminant((*_1));
-        switchInt(move _27) -> [0: bb11, 3: bb14, otherwise: bb15];
+        switchInt(move _27) -> [0: bb11, 3: bb12, otherwise: bb13];
     }
 
     bb1: {
@@ -71,7 +71,7 @@ fn partial_init::{closure#0}(_1: &mut {async fn body of partial_init()}) -> () {
         StorageDead(_5);
         StorageDead(_4);
         nop;
-        goto -> bb12;
+        goto -> bb5;
     }
 
     bb5: {
@@ -105,18 +105,10 @@ fn partial_init::{closure#0}(_1: &mut {async fn body of partial_init()}) -> () {
     }
 
     bb11: {
-        goto -> bb13;
-    }
-
-    bb12: {
-        goto -> bb5;
-    }
-
-    bb13: {
         goto -> bb10;
     }
 
-    bb14: {
+    bb12: {
         StorageLive(_4);
         StorageLive(_5);
         StorageLive(_8);
@@ -125,7 +117,7 @@ fn partial_init::{closure#0}(_1: &mut {async fn body of partial_init()}) -> () {
         goto -> bb1;
     }
 
-    bb15: {
+    bb13: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/async_fn.uninhabited_variant-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.uninhabited_variant-{closure#0}.StateTransform.diff
@@ -108,7 +108,7 @@
 +         _47 = std::future::ResumeTy(move _48);
 +         _46 = copy (_1.0: &mut {async fn body of uninhabited_variant()});
 +         _45 = discriminant((*_46));
-+         switchInt(move _45) -> [0: bb56, 1: bb55, 2: bb54, 3: bb52, 4: bb53, otherwise: bb1];
++         switchInt(move _45) -> [0: bb55, 1: bb54, 2: bb53, 3: bb51, 4: bb52, otherwise: bb1];
       }
   
       bb1: {
@@ -367,7 +367,7 @@
 -         drop(_1) -> [return: bb27, unwind: bb56];
 +         (((*_46) as variant#4).2: bool) = const false;
 +         nop;
-+         goto -> bb50;
++         goto -> bb27;
       }
   
       bb27: {
@@ -572,7 +572,7 @@
 -     bb56 (cleanup): {
 -         resume;
 +     bb45 (cleanup): {
-+         goto -> bb51;
++         goto -> bb50;
       }
   
 -     bb57 (cleanup): {
@@ -609,22 +609,16 @@
 -     bb61 (cleanup): {
 -         StorageDead(_4);
 -         goto -> bb70;
-+     bb50: {
-+         goto -> bb27;
++     bb50 (cleanup): {
++         discriminant((*_46)) = 2;
++         resume;
       }
   
 -     bb62 (cleanup): {
 -         _43 = const false;
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb56, unwind terminate(cleanup)];
-+     bb51 (cleanup): {
-+         discriminant((*_46)) = 2;
-+         resume;
-      }
-  
--     bb63: {
--         drop(_3) -> [return: bb26, unwind: bb55];
-+     bb52: {
++     bb51: {
 +         StorageLive(_4);
 +         StorageLive(_6);
 +         StorageLive(_7);
@@ -634,9 +628,9 @@
 +         goto -> bb11;
       }
   
--     bb64: {
--         switchInt(copy _43) -> [0: bb26, otherwise: bb63];
-+     bb53: {
+-     bb63: {
+-         drop(_3) -> [return: bb26, unwind: bb55];
++     bb52: {
 +         StorageLive(_4);
 +         StorageLive(_24);
 +         StorageLive(_25);
@@ -647,18 +641,22 @@
 +         goto -> bb22;
       }
   
+-     bb64: {
+-         switchInt(copy _43) -> [0: bb26, otherwise: bb63];
++     bb53: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb53, unwind continue];
+      }
+  
 -     bb65: {
 -         drop(_3) -> [return: bb35, unwind: bb62];
 +     bb54: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb54, unwind continue];
++         assert(const false, "`async fn` resumed after completion") -> [success: bb54, unwind continue];
       }
   
 -     bb66: {
 -         switchInt(copy _43) -> [0: bb35, otherwise: bb65];
-+     bb55: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb55, unwind continue];
-      }
-  
+-     }
+- 
 -     bb67 (cleanup): {
 -         drop(_3) -> [return: bb55, unwind terminate(cleanup)];
 -     }
@@ -673,7 +671,7 @@
 - 
 -     bb70 (cleanup): {
 -         switchInt(copy _43) -> [0: bb62, otherwise: bb69];
-+     bb56: {
++     bb55: {
 +         (((*_46) as variant#4).2: bool) = const false;
 +         nop;
 +         (((*_46) as variant#4).2: bool) = const true;

--- a/tests/mir-opt/coroutine/async_fn.uninhabited_variant-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.uninhabited_variant-{closure#0}.coroutine_drop.0.mir
@@ -68,7 +68,7 @@ fn uninhabited_variant::{closure#0}(_1: &mut {async fn body of uninhabited_varia
 
     bb0: {
         _45 = discriminant((*_1));
-        switchInt(move _45) -> [0: bb22, 3: bb25, 4: bb26, otherwise: bb27];
+        switchInt(move _45) -> [0: bb22, 3: bb23, 4: bb24, otherwise: bb25];
     }
 
     bb1: {
@@ -114,7 +114,7 @@ fn uninhabited_variant::{closure#0}(_1: &mut {async fn body of uninhabited_varia
     bb8: {
         (((*_1) as variant#4).2: bool) = const false;
         nop;
-        goto -> bb23;
+        goto -> bb9;
     }
 
     bb9: {
@@ -180,18 +180,10 @@ fn uninhabited_variant::{closure#0}(_1: &mut {async fn body of uninhabited_varia
     }
 
     bb22: {
-        goto -> bb24;
-    }
-
-    bb23: {
-        goto -> bb9;
-    }
-
-    bb24: {
         goto -> bb21;
     }
 
-    bb25: {
+    bb23: {
         StorageLive(_4);
         StorageLive(_6);
         StorageLive(_7);
@@ -200,7 +192,7 @@ fn uninhabited_variant::{closure#0}(_1: &mut {async fn body of uninhabited_varia
         goto -> bb4;
     }
 
-    bb26: {
+    bb24: {
         StorageLive(_4);
         StorageLive(_24);
         StorageLive(_25);
@@ -210,7 +202,7 @@ fn uninhabited_variant::{closure#0}(_1: &mut {async fn body of uninhabited_varia
         goto -> bb1;
     }
 
-    bb27: {
+    bb25: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/coroutine.main-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/coroutine.main-{closure#0}.StateTransform.diff
@@ -47,7 +47,7 @@
 -         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb31];
 +         _18 = copy (_1.0: &mut {coroutine@$DIR/coroutine.rs:19:5: 19:18});
 +         _17 = discriminant((*_18));
-+         switchInt(move _17) -> [0: bb36, 1: bb34, 2: bb33, 3: bb31, 4: bb32, otherwise: bb35];
++         switchInt(move _17) -> [0: bb35, 1: bb33, 2: bb32, 3: bb30, 4: bb31, otherwise: bb34];
       }
   
       bb1: {
@@ -149,7 +149,7 @@
   
       bb13: {
 -         drop(_1) -> [return: bb14, unwind: bb37];
-+         goto -> bb29;
++         goto -> bb14;
       }
   
       bb14: {
@@ -261,39 +261,31 @@
 -         StorageDead(_12);
 -         StorageDead(_10);
 -         StorageDead(_9);
--         goto -> bb29;
-+         goto -> bb30;
+          goto -> bb29;
       }
   
--     bb29 (cleanup): {
+      bb29 (cleanup): {
 -         StorageDead(_11);
 -         StorageDead(_8);
 -         goto -> bb35;
-+     bb29: {
-+         goto -> bb14;
-      }
-  
-      bb30 (cleanup): {
--         StorageDead(_7);
--         drop(_5) -> [return: bb32, unwind terminate(cleanup)];
 +         discriminant((*_18)) = 2;
 +         resume;
       }
   
--     bb31 (cleanup): {
--         StorageDead(_6);
--         goto -> bb32;
-+     bb31: {
+-     bb30 (cleanup): {
+-         StorageDead(_7);
+-         drop(_5) -> [return: bb32, unwind terminate(cleanup)];
++     bb30: {
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         _3 = move _2;
 +         goto -> bb4;
       }
   
--     bb32 (cleanup): {
--         StorageDead(_5);
--         goto -> bb33;
-+     bb32: {
+-     bb31 (cleanup): {
+-         StorageDead(_6);
+-         goto -> bb32;
++     bb31: {
 +         StorageLive(_8);
 +         StorageLive(_9);
 +         StorageLive(_11);
@@ -302,26 +294,31 @@
 +         goto -> bb10;
       }
   
+-     bb32 (cleanup): {
+-         StorageDead(_5);
+-         goto -> bb33;
++     bb32: {
++         assert(const false, "coroutine resumed after panicking") -> [success: bb32, unwind continue];
+      }
+  
 -     bb33 (cleanup): {
 -         StorageDead(_4);
 -         goto -> bb34;
 +     bb33: {
-+         assert(const false, "coroutine resumed after panicking") -> [success: bb33, unwind continue];
++         assert(const false, "coroutine resumed after completion") -> [success: bb33, unwind continue];
       }
   
 -     bb34 (cleanup): {
 -         StorageDead(_3);
 -         goto -> bb35;
 +     bb34: {
-+         assert(const false, "coroutine resumed after completion") -> [success: bb34, unwind continue];
++         unreachable;
       }
   
 -     bb35 (cleanup): {
 -         drop(_2) -> [return: bb36, unwind terminate(cleanup)];
-+     bb35: {
-+         unreachable;
-      }
-  
+-     }
+- 
 -     bb36 (cleanup): {
 -         drop(_1) -> [return: bb37, unwind terminate(cleanup)];
 -     }
@@ -332,7 +329,7 @@
 - 
 -     bb38 (cleanup): {
 -         drop(_1) -> [return: bb37, unwind terminate(cleanup)];
-+     bb36: {
++     bb35: {
 +         (((*_18) as variant#4).0: std::string::String) = move _2;
 +         StorageLive(_3);
 +         StorageLive(_4);

--- a/tests/mir-opt/coroutine/coroutine.main-{closure#1}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/coroutine.main-{closure#1}.StateTransform.diff
@@ -47,7 +47,7 @@
 -         _5 = <String as Clone>::clone(move _6) -> [return: bb1, unwind: bb31];
 +         _18 = copy (_1.0: &mut {coroutine@$DIR/coroutine.rs:26:5: 26:18});
 +         _17 = discriminant((*_18));
-+         switchInt(move _17) -> [0: bb36, 1: bb34, 2: bb33, 3: bb31, 4: bb32, otherwise: bb35];
++         switchInt(move _17) -> [0: bb35, 1: bb33, 2: bb32, 3: bb30, 4: bb31, otherwise: bb34];
       }
   
       bb1: {
@@ -149,7 +149,7 @@
   
       bb13: {
 -         drop(_1) -> [return: bb14, unwind: bb37];
-+         goto -> bb29;
++         goto -> bb14;
       }
   
       bb14: {
@@ -261,39 +261,31 @@
 -         StorageDead(_12);
 -         StorageDead(_10);
 -         StorageDead(_9);
--         goto -> bb29;
-+         goto -> bb30;
+          goto -> bb29;
       }
   
--     bb29 (cleanup): {
+      bb29 (cleanup): {
 -         StorageDead(_11);
 -         StorageDead(_8);
 -         goto -> bb35;
-+     bb29: {
-+         goto -> bb14;
-      }
-  
-      bb30 (cleanup): {
--         StorageDead(_7);
--         drop(_5) -> [return: bb32, unwind terminate(cleanup)];
 +         discriminant((*_18)) = 2;
 +         resume;
       }
   
--     bb31 (cleanup): {
--         StorageDead(_6);
--         goto -> bb32;
-+     bb31: {
+-     bb30 (cleanup): {
+-         StorageDead(_7);
+-         drop(_5) -> [return: bb32, unwind terminate(cleanup)];
++     bb30: {
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         _3 = move _2;
 +         goto -> bb4;
       }
   
--     bb32 (cleanup): {
--         StorageDead(_5);
--         goto -> bb33;
-+     bb32: {
+-     bb31 (cleanup): {
+-         StorageDead(_6);
+-         goto -> bb32;
++     bb31: {
 +         StorageLive(_8);
 +         StorageLive(_9);
 +         StorageLive(_11);
@@ -302,26 +294,31 @@
 +         goto -> bb10;
       }
   
+-     bb32 (cleanup): {
+-         StorageDead(_5);
+-         goto -> bb33;
++     bb32: {
++         assert(const false, "coroutine resumed after panicking") -> [success: bb32, unwind continue];
+      }
+  
 -     bb33 (cleanup): {
 -         StorageDead(_4);
 -         goto -> bb34;
 +     bb33: {
-+         assert(const false, "coroutine resumed after panicking") -> [success: bb33, unwind continue];
++         assert(const false, "coroutine resumed after completion") -> [success: bb33, unwind continue];
       }
   
 -     bb34 (cleanup): {
 -         StorageDead(_3);
 -         goto -> bb35;
 +     bb34: {
-+         assert(const false, "coroutine resumed after completion") -> [success: bb34, unwind continue];
++         unreachable;
       }
   
 -     bb35 (cleanup): {
 -         drop(_2) -> [return: bb36, unwind terminate(cleanup)];
-+     bb35: {
-+         unreachable;
-      }
-  
+-     }
+- 
 -     bb36 (cleanup): {
 -         drop(_1) -> [return: bb37, unwind terminate(cleanup)];
 -     }
@@ -332,7 +329,7 @@
 - 
 -     bb38 (cleanup): {
 -         drop(_1) -> [return: bb37, unwind terminate(cleanup)];
-+     bb36: {
++     bb35: {
 +         (((*_18) as variant#4).0: std::string::String) = move _2;
 +         StorageLive(_3);
 +         StorageLive(_4);

--- a/tests/mir-opt/coroutine/coroutine_drop_cleanup.main-{closure#0}.coroutine_drop.0.panic-abort.mir
+++ b/tests/mir-opt/coroutine/coroutine_drop_cleanup.main-{closure#0}.coroutine_drop.0.panic-abort.mir
@@ -14,7 +14,7 @@ fn main::{closure#0}(_1: &mut {coroutine@$DIR/coroutine_drop_cleanup.rs:12:5: 12
 
     bb0: {
         _7 = discriminant((*_1));
-        switchInt(move _7) -> [0: bb5, 3: bb8, otherwise: bb9];
+        switchInt(move _7) -> [0: bb5, 3: bb6, otherwise: bb7];
     }
 
     bb1: {
@@ -25,7 +25,7 @@ fn main::{closure#0}(_1: &mut {coroutine@$DIR/coroutine_drop_cleanup.rs:12:5: 12
 
     bb2: {
         nop;
-        goto -> bb6;
+        goto -> bb3;
     }
 
     bb3: {
@@ -37,24 +37,16 @@ fn main::{closure#0}(_1: &mut {coroutine@$DIR/coroutine_drop_cleanup.rs:12:5: 12
     }
 
     bb5: {
-        goto -> bb7;
-    }
-
-    bb6: {
-        goto -> bb3;
-    }
-
-    bb7: {
         goto -> bb4;
     }
 
-    bb8: {
+    bb6: {
         StorageLive(_4);
         StorageLive(_5);
         goto -> bb1;
     }
 
-    bb9: {
+    bb7: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/coroutine_drop_cleanup.main-{closure#0}.coroutine_drop.0.panic-unwind.mir
+++ b/tests/mir-opt/coroutine/coroutine_drop_cleanup.main-{closure#0}.coroutine_drop.0.panic-unwind.mir
@@ -14,7 +14,7 @@ fn main::{closure#0}(_1: &mut {coroutine@$DIR/coroutine_drop_cleanup.rs:12:5: 12
 
     bb0: {
         _7 = discriminant((*_1));
-        switchInt(move _7) -> [0: bb7, 3: bb10, otherwise: bb11];
+        switchInt(move _7) -> [0: bb7, 3: bb8, otherwise: bb9];
     }
 
     bb1: {
@@ -25,7 +25,7 @@ fn main::{closure#0}(_1: &mut {coroutine@$DIR/coroutine_drop_cleanup.rs:12:5: 12
 
     bb2: {
         nop;
-        goto -> bb8;
+        goto -> bb3;
     }
 
     bb3: {
@@ -46,24 +46,16 @@ fn main::{closure#0}(_1: &mut {coroutine@$DIR/coroutine_drop_cleanup.rs:12:5: 12
     }
 
     bb7: {
-        goto -> bb9;
-    }
-
-    bb8: {
-        goto -> bb3;
-    }
-
-    bb9: {
         goto -> bb6;
     }
 
-    bb10: {
+    bb8: {
         StorageLive(_4);
         StorageLive(_5);
         goto -> bb1;
     }
 
-    bb11: {
+    bb9: {
         return;
     }
 }

--- a/tests/mir-opt/coroutine/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.panic-abort.diff
+++ b/tests/mir-opt/coroutine/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.panic-abort.diff
@@ -51,7 +51,7 @@
 -         _5 = yield(move _6) -> [resume: bb1, drop: bb6];
 +         _13 = copy (_1.0: &mut {coroutine@$DIR/coroutine_storage_dead_unwind.rs:24:5: 24:7});
 +         _12 = discriminant((*_13));
-+         switchInt(move _12) -> [0: bb10, 1: bb8, 3: bb7, otherwise: bb9];
++         switchInt(move _12) -> [0: bb9, 1: bb7, 3: bb6, otherwise: bb8];
       }
   
       bb1: {
@@ -88,7 +88,7 @@
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb5, unwind unreachable];
 +         nop;
-+         goto -> bb6;
++         goto -> bb5;
       }
   
       bb5: {
@@ -102,28 +102,24 @@
 -         StorageDead(_5);
 -         StorageDead(_4);
 -         drop(_3) -> [return: bb7, unwind unreachable];
-+         goto -> bb5;
-      }
-  
-      bb7: {
--         StorageDead(_3);
--         drop(_1) -> [return: bb8, unwind unreachable];
 +         StorageLive(_5);
 +         StorageLive(_6);
 +         _5 = move _2;
 +         goto -> bb1;
       }
   
+      bb7: {
+-         StorageDead(_3);
+-         drop(_1) -> [return: bb8, unwind unreachable];
++         assert(const false, "coroutine resumed after completion") -> [success: bb7, unwind unreachable];
+      }
+  
       bb8: {
 -         coroutine_drop;
-+         assert(const false, "coroutine resumed after completion") -> [success: bb8, unwind unreachable];
-+     }
-+ 
-+     bb9: {
 +         unreachable;
 +     }
 + 
-+     bb10: {
++     bb9: {
 +         nop;
 +         (((*_13) as variant#3).0: Foo) = Foo(const 5_i32);
 +         nop;

--- a/tests/mir-opt/coroutine/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.panic-unwind.diff
+++ b/tests/mir-opt/coroutine/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.panic-unwind.diff
@@ -51,7 +51,7 @@
 -         _5 = yield(move _6) -> [resume: bb1, drop: bb6];
 +         _13 = copy (_1.0: &mut {coroutine@$DIR/coroutine_storage_dead_unwind.rs:24:5: 24:7});
 +         _12 = discriminant((*_13));
-+         switchInt(move _12) -> [0: bb18, 1: bb16, 2: bb15, 3: bb14, otherwise: bb17];
++         switchInt(move _12) -> [0: bb17, 1: bb15, 2: bb14, 3: bb13, otherwise: bb16];
       }
   
       bb1: {
@@ -90,7 +90,7 @@
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb5, unwind: bb14];
 +         nop;
-+         goto -> bb12;
++         goto -> bb5;
       }
   
       bb5: {
@@ -141,49 +141,44 @@
       bb11 (cleanup): {
 -         StorageDead(_8);
 -         StorageDead(_7);
--         goto -> bb12;
-+         goto -> bb13;
+          goto -> bb12;
       }
   
--     bb12 (cleanup): {
+      bb12 (cleanup): {
 -         StorageDead(_4);
 -         goto -> bb13;
-+     bb12: {
-+         goto -> bb5;
-      }
-  
-      bb13 (cleanup): {
--         StorageDead(_3);
--         drop(_1) -> [return: bb14, unwind terminate(cleanup)];
 +         discriminant((*_13)) = 2;
 +         resume;
       }
   
--     bb14 (cleanup): {
--         resume;
-+     bb14: {
+-     bb13 (cleanup): {
+-         StorageDead(_3);
+-         drop(_1) -> [return: bb14, unwind terminate(cleanup)];
++     bb13: {
 +         StorageLive(_5);
 +         StorageLive(_6);
 +         _5 = move _2;
 +         goto -> bb1;
       }
   
+-     bb14 (cleanup): {
+-         resume;
++     bb14: {
++         assert(const false, "coroutine resumed after panicking") -> [success: bb14, unwind continue];
+      }
+  
 -     bb15 (cleanup): {
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb14, unwind terminate(cleanup)];
 +     bb15: {
-+         assert(const false, "coroutine resumed after panicking") -> [success: bb15, unwind continue];
++         assert(const false, "coroutine resumed after completion") -> [success: bb15, unwind continue];
 +     }
 + 
 +     bb16: {
-+         assert(const false, "coroutine resumed after completion") -> [success: bb16, unwind continue];
-+     }
-+ 
-+     bb17: {
 +         unreachable;
 +     }
 + 
-+     bb18: {
++     bb17: {
 +         nop;
 +         (((*_13) as variant#3).0: Foo) = Foo(const 5_i32);
 +         nop;

--- a/tests/mir-opt/early_otherwise_branch_unwind.poll.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_unwind.poll.EarlyOtherwiseBranch.diff
@@ -69,12 +69,12 @@
           goto -> bb15;
       }
   
-      bb9 (cleanup): {
-          resume;
+      bb9: {
+          return;
       }
   
-      bb10: {
-          return;
+      bb10 (cleanup): {
+          resume;
       }
   
       bb11: {
@@ -83,7 +83,7 @@
   
       bb12: {
           _7 = const false;
-          goto -> bb10;
+          goto -> bb9;
       }
   
       bb13: {
@@ -96,15 +96,15 @@
       }
   
       bb15: {
-          switchInt(copy _4) -> [0: bb11, otherwise: bb10];
+          switchInt(copy _4) -> [0: bb11, otherwise: bb9];
       }
   
       bb16 (cleanup): {
-          goto -> bb9;
+          goto -> bb10;
       }
   
       bb17 (cleanup): {
-          switchInt(copy _4) -> [0: bb16, otherwise: bb9];
+          switchInt(copy _4) -> [0: bb16, otherwise: bb10];
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch_unwind.unwind.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_unwind.unwind.EarlyOtherwiseBranch.diff
@@ -62,12 +62,12 @@
           goto -> bb15;
       }
   
-      bb9 (cleanup): {
-          resume;
+      bb9: {
+          return;
       }
   
-      bb10: {
-          return;
+      bb10 (cleanup): {
+          resume;
       }
   
       bb11: {
@@ -76,7 +76,7 @@
   
       bb12: {
           _6 = const false;
-          goto -> bb10;
+          goto -> bb9;
       }
   
       bb13: {
@@ -89,15 +89,15 @@
       }
   
       bb15: {
-          switchInt(copy _4) -> [1: bb11, otherwise: bb10];
+          switchInt(copy _4) -> [1: bb11, otherwise: bb9];
       }
   
       bb16 (cleanup): {
-          goto -> bb9;
+          goto -> bb10;
       }
   
       bb17 (cleanup): {
-          switchInt(copy _4) -> [1: bb16, otherwise: bb9];
+          switchInt(copy _4) -> [1: bb16, otherwise: bb10];
       }
   }
   

--- a/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-abort.diff
@@ -363,44 +363,44 @@
       }
   
       bb11: {
-          _0 = const 3_u8;
-          goto -> bb14;
-      }
-  
-      bb12: {
-          _0 = const 2_u8;
-          goto -> bb14;
-      }
-  
-      bb13: {
-          _0 = const 1_u8;
-          goto -> bb14;
-      }
-  
-      bb14: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb15: {
           _22 = const false;
           _23 = const false;
           StorageDead(_2);
           _19 = discriminant(_1);
-          switchInt(move _19) -> [0: bb13, 1: bb12, 2: bb11, otherwise: bb2];
+          switchInt(move _19) -> [0: bb14, 1: bb13, 2: bb12, otherwise: bb2];
+      }
+  
+      bb12: {
+          _0 = const 3_u8;
+          goto -> bb15;
+      }
+  
+      bb13: {
+          _0 = const 2_u8;
+          goto -> bb15;
+      }
+  
+      bb14: {
+          _0 = const 1_u8;
+          goto -> bb15;
+      }
+  
+      bb15: {
+          StorageDead(_1);
+          return;
       }
   
       bb16: {
-          switchInt(copy _23) -> [0: bb15, otherwise: bb17];
+          switchInt(copy _23) -> [0: bb11, otherwise: bb17];
       }
   
       bb17: {
-          drop(((_2 as Some).0: std::string::String)) -> [return: bb15, unwind unreachable];
+          drop(((_2 as Some).0: std::string::String)) -> [return: bb11, unwind unreachable];
       }
   
       bb18: {
           _24 = discriminant(_2);
-          switchInt(move _24) -> [1: bb16, otherwise: bb15];
+          switchInt(move _24) -> [1: bb16, otherwise: bb11];
       }
   
       bb19: {
@@ -489,16 +489,16 @@
 + 
 +     bb27: {
 +         _24 = discriminant(_2);
-+         switchInt(move _24) -> [1: bb28, otherwise: bb15];
++         switchInt(move _24) -> [1: bb28, otherwise: bb11];
 +     }
 + 
 +     bb28: {
-+         goto -> bb15;
++         goto -> bb11;
 +     }
 + 
 +     bb29: {
 +         _24 = discriminant(_2);
-+         switchInt(move _24) -> [1: bb30, otherwise: bb15];
++         switchInt(move _24) -> [1: bb30, otherwise: bb11];
 +     }
 + 
 +     bb30: {

--- a/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.chained_conditions.JumpThreading.panic-unwind.diff
@@ -363,61 +363,61 @@
       }
   
       bb11: {
-          _0 = const 3_u8;
-          goto -> bb14;
-      }
-  
-      bb12: {
-          _0 = const 2_u8;
-          goto -> bb14;
-      }
-  
-      bb13: {
-          _0 = const 1_u8;
-          goto -> bb14;
-      }
-  
-      bb14: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb15 (cleanup): {
-          resume;
-      }
-  
-      bb16: {
           _22 = const false;
           _23 = const false;
           StorageDead(_2);
           _19 = discriminant(_1);
-          switchInt(move _19) -> [0: bb13, 1: bb12, 2: bb11, otherwise: bb2];
+          switchInt(move _19) -> [0: bb14, 1: bb13, 2: bb12, otherwise: bb2];
+      }
+  
+      bb12: {
+          _0 = const 3_u8;
+          goto -> bb15;
+      }
+  
+      bb13: {
+          _0 = const 2_u8;
+          goto -> bb15;
+      }
+  
+      bb14: {
+          _0 = const 1_u8;
+          goto -> bb15;
+      }
+  
+      bb15: {
+          StorageDead(_1);
+          return;
+      }
+  
+      bb16 (cleanup): {
+          resume;
       }
   
       bb17: {
-          switchInt(copy _23) -> [0: bb16, otherwise: bb18];
+          switchInt(copy _23) -> [0: bb11, otherwise: bb18];
       }
   
       bb18: {
-          drop(((_2 as Some).0: std::string::String)) -> [return: bb16, unwind: bb15];
+          drop(((_2 as Some).0: std::string::String)) -> [return: bb11, unwind: bb16];
       }
   
       bb19: {
           _24 = discriminant(_2);
-          switchInt(move _24) -> [1: bb17, otherwise: bb16];
+          switchInt(move _24) -> [1: bb17, otherwise: bb11];
       }
   
       bb20 (cleanup): {
-          switchInt(copy _23) -> [0: bb15, otherwise: bb21];
+          switchInt(copy _23) -> [0: bb16, otherwise: bb21];
       }
   
       bb21 (cleanup): {
-          drop(((_2 as Some).0: std::string::String)) -> [return: bb15, unwind terminate(cleanup)];
+          drop(((_2 as Some).0: std::string::String)) -> [return: bb16, unwind terminate(cleanup)];
       }
   
       bb22 (cleanup): {
           _26 = discriminant(_2);
-          switchInt(move _26) -> [1: bb20, otherwise: bb15];
+          switchInt(move _26) -> [1: bb20, otherwise: bb16];
       }
   
       bb23: {
@@ -506,16 +506,16 @@
 + 
 +     bb31: {
 +         _24 = discriminant(_2);
-+         switchInt(move _24) -> [1: bb32, otherwise: bb16];
++         switchInt(move _24) -> [1: bb32, otherwise: bb11];
 +     }
 + 
 +     bb32: {
-+         goto -> bb16;
++         goto -> bb11;
 +     }
 + 
 +     bb33: {
 +         _24 = discriminant(_2);
-+         switchInt(move _24) -> [1: bb34, otherwise: bb16];
++         switchInt(move _24) -> [1: bb34, otherwise: bb11];
 +     }
 + 
 +     bb34: {

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -226,7 +226,7 @@
 -     bb22: {
 -         drop(_2) -> [return: bb24, unwind: bb26];
 +     bb19: {
-+         goto -> bb24;
++         goto -> bb21;
       }
   
 -     bb23: {
@@ -251,10 +251,6 @@
 -     bb26 (cleanup): {
 +     bb23 (cleanup): {
           resume;
-+     }
-+ 
-+     bb24: {
-+         goto -> bb21;
       }
   }
   

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -226,7 +226,7 @@
 -     bb22: {
 -         drop(_2) -> [return: bb24, unwind: bb26];
 +     bb19: {
-+         goto -> bb24;
++         goto -> bb21;
       }
   
 -     bb23: {
@@ -251,10 +251,6 @@
 -     bb26 (cleanup): {
 +     bb23 (cleanup): {
           resume;
-+     }
-+ 
-+     bb24: {
-+         goto -> bb21;
       }
   }
   

--- a/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
+++ b/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
@@ -48,7 +48,7 @@
   
       bb5: {
 -         drop(_1) -> [return: bb6, unwind: bb9];
-+         goto -> bb10;
++         goto -> bb6;
       }
   
       bb6: {
@@ -67,10 +67,6 @@
   
       bb9 (cleanup): {
           resume;
-+     }
-+ 
-+     bb10: {
-+         goto -> bb6;
       }
   }
   

--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_glue.[String].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_glue.[String].AddMovesForPackedDrops.before.mir
@@ -10,7 +10,7 @@ fn std::ptr::drop_glue(_1: &mut [String]) -> () {
     let mut _7: bool;
 
     bb0: {
-        goto -> bb8;
+        goto -> bb7;
     }
 
     bb1: {
@@ -47,9 +47,5 @@ fn std::ptr::drop_glue(_1: &mut [String]) -> () {
         _2 = PtrMetadata(copy _1);
         _3 = const 0_usize;
         goto -> bb6;
-    }
-
-    bb8: {
-        goto -> bb7;
     }
 }

--- a/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-abort.mir
+++ b/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-abort.mir
@@ -70,7 +70,7 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb7: {
-        goto -> bb15;
+        goto -> bb8;
     }
 
     bb8: {
@@ -103,9 +103,5 @@ fn method_1(_1: Guard) -> () {
 
     bb14 (cleanup): {
         resume;
-    }
-
-    bb15: {
-        goto -> bb8;
     }
 }

--- a/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-unwind.mir
+++ b/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-unwind.mir
@@ -70,7 +70,7 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb7: {
-        goto -> bb15;
+        goto -> bb8;
     }
 
     bb8: {
@@ -103,9 +103,5 @@ fn method_1(_1: Guard) -> () {
 
     bb14 (cleanup): {
         resume;
-    }
-
-    bb15: {
-        goto -> bb8;
     }
 }

--- a/tests/mir-opt/unusual_item_types.core.ptr-drop_glue.Vec_i32_.AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/unusual_item_types.core.ptr-drop_glue.Vec_i32_.AddMovesForPackedDrops.before.mir
@@ -6,7 +6,7 @@ fn std::ptr::drop_glue(_1: &mut Vec<i32>) -> () {
     let mut _3: ();
 
     bb0: {
-        goto -> bb6;
+        goto -> bb5;
     }
 
     bb1: {
@@ -17,20 +17,16 @@ fn std::ptr::drop_glue(_1: &mut Vec<i32>) -> () {
         resume;
     }
 
-    bb3: {
-        goto -> bb1;
-    }
-
-    bb4 (cleanup): {
+    bb3 (cleanup): {
         drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb2, unwind terminate(cleanup)];
     }
 
-    bb5: {
-        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb3, unwind: bb2];
+    bb4: {
+        drop(((*_1).0: alloc::raw_vec::RawVec<i32>)) -> [return: bb1, unwind: bb2];
     }
 
-    bb6: {
+    bb5: {
         _2 = &mut (*_1);
-        _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb5, unwind: bb4];
+        _3 = <Vec<i32> as Drop>::drop(move _2) -> [return: bb4, unwind: bb3];
     }
 }

--- a/tests/run-make/repr128-dwarf/rmake.rs
+++ b/tests/run-make/repr128-dwarf/rmake.rs
@@ -59,21 +59,17 @@ fn main() {
         let unit = dwarf.unit(header).unwrap();
         let mut cursor = unit.entries();
 
-        let get_name = |entry: &DebuggingInformationEntry<'_, '_, _>| {
+        let get_name = |entry: &DebuggingInformationEntry<_>| {
             let name = dwarf
-                .attr_string(
-                    &unit,
-                    entry.attr(gimli::constants::DW_AT_name).unwrap().unwrap().value(),
-                )
+                .attr_string(&unit, entry.attr(gimli::constants::DW_AT_name).unwrap().value())
                 .unwrap();
             name.to_string().unwrap().to_string()
         };
 
-        while let Some((_, entry)) = cursor.next_dfs().unwrap() {
+        while let Some(entry) = cursor.next_dfs().unwrap() {
             match entry.tag() {
                 gimli::constants::DW_TAG_variant => {
-                    let Some(value) = entry.attr(gimli::constants::DW_AT_discr_value).unwrap()
-                    else {
+                    let Some(value) = entry.attr(gimli::constants::DW_AT_discr_value) else {
                         // `std` enums might have variants without `DW_AT_discr_value`.
                         continue;
                     };
@@ -84,9 +80,11 @@ fn main() {
                     };
                     // The `DW_TAG_member` that is a child of `DW_TAG_variant` will contain the
                     // variant's name.
-                    let Some((1, child_entry)) = cursor.next_dfs().unwrap() else {
+                    let entry_depth = entry.depth;
+                    let Some(child_entry) = cursor.next_dfs().unwrap() else {
                         panic!("Missing child of DW_TAG_variant");
                     };
+                    assert_eq!(child_entry.depth, entry_depth + 1);
                     assert_eq!(child_entry.tag(), gimli::constants::DW_TAG_member);
                     let name = get_name(child_entry);
                     if let Some(expected) = variants_to_find.remove(name.as_str()) {
@@ -99,12 +97,7 @@ fn main() {
                 gimli::constants::DW_TAG_enumerator => {
                     let name = get_name(entry);
                     if let Some(expected) = enumerators_to_find.remove(name.as_str()) {
-                        match entry
-                            .attr(gimli::constants::DW_AT_const_value)
-                            .unwrap()
-                            .unwrap()
-                            .value()
-                        {
+                        match entry.attr(gimli::constants::DW_AT_const_value).unwrap().value() {
                             AttributeValue::Block(value) => {
                                 // This test uses LE byte order is used for consistent values across
                                 // architectures.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1689,6 +1689,7 @@ dep-bumps = [
 ]
 
 [assign.owners]
+"/.github/renovate.json5" =                              ["infra-ci"]
 "/.github/workflows" =                                   ["infra-ci"]
 "/Cargo.lock" =                                          ["@Mark-Simulacrum"]
 "/Cargo.toml" =                                          ["@Mark-Simulacrum"]


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#159195 (Drop elaboration: Only create a reset block if there are flags to reset.)
 - rust-lang/rust#160318 (Bump thorin-dwp (0.10), gimli (0.33), and object (0.38.1))
 - rust-lang/rust#160385 (Assign ownership for Renovate configuration file)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=159195,160318,160385)
<!-- homu-ignore:end -->

