### PR TITLE
interpret: skip deref-projection validity checks when they are not needed

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -315,7 +315,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             self.storage_live_dyn(local, meta)?;
         }
         // Now we can finally actually evaluate the callee place.
-        let callee_arg = self.eval_place(*callee_arg)?;
+        let callee_arg =
+            self.eval_place(*callee_arg, /* skip_validity_for_simple_deref */ false)?;
         // We allow some transmutes here.
         // FIXME: Depending on the PassMode, this should reset some padding to uninitialized. (This
         // is true for all `copy_op`, but there are a lot of special cases for argument passing
@@ -498,7 +499,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     // This argument is a VaList holding the remaining caller-side arguments.
                     ecx.storage_live(local)?;
 
-                    let place = ecx.eval_place(dest)?;
+                    let place =
+                        ecx.eval_place(dest, /* skip_validity_for_simple_deref */ false)?;
                     let mplace = ecx.force_allocation(&place)?;
 
                     // Consume the remaining arguments by putting them into the variable argument

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -590,15 +590,27 @@ where
 
     /// Computes a place. You should only use this if you intend to write into this
     /// place; for reading, a more efficient alternative is `eval_place_to_op`.
+    ///
+    /// If `skip_validity_for_simple_deref` is true, then we do not check validity of the inner
+    /// pointer for places of the form `*ptr`. The caller must justify why that is okay.
     #[instrument(skip(self), level = "trace")]
     pub fn eval_place(
         &self,
         mir_place: mir::Place<'tcx>,
+        skip_validity_for_simple_deref: bool,
     ) -> InterpResult<'tcx, PlaceTy<'tcx, M::Provenance>> {
         let _trace =
             enter_trace_span!(M, step::eval_place, ?mir_place, tracing_separate_thread = Empty);
 
         let mut place = self.local_to_place(mir_place.local)?;
+        if skip_validity_for_simple_deref
+            && mir_place.projection.as_slice() == &[mir::ProjectionElem::Deref]
+        {
+            // We want to skip the checks in `deref_pointer`.
+            let val = self.read_immediate(&place)?;
+            let place = self.imm_ptr_to_mplace(&val)?;
+            return interp_ok(place.into());
+        }
         // Using `try_fold` turned out to be bad for performance, hence the loop.
         for elem in mir_place.projection.iter() {
             place = self.project(&place, elem)?

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -479,32 +479,34 @@ where
         trace!("deref to {} on {:?}", val.layout.ty, *val);
         let mplace = self.imm_ptr_to_mplace(&val)?;
 
-        // This is conceptually a typed load from `src` to get the pointer. Most of the time when
-        // we do typed loads for primitive operations, all relevant invariants are checked
-        // implicitly, e.g. when we call `to_bool()` on a Boolean.
-        // But here, we do need to specifically check for metadata validity, null, alignment, and
-        // dereferenceability, or they will not be checked anywhere at all.
-        // This duplicates some of the logic in the validity check, but so far we found no
-        // good way to share that logic.
-        if ptr_ty.is_ref() || ptr_ty.is_box() {
-            let kind = if ptr_ty.is_ref() { "reference" } else { "box" };
+        if M::enforce_validity(self, val.layout) {
+            // This is conceptually a typed load from `src` to get the pointer. Most of the time when
+            // we do typed loads for primitive operations, all relevant invariants are checked
+            // implicitly, e.g. when we call `to_bool()` on a Boolean.
+            // But here, we do need to specifically check for metadata validity, null, alignment, and
+            // dereferenceability, or they will not be checked anywhere at all.
+            // This duplicates some of the logic in the validity check, but so far we found no
+            // good way to share that logic.
+            if ptr_ty.is_ref() || ptr_ty.is_box() {
+                let kind = if ptr_ty.is_ref() { "reference" } else { "box" };
 
-            // Null check.
-            let scalar_ptr = Scalar::from_maybe_pointer(mplace.ptr(), self);
-            if self.scalar_may_be_null(scalar_ptr)? {
-                let maybe = !M::Provenance::OFFSET_IS_ADDR && matches!(scalar_ptr, Scalar::Ptr(..));
-                throw_ub_format!(
-                    "dereferencing a {maybe}null {kind}",
-                    maybe = if maybe { "maybe-" } else { "" }
-                );
-            }
+                // Null check.
+                let scalar_ptr = Scalar::from_maybe_pointer(mplace.ptr(), self);
+                if self.scalar_may_be_null(scalar_ptr)? {
+                    let maybe =
+                        !M::Provenance::OFFSET_IS_ADDR && matches!(scalar_ptr, Scalar::Ptr(..));
+                    throw_ub_format!(
+                        "dereferencing a {maybe}null {kind}",
+                        maybe = if maybe { "maybe-" } else { "" }
+                    );
+                }
 
-            // Dereferencability and alignment check. This also implicitly checks metadata validity.
-            let (size, align) = self
-                .size_and_align_of_val(&mplace)?
-                .unwrap_or_else(|| (mplace.layout.size, mplace.layout.align.abi));
-            self.check_ptr_access(mplace.ptr(), size, CheckInAllocMsg::Dereferenceable(kind))?;
-            self.check_ptr_align(mplace.ptr(), align).map_err_kind(|err| {
+                // Dereferencability and alignment check. This also implicitly checks metadata validity.
+                let (size, align) = self
+                    .size_and_align_of_val(&mplace)?
+                    .unwrap_or_else(|| (mplace.layout.size, mplace.layout.align.abi));
+                self.check_ptr_access(mplace.ptr(), size, CheckInAllocMsg::Dereferenceable(kind))?;
+                self.check_ptr_align(mplace.ptr(), align).map_err_kind(|err| {
                 let err_ub!(AlignmentCheckFailed(Misalignment { required, has }, _msg)) = err else { bug!() };
                 err_ub_format!(
                     "encountered an unaligned {kind} (required {required_bytes} byte alignment but found {found_bytes})",
@@ -512,21 +514,22 @@ where
                     found_bytes = has.bytes()
                 )
             })?;
-        } else {
-            assert!(ptr_ty.is_raw_ptr());
-            // For raw pointers, the validity invariant is pretty weak, but we do require the vtable
-            // to make sense, so we do have to check that if there is one.
-            if mplace.layout.is_unsized() {
-                let tail = self.tcx.struct_tail_for_codegen(mplace.layout.ty, self.typing_env);
-                match tail.kind() {
-                    ty::Dynamic(data, _) => {
-                        let vtable = mplace.meta().unwrap_meta().to_pointer(self)?;
-                        self.get_ptr_vtable_ty(vtable, Some(data))?;
+            } else {
+                assert!(ptr_ty.is_raw_ptr());
+                // For raw pointers, the validity invariant is pretty weak, but we do require the vtable
+                // to make sense, so we do have to check that if there is one.
+                if mplace.layout.is_unsized() {
+                    let tail = self.tcx.struct_tail_for_codegen(mplace.layout.ty, self.typing_env);
+                    match tail.kind() {
+                        ty::Dynamic(data, _) => {
+                            let vtable = mplace.meta().unwrap_meta().to_pointer(self)?;
+                            self.get_ptr_vtable_ty(vtable, Some(data))?;
+                        }
+                        ty::Slice(..) | ty::Str | ty::Foreign(..) => {
+                            // Nothing to check (`read_immediate` already ensured initialization).
+                        }
+                        _ => bug!("Unexpected unsized type tail: {:?}", tail),
                     }
-                    ty::Slice(..) | ty::Str | ty::Foreign(..) => {
-                        // Nothing to check (`read_immediate` already ensured initialization).
-                    }
-                    _ => bug!("Unexpected unsized type tail: {:?}", tail),
                 }
             }
         }

--- a/compiler/rustc_const_eval/src/interpret/projection.rs
+++ b/compiler/rustc_const_eval/src/interpret/projection.rs
@@ -414,7 +414,7 @@ where
             UnwrapUnsafeBinder(target) => base.transmute(self.layout_of(target)?, self)?,
             Field(field, _) => self.project_field(base, field)?,
             Downcast(_, variant) => self.project_downcast(base, variant)?,
-            Deref => self.deref_pointer(&base.to_op(self)?)?.into(),
+            Deref => self.deref_pointer(base)?.into(),
             Index(local) => {
                 let layout = self.layout_of(self.tcx.types.usize)?;
                 let n = self.local_to_op(local, Some(layout))?;

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -93,7 +93,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             Assign((place, rvalue)) => self.eval_rvalue_into_place(rvalue, *place)?,
 
             SetDiscriminant { place, variant_index } => {
-                let dest = self.eval_place(**place)?;
+                let dest =
+                    self.eval_place(**place, /* skip_validity_for_simple_deref */ false)?;
                 self.write_discriminant(*variant_index, &dest)?;
             }
 
@@ -115,7 +116,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
             // Evaluate the place expression, without reading from it.
             PlaceMention(place) => {
-                let _ = self.eval_place(**place)?;
+                let _ =
+                    self.eval_place(**place, /* skip_validity_for_simple_deref */ false)?;
             }
 
             // This exists purely to guide borrowck lifetime inference, and does not have
@@ -159,7 +161,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         rvalue: &mir::Rvalue<'tcx>,
         place: mir::Place<'tcx>,
     ) -> InterpResult<'tcx> {
-        let dest = self.eval_place(place)?;
+        // We can skip validity because we'll write to the place which checks everything we care
+        // about for references, and the pointee must be sized so there's nothing to check for raw
+        // pointers.
+        let dest = self.eval_place(place, /* skip_validity_for_simple_deref */ true)?;
         // FIXME: ensure some kind of non-aliasing between LHS and RHS?
         // Also see https://github.com/rust-lang/rust/issues/68364.
 
@@ -206,7 +211,9 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             }
 
             Ref(_, borrow_kind, place) => {
-                let src = self.eval_place(place)?;
+                // `x = &*ptr` does not need a validity check on `ptr` because we will already
+                // check `x` below.
+                let src = self.eval_place(place, /* skip_validity_for_simple_deref */ true)?;
                 let place = self.force_allocation(&src)?;
                 let mut val = ImmTy::from_immediate(place.to_ref(self), dest.layout);
                 // A fresh reference was created, make sure it gets retagged with the right mode.
@@ -251,7 +258,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     false
                 };
 
-                let src = self.eval_place(place)?;
+                let src =
+                    self.eval_place(place, /* skip_validity_for_simple_deref */ false)?;
                 let place = self.force_allocation(&src)?;
                 let mut val = ImmTy::from_immediate(place.to_ref(self), dest.layout);
                 if !place_base_raw && !kind.is_fake() {
@@ -403,7 +411,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 FnArg::Copy(op)
             }
             mir::Operand::Move(place) => {
-                let place = self.eval_place(*place)?;
+                // We will read from this place, which checks everything there is to check,
+                // so we can skip the extra validity check here.
+                let place =
+                    self.eval_place(*place, /* skip_validity_for_simple_deref */ true)?;
                 if move_definitely_disjoint {
                     // We still have to ensure that no *other* pointers are used to access this place,
                     // so *if* it is in memory then we have to treat it as `InPlace`.
@@ -553,7 +564,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 let old_loc = self.frame().loc;
 
                 // Evaluation order consistent with assignment: destination first.
-                let dest_place = self.eval_place(destination)?;
+                let dest_place =
+                    self.eval_place(destination, /* skip_validity_for_simple_deref */ false)?;
                 let EvaluatedCalleeAndArgs { callee, args, fn_sig, fn_abi, with_caller_location } =
                     self.eval_callee_and_args(terminator, func, args, &destination)?;
 
@@ -602,7 +614,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     drop.is_none(),
                     "Async Drop must be expanded or reset to sync in runtime MIR"
                 );
-                let place = self.eval_place(place)?;
+                let place =
+                    self.eval_place(place, /* skip_validity_for_simple_deref */ false)?;
                 let instance = {
                     let _trace =
                         enter_trace_span!(M, resolve::resolve_drop_glue, ty = ?place.layout.ty);

--- a/src/tools/miri/tests/fail/coroutine-pinned-moved.stderr
+++ b/src/tools/miri/tests/fail/coroutine-pinned-moved.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: reference not dereferenceable: ALLOC has been freed, so this pointer is dangling
+error: Undefined Behavior: memory access failed: ALLOC has been freed, so this pointer is dangling
   --> tests/fail/coroutine-pinned-moved.rs:LL:CC
    |
 LL |         *num += 1;

--- a/src/tools/miri/tests/fail/dangling_pointers/deref-invalid-ptr.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/deref-invalid-ptr.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
+error: Undefined Behavior: memory access failed: attempting to access 4 bytes, but got 0x10[noalloc] which is a dangling pointer (it has no provenance)
   --> tests/fail/dangling_pointers/deref-invalid-ptr.rs:LL:CC
    |
 LL |     let _y = unsafe { *(&*x as *const u32) };
-   |                         ^^^ Undefined Behavior occurred here
+   |                       ^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/dangling_pointers/stack_temporary.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/stack_temporary.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: reference not dereferenceable: ALLOC has been freed, so this pointer is dangling
+error: Undefined Behavior: memory access failed: ALLOC has been freed, so this pointer is dangling
   --> tests/fail/dangling_pointers/stack_temporary.rs:LL:CC
    |
 LL |         let val = *x;

--- a/src/tools/miri/tests/fail/dangling_pointers/storage_dead_dangling.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/storage_dead_dangling.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got $HEX[noalloc] which is a dangling pointer (it has no provenance)
+error: Undefined Behavior: memory access failed: attempting to access 4 bytes, but got $HEX[noalloc] which is a dangling pointer (it has no provenance)
   --> tests/fail/dangling_pointers/storage_dead_dangling.rs:LL:CC
    |
 LL |     let _x = unsafe { *&mut *(LEAK as *mut i32) };

--- a/src/tools/miri/tests/fail/provenance/pointer_partial_overwrite.stderr
+++ b/src/tools/miri/tests/fail/provenance/pointer_partial_overwrite.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got $HEX[noalloc] which is a dangling pointer (it has no provenance)
+error: Undefined Behavior: memory access failed: attempting to access 4 bytes, but got $HEX[noalloc] which is a dangling pointer (it has no provenance)
   --> tests/fail/provenance/pointer_partial_overwrite.rs:LL:CC
    |
 LL |     let x = *p;

--- a/src/tools/miri/tests/fail/rc_as_ptr.stderr
+++ b/src/tools/miri/tests/fail/rc_as_ptr.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: box not dereferenceable: ALLOC has been freed, so this pointer is dangling
+error: Undefined Behavior: memory access failed: ALLOC has been freed, so this pointer is dangling
   --> tests/fail/rc_as_ptr.rs:LL:CC
    |
 LL |     assert_eq!(42, **unsafe { &*Weak::as_ptr(&weak) });

--- a/tests/ui/const-ptr/forbidden_slices.rs
+++ b/tests/ui/const-ptr/forbidden_slices.rs
@@ -20,7 +20,7 @@ pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
 
 // Out of bounds
 pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
-//~^ ERROR: reference must be dereferenceable for 8 bytes
+//~^ ERROR: dangling reference (going beyond the bounds of its allocation)
 
 // Reading uninitialized  data
 pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }; //~ ERROR: uninitialized memory
@@ -39,14 +39,14 @@ pub static S7: &[u16] = unsafe {
 
 // Unaligned read
 pub static S8: &[u64] = unsafe {
+    //~^ ERROR: dangling reference (going beyond the bounds of its allocation)
     let ptr = (&D4 as *const [u32; 2] as *const u32).byte_add(1).cast::<u64>();
 
     from_raw_parts(ptr, 1)
-    //~^ ERROR: reference must be dereferenceable for 8 bytes
 };
 
 pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-//~^ ERROR: null reference
+//~^ ERROR encountered a null reference
 pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) }; // errors inside libcore
 //~^ ERROR 0 < pointee_size && pointee_size <= isize::MAX as usize
 pub static R2: &[u32] = unsafe {
@@ -70,9 +70,9 @@ pub static R6: &[bool] = unsafe {
     from_ptr_range(ptr..ptr.add(4))
 };
 pub static R7: &[u16] = unsafe {
+    //~^ ERROR: unaligned reference (required 2 byte alignment but found 1)
     let ptr = (&D2 as *const Struct as *const u16).byte_add(1);
     from_ptr_range(ptr..ptr.add(4))
-    //~^ ERROR: unaligned reference (required 2 byte alignment but found 1)
 };
 pub static R8: &[u64] = unsafe {
     let ptr = (&D4 as *const [u32; 2] as *const u32).byte_add(1).cast::<u64>();

--- a/tests/ui/const-ptr/forbidden_slices.stderr
+++ b/tests/ui/const-ptr/forbidden_slices.stderr
@@ -1,20 +1,35 @@
-error[E0080]: dereferencing a null reference
-  --> $DIR/forbidden_slices.rs:16:34
+error[E0080]: constructing invalid value of type &[u32]: encountered a null reference
+  --> $DIR/forbidden_slices.rs:16:1
    |
 LL | pub static S0: &[u32] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `S0` failed here
+   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
+           }
 
-error[E0080]: dereferencing a null reference
-  --> $DIR/forbidden_slices.rs:18:33
+error[E0080]: constructing invalid value of type &[()]: encountered a null reference
+  --> $DIR/forbidden_slices.rs:18:1
    |
 LL | pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `S1` failed here
+   | ^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
+           }
 
-error[E0080]: reference not dereferenceable: reference must be dereferenceable for 8 bytes, but got ALLOC$ID which is only 4 bytes from the end of the allocation
-  --> $DIR/forbidden_slices.rs:22:34
+error[E0080]: constructing invalid value of type &[u32]: encountered a dangling reference (going beyond the bounds of its allocation)
+  --> $DIR/forbidden_slices.rs:22:1
    |
 LL | pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `S2` failed here
+   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               ╾ALLOC$ID╼ HEX_DUMP
+           }
 
 error[E0080]: constructing invalid value of type &[u8]: at .<deref>[0], encountered uninitialized memory, but expected an integer
   --> $DIR/forbidden_slices.rs:26:1
@@ -62,17 +77,27 @@ LL | pub static S7: &[u16] = unsafe {
                ╾ALLOC$ID╼ HEX_DUMP
            }
 
-error[E0080]: reference not dereferenceable: reference must be dereferenceable for 8 bytes, but got ALLOC$ID+0x1 which is only 7 bytes from the end of the allocation
-  --> $DIR/forbidden_slices.rs:44:5
+error[E0080]: constructing invalid value of type &[u64]: encountered a dangling reference (going beyond the bounds of its allocation)
+  --> $DIR/forbidden_slices.rs:41:1
    |
-LL |     from_raw_parts(ptr, 1)
-   |     ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `S8` failed here
+LL | pub static S8: &[u64] = unsafe {
+   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               ╾ALLOC$ID╼ HEX_DUMP
+           }
 
-error[E0080]: dereferencing a null reference
-  --> $DIR/forbidden_slices.rs:48:34
+error[E0080]: constructing invalid value of type &[u32]: encountered a null reference
+  --> $DIR/forbidden_slices.rs:48:1
    |
 LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `R0` failed here
+   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
+           }
 
 error[E0080]: evaluation panicked: assertion failed: 0 < pointee_size && pointee_size <= isize::MAX as usize
   --> $DIR/forbidden_slices.rs:50:33
@@ -121,11 +146,16 @@ LL | pub static R6: &[bool] = unsafe {
                ╾ALLOC$ID╼ HEX_DUMP
            }
 
-error[E0080]: encountered an unaligned reference (required 2 byte alignment but found 1)
-  --> $DIR/forbidden_slices.rs:74:5
+error[E0080]: constructing invalid value of type &[u16]: encountered an unaligned reference (required 2 byte alignment but found 1)
+  --> $DIR/forbidden_slices.rs:72:1
    |
-LL |     from_ptr_range(ptr..ptr.add(4))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `R7` failed here
+LL | pub static R7: &[u16] = unsafe {
+   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               ╾ALLOC$ID╼ HEX_DUMP
+           }
 
 error[E0080]: in-bounds pointer arithmetic failed: attempting to offset pointer by 8 bytes, but got ALLOC$ID+0x1 which is only 7 bytes from the end of the allocation
   --> $DIR/forbidden_slices.rs:79:25

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.rs
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.rs
@@ -10,10 +10,10 @@
 use std::intrinsics;
 
 const _X: &'static u8 = unsafe {
+    //~^ ERROR: dangling reference (use-after-free)
     let ptr = intrinsics::const_allocate(4, 4);
     intrinsics::const_deallocate(ptr, 4, 4);
     &*ptr
-    //~^ ERROR: this pointer is dangling
 };
 
 const _Y: u8 = unsafe {

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.stderr
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.stderr
@@ -1,10 +1,15 @@
-error[E0080]: reference not dereferenceable: ALLOC$ID has been freed, so this pointer is dangling
-  --> $DIR/dealloc_intrinsic_dangling.rs:15:5
+error[E0080]: constructing invalid value of type &u8: encountered a dangling reference (use-after-free)
+  --> $DIR/dealloc_intrinsic_dangling.rs:12:1
    |
-LL |     &*ptr
-   |     ^^^^^ evaluation of `_X` failed here
+LL | const _X: &'static u8 = unsafe {
+   | ^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               ╾ALLOC$ID╼ │ ╾─╼
+           }
 
-error[E0080]: reference not dereferenceable: ALLOC$ID has been freed, so this pointer is dangling
+error[E0080]: memory access failed: ALLOC$ID has been freed, so this pointer is dangling
   --> $DIR/dealloc_intrinsic_dangling.rs:23:5
    |
 LL |     *reference

--- a/tests/ui/consts/const-eval/issue-49296.stderr
+++ b/tests/ui/consts/const-eval/issue-49296.stderr
@@ -1,4 +1,4 @@
-error[E0080]: reference not dereferenceable: ALLOC$ID has been freed, so this pointer is dangling
+error[E0080]: memory access failed: ALLOC$ID has been freed, so this pointer is dangling
   --> $DIR/issue-49296.rs:9:16
    |
 LL | const X: u64 = *wat(42);

--- a/tests/ui/consts/const-eval/nonnull_as_ref_ub.stderr
+++ b/tests/ui/consts/const-eval/nonnull_as_ref_ub.stderr
@@ -1,11 +1,8 @@
-error[E0080]: reference not dereferenceable: reference must be dereferenceable for 1 byte, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
-  --> $DIR/nonnull_as_ref_ub.rs:4:39
+error[E0080]: memory access failed: attempting to access 1 byte, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
+  --> $DIR/nonnull_as_ref_ub.rs:4:29
    |
 LL | const _: () = assert!(42 == *unsafe { NON_NULL.as_ref() });
-   |                                       ^^^^^^^^^^^^^^^^^ evaluation of `_` failed inside this call
-   |
-note: inside `NonNull::<u8>::as_ref::<'_>`
-  --> $SRC_DIR/core/src/ptr/non_null.rs:LL:COL
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
@@ -1,14 +1,24 @@
-error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
-  --> $DIR/ub-incorrect-vtable.rs:19:14
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/ub-incorrect-vtable.rs:18:1
    |
-LL |     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_ALIGNMENT` failed here
+LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 4) {
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
+           }
 
-error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
-  --> $DIR/ub-incorrect-vtable.rs:23:14
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/ub-incorrect-vtable.rs:22:1
    |
-LL |     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_SIZE` failed here
+LL | const INVALID_VTABLE_SIZE: &dyn Trait =
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 4) {
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼                         │ ╾──╼╾──╼
+           }
 
 error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:31:1

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
@@ -1,14 +1,24 @@
-error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
-  --> $DIR/ub-incorrect-vtable.rs:19:14
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/ub-incorrect-vtable.rs:18:1
    |
-LL |     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_ALIGNMENT` failed here
+LL | const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 16, align: 8) {
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
+           }
 
-error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
-  --> $DIR/ub-incorrect-vtable.rs:23:14
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/ub-incorrect-vtable.rs:22:1
    |
-LL |     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INVALID_VTABLE_SIZE` failed here
+LL | const INVALID_VTABLE_SIZE: &dyn Trait =
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 16, align: 8) {
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾──────╼╾──────╼
+           }
 
 error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-incorrect-vtable.rs:31:1

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.rs
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.rs
@@ -17,11 +17,11 @@ trait Trait {}
 
 const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
-//~^ ERROR vtable
+//~^^ ERROR vtable
 
 const INVALID_VTABLE_SIZE: &dyn Trait =
     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
-//~^ ERROR vtable
+//~^^ ERROR vtable
 
 #[repr(transparent)]
 struct W<T>(T);

--- a/tests/ui/consts/const-eval/ub-wide-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.rs
@@ -140,11 +140,11 @@ const DYN_METADATA: ptr::DynMetadata<dyn Send> = ptr::metadata::<dyn Send>(ptr::
 
 static mut RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF: *const dyn Trait = unsafe {
     mem::transmute::<_, &dyn Trait>((&92u8, 0usize))
-    //~^ ERROR null pointer
+    //~^^ ERROR null pointer
 };
 static mut RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF: *const dyn Trait = unsafe {
     mem::transmute::<_, &dyn Trait>((&92u8, &3u64))
-    //~^ ERROR vtable
+    //~^^ ERROR vtable
 };
 
 fn main() {}

--- a/tests/ui/consts/const-eval/ub-wide-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.stderr
@@ -226,23 +226,38 @@ LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u
                ╾ALLOC$ID╼ HEX_DUMP
            }
 
-error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
-  --> $DIR/ub-wide-ptr.rs:119:57
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/ub-wide-ptr.rs:119:1
    |
 LL | const TRAIT_OBJ_UNALIGNED_VTABLE: &dyn Trait = unsafe { mem::transmute((&92u8, &[0u8; 128])) };
-   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_UNALIGNED_VTABLE` failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
+           }
 
-error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
-  --> $DIR/ub-wide-ptr.rs:121:57
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/ub-wide-ptr.rs:121:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NULL: &dyn Trait = unsafe { mem::transmute((&92u8, &[0usize; 8])) };
-   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_BAD_DROP_FN_NULL` failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
+           }
 
-error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
-  --> $DIR/ub-wide-ptr.rs:123:56
+error[E0080]: constructing invalid value of type &dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/ub-wide-ptr.rs:123:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_INT: &dyn Trait = unsafe { mem::transmute((&92u8, &[1usize; 8])) };
-   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `TRAIT_OBJ_BAD_DROP_FN_INT` failed here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
+           }
 
 error[E0080]: constructing invalid value of type W<&dyn Trait>: at .0, encountered ALLOC$ID<imm>, but expected a vtable pointer
   --> $DIR/ub-wide-ptr.rs:125:1
