### PR TITLE
PowerPC inline ASM: Fix scalar floats being in the wrong vector lane on little endian

### DIFF
--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -1,7 +1,7 @@
 use std::assert_matches;
 use std::fmt::Write;
 
-use rustc_abi::{BackendRepr, Float, Integer, Primitive, Scalar, Size};
+use rustc_abi::{BackendRepr, Endian, Float, Integer, Primitive, Scalar, Size};
 use rustc_ast::{InlineAsmOptions, InlineAsmTemplatePiece};
 use rustc_codegen_ssa::mir::operand::OperandValue;
 use rustc_codegen_ssa::traits::*;
@@ -12,6 +12,7 @@ use rustc_middle::ty::layout::TyAndLayout;
 use rustc_middle::{bug, span_bug};
 use rustc_span::{Pos, Span, Symbol, sym};
 use rustc_target::asm::*;
+use rustc_target::spec::HasTargetSpec;
 use smallvec::SmallVec;
 use tracing::debug;
 
@@ -1244,24 +1245,16 @@ fn llvm_fixup_input<'ll, 'tcx>(
         (
             PowerPC(PowerPCInlineAsmRegClass::vreg | PowerPCInlineAsmRegClass::vsreg),
             BackendRepr::Scalar(s),
-        ) if s.primitive() == Primitive::Float(Float::F32) => {
-            let value = bx.insert_element(
-                bx.const_undef(bx.type_vector(bx.type_f32(), 4)),
+        ) if let Primitive::Float(float @ (Float::F32 | Float::F64)) = s.primitive() => {
+            let num_lanes = 16 / float.size().bytes();
+            bx.insert_element(
+                bx.const_undef(bx.type_vector(bx.type_from_float(float), num_lanes)),
                 value,
-                bx.const_usize(0),
-            );
-            bx.bitcast(value, bx.type_vector(bx.type_f32(), 4))
-        }
-        (
-            PowerPC(PowerPCInlineAsmRegClass::vreg | PowerPCInlineAsmRegClass::vsreg),
-            BackendRepr::Scalar(s),
-        ) if s.primitive() == Primitive::Float(Float::F64) => {
-            let value = bx.insert_element(
-                bx.const_undef(bx.type_vector(bx.type_f64(), 2)),
-                value,
-                bx.const_usize(0),
-            );
-            bx.bitcast(value, bx.type_vector(bx.type_f64(), 2))
+                bx.const_usize(match bx.target_spec().endian {
+                    Endian::Little => num_lanes - 1,
+                    Endian::Big => 0,
+                }),
+            )
         }
         _ => value,
     }
@@ -1416,16 +1409,15 @@ fn llvm_fixup_output<'ll, 'tcx>(
         (
             PowerPC(PowerPCInlineAsmRegClass::vreg | PowerPCInlineAsmRegClass::vsreg),
             BackendRepr::Scalar(s),
-        ) if s.primitive() == Primitive::Float(Float::F32) => {
-            let value = bx.bitcast(value, bx.type_vector(bx.type_f32(), 4));
-            bx.extract_element(value, bx.const_usize(0))
-        }
-        (
-            PowerPC(PowerPCInlineAsmRegClass::vreg | PowerPCInlineAsmRegClass::vsreg),
-            BackendRepr::Scalar(s),
-        ) if s.primitive() == Primitive::Float(Float::F64) => {
-            let value = bx.bitcast(value, bx.type_vector(bx.type_f64(), 2));
-            bx.extract_element(value, bx.const_usize(0))
+        ) if let Primitive::Float(float @ (Float::F32 | Float::F64)) = s.primitive() => {
+            let num_lanes = 16 / float.size().bytes();
+            bx.extract_element(
+                value,
+                bx.const_usize(match bx.target_spec().endian {
+                    Endian::Little => num_lanes - 1,
+                    Endian::Big => 0,
+                }),
+            )
         }
         _ => value,
     }
@@ -1566,11 +1558,9 @@ fn llvm_fixup_output_type<'ll, 'tcx>(
         (
             PowerPC(PowerPCInlineAsmRegClass::vreg | PowerPCInlineAsmRegClass::vsreg),
             BackendRepr::Scalar(s),
-        ) if s.primitive() == Primitive::Float(Float::F32) => cx.type_vector(cx.type_f32(), 4),
-        (
-            PowerPC(PowerPCInlineAsmRegClass::vreg | PowerPCInlineAsmRegClass::vsreg),
-            BackendRepr::Scalar(s),
-        ) if s.primitive() == Primitive::Float(Float::F64) => cx.type_vector(cx.type_f64(), 2),
+        ) if let Primitive::Float(float @ (Float::F32 | Float::F64)) = s.primitive() => {
+            cx.type_vector(cx.type_from_float(float), 16 / float.size().bytes())
+        }
         _ => layout.llvm_type(cx),
     }
 }

