### PR TITLE
Run try builds on EC2 by default

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -71,6 +71,10 @@ runners:
     os: codebuild-ubuntu-22-8c-$github.run_id-$github.run_attempt
     <<: *base-job
 
+  - &job-linux-48c-ec2
+    os: ec2-ubuntu26.04-c8a.12xlarge-x64-linux-$github.run_id-$github.run_attempt
+    <<: *base-job
+
 envs:
   production:
     &production
@@ -106,7 +110,6 @@ jobs:
       IMAGE: dist-x86_64-linux
       CODEGEN_BACKENDS: llvm,cranelift
       DOCKER_SCRIPT: dist.sh
-    <<: *job-linux-36c-codebuild
 
 
 # Jobs that run on each push to a pull request (PR).
@@ -176,7 +179,7 @@ pr:
 # These jobs automatically inherit envs.try, to avoid repeating
 # it in each job definition.
 try:
-  - <<: *job-dist-x86_64-linux
+  - <<: [*job-dist-x86_64-linux, *job-linux-48c-ec2]
     name: dist-x86_64-linux-quick
 
 # Jobs that only run when explicitly invoked in one of the following ways:
@@ -189,21 +192,12 @@ optional:
     env:
       IMAGE: pr-check-1
     <<: *job-linux-4c
-  - name: dist-x86_64-linux-ec2
-    os: ec2-ubuntu26.04-c8a.12xlarge-x64-linux-$github.run_id-$github.run_attempt
-    free_disk: true
-    env:
-      IMAGE: dist-x86_64-linux
-      CODEGEN_BACKENDS: llvm,cranelift
-      DOCKER_SCRIPT: dist.sh
-  - name: dist-x86_64-linux-ec2-quick
-    os: ec2-ubuntu26.04-c8a.12xlarge-x64-linux-$github.run_id-$github.run_attempt
-    free_disk: true
-    env:
-      IMAGE: dist-x86_64-linux
-      CODEGEN_BACKENDS: llvm,cranelift
-      DOCKER_SCRIPT: dist.sh
-      DIST_TRY_BUILD: 1
+  - <<: [*job-dist-x86_64-linux, *job-linux-36c-codebuild]
+    name: dist-x86_64-linux-quick-codebuild
+  # We repeat the try job here so that it can be explicitly executed using `@bors try jobs`, to test
+  # full x64 Linux dist try builds on EC2.
+  - <<: [*job-dist-x86_64-linux, *job-linux-48c-ec2]
+    name: dist-x86_64-linux-quick
 
 # Main CI jobs that have to be green to merge a commit into the default branch.
 #
@@ -311,7 +305,7 @@ auto:
   - name: dist-x86_64-illumos
     <<: *job-linux-4c
 
-  - <<: *job-dist-x86_64-linux
+  - <<: [*job-dist-x86_64-linux, *job-linux-36c-codebuild]
 
   - name: dist-x86_64-linux-alt
     env:

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -193,7 +193,14 @@ optional:
       IMAGE: pr-check-1
     <<: *job-linux-4c
   - <<: [*job-dist-x86_64-linux, *job-linux-36c-codebuild]
+    name: dist-x86_64-linux-codebuild
+  - <<: [*job-dist-x86_64-linux, *job-linux-36c-codebuild]
     name: dist-x86_64-linux-quick-codebuild
+    env:
+      IMAGE: dist-x86_64-linux
+      CODEGEN_BACKENDS: llvm,cranelift
+      DOCKER_SCRIPT: dist.sh
+      DIST_TRY_BUILD: 1
   # We repeat the try job here so that it can be explicitly executed using `@bors try jobs`, to test
   # full x64 Linux dist try builds on EC2.
   - <<: [*job-dist-x86_64-linux, *job-linux-48c-ec2]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160427)*
<!-- homu-ignore:end -->

This PR switches try builds to EC2 instances by default, while still giving us the option to do a try build on codebuild.

x64 Linux auto jobs are still using CodeBuild, for now.

This script can be used to test the configuration of the generated CI jobs locally:

```bash
#!/bin/bash

#export GITHUB_EVENT_NAME=pull_request
#export GITHUB_REF=refs/heads/pr/1
export GITHUB_EVENT_NAME=push
export GITHUB_REF=refs/heads/automation/bors/try
#export GITHUB_REF=refs/heads/automation/bors/auto

#export COMMIT_MESSAGE="try-job: dist-x86_64-linux-quick"
export COMMIT_MESSAGE="msg"
export GITHUB_RUN_ID=123
export GITHUB_RUN_ATTEMPT=1

cargo run --manifest-path src/ci/citool/Cargo.toml calculate-job-matrix
```

CI runs:
- `@bors try` - https://github.com/rust-lang/rust/pull/160427#issuecomment-5165585655 (59m)
- `@bors try jobs=dist-x86_64-linux-quick`: https://github.com/rust-lang/rust/pull/160427#issuecomment-5166491874 (1h 32m)
- `@bors try jobs=dist-x86_64-linux-codebuild`: https://github.com/rust-lang/rust/pull/160427#issuecomment-5168717243 (3h 6m)
- `@bors try jobs=dist-x86_64-linux`: https://github.com/rust-lang/rust/pull/160427#issuecomment-5170589255 (3h 6m)

r? @Mark-Simulacrum