### PR TITLE
Move duplicate-names check for #[rustc_must_implement_one_of] to attribute parser

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use rustc_ast::{LitIntType, LitKind, MetaItemLit};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_feature::AttributeStability;
 use rustc_hir::LangItem;
 use rustc_hir::attrs::{
@@ -70,6 +71,18 @@ impl SingleAttributeParser for RustcMustImplementOneOfParser {
         }
         if errored {
             return None;
+        }
+
+        if cx.target == Target::Trait {
+            // Check for duplicates
+            let mut seen: FxHashMap<Symbol, Span> = FxHashMap::default();
+            for ident in &fn_names {
+                if let Some(dup) = seen.insert(ident.name, ident.span) {
+                    cx.emit_err(diagnostics::FunctionNamesDuplicated {
+                        spans: vec![dup, ident.span],
+                    });
+                }
+            }
         }
 
         Some(AttributeKind::RustcMustImplementOneOf { attr_span: cx.attr_span, fn_names })

--- a/compiler/rustc_attr_parsing/src/diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/diagnostics.rs
@@ -60,6 +60,14 @@ pub(crate) struct MustBeNameOfAssociatedFunction {
 }
 
 #[derive(Diagnostic)]
+#[diag("functions names are duplicated")]
+#[note("all `#[rustc_must_implement_one_of]` arguments must be unique")]
+pub(crate) struct FunctionNamesDuplicated {
+    #[primary_span]
+    pub spans: Vec<Span>,
+}
+
+#[derive(Diagnostic)]
 #[diag("unsafe attribute used without unsafe")]
 pub(crate) struct UnsafeAttrOutsideUnsafeLint {
     #[label("usage of unsafe attribute")]

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -12,7 +12,6 @@ use rustc_abi::ExternAbi;
 use rustc_ast::{AttrStyle, MetaItemKind, ast};
 use rustc_attr_parsing::AttributeParser;
 use rustc_data_structures::thin_vec::ThinVec;
-use rustc_data_structures::unord::UnordMap;
 use rustc_errors::{DiagCtxtHandle, IntoDiagArg, MultiSpan, msg};
 use rustc_feature::BUILTIN_ATTRIBUTE_MAP;
 use rustc_hir::attrs::diagnostic::Directive;
@@ -457,17 +456,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 None => {
                     self.dcx().emit_err(diagnostics::FunctionNotFoundInTrait { span: ident.span });
                 }
-            }
-        }
-        // Check for duplicates
-
-        let mut set: UnordMap<Symbol, Span> = Default::default();
-
-        for ident in &*list {
-            if let Some(dup) = set.insert(ident.name, ident.span) {
-                self.tcx.dcx().emit_err(diagnostics::FunctionNamesDuplicated {
-                    spans: vec![dup, ident.span],
-                });
             }
         }
     }

--- a/compiler/rustc_passes/src/diagnostics.rs
+++ b/compiler/rustc_passes/src/diagnostics.rs
@@ -1119,14 +1119,6 @@ pub(crate) struct FunctionNotFoundInTrait {
 }
 
 #[derive(Diagnostic)]
-#[diag("functions names are duplicated")]
-#[note("all `#[rustc_must_implement_one_of]` arguments must be unique")]
-pub(crate) struct FunctionNamesDuplicated {
-    #[primary_span]
-    pub spans: Vec<Span>,
-}
-
-#[derive(Diagnostic)]
 #[diag("there is no parameter `{$argument_name}` on trait `{$trait_name}`")]
 pub(crate) struct UnknownFormatParameterForOnUnimplementedAttr {
     pub argument_name: Symbol,

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.rs
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.rs
@@ -65,7 +65,7 @@ trait TrTwoDefaults {
     fn c(); //~ ERROR function doesn't have a default implementation
 }
 
-#[rustc_must_implement_one_of(abc, xyz)]
+#[rustc_must_implement_one_of(abc, abc)]
 //~^ ERROR the `rustc_must_implement_one_of` attribute cannot be used on functions
 fn function() {}
 

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.stderr
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.stderr
@@ -59,7 +59,7 @@ LL | #[rustc_must_implement_one_of(,)]
 error: the `rustc_must_implement_one_of` attribute cannot be used on functions
   --> $DIR/rustc_must_implement_one_of_misuse.rs:68:3
    |
-LL | #[rustc_must_implement_one_of(abc, xyz)]
+LL | #[rustc_must_implement_one_of(abc, abc)]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: the `rustc_must_implement_one_of` attribute can only be applied to traits


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/131229 which is the parent issue of https://github.com/rust-lang/rust/issues/153101