--- a/tests/assembly-llvm/asm/powerpc-types.rs
+++ b/tests/assembly-llvm/asm/powerpc-types.rs
@@ -1,43 +1,97 @@
+// ignore-tidy-file-linelength (some revision //@ lines are over 100 chars long)
+
 //@ add-minicore
-//@ revisions: powerpc powerpc_altivec powerpc_vsx powerpc64 powerpc64_vsx
+//@ revisions: powerpc powerpc_altivec powerpc_vsx powerpc_power8 powerpc64 powerpc64_vsx powerpc64_power8 powerpc64le
 //@ assembly-output: emit-asm
 //@[powerpc] compile-flags: --target powerpc-unknown-linux-gnu
 //@[powerpc] needs-llvm-components: powerpc
 //@[powerpc_altivec] compile-flags: --target powerpc-unknown-linux-gnu -C target-feature=+altivec --cfg altivec
 //@[powerpc_altivec] needs-llvm-components: powerpc
+//@[powerpc_altivec] filecheck-flags: --check-prefix altivec
 //@[powerpc_vsx] compile-flags: --target powerpc-unknown-linux-gnu -C target-feature=+altivec,+vsx --cfg altivec --cfg vsx
 //@[powerpc_vsx] needs-llvm-components: powerpc
+//@[powerpc_vsx] filecheck-flags: --check-prefix altivec --check-prefix vsx
+//@[powerpc_power8] compile-flags: --target powerpc-unknown-linux-gnu -C target-feature=+altivec,+vsx,+power8-vector --cfg altivec --cfg vsx --cfg power8
+//@[powerpc_power8] needs-llvm-components: powerpc
+//@[powerpc_power8] filecheck-flags: --check-prefix altivec --check-prefix vsx --check-prefix power8
 //@[powerpc64] compile-flags: --target powerpc64-unknown-linux-gnu --cfg altivec
 //@[powerpc64] needs-llvm-components: powerpc
-//@[powerpc64_vsx] compile-flags: --target powerpc64-unknown-linux-gnu -C target-feature=+vsx --cfg altivec --cfg vsx
+//@[powerpc64] filecheck-flags: --check-prefix altivec
+//@[powerpc64_vsx] compile-flags: --target powerpc64-unknown-linux-gnu -C target-feature=+vsx --cfg powerpc64 --cfg altivec --cfg vsx
 //@[powerpc64_vsx] needs-llvm-components: powerpc
-//@ compile-flags: -Zmerge-functions=disabled
+//@[powerpc64_vsx] filecheck-flags: --check-prefix powerpc64 --check-prefix altivec --check-prefix vsx
+//@[powerpc64_power8] compile-flags: --target powerpc64-unknown-linux-gnu -C target-feature=+vsx,+power8-vector --cfg powerpc64 --cfg altivec --cfg vsx --cfg power8
+//@[powerpc64_power8] needs-llvm-components: powerpc
+//@[powerpc64_power8] filecheck-flags: --check-prefix powerpc64 --check-prefix altivec --check-prefix vsx --check-prefix power8
+//@[powerpc64le] compile-flags: --target powerpc64le-unknown-linux-gnu --cfg powerpc64 --cfg altivec --cfg vsx --cfg power8
+//@[powerpc64le] needs-llvm-components: powerpc
+//@[powerpc64le] filecheck-flags: --check-prefix powerpc64 --check-prefix altivec --check-prefix vsx --check-prefix power8
+//@ compile-flags: -Zmerge-functions=disabled -O
+//@ compile-flags: --check-cfg=cfg(altivec,vsx,power8)
 
-#![feature(no_core, asm_experimental_arch)]
+#![feature(no_core)]
 #![crate_type = "rlib"]
 #![no_core]
-#![allow(asm_sub_register, non_camel_case_types)]
+#![allow(asm_sub_register, non_camel_case_types, unused_imports)]
+#![deny(unexpected_cfgs)]
 
 extern crate minicore;
 use minicore::simd::*;
 use minicore::*;
 
+#[cfg_attr(powerpc64, cfg(not(target_arch = "powerpc64")))]
+#[cfg_attr(not(powerpc64), cfg(target_arch = "powerpc64"))]
+compile_error!("powerpc64 cfg and target arch mismatch");
 #[cfg_attr(altivec, cfg(not(target_feature = "altivec")))]
 #[cfg_attr(not(altivec), cfg(target_feature = "altivec"))]
 compile_error!("altivec cfg and target feature mismatch");
 #[cfg_attr(vsx, cfg(not(target_feature = "vsx")))]
 #[cfg_attr(not(vsx), cfg(target_feature = "vsx"))]
 compile_error!("vsx cfg and target feature mismatch");
+#[cfg_attr(power8, cfg(not(target_feature = "power8-vector")))]
+#[cfg_attr(not(power8), cfg(target_feature = "power8-vector"))]
+compile_error!("power8-vector cfg and target feature mismatch");
 
-type ptr = *const i32;
+// Check floating point scalars are put in the right vector lane. This uses power8 for consistent
+// assembly between powerpc64le and big-endian powerpc/powerpc64.
 
