### PR TITLE
normalize in relations, not generalize, when relating infer with alias

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -479,10 +479,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             let projected_ty = curr_projected_ty.projection_ty_core(
                 tcx,
                 proj,
-                |ty| self.normalize(ty::Unnormalized::new_wip(ty), locations),
-                |ty, variant_index, field, ()| {
-                    PlaceTy::field_ty(tcx, ty, variant_index, field).skip_norm_wip()
-                },
+                |ty| self.normalize(ty, locations),
+                |()| None,
                 |_| unreachable!(),
             );
             curr_projected_ty = projected_ty;

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -379,6 +379,19 @@ impl<'b, 'tcx> TypeRelation<TyCtxt<'tcx>> for NllTypeRelating<'_, 'b, 'tcx> {
                 );
             }
 
+            (&ty::Alias(ty::IsRigid::No, _), _) | (_, &ty::Alias(ty::IsRigid::No, _))
+                if infcx.next_trait_solver() =>
+            {
+                // NOTE(khyperia): If this turns out to be possible, either the caller should
+                // normalize the alias, or we should normalize the alias here. See the PR that
+                // introduced this comment for how to do so, which normalizes aliases in other
+                // relations.
+                span_bug!(
+                    self.span(),
+                    "it should not be possible to encounter unnormalized aliases in borrowck"
+                );
+            }
+
             (&ty::Infer(ty::TyVar(a_vid)), _) => {
                 infcx.instantiate_ty_var(self, true, a_vid, self.ambient_variance, b)?
             }
@@ -589,9 +602,5 @@ impl<'b, 'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for NllTypeRelating<'_
                 region_constraints: None,
             },
         );
-    }
-
-    fn ambient_variance(&self) -> ty::Variance {
-        self.ambient_variance
     }
 }

