### PR TITLE
Remove redundant target check from check_eii_impl

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -211,7 +211,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 self.check_rustc_legacy_const_generics(item, *attr_span, fn_indexes)
             }
             AttributeKind::Doc(attr) => self.check_doc_attrs(attr, hir_id, target),
-            AttributeKind::EiiImpls(impls) => self.check_eii_impl(impls, target),
+            AttributeKind::EiiImpls(impls) => self.check_eii_impl(impls),
             AttributeKind::RustcMustImplementOneOf { attr_span, fn_names } => {
                 self.check_rustc_must_implement_one_of(*attr_span, fn_names, hir_id, target)
             }
@@ -472,15 +472,10 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         }
     }
 
-    fn check_eii_impl(&self, impls: &[EiiImpl], target: Target) {
+    /// Checks that each externally implementable item (EII) implementation uses `unsafe`
+    /// exactly when its declaration requires it.
+    fn check_eii_impl(&self, impls: &[EiiImpl]) {
         for EiiImpl { span, inner_span, resolution, impl_unsafe_span, is_default: _ } in impls {
-            match target {
-                Target::Fn | Target::Static => {}
-                _ => {
-                    self.dcx().emit_err(diagnostics::EiiImplTarget { span: *span });
-                }
-            }
-
             let impl_unsafe = match resolution {
                 EiiImplResolution::Macro(eii_macro) => find_attr!(
                     self.tcx,

--- a/compiler/rustc_passes/src/diagnostics.rs
+++ b/compiler/rustc_passes/src/diagnostics.rs
@@ -1028,13 +1028,6 @@ pub(crate) enum UnexportableItem<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag("`eii_macro_for` is only valid on functions and statics")]
-pub(crate) struct EiiImplTarget {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag("`#[{$name}]` is unsafe to implement")]
 pub(crate) struct EiiImplRequiresUnsafe {
     #[primary_span]


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/131229 which is the parent issue of https://github.com/rust-lang/rust/issues/153101