### PR TITLE
perf: Avoid freshening the same predicate twice per selection

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -328,8 +328,19 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // separately rather than using `stack.fresh_trait_pred` --
         // this is because we want the unbound variables to be
         // replaced with fresh types starting from index 0.
-        let cache_fresh_trait_pred =
-            stack.obligation.predicate.fold_with(&mut TypeFreshener::new(self.infcx));
+        //
+        // Without type or const inference variables the freshener allocates no
+        // indices, leaving only region erasure, which does not depend on the
+        // numbering, so `stack.fresh_trait_pred` holds the same value.
+        let cache_fresh_trait_pred = if stack.obligation.predicate.has_non_region_infer() {
+            stack.obligation.predicate.fold_with(&mut TypeFreshener::new(self.infcx))
+        } else {
+            debug_assert_eq!(
+                stack.fresh_trait_pred,
+                stack.obligation.predicate.fold_with(&mut TypeFreshener::new(self.infcx)),
+            );
+            stack.fresh_trait_pred
+        };
         debug!(?cache_fresh_trait_pred);
         debug_assert!(!stack.obligation.predicate.has_escaping_bound_vars());
 


### PR DESCRIPTION
`candidate_from_obligation` freshens a predicate that `push_stack` already freshened. The two results can only differ if the predicate contains type or const inference variables. If it has none, we reuse `stack.fresh_trait_pred` and skip the second freshening.
