### PR TITLE
Avoid resolving path keywords outside `TypeNS`

### DIFF
--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -419,7 +419,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         ignore_import: Option<Import<'ra>>,
     ) -> Result<Decl<'ra>, Determinacy> {
         // Make sure `self`, `super` etc produce an error when passed to here.
-        if !matches!(scope_set, ScopeSet::Module(..)) && ident.name.is_path_segment_keyword() {
+        if ident.name.is_path_segment_keyword() {
             return Err(Determinacy::Determined);
         }
 
@@ -1077,10 +1077,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     {
                         let module = self.resolve_crate_root(ident);
                         return Ok(module.self_decl.unwrap());
-                    } else if ident.name == kw::Super {
-                        // FIXME: Implement these with renaming requirements so that e.g.
-                        // `use super;` doesn't work, but `use super as name;` does.
-                        // Fall through here to get an error from `early_resolve_...`.
                     }
                 }
 

--- a/tests/ui/resolve/macro-determinacy-non-module-issue-160195.env_first.stderr
+++ b/tests/ui/resolve/macro-determinacy-non-module-issue-160195.env_first.stderr
@@ -1,0 +1,8 @@
+error: `env!()` takes 1 or 2 arguments
+  --> $DIR/macro-determinacy-non-module-issue-160195.rs:12:22
+   |
+LL |     include!(concat!(env!()));
+   |                      ^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/resolve/macro-determinacy-non-module-issue-160195.env_second.stderr
+++ b/tests/ui/resolve/macro-determinacy-non-module-issue-160195.env_second.stderr
@@ -1,0 +1,8 @@
+error: `env!()` takes 1 or 2 arguments
+  --> $DIR/macro-determinacy-non-module-issue-160195.rs:12:22
+   |
+LL |     include!(concat!(env!()));
+   |                      ^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/resolve/macro-determinacy-non-module-issue-160195.rs
+++ b/tests/ui/resolve/macro-determinacy-non-module-issue-160195.rs
@@ -1,0 +1,21 @@
+//@ revisions: env_first env_second
+
+#[cfg(env_first)]
+pub mod env {
+    #[derive(Default)]
+    pub struct BusinessData;
+}
+
+pub mod interface {
+    use crate::env::{self};
+
+    include!(concat!(env!())); //~ ERROR `env!()` takes 1 or 2 arguments
+}
+
+#[cfg(env_second)]
+pub mod env {
+    #[derive(Default)]
+    pub struct BusinessData;
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/160195

After allowing trailing `self`, `self` imports were resolved in all namespaces wrongly. Resolving path keywords should return `Determined` immediately outside `TypeNS`.

r? petrochenkov