### PR TITLE
Remove `RegionExt`; move methods to `Region` in `rustc_type_ir`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -14,7 +14,7 @@ use rustc_infer::traits::query::{
 };
 use rustc_middle::ty::error::TypeError;
 use rustc_middle::ty::{
-    self, RePlaceholder, Region, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, UniverseIndex,
+    self, RePlaceholder, Region, RegionVid, Ty, TyCtxt, TypeFoldable, UniverseIndex,
 };
 use rustc_span::Span;
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -26,7 +26,7 @@ use rustc_middle::mir::{
 };
 use rustc_middle::ty::print::PrintTraitRefExt as _;
 use rustc_middle::ty::{
-    self, PredicateKind, RegionExt, Ty, TyCtxt, TypeSuperVisitable, TypeVisitor, Upcast,
+    self, PredicateKind, Ty, TyCtxt, TypeSuperVisitable, TypeVisitor, Upcast,
     suggest_constraining_type_params,
 };
 use rustc_mir_dataflow::move_paths::{Init, InitKind, InitLocation, MoveOutIndex, MovePathIndex};

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -15,8 +15,7 @@ use rustc_middle::bug;
 use rustc_middle::hir::place::PlaceBase;
 use rustc_middle::mir::{AnnotationSource, ConstraintCategory, ReturnConstraint};
 use rustc_middle::ty::{
-    self, GenericArgs, Region, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitor,
-    fold_regions,
+    self, GenericArgs, Region, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitor, fold_regions,
 };
 use rustc_span::{Ident, Span, kw};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -12,7 +12,7 @@ use rustc_index::IndexSlice;
 use rustc_middle::mir::pretty::PrettyPrintMirOptions;
 use rustc_middle::mir::{Body, MirDumper, PassWhere, Promoted};
 use rustc_middle::ty::print::with_no_trimmed_paths;
-use rustc_middle::ty::{self, RegionExt, TyCtxt};
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_mir_dataflow::move_paths::MoveData;
 use rustc_mir_dataflow::points::DenseLocationMap;
 use rustc_session::config::MirIncludeSpans;

--- a/compiler/rustc_borrowck/src/polonius/dump.rs
+++ b/compiler/rustc_borrowck/src/polonius/dump.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_index::IndexVec;
 use rustc_middle::mir::pretty::{MirDumper, PassWhere, PrettyPrintMirOptions};
 use rustc_middle::mir::{Body, Location};
-use rustc_middle::ty::{RegionExt, RegionVid, TyCtxt};
+use rustc_middle::ty::{RegionVid, TyCtxt};
 use rustc_mir_dataflow::points::PointIndex;
 use rustc_session::config::MirIncludeSpans;
 

--- a/compiler/rustc_borrowck/src/region_infer/graphviz.rs
+++ b/compiler/rustc_borrowck/src/region_infer/graphviz.rs
@@ -7,7 +7,7 @@ use std::io::{self, Write};
 
 use itertools::Itertools;
 use rustc_graphviz as dot;
-use rustc_middle::ty::{RegionExt, UniverseIndex};
+use rustc_middle::ty::UniverseIndex;
 
 use super::*;
 

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -17,9 +17,7 @@ use rustc_middle::mir::{
     TerminatorKind,
 };
 use rustc_middle::traits::{ObligationCause, ObligationCauseCode};
-use rustc_middle::ty::{
-    self, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, UniverseIndex, fold_regions,
-};
+use rustc_middle::ty::{self, RegionVid, Ty, TyCtxt, TypeFoldable, UniverseIndex, fold_regions};
 use rustc_mir_dataflow::points::DenseLocationMap;
 use rustc_span::hygiene::DesugaringKind;
 use rustc_span::{DUMMY_SP, Span};

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
@@ -11,7 +11,7 @@ use rustc_macros::extension;
 use rustc_middle::mir::{Body, ConstraintCategory};
 use rustc_middle::ty::{
     self, DefiningScopeKind, DefinitionSiteHiddenType, FallibleTypeFolder, Flags, GenericArg,
-    GenericArgsRef, OpaqueTypeKey, ProvisionalHiddenType, Region, RegionExt, RegionVid, Ty, TyCtxt,
+    GenericArgsRef, OpaqueTypeKey, ProvisionalHiddenType, Region, RegionVid, Ty, TyCtxt,
     TypeFoldable, TypeSuperFoldable, TypeVisitableExt, Unnormalized, fold_regions,
 };
 use rustc_mir_dataflow::points::DenseLocationMap;