-extern "C" {
-    fn extern_func();
-    static extern_static: u8;
+// power8-LABEL: f32_to_f64:
+// power8: .cfi_startproc
+// power8-NEXT: xscvdpspn [[#INPUT:]], 1
+// powerpc64le-NEXT: vmrgow [[#INPUT - 32]], [[#INPUT - 32]], [[#INPUT - 32]]
+// power8-NEXT: #APP
+// power8-NEXT: xscvspdp 1, [[#INPUT]]
+// power8-NEXT: #NO_APP
+// power8-NEXT: blr
+#[cfg(power8)]
+#[unsafe(no_mangle)]
+pub fn f32_to_f64(x: f32) -> f64 {
+    let res;
+    unsafe {
+        asm!("xscvspdp {}, {}", out(vsreg) res, in(vsreg) x, options(pure, nostack, nomem));
+    };
+    res
+}
+
+// power8-LABEL: f64_to_f32:
+// power8: .cfi_startproc
+// power8-NEXT: #APP
+// power8-NEXT: xscvdpsp [[#OUTPUT:]], 1
+// power8-NEXT: #NO_APP
+// power8-NEXT: xscvspdpn 1, [[#OUTPUT]]
+// power8-NEXT: blr
+#[cfg(power8)]
+#[unsafe(no_mangle)]
+pub fn f64_to_f32(x: f64) -> f32 {
+    let res;
+    unsafe {
+        asm!("xscvdpsp {}, {}", out(vsreg) res, in(vsreg) x, options(pure, nostack, nomem));
+    };
+    res
 }
 
 macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe fn $func(x: $ty) -> $ty {
         let y;
         asm!(concat!($mov," {}, {}"), out($class) y, in($class) x);
@@ -46,7 +100,7 @@ macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
 };}
 
 macro_rules! check_reg { ($func:ident, $ty:ty, $rego:tt, $regc:tt, $mov:literal) => {
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe fn $func(x: $ty) -> $ty {
         let y;
         asm!(concat!($mov, " ", $rego, ", ", $rego), lateout($regc) y, in($regc) x);
@@ -116,179 +170,115 @@ check!(reg_f32, f32, freg, "fmr");
 // CHECK: #NO_APP
 check!(reg_f64, f64, freg, "fmr");
 
-// powerpc_altivec-LABEL: vreg_i8x16:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i8x16:
-// powerpc64: #APP
-// powerpc64: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i8x16:
+// altivec: #APP
+// altivec: vmr {{[0-9]+}}, {{[0-9]+}}
+// altivec: #NO_APP
 #[cfg(altivec)]
 check!(vreg_i8x16, i8x16, vreg, "vmr");
 
-// powerpc_altivec-LABEL: vreg_i16x8:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i16x8:
-// powerpc64: #APP
-// powerpc64: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i16x8:
+// altivec: #APP
+// altivec: vmr {{[0-9]+}}, {{[0-9]+}}
+// altivec: #NO_APP
 #[cfg(altivec)]
 check!(vreg_i16x8, i16x8, vreg, "vmr");
 
-// powerpc_altivec-LABEL: vreg_i32x4:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i32x4:
-// powerpc64: #APP
-// powerpc64: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i32x4:
+// altivec: #APP
+// altivec: vmr {{[0-9]+}}, {{[0-9]+}}
+// altivec: #NO_APP
 #[cfg(altivec)]
 check!(vreg_i32x4, i32x4, vreg, "vmr");
 
-// powerpc_vsx-LABEL: vreg_i64x2:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_i64x2:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_i64x2:
+// vsx: #APP
+// vsx: vmr {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vreg_i64x2, i64x2, vreg, "vmr");
 
-// powerpc_altivec-LABEL: vreg_f32x4:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_f32x4:
-// powerpc64: #APP
-// powerpc64: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_f32x4:
+// altivec: #APP
+// altivec: vmr {{[0-9]+}}, {{[0-9]+}}
+// altivec: #NO_APP
 #[cfg(altivec)]
 check!(vreg_f32x4, f32x4, vreg, "vmr");
 
-// powerpc_vsx-LABEL: vreg_f64x2:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f64x2:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f64x2:
+// vsx: #APP
+// vsx: vmr {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vreg_f64x2, f64x2, vreg, "vmr");
 
-// powerpc_vsx-LABEL: vreg_f32:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f32:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f32:
+// vsx: #APP
+// vsx: vmr {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vreg_f32, f32, vreg, "vmr");
 
-// powerpc_vsx-LABEL: vreg_f64:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f64:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f64:
+// vsx: #APP
+// vsx: vmr {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vreg_f64, f64, vreg, "vmr");
 
-// powerpc_vsx-LABEL: vsreg_i8x16:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i8x16:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i8x16:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_i8x16, i8x16, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i16x8:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i16x8:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i16x8:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_i16x8, i16x8, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i32x4:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i32x4:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i32x4:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_i32x4, i32x4, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i64x2:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i64x2:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i64x2:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_i64x2, i64x2, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f32x4:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f32x4:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f32x4:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_f32x4, f32x4, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f64x2:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f64x2:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f64x2:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_f64x2, f64x2, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f32:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f32:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f32:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_f32, f32, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f64:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f64:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f64:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_f64, f64, vsreg, "xvsqrtdp");
 
@@ -366,354 +356,226 @@ check_reg!(reg_f32_f18, f32, "18", "f18", "fmr");
 // CHECK: #NO_APP
 check_reg!(reg_f64_f18, f64, "18", "f18", "fmr");
 
-// powerpc_altivec-LABEL: vreg_i8x16_v0:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 0, 0
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i8x16_v0:
-// powerpc64: #APP
-// powerpc64: vmr 0, 0
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i8x16_v0:
+// altivec: #APP
+// altivec: vmr 0, 0
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_i8x16_v0, i8x16, "0", "v0", "vmr");
 
-// powerpc_altivec-LABEL: vreg_i16x8_v0:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 0, 0
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i16x8_v0:
-// powerpc64: #APP
-// powerpc64: vmr 0, 0
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i16x8_v0:
+// altivec: #APP
+// altivec: vmr 0, 0
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_i16x8_v0, i16x8, "0", "v0", "vmr");
 
-// powerpc_altivec-LABEL: vreg_i32x4_v0:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 0, 0
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i32x4_v0:
-// powerpc64: #APP
-// powerpc64: vmr 0, 0
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i32x4_v0:
+// altivec: #APP
+// altivec: vmr 0, 0
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_i32x4_v0, i32x4, "0", "v0", "vmr");
 
