### PR TITLE
session: Enable next-solver globally for assumptions-on-binders

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -936,3 +936,39 @@ fn test_edition_parsing() {
     let sessopts = build_session_options(&mut early_dcx, &matches);
     assert!(sessopts.edition == Edition::Edition2018)
 }
+
+#[test]
+fn test_assumptions_on_binders_enables_next_solver_globally() {
+    let globally = NextSolverConfig { coherence: true, globally: true };
+    let mut early_dcx = EarlyDiagCtxt::new(ErrorOutputType::default());
+
+    // `-Zassumptions-on-binders` alone enables the next solver globally.
+    let matches = optgroups().parse(&["-Zassumptions-on-binders".to_string()]).unwrap();
+    let opts = build_session_options(&mut early_dcx, &matches);
+    assert!(opts.unstable_opts.assumptions_on_binders);
+    assert_eq!(opts.unstable_opts.next_solver, globally);
+
+    // Flag order must not matter when both `-Zassumptions-on-binders` and `-Znext-solver`
+    // are present.
+    for args in [
+        ["-Zassumptions-on-binders".to_string(), "-Znext-solver=coherence".to_string()],
+        ["-Znext-solver=coherence".to_string(), "-Zassumptions-on-binders".to_string()],
+    ] {
+        let matches = optgroups().parse(&args).unwrap();
+        let opts = build_session_options(&mut early_dcx, &matches);
+        assert!(opts.unstable_opts.assumptions_on_binders);
+        assert_eq!(opts.unstable_opts.next_solver, globally);
+    }
+
+    // `-Zassumptions-on-binders` overrides `-Znext-solver=no` regardless of order, since
+    // the assumptions implementation requires the next solver.
+    for args in [
+        ["-Zassumptions-on-binders".to_string(), "-Znext-solver=no".to_string()],
+        ["-Znext-solver=no".to_string(), "-Zassumptions-on-binders".to_string()],
+    ] {
+        let matches = optgroups().parse(&args).unwrap();
+        let opts = build_session_options(&mut early_dcx, &matches);
+        assert!(opts.unstable_opts.assumptions_on_binders);
+        assert_eq!(opts.unstable_opts.next_solver, globally);
+    }
+}

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -961,7 +961,8 @@ fn test_assumptions_on_binders_enables_next_solver_globally() {
     }
 
     // `-Zassumptions-on-binders` overrides `-Znext-solver=no` regardless of order, since
