### PR TITLE
Add regression tests for a number of ICEs and diagnostics issues labelled `E-needs-test`

### DIFF
--- a/tests/crashes/129372.rs
+++ b/tests/crashes/129372.rs
@@ -1,0 +1,53 @@
+//@ known-bug: #129372
+//@ compile-flags: -Cdebuginfo=2 -Copt-level=0
+//@ ignore-backends: gcc
+
+pub struct Wrapper<T>(T);
+struct Struct;
+
+pub trait TraitA {
+    type AssocA<'t>;
+}
+pub trait TraitB {
+    type AssocB;
+}
+
+pub fn helper(v: impl MethodTrait) {
+    let _local_that_causes_ice = v.method();
+}
+
+pub fn main() {
+    helper(Wrapper(Struct));
+}
+
+pub trait MethodTrait {
+    type Assoc<'a>;
+
+    fn method(self) -> impl for<'a> FnMut(&'a ()) -> Self::Assoc<'a>;
+}
+
+impl<T: TraitB> MethodTrait for T
+where
+    <T as TraitB>::AssocB: TraitA,
+{
+    type Assoc<'a> = <T::AssocB as TraitA>::AssocA<'a>;
+
+    fn method(self) -> impl for<'a> FnMut(&'a ()) -> Self::Assoc<'a> {
+        move |_| loop {}
+    }
+}
+
+impl<T, B> TraitB for Wrapper<B>
+where
+    B: TraitB<AssocB = T>,
+{
+    type AssocB = T;
+}
+
+impl TraitB for Struct {
+    type AssocB = Struct;
+}
+
+impl TraitA for Struct {
+    type AssocA<'t> = Self;
+}