-// powerpc_vsx-LABEL: vreg_i64x2_v0:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_i64x2_v0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_i64x2_v0:
+// vsx: #APP
+// vsx: vmr 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_i64x2_v0, i64x2, "0", "v0", "vmr");
 
-// powerpc_altivec-LABEL: vreg_f32x4_v0:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 0, 0
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_f32x4_v0:
-// powerpc64: #APP
-// powerpc64: vmr 0, 0
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_f32x4_v0:
+// altivec: #APP
+// altivec: vmr 0, 0
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_f32x4_v0, f32x4, "0", "v0", "vmr");
 
-// powerpc_vsx-LABEL: vreg_f64x2_v0:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f64x2_v0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f64x2_v0:
+// vsx: #APP
+// vsx: vmr 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f64x2_v0, f64x2, "0", "v0", "vmr");
 
-// powerpc_vsx-LABEL: vreg_f32_v0:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f32_v0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f32_v0:
+// vsx: #APP
+// vsx: vmr 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f32_v0, f32, "0", "v0", "vmr");
 
-// powerpc_vsx-LABEL: vreg_f64_v0:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f64_v0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f64_v0:
+// vsx: #APP
+// vsx: vmr 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f64_v0, f64, "0", "v0", "vmr");
 
-// powerpc_altivec-LABEL: vreg_i8x16_v18:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 18, 18
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i8x16_v18:
-// powerpc64: #APP
-// powerpc64: vmr 18, 18
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i8x16_v18:
+// altivec: #APP
+// altivec: vmr 18, 18
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_i8x16_v18, i8x16, "18", "v18", "vmr");
 
-// powerpc_altivec-LABEL: vreg_i16x8_v18:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 18, 18
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i16x8_v18:
-// powerpc64: #APP
-// powerpc64: vmr 18, 18
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i16x8_v18:
+// altivec: #APP
+// altivec: vmr 18, 18
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_i16x8_v18, i16x8, "18", "v18", "vmr");
 
-// powerpc_altivec-LABEL: vreg_i32x4_v18:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 18, 18
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i32x4_v18:
-// powerpc64: #APP
-// powerpc64: vmr 18, 18
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i32x4_v18:
+// altivec: #APP
+// altivec: vmr 18, 18
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_i32x4_v18, i32x4, "18", "v18", "vmr");
 
-// powerpc_vsx-LABEL: vreg_i64x2_v18:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 18, 18
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_i64x2_v18:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 18, 18
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_i64x2_v18:
+// vsx: #APP
+// vsx: vmr 18, 18
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_i64x2_v18, i64x2, "18", "v18", "vmr");
 
-// powerpc_altivec-LABEL: vreg_f32x4_v18:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 18, 18
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_f32x4_v18:
-// powerpc64: #APP
-// powerpc64: vmr 18, 18
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_f32x4_v18:
+// altivec: #APP
+// altivec: vmr 18, 18
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_f32x4_v18, f32x4, "18", "v18", "vmr");
 
-// powerpc_vsx-LABEL: vreg_f64x2_v18:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 18, 18
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f64x2_v18:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 18, 18
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f64x2_v18:
+// vsx: #APP
+// vsx: vmr 18, 18
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f64x2_v18, f64x2, "18", "v18", "vmr");
 
