### PR TITLE
Fix: WF ICE assumptions on binders

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -1127,6 +1127,7 @@ where
                     return Ok(false);
                 }
                 match ecx.probe(|_| ProbeKind::ProjectionCompatibility).enter(|ecx| {
+                    let target_projection = ecx.resolve_vars_if_possible(target_projection);
                     ecx.enter_forall_with_assumptions(
                         target_projection,
                         param_env,
@@ -1152,6 +1153,8 @@ where
                     ty::ExistentialPredicate::Trait(target_principal) => {
                         let source_principal = upcast_principal.unwrap();
                         let target_principal = bound.rebind(target_principal);
+                        // We might unify infer vars in previous iterations.
+                        let target_principal = ecx.resolve_vars_if_possible(target_principal);
                         ecx.enter_forall_with_assumptions(
                             target_principal,
                             param_env,
@@ -1184,6 +1187,9 @@ where
                         let Some(matching) = matching_projection else {
                             return Err(NoSolution.into());
                         };
+
+                        // We might unify infer vars in previous iterations.
+                        let target_projection = ecx.resolve_vars_if_possible(target_projection);
                         ecx.enter_forall_with_assumptions(
                             target_projection,
                             param_env,

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -324,6 +324,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
         param_env: ty::ParamEnv<'tcx>,
         term: ty::Term<'tcx>,
     ) -> Option<Vec<Goal<'tcx, ty::Predicate<'tcx>>>> {
+        let term = self.0.resolve_vars_if_possible(term);
         crate::traits::wf::unnormalized_obligations(
             &self.0,
             param_env,

--- a/tests/ui/assumptions_on_binders/resolve-infer-var-wf.rs
+++ b/tests/ui/assumptions_on_binders/resolve-infer-var-wf.rs
@@ -1,0 +1,44 @@
+//@ compile-flags: -Znext-solver=globally -Zassumptions-on-binders
+//@ check-pass
+
+// Computing placeholder assumptions when entering a binder visits every
+// type and const in the goal predicate and computes their WF obligations.
+// The visited terms may contain resolvable inference variables; the solver
+// must resolve them first, otherwise computing WF obligations ICEs with
+// `assertion failed: term == infcx.resolve_vars_if_possible(term)`.
+
+use std::marker::PhantomData;
+
+fn hint_app<TArg, TRet>(f: &dyn Fn(TArg) -> TRet) -> &dyn Fn(TArg) -> TRet {
+    f
+}
+
+enum List<'a, A> {
+    Nil(PhantomData<&'a A>),
+}
+
+enum Tree<'a> {
+    Leaf(PhantomData<&'a ()>),
+}
+
+type Priqueue<'a> = &'a List<'a, &'a Tree<'a>>;
+
+struct Program;
+
+impl<'a> Program {
+    fn alloc<T>(&'a self, t: T) -> &'a T {
+        todo!()
+    }
+
+    fn unzip(
+        &'a self,
+        t: &'a Tree,
+        cont: &dyn Fn(Priqueue) -> Priqueue,
+    ) -> Priqueue<'a> {
+        match t {
+            _ => hint_app(cont)(self.alloc(List::Nil(PhantomData))),
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/assumptions_on_binders/resolve-infer-var-wf.rs
+++ b/tests/ui/assumptions_on_binders/resolve-infer-var-wf.rs
@@ -1,0 +1,38 @@
+//@ compile-flags: -Znext-solver=globally -Zassumptions-on-binders
+//@ check-pass
+
+use std::marker::PhantomData;
+
+fn hint_app<TArg, TRet>(f: &dyn Fn(TArg) -> TRet) -> &dyn Fn(TArg) -> TRet {
+    f
+}
+
+enum List<'a, A> {
+    Nil(PhantomData<&'a A>),
+}
+
+enum Tree<'a> {
+    Leaf(PhantomData<&'a ()>),
+}
+
+type Priqueue<'a> = &'a List<'a, &'a Tree<'a>>;
+
+struct Program;
+
+impl<'a> Program {
+    fn alloc<T>(&'a self, t: T) -> &'a T {
+        todo!()
+    }
+
+    fn unzip(
+        &'a self,
+        t: &'a Tree,
+        cont: &dyn Fn(Priqueue) -> Priqueue,
+    ) -> Priqueue<'a> {
+        match t {
+            _ => hint_app(cont)(self.alloc(List::Nil(PhantomData))),
+        }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160497)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#160293

`-Zassumptions-on-binders` ICEs because the solver's `well_formed_goals` passes terms with resolvable inference variables to `unnormalized_obligations`, which asserts they're already resolved (unlike other callers).

Resolve inference variables before computing WF obligations.