--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -6,8 +6,7 @@ use rustc_infer::infer::outlives::env::RegionBoundPairs;
 use rustc_infer::infer::outlives::obligations::{TypeOutlives, TypeOutlivesDelegate};
 use rustc_infer::infer::region_constraints::{GenericKind, VerifyBound};
 use rustc_middle::ty::{
-    self, GenericArgKind, RegionExt, TyCtxt, TypeFoldable, TypeVisitableExt, elaborate,
-    fold_regions,
+    self, GenericArgKind, TyCtxt, TypeFoldable, TypeVisitableExt, elaborate, fold_regions,
 };
 use rustc_span::Span;
 use tracing::{debug, instrument};

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -27,7 +27,7 @@ use rustc_middle::mir::RETURN_PLACE;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{
     self, BoundVariableKind, GenericArgs, GenericArgsRef, InlineConstArgs, InlineConstArgsParts,
-    List, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, fold_regions,
+    List, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, fold_regions,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{ErrorGuaranteed, kw, sym};

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -26,8 +26,8 @@ use rustc_macros::extension;
 use rustc_middle::mir::RETURN_PLACE;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{
-    self, GenericArgs, GenericArgsRef, InlineConstArgs, InlineConstArgsParts, RegionExt, RegionVid,
-    Ty, TyCtxt, TypeFoldable, TypeVisitableExt, fold_regions,
+    self, GenericArgs, GenericArgsRef, InlineConstArgs, InlineConstArgsParts, RegionVid, Ty,
+    TyCtxt, TypeFoldable, TypeVisitableExt, fold_regions,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{ErrorGuaranteed, kw, sym};
@@ -524,7 +524,10 @@ impl<'tcx> UniversalRegionsBuilder<'_, 'tcx> {
         for (idx, bound_var) in bound_inputs_and_output.bound_vars().iter().enumerate() {
             if let ty::BoundVariableKind::Region(kind) = bound_var {
                 let kind = ty::LateParamRegionKind::from_bound(ty::BoundVar::from_usize(idx), kind);
-                let r = ty::Region::new_late_param(self.infcx.tcx, self.mir_def.to_def_id(), kind);
+                let r = ty::Region::new_late_param(
+                    self.infcx.tcx,
+                    ty::LateParamRegion { scope: self.mir_def.to_def_id(), kind },
+                );
                 let region_vid = {
                     let name = r.get_name_or_anon(self.infcx.tcx);
                     self.infcx.next_nll_region_var(NllRegionVariableOrigin::FreeRegion, || {
@@ -893,8 +896,10 @@ impl<'tcx> BorrowckInferCtxt<'tcx> {
         let (value, _map) = self.tcx.instantiate_bound_regions(value, |br| {
             debug!(?br);
             let kind = ty::LateParamRegionKind::from_bound(br.var, br.kind);
-            let liberated_region =
-                ty::Region::new_late_param(self.tcx, all_outlive_scope.to_def_id(), kind);
+            let liberated_region = ty::Region::new_late_param(
+                self.tcx,
+                ty::LateParamRegion { scope: all_outlive_scope.to_def_id(), kind },
+            );
             ty::Region::new_var(self.tcx, indices.to_region_vid(liberated_region))
         });
         value
@@ -1003,7 +1008,10 @@ fn for_each_late_bound_region_in_item<'tcx>(
     for (idx, bound_var) in bound_vars.iter().enumerate() {
         if let ty::BoundVariableKind::Region(kind) = bound_var {
             let kind = ty::LateParamRegionKind::from_bound(ty::BoundVar::from_usize(idx), kind);
-            let liberated_region = ty::Region::new_late_param(tcx, mir_def_id.to_def_id(), kind);
+            let liberated_region = ty::Region::new_late_param(
+                tcx,
+                ty::LateParamRegion { scope: mir_def_id.to_def_id(), kind },
+            );
             f(liberated_region);
         }
     }

--- a/compiler/rustc_hir_analysis/src/check/always_applicable.rs
+++ b/compiler/rustc_hir_analysis/src/check/always_applicable.rs
@@ -11,7 +11,7 @@ use rustc_infer::infer::{RegionResolutionError, TyCtxtInferExt};
 use rustc_infer::traits::{ObligationCause, ObligationCauseCode};
 use rustc_middle::span_bug;
 use rustc_middle::ty::util::CheckRegions;
-use rustc_middle::ty::{self, GenericArgsRef, RegionExt, Ty, TyCtxt, TypeVisitableExt, TypingMode};
+use rustc_middle::ty::{self, GenericArgsRef, Ty, TyCtxt, TypeVisitableExt, TypingMode};
 use rustc_span::sym;
 use rustc_trait_selection::regions::InferCtxtRegionExt;
 use rustc_trait_selection::traits::{self, ObligationCtxt};

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -14,9 +14,9 @@ use rustc_infer::infer::{self, BoundRegionConversionTime, InferCtxt, TyCtxtInfer
 use rustc_infer::traits::{TraitErrors, util};
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::{
-    self, BottomUpFolder, GenericArgs, GenericParamDefKind, Generics, RegionExt, Ty, TyCtxt,
-    TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitable, TypeVisitableExt, TypeVisitor,
-    TypingMode, Unnormalized, Upcast,
+    self, BottomUpFolder, GenericArgs, GenericParamDefKind, Generics, Ty, TyCtxt, TypeFoldable,
+    TypeFolder, TypeSuperFoldable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode,
+    Unnormalized, Upcast,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{BytePos, DUMMY_SP, Span};

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -14,9 +14,9 @@ use rustc_infer::infer::{self, BoundRegionConversionTime, InferCtxt, TyCtxtInfer
 use rustc_infer::traits::util;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::{
-    self, BottomUpFolder, GenericArgs, GenericParamDefKind, Generics, RegionExt, Ty, TyCtxt,
-    TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitable, TypeVisitableExt, TypeVisitor,
-    TypingMode, Unnormalized, Upcast,
+    self, BottomUpFolder, GenericArgs, GenericParamDefKind, Generics, Ty, TyCtxt, TypeFoldable,
+    TypeFolder, TypeSuperFoldable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode,
+    Unnormalized, Upcast,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{BytePos, DUMMY_SP, Span};
@@ -414,8 +414,10 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for RemapLateParam<'tcx> {
         if let ty::ReLateParam(fr) = r.kind() {
             ty::Region::new_late_param(
                 self.tcx,
-                fr.scope,
-                self.mapping.get(&fr.kind).copied().unwrap_or(fr.kind),
+                ty::LateParamRegion {
+                    scope: fr.scope,
+                    kind: self.mapping.get(&fr.kind).copied().unwrap_or(fr.kind),
+                },
             )
         } else {
             r

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -89,7 +89,7 @@ use rustc_middle::query::Providers;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::print::with_types_for_signature;
 use rustc_middle::ty::{
-    self, GenericArgs, GenericArgsRef, OutlivesClause, Region, RegionExt, Ty, TyCtxt, TypingMode,
+    self, GenericArgs, GenericArgsRef, OutlivesClause, Region, Ty, TyCtxt, TypingMode,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_session::diagnostics::feature_err;

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -23,9 +23,9 @@ use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::traits::solve::NoSolution;
 use rustc_middle::ty::trait_def::TraitSpecializationKind;
 use rustc_middle::ty::{
-    self, GenericArgKind, GenericArgs, GenericParamDefKind, RegionExt, Ty, TyCtxt, TypeFlags,
-    TypeFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode,
-    Unnormalized, Upcast,
+    self, GenericArgKind, GenericArgs, GenericParamDefKind, Ty, TyCtxt, TypeFlags, TypeFoldable,
+    TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode, Unnormalized,
+    Upcast,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_session::diagnostics::feature_err;

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -22,9 +22,9 @@ use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::traits::solve::NoSolution;
 use rustc_middle::ty::trait_def::TraitSpecializationKind;
 use rustc_middle::ty::{
-    self, GenericArgKind, GenericArgs, GenericParamDefKind, RegionExt, Ty, TyCtxt, TypeFlags,
-    TypeFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode,
-    Unnormalized, Upcast,
+    self, GenericArgKind, GenericArgs, GenericParamDefKind, Ty, TyCtxt, TypeFlags, TypeFoldable,
+    TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode, Unnormalized,
+    Upcast,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_session::diagnostics::feature_err;
@@ -2424,7 +2424,10 @@ fn lint_redundant_lifetimes<'tcx>(
         {
             let ty::BoundVariableKind::Region(kind) = var else { continue };
             let kind = ty::LateParamRegionKind::from_bound(ty::BoundVar::from_usize(idx), kind);
-            lifetimes.push(ty::Region::new_late_param(tcx, owner_id.to_def_id(), kind));
+            lifetimes.push(ty::Region::new_late_param(
+                tcx,
+                ty::LateParamRegion { scope: owner_id.to_def_id(), kind },
+            ));
         }
     }
     lifetimes.retain(|candidate| candidate.is_named(tcx));

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -34,8 +34,8 @@ use rustc_lint_defs::builtin::REPR_C_ENUMS_LARGER_THAN_INT;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::util::{Discr, IntTypeExt};
 use rustc_middle::ty::{
-    self, AdtKind, Const, IsSuggestable, RegionExt, Ty, TyCtxt, TypeVisitableExt, TypingMode,
-    Unnormalized, fold_regions,
+    self, AdtKind, Const, IsSuggestable, Ty, TyCtxt, TypeVisitableExt, TypingMode, Unnormalized,
+    fold_regions,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -32,8 +32,8 @@ use rustc_infer::traits::{DynCompatibilityViolation, ObligationCause};
 use rustc_middle::query::Providers;
 use rustc_middle::ty::util::{Discr, IntTypeExt};
 use rustc_middle::ty::{
-    self, AdtKind, Const, IsSuggestable, RegionExt, Ty, TyCtxt, TypeVisitableExt, TypingMode,
-    Unnormalized, fold_regions,
+    self, AdtKind, Const, IsSuggestable, Ty, TyCtxt, TypeVisitableExt, TypingMode, Unnormalized,
+    fold_regions,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};

--- a/compiler/rustc_hir_analysis/src/collect/clauses_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/clauses_of.rs
@@ -7,8 +7,7 @@ use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::find_attr;
 use rustc_middle::ty::{
-    self, GenericClauses, ImplTraitInTraitData, RegionExt, Ty, TyCtxt, TypeVisitable, TypeVisitor,
-    Upcast,
+    self, GenericClauses, ImplTraitInTraitData, Ty, TyCtxt, TypeVisitable, TypeVisitor, Upcast,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{DUMMY_SP, Ident, Span};

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -33,7 +33,7 @@ use tracing::{debug, debug_span, instrument};
 use crate::diagnostics;
 use crate::hir::definitions::PerParentDisambiguatorState;
 
-#[extension(trait RegionExt)]
+#[extension(trait ResolvedArgExt)]
 impl ResolvedArg {
     fn early(param: &GenericParam<'_>) -> ResolvedArg {
         ResolvedArg::EarlyBound(param.def_id)

--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -7,8 +7,7 @@ use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{DelegationSelfTyPropagationKind, PathSegment};
 use rustc_middle::ty::{
-    self, EarlyBinder, RegionExt, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
-    TypeVisitableExt,
+    self, EarlyBinder, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt,
 };
 use rustc_span::{ErrorGuaranteed, Span, kw};
 

--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -9,8 +9,7 @@ use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{DelegationSelfTyPropagationKind, PathSegment};
 use rustc_middle::ty::{
-    self, EarlyBinder, RegionExt, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
-    TypeVisitableExt,
+    self, EarlyBinder, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt,
 };
 use rustc_span::{ErrorGuaranteed, Span, kw};
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -44,7 +44,7 @@ use rustc_macros::{TypeFoldable, TypeVisitable};
 use rustc_middle::middle::stability::AllowUnstable;
 use rustc_middle::ty::{
     self, Const, FnSigKind, GenericArgKind, GenericArgsRef, GenericParamDefKind, LitToConstInput,
-    RegionExt, Ty, TyCtxt, TypeSuperFoldable, TypeVisitableExt, TypingMode, Unnormalized, Upcast,
+    Ty, TyCtxt, TypeSuperFoldable, TypeVisitableExt, TypingMode, Unnormalized, Upcast,
     const_lit_matches_ty, fold_regions,
 };
 use rustc_middle::{bug, span_bug};

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -39,7 +39,7 @@ use rustc_macros::{TypeFoldable, TypeVisitable};
 use rustc_middle::middle::stability::AllowUnstable;
 use rustc_middle::ty::{
     self, Const, FnSigKind, GenericArgKind, GenericArgsRef, GenericParamDefKind, LitToConstInput,
-    RegionExt, Ty, TyCtxt, TypeSuperFoldable, TypeVisitableExt, TypingMode, Unnormalized, Upcast,
+    Ty, TyCtxt, TypeSuperFoldable, TypeVisitableExt, TypingMode, Unnormalized, Upcast,
     const_lit_matches_ty, fold_regions,
 };
 use rustc_middle::{bug, span_bug};
@@ -608,8 +608,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             rbv::ResolvedArg::Free(scope, id) => {
                 ty::Region::new_late_param(
                     tcx,
-                    scope.to_def_id(),
-                    ty::LateParamRegionKind::Named(id.to_def_id()),
+                    ty::LateParamRegion {
+                        scope: scope.to_def_id(),
+                        kind: ty::LateParamRegionKind::Named(id.to_def_id()),
+                    },
                 )
 
                 // (*) -- not late-bound, won't change

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -31,9 +31,7 @@ use rustc_middle::ty::print::{
     PrintTraitRefExt as _, with_crate_prefix, with_forced_trimmed_paths,
     with_no_visible_paths_if_doc_hidden,
 };
-use rustc_middle::ty::{
-    self, GenericArgKind, IsSuggestable, RegionExt, Ty, TyCtxt, TypeVisitableExt,
-};
+use rustc_middle::ty::{self, GenericArgKind, IsSuggestable, Ty, TyCtxt, TypeVisitableExt};
 use rustc_span::def_id::DefIdSet;
 use rustc_span::{
     DUMMY_SP, ErrorGuaranteed, ExpnKind, FileName, Ident, MacroKind, Span, Symbol, edit_distance,

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -30,8 +30,8 @@ use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::{
     self, BoundVarReplacerDelegate, ConstVid, FloatVid, GenericArg, GenericArgKind, GenericArgs,
     GenericArgsRef, GenericParamDefKind, InferConst, OpaqueTypeKey, ProvisionalHiddenType,
-    PseudoCanonicalInput, RegionExt, Term, Ty, TyCtxt, TyVid, TypeFoldable, TypeFolder,
-    TypeSuperFoldable, TypeVisitable, TypeVisitableExt, TypingEnv, TypingMode, fold_regions,
+    PseudoCanonicalInput, Term, Ty, TyCtxt, TyVid, TypeFoldable, TypeFolder, TypeSuperFoldable,
+    TypeVisitable, TypeVisitableExt, TypingEnv, TypingMode, fold_regions,
 };
 use rustc_span::{DUMMY_SP, Span, Symbol};
 use rustc_type_ir::{CanonicalizerState, MayBeErased};

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -30,7 +30,7 @@ use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::{
     self, BoundVarReplacerDelegate, ConstVid, FloatVid, GenericArg, GenericArgKind, GenericArgs,
     GenericArgsRef, GenericParamDefKind, InferConst, IntVid, OpaqueTypeKey, ProvisionalHiddenType,
-    PseudoCanonicalInput, RegionExt, Term, TermKind, Ty, TyCtxt, TyVid, TypeFoldable, TypeFolder,
+    PseudoCanonicalInput, Term, TermKind, Ty, TyCtxt, TyVid, TypeFoldable, TypeFolder,
     TypeSuperFoldable, TypeVisitable, TypeVisitableExt, TypingEnv, TypingMode, fold_regions,
 };
 use rustc_span::{DUMMY_SP, Span, Symbol};

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -65,8 +65,8 @@ use rustc_middle::bug;
 use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::ty::outlives::{Component, push_outlives_components};
 use rustc_middle::ty::{
-    self, GenericArgKind, GenericArgsRef, PolyTypeOutlivesClause, Region, RegionExt, RegionVid, Ty,
-    TyCtxt, TypeVisitableExt, eager_resolve_vars,
+    self, GenericArgKind, GenericArgsRef, PolyTypeOutlivesClause, Region, RegionVid, Ty, TyCtxt,
+    TypeVisitableExt, eager_resolve_vars,
 };
 use rustc_span::Span;
 use smallvec::smallvec;

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -8,7 +8,7 @@ use rustc_data_structures::undo_log::UndoLogs;
 use rustc_data_structures::unify as ut;
 use rustc_index::IndexVec;
 use rustc_macros::{TypeFoldable, TypeVisitable};
-use rustc_middle::ty::{self, ReBound, ReStatic, ReVar, Region, RegionExt, RegionVid, Ty, TyCtxt};
+use rustc_middle::ty::{self, ReBound, ReStatic, ReVar, Region, RegionVid, Ty, TyCtxt};
 use rustc_middle::{bug, span_bug};
 use tracing::{debug, instrument};
 

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -17,7 +17,7 @@ use rustc_middle::ty::relate::{
     structurally_relate_tys,
 };
 use rustc_middle::ty::{
-    self, RegionExt, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
+    self, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
     Unnormalized,
 };
 use rustc_middle::{bug, span_bug};

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -16,7 +16,7 @@ use rustc_middle::ty::relate::{
     structurally_relate_tys,
 };
 use rustc_middle::ty::{
-    self, RegionExt, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
+    self, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
     Unnormalized,
 };
 use rustc_middle::{bug, span_bug};
@@ -320,8 +320,10 @@ where
                         ),
                         ParamKind::Free(def_id) => ty::Region::new_late_param(
                             self.tcx,
-                            self.parent_def_id.to_def_id(),
-                            ty::LateParamRegionKind::Named(def_id),
+                            ty::LateParamRegion {
+                                scope: self.parent_def_id.to_def_id(),
+                                kind: ty::LateParamRegionKind::Named(def_id),
+                            },
                         ),
                         // Totally ignore late bound args from binders.
                         ParamKind::Late => return true,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -68,7 +68,6 @@ use crate::traits::solve::{
     PredefinedOpaques,
 };
 use crate::ty::predicate::ExistentialPredicateStableCmpExt as _;
-use crate::ty::region::RegionExt;
 use crate::ty::{
     self, AdtDef, AdtDefData, AdtKind, Binder, Clause, ClausePolarity, Clauses, Const, FnSigKind,
     GenericArg, GenericArgs, GenericArgsRef, GenericParamDefKind, List, ListWithCachedTypeInfo,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -64,7 +64,6 @@ use crate::thir::Thir;
 use crate::traits;
 use crate::traits::solve::{ExternalConstraints, ExternalConstraintsData, PredefinedOpaques};
 use crate::ty::predicate::ExistentialPredicateStableCmpExt as _;
-use crate::ty::region::RegionExt;
 use crate::ty::{
     self, AdtDef, AdtDefData, AdtKind, Binder, Clause, Clauses, Const, FnSigKind, GenericArg,
     GenericArgs, GenericArgsRef, GenericParamDefKind, List, ListWithCachedTypeInfo, ParamConst,
@@ -2632,8 +2631,10 @@ impl<'tcx> TyCtxt<'tcx> {
                     let new_parent = self.local_parent(lbv);
                     return ty::Region::new_late_param(
                         self,
-                        new_parent.to_def_id(),
-                        ty::LateParamRegionKind::Named(lbv.to_def_id()),
+                        ty::LateParamRegion {
+                            scope: new_parent.to_def_id(),
+                            kind: ty::LateParamRegionKind::Named(lbv.to_def_id()),
+                        },
                     );
                 }
                 resolve_bound_vars::ResolvedArg::Error(guar) => {

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -12,8 +12,8 @@ use rustc_span::{DUMMY_SP, Span, Symbol};
 use rustc_type_ir::lang_items::{SolverAdtLangItem, SolverProjectionLangItem, SolverTraitLangItem};
 use rustc_type_ir::solve::CanonicalInputData;
 use rustc_type_ir::{
-    BoundVar, CollectAndApply, DebruijnIndex, Interner, TypeFoldable, Unnormalized, VisitorResult,
-    search_graph, try_visit,
+    BoundVar, CollectAndApply, DebruijnIndex, Interner, RegionVid, TypeFoldable, Unnormalized,
+    VisitorResult, search_graph, try_visit,
 };
 
 use crate::dep_graph::{DepKind, DepNodeIndex};
@@ -650,6 +650,10 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.dcx().span_delayed_bug(DUMMY_SP, msg.to_string())
     }
 
+    fn span_delayed_bug(self, span: Self::Span, msg: impl ToString) -> ErrorGuaranteed {
+        self.dcx().span_delayed_bug(span, msg.to_string())
+    }
+
     fn is_general_coroutine(self, coroutine_def_id: DefId) -> bool {
         self.is_general_coroutine(coroutine_def_id)
     }
@@ -731,6 +735,15 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
 
     fn get_re_static_lifetime(self) -> Region<'tcx> {
         self.lifetimes.re_static
+    }
+
+    fn intern_re_var(self, rv: RegionVid) -> Region<'tcx> {
+        // Use a pre-interned one when possible.
+        self.lifetimes
+            .re_vars
+            .get(rv.as_usize())
+            .copied()
+            .unwrap_or_else(|| self.intern_region(ty::ReVar(rv)))
     }
 
     fn intern_region(self, region_kind: RegionKind<'tcx>) -> Region<'tcx> {

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -621,6 +621,10 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.dcx().span_delayed_bug(DUMMY_SP, msg.to_string())
     }
 
+    fn span_delayed_bug(self, span: Self::Span, msg: impl ToString) -> ErrorGuaranteed {
+        self.dcx().span_delayed_bug(span, msg.to_string())
+    }
+
     fn is_general_coroutine(self, coroutine_def_id: DefId) -> bool {
         self.is_general_coroutine(coroutine_def_id)
     }
@@ -733,6 +737,15 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
 
     fn get_re_static_lifetime(self) -> Region<'tcx> {
         self.lifetimes.re_static
+    }
+
+    fn intern_re_var(self, rv: RegionVid) -> Region<'tcx> {
+        // Use a pre-interned one when possible.
+        self.lifetimes
+            .re_vars
+            .get(rv.as_usize())
+            .copied()
+            .unwrap_or_else(|| self.intern_region(ty::ReVar(rv)))
     }
 
     fn intern_region(self, region_kind: RegionKind<'tcx>) -> Region<'tcx> {

--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -2,7 +2,6 @@ use rustc_data_structures::fx::FxIndexMap;
 use rustc_hir::def_id::DefId;
 use rustc_type_ir::data_structures::DelayedMap;
 
-use crate::ty::region::RegionExt;
 use crate::ty::{
     self, Binder, BoundTy, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
     TypeVisitableExt,

--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -2,7 +2,6 @@ use rustc_data_structures::fx::FxIndexMap;
 use rustc_hir::def_id::DefId;
 use rustc_type_ir::data_structures::DelayedMap;
 
-use crate::ty::region::RegionExt;
 use crate::ty::{
     self, Binder, BoundTy, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
     TypeVisitableExt,
@@ -282,7 +281,7 @@ impl<'tcx> TyCtxt<'tcx> {
     {
         self.instantiate_bound_regions_uncached(value, |br| {
             let kind = ty::LateParamRegionKind::from_bound(br.var, br.kind);
-            ty::Region::new_late_param(self, all_outlive_scope, kind)
+            ty::Region::new_late_param(self, ty::LateParamRegion { scope: all_outlive_scope, kind })
         })
     }
 

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -9,7 +9,6 @@ use rustc_type_ir::{TypeSuperVisitable as _, TypeVisitable, TypeVisitor};
 use tracing::instrument;
 
 use super::{Clause, InstantiatedClauses, ParamConst, ParamTy, Ty, TyCtxt, Unnormalized};
-use crate::ty::region::RegionExt;
 use crate::ty::{self, ClauseKind, EarlyBinder, GenericArgsRef, Region, RegionKind, TyKind};
 
 #[derive(Clone, Debug, TyEncodable, TyDecodable, StableHash)]
@@ -151,6 +150,13 @@ impl std::fmt::Debug for Generics {
 impl<'tcx> rustc_type_ir::inherent::GenericsOf<TyCtxt<'tcx>> for &'tcx Generics {
     fn count(&self) -> usize {
         self.parent_count + self.own_params.len()
+    }
+    fn generics_of_early_param_region_def_id(
+        tcx: TyCtxt<'tcx>,
+        def_id: DefId,
+        epr: ty::EarlyParamRegion,
+    ) -> DefId {
+        tcx.generics_of(def_id).region_param(epr, tcx).def_id
     }
 }
 

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -151,12 +151,8 @@ impl<'tcx> rustc_type_ir::inherent::GenericsOf<TyCtxt<'tcx>> for &'tcx Generics 
     fn count(&self) -> usize {
         self.parent_count + self.own_params.len()
     }
-    fn generics_of_early_param_region_def_id(
-        tcx: TyCtxt<'tcx>,
-        def_id: DefId,
-        epr: ty::EarlyParamRegion,
-    ) -> DefId {
-        tcx.generics_of(def_id).region_param(epr, tcx).def_id
+    fn param_region_def_id(self, tcx: TyCtxt<'tcx>, ebr: ty::EarlyParamRegion) -> DefId {
+        self.region_param(ebr, tcx).def_id
     }
 }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -96,8 +96,7 @@ pub use self::predicate::{
     TraitRef, TypeOutlivesClause,
 };
 pub use self::region::{
-    EarlyParamRegion, LateParamRegion, LateParamRegionKind, Region, RegionExt, RegionKind,
-    RegionVid,
+    EarlyParamRegion, LateParamRegion, LateParamRegionKind, Region, RegionKind, RegionVid,
 };
 pub use self::sty::{
     Alias, AliasTy, AliasTyKind, Article, Binder, BoundConst, BoundRegion, BoundRegionKind,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -94,8 +94,7 @@ pub use self::predicate::{
     TraitRef, TypeOutlivesClause,
 };
 pub use self::region::{
-    EarlyParamRegion, LateParamRegion, LateParamRegionKind, Region, RegionExt, RegionKind,
-    RegionVid,
+    EarlyParamRegion, LateParamRegion, LateParamRegionKind, Region, RegionKind, RegionVid,
 };
 pub use self::sty::{
     Alias, AliasTy, AliasTyKind, Article, Binder, BoundConst, BoundRegion, BoundRegionKind,

--- a/compiler/rustc_middle/src/ty/opaque_types.rs
+++ b/compiler/rustc_middle/src/ty/opaque_types.rs
@@ -5,8 +5,7 @@ use tracing::{debug, instrument, trace};
 
 use crate::diagnostics::ConstNotUsedTraitAlias;
 use crate::ty::{
-    self, GenericArg, GenericArgKind, RegionExt, Ty, TyCtxt, TypeFoldable, TypeFolder,
-    TypeSuperFoldable,
+    self, GenericArg, GenericArgKind, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
 };
 
 pub type OpaqueTypeKey<'tcx> = rustc_type_ir::OpaqueTypeKey<TyCtxt<'tcx>>;

--- a/compiler/rustc_middle/src/ty/opaque_types.rs
+++ b/compiler/rustc_middle/src/ty/opaque_types.rs
@@ -5,8 +5,7 @@ use tracing::{debug, instrument, trace};
 
 use crate::error::ConstNotUsedTraitAlias;
 use crate::ty::{
-    self, GenericArg, GenericArgKind, RegionExt, Ty, TyCtxt, TypeFoldable, TypeFolder,
-    TypeSuperFoldable,
+    self, GenericArg, GenericArgKind, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
 };
 
 pub type OpaqueTypeKey<'tcx> = rustc_type_ir::OpaqueTypeKey<TyCtxt<'tcx>>;

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -24,7 +24,6 @@ use smallvec::SmallVec;
 use super::*;
 use crate::mir::interpret::{AllocRange, GlobalAlloc, Pointer, Provenance, Scalar};
 use crate::query::{IntoQueryKey, Providers};
-use crate::ty::region::RegionExt;
 use crate::ty::{
     ConstInt, Expr, GenericArgKind, ParamConst, ScalarInt, Term, TermKind, TraitPredicate,
     TypeFoldable, TypeSuperFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitableExt,

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -24,7 +24,6 @@ use smallvec::SmallVec;
 use super::*;
 use crate::mir::interpret::{AllocRange, GlobalAlloc, Pointer, Provenance, Scalar};
 use crate::query::{IntoQueryKey, Providers};
-use crate::ty::region::RegionExt;
 use crate::ty::{
     ConstInt, Expr, GenericArgKind, ParamConst, ScalarInt, Term, TermKind, TraitClause,
     TypeFoldable, TypeSuperFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitableExt,

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -1,7 +1,6 @@
-use rustc_errors::MultiSpan;
 use rustc_hir::def_id::DefId;
-use rustc_macros::{StableHash, TyDecodable, TyEncodable, extension};
-use rustc_span::{DUMMY_SP, ErrorGuaranteed, Symbol, kw, sym};
+use rustc_macros::{StableHash, TyDecodable, TyEncodable};
+use rustc_span::{Symbol, kw};
 pub use rustc_type_ir::RegionVid;
 use rustc_type_ir::{
     LateParamRegion as IrLateParamRegion, Region as IrRegion, RegionKind as IrRegionKind,
@@ -13,139 +12,6 @@ pub type Region<'tcx> = IrRegion<TyCtxt<'tcx>>;
 pub type RegionKind<'tcx> = IrRegionKind<TyCtxt<'tcx>>;
 pub type LateParamRegion<'tcx> = IrLateParamRegion<TyCtxt<'tcx>>;
 
-#[extension(pub trait RegionExt<'tcx>)]
-impl<'tcx> Region<'tcx> {
-    #[inline]
-    fn new_early_param(
-        tcx: TyCtxt<'tcx>,
-        early_bound_region: ty::EarlyParamRegion,
-    ) -> Region<'tcx> {
-        tcx.intern_region(ty::ReEarlyParam(early_bound_region))
-    }
-
-    #[inline]
-    fn new_late_param(tcx: TyCtxt<'tcx>, scope: DefId, kind: LateParamRegionKind) -> Region<'tcx> {
-        let data = LateParamRegion { scope, kind };
-        tcx.intern_region(ty::ReLateParam(data))
-    }
-
-    #[inline]
-    fn new_var(tcx: TyCtxt<'tcx>, v: ty::RegionVid) -> Region<'tcx> {
-        // Use a pre-interned one when possible.
-        tcx.lifetimes
-            .re_vars
-            .get(v.as_usize())
-            .copied()
-            .unwrap_or_else(|| tcx.intern_region(ty::ReVar(v)))
-    }
-
-    /// Constructs a `RegionKind::ReError` region.
-    #[track_caller]
-    fn new_error(tcx: TyCtxt<'tcx>, guar: ErrorGuaranteed) -> Region<'tcx> {
-        tcx.intern_region(ty::ReError(guar))
-    }
-
-    /// Constructs a `RegionKind::ReError` region and registers a delayed bug to ensure it gets
-    /// used.
-    #[track_caller]
-    fn new_error_misc(tcx: TyCtxt<'tcx>) -> Region<'tcx> {
-        Region::new_error_with_message(
-            tcx,
-            DUMMY_SP,
-            "RegionKind::ReError constructed but no error reported",
-        )
-    }
-
-    /// Constructs a `RegionKind::ReError` region and registers a delayed bug with the given `msg`
-    /// to ensure it gets used.
-    #[track_caller]
-    fn new_error_with_message<S: Into<MultiSpan>>(
-        tcx: TyCtxt<'tcx>,
-        span: S,
-        msg: &'static str,
-    ) -> Region<'tcx> {
-        let reported = tcx.dcx().span_delayed_bug(span, msg);
-        Region::new_error(tcx, reported)
-    }
-
-    /// Avoid this in favour of more specific `new_*` methods, where possible,
-    /// to avoid the cost of the `match`.
-    fn new_from_kind(tcx: TyCtxt<'tcx>, kind: RegionKind<'tcx>) -> Region<'tcx> {
-        match kind {
-            ty::ReEarlyParam(region) => Region::new_early_param(tcx, region),
-            ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), region) => {
-                Region::new_bound(tcx, debruijn, region)
-            }
-            ty::ReBound(ty::BoundVarIndexKind::Canonical, region) => {
-                Region::new_canonical_bound(tcx, region.var)
-            }
-            ty::ReLateParam(ty::LateParamRegion { scope, kind }) => {
-                Region::new_late_param(tcx, scope, kind)
-            }
-            ty::ReStatic => tcx.lifetimes.re_static,
-            ty::ReVar(vid) => Region::new_var(tcx, vid),
-            ty::RePlaceholder(region) => Region::new_placeholder(tcx, region),
-            ty::ReErased => tcx.lifetimes.re_erased,
-            ty::ReError(reported) => Region::new_error(tcx, reported),
-        }
-    }
-
-    fn get_name(self, tcx: TyCtxt<'tcx>) -> Option<Symbol> {
-        match self.kind() {
-            ty::ReEarlyParam(ebr) => ebr.is_named().then_some(ebr.name),
-            ty::ReBound(_, br) => br.kind.get_name(tcx),
-            ty::ReLateParam(fr) => fr.kind.get_name(tcx),
-            ty::ReStatic => Some(kw::StaticLifetime),
-            ty::RePlaceholder(placeholder) => placeholder.bound.kind.get_name(tcx),
-            _ => None,
-        }
-    }
-
-    fn get_name_or_anon(self, tcx: TyCtxt<'tcx>) -> Symbol {
-        match self.get_name(tcx) {
-            Some(name) => name,
-            None => sym::anon,
-        }
-    }
-
-    /// Is this region named by the user?
-    fn is_named(self, tcx: TyCtxt<'tcx>) -> bool {
-        match self.kind() {
-            ty::ReEarlyParam(ebr) => ebr.is_named(),
-            ty::ReBound(_, br) => br.kind.is_named(tcx),
-            ty::ReLateParam(fr) => fr.kind.is_named(tcx),
-            ty::ReStatic => true,
-            ty::ReVar(..) => false,
-            ty::RePlaceholder(placeholder) => placeholder.bound.kind.is_named(tcx),
-            ty::ReErased => false,
-            ty::ReError(_) => false,
-        }
-    }
-
-    #[inline]
-    fn bound_at_or_above_binder(self, index: ty::DebruijnIndex) -> bool {
-        match self.kind() {
-            ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), _) => debruijn >= index,
-            _ => false,
-        }
-    }
-
-    /// Given some item `binding_item`, check if this region is a generic parameter introduced by it
-    /// or one of the parent generics. Returns the `DefId` of the parameter definition if so.
-    fn opt_param_def_id(self, tcx: TyCtxt<'tcx>, binding_item: DefId) -> Option<DefId> {
-        match self.kind() {
-            ty::ReEarlyParam(ebr) => {
-                Some(tcx.generics_of(binding_item).region_param(ebr, tcx).def_id)
-            }
-            ty::ReLateParam(ty::LateParamRegion {
-                kind: ty::LateParamRegionKind::Named(def_id),
-                ..
-            }) => Some(def_id),
-            _ => None,
-        }
-    }
-}
-
 #[derive(Copy, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 #[derive(StableHash)]
 pub struct EarlyParamRegion {
@@ -154,6 +20,12 @@ pub struct EarlyParamRegion {
 }
 
 impl EarlyParamRegion {
+    #[inline]
+    pub fn get_name(&self) -> Option<Symbol> {
+        if self.is_named() { Some(self.name) } else { None }
+    }
+
+    #[inline]
     /// Does this early bound region have a name? Early bound regions normally
     /// always have names except when using anonymous lifetimes (`'_`).
     pub fn is_named(&self) -> bool {
@@ -164,6 +36,20 @@ impl EarlyParamRegion {
 impl rustc_type_ir::inherent::ParamLike for EarlyParamRegion {
     fn index(self) -> u32 {
         self.index
+    }
+}
+
+impl<'tcx> rustc_type_ir::inherent::RegionName<TyCtxt<'tcx>> for EarlyParamRegion {
+    #[inline]
+    fn get_name(&self, _tcx: TyCtxt<'tcx>) -> Option<Symbol> {
+        self.get_name()
+    }
+
+    #[inline]
+    /// Does this early bound region have a name? Early bound regions normally
+    /// always have names except when using anonymous lifetimes (`'_`).
+    fn is_named(&self, _tcx: TyCtxt<'tcx>) -> bool {
+        self.is_named()
     }
 }
 

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -123,6 +123,24 @@ impl LateParamRegionKind {
     }
 }
 
+impl<'tcx> rustc_type_ir::inherent::RegionName<TyCtxt<'tcx>> for LateParamRegionKind {
+    #[inline]
+    fn get_name(&self, tcx: TyCtxt<'tcx>) -> Option<Symbol> {
+        self.get_name(tcx)
+    }
+
+    #[inline]
+    fn is_named(&self, tcx: TyCtxt<'tcx>) -> bool {
+        self.is_named(tcx)
+    }
+}
+
+impl<'tcx> rustc_type_ir::inherent::DefIdGetter<TyCtxt<'tcx>> for LateParamRegionKind {
+    fn get_def_id(self) -> Option<DefId> {
+        self.get_id()
+    }
+}
+
 // Some types are used a lot. Make sure they don't unintentionally get bigger.
 #[cfg(target_pointer_width = "64")]
 mod size_asserts {

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -1,7 +1,6 @@
-use rustc_errors::MultiSpan;
 use rustc_hir::def_id::DefId;
-use rustc_macros::{StableHash, TyDecodable, TyEncodable, extension};
-use rustc_span::{DUMMY_SP, ErrorGuaranteed, Symbol, kw, sym};
+use rustc_macros::{StableHash, TyDecodable, TyEncodable};
+use rustc_span::{Symbol, kw};
 pub use rustc_type_ir::RegionVid;
 use rustc_type_ir::{Region as IrRegion, RegionKind as IrRegionKind};
 
@@ -9,139 +8,6 @@ use crate::ty::{self, BoundVar, TyCtxt};
 
 pub type Region<'tcx> = IrRegion<TyCtxt<'tcx>>;
 pub type RegionKind<'tcx> = IrRegionKind<TyCtxt<'tcx>>;
-
-#[extension(pub trait RegionExt<'tcx>)]
-impl<'tcx> Region<'tcx> {
-    #[inline]
-    fn new_early_param(
-        tcx: TyCtxt<'tcx>,
-        early_bound_region: ty::EarlyParamRegion,
-    ) -> Region<'tcx> {
-        tcx.intern_region(ty::ReEarlyParam(early_bound_region))
-    }
-
-    #[inline]
-    fn new_late_param(tcx: TyCtxt<'tcx>, scope: DefId, kind: LateParamRegionKind) -> Region<'tcx> {
-        let data = LateParamRegion { scope, kind };
-        tcx.intern_region(ty::ReLateParam(data))
-    }
-
-    #[inline]
-    fn new_var(tcx: TyCtxt<'tcx>, v: ty::RegionVid) -> Region<'tcx> {
-        // Use a pre-interned one when possible.
-        tcx.lifetimes
-            .re_vars
-            .get(v.as_usize())
-            .copied()
-            .unwrap_or_else(|| tcx.intern_region(ty::ReVar(v)))
-    }
-
-    /// Constructs a `RegionKind::ReError` region.
-    #[track_caller]
-    fn new_error(tcx: TyCtxt<'tcx>, guar: ErrorGuaranteed) -> Region<'tcx> {
-        tcx.intern_region(ty::ReError(guar))
-    }
-
-    /// Constructs a `RegionKind::ReError` region and registers a delayed bug to ensure it gets
-    /// used.
-    #[track_caller]
-    fn new_error_misc(tcx: TyCtxt<'tcx>) -> Region<'tcx> {
-        Region::new_error_with_message(
-            tcx,
-            DUMMY_SP,
-            "RegionKind::ReError constructed but no error reported",
-        )
-    }
-
-    /// Constructs a `RegionKind::ReError` region and registers a delayed bug with the given `msg`
-    /// to ensure it gets used.
-    #[track_caller]
-    fn new_error_with_message<S: Into<MultiSpan>>(
-        tcx: TyCtxt<'tcx>,
-        span: S,
-        msg: &'static str,
-    ) -> Region<'tcx> {
-        let reported = tcx.dcx().span_delayed_bug(span, msg);
-        Region::new_error(tcx, reported)
-    }
-
-    /// Avoid this in favour of more specific `new_*` methods, where possible,
-    /// to avoid the cost of the `match`.
-    fn new_from_kind(tcx: TyCtxt<'tcx>, kind: RegionKind<'tcx>) -> Region<'tcx> {
-        match kind {
-            ty::ReEarlyParam(region) => Region::new_early_param(tcx, region),
-            ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), region) => {
-                Region::new_bound(tcx, debruijn, region)
-            }
-            ty::ReBound(ty::BoundVarIndexKind::Canonical, region) => {
-                Region::new_canonical_bound(tcx, region.var)
-            }
-            ty::ReLateParam(ty::LateParamRegion { scope, kind }) => {
-                Region::new_late_param(tcx, scope, kind)
-            }
-            ty::ReStatic => tcx.lifetimes.re_static,
-            ty::ReVar(vid) => Region::new_var(tcx, vid),
-            ty::RePlaceholder(region) => Region::new_placeholder(tcx, region),
-            ty::ReErased => tcx.lifetimes.re_erased,
-            ty::ReError(reported) => Region::new_error(tcx, reported),
-        }
-    }
-
-    fn get_name(self, tcx: TyCtxt<'tcx>) -> Option<Symbol> {
-        match self.kind() {
-            ty::ReEarlyParam(ebr) => ebr.is_named().then_some(ebr.name),
-            ty::ReBound(_, br) => br.kind.get_name(tcx),
-            ty::ReLateParam(fr) => fr.kind.get_name(tcx),
-            ty::ReStatic => Some(kw::StaticLifetime),
-            ty::RePlaceholder(placeholder) => placeholder.bound.kind.get_name(tcx),
-            _ => None,
-        }
-    }
-
-    fn get_name_or_anon(self, tcx: TyCtxt<'tcx>) -> Symbol {
-        match self.get_name(tcx) {
-            Some(name) => name,
-            None => sym::anon,
-        }
-    }
-
-    /// Is this region named by the user?
-    fn is_named(self, tcx: TyCtxt<'tcx>) -> bool {
-        match self.kind() {
-            ty::ReEarlyParam(ebr) => ebr.is_named(),
-            ty::ReBound(_, br) => br.kind.is_named(tcx),
-            ty::ReLateParam(fr) => fr.kind.is_named(tcx),
-            ty::ReStatic => true,
-            ty::ReVar(..) => false,
-            ty::RePlaceholder(placeholder) => placeholder.bound.kind.is_named(tcx),
-            ty::ReErased => false,
-            ty::ReError(_) => false,
-        }
-    }
-
-    #[inline]
-    fn bound_at_or_above_binder(self, index: ty::DebruijnIndex) -> bool {
-        match self.kind() {
-            ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), _) => debruijn >= index,
-            _ => false,
-        }
-    }
-
-    /// Given some item `binding_item`, check if this region is a generic parameter introduced by it
-    /// or one of the parent generics. Returns the `DefId` of the parameter definition if so.
-    fn opt_param_def_id(self, tcx: TyCtxt<'tcx>, binding_item: DefId) -> Option<DefId> {
-        match self.kind() {
-            ty::ReEarlyParam(ebr) => {
-                Some(tcx.generics_of(binding_item).region_param(ebr, tcx).def_id)
-            }
-            ty::ReLateParam(ty::LateParamRegion {
-                kind: ty::LateParamRegionKind::Named(def_id),
-                ..
-            }) => Some(def_id),
-            _ => None,
-        }
-    }
-}
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 #[derive(StableHash)]
@@ -151,6 +17,12 @@ pub struct EarlyParamRegion {
 }
 
 impl EarlyParamRegion {
+    #[inline]
+    pub fn get_name(&self) -> Option<Symbol> {
+        if self.is_named() { Some(self.name) } else { None }
+    }
+
+    #[inline]
     /// Does this early bound region have a name? Early bound regions normally
     /// always have names except when using anonymous lifetimes (`'_`).
     pub fn is_named(&self) -> bool {
@@ -161,6 +33,20 @@ impl EarlyParamRegion {
 impl rustc_type_ir::inherent::ParamLike for EarlyParamRegion {
     fn index(self) -> u32 {
         self.index
+    }
+}
+
+impl<'tcx> rustc_type_ir::inherent::RegionName<TyCtxt<'tcx>> for EarlyParamRegion {
+    #[inline]
+    fn get_name(&self, _tcx: TyCtxt<'tcx>) -> Option<Symbol> {
+        self.get_name()
+    }
+
+    #[inline]
+    /// Does this early bound region have a name? Early bound regions normally
+    /// always have names except when using anonymous lifetimes (`'_`).
+    fn is_named(&self, _tcx: TyCtxt<'tcx>) -> bool {
+        self.is_named()
     }
 }
 
@@ -183,6 +69,34 @@ impl std::fmt::Debug for EarlyParamRegion {
 pub struct LateParamRegion {
     pub scope: DefId,
     pub kind: LateParamRegionKind,
+}
+
+impl<'tcx> rustc_type_ir::inherent::RegionName<TyCtxt<'tcx>> for LateParamRegion {
+    #[inline]
+    fn get_name(&self, tcx: TyCtxt<'tcx>) -> Option<Symbol> {
+        self.kind.get_name(tcx)
+    }
+
+    #[inline]
+    fn is_named(&self, tcx: TyCtxt<'tcx>) -> bool {
+        self.kind.is_named(tcx)
+    }
+}
+
+impl LateParamRegion {
+    #[inline]
+    pub fn get_def_id(self) -> Option<DefId> {
+        match self.kind {
+            ty::LateParamRegionKind::Named(def_id) => Some(def_id),
+            _ => None,
+        }
+    }
+}
+
+impl<'tcx> rustc_type_ir::inherent::DefIdGetter<TyCtxt<'tcx>> for LateParamRegion {
+    fn get_def_id(self) -> Option<DefId> {
+        self.get_def_id()
+    }
 }
 
 /// When liberating bound regions, we map their [`ty::BoundRegionKind`]

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2196,8 +2196,16 @@ impl<'tcx> rustc_type_ir::inherent::Tys<TyCtxt<'tcx>> for &'tcx ty::List<Ty<'tcx
 }
 
 impl<'tcx> rustc_type_ir::inherent::Symbol<TyCtxt<'tcx>> for Symbol {
-    fn is_kw_underscore_lifetime(self) -> bool {
-        self == kw::UnderscoreLifetime
+    fn get_kw_underscore_lifetime() -> Self {
+        kw::UnderscoreLifetime
+    }
+
+    fn get_kw_static_lifetime() -> Self {
+        kw::StaticLifetime
+    }
+
+    fn get_sym_anon() -> Self {
+        sym::anon
     }
 }
 

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2196,17 +2196,9 @@ impl<'tcx> rustc_type_ir::inherent::Tys<TyCtxt<'tcx>> for &'tcx ty::List<Ty<'tcx
 }
 
 impl<'tcx> rustc_type_ir::inherent::Symbol<TyCtxt<'tcx>> for Symbol {
-    fn get_kw_underscore_lifetime() -> Self {
-        kw::UnderscoreLifetime
-    }
-
-    fn get_kw_static_lifetime() -> Self {
-        kw::StaticLifetime
-    }
-
-    fn get_sym_anon() -> Self {
-        sym::anon
-    }
+    const KW_UNDERSCORE_LIFETIME: Self = kw::UnderscoreLifetime;
+    const KW_STATIC_LIFETIME: Self = kw::StaticLifetime;
+    const SYM_ANON: Self = sym::anon;
 }
 
 // Some types are used a lot. Make sure they don't unintentionally get bigger.

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2202,8 +2202,16 @@ impl<'tcx> rustc_type_ir::inherent::Tys<TyCtxt<'tcx>> for &'tcx ty::List<Ty<'tcx
 }
 
 impl<'tcx> rustc_type_ir::inherent::Symbol<TyCtxt<'tcx>> for Symbol {
-    fn is_kw_underscore_lifetime(self) -> bool {
-        self == kw::UnderscoreLifetime
+    fn get_kw_underscore_lifetime() -> Self {
+        kw::UnderscoreLifetime
+    }
+
+    fn get_kw_static_lifetime() -> Self {
+        kw::StaticLifetime
+    }
+
+    fn get_sym_anon() -> Self {
+        sym::anon
     }
 }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/named_anon_conflict.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/named_anon_conflict.rs
@@ -3,7 +3,6 @@
 
 use rustc_errors::Diag;
 use rustc_middle::ty;
-use rustc_middle::ty::RegionExt;
 use tracing::debug;
 
 use crate::diagnostics::ExplicitLifetimeRequired;

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
@@ -9,9 +9,7 @@ use rustc_hir::def_id::{CRATE_DEF_ID, DefId};
 use rustc_middle::bug;
 use rustc_middle::ty::error::ExpectedFound;
 use rustc_middle::ty::print::{FmtPrinter, Print, PrintTraitRefExt as _, RegionHighlightMode};
-use rustc_middle::ty::{
-    self, GenericArgsRef, IsSuggestable, RePlaceholder, Region, RegionExt, TyCtxt,
-};
+use rustc_middle::ty::{self, GenericArgsRef, IsSuggestable, RePlaceholder, Region, TyCtxt};
 use tracing::{debug, instrument};
 
 use crate::diagnostics::{

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
@@ -8,9 +8,7 @@ use rustc_hir::def_id::{CRATE_DEF_ID, DefId};
 use rustc_middle::bug;
 use rustc_middle::ty::error::ExpectedFound;
 use rustc_middle::ty::print::{FmtPrinter, Print, PrintTraitRefExt as _, RegionHighlightMode};
-use rustc_middle::ty::{
-    self, GenericArgsRef, IsSuggestable, RePlaceholder, Region, RegionExt, TyCtxt,
-};
+use rustc_middle::ty::{self, GenericArgsRef, IsSuggestable, RePlaceholder, Region, TyCtxt};
 use rustc_structures::Limit;
 use tracing::{debug, instrument};
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
@@ -8,7 +8,7 @@ use rustc_hir::{
     self as hir, AmbigArg, GenericBound, GenericParam, GenericParamKind, Item, ItemKind, Lifetime,
     LifetimeKind, LifetimeParamKind, MissingLifetimeKind, Node, TyKind,
 };
-use rustc_middle::ty::{self, RegionExt, Ty, TyCtxt, TypeSuperVisitable, TypeVisitor};
+use rustc_middle::ty::{self, Ty, TyCtxt, TypeSuperVisitable, TypeVisitor};
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{Ident, Span};
 use tracing::debug;

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/trait_impl_difference.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/trait_impl_difference.rs
@@ -10,7 +10,7 @@ use rustc_middle::hir::nested_filter;
 use rustc_middle::traits::ObligationCauseCode;
 use rustc_middle::ty::error::ExpectedFound;
 use rustc_middle::ty::print::RegionHighlightMode;
-use rustc_middle::ty::{self, RegionExt, TyCtxt, TypeVisitable};
+use rustc_middle::ty::{self, TyCtxt, TypeVisitable};
 use rustc_span::{Ident, Span};
 use tracing::debug;
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -13,7 +13,7 @@ use rustc_middle::traits::ObligationCauseCode;
 use rustc_middle::ty::error::TypeError;
 use rustc_middle::ty::print::RegionHighlightMode;
 use rustc_middle::ty::{
-    self, IsSuggestable, Region, RegionExt, Ty, TyCtxt, TypeVisitableExt as _, Upcast as _,
+    self, IsSuggestable, Region, Ty, TyCtxt, TypeVisitableExt as _, Upcast as _,
 };
 use rustc_span::{BytePos, ErrorGuaranteed, Span, Symbol, kw, sym};
 use tracing::{debug, instrument};

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -32,7 +32,7 @@ use rustc_macros::TypeVisitable;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::{
-    self, BottomUpFolder, Clause, GenericArgs, GenericArgsRef, RegionExt, Ty, TyCtxt, TypeFoldable,
+    self, BottomUpFolder, Clause, GenericArgs, GenericArgsRef, Ty, TyCtxt, TypeFoldable,
     TypeFolder, TypeSuperFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypingMode,
     Unnormalized, Upcast,
 };

--- a/compiler/rustc_ty_utils/src/implied_bounds.rs
+++ b/compiler/rustc_ty_utils/src/implied_bounds.rs
@@ -5,7 +5,7 @@ use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::query::Providers;
-use rustc_middle::ty::{self, RegionExt, Ty, TyCtxt, Unnormalized, fold_regions};
+use rustc_middle::ty::{self, Ty, TyCtxt, Unnormalized, fold_regions};
 use rustc_middle::{bug, span_bug};
 use rustc_span::Span;
 

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -6,8 +6,8 @@ use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::bug;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::{
-    self, RegionExt, SizedTraitKind, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitor,
-    Unnormalized, Upcast, fold_regions,
+    self, SizedTraitKind, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitor, Unnormalized,
+    Upcast, fold_regions,
 };
 use rustc_span::DUMMY_SP;
 use rustc_span::def_id::{CRATE_DEF_ID, DefId, LocalDefId};

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -1028,7 +1028,7 @@ impl<I: Interner> BoundRegionKind<I> {
         match *self {
             ty::BoundRegionKind::Named(def_id) => {
                 let name = tcx.item_name(def_id);
-                if name == I::Symbol::get_kw_underscore_lifetime() { None } else { Some(name) }
+                if name == I::Symbol::KW_UNDERSCORE_LIFETIME { None } else { Some(name) }
             }
             ty::BoundRegionKind::NamedForPrinting(name) => Some(name),
             _ => None,

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -1028,7 +1028,7 @@ impl<I: Interner> BoundRegionKind<I> {
         match *self {
             ty::BoundRegionKind::Named(def_id) => {
                 let name = tcx.item_name(def_id);
-                if name.is_kw_underscore_lifetime() { None } else { Some(name) }
+                if name == I::Symbol::get_kw_underscore_lifetime() { None } else { Some(name) }
             }
             ty::BoundRegionKind::NamedForPrinting(name) => Some(name),
             _ => None,

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -286,11 +286,7 @@ pub trait ExprConst<I: Interner<ExprConst = Self>>: Copy + Debug + Hash + Eq + R
 #[rust_analyzer::prefer_underscore_import]
 pub trait GenericsOf<I: Interner<GenericsOf = Self>> {
     fn count(&self) -> usize;
-    fn generics_of_early_param_region_def_id(
-        interner: I,
-        def_id: I::DefId,
-        ebr: I::EarlyParamRegion,
-    ) -> I::DefId;
+    fn param_region_def_id(self, interner: I, ebr: I::EarlyParamRegion) -> I::DefId;
 }
 
 #[rust_analyzer::prefer_underscore_import]
@@ -774,9 +770,9 @@ impl<'a, S: SliceLike> SliceLike for &'a S {
 
 #[rust_analyzer::prefer_underscore_import]
 pub trait Symbol<I: Interner>: Copy + Hash + PartialEq + Eq + Debug {
-    fn get_kw_underscore_lifetime() -> I::Symbol;
-    fn get_kw_static_lifetime() -> I::Symbol;
-    fn get_sym_anon() -> I::Symbol;
+    const KW_UNDERSCORE_LIFETIME: Self;
+    const KW_STATIC_LIFETIME: Self;
+    const SYM_ANON: Self;
 }
 
 pub trait RegionName<I: Interner>: Copy + Hash + PartialEq + Eq + Debug {

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -286,6 +286,11 @@ pub trait ExprConst<I: Interner<ExprConst = Self>>: Copy + Debug + Hash + Eq + R
 #[rust_analyzer::prefer_underscore_import]
 pub trait GenericsOf<I: Interner<GenericsOf = Self>> {
     fn count(&self) -> usize;
+    fn generics_of_early_param_region_def_id(
+        interner: I,
+        def_id: I::DefId,
+        ebr: I::EarlyParamRegion,
+    ) -> I::DefId;
 }
 
 #[rust_analyzer::prefer_underscore_import]
@@ -768,6 +773,17 @@ impl<'a, S: SliceLike> SliceLike for &'a S {
 }
 
 #[rust_analyzer::prefer_underscore_import]
-pub trait Symbol<I>: Copy + Hash + PartialEq + Eq + Debug {
-    fn is_kw_underscore_lifetime(self) -> bool;
+pub trait Symbol<I: Interner>: Copy + Hash + PartialEq + Eq + Debug {
+    fn get_kw_underscore_lifetime() -> I::Symbol;
+    fn get_kw_static_lifetime() -> I::Symbol;
+    fn get_sym_anon() -> I::Symbol;
+}
+
+pub trait RegionName<I: Interner>: Copy + Hash + PartialEq + Eq + Debug {
+    fn get_name(&self, interner: I) -> Option<I::Symbol>;
+    fn is_named(&self, interner: I) -> bool;
+}
+
+pub trait DefIdGetter<I: Interner>: Copy + Hash + PartialEq + Eq + Debug {
+    fn get_def_id(self) -> Option<I::DefId>;
 }

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -21,8 +21,8 @@ use crate::solve::{
 };
 use crate::visit::{Flags, TypeVisitable};
 use crate::{
-    self as ty, self as ty, AliasTermKind, BoundRegion, BoundVar, CanonicalParamEnvCache,
-    DebruijnIndex, Region, RegionKind, RegionVid, TraitRef, search_graph,
+    self as ty, AliasTermKind, BoundRegion, BoundVar, CanonicalParamEnvCache, DebruijnIndex,
+    Region, RegionKind, RegionVid, TraitRef, search_graph,
 };
 
 /// The central trait in the shared abstraction layer, specifying all implementation-specific
@@ -211,16 +211,31 @@ pub trait Interner:
     /// Do not uplift, the underlying types differ between r-a and rustc.
     ///
     /// See <https://github.com/rust-lang/rust/pull/160986#issuecomment-5269817932>.
-    type EarlyParamRegion: ParamLike;
+    type EarlyParamRegion: ParamLike + RegionName<Self>;
     /// (2026/08/13)
     /// Do not uplift, the underlying types differ between r-a and rustc.
     ///
     /// See <https://github.com/rust-lang/rust/pull/160986#issuecomment-5269817932>.
     #[cfg(feature = "nightly")]
-    type LateParamRegionKind: Clone + Copy + Debug + PartialEq + Eq + Hash + StableHash;
+    type LateParamRegionKind: Clone
+        + Copy
+        + Debug
+        + PartialEq
+        + Eq
+        + Hash
+        + StableHash
+        + DefIdGetter<Self>
+        + RegionName<Self>;
 
     #[cfg(not(feature = "nightly"))]
-    type LateParamRegionKind: Clone + Copy + Debug + PartialEq + Eq + Hash;
+    type LateParamRegionKind: Clone
+        + Copy
+        + Debug
+        + PartialEq
+        + Eq
+        + Hash
+        + DefIdGetter<Self>
+        + RegionName<Self>;
 
     type InternedRegionKind: Interned<Self, Value = RegionKind<Self>>;
 

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -21,8 +21,8 @@ use crate::solve::{
 };
 use crate::visit::{Flags, TypeVisitable};
 use crate::{
-    self as ty, AliasTermKind, BoundRegion, BoundVar, CanonicalParamEnvCache, DebruijnIndex,
-    Region, RegionKind, TraitRef, search_graph,
+    self as ty, self as ty, AliasTermKind, BoundRegion, BoundVar, CanonicalParamEnvCache,
+    DebruijnIndex, Region, RegionKind, RegionVid, TraitRef, search_graph,
 };
 
 /// The central trait in the shared abstraction layer, specifying all implementation-specific
@@ -491,6 +491,7 @@ pub trait Interner:
     fn is_impl_trait_in_trait(self, def_id: Self::DefId) -> bool;
 
     fn delay_bug(self, msg: impl ToString) -> Self::ErrorGuaranteed;
+    fn span_delayed_bug(self, span: Self::Span, msg: impl ToString) -> Self::ErrorGuaranteed;
 
     fn is_general_coroutine(self, coroutine_def_id: Self::CoroutineId) -> bool;
     fn coroutine_is_async(self, coroutine_def_id: Self::CoroutineId) -> bool;
@@ -527,6 +528,8 @@ pub trait Interner:
     fn get_anon_re_canonical_bounds_lifetime(self, idx: usize) -> Option<Region<Self>>;
 
     fn get_re_static_lifetime(self) -> Region<Self>;
+
+    fn intern_re_var(self, rv: RegionVid) -> Region<Self>;
 
     fn intern_region(self, region_kind: RegionKind<Self>) -> Region<Self>;
 

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -19,7 +19,7 @@ use crate::solve::{
 use crate::visit::{Flags, TypeVisitable};
 use crate::{
     self as ty, BoundRegion, BoundVar, CanonicalParamEnvCacheEntry, DebruijnIndex, Region,
-    RegionKind, TraitRef, search_graph,
+    RegionKind, RegionVid, TraitRef, search_graph,
 };
 
 #[cfg_attr(feature = "nightly", rustc_diagnostic_item = "type_ir_interner")]
@@ -184,8 +184,8 @@ pub trait Interner:
     type ScalarInt: Copy + Debug + Hash + Eq;
 
     // Kinds of regions
-    type EarlyParamRegion: ParamLike;
-    type LateParamRegion: Copy + Debug + Hash + Eq;
+    type EarlyParamRegion: RegionName<Self> + ParamLike;
+    type LateParamRegion: RegionName<Self> + DefIdGetter<Self>;
 
     type InternedRegionKind: Interned<Self, Value = RegionKind<Self>>;
 
@@ -441,6 +441,7 @@ pub trait Interner:
     fn is_impl_trait_in_trait(self, def_id: Self::DefId) -> bool;
 
     fn delay_bug(self, msg: impl ToString) -> Self::ErrorGuaranteed;
+    fn span_delayed_bug(self, span: Self::Span, msg: impl ToString) -> Self::ErrorGuaranteed;
 
     fn is_general_coroutine(self, coroutine_def_id: Self::CoroutineId) -> bool;
     fn coroutine_is_async(self, coroutine_def_id: Self::CoroutineId) -> bool;
@@ -479,6 +480,8 @@ pub trait Interner:
     fn get_anon_re_canonical_bounds_lifetime(self, idx: usize) -> Option<Region<Self>>;
 
     fn get_re_static_lifetime(self) -> Region<Self>;
+
+    fn intern_re_var(self, rv: RegionVid) -> Region<Self>;
 
     fn intern_region(self, region_kind: RegionKind<Self>) -> Region<Self>;
 

--- a/compiler/rustc_type_ir/src/sty/mod.rs
+++ b/compiler/rustc_type_ir/src/sty/mod.rs
@@ -25,6 +25,90 @@ pub struct Region<I: Interner>(pub I::InternedRegionKind);
 // These are only the `inherent` trait methods that have been ported across
 impl<I: Interner> Region<I> {
     #[inline]
+    pub fn new_var(interner: I, v: RegionVid) -> Self {
+        interner.intern_re_var(v)
+    }
+
+    pub fn get_name(self, interner: I) -> Option<I::Symbol> {
+        match self.kind() {
+            RegionKind::ReEarlyParam(ebr) => ebr.get_name(interner),
+            RegionKind::ReBound(_, br) => br.kind.get_name(interner),
+            RegionKind::ReLateParam(fr) => fr.get_name(interner),
+            RegionKind::ReStatic => Some(I::Symbol::get_kw_static_lifetime()),
+            RegionKind::RePlaceholder(placeholder) => placeholder.bound.kind.get_name(interner),
+            _ => None,
+        }
+    }
+
+    pub fn get_name_or_anon(self, interner: I) -> I::Symbol {
+        match self.get_name(interner) {
+            Some(name) => name,
+            None => I::Symbol::get_sym_anon(),
+        }
+    }
+
+    /// Given some item `binding_item`, check if this region is a generic parameter introduced by it
+    /// or one of the parent generics. Returns the `DefId` of the parameter definition if so.
+    pub fn opt_param_def_id(self, interner: I, binding_item: I::DefId) -> Option<I::DefId> {
+        match self.kind() {
+            RegionKind::ReEarlyParam(ebr) => Some(
+                I::GenericsOf::generics_of_early_param_region_def_id(interner, binding_item, ebr),
+            ),
+            RegionKind::ReLateParam(param) => param.get_def_id(),
+            _ => None,
+        }
+    }
+
+    /// Is this region named by the user?
+    pub fn is_named(self, interner: I) -> bool {
+        match self.kind() {
+            RegionKind::ReEarlyParam(ebr) => ebr.is_named(interner),
+            RegionKind::ReBound(_, br) => br.kind.is_named(interner),
+            RegionKind::ReLateParam(fr) => fr.is_named(interner),
+            RegionKind::ReStatic => true,
+            RegionKind::ReVar(..) => false,
+            RegionKind::RePlaceholder(placeholder) => placeholder.bound.kind.is_named(interner),
+            RegionKind::ReErased => false,
+            RegionKind::ReError(_) => false,
+        }
+    }
+
+    /// Constructs a `RegionKind::ReError` region and registers a delayed bug to ensure it gets
+    /// used.
+    #[track_caller]
+    pub fn new_error_misc(interner: I) -> Self {
+        Self::new_error_with_message(
+            interner,
+            I::Span::dummy(),
+            "RegionKind::ReError constructed but no error reported",
+        )
+    }
+
+    /// Constructs a `RegionKind::ReError` region and registers a delayed bug with the given `msg`
+    /// to ensure it gets used.
+    #[track_caller]
+    pub fn new_error_with_message(interner: I, span: I::Span, msg: impl ToString) -> Self {
+        let reported = interner.span_delayed_bug(span, msg);
+        Self::new_error(interner, reported)
+    }
+
+    #[inline]
+    pub fn new_late_param(interner: I, late_param_region: I::LateParamRegion) -> Self {
+        interner.intern_region(RegionKind::ReLateParam(late_param_region))
+    }
+
+    #[inline]
+    pub fn new_early_param(interner: I, early_bound_region: I::EarlyParamRegion) -> Self {
+        interner.intern_region(RegionKind::ReEarlyParam(early_bound_region))
+    }
+
+    /// Constructs a `RegionKind::ReError` region.
+    #[track_caller]
+    pub fn new_error(interner: I, guar: I::ErrorGuaranteed) -> Self {
+        interner.intern_region(RegionKind::ReError(guar))
+    }
+
+    #[inline]
     pub fn new_bound(interner: I, debruijn: DebruijnIndex, bound_region: BoundRegion<I>) -> Self {
         interner.intern_bound_region(debruijn, bound_region)
     }
@@ -158,6 +242,14 @@ impl<I: Interner> Region<I> {
     #[inline]
     pub fn kind(self) -> RegionKind<I> {
         self.0.get()
+    }
+
+    #[inline]
+    pub fn bound_at_or_above_binder(self, index: DebruijnIndex) -> bool {
+        match self.kind() {
+            RegionKind::ReBound(BoundVarIndexKind::Bound(debruijn), _) => debruijn >= index,
+            _ => false,
+        }
     }
 }
 

--- a/compiler/rustc_type_ir/src/sty/mod.rs
+++ b/compiler/rustc_type_ir/src/sty/mod.rs
@@ -33,8 +33,8 @@ impl<I: Interner> Region<I> {
         match self.kind() {
             RegionKind::ReEarlyParam(ebr) => ebr.get_name(interner),
             RegionKind::ReBound(_, br) => br.kind.get_name(interner),
-            RegionKind::ReLateParam(fr) => fr.get_name(interner),
-            RegionKind::ReStatic => Some(I::Symbol::get_kw_static_lifetime()),
+            RegionKind::ReLateParam(fr) => fr.kind.get_name(interner),
+            RegionKind::ReStatic => Some(I::Symbol::KW_STATIC_LIFETIME),
             RegionKind::RePlaceholder(placeholder) => placeholder.bound.kind.get_name(interner),
             _ => None,
         }
@@ -43,7 +43,7 @@ impl<I: Interner> Region<I> {
     pub fn get_name_or_anon(self, interner: I) -> I::Symbol {
         match self.get_name(interner) {
             Some(name) => name,
-            None => I::Symbol::get_sym_anon(),
+            None => I::Symbol::SYM_ANON,
         }
     }
 
@@ -51,10 +51,10 @@ impl<I: Interner> Region<I> {
     /// or one of the parent generics. Returns the `DefId` of the parameter definition if so.
     pub fn opt_param_def_id(self, interner: I, binding_item: I::DefId) -> Option<I::DefId> {
         match self.kind() {
-            RegionKind::ReEarlyParam(ebr) => Some(
-                I::GenericsOf::generics_of_early_param_region_def_id(interner, binding_item, ebr),
-            ),
-            RegionKind::ReLateParam(param) => param.get_def_id(),
+            RegionKind::ReEarlyParam(ebr) => {
+                Some(interner.generics_of(binding_item).param_region_def_id(interner, ebr))
+            }
+            RegionKind::ReLateParam(param) => param.kind.get_def_id(),
             _ => None,
         }
     }
@@ -64,7 +64,7 @@ impl<I: Interner> Region<I> {
         match self.kind() {
             RegionKind::ReEarlyParam(ebr) => ebr.is_named(interner),
             RegionKind::ReBound(_, br) => br.kind.is_named(interner),
-            RegionKind::ReLateParam(fr) => fr.is_named(interner),
+            RegionKind::ReLateParam(fr) => fr.kind.is_named(interner),
             RegionKind::ReStatic => true,
             RegionKind::ReVar(..) => false,
             RegionKind::RePlaceholder(placeholder) => placeholder.bound.kind.is_named(interner),
@@ -93,8 +93,8 @@ impl<I: Interner> Region<I> {
     }
 
     #[inline]
-    pub fn new_late_param(interner: I, late_param_region: I::LateParamRegion) -> Self {
-        interner.intern_region(RegionKind::ReLateParam(late_param_region))
+    pub fn new_late_param(interner: I, scope: I::DefId, kind: I::LateParamRegionKind) -> Self {
+        interner.intern_region(RegionKind::ReLateParam(LateParamRegion { scope, kind }))
     }
 
     #[inline]

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -48,8 +48,7 @@ use rustc_hir_analysis::{lower_const_arg_for_rustdoc, lower_ty};
 use rustc_middle::metadata::Reexport;
 use rustc_middle::middle::resolve_bound_vars as rbv;
 use rustc_middle::ty::{
-    self, AdtKind, GenericArgsRef, RegionExt, Ty, TyCtxt, TypeVisitableExt, TypingMode,
-    Unnormalized,
+    self, AdtKind, GenericArgsRef, Ty, TyCtxt, TypeVisitableExt, TypingMode, Unnormalized,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::ExpnKind;

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -47,8 +47,7 @@ use rustc_hir_analysis::{lower_const_arg_for_rustdoc, lower_ty};
 use rustc_middle::metadata::Reexport;
 use rustc_middle::middle::resolve_bound_vars as rbv;
 use rustc_middle::ty::{
-    self, AdtKind, GenericArgsRef, RegionExt, Ty, TyCtxt, TypeVisitableExt, TypingMode,
-    Unnormalized,
+    self, AdtKind, GenericArgsRef, Ty, TyCtxt, TypeVisitableExt, TypingMode, Unnormalized,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::ExpnKind;


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160509)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Removes `RegionExt` from `rustc_middle` with all methods on `Region`. 

Some changes I think are worth pointing out (of which are all in the first commit -> f949bb7183e75bd027f01a51c3cf8ea9b3052ed2) ;

- Changed the signature of `Region::new_late_param` to accept a `I::LateParamRegion` where previously it was able to construct a `LateParamRegion` from some method parameters.

**added to interner:**
- `fn span_delayed_bug(self, span: Self::Span, msg: impl ToString) -> Self::ErrorGuaranteed;` which could be useful elsewhere when porting things across to `rustc_type_ir`
- `fn generics_of_early_param_region_def_id(self, def_id: Self::DefId, ebr: Self::EarlyParamRegion) -> Self::DefId;` which is quite nasty but calling `generics_of` returned another type that I would have possibly create a trait for which felt more messy.
- `fn get_re_var_lifetime(self, var_idx: usize) -> Option<Region<'tcx>>` need to get a region in `Region::new_var`. 

**traits added to inherent**
- `RegionName` so we can get the names of `LateParamRegion` and `EarlyParamRegion` with a `get_name()` and also `is_named()`.
- `DefIdGetter` so we can get the `DefId` of `kind` in `LateParamRegion`

r? lcnr

Part of https://github.com/rust-lang/rust/issues/159654