### PR TITLE
fd-views: AsRef<File>&Co. for BorrowedFd

### DIFF
--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -89,6 +89,26 @@ impl BorrowedFd<'_> {
     pub const unsafe fn borrow_raw(fd: RawFd) -> Self {
         Self { fd: ValidRawFd::new(fd).expect("fd != -1"), _phantom: PhantomData }
     }
+
+    /// Converts a `BorrowedFd` into a reference to a file-like type.
+    ///
+    /// ```rust
+    /// # #![feature(fd_view)]
+    /// # use std::fs::File;
+    /// # use std::io;
+    /// # use std::os::fd::AsFd;
+    /// let meta = io::stdout().as_fd().to_view::<File>().metadata().unwrap();
+    /// if meta.is_file() {
+    ///     println!("stdout is a regular file");
+    /// }
+    /// ```
+    #[unstable(feature = "fd_view", issue = "160402")]
+    pub fn to_view<T>(&self) -> &T
+    where
+        Self: AsRef<T>,
+    {
+        self.as_ref()
+    }
 }
 
 impl OwnedFd {
@@ -433,6 +453,58 @@ impl From<OwnedFd> for crate::net::UdpSocket {
         ))))
     }
 }
+
+/// Implements `AsRef<$t>` conversions from `BorrowedFd` to the specified types.
+///
+/// # Safety
+///
+/// It must be sound to transmute `&BorrowedFd` to `&$t`.
+///
+/// This typically implies that:
+///
+/// - $t must be a wrapper with `BorrowedFd`, `OwnedFd` or `RawFd` being the single non-ZST-field.
+///   Nominally it also requires repr(transparent), but std can cheat because we can stay in
+///   sync with rustc's layout implementation details.
+/// - `&$t` must not have any methods that would allow closing the file descriptor.
+/// - `&$t` impls must tolerate instances being created from any kind of file-descriptor without
+///   going through some dedicated constructor function, akin to `From<OwnedFd>` being a noop
+///   conversion.
+pub(crate) macro unsafe_impl_fd_asrefs {
+    ($($t:ty),*$(,)?) => {$(
+        #[unstable(feature = "fd_view", issue = "160402")]
+        #[unstable_feature_bound(fd_view)]
+        impl AsRef<$t> for BorrowedFd<'_> {
+            #[inline]
+            fn as_ref(&self) -> &$t {
+                use core::mem;
+
+                // These are neither necessary nor sufficient, but generally
+                // a type that implements them is more likely to have the required behavior.
+                fn type_check<T: From<OwnedFd> + Into<OwnedFd> + AsFd>() {}
+
+                // sanity check in case layouts change
+                const {
+                    assert!(mem::size_of::<RawFd>() == mem::size_of::<$t>());
+                    assert!(mem::size_of::<RawFd>() == mem::size_of::<BorrowedFd<'_>>());
+                }
+                type_check::<$t>();
+                // SAFETY: See macro-level requirements.
+                unsafe { mem::transmute::<&BorrowedFd<'_>, &$t>(self) }
+            }
+        }
+    )*}
+}
+
+#[cfg(not(target_os = "trusty"))]
+unsafe_impl_fd_asrefs!(
+    crate::fs::File,
+    crate::net::TcpStream,
+    crate::net::TcpListener,
+    crate::net::UdpSocket,
+);
+
+#[cfg(unix)]
+unsafe_impl_fd_asrefs!(io::PipeWriter, io::PipeReader);
 
 #[stable(feature = "asfd_ptrs", since = "1.64.0")]
 /// This impl allows implementing traits that require `AsFd` on Arc.

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -20,7 +20,9 @@ use super::{SocketAncillary, recv_vectored_with_ancillary_from, send_vectored_wi
 #[cfg(any(doc, target_os = "android", target_os = "linux", target_os = "cygwin"))]
 use crate::io::{IoSlice, IoSliceMut};
 use crate::net::Shutdown;
-use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+use crate::os::unix::io::{
+    AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd, unsafe_impl_fd_asrefs,
+};
 use crate::path::Path;
 use crate::sys::net::Socket;
 use crate::sys::{AsInner, FromInner, IntoInner, cvt};
@@ -989,6 +991,11 @@ impl AsFd for UnixDatagram {
         self.0.as_inner().as_fd()
     }
 }
+
+// SAFETY: It's a tower of 1-field wrappers around OwnedFd.
+// No methods to close the socket, no methods with safety preconditions,
+// other than the fd being valid.
+unsafe_impl_fd_asrefs!(UnixDatagram);
 
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl From<UnixDatagram> for OwnedFd {

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -1,5 +1,7 @@
 use super::{SocketAddr, UnixStream, sockaddr_un};
-use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+use crate::os::unix::io::{
+    AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd, unsafe_impl_fd_asrefs,
+};
 use crate::path::Path;
 use crate::sys::net::Socket;
 use crate::sys::{AsInner, FromInner, IntoInner, cvt};
@@ -346,6 +348,11 @@ impl From<OwnedFd> for UnixListener {
         UnixListener(Socket::from_inner(FromInner::from_inner(fd)))
     }
 }
+
+// SAFETY: It's a tower of 1-field wrappers around OwnedFd.
+// No methods to close the socket, no methods with safety preconditions,
+// other than the fd being valid.
+unsafe_impl_fd_asrefs!(UnixListener);
 
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl From<UnixListener> for OwnedFd {

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -34,7 +34,9 @@ use super::{UCred, peer_cred};
 use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::Shutdown;
-use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+use crate::os::unix::io::{
+    AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd, unsafe_impl_fd_asrefs,
+};
 use crate::path::Path;
 use crate::sys::net::Socket;
 use crate::sys::{AsInner, FromInner, cvt};
@@ -720,6 +722,11 @@ impl AsFd for UnixStream {
         self.0.as_fd()
     }
 }
+
+// SAFETY: It's a tower of 1-field wrappers around OwnedFd.
+// No methods to close the socket, no methods with safety preconditions,
+// other than the fd being valid.
+unsafe_impl_fd_asrefs!(UnixStream);
 
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl From<UnixStream> for OwnedFd {

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -150,6 +150,26 @@ impl BorrowedHandle<'_> {
     pub const unsafe fn borrow_raw(handle: RawHandle) -> Self {
         Self { handle, _phantom: PhantomData }
     }
+
+    /// Converts a `BorrowedHandle` into a reference to a file-like type.
+    ///
+    /// ```rust
+    /// # #![feature(fd_view)]
+    /// # use std::fs::File;
+    /// # use std::io;
+    /// # use std::os::windows::io::AsHandle;
+    /// let meta = io::stdout().as_handle().to_view::<File>().metadata().unwrap();
+    /// if meta.is_file() {
+    ///     println!("stdout is a regular file");
+    /// }
+    /// ```
+    #[unstable(feature = "fd_view", issue = "160402")]
+    pub fn to_view<T>(&self) -> &T
+    where
+        Self: AsRef<T>,
+    {
+        self.as_ref()
+    }
 }
 
 #[stable(feature = "io_safety", since = "1.63.0")]
@@ -677,6 +697,49 @@ impl AsHandle for io::PipeWriter {
         self.0.as_handle()
     }
 }
