### PR TITLE
Fix lookup of object files

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1,7 +1,7 @@
 mod raw_dylib;
 
 use std::collections::BTreeSet;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::fs::{File, OpenOptions, read};
 use std::io::{BufReader, BufWriter, Write};
 use std::ops::{ControlFlow, Deref};
@@ -2061,9 +2061,12 @@ fn get_object_file_path(sess: &Session, name: &str, self_contained: bool) -> Pat
         }
     }
 
-    for (_, path) in sess.target_filesearch().get_file_candidates(name, "", PathKind::Native) {
-        if path.file_name().map_or(false, |n| n == OsStr::new(name)) && path.exists() {
-            return path;
+    // Note: this is O(n^2), it could be expensive-ish if we lookup many object files for many
+    // search paths
+    for search_path in sess.target_filesearch().search_paths(PathKind::Native) {
+        let file_path = search_path.dir.join(name);
+        if file_path.exists() {
+            return file_path;
         }
     }
     PathBuf::from(name)

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -434,7 +434,7 @@ impl<'a> CrateLocator<'a> {
             }
 
             for (hash, spf_path) in
-                self.filesearch.get_file_candidates(prefix, suffix, self.path_kind)
+                self.filesearch.get_library_candidates(prefix, suffix, self.path_kind)
             {
                 info!("lib candidate: {}", spf_path.display());
 
@@ -462,7 +462,7 @@ impl<'a> CrateLocator<'a> {
         }
 
         if should_check_staticlibs {
-            for (_, path) in self.filesearch.get_file_candidates(
+            for (_, path) in self.filesearch.get_library_candidates(
                 staticlib_prefix,
                 staticlib_suffix,
                 self.path_kind,

--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -35,7 +35,11 @@ impl FileSearch {
 
     /// Return files from the search dirs of this filesearch that match the given `prefix` and
     /// `suffix` and have the given `kind`.
-    pub fn get_file_candidates<'b>(
+    ///
+    /// Note that this function only searches files that match lib/staticlib/dlllib prefixes, not
+    /// all files from the search paths!
+    /// Access `search_paths` directly if you want to scan all files within them.
+    pub fn get_library_candidates<'b>(
         &'b self,
         prefix: &'b str,
         suffix: &'b str,
@@ -65,6 +69,9 @@ impl FileSearch {
         target: &Target,
         use_implicit_sysroot_deps: bool,
     ) -> Self {
+        // We keep a list of all found paths that look like libraries in `FileSearch`, to optimize
+        // lookup in `get_library_candidates`.
+        // These prefixes should be kept in sync with `CrateLocator::find_library_crate`.
         let prefixes = ["lib", &target.staticlib_prefix, &target.dll_prefix];
 
         // Load all files from all search paths, filter them by supported prefixes, and sort them,


### PR DESCRIPTION
I broke this in https://github.com/rust-lang/rust/pull/158823. I wanted to optimize the potentially O(n^2) object file lookup, but didn't realize that we have to search all search paths here, not only files that we already prefiltered for the lib prefixes.

r? @petrochenkov

Fixes: https://github.com/rust-lang/rust/issues/160446
