### PR TITLE
Do not use -Werror when building rustc_llvm with GCC

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -251,8 +251,11 @@ fn main() {
     // for this platform. See https://github.com/rust-lang/rust/pull/145031#issuecomment-3162677202.
     // Moreover, LLVM generally guarantees warning-freedom only when building with Clang, as other
     // compilers have too many false positives. This is typically the case for MSVC, which throws
-    // many false-positive warnings. We keep it excluded, for these reasons.
-    if std::env::var_os("CI").is_some() && !target.contains("msvc") {
+    // many false-positive warnings, and also GCC. We keep these excluded, for these reasons.
+    let is_msvc = target.contains("msvc");
+    let compiler_is_gcc =
+        tracked_env_var_os("LLVM_COMPILER_IS_GNU_LIKE").as_deref() == Some(OsStr::new("1"));
+    if std::env::var_os("CI").is_some() && !is_msvc && !compiler_is_gcc {
         cfg.warnings_into_errors(true);
     }
     for flag in &cxxflags {

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1487,6 +1487,9 @@ fn rustc_llvm_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetSelect
     if builder.config.llvm_assertions {
         cargo.env("LLVM_ASSERTIONS", "1");
     }
+    if builder.cxx_tool(target).is_like_gnu() || builder.cc_tool(target).is_like_gnu() {
+        cargo.env("LLVM_COMPILER_IS_GNU_LIKE", "1");
+    }
 }
 
 /// `RustcLink` copies compiler rlibs from a rustc build into a compiler sysroot.


### PR DESCRIPTION
Should hopefully unblock Illumos build failure for LLVM 23 upgrade (https://github.com/rust-lang/rust/pull/158734#issuecomment-5160103329).