+
+/// Implements `AsRef<$t>` conversions from `BorrowedHandle` to the specified types.
+///
+/// # Safety
+///
+/// It must be sound to transmute `&BorrowedHandle` to `&$t`.
+///
+/// This typically implies that:
+///
+/// - $t must be a wrapper with `BorrowedHandle`, `OwnedHandle` or `RawHandle` being the single non-ZST-field.
+///   Nominally it also requires repr(transparent), but std can cheat because we can stay in
+///   sync with rustc's layout implementation details.
+/// - `&$t` must not have any methods that would allow closing the file descriptor.
+/// - `&$t` impls must tolerate instances being created from any kind of file-descriptor without
+///   going through some dedicated constructor function, akin to `From<OwnedHandle>` being a noop
+///   conversion.
+pub(crate) macro unsafe_impl_handle_asrefs {
+    ($($t:ty),*$(,)?) => {$(
+        #[unstable(feature = "fd_view", issue = "160402")]
+        #[unstable_feature_bound(fd_view)]
+        impl AsRef<$t> for BorrowedHandle<'_> {
+            #[inline]
+            fn as_ref(&self) -> &$t {
+                use core::mem;
+
+                // These are neither necessary nor sufficient, but generally
+                // a type that implements them is more likely to have the required behavior.
+                fn type_check<T: From<OwnedHandle> + Into<OwnedHandle> + AsHandle>() {}
+
+                // sanity check in case layouts change
+                const {
+                    assert!(mem::size_of::<RawHandle>() == mem::size_of::<$t>());
+                    assert!(mem::size_of::<RawHandle>() == mem::size_of::<BorrowedHandle<'_>>());
+                }
+                type_check::<$t>();
+                // SAFETY: See macro-level requirements.
+                unsafe { mem::transmute::<&BorrowedHandle<'_>, &$t>(self) }
+            }
+        }
+    )*}
+}
+
+unsafe_impl_handle_asrefs!(crate::fs::File, io::PipeWriter, io::PipeReader,);
 
 #[stable(feature = "anonymous_pipe", since = "1.87.0")]
 impl From<io::PipeWriter> for OwnedHandle {


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/160402

This uses `#[unstable_feature_bound]` so the trait impls are _not_ insta-stable, so no FCP needed yet. But they're infectious to callers which means we currently can't dogfood the added API in std itself.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
