### PR TITLE
Simplify the item info collection visitor running before late resolution

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -5642,41 +5642,14 @@ fn required_generic_args_suggestion(generics: &ast::Generics) -> Option<String> 
 
 impl Visitor<'_> for ItemInfoCollector<'_, '_, '_> {
     fn visit_item(&mut self, item: &Item) {
-        match &item.kind {
-            ItemKind::TyAlias(TyAlias { generics, .. })
-            | ItemKind::Const(ConstItem { generics, .. })
-            | ItemKind::Fn(Fn { generics, .. })
-            | ItemKind::Enum(_, generics, _)
-            | ItemKind::Struct(_, generics, _)
-            | ItemKind::Union(_, generics, _)
-            | ItemKind::Impl(Impl { generics, .. })
-            | ItemKind::Trait(Trait { generics, .. })
-            | ItemKind::TraitAlias(TraitAlias { generics, .. }) => {
-                let def_id = self.r.owner_def_id(item.id);
-                let count = generics
-                    .params
-                    .iter()
-                    .filter(|param| matches!(param.kind, ast::GenericParamKind::Lifetime { .. }))
-                    .count();
-                self.r.item_generics_num_lifetimes.insert(def_id, count);
-            }
-
-            ItemKind::Use(..)
-            | ItemKind::ExternCrate(..)
-            | ItemKind::Mod(..)
-            | ItemKind::ForeignMod(..)
-            | ItemKind::Static(..)
-            | ItemKind::ConstBlock(..)
-            | ItemKind::MacroDef(..)
-            | ItemKind::GlobalAsm(..)
-            | ItemKind::MacCall(..)
-            | ItemKind::DelegationMac(..) => {}
-            ItemKind::Delegation(..) => {
-                // Delegated functions have lifetimes, their count is not necessarily zero.
-                // But skipping the delegation items here doesn't mean that the count will be considered zero,
-                // it means there will be a panic when retrieving the count,
-                // but for delegation items we are never actually retrieving that count in practice.
-            }
+        if let Some(generics) = item.opt_generics() {
+            let def_id = self.r.owner_def_id(item.id);
+            let count = generics
+                .params
+                .iter()
+                .filter(|param| matches!(param.kind, ast::GenericParamKind::Lifetime { .. }))
+                .count();
+            self.r.item_generics_num_lifetimes.insert(def_id, count);
         }
         visit::walk_item(self, item)
     }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3435,10 +3435,16 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                     |this| this.resolve_delegation(delegation, item.id, false),
                 );
             }
-            AssocItemKind::Type(TyAlias { generics, .. }) => self
-                .with_lifetime_rib(LifetimeRibKind::AnonymousReportError, |this| {
+            AssocItemKind::Type(TyAlias { generics, .. }) => {
+                if let Some(suggestion) = required_generic_args_suggestion(generics) {
+                    self.r
+                        .item_required_generic_args_suggestions
+                        .insert(self.r.current_owner.def_id, suggestion);
+                }
+                self.with_lifetime_rib(LifetimeRibKind::AnonymousReportError, |this| {
                     walk_assoc_item(this, generics, LifetimeBinderKind::Item, item)
-                }),
+                })
+            }
             AssocItemKind::MacCall(_) | AssocItemKind::DelegationMac(..) => {
                 panic!("unexpanded macro in resolve!")
             }