--- a/compiler/rustc_infer/src/infer/relate/generalize.rs
+++ b/compiler/rustc_infer/src/infer/relate/generalize.rs
@@ -161,81 +161,32 @@ impl<'tcx> InferCtxt<'tcx> {
             let Some(source_alias) = source_term.to_alias_term() else {
                 bug!("generalized `{source_term:?} to infer, not an alias");
             };
-            if self.next_trait_solver() {
-                if let Some(generalized_ty) = generalized_term.as_type() {
-                    match instantiation_variance {
-                        ty::Invariant => relation.register_predicates([ty::ProjectionPredicate {
-                            projection_term: source_alias.into(),
-                            term: generalized_ty.into(),
-                        }]),
-                        ty::Covariant => {
-                            // Generate a new var, then do:
-                            // `source_alias == ?A && ?A <: generalized_ty`
-                            let new_var = self.next_ty_var(relation.span());
-                            relation.register_predicates([
-                                ty::PredicateKind::Subtype(ty::SubtypePredicate {
-                                    a_is_expected: !target_is_expected,
-                                    a: new_var,
-                                    b: generalized_ty,
-                                }),
-                                ty::PredicateKind::Clause(ty::ClauseKind::Projection(
-                                    ty::ProjectionPredicate {
-                                        projection_term: source_alias.into(),
-                                        term: new_var.into(),
-                                    },
-                                )),
-                            ]);
-                        }
-                        ty::Contravariant => {
-                            // a :> b is b <: a
-                            let new_var = self.next_ty_var(relation.span());
-                            relation.register_predicates([
-                                ty::PredicateKind::Subtype(ty::SubtypePredicate {
-                                    a_is_expected: target_is_expected,
-                                    a: generalized_ty,
-                                    b: new_var,
-                                }),
-                                ty::PredicateKind::Clause(ty::ClauseKind::Projection(
-                                    ty::ProjectionPredicate {
-                                        projection_term: source_alias.into(),
-                                        term: new_var.into(),
-                                    },
-                                )),
-                            ]);
-                        }
-                        ty::Bivariant => unreachable!("bivariant generalization"),
-                    }
-                } else {
-                    debug_assert_eq!(instantiation_variance, ty::Variance::Invariant);
+            assert!(
+                !self.next_trait_solver(),
+                "nonrigid aliases should be handled in relations, not here"
+            );
+            match source_alias.kind {
+                ty::AliasTermKind::ProjectionTy { .. }
+                | ty::AliasTermKind::ProjectionConst { .. } => {
+                    // FIXME: This does not handle subtyping correctly, we could
+                    // instead create a new inference variable `?normalized_source`, emitting
+                    // `Projection(normalized_source, ?ty_normalized)` and
+                    // `?normalized_source <: generalized_term`.
                     relation.register_predicates([ty::ProjectionPredicate {
                         projection_term: source_alias,
                         term: generalized_term,
                     }]);
                 }
-            } else {
-                match source_alias.kind {
-                    ty::AliasTermKind::ProjectionTy { .. }
-                    | ty::AliasTermKind::ProjectionConst { .. } => {
-                        // FIXME: This does not handle subtyping correctly, we could
-                        // instead create a new inference variable `?normalized_source`, emitting
-                        // `Projection(normalized_source, ?ty_normalized)` and
-                        // `?normalized_source <: generalized_term`.
-                        relation.register_predicates([ty::ProjectionPredicate {
-                            projection_term: source_alias,
-                            term: generalized_term,
-                        }]);
-                    }
-                    // The old solver only accepts projection predicates for associated types.
-                    ty::AliasTermKind::InherentTy { .. }
-                    | ty::AliasTermKind::FreeTy { .. }
-                    | ty::AliasTermKind::OpaqueTy { .. } => {
-                        return Err(TypeError::CyclicTy(source_term.expect_type()));
-                    }
-                    ty::AliasTermKind::InherentConst { .. }
-                    | ty::AliasTermKind::FreeConst { .. }
-                    | ty::AliasTermKind::AnonConst { .. } => {
-                        return Err(TypeError::CyclicConst(source_term.expect_const()));
-                    }
+                // The old solver only accepts projection predicates for associated types.
+                ty::AliasTermKind::InherentTy { .. }
+                | ty::AliasTermKind::FreeTy { .. }
+                | ty::AliasTermKind::OpaqueTy { .. } => {
+                    return Err(TypeError::CyclicTy(source_term.expect_type()));
+                }
+                ty::AliasTermKind::InherentConst { .. }
+                | ty::AliasTermKind::FreeConst { .. }
+                | ty::AliasTermKind::AnonConst { .. } => {
+                    return Err(TypeError::CyclicConst(source_term.expect_const()));
                 }
             }
         } else {

--- a/compiler/rustc_infer/src/infer/relate/lattice.rs
+++ b/compiler/rustc_infer/src/infer/relate/lattice.rs
@@ -18,6 +18,7 @@
 //! [lattices]: https://en.wikipedia.org/wiki/Lattice_(order)
 
 use rustc_hir::def_id::DefId;
+use rustc_middle::span_bug;
 use rustc_middle::traits::solve::Goal;
 use rustc_middle::ty::relate::combine::{combine_ty_args, super_combine_consts, super_combine_tys};
 use rustc_middle::ty::relate::{Relate, RelateResult, TypeRelation};
@@ -159,6 +160,19 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for LatticeOp<'_, 'tcx> {
                 Ok(v)
             }
 
+            (&ty::Alias(ty::IsRigid::No, _), _) | (_, &ty::Alias(ty::IsRigid::No, _))
+                if infcx.next_trait_solver() =>
+            {
+                // NOTE(khyperia): If this turns out to be possible, either the caller should
+                // normalize the alias, or we should normalize the alias here. See the PR that
+                // introduced this comment for how to do so, which normalizes aliases in other
+                // relations.
+                span_bug!(
+                    self.span(),
+                    "it should not be possible to encounter unnormalized aliases in lattice relation"
+                );
+            }
+
             (
                 &ty::Alias(_, ty::AliasTy { kind: ty::Opaque { def_id: a_def_id }, .. }),
                 &ty::Alias(_, ty::AliasTy { kind: ty::Opaque { def_id: b_def_id }, .. }),
@@ -284,10 +298,5 @@ impl<'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for LatticeOp<'_, 'tcx> {
                 goal.predicate,
             )
         }))
-    }
-
-    fn ambient_variance(&self) -> ty::Variance {
-        // FIXME(deferred_projection_equality): This isn't right, I think?
-        ty::Variance::Invariant
     }
 }

