### PR TITLE
Prove nested goals before const evaluation

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1405,6 +1405,14 @@ where
         expected_term: I::Term,
         alias_const: ty::AliasConst<I>,
     ) -> QueryResultOrRerunNonErased<I> {
+        // Evaluation instantiates the constant's body with its arguments. An argument whose
+        // type does not match its parameter makes that body ill-formed, which CTFE cannot run.
+        self.try_evaluate_added_goals().inspect_err(|_| {
+            // Without recording the response here we attribute the error to this goal rather
+            // than to the nested goal which actually failed.
+            self.inspect.make_canonical_response(Certainty::Yes);
+        })?;
+
         match self.evaluate_const(param_env, alias_const)? {
             Some(evaluated) => {
                 self.eq(param_env, expected_term, evaluated.into())?;

--- a/tests/ui/const-generics/gca/mismatched-const-arg-type.rs
+++ b/tests/ui/const-generics/gca/mismatched-const-arg-type.rs
@@ -1,0 +1,55 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/156780>.
+
+//@ compile-flags: -Znext-solver
+
+#![feature(
+    generic_const_args,
+    generic_const_items,
+    macroless_generic_const_args,
+    min_generic_const_args
+)]
+#![expect(incomplete_features)]
+
+const F: f64 = 1.0;
+
+const ADD1<const N: usize>: usize = N + 1;
+
+const IGNORE<const N: usize>: usize = 0;
+
+trait Tr {
+    const C<const N: usize>: usize;
+}
+
+impl Tr for () {
+    const C<const N: usize>: usize = N + 1;
+}
+
+fn main() {
+    let _: [(); ADD1::<1f64>];
+    //~^ ERROR: the constant `1f64` is not of type `usize`
+    //~| ERROR: is not well-formed
+    let _: [(); ADD1::<1u8>];
+    //~^ ERROR: the constant `1` is not of type `usize`
+    //~| ERROR: is not well-formed
+    let _: [(); ADD1::<1i32>];
+    //~^ ERROR: the constant `1` is not of type `usize`
+    //~| ERROR: is not well-formed
+    let _: [(); ADD1::<true>];
+    //~^ ERROR: the constant `true` is not of type `usize`
+    //~| ERROR: is not well-formed
+    let _: [(); ADD1::<'a'>];
+    //~^ ERROR: the constant `'a'` is not of type `usize`
+    //~| ERROR: is not well-formed
+    let _: [(); ADD1::<"s">];
+    //~^ ERROR: the constant `"s"` is not of type `usize`
+    //~| ERROR: is not well-formed
+    let _: [(); ADD1::<F>];
+    //~^ ERROR: the constant `1f64` is not of type `usize`
+    //~| ERROR: is not well-formed
+    let _: [(); IGNORE::<1f64>];
+    //~^ ERROR: the constant `1f64` is not of type `usize`
+    //~| ERROR: is not well-formed
+    let _: [(); <() as Tr>::C::<1f64>];
+    //~^ ERROR: type mismatch resolving `<() as Tr>::C<1f64> == _`
+    //~| ERROR: is not well-formed
+}

--- a/tests/ui/const-generics/gca/mismatched-const-arg-type.stderr
+++ b/tests/ui/const-generics/gca/mismatched-const-arg-type.stderr
@@ -1,0 +1,111 @@
+error: the constant `1f64` is not of type `usize`
+  --> $DIR/mismatched-const-arg-type.rs:28:12
+   |
+LL |     let _: [(); ADD1::<1f64>];
+   |            ^^^^^^^^^^^^^^^^^^ expected `usize`, found `f64`
+
+error: the constant `1` is not of type `usize`
+  --> $DIR/mismatched-const-arg-type.rs:31:12
+   |
+LL |     let _: [(); ADD1::<1u8>];
+   |            ^^^^^^^^^^^^^^^^^ expected `usize`, found `u8`
+
+error: the constant `1` is not of type `usize`
+  --> $DIR/mismatched-const-arg-type.rs:34:12
+   |
+LL |     let _: [(); ADD1::<1i32>];
+   |            ^^^^^^^^^^^^^^^^^^ expected `usize`, found `i32`
+
+error: the constant `true` is not of type `usize`
+  --> $DIR/mismatched-const-arg-type.rs:37:12
+   |
+LL |     let _: [(); ADD1::<true>];
+   |            ^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+
+error: the constant `'a'` is not of type `usize`
+  --> $DIR/mismatched-const-arg-type.rs:40:12
+   |
+LL |     let _: [(); ADD1::<'a'>];
+   |            ^^^^^^^^^^^^^^^^^ expected `usize`, found `char`
+
+error: the constant `"s"` is not of type `usize`
+  --> $DIR/mismatched-const-arg-type.rs:43:12
+   |
+LL |     let _: [(); ADD1::<"s">];
+   |            ^^^^^^^^^^^^^^^^^ expected `usize`, found `&'static str`
+
+error: the constant `1f64` is not of type `usize`
+  --> $DIR/mismatched-const-arg-type.rs:46:12
+   |
+LL |     let _: [(); ADD1::<F>];
+   |            ^^^^^^^^^^^^^^^ expected `usize`, found `f64`
+
+error: the constant `1f64` is not of type `usize`
+  --> $DIR/mismatched-const-arg-type.rs:49:12
+   |
+LL |     let _: [(); IGNORE::<1f64>];
+   |            ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `f64`
+
+error[E0271]: type mismatch resolving `<() as Tr>::C<1f64> == _`
+  --> $DIR/mismatched-const-arg-type.rs:52:12
+   |
+LL |     let _: [(); <() as Tr>::C::<1f64>];
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ types differ
+
+error: the type `[(); ADD1::<1f64>]` is not well-formed
+  --> $DIR/mismatched-const-arg-type.rs:28:12
+   |
+LL |     let _: [(); ADD1::<1f64>];
+   |            ^^^^^^^^^^^^^^^^^^
+
+error: the type `[(); ADD1::<1>]` is not well-formed
+  --> $DIR/mismatched-const-arg-type.rs:31:12
+   |
+LL |     let _: [(); ADD1::<1u8>];
+   |            ^^^^^^^^^^^^^^^^^
+
+error: the type `[(); ADD1::<1>]` is not well-formed
+  --> $DIR/mismatched-const-arg-type.rs:34:12
+   |
+LL |     let _: [(); ADD1::<1i32>];
+   |            ^^^^^^^^^^^^^^^^^^
+
+error: the type `[(); ADD1::<true>]` is not well-formed
+  --> $DIR/mismatched-const-arg-type.rs:37:12
+   |
+LL |     let _: [(); ADD1::<true>];
+   |            ^^^^^^^^^^^^^^^^^^
+
+error: the type `[(); ADD1::<'a'>]` is not well-formed
+  --> $DIR/mismatched-const-arg-type.rs:40:12
+   |
+LL |     let _: [(); ADD1::<'a'>];
+   |            ^^^^^^^^^^^^^^^^^
+
+error: the type `[(); ADD1::<"s">]` is not well-formed
+  --> $DIR/mismatched-const-arg-type.rs:43:12
+   |
+LL |     let _: [(); ADD1::<"s">];
+   |            ^^^^^^^^^^^^^^^^^
+
+error: the type `[(); ADD1::<1f64>]` is not well-formed
+  --> $DIR/mismatched-const-arg-type.rs:46:12
+   |
+LL |     let _: [(); ADD1::<F>];
+   |            ^^^^^^^^^^^^^^^
+
+error: the type `[(); IGNORE::<1f64>]` is not well-formed
+  --> $DIR/mismatched-const-arg-type.rs:49:12
+   |
+LL |     let _: [(); IGNORE::<1f64>];
+   |            ^^^^^^^^^^^^^^^^^^^^
+
+error: the type `[(); <() as Tr>::C::<1f64>]` is not well-formed
+  --> $DIR/mismatched-const-arg-type.rs:52:12
+   |
+LL |     let _: [(); <() as Tr>::C::<1f64>];
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 18 previous errors
+
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
Fixes rust-lang/rust#156780. 
Tracking issue: rust-lang/rust#132980.

`evaluate_const_and_instantiate_projection_term` handed the constant to CTFE before proving the nested goals already registered for it. Evaluation instantiates the item's body with its arguments, so an argument whose type does not match its parameter produced ill-formed MIR and ICEd the interpreter instead of the `ConstArgHasType` goal reporting the mismatch.

`const IGNORE<const N: usize>: usize = 0;` reports the mismatch today because its body never reads `N`. 
`const ADD1<const N: usize>: usize = N + 1;` ICEs.

This is not specific to literals. `const F: f64 = 1.0;` with `ADD1::<F>` ICEs the same way, so checking the literal during lowering, as rust-lang/rust#156944 attempted, would not have covered it.

I'm not completely sure about the call to `self.inspect.make_canonical_response`. `evaluate_added_goals_and_make_canonical_response` records the response before evaluating nested goals so a failure still leaves an attributable proof tree. Without it every case reports:

```
error[E0271]: type mismatch resolving `IGNORE<1f64> == _`
  --> tests/ui/const-generics/gca/mismatched-const-arg-type.rs:49:12
   |
49 |     let _: [(); IGNORE::<1f64>];
   |            ^^^^^^^^^^^^^^^^^^^^ types differ
```

This adds a `try_evaluate_added_goals` call before each const evaluated during normalization. The tail `evaluate_added_goals_and_make_canonical_response` calls it again, so goals which come back ambiguous are evaluated twice.

r? @lcnr 