### PR TITLE
Fix a couple of links in AVR target documentation

### DIFF
--- a/src/doc/rustc/src/platform-support/avr-none.md
+++ b/src/doc/rustc/src/platform-support/avr-none.md
@@ -66,7 +66,7 @@ recommended to always use `--release` to avoid running out of space.
 Also, please note that specifying `-C target-cpu`[^1] is required - here's a list of
 the possible variants:
 
-https://github.com/llvm/llvm-project/blob/093d4db2f3c874d4683fb01194b00dbb20e5c713/clang/lib/Basic/Targets/AVR.cpp#L32
+[https://github.com/llvm/llvm-project/blob/d5a6124259b55789bc49489632efa7c168a4f6cb/clang/lib/Basic/Targets/AVR.cpp#L48](https://github.com/llvm/llvm-project/blob/d5a6124259b55789bc49489632efa7c168a4f6cb/clang/lib/Basic/Targets/AVR.cpp#L48)
 
 Note that devices that have no SRAM are not supported, same as when compiling C/C++ programs with avr-gcc or Clang.
 
@@ -86,4 +86,4 @@ $ simavr -m atmega328p ./target/avr-none/release/your-project.elf
 ```
 
 Alternatively, if you want to write a couple of actual `#[test]`s, you can use
-[`avr-tester`](https://github.com/Patryk27/avr-tester).
+[`avr-tester`](https://crates.io/crates/avr-tester).


### PR DESCRIPTION
- Update a link to MCU list in the code and make it an actual link
- Make avr-tester link point to the crate page (which is more expected and informative) instead of a repository (which has also moved)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