-// powerpc_vsx-LABEL: vreg_f32_v18:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 18, 18
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f32_v18:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 18, 18
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f32_v18:
+// vsx: #APP
+// vsx: vmr 18, 18
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f32_v18, f32, "18", "v18", "vmr");
 
-// powerpc_vsx-LABEL: vreg_f64_v18:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 18, 18
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f64_v18:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 18, 18
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f64_v18:
+// vsx: #APP
+// vsx: vmr 18, 18
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f64_v18, f64, "18", "v18", "vmr");
 
-// powerpc_vsx-LABEL: vsreg_i8x16_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i8x16_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i8x16_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i8x16_vs0, i8x16, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i16x8_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i16x8_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i16x8_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i16x8_vs0, i16x8, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i32x4_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i32x4_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i32x4_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i32x4_vs0, i32x4, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i64x2_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i64x2_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i64x2_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i64x2_vs0, i64x2, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f32x4_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f32x4_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f32x4_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f32x4_vs0, f32x4, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f64x2_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f64x2_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f64x2_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f64x2_vs0, f64x2, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f32_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f32_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f32_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f32_vs0, f32, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f64_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f64_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f64_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f64_vs0, f64, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i8x16_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i8x16_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i8x16_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i8x16_v40, i8x16, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i16x8_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i16x8_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i16x8_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i16x8_v40, i16x8, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i32x4_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i32x4_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i32x4_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i32x4_v40, i32x4, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i64x2_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i64x2_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i64x2_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i64x2_v40, i64x2, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f32x4_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f32x4_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f32x4_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f32x4_v40, f32x4, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f64x2_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f64x2_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f64x2_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f64x2_v40, f64x2, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f32_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f32_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f32_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f32_v40, f32, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f64_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f64_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f64_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f64_v40, f64, "40", "vs40", "xvsqrtdp");

--- a/tests/assembly-llvm/asm/powerpc-types.rs
+++ b/tests/assembly-llvm/asm/powerpc-types.rs
@@ -1,43 +1,97 @@
+// ignore-tidy-file-linelength (some revision //@ lines are over 100 chars long)
+
 //@ add-minicore
-//@ revisions: powerpc powerpc_altivec powerpc_vsx powerpc64 powerpc64_vsx
+//@ revisions: powerpc powerpc_altivec powerpc_vsx powerpc_power8 powerpc64 powerpc64_vsx powerpc64_power8 powerpc64le
 //@ assembly-output: emit-asm
 //@[powerpc] compile-flags: --target powerpc-unknown-linux-gnu
 //@[powerpc] needs-llvm-components: powerpc
 //@[powerpc_altivec] compile-flags: --target powerpc-unknown-linux-gnu -C target-feature=+altivec --cfg altivec
 //@[powerpc_altivec] needs-llvm-components: powerpc
+//@[powerpc_altivec] filecheck-flags: --check-prefix altivec
 //@[powerpc_vsx] compile-flags: --target powerpc-unknown-linux-gnu -C target-feature=+altivec,+vsx --cfg altivec --cfg vsx
 //@[powerpc_vsx] needs-llvm-components: powerpc
+//@[powerpc_vsx] filecheck-flags: --check-prefix altivec --check-prefix vsx
+//@[powerpc_power8] compile-flags: --target powerpc-unknown-linux-gnu -C target-feature=+altivec,+vsx,+power8-vector --cfg altivec --cfg vsx --cfg power8
+//@[powerpc_power8] needs-llvm-components: powerpc
+//@[powerpc_power8] filecheck-flags: --check-prefix altivec --check-prefix vsx --check-prefix power8
 //@[powerpc64] compile-flags: --target powerpc64-unknown-linux-gnu --cfg altivec
 //@[powerpc64] needs-llvm-components: powerpc
-//@[powerpc64_vsx] compile-flags: --target powerpc64-unknown-linux-gnu -C target-feature=+vsx --cfg altivec --cfg vsx
+//@[powerpc64] filecheck-flags: --check-prefix altivec
+//@[powerpc64_vsx] compile-flags: --target powerpc64-unknown-linux-gnu -C target-feature=+vsx --cfg powerpc64 --cfg altivec --cfg vsx
 //@[powerpc64_vsx] needs-llvm-components: powerpc
+//@[powerpc64_vsx] filecheck-flags: --check-prefix powerpc64 --check-prefix altivec --check-prefix vsx
+//@[powerpc64_power8] compile-flags: --target powerpc64-unknown-linux-gnu -C target-feature=+vsx,+power8-vector --cfg powerpc64 --cfg altivec --cfg vsx --cfg power8
+//@[powerpc64_power8] needs-llvm-components: powerpc
+//@[powerpc64_power8] filecheck-flags: --check-prefix powerpc64 --check-prefix altivec --check-prefix vsx --check-prefix power8
+//@[powerpc64le] compile-flags: --target powerpc64le-unknown-linux-gnu --cfg powerpc64 --cfg altivec --cfg vsx --cfg power8
+//@[powerpc64le] needs-llvm-components: powerpc
+//@[powerpc64le] filecheck-flags: --check-prefix powerpc64 --check-prefix altivec --check-prefix vsx --check-prefix power8
 //@ compile-flags: -Zmerge-functions=disabled
