### PR TITLE
docs: fix typo in AllowExprMetavar comment

### DIFF
--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -489,7 +489,7 @@ fn expr_to_lit<'sess>(
     }
 }
 
-/// Whether expansions of `expr` metavariables from decrarative macros
+/// Whether expansions of `expr` metavariables from declarative  macros
 /// are permitted. Used when parsing meta items; currently, only `cfg` predicates
 /// enable this option
 #[derive(Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Fixes a small typo in the documentation comment for AllowExprMetavar.  Changes decrarative to `declarative`.

Change in compiler/rustc_attr_parsing/src/parser.rs: Line 492

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
