### PR TITLE
Manage `pending` better in `try_evaluate_obligations`

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -209,7 +209,15 @@ where
         let mut errors = Vec::new();
         loop {
             let mut any_changed = false;
-            for (mut obligation, stalled_on) in mem::take(&mut self.obligations.pending) {
+
+            // This loop empties and reconstructs `self.obligations.pending`, which can have many
+            // items (thousands in extreme cases) and very often the new length is the same as the
+            // old. Reserving capacity up front avoids repeated reallocations during the
+            // reconstruction.
+            let pending = mem::take(&mut self.obligations.pending);
+            self.obligations.pending.reserve(pending.capacity());
+
+            for (mut obligation, stalled_on) in pending {
                 let goal = obligation.as_goal();
                 let delegate = <&SolverDelegate<'tcx>>::from(infcx);
 


### PR DESCRIPTION
For extreme new-solver cases like `nacl-0.5.3` and `ijson-0.1.6` the loop in `try_evaluate_obligations` can be very inefficient. This commit makes a very simple capacity tweak to the `pending` vec to fix that.

There are some other possible changes to this function to improve performance further but they are more complicated so I'm doing this easy one first.

r? @lcnr