-    // the assumptions implementation requires the next solver.
+    // the assumptions implementation requires the next solver. This also emits an early
+    // warning (covered by the UI test `next-solver-no-overridden`).
     for args in [
         ["-Zassumptions-on-binders".to_string(), "-Znext-solver=no".to_string()],
         ["-Znext-solver=no".to_string(), "-Zassumptions-on-binders".to_string()],

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2691,6 +2691,14 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
     // parsing so the effective config is independent of flag order and so consumers that
     // read `next_solver.globally` directly (e.g. feature-gate checks) see the right value.
     if unstable_opts.assumptions_on_binders {
+        // `NextSolverConfig::default()` has `coherence: true`; the only way `coherence` is
+        // false here is an explicit `-Znext-solver=no`.
+        if !unstable_opts.next_solver.coherence {
+            early_dcx.early_warn(
+                "-Zassumptions-on-binders unconditionally enables the next trait solver; \
+                 `-Znext-solver=no` is ignored",
+            );
+        }
         unstable_opts.next_solver = NextSolverConfig { coherence: true, globally: true };
     }
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2687,6 +2687,13 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
 
     let mut unstable_opts = UnstableOptions::build(early_dcx, matches, &mut collected_options);
 
+    // `-Zassumptions-on-binders` requires the next trait solver globally. Normalize after
+    // parsing so the effective config is independent of flag order and so consumers that
+    // read `next_solver.globally` directly (e.g. feature-gate checks) see the right value.
+    if unstable_opts.assumptions_on_binders {
+        unstable_opts.next_solver = NextSolverConfig { coherence: true, globally: true };
+    }
+
     if unstable_opts.staticlib_hide_internal_symbols && !crate_types.contains(&CrateType::StaticLib)
     {
         early_dcx.early_warn(

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2358,7 +2358,8 @@ options! {
     assume_incomplete_release: bool = (false, parse_bool, [TRACKED],
         "make cfg(version) treat the current version as incomplete (default: no)"),
     assumptions_on_binders: bool = (false, parse_bool, [TRACKED],
-        "allow deducing higher-ranked outlives assumptions from all binders (`for<'a>`)"),
+        "allow deducing higher-ranked outlives assumptions from all binders (`for<'a>`); \
+         implies `-Znext-solver=globally`"),
     autodiff: Vec<crate::config::AutoDiff> = (Vec::new(), parse_autodiff, [TRACKED],
         "a list of autodiff flags to enable
         Mandatory setting:

--- a/tests/ui/assumptions_on_binders/alias_outlives.rs
+++ b/tests/ui/assumptions_on_binders/alias_outlives.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Znext-solver -Zassumptions-on-binders
+//@ compile-flags: -Zassumptions-on-binders
 
 // test that a `<T as AliasHaver>::Assoc: '!a_u1` constraint is considered to be satisfied
 // if there's a `T::Assoc: 'static` assumption in the root universe and if not that it is

--- a/tests/ui/assumptions_on_binders/implied_higher_ranked_alias_outlives_assumption.rs
+++ b/tests/ui/assumptions_on_binders/implied_higher_ranked_alias_outlives_assumption.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Znext-solver -Zassumptions-on-binders
+//@ compile-flags: -Zassumptions-on-binders
 //@ check-pass
 
 #![feature(generic_const_items)]

--- a/tests/ui/assumptions_on_binders/next-solver-no-overridden.rs
+++ b/tests/ui/assumptions_on_binders/next-solver-no-overridden.rs
@@ -1,0 +1,6 @@
+//@ check-pass
+//@ compile-flags: -Zassumptions-on-binders -Znext-solver=no
+
+#![crate_type = "lib"]
+
+//~? WARN unconditionally enables the next trait solver

--- a/tests/ui/assumptions_on_binders/next-solver-no-overridden.stderr
+++ b/tests/ui/assumptions_on_binders/next-solver-no-overridden.stderr
@@ -1,0 +1,2 @@
+warning: -Zassumptions-on-binders unconditionally enables the next trait solver; `-Znext-solver=no` is ignored
+

--- a/tests/ui/assumptions_on_binders/placeholder-assumptions-issue-157840.rs
+++ b/tests/ui/assumptions_on_binders/placeholder-assumptions-issue-157840.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Znext-solver=globally -Zassumptions-on-binders
+//@ compile-flags: -Zassumptions-on-binders
 
 trait Trait<T> {}
 

--- a/tests/ui/assumptions_on_binders/resolved-region-var-max-universe.rs
+++ b/tests/ui/assumptions_on_binders/resolved-region-var-max-universe.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zassumptions-on-binders -Znext-solver=globally
+//@ compile-flags: -Zassumptions-on-binders
 
 // Regression test for an ICE in the `MaxUniverse` region visitor. When computing
 // the max universe of a region constraint, a `ReVar` term could already have been

--- a/tests/ui/assumptions_on_binders/type_relation_binders_inside_solver-1.rs
+++ b/tests/ui/assumptions_on_binders/type_relation_binders_inside_solver-1.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-//@ compile-flags: -Znext-solver -Zassumptions-on-binders
+//@ compile-flags: -Zassumptions-on-binders
 
 #![crate_type = "lib"]
 

--- a/tests/ui/assumptions_on_binders/type_relation_binders_inside_solver-2.rs
+++ b/tests/ui/assumptions_on_binders/type_relation_binders_inside_solver-2.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-//@ compile-flags: -Znext-solver -Zassumptions-on-binders
+//@ compile-flags: -Zassumptions-on-binders
 
 #![crate_type = "lib"]
 

--- a/tests/ui/assumptions_on_binders/type_relation_binders_inside_solver-3.rs
+++ b/tests/ui/assumptions_on_binders/type_relation_binders_inside_solver-3.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-//@ compile-flags: -Znext-solver -Zassumptions-on-binders
+//@ compile-flags: -Zassumptions-on-binders
 
 #![crate_type = "lib"]
 


### PR DESCRIPTION
Zulip: https://rust-lang.zulipchat.com/#narrow/channel/618216-t-types.2Fcall-for-participation/topic/assumptions.20on.20binders.3A.20enable.20next-solver.20automatically/with/614548133

`-Zassumptions-on-binders` already needs the next trait solver, but you still had to pass `-Znext-solver` by hand. Easy to forget, and some spots (feature gates) read `next_solver.globally` directly, so just special-casing `next_trait_solver_globally()` wouldn't cut it.

After `-Z` parsing, if assumptions-on-binders is on, force `NextSolverConfig { coherence: true, globally: true }`. Same pattern as `-Zretpoline-external-thunk`. Flag order doesn't matter. `-Znext-solver=no` gets overridden too; imo that's the right call since the assumptions code can't run on the old solver. A hard conflict error would also be fine, just more annoying for day-to-day hacking.

Covered the flag alone, both orderings, and `=no` in a unit test. Dropped the explicit `-Znext-solver` from one UI test under `assumptions_on_binders`.

btw idk if we should strip `-Znext-solver` from the rest of that folder asap or leave the redundancy. irl I'd leave it for now. fyi this also means anything checking `next_solver.globally` sees the effective config. ltm if you'd rather go the conflict-error route instead of overriding `=no`.