### PR TITLE
Add regression test for opaque type

### DIFF
--- a/tests/ui/const-generics/mgca/opaque-ty-assoc-const-equality-117923.rs
+++ b/tests/ui/const-generics/mgca/opaque-ty-assoc-const-equality-117923.rs
@@ -1,0 +1,22 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/117923>.
+//@ check-pass
+#![feature(min_generic_const_args, macroless_generic_const_args)]
+#![allow(incomplete_features, dead_code)]
+
+trait Trait {
+    type const CT: usize;
+}
+
+struct Type<const N: usize> {
+    field: [u8; N],
+}
+
+impl<const N: usize> Trait for Type<N> {
+    type const CT: usize = N;
+}
+
+fn func<const N: usize>() -> impl Trait<CT = { <Type<N> as Trait>::CT }> {
+    Type { field: [0; N] }
+}
+
+fn main() {}


### PR DESCRIPTION
Closes rust-lang/rust#117923 adds suggested check pass test, adapted to the current min_generic_const_args.