+//@ compile-flags: --check-cfg=cfg(altivec,vsx,power8)
 
-#![feature(no_core, asm_experimental_arch)]
+#![feature(no_core)]
 #![crate_type = "rlib"]
 #![no_core]
-#![allow(asm_sub_register, non_camel_case_types)]
+#![allow(asm_sub_register, non_camel_case_types, unused_imports)]
+#![deny(unexpected_cfgs)]
 
 extern crate minicore;
 use minicore::simd::*;
 use minicore::*;
 
+#[cfg_attr(powerpc64, cfg(not(target_arch = "powerpc64")))]
+#[cfg_attr(not(powerpc64), cfg(target_arch = "powerpc64"))]
+compile_error!("powerpc64 cfg and target arch mismatch");
 #[cfg_attr(altivec, cfg(not(target_feature = "altivec")))]
 #[cfg_attr(not(altivec), cfg(target_feature = "altivec"))]
 compile_error!("altivec cfg and target feature mismatch");
 #[cfg_attr(vsx, cfg(not(target_feature = "vsx")))]
 #[cfg_attr(not(vsx), cfg(target_feature = "vsx"))]
 compile_error!("vsx cfg and target feature mismatch");
+#[cfg_attr(power8, cfg(not(target_feature = "power8-vector")))]
+#[cfg_attr(not(power8), cfg(target_feature = "power8-vector"))]
+compile_error!("power8-vector cfg and target feature mismatch");
 
-type ptr = *const i32;
+// Check floating point scalars are put in the right vector lane. This uses power8 for consistent
+// assembly between powerpc64le and big-endian powerpc/powerpc64.
 