@@ -288,17 +303,27 @@ LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transm
                ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
            }
 
-error[E0080]: using null pointer as vtable pointer but it does not point to a vtable
-  --> $DIR/ub-wide-ptr.rs:142:5
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered null pointer, but expected a vtable pointer
+  --> $DIR/ub-wide-ptr.rs:141:1
    |
-LL |     mem::transmute::<_, &dyn Trait>((&92u8, 0usize))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF` failed here
+LL | static mut RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF: *const dyn Trait = unsafe {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               ╾ALLOC$ID╼ HEX_DUMP
+           }
 
-error[E0080]: using ALLOC$ID as vtable pointer but it does not point to a vtable
-  --> $DIR/ub-wide-ptr.rs:146:5
+error[E0080]: constructing invalid value of type *const dyn Trait: encountered ALLOC$ID<imm>, but expected a vtable pointer
+  --> $DIR/ub-wide-ptr.rs:145:1
    |
-LL |     mem::transmute::<_, &dyn Trait>((&92u8, &3u64))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF` failed here
+LL | static mut RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF: *const dyn Trait = unsafe {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
+   |
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               ╾ALLOC$ID╼ ╾ALLOC$ID╼ │ ╾─╼
+           }
 
 error: aborting due to 29 previous errors
 

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.rs
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.rs
@@ -84,8 +84,8 @@ fn dangling() {
         // Undefined behaviour (integer as pointer), who doesn't love tests like this.
         Some(&mut *(42 as *mut i32))
     } }
