### PR TITLE
Fix duplicated words in comments and docs

### DIFF
--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -723,7 +723,7 @@ impl<'tcx> InferCtxt<'tcx> {
     /// more information.
     ///
     /// `InferCtxt` has two uses: the trait solver calls some methods on it, because the `InferCtxt`
-    /// works as a kind of store for for example type unification information.
+    /// works as a kind of store for, for example, type unification information.
     /// `InferCtxt` is also often used outside the trait solver during typeck.
     /// There, we don't care about the `ErasedNotCoherence` case and should never encounter it.
     /// To make sure these two uses are never confused, we want to statically encode this information.

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -298,7 +298,7 @@ impl<'tcx> ConstToPat<'tcx> {
                             })
                         }
                         hir::Node::Arm(hir::Arm { guard: Some(guard), .. }) => {
-                            // Modify the the match arm if condition and add a check for equality.
+                            // Modify the match arm if condition and add a check for equality.
                             Some(SuggestEq::AddToIf {
                                 span: guard.span.shrink_to_hi(),
                                 pat_span: self.span,

--- a/compiler/rustc_trait_selection/src/traits/outlives_for_liveness.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_for_liveness.rs
@@ -145,7 +145,7 @@ pub(crate) fn args_known_to_outlive_alias_params<'tcx>(
 
 /// For each *captured* region of this alias, compute the *captured* identity
 /// args that are known to outlive it, given the definition of the opaque type
-/// in the the *parent* context.
+/// in the *parent* context.
 ///
 /// Some examples:
 /// ```ignore (illustrative)

--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
 # This file contains lookup functions that associate rust types with their synthetic/summary
 # providers.
 #
-# LLDB caches the results of the the commands in `lldb_commands`, but that caching is "shallow". It
+# LLDB caches the results of the commands in `lldb_commands`, but that caching is "shallow". It
 # purely associates the type with the function given, whether it is a regular function or a class
 # constructor. If the function makes decisions about what type of SyntheticProvider to return, that
 # processing is done **each time a value of that type is encountered**.

--- a/tests/codegen-llvm/sanitizer/cfi/external_weak_symbols.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/external_weak_symbols.rs
@@ -1,4 +1,4 @@
-// Verifies that type metadata identifiers for for weakly-linked symbols are
+// Verifies that type metadata identifiers for weakly-linked symbols are
 // emitted correctly.
 //
 //@ needs-sanitizer-cfi

--- a/tests/debuginfo/lexical-scope-in-if-let.rs
+++ b/tests/debuginfo/lexical-scope-in-if-let.rs
@@ -48,7 +48,7 @@
 
 // === CDB TESTS ==================================================================================
 
-// Note: `/n` causes the the output to be sorted to avoid depending on the order in PDB which may
+// Note: `/n` causes the output to be sorted to avoid depending on the order in PDB which may
 // be arbitrary.
 
 //@ cdb-command: g

--- a/tests/ui/coercion/constrain-expectation-in-arg.rs
+++ b/tests/ui/coercion/constrain-expectation-in-arg.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-// Regression test for for #129286.
+// Regression test for #129286.
 // Makes sure that we don't have unconstrained type variables that come from
 // bivariant type parameters due to the way that we construct expectation types
 // when checking call expressions in HIR typeck.


### PR DESCRIPTION
Fixes duplicated words (`the the`, `for for`) in comments and doc comments.

Only files owned by this repository are touched; occurrences in submodules and subtrees (clippy, miri, rust-analyzer, rustc-dev-guide, compiler-builtins, stdarch) are left for their own repositories.

`for for` in `impl Trait for for<'a> fn(..)` and "checks for for-loops" are intentional and untouched.