-extern "C" {
-    fn extern_func();
-    static extern_static: u8;
+// power8-LABEL: f32_to_f64:
+// power8: .cfi_startproc
+// power8-NEXT: xscvdpspn [[#INPUT:]], 1
+// powerpc64le-NEXT: vmrgow [[#INPUT - 32]], [[#INPUT - 32]], [[#INPUT - 32]]
+// power8-NEXT: #APP
+// power8-NEXT: xscvspdp 1, [[#INPUT]]
+// power8-NEXT: #NO_APP
+// power8-NEXT: blr
+#[cfg(power8)]
+#[unsafe(no_mangle)]
+pub fn f32_to_f64(x: f32) -> f64 {
+    let res;
+    unsafe {
+        asm!("xscvspdp {}, {}", out(vsreg) res, in(vsreg) x, options(pure, nostack, nomem));
+    };
+    res
+}
+
+// power8-LABEL: f64_to_f32:
+// power8: .cfi_startproc
+// power8-NEXT: #APP
+// power8-NEXT: xscvdpsp [[#OUTPUT:]], 1
+// power8-NEXT: #NO_APP
+// power8-NEXT: xscvspdpn 1, [[#OUTPUT]]
+// power8-NEXT: blr
+#[cfg(power8)]
+#[unsafe(no_mangle)]
+pub fn f64_to_f32(x: f64) -> f32 {
+    let res;
+    unsafe {
+        asm!("xscvdpsp {}, {}", out(vsreg) res, in(vsreg) x, options(pure, nostack, nomem));
+    };
+    res
 }
 
 macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe fn $func(x: $ty) -> $ty {
         let y;
         asm!(concat!($mov," {}, {}"), out($class) y, in($class) x);
@@ -46,7 +100,7 @@ macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
 };}
 
 macro_rules! check_reg { ($func:ident, $ty:ty, $rego:tt, $regc:tt, $mov:literal) => {
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub unsafe fn $func(x: $ty) -> $ty {
         let y;
         asm!(concat!($mov, " ", $rego, ", ", $rego), lateout($regc) y, in($regc) x);
@@ -116,179 +170,115 @@ check!(reg_f32, f32, freg, "fmr");
 // CHECK: #NO_APP
 check!(reg_f64, f64, freg, "fmr");
 
-// powerpc_altivec-LABEL: vreg_i8x16:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i8x16:
-// powerpc64: #APP
-// powerpc64: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i8x16:
+// altivec: #APP
+// altivec: vmr {{[0-9]+}}, {{[0-9]+}}
+// altivec: #NO_APP
 #[cfg(altivec)]
 check!(vreg_i8x16, i8x16, vreg, "vmr");
 
-// powerpc_altivec-LABEL: vreg_i16x8:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i16x8:
-// powerpc64: #APP
-// powerpc64: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i16x8:
+// altivec: #APP
+// altivec: vmr {{[0-9]+}}, {{[0-9]+}}
+// altivec: #NO_APP
 #[cfg(altivec)]
 check!(vreg_i16x8, i16x8, vreg, "vmr");
 
-// powerpc_altivec-LABEL: vreg_i32x4:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i32x4:
-// powerpc64: #APP
-// powerpc64: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i32x4:
+// altivec: #APP
+// altivec: vmr {{[0-9]+}}, {{[0-9]+}}
+// altivec: #NO_APP
 #[cfg(altivec)]
 check!(vreg_i32x4, i32x4, vreg, "vmr");
 
-// powerpc_vsx-LABEL: vreg_i64x2:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_i64x2:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_i64x2:
+// vsx: #APP
+// vsx: vmr {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vreg_i64x2, i64x2, vreg, "vmr");
 
-// powerpc_altivec-LABEL: vreg_f32x4:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_f32x4:
-// powerpc64: #APP
-// powerpc64: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_f32x4:
+// altivec: #APP
+// altivec: vmr {{[0-9]+}}, {{[0-9]+}}
+// altivec: #NO_APP
 #[cfg(altivec)]
 check!(vreg_f32x4, f32x4, vreg, "vmr");
 
-// powerpc_vsx-LABEL: vreg_f64x2:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f64x2:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f64x2:
+// vsx: #APP
+// vsx: vmr {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vreg_f64x2, f64x2, vreg, "vmr");
 
-// powerpc_vsx-LABEL: vreg_f32:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f32:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f32:
+// vsx: #APP
+// vsx: vmr {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vreg_f32, f32, vreg, "vmr");
 
-// powerpc_vsx-LABEL: vreg_f64:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f64:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f64:
+// vsx: #APP
+// vsx: vmr {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vreg_f64, f64, vreg, "vmr");
 
-// powerpc_vsx-LABEL: vsreg_i8x16:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i8x16:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i8x16:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_i8x16, i8x16, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i16x8:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i16x8:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i16x8:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_i16x8, i16x8, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i32x4:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i32x4:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i32x4:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_i32x4, i32x4, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i64x2:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i64x2:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i64x2:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_i64x2, i64x2, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f32x4:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f32x4:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f32x4:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_f32x4, f32x4, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f64x2:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f64x2:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f64x2:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_f64x2, f64x2, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f32:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f32:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f32:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_f32, f32, vsreg, "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f64:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f64:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f64:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_f64, f64, vsreg, "xvsqrtdp");
 
@@ -366,354 +356,226 @@ check_reg!(reg_f32_f18, f32, "18", "f18", "fmr");
 // CHECK: #NO_APP
 check_reg!(reg_f64_f18, f64, "18", "f18", "fmr");
 
-// powerpc_altivec-LABEL: vreg_i8x16_v0:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 0, 0
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i8x16_v0:
-// powerpc64: #APP
-// powerpc64: vmr 0, 0
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i8x16_v0:
+// altivec: #APP
+// altivec: vmr 0, 0
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_i8x16_v0, i8x16, "0", "v0", "vmr");
 
-// powerpc_altivec-LABEL: vreg_i16x8_v0:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 0, 0
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i16x8_v0:
-// powerpc64: #APP
-// powerpc64: vmr 0, 0
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i16x8_v0:
+// altivec: #APP
+// altivec: vmr 0, 0
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_i16x8_v0, i16x8, "0", "v0", "vmr");
 
-// powerpc_altivec-LABEL: vreg_i32x4_v0:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 0, 0
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i32x4_v0:
-// powerpc64: #APP
-// powerpc64: vmr 0, 0
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i32x4_v0:
+// altivec: #APP
+// altivec: vmr 0, 0
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_i32x4_v0, i32x4, "0", "v0", "vmr");
 
-// powerpc_vsx-LABEL: vreg_i64x2_v0:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_i64x2_v0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_i64x2_v0:
+// vsx: #APP
+// vsx: vmr 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_i64x2_v0, i64x2, "0", "v0", "vmr");
 
-// powerpc_altivec-LABEL: vreg_f32x4_v0:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 0, 0
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_f32x4_v0:
-// powerpc64: #APP
-// powerpc64: vmr 0, 0
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_f32x4_v0:
+// altivec: #APP
+// altivec: vmr 0, 0
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_f32x4_v0, f32x4, "0", "v0", "vmr");
 
-// powerpc_vsx-LABEL: vreg_f64x2_v0:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f64x2_v0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f64x2_v0:
+// vsx: #APP
+// vsx: vmr 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f64x2_v0, f64x2, "0", "v0", "vmr");
 
-// powerpc_vsx-LABEL: vreg_f32_v0:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f32_v0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f32_v0:
+// vsx: #APP
+// vsx: vmr 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f32_v0, f32, "0", "v0", "vmr");
 
-// powerpc_vsx-LABEL: vreg_f64_v0:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f64_v0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f64_v0:
+// vsx: #APP
+// vsx: vmr 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f64_v0, f64, "0", "v0", "vmr");
 
-// powerpc_altivec-LABEL: vreg_i8x16_v18:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 18, 18
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i8x16_v18:
-// powerpc64: #APP
-// powerpc64: vmr 18, 18
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i8x16_v18:
+// altivec: #APP
+// altivec: vmr 18, 18
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_i8x16_v18, i8x16, "18", "v18", "vmr");
 