-    const INT2PTR: Option<&mut i32> = helper_int2ptr(); //~ ERROR reference not dereferenceable
-    static INT2PTR_STATIC: Option<&mut i32> = helper_int2ptr(); //~ ERROR reference not dereferenceable
+    const INT2PTR: Option<&mut i32> = helper_int2ptr(); //~ ERROR encountered a dangling reference
+    static INT2PTR_STATIC: Option<&mut i32> = helper_int2ptr(); //~ ERROR encountered a dangling reference
 
     const fn helper_dangling() -> Option<&'static mut i32> { unsafe {
         // Undefined behaviour (dangling pointer), who doesn't love tests like this.

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
@@ -120,29 +120,27 @@ LL | const RAW_MUT_COERCE_C: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    = note: to avoid accidentally creating global mutable state, such temporaries must be immutable
    = help: if you really want global mutable state, try replacing the temporary by an interior mutable `static` or a `static mut`
 
-error[E0080]: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x2a[noalloc] which is a dangling pointer (it has no provenance)
-  --> $DIR/mut_ref_in_final.rs:87:39
+error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (0x2a[noalloc] has no provenance)
+  --> $DIR/mut_ref_in_final.rs:87:5
    |
 LL |     const INT2PTR: Option<&mut i32> = helper_int2ptr();
