### PR TITLE
Add more context to dyn-compatibility diagnostic for receiver-less associated functions

### DIFF
--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -925,7 +925,8 @@ impl DynCompatibilityViolationSolution {
                 err.span_suggestion(
                     add_self_sugg.1,
                     format!(
-                        "consider turning `{name}` into a method by giving it a `&self` argument"
+                        "consider turning `{name}` into a method by giving it a `&self` \
+                             argument, so that it is accessible through the trait object's vtable"
                     ),
                     add_self_sugg.0,
                     Applicability::MaybeIncorrect,
@@ -933,8 +934,8 @@ impl DynCompatibilityViolationSolution {
                 err.span_suggestion(
                     make_sized_sugg.1,
                     format!(
-                        "alternatively, consider constraining `{name}` so it does not apply to \
-                             trait objects"
+                        "alternatively, consider constraining `{name}` so it is explicitly \
+                             marked as not applying to trait objects"
                     ),
                     make_sized_sugg.0,
                     Applicability::MaybeIncorrect,

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning-3.old.stderr
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning-3.old.stderr
@@ -79,11 +79,11 @@ LL | trait A { fn g(b: B) -> B; }
    |       -      ^ ...because associated function `g` has no `self` parameter
    |       |
    |       this trait is not dyn compatible...
-help: consider turning `g` into a method by giving it a `&self` argument
+help: consider turning `g` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL | trait A { fn g(&self, b: B) -> B; }
    |                ++++++
-help: alternatively, consider constraining `g` so it does not apply to trait objects
+help: alternatively, consider constraining `g` so it is explicitly marked as not applying to trait objects
    |
 LL | trait A { fn g(b: B) -> B where Self: Sized; }
    |                           +++++++++++++++++
@@ -121,11 +121,11 @@ LL | trait B { fn f(a: A) -> A; }
    |       -      ^ ...because associated function `f` has no `self` parameter
    |       |
    |       this trait is not dyn compatible...
-help: consider turning `f` into a method by giving it a `&self` argument
+help: consider turning `f` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL | trait B { fn f(&self, a: A) -> A; }
    |                ++++++
-help: alternatively, consider constraining `f` so it does not apply to trait objects
+help: alternatively, consider constraining `f` so it is explicitly marked as not applying to trait objects
    |
 LL | trait B { fn f(a: A) -> A where Self: Sized; }
    |                           +++++++++++++++++

--- a/tests/ui/dyn-compatibility/dyn-incompat-const-slice.stderr
+++ b/tests/ui/dyn-compatibility/dyn-incompat-const-slice.stderr
@@ -13,11 +13,11 @@ LL | trait Qiz {
 LL |   fn qiz();
    |      ^^^ ...because associated function `qiz` has no `self` parameter
    = help: only type `Foo` implements `Qiz`; consider using it directly instead.
-help: consider turning `qiz` into a method by giving it a `&self` argument
+help: consider turning `qiz` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |   fn qiz(&self);
    |          +++++
-help: alternatively, consider constraining `qiz` so it does not apply to trait objects
+help: alternatively, consider constraining `qiz` so it is explicitly marked as not applying to trait objects
    |
 LL |   fn qiz() where Self: Sized;
    |            +++++++++++++++++
@@ -37,11 +37,11 @@ LL | trait Qiz {
 LL |   fn qiz();
    |      ^^^ ...because associated function `qiz` has no `self` parameter
    = help: only type `Foo` implements `Qiz`; consider using it directly instead.
-help: consider turning `qiz` into a method by giving it a `&self` argument
+help: consider turning `qiz` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |   fn qiz(&self);
    |          +++++
-help: alternatively, consider constraining `qiz` so it does not apply to trait objects
+help: alternatively, consider constraining `qiz` so it is explicitly marked as not applying to trait objects
    |
 LL |   fn qiz() where Self: Sized;
    |            +++++++++++++++++

--- a/tests/ui/dyn-compatibility/no-static.stderr
+++ b/tests/ui/dyn-compatibility/no-static.stderr
@@ -13,11 +13,11 @@ LL | trait Foo {
 LL |     fn foo() {}
    |        ^^^ ...because associated function `foo` has no `self` parameter
    = help: only type `Bar` implements `Foo`; consider using it directly instead.
-help: consider turning `foo` into a method by giving it a `&self` argument
+help: consider turning `foo` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn foo(&self) {}
    |            +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
+help: alternatively, consider constraining `foo` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn foo() where Self: Sized {}
    |              +++++++++++++++++
@@ -37,11 +37,11 @@ LL | trait Foo {
 LL |     fn foo() {}
    |        ^^^ ...because associated function `foo` has no `self` parameter
    = help: only type `Bar` implements `Foo`; consider using it directly instead.
-help: consider turning `foo` into a method by giving it a `&self` argument
+help: consider turning `foo` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn foo(&self) {}
    |            +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
+help: alternatively, consider constraining `foo` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn foo() where Self: Sized {}
    |              +++++++++++++++++

--- a/tests/ui/dyn-compatibility/spurious-dyn-compat-errors-58734.stderr
+++ b/tests/ui/dyn-compatibility/spurious-dyn-compat-errors-58734.stderr
@@ -28,11 +28,11 @@ LL | trait Trait {
 LL |     fn dyn_incompatible() -> Self;
    |        ^^^^^^^^^^^^^^^^ ...because associated function `dyn_incompatible` has no `self` parameter
    = help: only type `()` implements `Trait`; consider using it directly instead.
-help: consider turning `dyn_incompatible` into a method by giving it a `&self` argument
+help: consider turning `dyn_incompatible` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn dyn_incompatible(&self) -> Self;
    |                         +++++
-help: alternatively, consider constraining `dyn_incompatible` so it does not apply to trait objects
+help: alternatively, consider constraining `dyn_incompatible` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn dyn_incompatible() -> Self where Self: Sized;
    |                                   +++++++++++++++++

--- a/tests/ui/dyn-compatibility/static-constructor-prevents-dyn-no-api-guidance.rs
+++ b/tests/ui/dyn-compatibility/static-constructor-prevents-dyn-no-api-guidance.rs
@@ -1,0 +1,9 @@
+trait Factory {
+    fn create() -> Box<dyn Factory>;
+    //~^ ERROR the trait `Factory` is not dyn compatible
+}
+
+fn use_factory(_: &dyn Factory) {}
+//~^ ERROR the trait `Factory` is not dyn compatible
+
+fn main() {}

--- a/tests/ui/dyn-compatibility/static-constructor-prevents-dyn-no-api-guidance.stderr
+++ b/tests/ui/dyn-compatibility/static-constructor-prevents-dyn-no-api-guidance.stderr
@@ -1,0 +1,54 @@
+error[E0038]: the trait `Factory` is not dyn compatible
+  --> $DIR/static-constructor-prevents-dyn-no-api-guidance.rs:6:20
+   |
+LL | fn use_factory(_: &dyn Factory) {}
+   |                    ^^^^^^^^^^^ `Factory` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/static-constructor-prevents-dyn-no-api-guidance.rs:2:8
+   |
+LL | trait Factory {
+   |       ------- this trait is not dyn compatible...
+LL |     fn create() -> Box<dyn Factory>;
+   |        ^^^^^^ ...because associated function `create` has no `self` parameter
+help: consider turning `create` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
+   |
+LL |     fn create(&self) -> Box<dyn Factory>;
+   |               +++++
+help: alternatively, consider constraining `create` so it is explicitly marked as not applying to trait objects
+   |
+LL |     fn create() -> Box<dyn Factory> where Self: Sized;
+   |                                     +++++++++++++++++
+
+error[E0038]: the trait `Factory` is not dyn compatible
+  --> $DIR/static-constructor-prevents-dyn-no-api-guidance.rs:2:24
+   |
+LL |     fn create() -> Box<dyn Factory>;
+   |                        ^^^^^^^^^^^ `Factory` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/static-constructor-prevents-dyn-no-api-guidance.rs:2:8
+   |
+LL | trait Factory {
+   |       ------- this trait is not dyn compatible...
+LL |     fn create() -> Box<dyn Factory>;
+   |        ^^^^^^ ...because associated function `create` has no `self` parameter
+help: consider turning `create` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
+   |
+LL |     fn create(&self) -> Box<dyn Factory>;
+   |               +++++
+help: alternatively, consider constraining `create` so it is explicitly marked as not applying to trait objects
+   |
+LL |     fn create() -> Box<dyn Factory> where Self: Sized;
+   |                                     +++++++++++++++++
+help: you might have meant to use `Self` to refer to the implementing type
+   |
+LL -     fn create() -> Box<dyn Factory>;
+LL +     fn create() -> Box<Self>;
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/dyn-compatibility/taint-const-eval.stderr
+++ b/tests/ui/dyn-compatibility/taint-const-eval.stderr
@@ -12,11 +12,11 @@ LL | trait Qux {
    |       --- this trait is not dyn compatible...
 LL |     fn bar();
    |        ^^^ ...because associated function `bar` has no `self` parameter
-help: consider turning `bar` into a method by giving it a `&self` argument
+help: consider turning `bar` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn bar(&self);
    |            +++++
-help: alternatively, consider constraining `bar` so it does not apply to trait objects
+help: alternatively, consider constraining `bar` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn bar() where Self: Sized;
    |              +++++++++++++++++

--- a/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
+++ b/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
@@ -17,11 +17,11 @@ LL |     fn foo() -> Self;
              B
            consider defining an enum where each variant holds one of these types,
            implementing `DynIncompatible` for this new enum and using it instead
-help: consider turning `foo` into a method by giving it a `&self` argument
+help: consider turning `foo` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn foo(&self) -> Self;
    |            +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
+help: alternatively, consider constraining `foo` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
@@ -67,11 +67,11 @@ LL |     fn foo() -> Self;
              B
            consider defining an enum where each variant holds one of these types,
            implementing `DynIncompatible` for this new enum and using it instead
-help: consider turning `foo` into a method by giving it a `&self` argument
+help: consider turning `foo` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn foo(&self) -> Self;
    |            +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
+help: alternatively, consider constraining `foo` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
@@ -100,11 +100,11 @@ help: consider using an opaque type instead
 LL - fn car() -> dyn DynIncompatible {
 LL + fn car() -> impl DynIncompatible {
    |
-help: consider turning `foo` into a method by giving it a `&self` argument
+help: consider turning `foo` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn foo(&self) -> Self;
    |            +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
+help: alternatively, consider constraining `foo` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
@@ -134,11 +134,11 @@ help: consider using an opaque type instead
 LL - fn car() -> dyn DynIncompatible {
 LL + fn car() -> impl DynIncompatible {
    |
-help: consider turning `foo` into a method by giving it a `&self` argument
+help: consider turning `foo` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn foo(&self) -> Self;
    |            +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
+help: alternatively, consider constraining `foo` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++

--- a/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.stderr
+++ b/tests/ui/parallel-rustc/recursive-trait-fn-sig-issue-142064.stderr
@@ -40,11 +40,11 @@ LL | trait A { fn foo() -> A; }
    |       -      ^^^ ...because associated function `foo` has no `self` parameter
    |       |
    |       this trait is not dyn compatible...
-help: consider turning `foo` into a method by giving it a `&self` argument
+help: consider turning `foo` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL | trait A { fn foo(&self) -> A; }
    |                  +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
+help: alternatively, consider constraining `foo` so it is explicitly marked as not applying to trait objects
    |
 LL | trait A { fn foo() -> A where Self: Sized; }
    |                         +++++++++++++++++
@@ -95,11 +95,11 @@ LL | trait A { fn foo() -> A; }
    |       -      ^^^ ...because associated function `foo` has no `self` parameter
    |       |
    |       this trait is not dyn compatible...
-help: consider turning `foo` into a method by giving it a `&self` argument
+help: consider turning `foo` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL | trait A { fn foo(&self) -> A; }
    |                  +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
+help: alternatively, consider constraining `foo` so it is explicitly marked as not applying to trait objects
    |
 LL | trait A { fn foo() -> A where Self: Sized; }
    |                         +++++++++++++++++

--- a/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
+++ b/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
@@ -12,11 +12,11 @@ LL | trait Qux {
    |       --- this trait is not dyn compatible...
 LL |     fn bar() -> i32;
    |        ^^^ ...because associated function `bar` has no `self` parameter
-help: consider turning `bar` into a method by giving it a `&self` argument
+help: consider turning `bar` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn bar(&self) -> i32;
    |            +++++
-help: alternatively, consider constraining `bar` so it does not apply to trait objects
+help: alternatively, consider constraining `bar` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn bar() -> i32 where Self: Sized;
    |                     +++++++++++++++++
@@ -51,11 +51,11 @@ LL | trait Qux {
    |       --- this trait is not dyn compatible...
 LL |     fn bar() -> i32;
    |        ^^^ ...because associated function `bar` has no `self` parameter
-help: consider turning `bar` into a method by giving it a `&self` argument
+help: consider turning `bar` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn bar(&self) -> i32;
    |            +++++
-help: alternatively, consider constraining `bar` so it does not apply to trait objects
+help: alternatively, consider constraining `bar` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn bar() -> i32 where Self: Sized;
    |                     +++++++++++++++++

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-self-2021.stderr
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-self-2021.stderr
@@ -32,11 +32,11 @@ LL | trait B {
    |       - this trait is not dyn compatible...
 LL |     fn f(a: dyn B) -> dyn B;
    |        ^ ...because associated function `f` has no `self` parameter
-help: consider turning `f` into a method by giving it a `&self` argument
+help: consider turning `f` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn f(&self, a: dyn B) -> dyn B;
    |          ++++++
-help: alternatively, consider constraining `f` so it does not apply to trait objects
+help: alternatively, consider constraining `f` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn f(a: dyn B) -> dyn B where Self: Sized;
    |                             +++++++++++++++++

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-self.stderr
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-self.stderr
@@ -32,11 +32,11 @@ LL | trait B {
    |       - this trait is not dyn compatible...
 LL |     fn f(a: dyn B) -> dyn B;
    |        ^ ...because associated function `f` has no `self` parameter
-help: consider turning `f` into a method by giving it a `&self` argument
+help: consider turning `f` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn f(&self, a: dyn B) -> dyn B;
    |          ++++++
-help: alternatively, consider constraining `f` so it does not apply to trait objects
+help: alternatively, consider constraining `f` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn f(a: dyn B) -> dyn B where Self: Sized;
    |                             +++++++++++++++++

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.stderr
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.stderr
@@ -14,11 +14,11 @@ LL |     fn foo() where Self: Other, { }
    |        ^^^ ...because associated function `foo` has no `self` parameter
 LL |     fn bar(self: ()) {}
    |                  ^^ ...because method `bar`'s `self` parameter cannot be dispatched on
-help: consider turning `foo` into a method by giving it a `&self` argument
+help: consider turning `foo` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn foo(&self) where Self: Other, { }
    |            +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
+help: alternatively, consider constraining `foo` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn foo() where Self: Other, Self: Sized { }
    |                                 +++++++++++

--- a/tests/ui/traits/issue-72410.stderr
+++ b/tests/ui/traits/issue-72410.stderr
@@ -12,11 +12,11 @@ LL | pub trait Bar {
    |           --- this trait is not dyn compatible...
 LL |     fn map()
    |        ^^^ ...because associated function `map` has no `self` parameter
-help: consider turning `map` into a method by giving it a `&self` argument
+help: consider turning `map` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn map(&self)
    |            +++++
-help: alternatively, consider constraining `map` so it does not apply to trait objects
+help: alternatively, consider constraining `map` so it is explicitly marked as not applying to trait objects
    |
 LL |     where for<'a> &'a mut [dyn Bar]:, Self: Sized ;
    |                                     +++++++++++++

--- a/tests/ui/traits/missing-for-type-in-impl.e2015.stderr
+++ b/tests/ui/traits/missing-for-type-in-impl.e2015.stderr
@@ -48,11 +48,11 @@ LL | trait Foo<T> {
    |       --- this trait is not dyn compatible...
 LL |     fn id(me: T) -> T;
    |        ^^ ...because associated function `id` has no `self` parameter
-help: consider turning `id` into a method by giving it a `&self` argument
+help: consider turning `id` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn id(&self, me: T) -> T;
    |           ++++++
-help: alternatively, consider constraining `id` so it does not apply to trait objects
+help: alternatively, consider constraining `id` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn id(me: T) -> T where Self: Sized;
    |                       +++++++++++++++++

--- a/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.stderr
+++ b/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.stderr
@@ -12,11 +12,11 @@ LL | trait FromResidual<R = <Self as Try>::Residual> {
    |       ------------ this trait is not dyn compatible...
 LL |     fn from_residual(residual: R) -> Self;
    |        ^^^^^^^^^^^^^ ...because associated function `from_residual` has no `self` parameter
-help: consider turning `from_residual` into a method by giving it a `&self` argument
+help: consider turning `from_residual` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn from_residual(&self, residual: R) -> Self;
    |                      ++++++
-help: alternatively, consider constraining `from_residual` so it does not apply to trait objects
+help: alternatively, consider constraining `from_residual` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn from_residual(residual: R) -> Self where Self: Sized;
    |                                           +++++++++++++++++

--- a/tests/ui/traits/object/safety.stderr
+++ b/tests/ui/traits/object/safety.stderr
@@ -13,11 +13,11 @@ LL | trait Tr {
 LL |     fn foo();
    |        ^^^ ...because associated function `foo` has no `self` parameter
    = help: only type `St` implements `Tr`; consider using it directly instead.
-help: consider turning `foo` into a method by giving it a `&self` argument
+help: consider turning `foo` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
    |
 LL |     fn foo(&self);
    |            +++++
-help: alternatively, consider constraining `foo` so it does not apply to trait objects
+help: alternatively, consider constraining `foo` so it is explicitly marked as not applying to trait objects
    |
 LL |     fn foo() where Self: Sized;
    |              +++++++++++++++++


### PR DESCRIPTION
Fixes rust-lang/rust#159492

Expands the two suggestion messages for the "no `self` parameter" 
dyn-compatibility violation to explain *why* each fix works, per the issue.

Before:
  help: consider turning `create` into a method by giving it a `&self` argument
  help: alternatively, consider constraining `create` so it does not apply to trait objects

After:
  help: consider turning `create` into a method by giving it a `&self` argument, so that it is accessible through the trait object's vtable
  help: alternatively, consider constraining `create` so it is explicitly marked as not applying to trait objects

Only the two strings in `DynCompatibilityViolationSolution::add_to` 
(rustc_middle/src/traits/mod.rs) changed — no logic, applicability, or span changes.

Added a regression test using the issue's exact example 
(tests/ui/dyn-compatibility/static-constructor-prevents-dyn-no-api-guidance.rs).

Verified against a locally-built rustc; full `tests/ui` suite passes 
(21643 passed, 0 failed). Note: `next-solver` compare-mode has pre-existing, 
unrelated failures on 3 tests in this directory, confirmed present on `main` 
without this diff.