### PR TITLE
fix: Check the fallback map before queueing child in `visible_parent_map` breadth-first search

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::mem;
 use std::sync::Arc;
 
+use rustc_data_structures::unord::ExtendUnord;
 use rustc_hir::attrs::Deprecation;
 use rustc_hir::def::{CtorKind, DefKind};
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LOCAL_CRATE};
@@ -472,7 +473,7 @@ pub(in crate::rmeta) fn provide(providers: &mut Providers) {
             // the former.
             // This is a rudimentary check that does not catch all cases,
             // just the easiest.
-            let mut fallback_map: Vec<(DefId, DefId)> = Default::default();
+            let mut fallback_map: DefIdMap<DefId> = Default::default();
 
             // Issue 46112: We want the map to prefer the shortest
             // paths when reporting the path to an item. Therefore we
@@ -533,14 +534,24 @@ pub(in crate::rmeta) fn provide(providers: &mut Providers) {
                             }
                         }
                         Entry::Vacant(entry) => {
+                            if !fallback {
+                                entry.insert(parent);
+                            }
+
+                            // Make sure that we have not already explored this child
+                            // through a previous fallback entry further up the BFS,
+                            // in which case we do not want to put it back into the BFS queue,
+                            // nor record a new fallback parent.
+                            if fallback_map.contains_key(&def_id) {
+                                return;
+                            }
+
                             if fallback {
                                 // We do all of the same steps to fallback entries as to
                                 // preferred entries, except for recording them in a separate map.
                                 // It is important to not return early in the fallback cases to
                                 // ensure that we extend the BFS to the children of fallback items.
-                                fallback_map.push((def_id, parent));
-                            } else {
-                                entry.insert(parent);
+                                fallback_map.insert(def_id, parent);
                             }
 
                             if child.res.module_like_def_id().is_some() {
@@ -560,12 +571,13 @@ pub(in crate::rmeta) fn provide(providers: &mut Providers) {
             // Fill in any missing entries with the less preferable path.
             // If this path re-exports the child as `_`, we still use this
             // path in a diagnostic that suggests importing `::*`.
+            // We must extend the fallback map with items from the visible parent map
+            // as the extend call overrides existing entries from the latter map,
+            // which we prefer over fallback entries.
+            let mut merged_visible_parent_map = fallback_map;
+            merged_visible_parent_map.extend_unord(visible_parent_map.into_items());
 
-            for (child, parent) in fallback_map {
-                visible_parent_map.entry(child).or_insert(parent);
-            }
-
-            visible_parent_map
+            merged_visible_parent_map
         },
 
         dependency_formats: |tcx, ()| Arc::new(crate::dependency_format::calculate(tcx)),

--- a/tests/ui/suggestions/suggest-path-through-direct-dep-crate/auxiliary/direct-dep-with-multiple-reexports.rs
+++ b/tests/ui/suggestions/suggest-path-through-direct-dep-crate/auxiliary/direct-dep-with-multiple-reexports.rs
@@ -1,0 +1,15 @@
+#![crate_type = "lib"]
+
+extern crate transitive_dep;
+
+mod private {
+    pub use crate::transitive_dep::Struct;
+}
+
+#[doc(hidden)]
+pub use crate::private::*;
+
+#[doc(hidden)]
+pub mod __private {
+    pub use crate::private::*;
+}

--- a/tests/ui/suggestions/suggest-path-through-direct-dep-crate/use-shortest-hidden-reexport-path.rs
+++ b/tests/ui/suggestions/suggest-path-through-direct-dep-crate/use-shortest-hidden-reexport-path.rs
@@ -1,0 +1,16 @@
+//@ aux-build: transitive-dep.rs
+//@ aux-build: direct-dep-with-multiple-reexports.rs
+
+extern crate direct_dep_with_multiple_reexports as direct_dep;
+
+struct Struct;
+//~^ NOTE `Struct` is defined in the current crate
+
+fn main() {
+    let _: direct_dep::Struct = Struct;
+    //~^ ERROR mismatched types
+    //~| NOTE expected `direct_dep::Struct`, found `Struct`
+    //~| NOTE expected due to this
+    //~| NOTE `Struct` and `direct_dep::Struct` have similar names, but are actually distinct types
+    //~| NOTE `direct_dep::Struct` is defined in crate `transitive_dep`
+}

--- a/tests/ui/suggestions/suggest-path-through-direct-dep-crate/use-shortest-hidden-reexport-path.stderr
+++ b/tests/ui/suggestions/suggest-path-through-direct-dep-crate/use-shortest-hidden-reexport-path.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/use-shortest-hidden-reexport-path.rs:10:33
+   |
+LL |     let _: direct_dep::Struct = Struct;
+   |            ------------------   ^^^^^^ expected `direct_dep::Struct`, found `Struct`
+   |            |
+   |            expected due to this
+   |
+   = note: `Struct` and `direct_dep::Struct` have similar names, but are actually distinct types
+note: `Struct` is defined in the current crate
+  --> $DIR/use-shortest-hidden-reexport-path.rs:6:1
+   |
+LL | struct Struct;
+   | ^^^^^^^^^^^^^
+note: `direct_dep::Struct` is defined in crate `transitive_dep`
+  --> $DIR/auxiliary/transitive-dep.rs:3:1
+   |
+LL | pub struct Struct;
+   | ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160464)*
<!-- homu-ignore:end -->

The fix in rust-lang/rust#159881 extended the `visible_parent_map` breadth-first search (BFS) to include items nested within "fallback" items, such as `#[doc(hidden)]` modules and re-exports. However, the fix resulted in fallback entries not being checked before enqueueing new items into the BFS, resulting in fallback items being explored in the BFS multiple times, once for each fallback parent, up until a non-fallback visible parent is found instead, if any.

This PR adds a check before new fallback items are recorded and the BFS queue is extended that ensures that the item has not already been searched through a fallback parent item.

Fixes the `libc` performance regression described in rust-lang/rust#160439. (Fixes rust-lang/rust#160439.)

Unfortunately, I could not think of a way to write a test case that covers the regression that this PR fixes, as it would require a massive crate with a very large number of "fallback" parents, and the test would be performance-based.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
