### PR TITLE
do not map llvm_features_by_flags back into Rust-level cfg(target_feature)

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -730,8 +730,11 @@ pub(crate) fn global_llvm_features(sess: &Session, only_base_features: bool) -> 
         target_features::flag_to_backend_features(sess, extend_backend_features);
     }
 
-    // We add this in the "base target" so that these show up in `sess.unstable_target_features`.
-    llvm_features_by_flags(sess, &mut features);
+    // `-C` flags that map to LLVM target features.
+    // We skip these in `cfg` as they aren't "target features" in the Rust sense.
+    if !only_base_features {
+        llvm_features_by_flags(sess, &mut features);
+    }
 
     features
 }


### PR DESCRIPTION
For some reason, we currently apply `llvm_features_by_flags` also to the "informational LLVM target machine" that we create to populate `cfg(target_feature)`. This strikes me as odd: these are things that we do *not* treat as target features on the Rust level, why should they affect `cfg(target_feature)`?

From what I was able to find, the only LLVM target feature set by `llvm_features_by_flags` that has a corresponding Rust target feature is wasm's `exception-handling`. That one is unstable (tracking: https://github.com/rust-lang/rust/issues/150260), so this PR should change nothing for stable users. On unstable, this PR means that if you set `-Cpanic=unwind` you no longer get `cfg(target_feature = "exception-handling")`. Is that okay? Is that a problem? I don't know.  This behavior has been around since https://github.com/rust-lang/rust/pull/121438 but it does not look like it was discussed much in that PR; it is not clear whether this was even intentional (this code is a total mess, after all).
What is even supposed to happen in cases like `-Cpanic=unwind -Ctarget-feature=-exception-handling`? It is very strange to have two flags both affect the same LLVM target feature. The easiest way to resolve this would be to mark the `exception-handling` target feature as "forbidden" so it can no longer be toggled via `-Ctarget-feature`. But that may be a bad idea?
Cc @bjorn3 @alexcrichton @cuviper @coolreader18  