-// powerpc_altivec-LABEL: vreg_i16x8_v18:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 18, 18
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i16x8_v18:
-// powerpc64: #APP
-// powerpc64: vmr 18, 18
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i16x8_v18:
+// altivec: #APP
+// altivec: vmr 18, 18
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_i16x8_v18, i16x8, "18", "v18", "vmr");
 
-// powerpc_altivec-LABEL: vreg_i32x4_v18:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 18, 18
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_i32x4_v18:
-// powerpc64: #APP
-// powerpc64: vmr 18, 18
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_i32x4_v18:
+// altivec: #APP
+// altivec: vmr 18, 18
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_i32x4_v18, i32x4, "18", "v18", "vmr");
 
-// powerpc_vsx-LABEL: vreg_i64x2_v18:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 18, 18
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_i64x2_v18:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 18, 18
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_i64x2_v18:
+// vsx: #APP
+// vsx: vmr 18, 18
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_i64x2_v18, i64x2, "18", "v18", "vmr");
 
-// powerpc_altivec-LABEL: vreg_f32x4_v18:
-// powerpc_altivec: #APP
-// powerpc_altivec: vmr 18, 18
-// powerpc_altivec: #NO_APP
-// powerpc64-LABEL: vreg_f32x4_v18:
-// powerpc64: #APP
-// powerpc64: vmr 18, 18
-// powerpc64: #NO_APP
+// altivec-LABEL: vreg_f32x4_v18:
+// altivec: #APP
+// altivec: vmr 18, 18
+// altivec: #NO_APP
 #[cfg(altivec)]
 check_reg!(vreg_f32x4_v18, f32x4, "18", "v18", "vmr");
 
-// powerpc_vsx-LABEL: vreg_f64x2_v18:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 18, 18
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f64x2_v18:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 18, 18
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f64x2_v18:
+// vsx: #APP
+// vsx: vmr 18, 18
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f64x2_v18, f64x2, "18", "v18", "vmr");
 
-// powerpc_vsx-LABEL: vreg_f32_v18:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 18, 18
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f32_v18:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 18, 18
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f32_v18:
+// vsx: #APP
+// vsx: vmr 18, 18
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f32_v18, f32, "18", "v18", "vmr");
 
-// powerpc_vsx-LABEL: vreg_f64_v18:
-// powerpc_vsx: #APP
-// powerpc_vsx: vmr 18, 18
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vreg_f64_v18:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: vmr 18, 18
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vreg_f64_v18:
+// vsx: #APP
+// vsx: vmr 18, 18
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f64_v18, f64, "18", "v18", "vmr");
 
-// powerpc_vsx-LABEL: vsreg_i8x16_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i8x16_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i8x16_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i8x16_vs0, i8x16, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i16x8_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i16x8_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i16x8_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i16x8_vs0, i16x8, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i32x4_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i32x4_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i32x4_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i32x4_vs0, i32x4, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i64x2_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i64x2_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i64x2_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i64x2_vs0, i64x2, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f32x4_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f32x4_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f32x4_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f32x4_vs0, f32x4, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f64x2_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f64x2_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f64x2_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f64x2_vs0, f64x2, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f32_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f32_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f32_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f32_vs0, f32, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f64_vs0:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 0, 0
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f64_vs0:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 0, 0
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f64_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f64_vs0, f64, "0", "vs0", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i8x16_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i8x16_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i8x16_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i8x16_v40, i8x16, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i16x8_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i16x8_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i16x8_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i16x8_v40, i16x8, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i32x4_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i32x4_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i32x4_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i32x4_v40, i32x4, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_i64x2_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_i64x2_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_i64x2_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_i64x2_v40, i64x2, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f32x4_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f32x4_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f32x4_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f32x4_v40, f32x4, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f64x2_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f64x2_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f64x2_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f64x2_v40, f64x2, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f32_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f32_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f32_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f32_v40, f32, "40", "vs40", "xvsqrtdp");
 
-// powerpc_vsx-LABEL: vsreg_f64_v40:
-// powerpc_vsx: #APP
-// powerpc_vsx: xvsqrtdp 40, 40
-// powerpc_vsx: #NO_APP
-// powerpc64_vsx-LABEL: vsreg_f64_v40:
-// powerpc64_vsx: #APP
-// powerpc64_vsx: xvsqrtdp 40, 40
-// powerpc64_vsx: #NO_APP
+// vsx-LABEL: vsreg_f64_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f64_v40, f64, "40", "vs40", "xvsqrtdp");


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160441)*
<!-- homu-ignore:end -->

64-bit PowerPC supports both big and little endian, however registers are always big endian. As a consequence of this, the order of vector lanes is reversed on little endian; however scalar `f32` and `f64` are always stored in the actual (big-endian) lane 0. This PR fixes the LLVM ASM fixup to take that into account.

Ping target maintainers: @daltenty @gilamn5tr @amy-kwan @Gelbpunkt @famfo @neuschaefer