### PR TITLE
Use `thread::available_parallelism` as the default limit for backend parallelism

### DIFF
--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -15,7 +15,7 @@ use rustc_parse::lexer::StripTokens;
 use rustc_parse::new_parser_from_source_str;
 use rustc_parse::parser::Recovery;
 use rustc_query_impl::print_query_stack;
-use rustc_session::config::{self, BackendJobs, Cfg, CheckCfg, ExpectedValues, Input, OutFileName};
+use rustc_session::config::{self, Cfg, CheckCfg, ExpectedValues, Input, OutFileName};
 use rustc_session::parse::ParseSess;
 use rustc_session::{CompilerIO, EarlyDiagCtxt, Session, lint};
 use rustc_span::source_map::{FileLoader, RealFileLoader, SourceMapInputs};
@@ -375,9 +375,7 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
 
     // Initialize jobserver as early as possible.
     let early_dcx = EarlyDiagCtxt::new(config.opts.error_format);
-    if let Some(limit) =
-        config.opts.jobs.frontend.max(config.opts.jobs.backend.map(BackendJobs::value))
-    {
+    if let Some(limit) = config.opts.jobs.frontend.max(config.opts.jobs.backend) {
         jobserver::initialize(limit.get(), |err| {
             let note = "the build environment is likely misconfigured";
             early_dcx.early_struct_warn(err).with_note(note).emit()

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1650,26 +1650,6 @@ impl PointerAuthOption {
 }
 
 #[derive(Clone, Copy)]
-pub enum BackendJobs {
-    /// The number of backend jobs has a static limit.
-    Limited(NonZero<usize>),
-    /// The number of backend jobs is either unlimited if there's an inherited jobserver,
-    /// or limited to 32 if there's no inherited jobserver.
-    /// This variant exists only to preserve the historical behavior.
-    /// FIXME: Just use `thread::available_parallelism` as the default static limit.
-    UnlimitedOr32,
-}
-
-impl BackendJobs {
-    pub fn value(self) -> NonZero<usize> {
-        match self {
-            BackendJobs::Limited(n) => n,
-            BackendJobs::UnlimitedOr32 => NonZero::new(32).unwrap(),
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
 pub enum LinkerJobs {
     /// Do not pass anything to the linker, use it's default behavior.
     Default,
@@ -1682,7 +1662,7 @@ pub enum LinkerJobs {
 #[derive(Clone, Copy)]
 pub struct Jobs {
     pub frontend: Option<NonZero<usize>>,
-    pub backend: Option<BackendJobs>,
+    pub backend: Option<NonZero<usize>>,
     pub linker: LinkerJobs,
 }
 
@@ -1735,11 +1715,12 @@ fn parse_jobs_all(
             let backend =
                 parse_jobs_one(early_dcx, opt_name, &jobs_backend, unstable, &mut available);
             check_upper_limit(backend, opt_name);
-            backend.map(BackendJobs::Limited)
+            backend
         }
         None => match jobs {
-            Some(n) => n.map(BackendJobs::Limited),
-            None => Some(BackendJobs::UnlimitedOr32),
+            Some(n) => n,
+            // Use all available parallelism as the default.
+            None => parse_jobs_one(early_dcx, "", "0", unstable, &mut available),
         },
     };
     let linker = match matches.opt_str("jobs-linker") {


### PR DESCRIPTION
Instead of the old scheme with 32-or-unlimited, depending on inherited-ness of the jobserver.

Not sure if this needs some wider discussion or not.
In the most common case (rustc is called from cargo) nothing changes, because cargo already limits the parallelism to `thread::available_parallelism` by default, and passes this limit to rustc through jobserver.

https://github.com/rust-lang/rust/pull/160387 will become simpler if this PR is merged first.
r? @bjorn3 @Zoxc 