### PR TITLE
bootstrap: Don't produce mutated/filtered PathSets during command-line matching

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -699,7 +699,7 @@ macro_rules! tool_check_step {
             const IS_HOST: bool = true;
 
             fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-                run.selectors(&[$path $(, $alt_path )*])
+                run.multi_path(&[$path $(, $alt_path )*])
             }
 
             fn is_default_step(_builder: &Builder<'_>) -> bool {

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3519,7 +3519,7 @@ impl CommandLineStep for CrateRustdoc {
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.selectors(&["src/librustdoc", "src/tools/rustdoc"])
+        run.multi_path(&["src/librustdoc", "src/tools/rustdoc"])
     }
 
     fn is_default_step(_builder: &Builder<'_>) -> bool {

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -704,7 +704,7 @@ impl CommandLineStep for Rustdoc {
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.selectors(&["src/tools/rustdoc", "src/librustdoc"])
+        run.multi_path(&["src/tools/rustdoc", "src/librustdoc"])
     }
 
     fn is_default_step(_builder: &Builder<'_>) -> bool {

--- a/src/bootstrap/src/core/builder/cli_paths.rs
+++ b/src/bootstrap/src/core/builder/cli_paths.rs
@@ -195,7 +195,7 @@ pub(crate) fn match_paths_to_steps_and_run(
     let mut steps_to_run = vec![];
 
     for StepExtra { desc, should_run } in &steps {
-        let pathsets = should_run.pathset_for_paths_removing_matches(&mut paths);
+        let pathsets = should_run.pathsets_for_paths_flagging_matches(&mut paths);
 
         // This value is used for sorting the step execution order.
         // By default, `usize::MAX` is used as the index for steps to assign them the lowest priority.

--- a/src/bootstrap/src/core/builder/cli_paths.rs
+++ b/src/bootstrap/src/core/builder/cli_paths.rs
@@ -73,14 +73,6 @@ pub(crate) struct CLIStepPath {
     pub(crate) will_be_executed: bool,
 }
 
-#[cfg(test)]
-impl CLIStepPath {
-    pub(crate) fn will_be_executed(mut self, will_be_executed: bool) -> Self {
-        self.will_be_executed = will_be_executed;
-        self
-    }
-}
-
 impl Debug for CLIStepPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.path.display())

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_rustdoc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_rustdoc.snap
@@ -4,4 +4,4 @@ expression: build rustdoc
 ---
 [Build] tool::Rustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({src/tools/rustdoc})
+    - Set({src/librustdoc, src/tools/rustdoc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_rustdoc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_rustdoc.snap
@@ -4,4 +4,4 @@ expression: check rustdoc
 ---
 [Check] check::Rustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({src/tools/rustdoc})
+    - Set({src/librustdoc, src/tools/rustdoc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_library_core_and_alloc_and_stdarch.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_library_core_and_alloc_and_stdarch.snap
@@ -1,0 +1,11 @@
+---
+source: src/bootstrap/src/core/builder/cli_paths/tests.rs
+expression: test library/core library/alloc library/stdarch
+---
+[Test] test::Crate
+    targets: [aarch64-unknown-linux-gnu]
+    - Set({library/alloc})
+    - Set({library/core})
+[Test] test::StdarchVerify
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({library/stdarch/crates/stdarch-verify})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_librustdoc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_librustdoc.snap
@@ -4,4 +4,4 @@ expression: test librustdoc
 ---
 [Test] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({src/librustdoc})
+    - Set({src/librustdoc, src/tools/rustdoc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_librustdoc_rustdoc_html.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_librustdoc_rustdoc_html.snap
@@ -4,7 +4,7 @@ expression: test librustdoc rustdoc-html
 ---
 [Test] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({src/librustdoc})
+    - Set({src/librustdoc, src/tools/rustdoc})
 [Test] test::RustdocHtml
     targets: [x86_64-unknown-linux-gnu]
     - Suite(tests/rustdoc-html)

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_rustdoc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_rustdoc.snap
@@ -4,7 +4,7 @@ expression: test rustdoc
 ---
 [Test] test::CrateRustdoc
     targets: [x86_64-unknown-linux-gnu]
-    - Set({src/tools/rustdoc})
+    - Set({src/librustdoc, src/tools/rustdoc})
 [Test] test::RustdocBook
     targets: [x86_64-unknown-linux-gnu]
     - Set({src/doc/rustdoc})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_rustdoc_skip_rustdoc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_rustdoc_skip_rustdoc.snap
@@ -1,0 +1,5 @@
+---
+source: src/bootstrap/src/core/builder/cli_paths/tests.rs
+expression: test rustdoc --skip=rustdoc
+---
+

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_src_tools_miri_and_cargo_miri.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_src_tools_miri_and_cargo_miri.snap
@@ -1,0 +1,10 @@
+---
+source: src/bootstrap/src/core/builder/cli_paths/tests.rs
+expression: test src/tools/miri src/tools/miri/cargo-miri
+---
+[Test] test::Miri
+    targets: [aarch64-unknown-linux-gnu]
+    - Set({src/tools/miri})
+[Test] test::CargoMiri
+    targets: [aarch64-unknown-linux-gnu]
+    - Set({src/tools/miri/cargo-miri})

--- a/src/bootstrap/src/core/builder/cli_paths/tests.rs
+++ b/src/bootstrap/src/core/builder/cli_paths/tests.rs
@@ -171,6 +171,7 @@ declare_tests!(
     (x_test_librustdoc_rustdoc_html, "test librustdoc rustdoc-html"),
     (x_test_rustdoc, "test rustdoc"),
     (x_test_rustdoc_html, "test rustdoc-html"),
+    (x_test_rustdoc_skip_rustdoc, "test rustdoc --skip=rustdoc"),
     (x_test_semver_check, "test std-semver-check"),
     (x_test_skip_coverage, "test --skip=coverage"),
     (x_test_skip_coverage_map, "test --skip=coverage-map"),

--- a/src/bootstrap/src/core/builder/cli_paths/tests.rs
+++ b/src/bootstrap/src/core/builder/cli_paths/tests.rs
@@ -165,6 +165,7 @@ declare_tests!(
     (x_test_coverage_skip_coverage_run, "test coverage --skip=coverage-run"),
     (x_test_debuginfo, "test debuginfo"),
     (x_test_library, "test library"),
+    (x_test_library_core_and_alloc_and_stdarch, "test library/core library/alloc library/stdarch"),
     (x_test_librustdoc, "test librustdoc"),
     (x_test_librustdoc_rustdoc, "test librustdoc rustdoc"),
     (x_test_librustdoc_rustdoc_html, "test librustdoc rustdoc-html"),
@@ -178,6 +179,7 @@ declare_tests!(
     (x_test_skip_tests_coverage, "test --skip=tests/coverage"),
     // From `src/ci/docker/scripts/stage_2_test_set2.sh`.
     (x_test_skip_tests_etc, "test --skip=tests --skip=library --skip=tidyselftest"),
+    (x_test_src_tools_miri_and_cargo_miri, "test src/tools/miri src/tools/miri/cargo-miri"),
     (x_test_tests, "test tests"),
     (x_test_tests_skip_coverage, "test tests --skip=coverage"),
     (x_test_tests_ui, "test tests/ui"),

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -393,10 +393,6 @@ pub enum PathSet {
 }
 
 impl PathSet {
-    fn empty() -> PathSet {
-        PathSet::Set(BTreeSet::new())
-    }
-
     fn one<P: Into<PathBuf>>(path: P) -> PathSet {
         let mut set = BTreeSet::new();
         set.insert(TaskPath { path: path.into() });
@@ -416,33 +412,31 @@ impl PathSet {
         p.path.ends_with(needle) || p.path.starts_with(needle)
     }
 
-    /// Return all `TaskPath`s in `Self` that contain any of the `needles`, removing the
-    /// matched needles.
-    ///
-    /// This is used for `StepDescription::krate`, which passes all matching crates at once to
-    /// `Step::make_run`, rather than calling it many times with a single crate.
-    /// See `tests.rs` for examples.
-    fn intersection_removing_matches(&self, needles: &mut [CLIStepPath]) -> PathSet {
-        let mut check = |p| {
+    /// Returns true if self is matched by any of the command-line selectors,
+    /// and mutates those selectors to flag them as will-be-executed.
+    fn match_and_flag_selectors(&self, selectors: &mut [CLIStepPath]) -> bool {
+        let mut check_and_flag = |p| {
             let mut result = false;
-            for n in needles.iter_mut() {
-                let matched = Self::check(p, &n.path);
+            for selector in selectors.iter_mut() {
+                let matched = Self::check(p, &selector.path);
                 if matched {
-                    n.will_be_executed = true;
+                    selector.will_be_executed = true;
                     result = true;
                 }
             }
             result
         };
+
         match self {
-            PathSet::Set(set) => PathSet::Set(set.iter().filter(|&p| check(p)).cloned().collect()),
-            PathSet::Suite(suite) => {
-                if check(suite) {
-                    self.clone()
-                } else {
-                    PathSet::empty()
+            PathSet::Set(set) => {
+                // Flag all matching selectors, not just the first match.
+                let mut matched = false;
+                for p in set {
+                    matched |= check_and_flag(p);
                 }
+                matched
             }
+            PathSet::Suite(suite) => check_and_flag(suite),
         }
     }
 
@@ -607,7 +601,7 @@ impl<'a> ShouldRun<'a> {
     }
 
     /// Multiple on-disk paths that should select the same unit of work.
-    pub fn selectors(mut self, paths: &[&str]) -> Self {
+    pub fn multi_path(mut self, paths: &[&str]) -> Self {
         let mut set = BTreeSet::new();
         for path in paths {
             self.assert_valid_path(path);
@@ -639,12 +633,11 @@ impl<'a> ShouldRun<'a> {
     ///
     /// The reason we return PathSet instead of PathBuf is to allow for aliases that mean the same thing
     /// (for now, just `all_krates` and `paths`, but we may want to add an `aliases` function in the future?)
-    fn pathset_for_paths_removing_matches(&self, paths: &mut [CLIStepPath]) -> Vec<PathSet> {
+    fn pathsets_for_paths_flagging_matches(&self, paths: &mut [CLIStepPath]) -> Vec<PathSet> {
         let mut sets = vec![];
         for pathset in &self.paths {
-            let subset = pathset.intersection_removing_matches(paths);
-            if subset != PathSet::empty() {
-                sets.push(subset);
+            if pathset.match_and_flag_selectors(paths) {
+                sets.push(pathset.clone());
             }
         }
         sets

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -51,52 +51,6 @@ fn test_invalid() {
 }
 
 #[test]
-fn test_intersection() {
-    let set = |paths: &[&str]| {
-        PathSet::Set(paths.into_iter().map(|p| TaskPath { path: p.into() }).collect())
-    };
-    let library_set = set(&["library/core", "library/alloc", "library/std"]);
-    let mut command_paths = vec![
-        CLIStepPath::from(PathBuf::from("library/core")),
-        CLIStepPath::from(PathBuf::from("library/alloc")),
-        CLIStepPath::from(PathBuf::from("library/stdarch")),
-    ];
-    let subset = library_set.intersection_removing_matches(&mut command_paths);
-    assert_eq!(subset, set(&["library/core", "library/alloc"]),);
-    assert_eq!(
-        command_paths,
-        vec![
-            CLIStepPath::from(PathBuf::from("library/core")).will_be_executed(true),
-            CLIStepPath::from(PathBuf::from("library/alloc")).will_be_executed(true),
-            CLIStepPath::from(PathBuf::from("library/stdarch")).will_be_executed(false),
-        ]
-    );
-}
-
-#[test]
-fn test_resolve_parent_and_subpaths() {
-    let set = |paths: &[&str]| {
-        PathSet::Set(paths.into_iter().map(|p| TaskPath { path: p.into() }).collect())
-    };
-
-    let mut command_paths = vec![
-        CLIStepPath::from(PathBuf::from("src/tools/miri")),
-        CLIStepPath::from(PathBuf::from("src/tools/miri/cargo-miri")),
-    ];
-
-    let library_set = set(&["src/tools/miri", "src/tools/miri/cargo-miri"]);
-    library_set.intersection_removing_matches(&mut command_paths);
-
-    assert_eq!(
-        command_paths,
-        vec![
-            CLIStepPath::from(PathBuf::from("src/tools/miri")).will_be_executed(true),
-            CLIStepPath::from(PathBuf::from("src/tools/miri/cargo-miri")).will_be_executed(true),
-        ]
-    );
-}
-
-#[test]
 fn validate_path_remap() {
     let build = Build::new(configure("test", &[TEST_TRIPLE_1], &[TEST_TRIPLE_1]));
 


### PR DESCRIPTION
A single CommandLineStep can register ”multiple paths” along two different axes:
- Registering multiple `PathSet`s
- Registering an individual `PathSet` containing multiple paths

In the latter case (a PathSet containing multiple paths), the intent is that those paths represent multiple names for the *same* unit of work, not separate units of work. It therefore does not make sense to create a modified copy of the PathSet that removes some paths, which is what the path-matching code currently does.

This PR therefore removes the code for producing filtered copies of a PathSet. If a multi-path PathSet is matched by a command-line selector, the entire PathSet will be considered matched.

The only steps that register multi-path PathSets are rustdoc-related ones, and we can be pretty confident that they aren't relying on the current (questionable) behaviour.

There should be no change to user-facing bootstrap behaviour.