### PR TITLE
bump tracing-tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5927,9 +5927,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-tree"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b56c62d2c80033cb36fae448730a2f2ef99410fe3ecbffc916681a32f6807dbe"
+checksum = "ac87aa03b6a4d5a7e4810d1a80c19601dbe0f8a837e9177f23af721c7ba7beec"
 dependencies = [
  "nu-ansi-term",
  "tracing-core",

--- a/compiler/rustc_log/Cargo.toml
+++ b/compiler/rustc_log/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 tracing = "0.1.41"
 tracing-core = "0.1.34"
 tracing-subscriber = { version = "0.3.3", default-features = false, features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi", "json"] }
-tracing-tree = "0.3.1"
+tracing-tree = "0.4.1"
 # tidy-alphabetical-end
 
 [features]

--- a/compiler/rustc_pattern_analysis/Cargo.toml
+++ b/compiler/rustc_pattern_analysis/Cargo.toml
@@ -24,7 +24,7 @@ tracing = "0.1"
 [dev-dependencies]
 # tidy-alphabetical-start
 tracing-subscriber = { version = "0.3.3", default-features = false, features = ["fmt", "env-filter", "ansi"] }
-tracing-tree = "0.3.0"
+tracing-tree = "0.4.1"
 # tidy-alphabetical-end
 
 [features]

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -26,7 +26,7 @@ stringdex = "=0.0.6"
 tempfile = "3"
 threadpool = "1.8.1"
 tracing = "0.1"
-tracing-tree = "0.3.0"
+tracing-tree = "0.4.1"
 unicode-segmentation = "1.9"
 # tidy-alphabetical-end
 


### PR DESCRIPTION
This removes the timestamps from the trace which apparently are meant to be turned off by default but that was buggy in old versions of tracing-trees.

r? @oli-obk 