### PR TITLE
[rustdoc] Change table odd table rows background color to not make it the same as inline code

### DIFF
--- a/src/librustdoc/html/static/css/noscript.css
+++ b/src/librustdoc/html/static/css/noscript.css
@@ -48,7 +48,7 @@ nav.sub {
 	--sidebar-background-color: #f5f5f5;
 	--sidebar-background-color-hover: #e0e0e0;
 	--sidebar-border-color: #ddd;
-	--code-block-background-color: #f5f5f5;
+	--code-block-background-color: #eaeaea;
 	--scrollbar-track-background-color: #dcdcdc;
 	--scrollbar-thumb-background-color: rgba(36, 37, 39, 0.6);
 	--scrollbar-color: rgba(36, 37, 39, 0.6) #d9d9d9;
@@ -244,7 +244,7 @@ nav.sub {
 		--crate-search-hover-border: #2196f3;
 		--src-sidebar-background-selected: #333;
 		--src-sidebar-background-hover: #444;
-		--table-alt-row-background-color: #2a2a2a;
+		--table-alt-row-background-color: #1d1d1d;
 		--codeblock-link-background: #333;
 		--scrape-example-toggle-line-background: #999;
 		--scrape-example-toggle-line-hover-background: #c5c5c5;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1145,7 +1145,7 @@ pre, .rustdoc.src .example-wrap, .example-wrap .src-line-numbers {
 	border: 1px solid var(--border-color);
 }
 
-.docblock table tbody tr:nth-child(2n) {
+.docblock table tbody tr:nth-child(odd) {
 	background: var(--table-alt-row-background-color);
 }
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -3217,7 +3217,7 @@ by default.
 	--sidebar-background-color: #f5f5f5;
 	--sidebar-background-color-hover: #e0e0e0;
 	--sidebar-border-color: #ddd;
-	--code-block-background-color: #f5f5f5;
+	--code-block-background-color: #eaeaea;
 	--scrollbar-track-background-color: #dcdcdc;
 	--scrollbar-thumb-background-color: rgba(36, 37, 39, 0.6);
 	--scrollbar-color: rgba(36, 37, 39, 0.6) #d9d9d9;
@@ -3412,7 +3412,7 @@ by default.
 	--crate-search-hover-border: #2196f3;
 	--src-sidebar-background-selected: #333;
 	--src-sidebar-background-hover: #444;
-	--table-alt-row-background-color: #2a2a2a;
+	--table-alt-row-background-color: #1d1d1d;
 	--codeblock-link-background: #333;
 	--scrape-example-toggle-line-background: #999;
 	--scrape-example-toggle-line-hover-background: #c5c5c5;
@@ -3532,7 +3532,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 	--crate-search-hover-border: #e0e0e0;
 	--src-sidebar-background-selected: #14191f;
 	--src-sidebar-background-hover: #14191f;
-	--table-alt-row-background-color: #191f26;
+	--table-alt-row-background-color: #000;
 	--codeblock-link-background: #333;
 	--scrape-example-toggle-line-background: #999;
 	--scrape-example-toggle-line-hover-background: #c5c5c5;

--- a/tests/rustdoc-gui/docblock-table.goml
+++ b/tests/rustdoc-gui/docblock-table.goml
@@ -11,16 +11,16 @@ define-function: (
     block {
         call-function: ("switch-theme", {"theme": |theme|})
         assert-css: (".top-doc .docblock table tbody tr:nth-child(1)", {
-            "background-color": "rgba(0, 0, 0, 0)",
+            "background-color": |zebra_stripe_color|,
         })
         assert-css: (".top-doc .docblock table tbody tr:nth-child(2)", {
-            "background-color": |zebra_stripe_color|,
-        })
-        assert-css: (".top-doc .docblock table tbody tr:nth-child(3)", {
             "background-color": "rgba(0, 0, 0, 0)",
         })
-        assert-css: (".top-doc .docblock table tbody tr:nth-child(4)", {
+        assert-css: (".top-doc .docblock table tbody tr:nth-child(3)", {
             "background-color": |zebra_stripe_color|,
+        })
+        assert-css: (".top-doc .docblock table tbody tr:nth-child(4)", {
+            "background-color": "rgba(0, 0, 0, 0)",
         })
         assert-css: (".top-doc .docblock table td", {
             "border-style": "solid",

--- a/tests/rustdoc-gui/docblock-table.goml
+++ b/tests/rustdoc-gui/docblock-table.goml
@@ -38,12 +38,12 @@ define-function: (
 call-function: ("check-colors", {
     "theme": "ayu",
     "border_color": "#5c6773",
-    "zebra_stripe_color": "#191f26",
+    "zebra_stripe_color": "#000",
 })
 call-function: ("check-colors", {
     "theme": "dark",
     "border_color": "#e0e0e0",
-    "zebra_stripe_color": "#2a2a2a",
+    "zebra_stripe_color": "#1d1d1d",
 })
 call-function: ("check-colors", {
     "theme": "light",


### PR DESCRIPTION
Fixes rust-lang/rust#159234.
Follow-up of https://github.com/rust-lang/rust/pull/105442.

It now looks like this:

<img width="418" height="163" alt="Screenshot From 2026-08-03 15-21-15" src="https://github.com/user-attachments/assets/97d2ae1c-e167-4cc0-8daf-d8937397faed" />
<img width="418" height="163" alt="Screenshot From 2026-08-03 15-21-21" src="https://github.com/user-attachments/assets/8916a49d-2496-4045-820a-12f10f18d81b" />
<img width="418" height="163" alt="Screenshot From 2026-08-03 15-21-25" src="https://github.com/user-attachments/assets/b44b3b3f-8ec7-4fea-b783-aedf1b452249" />

For the light theme, I had to make the inline code background darker so it would mix well with the alternative table rows background color.

r? @notriddle