--- a/compiler/rustc_infer/src/infer/relate/type_relating.rs
+++ b/compiler/rustc_infer/src/infer/relate/type_relating.rs
@@ -379,8 +379,4 @@ impl<'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for TypeRelating<'_, 'tcx>
             )
         }))
     }
-
-    fn ambient_variance(&self) -> ty::Variance {
-        self.ambient_variance
-    }
 }

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -190,22 +190,21 @@ impl<'tcx> PlaceTy<'tcx> {
         tcx: TyCtxt<'tcx>,
         elem: ProjectionElem<V, Ty<'tcx>>,
     ) -> PlaceTy<'tcx> {
-        self.projection_ty_core(tcx, &elem, |ty| ty, |_, _, _, ty| ty, |ty| ty)
+        self.projection_ty_core(tcx, &elem, |ty| ty.skip_norm_wip(), |ty| Some(ty), |ty| ty)
     }
 
     /// `place_ty.projection_ty_core(tcx, elem, |...| { ... })`
     /// projects `place_ty` onto `elem`, returning the appropriate
     /// `Ty` or downcast variant corresponding to that projection.
-    /// The `handle_field` callback must map a `FieldIdx` to its `Ty`,
-    /// (which should be trivial when `T` = `Ty`).
+    /// `trivial_field_ty` is used for when `T` = `Ty`, otherwise,
+    /// `PlaceTy::field_ty` is used to map a `FieldIdx` to its `Ty`.
     pub fn projection_ty_core<V, T>(
         self,
         tcx: TyCtxt<'tcx>,
         elem: &ProjectionElem<V, T>,
-        // FIXME(#155345): This should take `Unnormalized` as input and only
-        // normalize when actually required.
-        mut structurally_normalize: impl FnMut(Ty<'tcx>) -> Ty<'tcx>,
-        mut handle_field: impl FnMut(Ty<'tcx>, Option<VariantIdx>, FieldIdx, T) -> Ty<'tcx>,
+        // FIXME(#155345): This should only normalize when actually required.
+        mut normalize: impl FnMut(Unnormalized<'tcx, Ty<'tcx>>) -> Ty<'tcx>,
+        trivial_field_ty: impl Fn(T) -> Option<Ty<'tcx>>,
         mut handle_opaque_cast_and_subtype: impl FnMut(T) -> Ty<'tcx>,
     ) -> PlaceTy<'tcx>
     where
@@ -217,16 +216,17 @@ impl<'tcx> PlaceTy<'tcx> {
         }
         let answer = match *elem {
             ProjectionElem::Deref => {
-                let ty = structurally_normalize(self.ty).builtin_deref(true).unwrap_or_else(|| {
-                    bug!("deref projection of non-dereferenceable ty {:?}", self)
-                });
+                let ty =
+                    normalize(Unnormalized::new_wip(self.ty)).builtin_deref(true).unwrap_or_else(
+                        || bug!("deref projection of non-dereferenceable ty {:?}", self),
+                    );
                 PlaceTy::from_ty(ty)
             }
             ProjectionElem::Index(_) | ProjectionElem::ConstantIndex { .. } => {
-                PlaceTy::from_ty(structurally_normalize(self.ty).builtin_index().unwrap())
+                PlaceTy::from_ty(normalize(Unnormalized::new_wip(self.ty)).builtin_index().unwrap())
             }
             ProjectionElem::Subslice { from, to, from_end } => {
-                PlaceTy::from_ty(match structurally_normalize(self.ty).kind() {
+                PlaceTy::from_ty(match normalize(Unnormalized::new_wip(self.ty)).kind() {
                     ty::Slice(..) => self.ty,
                     ty::Array(inner, _) if !from_end => Ty::new_array(tcx, *inner, to - from),
                     ty::Array(inner, size) if from_end => {
@@ -242,12 +242,13 @@ impl<'tcx> PlaceTy<'tcx> {
             ProjectionElem::Downcast(_name, index) => {
                 PlaceTy { ty: self.ty, variant_index: Some(index) }
             }
-            ProjectionElem::Field(f, fty) => PlaceTy::from_ty(handle_field(
-                structurally_normalize(self.ty),
-                self.variant_index,
-                f,
-                fty,
-            )),
+            ProjectionElem::Field(f, fty) => PlaceTy::from_ty(match trivial_field_ty(fty) {
+                Some(ty) => ty,
+                None => {
+                    let self_ty = normalize(Unnormalized::new_wip(self.ty));
+                    normalize(PlaceTy::field_ty(tcx, self_ty, self.variant_index, f))
+                }
+            }),
             ProjectionElem::OpaqueCast(ty) => PlaceTy::from_ty(handle_opaque_cast_and_subtype(ty)),
 
             // FIXME(unsafe_binders): Rename `handle_opaque_cast_and_subtype` to be more general.

--- a/compiler/rustc_type_ir/src/relate/combine.rs
+++ b/compiler/rustc_type_ir/src/relate/combine.rs
@@ -31,8 +31,6 @@ where
         &mut self,
         obligations: impl IntoIterator<Item: Upcast<I, I::Predicate>>,
     );
-
-    fn ambient_variance(&self) -> ty::Variance;
 }
 
 pub fn super_combine_tys<Infcx, I, R>(
@@ -107,60 +105,10 @@ where
         {
             panic!("We do not expect to encounter `Fresh` variables in the new solver")
         }
-
-        (ty::Alias(ty::IsRigid::No, alias), _) | (_, ty::Alias(ty::IsRigid::No, alias))
+        (ty::Alias(ty::IsRigid::No, _), _) | (_, ty::Alias(ty::IsRigid::No, _))
             if infcx.next_trait_solver() =>
         {
-            // If both sides are aliases, arbitrarily do the LHS first
-            let terms_are_inverted = !matches!(a.kind(), ty::Alias(ty::IsRigid::No, _));
-            let other = if terms_are_inverted { a } else { b };
-            match (relation.ambient_variance(), terms_are_inverted) {
-                (ty::Invariant, _) => relation.register_predicates([ty::ProjectionPredicate {
-                    projection_term: alias.into(),
-                    term: other.into(),
-                }]),
-                (ty::Covariant, false) | (ty::Contravariant, true) => {
-                    // Generate a new var to represent `alias <: other`
-                    // with `alias == ?A && ?A <: other`
-                    let new_var = infcx.next_ty_infer();
-                    relation.register_predicates([
-                        ty::PredicateKind::Clause(ty::ClauseKind::Projection(
-                            ty::ProjectionPredicate {
-                                projection_term: alias.into(),
-                                term: new_var.into(),
-                            },
-                        )),
-                        ty::PredicateKind::Subtype(ty::SubtypePredicate {
-                            a_is_expected: !terms_are_inverted,
-                            a: new_var,
-                            b: other,
-                        }),
-                    ]);
-                }
-                (ty::Contravariant, false) | (ty::Covariant, true) => {
-                    // a :> b is b <: a
-                    let new_var = infcx.next_ty_infer();
-                    relation.register_predicates([
-                        ty::PredicateKind::Clause(ty::ClauseKind::Projection(
-                            ty::ProjectionPredicate {
-                                projection_term: alias.into(),
-                                term: new_var.into(),
-                            },
-                        )),
-                        ty::PredicateKind::Subtype(ty::SubtypePredicate {
-                            a_is_expected: terms_are_inverted,
-                            a: other,
-                            b: new_var,
-                        }),
-                    ]);
-                }
-                (ty::Bivariant, _) => {
-                    unreachable!(
-                        "cannot handle bivariant aliases in register_projection_with_variance"
-                    )
-                }
-            }
-            Ok(a)
+            panic!("non-rigid aliases should be handled in the caller of super_combine_tys")
         }
 
         // All other cases of inference are errors
@@ -231,6 +179,21 @@ where
             )
         }
 
+        (ty::ConstKind::Alias(ty::IsRigid::No, alias), _) if infcx.next_trait_solver() => {
+            relation.register_predicates([ty::ProjectionPredicate {
+                projection_term: alias.into(),
+                term: b.into(),
+            }]);
+            Ok(b)
+        }
+        (_, ty::ConstKind::Alias(ty::IsRigid::No, alias)) if infcx.next_trait_solver() => {
+            relation.register_predicates([ty::ProjectionPredicate {
+                projection_term: alias.into(),
+                term: a.into(),
+            }]);
+            Ok(b)
+        }
+
         (ty::ConstKind::Infer(ty::InferConst::Var(vid)), _) => {
             infcx.instantiate_const_var(relation, true, vid, b)?;
             Ok(b)
@@ -241,20 +204,11 @@ where
             Ok(a)
         }
 
-        (ty::ConstKind::Alias(ty::IsRigid::No, alias), _)
-        | (_, ty::ConstKind::Alias(ty::IsRigid::No, alias))
-            if (infcx.cx().features().generic_const_exprs() || infcx.next_trait_solver()) =>
+        (ty::ConstKind::Alias(ty::IsRigid::No, _), _)
+        | (_, ty::ConstKind::Alias(ty::IsRigid::No, _))
+            if infcx.cx().features().generic_const_exprs() =>
         {
-            if infcx.next_trait_solver() {
-                let other = if matches!(a.kind(), ty::ConstKind::Alias(..)) { b } else { a };
-                relation.register_predicates([ty::ProjectionPredicate {
-                    projection_term: alias.into(),
-                    term: other.into(),
-                }])
-            } else {
-                relation.register_predicates([ty::PredicateKind::ConstEquate(a, b)]);
-            }
-
+            relation.register_predicates([ty::PredicateKind::ConstEquate(a, b)]);
             Ok(b)
         }
 

--- a/compiler/rustc_type_ir/src/relate/solver_relating.rs
+++ b/compiler/rustc_type_ir/src/relate/solver_relating.rs
@@ -193,6 +193,25 @@ where
                 }
             }
 
+            (ty::Alias(ty::IsRigid::No, alias), _) if infcx.next_trait_solver() => {
+                let new_var = infcx.next_ty_infer();
+                self.goals.push(Goal::new(
+                    self.cx(),
+                    self.param_env,
+                    ty::ProjectionPredicate { projection_term: alias.into(), term: new_var.into() },
+                ));
+                self.tys(new_var, b)?;
+            }
+            (_, ty::Alias(ty::IsRigid::No, alias)) if infcx.next_trait_solver() => {
+                let new_var = infcx.next_ty_infer();
+                self.goals.push(Goal::new(
+                    self.cx(),
+                    self.param_env,
+                    ty::ProjectionPredicate { projection_term: alias.into(), term: new_var.into() },
+                ));
+                self.tys(a, new_var)?;
+            }
+
             (ty::Infer(ty::TyVar(a_vid)), _) => {
                 infcx.instantiate_ty_var(self, true, a_vid, self.ambient_variance, b)?;
             }
@@ -341,9 +360,5 @@ where
 
     fn register_goals(&mut self, obligations: impl IntoIterator<Item = Goal<I, I::Predicate>>) {
         self.goals.extend(obligations);
-    }
-
-    fn ambient_variance(&self) -> ty::Variance {
-        self.ambient_variance
     }
 }

--- a/tests/ui/traits/next-solver/borrowck-normalization.rs
+++ b/tests/ui/traits/next-solver/borrowck-normalization.rs
@@ -1,0 +1,23 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+//! https://github.com/rust-lang/rust/pull/160443 reworked how normalization works in type
+//! relations. Initially, that PR left out normalization in NllTypeRelating, as it seemed to be
+//! unused. However, upon doing a stage 2 build with -Znext-solver, turns out it *is* used. This is
+//! the extracted case from the failing crate, to have it as a proper test instead of just failing
+//! to compile stage 2.
+
+trait Trait {
+    type Item;
+}
+
+struct Struct<I: Trait> {
+    item: I::Item,
+}
+
+impl<I: Trait> Struct<I> {
+    fn func(self) {
+        let Self { item } = self;
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
This removes the wonky `<?0 as Trait>::Assoc == ?0` handling in generalize, as the alias will be normalized before generalization gets invoked. (... in the new solver, the old solver is not touched).

My gut feeling is that change is potentially minorly perf-sensitive I think, I've had perf impacts here before, and we're slightly changing the way aliases are handled - especially invariant relations now generate an extra var then immediately do a `equate_ty_vids_raw`, it short-circuited before.

r? lcnr