### PR TITLE
Split `aarch64-apple{,-macos-26}` => `aarch64-apple{,-macos-26}-{1,2}` jobs

### DIFF
--- a/src/ci/docker/scripts/stage_2_test_set1.sh
+++ b/src/ci/docker/scripts/stage_2_test_set1.sh
@@ -4,6 +4,8 @@ set -ex
 
 # Run a subset of tests. Used to run tests in parallel in multiple jobs.
 
+# NOTE: keep in sync with `aarch64-apple*-{1,2}` jobs.
+
 # When this job partition is run as part of PR CI, skip tidy to allow revealing more failures. The
 # dedicated `tidy` job failing won't block other PR CI jobs from completing, and so tidy failures
 # shouldn't inhibit revealing other failures in PR CI jobs.

--- a/src/ci/docker/scripts/stage_2_test_set2.sh
+++ b/src/ci/docker/scripts/stage_2_test_set2.sh
@@ -4,6 +4,8 @@ set -ex
 
 # Run a subset of tests. Used to run tests in parallel in multiple jobs.
 
+# NOTE: keep in sync with `aarch64-apple*-{1,2}` jobs.
+
 # When this job partition is run as part of PR CI, skip tidy to allow revealing more failures. The
 # dedicated `tidy` job failing won't block other PR CI jobs from completing, and so tidy failures
 # shouldn't inhibit revealing other failures in PR CI jobs.

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -585,11 +585,41 @@ auto:
       CODEGEN_BACKENDS: llvm,cranelift
     <<: *job-macos-15
 
-  - name: aarch64-apple
+  - name: aarch64-apple-1
     env:
-      SCRIPT: >
-        ./x.py --stage 2 test --host=aarch64-apple-darwin --target=aarch64-apple-darwin &&
-        ./x.py --stage 2 test --host=aarch64-apple-darwin --target=aarch64-apple-darwin src/tools/cargo
+      # NOTE: keep in sync with `src/ci/docker/scripts/stage_2_test_set1.sh`
+      SCRIPT: >-
+        ./x.py --stage 2 test
+        --host=aarch64-apple-darwin
+        --target=aarch64-apple-darwin
+        --skip compiler
+        --skip src
+      RUST_CONFIGURE_ARGS: >-
+        --enable-sanitizers
+        --enable-profiler
+        --set build.allocator=jemalloc
+      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+      # Aarch64 tooling only needs to support macOS 11.0 and up as nothing else
+      # supports the hardware, so only need to test it there.
+      MACOSX_DEPLOYMENT_TARGET: 11.0
+      MACOSX_STD_DEPLOYMENT_TARGET: 11.0
+    <<: *job-macos-15
+
+  - name: aarch64-apple-2
+    env:
+      # NOTE: keep in sync with `src/ci/docker/scripts/stage_2_test_set2.sh`,
+      # union `src/tools/cargo` specifically.
+      SCRIPT: >-
+        ./x.py --stage 2 test
+        --host=aarch64-apple-darwin
+        --target=aarch64-apple-darwin
+        --skip tests
+        --skip library
+        --skip tidyselftest
+        && ./x.py --stage 2 test
+        --host=aarch64-apple-darwin
+        --target=aarch64-apple-darwin
+        src/tools/cargo
       RUST_CONFIGURE_ARGS: >-
         --enable-sanitizers
         --enable-profiler
@@ -606,12 +636,43 @@ auto:
   # previous attempts have timed out multiple times. Remove/revert this job if
   # this hangs or times out, or if it becomes the slowest Merge CI job, and let
   # T-infra know.
-  - name: aarch64-apple-macos-26
+  - name: aarch64-apple-macos-26-1
     doc_url: https://github.com/rust-lang/rust/issues/157687
     env:
-      SCRIPT: >
-        ./x.py --stage 2 test --host=aarch64-apple-darwin --target=aarch64-apple-darwin &&
-        ./x.py --stage 2 test --host=aarch64-apple-darwin --target=aarch64-apple-darwin src/tools/cargo
+      # NOTE: keep in sync with `src/ci/docker/scripts/stage_2_test_set1.sh`
+      SCRIPT: >-
+        ./x.py --stage 2 test
+        --host=aarch64-apple-darwin
+        --target=aarch64-apple-darwin
+        --skip compiler
+        --skip src
+      RUST_CONFIGURE_ARGS: >-
+        --enable-sanitizers
+        --enable-profiler
+        --set rust.jemalloc
+      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+      # Aarch64 tooling only needs to support macOS 11.0 and up as nothing else
+      # supports the hardware, so only need to test it there.
+      MACOSX_DEPLOYMENT_TARGET: 11.0
+      MACOSX_STD_DEPLOYMENT_TARGET: 11.0
+    <<: *job-macos-26
+
+  - name: aarch64-apple-macos-26-2
+    doc_url: https://github.com/rust-lang/rust/issues/157687
+    env:
+      # NOTE: keep in sync with `src/ci/docker/scripts/stage_2_test_set2.sh`,
+      # union `src/tools/cargo` specifically.
+      SCRIPT: >-
+        ./x.py --stage 2 test
+        --host=aarch64-apple-darwin
+        --target=aarch64-apple-darwin
+        --skip tests
+        --skip library
+        --skip tidyselftest
+        && ./x.py --stage 2 test
+        --host=aarch64-apple-darwin
+        --target=aarch64-apple-darwin
+        src/tools/cargo
       RUST_CONFIGURE_ARGS: >-
         --enable-sanitizers
         --enable-profiler


### PR DESCRIPTION
## Summary

The aarch64 macos runners seem to be consistently among the slowest jobs, sometimes pushing our overall CI time to 4 hours on a bad run. Let's try to split the jobs to keep the overall Merge CI time manageable:

* `aarch64-apple` => `aarch64-apple-{1,2}`
* `aarch64-apple-macos-26` => `aarch64-apple-macos-26-{1,2}`

Discussed in [#t-infra > GHA macos-26 slowness @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/GHA.20macos-26.20slowness/near/613771526).

### Some imprecise stats

Looking at [CI dashboard](https://p.datadoghq.com/sb/3a172e20-e9e1-11ed-80e3-da7ad0900002-b5f7bb7e08b664a06b08527da85f7e30?fromUser=true&refresh_mode=sliding&tpl_var_branch_name%5B0%5D=automation%2Fbors%2Fauto&tpl_var_env%5B0%5D=%2A&tpl_var_is_default_branch%5B0%5D=%2A&tpl_var_pipeline_name%5B0%5D=CI&tpl_var_provider_instance%5B0%5D=%2A&tpl_var_provider_name%5B0%5D=github&from_ts=1783056725849&to_ts=1785735125849&live=true) over past month (as of 2026-08-03):

| Job                    |   Median |      P95 | Run counts |
|------------------------|---------:|---------:|-----------:|
| aarch64-apple          | 2.94 hr  |  3.59 hr |       156  |
| aarch64-apple-macos-26 | 3.12 hr  |  3.59 hr |       148  |

The median seems *okay*, the `macos-26` job is on par median wise with `i686-msvc-1` and `dist-x86_64-linux`. It's the P95 that's more concerning, since `i686-msvc-1` P95 is the second-worst at `3.25` hr.


r? infra-ci

---

try-job: `aarch64-apple*`