### PR TITLE
rustc_abi: Add `LayoutData::is_variant_uninhabited` method

### DIFF
--- a/compiler/rustc_abi/src/layout/ty.rs
+++ b/compiler/rustc_abi/src/layout/ty.rs
@@ -126,6 +126,13 @@ pub trait TyAbiInterface<'a, C>: Sized + std::fmt::Debug + std::fmt::Display {
 }
 
 impl<'a, Ty> TyAndLayout<'a, Ty> {
+    /// Synthetize a layout representing the variant-specific fields of an enum-like layout.
+    ///
+    /// Note that the resulting layout *does not* fully describes `self.ty` at that specific
+    /// variant: prefix fields (e.g. in coroutines) and tag information are lost.
+    ///
+    /// If you don't need type information about the variant's fields, prefer using
+    /// `self.layout.variants` directly.
     pub fn for_variant<C>(self, cx: &C, variant_index: VariantIdx) -> Self
     where
         Ty: TyAbiInterface<'a, C>,

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -2203,6 +2203,17 @@ impl<FieldIdx: Idx, VariantIdx: Idx> LayoutData<FieldIdx, VariantIdx> {
     pub fn is_uninhabited(&self) -> bool {
         self.uninhabited
     }
+
+    /// Returns `true` if the given variant is uninhabited.
+    pub fn is_variant_uninhabited(&self, variant: VariantIdx) -> bool {
+        match self.variants {
+            Variants::Empty => true,
+            Variants::Single { index } => variant != index || self.uninhabited,
+            Variants::Multiple { ref variants, .. } => {
+                variants.get(variant).map(|v| v.uninhabited).unwrap_or(true)
+            }
+        }
+    }
 }
 
 impl<FieldIdx: Idx, VariantIdx: Idx> fmt::Debug for LayoutData<FieldIdx, VariantIdx>

--- a/compiler/rustc_codegen_cranelift/src/discriminant.rs
+++ b/compiler/rustc_codegen_cranelift/src/discriminant.rs
@@ -14,7 +14,7 @@ pub(crate) fn codegen_set_discriminant<'tcx>(
     variant_index: VariantIdx,
 ) {
     let layout = place.layout();
-    if layout.for_variant(fx, variant_index).is_uninhabited() {
+    if layout.is_variant_uninhabited(variant_index) {
         return;
     }
     match layout.variants {

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -477,7 +477,7 @@ pub(super) fn codegen_tag_value<'tcx, V>(
 ) -> Result<Option<(FieldIdx, V)>, UninhabitedVariantError> {
     // By checking uninhabited-ness first we don't need to worry about types
     // like `(u32, !)` which are single-variant but weird.
-    if layout.for_variant(cx, variant_index).is_uninhabited() {
+    if layout.is_variant_uninhabited(variant_index) {
         return Err(UninhabitedVariantError);
     }
 

--- a/compiler/rustc_const_eval/src/interpret/discriminant.rs
+++ b/compiler/rustc_const_eval/src/interpret/discriminant.rs
@@ -210,7 +210,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // Reading the discriminant of an uninhabited variant is UB. This is the basis for the
         // `uninhabited_enum_branching` MIR pass. It also ensures consistency with
         // `write_discriminant`.
-        if op.layout().for_variant(self, index).is_uninhabited() {
+        if op.layout().is_variant_uninhabited(index) {
             throw_ub!(UninhabitedEnumVariantRead(Some(index)))
         }
         interp_ok(index)
@@ -252,7 +252,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // Therefore, there's no way to represent those variants in the given layout.
         // Essentially, uninhabited variants do not have a tag that corresponds to their
         // discriminant, so we have to bail out here.
-        if layout.for_variant(self, variant_index).is_uninhabited() {
+        if layout.is_variant_uninhabited(variant_index) {
             throw_ub!(UninhabitedEnumVariantWritten(variant_index))
         }
 


### PR DESCRIPTION
This is a cheaper alternative to `TyAndLayout::for_variant(_, idx).is_uninhabited()`, which avoids the extra work done by `TyAndLayout::for_variant`.

EDIT: Let me expand on the motivation from this [comment](https://github.com/rust-lang/rust/pull/160398#issuecomment-5167761369):

`TyAndLayout::for_variant` is a curious API: the resulting layout doesn't represent a Rust type in the strict sense (not even `pattern_type!(Enum is Variant { .. })`; instead, it only describes the "variant-specific" fields, and fields shared between variants (e.g. the enum tag or coroutine captures) are entirely missing.

As such, I believe alternative APIs should be used instead to clarify intent, when possible. This PR deals with the simplest cases, and a future PR will add `TyAndLayout::variant_field(self, cx, variant_idx, field_idx)` to deal with the next-most common case of only needing a variant layout for field lookups.