@@ -3684,6 +3690,11 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             }
             AssocItemKind::Type(TyAlias { ident, generics, .. }) => {
                 self.diag_metadata.in_non_gat_assoc_type = Some(generics.params.is_empty());
+                if let Some(suggestion) = required_generic_args_suggestion(generics) {
+                    self.r
+                        .item_required_generic_args_suggestions
+                        .insert(self.r.current_owner.def_id, suggestion);
+                }
                 debug!("resolve_implementation AssocItemKind::Type");
                 // We also need a new scope for the impl item type parameters.
                 self.with_generic_param_rib(
@@ -5667,16 +5678,6 @@ impl<'ast> Visitor<'ast> for ItemInfoCollector<'_, 'ast, '_, '_> {
             }
         }
         visit::walk_item(self, item)
-    }
-
-    fn visit_assoc_item(&mut self, item: &'ast AssocItem, ctxt: AssocCtxt) {
-        if let AssocItemKind::Type(ast::TyAlias { generics, .. }) = &item.kind {
-            let def_id = self.r.owner_def_id(item.id);
-            if let Some(suggestion) = required_generic_args_suggestion(generics) {
-                self.r.item_required_generic_args_suggestions.insert(def_id, suggestion);
-            }
-        }
-        visit::walk_assoc_item(self, item, ctxt);
     }
 }
 

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1121,6 +1121,12 @@ impl<'ast, 'ra, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'ra, 'tc
     }
     fn visit_fn(&mut self, fn_kind: FnKind<'ast>, _: &AttrVec, sp: Span, fn_id: NodeId) {
         let previous_value = self.diag_metadata.current_function;
+
+        if let FnKind::Fn(_, _, f) = fn_kind {
+            self.resolve_eii(f.eii_impl.as_deref());
+            self.r.collect_fn_info(&f.sig.decl, fn_id);
+        }
+
         match fn_kind {
             // Bail if the function is foreign, and thus cannot validly have
             // a body, or if there's no body for some other reason.
@@ -1145,10 +1151,6 @@ impl<'ast, 'ra, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'ra, 'tc
             FnKind::Closure(..) => {}
         };
         debug!("(resolving function) entering function");
-
-        if let FnKind::Fn(_, _, f) = fn_kind {
-            self.resolve_eii(f.eii_impl.as_deref());
-        }
 
         // Create a value rib for the function.
         self.with_rib(ValueNS, RibKind::FnOrCoroutine, |this| {
@@ -5591,11 +5593,10 @@ struct ItemInfoCollector<'a, 'ast, 'ra, 'tcx> {
     use_items: Vec<&'ast Item>,
 }
 
-impl ItemInfoCollector<'_, '_, '_, '_> {
-    fn collect_fn_info(&mut self, decl: &FnDecl, id: NodeId) {
-        self.r
-            .delegation_fn_sigs
-            .insert(self.r.owner_def_id(id), DelegationFnSig { has_self: decl.has_self() });
+impl Resolver<'_, '_> {
+    fn collect_fn_info(&mut self, decl: &FnDecl, _id: NodeId) {
+        self.delegation_fn_sigs
+            .insert(self.current_owner.def_id, DelegationFnSig { has_self: decl.has_self() });
     }
 }
 
@@ -5637,10 +5638,6 @@ impl<'ast> Visitor<'ast> for ItemInfoCollector<'_, 'ast, '_, '_> {
             | ItemKind::Impl(Impl { generics, .. })
             | ItemKind::Trait(Trait { generics, .. })
             | ItemKind::TraitAlias(TraitAlias { generics, .. }) => {
-                if let ItemKind::Fn(Fn { sig, .. }) = &item.kind {
-                    self.collect_fn_info(&sig.decl, item.id);
-                }
-
                 let def_id = self.r.owner_def_id(item.id);
                 let count = generics
                     .params
@@ -5650,19 +5647,12 @@ impl<'ast> Visitor<'ast> for ItemInfoCollector<'_, 'ast, '_, '_> {
                 self.r.item_generics_num_lifetimes.insert(def_id, count);
             }
 
-            ItemKind::ForeignMod(ForeignMod { items, .. }) => {
-                for foreign_item in items {
-                    if let ForeignItemKind::Fn(Fn { sig, .. }) = &foreign_item.kind {
-                        self.collect_fn_info(&sig.decl, foreign_item.id);
-                    }
-                }
-            }
-
             ItemKind::Use(..) | ItemKind::ExternCrate(..) => {
                 self.use_items.push(item);
             }
 
             ItemKind::Mod(..)
+            | ItemKind::ForeignMod(..)
             | ItemKind::Static(..)
             | ItemKind::ConstBlock(..)
             | ItemKind::MacroDef(..)
@@ -5680,10 +5670,6 @@ impl<'ast> Visitor<'ast> for ItemInfoCollector<'_, 'ast, '_, '_> {
     }
 
     fn visit_assoc_item(&mut self, item: &'ast AssocItem, ctxt: AssocCtxt) {
-        if let AssocItemKind::Fn(Fn { sig, .. }) = &item.kind {
-            self.collect_fn_info(&sig.decl, item.id);
-        }
-
         if let AssocItemKind::Type(ast::TyAlias { generics, .. }) = &item.kind {
             let def_id = self.r.owner_def_id(item.id);
             if let Some(suggestion) = required_generic_args_suggestion(generics) {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -852,6 +852,9 @@ struct LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
     /// `use` injections are delayed for better placement and deduplication.
     use_injections: Vec<UseError<'tcx>>,
+
+    /// All `use` and `extern crate` items, in the order in which they are visited.
+    use_items: Vec<&'ast Item>,
 }
 
 impl<'ra, 'tcx> AsRef<Resolver<'ra, 'tcx>> for LateResolutionVisitor<'_, '_, 'ra, 'tcx> {
@@ -1539,6 +1542,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             in_func_body: false,
             lifetime_uses: Default::default(),
             use_injections: Vec::new(),
+            use_items: Vec::new(),
         }
     }
 
@@ -3031,6 +3035,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 ),
 
             ItemKind::Use(use_tree) => {
+                self.use_items.push(item);
                 let maybe_exported = match use_tree.kind {
                     UseTreeKind::Simple(_) | UseTreeKind::Glob(_) => MaybeExported::Ok(item.id),
                     UseTreeKind::Nested { .. } => MaybeExported::NestedUse(&item.vis),
@@ -3076,7 +3081,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 );
             }
 
-            ItemKind::ExternCrate(..) => {}
+            ItemKind::ExternCrate(..) => self.use_items.push(item),
 
             ItemKind::MacCall(_) | ItemKind::DelegationMac(..) => {
                 panic!("unexpanded macro in resolve!")
@@ -5598,10 +5603,8 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 /// Walks the whole crate in DFS order, visiting each item, counting the declared number of
 /// lifetime generic parameters and function parameters. Also collects all `use` and
 /// `extern crate` items so that `check_unused` doesn't need to walk the crate again.
-struct ItemInfoCollector<'a, 'ast, 'ra, 'tcx> {
+struct ItemInfoCollector<'a, 'ra, 'tcx> {
     r: &'a mut Resolver<'ra, 'tcx>,
-    /// All `use` and `extern crate` items, in the order in which they are visited.
-    use_items: Vec<&'ast Item>,
 }
 
 impl Resolver<'_, '_> {
@@ -5637,8 +5640,8 @@ fn required_generic_args_suggestion(generics: &ast::Generics) -> Option<String> 
     if required.is_empty() { None } else { Some(format!("<{}>", required.join(", "))) }
 }
 
-impl<'ast> Visitor<'ast> for ItemInfoCollector<'_, 'ast, '_, '_> {
-    fn visit_item(&mut self, item: &'ast Item) {
+impl Visitor<'_> for ItemInfoCollector<'_, '_, '_> {
+    fn visit_item(&mut self, item: &Item) {
         match &item.kind {
             ItemKind::TyAlias(TyAlias { generics, .. })
             | ItemKind::Const(ConstItem { generics, .. })
@@ -5658,11 +5661,9 @@ impl<'ast> Visitor<'ast> for ItemInfoCollector<'_, 'ast, '_, '_> {
                 self.r.item_generics_num_lifetimes.insert(def_id, count);
             }
 
-            ItemKind::Use(..) | ItemKind::ExternCrate(..) => {
-                self.use_items.push(item);
-            }
-
-            ItemKind::Mod(..)
+            ItemKind::Use(..)
+            | ItemKind::ExternCrate(..)
+            | ItemKind::Mod(..)
             | ItemKind::ForeignMod(..)
             | ItemKind::Static(..)
             | ItemKind::ConstBlock(..)
@@ -5688,14 +5689,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         krate: &'ast Crate,
     ) -> (Vec<&'ast Item>, Vec<UseError<'tcx>>) {
         with_owner(self, CRATE_NODE_ID, |this| {
-            let mut info_collector = ItemInfoCollector { r: this, use_items: Vec::new() };
+            let mut info_collector = ItemInfoCollector { r: this };
             visit::walk_crate(&mut info_collector, krate);
-            let use_items = info_collector.use_items;
             let mut late_resolution_visitor = LateResolutionVisitor::new(this);
             late_resolution_visitor
                 .resolve_doc_links(&krate.attrs, MaybeExported::Ok(CRATE_NODE_ID));
             visit::walk_crate(&mut late_resolution_visitor, krate);
-            let LateResolutionVisitor { use_injections, diag_metadata, .. } =
+            let LateResolutionVisitor { use_injections, diag_metadata, use_items, .. } =
                 late_resolution_visitor;
             for (id, span) in diag_metadata.unused_labels.iter() {
                 this.lint_buffer.buffer_lint(


### PR DESCRIPTION
r? @petrochenkov 

I mainly want 52cc1ace3b536552d2bf057920abf8b26384d2a9 (use item collection in late resolution visitor), as my first step to refactor use item lowering needs to track the owner, which the info collection visitor doesn't do right now, and it seems annoying to add when there is a perfectly good visitor already tracking it right there.

I tried getting rid of the info collection visitor entirely, but counting the number of generic lifetime parameters of free items is necessary for diagnostics in the late visitor when visiting paths. A path can refer to an item that is visited later, so we haven't recorded the number of generic lifetime parameters yet (if we do it in the late visitor). If we collect them in the def collector, we have to handle macro invocations in generic parameter definition position. It wasn't clear to me how to handle that without severe spaghetti code, so the visitor stays around for now.

 

