### PR TITLE
Minor fixes to `core::io` & `alloc::io` Documentation

### DIFF
--- a/library/alloc/src/io/buffered/mod.rs
+++ b/library/alloc/src/io/buffered/mod.rs
@@ -132,6 +132,7 @@ impl<W> IntoInnerError<W> {
     /// obtain ownership of the underlying error.
     ///
     /// # Example
+    ///
     /// ```
     /// use std::io::{BufWriter, ErrorKind, Write};
     ///
@@ -154,6 +155,7 @@ impl<W> IntoInnerError<W> {
     /// advanced error recovery.
     ///
     /// # Example
+    ///
     /// ```
     /// use std::io::{BufWriter, ErrorKind, Write};
     ///

--- a/library/alloc/src/io/prelude.rs
+++ b/library/alloc/src/io/prelude.rs
@@ -4,8 +4,9 @@
 //! by adding a glob import to the top of I/O heavy modules:
 //!
 //! ```
+//! # #![feature(alloc_io)]
 //! # #![allow(unused_imports)]
-//! use std::io::prelude::*;
+//! use alloc::io::prelude::*;
 //! ```
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/io/error.rs
+++ b/library/core/src/io/error.rs
@@ -1115,6 +1115,7 @@ impl fmt::Display for ErrorKind {
     /// This is similar to `impl Display for Error`, but doesn't require first converting to Error.
     ///
     /// # Examples
+    ///
     /// ```
     /// use core::io::ErrorKind;
     /// assert_eq!("entity not found", ErrorKind::NotFound.to_string());

--- a/library/core/src/io/prelude.rs
+++ b/library/core/src/io/prelude.rs
@@ -4,8 +4,9 @@
 //! by adding a glob import to the top of I/O heavy modules:
 //!
 //! ```
+//! # #![feature(core_io)]
 //! # #![allow(unused_imports)]
-//! use std::io::prelude::*;
+//! use core::io::prelude::*;
 //! ```
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

ACP: https://github.com/rust-lang/libs-team/issues/755
Tracking issue: https://github.com/rust-lang/rust/issues/154046
Supersedes: rust-lang/rust#160413

## Description

Minor tweaks to the documentation in `core::io` and `alloc::io` after proof-reading. In rust-lang/rust#160413 I attempted to rewrite all example snippets to be `no_std`/`no_alloc` compatible where relevant. I've closed that in favour of smaller adjustments, as there are many examples of `std`-requiring code snippets in `core` documentation (e.g., [`core::borrow`](https://doc.rust-lang.org/stable/core/borrow/trait.Borrow.html)).

---

## Notes

* No AI tooling of any kind was used during the creation of this PR.