--- a/tests/ui/impl-trait/malformed-tait-impl-with-const-param.incr.stderr
+++ b/tests/ui/impl-trait/malformed-tait-impl-with-const-param.incr.stderr
@@ -1,0 +1,27 @@
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/malformed-tait-impl-with-const-param.rs:15:32
+   |
+LL | impl<const B: Word> Trait for &'a () {
+   |                                ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | impl<'a, const B: Word> Trait for &'a () {
+   |      +++
+
+error[E0407]: method `constrain` is not a member of trait `Trait`
+  --> $DIR/malformed-tait-impl-with-const-param.rs:20:5
+   |
+LL |     fn constrain(self) -> (Self::Opaque1,) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `Trait`
+
+error[E0425]: cannot find type `Word` in this scope
+  --> $DIR/malformed-tait-impl-with-const-param.rs:15:15
+   |
+LL | impl<const B: Word> Trait for &'a () {
+   |               ^^^^ not found in this scope
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0261, E0407, E0425.
+For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/impl-trait/malformed-tait-impl-with-const-param.normal.stderr
+++ b/tests/ui/impl-trait/malformed-tait-impl-with-const-param.normal.stderr
@@ -1,0 +1,27 @@
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/malformed-tait-impl-with-const-param.rs:15:32
+   |
+LL | impl<const B: Word> Trait for &'a () {
+   |                                ^^ undeclared lifetime
+   |
+help: consider introducing lifetime `'a` here
+   |
+LL | impl<'a, const B: Word> Trait for &'a () {
+   |      +++
+
+error[E0407]: method `constrain` is not a member of trait `Trait`
+  --> $DIR/malformed-tait-impl-with-const-param.rs:20:5
+   |
+LL |     fn constrain(self) -> (Self::Opaque1,) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `Trait`
+
+error[E0425]: cannot find type `Word` in this scope
+  --> $DIR/malformed-tait-impl-with-const-param.rs:15:15
+   |
+LL | impl<const B: Word> Trait for &'a () {
+   |               ^^^^ not found in this scope
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0261, E0407, E0425.
+For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/impl-trait/malformed-tait-impl-with-const-param.rs
+++ b/tests/ui/impl-trait/malformed-tait-impl-with-const-param.rs
@@ -1,0 +1,24 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/122214.
+//!
+//! The reported ICE only happened under incremental compilation, where the const inference
+//! variable reached `HashStable`, but this used to crash without it as well, so check both.
+
+//@ revisions: normal incr
+//@[incr] incremental
+
+#![feature(impl_trait_in_assoc_type, const_precise_live_drops)]
+
+trait Trait {
+    type Opaque1;
+}
+
+impl<const B: Word> Trait for &'a () {
+    //~^ ERROR use of undeclared lifetime name `'a`
+    //~| ERROR cannot find type `Word` in this scope
+    type Opaque1 = impl Sized;
+
+    fn constrain(self) -> (Self::Opaque1,) {}
+    //~^ ERROR method `constrain` is not a member of trait `Trait`
+}
+
+fn main() {}

--- a/tests/ui/traits/alias/trait-alias-with-self-in-dyn-object.rs
+++ b/tests/ui/traits/alias/trait-alias-with-self-in-dyn-object.rs
@@ -1,0 +1,10 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/138891.
+
+#![feature(trait_alias)]
+trait F = Fn() -> Self;
+
+fn _f3<Fut>(a: dyn F<Fut>) {}
+//~^ ERROR trait alias takes 0 generic arguments but 1 generic argument was supplied
+//~| ERROR associated type binding in trait object type mentions `Self`
+
+fn main() {}

--- a/tests/ui/traits/alias/trait-alias-with-self-in-dyn-object.stderr
+++ b/tests/ui/traits/alias/trait-alias-with-self-in-dyn-object.stderr
@@ -1,0 +1,26 @@
+error[E0107]: trait alias takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/trait-alias-with-self-in-dyn-object.rs:6:20
+   |
+LL | fn _f3<Fut>(a: dyn F<Fut>) {}
+   |                    ^----- help: remove the unnecessary generics
+   |                    |
+   |                    expected 0 generic arguments
+   |
+note: trait alias defined here, with 0 generic parameters
+  --> $DIR/trait-alias-with-self-in-dyn-object.rs:4:7
+   |
+LL | trait F = Fn() -> Self;
+   |       ^
+
+error: associated type binding in trait object type mentions `Self`
+  --> $DIR/trait-alias-with-self-in-dyn-object.rs:6:16
+   |
+LL | trait F = Fn() -> Self;
+   |                   ---- this binding mentions `Self`
+LL |
+LL | fn _f3<Fut>(a: dyn F<Fut>) {}
+   |                ^^^^^^^^^^ contains a mention of `Self`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/transmutability/unsafe-binder-opaque-type-layout.rs
+++ b/tests/ui/transmutability/unsafe-binder-opaque-type-layout.rs
@@ -1,0 +1,17 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/141400.
+
+#![feature(unsafe_binders)]
+#![feature(transmutability)]
+#![feature(type_alias_impl_trait)]
+#![allow(incomplete_features)]
+
+trait OpaqueTrait {}
+type OpaqueType = unsafe<> impl OpaqueTrait;
+//~^ ERROR the trait bound `OpaqueType::{opaque#0}: Copy` is not satisfied
+//~| ERROR unconstrained opaque type
+trait AnotherTrait {}
+impl<T: std::mem::TransmuteFrom<()>> AnotherTrait for T {}
+impl AnotherTrait for OpaqueType {}
+//~^ ERROR conflicting implementations of trait `AnotherTrait`
+
+pub fn main() {}

--- a/tests/ui/transmutability/unsafe-binder-opaque-type-layout.stderr
+++ b/tests/ui/transmutability/unsafe-binder-opaque-type-layout.stderr
@@ -1,0 +1,26 @@
+error[E0277]: the trait bound `OpaqueType::{opaque#0}: Copy` is not satisfied
+  --> $DIR/unsafe-binder-opaque-type-layout.rs:9:19
+   |
+LL | type OpaqueType = unsafe<> impl OpaqueTrait;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `OpaqueType::{opaque#0}`
+
+error[E0119]: conflicting implementations of trait `AnotherTrait` for type `unsafe<> _`
+  --> $DIR/unsafe-binder-opaque-type-layout.rs:14:1
+   |
+LL | impl<T: std::mem::TransmuteFrom<()>> AnotherTrait for T {}
+   | ------------------------------------------------------- first implementation here
+LL | impl AnotherTrait for OpaqueType {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `unsafe<> _`
+
+error: unconstrained opaque type
+  --> $DIR/unsafe-binder-opaque-type-layout.rs:9:28
+   |
+LL | type OpaqueType = unsafe<> impl OpaqueTrait;
+   |                            ^^^^^^^^^^^^^^^^
+   |
+   = note: `OpaqueType` must be used in combination with a concrete type within the same crate
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0119, E0277.
+For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/type-alias-impl-trait/nested-tait-inline-mir-validation.rs
+++ b/tests/ui/type-alias-impl-trait/nested-tait-inline-mir-validation.rs
@@ -1,0 +1,35 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/118478.
+
+//@ check-pass
+//@ compile-flags: -Zmir-opt-level=3
+
+#![feature(type_alias_impl_trait)]
+#![crate_type = "lib"]
+pub trait Tr {
+    fn get(&self) -> u32;
+}
+
+impl Tr for (u32,) {
+    #[inline]
+    fn get(&self) -> u32 { self.0 }
+}
+
+pub fn tr1() -> impl Tr {
+    (32,)
+}
+
+pub fn tr2() -> impl Tr {
+    struct Inner {
+        x: X,
+    }
+    type X = impl Tr;
+    impl Tr for Inner {
+        fn get(&self) -> u32 {
+            self.x.get()
+        }
+    }
+
+    Inner {
+        x: tr1(),
+    }
+}

--- a/tests/ui/typeck/self-param-in-fn-item-cast-to-fn-trait.rs
+++ b/tests/ui/typeck/self-param-in-fn-item-cast-to-fn-trait.rs
@@ -1,0 +1,7 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/111411.
+
+pub fn main() {
+    fn baz(&self) {}
+    //~^ ERROR `self` parameter is only allowed in associated functions
+    let _ = &baz as &dyn Fn(i32);
+}

--- a/tests/ui/typeck/self-param-in-fn-item-cast-to-fn-trait.stderr
+++ b/tests/ui/typeck/self-param-in-fn-item-cast-to-fn-trait.stderr
@@ -1,0 +1,10 @@
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/self-param-in-fn-item-cast-to-fn-trait.rs:4:12
+   |
+LL |     fn baz(&self) {}
+   |            ^^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/unboxed-closures/transmute-usize-to-rust-call-fn-ptr.rs
+++ b/tests/ui/unboxed-closures/transmute-usize-to-rust-call-fn-ptr.rs
@@ -1,0 +1,9 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/114665.
+
+//@ build-pass
+//@ compile-flags: -Zmir-opt-level=0
+
+#![feature(unboxed_closures)]
+fn main() {
+    unsafe { std::mem::transmute::<usize, extern "rust-call" fn()>(5); }
+}


### PR DESCRIPTION
These have since been fixed and need tests.

Closing rust-lang/rust#111411.
Closing rust-lang/rust#114665.
Closing rust-lang/rust#118478.
Closing rust-lang/rust#122214.
Closing rust-lang/rust#138891.
Closing rust-lang/rust#141400.
