### PR TITLE
move mir-opt miri tests to CI logic

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -769,30 +769,6 @@ impl CommandLineStep for Miri {
             let _time = helpers::timeit(builder);
             cargo.run(builder);
         }
-
-        // Run it again for mir-opt-level 4 to catch some miscompilations.
-        if builder.config.test_args().is_empty() {
-            cargo.env(
-                "MIRIFLAGS",
-                format!(
-                    "{} -O -Zmir-opt-level=4 -Cdebug-assertions=yes",
-                    env::var("MIRIFLAGS").unwrap_or_default()
-                ),
-            );
-            // Optimizations can change backtraces
-            cargo.env("MIRI_SKIP_UI_CHECKS", "1");
-            // `MIRI_SKIP_UI_CHECKS` and `RUSTC_BLESS` are incompatible
-            cargo.env_remove("RUSTC_BLESS");
-            // Optimizations can change error locations and remove UB so don't run `fail` tests.
-            cargo.args(["tests/pass", "tests/panic"]);
-
-            {
-                let _guard =
-                    builder.msg_test("miri (mir-opt-level 4)", target, target_compiler.stage);
-                let _time = helpers::timeit(builder);
-                cargo.run(builder);
-            }
-        }
     }
 }
 

--- a/src/ci/docker/host-x86_64/x86_64-gnu-miri/check-miri.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-miri/check-miri.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ignore-tidy-file-linelength
 
 set -eu
@@ -15,6 +15,8 @@ if [ -z "${PR_CI_JOB:-}" ]; then
 else
     python3 "$X_PY" test --stage 2 miri cargo-miri
 fi
+# Run the test suite again with mir optimizations, to catch some miscompilations.
+MIRIFLAGS="-O -Zmir-opt-level=4 -Cdebug-assertions=yes" MIRI_SKIP_UI_CHECKS=1 python3 "$X_PY" test --stage 2 miri -- tests/{pass,panic}
 # We natively run this script on x86_64-unknown-linux-gnu and x86_64-pc-windows-msvc.
 # Also cover some other targets via cross-testing, in particular all tier 1 targets.
 case $HOST_TARGET in
@@ -23,13 +25,12 @@ case $HOST_TARGET in
     # Fully test all main OSes, and all main architectures.
     python3 "$X_PY" test --stage 2 miri cargo-miri --target aarch64-apple-darwin
     python3 "$X_PY" test --stage 2 miri cargo-miri --target i686-pc-windows-msvc
-    # Only run "pass" tests for the remaining targets, which is quite a bit faster.
-    # We have to use `miri` instead of `src/tools/miri` here to avoid also running the cargo-miri
-    # tests.
-    python3 "$X_PY" test --stage 2 miri --target x86_64-pc-windows-gnu --test-args pass
-    python3 "$X_PY" test --stage 2 miri --target i686-unknown-linux-gnu --test-args pass
-    python3 "$X_PY" test --stage 2 miri --target aarch64-unknown-linux-gnu --test-args pass
-    python3 "$X_PY" test --stage 2 miri --target s390x-unknown-linux-gnu --test-args pass
+    # Only run "pass" tests for the remaining targets, which is a bit faster. We have to use `miri`
+    # instead of `src/tools/miri` here to avoid also running the cargo-miri tests.
+    python3 "$X_PY" test --stage 2 miri --target x86_64-pc-windows-gnu -- tests/pass
+    python3 "$X_PY" test --stage 2 miri --target i686-unknown-linux-gnu -- tests/pass
+    python3 "$X_PY" test --stage 2 miri --target aarch64-unknown-linux-gnu -- tests/pass
+    python3 "$X_PY" test --stage 2 miri --target s390x-unknown-linux-gnu -- tests/pass
     ;;
   x86_64-pc-windows-msvc)
     # Strangely, Linux targets do not work here. cargo always says
@@ -38,7 +39,7 @@ case $HOST_TARGET in
     #FIXME: Re-enable this once CI issues are fixed
     # See <https://github.com/rust-lang/rust/issues/127883>
     # For now, these tests are moved to `x86_64-msvc-ext2` in `src/ci/github-actions/jobs.yml`.
-    #python3 "$X_PY" test --stage 2 miri --target x86_64-apple-darwin --test-args pass
+    #python3 "$X_PY" test --stage 2 miri --target x86_64-apple-darwin -- pass
     ;;
   *)
     echo "FATAL: unexpected host $HOST_TARGET"
@@ -50,7 +51,7 @@ esac
 
 #FIXME: Re-enable this for msvc once CI issues are fixed
 if [ "$HOST_TARGET" != "x86_64-pc-windows-msvc" ]; then
-  python3 "$X_PY" miri --stage 2 library/core --test-args notest
-  python3 "$X_PY" miri --stage 2 library/alloc --test-args notest
-  python3 "$X_PY" miri --stage 2 library/std --test-args notest
+  python3 "$X_PY" miri --stage 2 library/core -- notest
+  python3 "$X_PY" miri --stage 2 library/alloc -- notest
+  python3 "$X_PY" miri --stage 2 library/std -- notest
 fi


### PR DESCRIPTION
It is useful to run Miri tests with mir-opts as that sometimes finds miscompilations.

However, doing so on every `./x test miri` is annoying as it makes that take a lot longer, and it is inconsistent with `./miri test` in the Miri repo. So remove this logic there, and instead have the check-miri script in CI invoke the test suite a 2nd time with mir-opts enabled.

Cc @rust-lang/miri