-   |                                       ^^^^^^^^^^^^^^^^ evaluation of `dangling::INT2PTR` failed inside this call
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
-note: inside `helper_int2ptr`
-  --> $DIR/mut_ref_in_final.rs:85:14
-   |
-LL |         Some(&mut *(42 as *mut i32))
-   |              ^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
+           }
 
-error[E0080]: reference not dereferenceable: reference must be dereferenceable for 4 bytes, but got 0x2a[noalloc] which is a dangling pointer (it has no provenance)
-  --> $DIR/mut_ref_in_final.rs:88:47
+error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (0x2a[noalloc] has no provenance)
+  --> $DIR/mut_ref_in_final.rs:88:5
    |
 LL |     static INT2PTR_STATIC: Option<&mut i32> = helper_int2ptr();
-   |                                               ^^^^^^^^^^^^^^^^ evaluation of `dangling::INT2PTR_STATIC` failed inside this call
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ it is undefined behavior to use this value
    |
-note: inside `helper_int2ptr`
-  --> $DIR/mut_ref_in_final.rs:85:14
-   |
-LL |         Some(&mut *(42 as *mut i32))
-   |              ^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
+   = note: the rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
+               HEX_DUMP
+           }
 
 error[E0080]: constructing invalid value of type Option<&mut i32>: at .<enum-variant(Some)>.0, encountered a dangling reference (use-after-free)
   --> $DIR/mut_ref_in_final.rs:94:5

--- a/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.stderr
+++ b/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.stderr
@@ -17,11 +17,11 @@ LL |     std::intrinsics::raw_eq(&(&0), &(&1))
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: encountered an unaligned reference (required 4 byte alignment but found 1)
-  --> $DIR/intrinsic-raw_eq-const-bad.rs:17:29
+error[E0080]: accessing memory with alignment 1, but alignment 4 is required
+  --> $DIR/intrinsic-raw_eq-const-bad.rs:17:5
    |
 LL |     std::intrinsics::raw_eq(aref, aref)
-   |                             ^^^^ evaluation of `RAW_EQ_NOT_ALIGNED` failed here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `RAW_EQ_NOT_ALIGNED` failed here
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160399)*
<!-- homu-ignore:end -->

Trying to claw back the perf regression from https://github.com/rust-lang/rust/pull/160012.

We could also, like, skip the entire check in const-eval when we don't care about validity. But the slowdown will also affect Miri so I want to first try what we can do without doing less UB checking.