### PR TITLE
Update expect messages in tcp.rs doc examples to follow the style guide

### DIFF
--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -239,7 +239,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// stream.shutdown(Shutdown::Both).expect("shutdown call failed");
+    /// stream.shutdown(Shutdown::Both).expect("shutdown should succeed");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
@@ -260,7 +260,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// let stream_clone = stream.try_clone().expect("clone failed...");
+    /// let stream_clone = stream.try_clone().expect("clone should succeed");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn try_clone(&self) -> io::Result<TcpStream> {
@@ -290,7 +290,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// stream.set_read_timeout(None).expect("set_read_timeout call failed");
+    /// stream.set_read_timeout(None).expect("set_read_timeout should succeed");
     /// ```
     ///
     /// An [`Err`] is returned if the zero [`Duration`] is passed to this
@@ -334,7 +334,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// stream.set_write_timeout(None).expect("set_write_timeout call failed");
+    /// stream.set_write_timeout(None).expect("set_write_timeout should succeed");
     /// ```
     ///
     /// An [`Err`] is returned if the zero [`Duration`] is passed to this
@@ -372,7 +372,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// stream.set_read_timeout(None).expect("set_read_timeout call failed");
+    /// stream.set_read_timeout(None).expect("set_read_timeout should succeed");
     /// assert_eq!(stream.read_timeout().unwrap(), None);
     /// ```
     #[stable(feature = "socket_timeout", since = "1.4.0")]
@@ -397,7 +397,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// stream.set_write_timeout(None).expect("set_write_timeout call failed");
+    /// stream.set_write_timeout(None).expect("set_write_timeout should succeed");
     /// assert_eq!(stream.write_timeout().unwrap(), None);
     /// ```
     #[stable(feature = "socket_timeout", since = "1.4.0")]
@@ -420,7 +420,7 @@ impl TcpStream {
     /// let stream = TcpStream::connect("127.0.0.1:8000")
     ///                        .expect("Couldn't connect to the server...");
     /// let mut buf = [0; 10];
-    /// let len = stream.peek(&mut buf).expect("peek failed");
+    /// let len = stream.peek(&mut buf).expect("peek should succeed");
     /// ```
     #[stable(feature = "peek", since = "1.18.0")]
     pub fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
@@ -445,7 +445,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// stream.set_linger(Some(Duration::from_secs(0))).expect("set_linger call failed");
+    /// stream.set_linger(Some(Duration::from_secs(0))).expect("set_linger should succeed");
     /// ```
     #[unstable(feature = "tcp_linger", issue = "88494")]
     pub fn set_linger(&self, linger: Option<Duration>) -> io::Result<()> {
@@ -466,7 +466,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// stream.set_linger(Some(Duration::from_secs(0))).expect("set_linger call failed");
+    /// stream.set_linger(Some(Duration::from_secs(0))).expect("set_linger should succeed");
     /// assert_eq!(stream.linger().unwrap(), Some(Duration::from_secs(0)));
     /// ```
     #[unstable(feature = "tcp_linger", issue = "88494")]
@@ -498,7 +498,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// stream.set_keepalive(true).expect("set_keepalive call failed");
+    /// stream.set_keepalive(true).expect("set_keepalive should succeed");
     #[unstable(feature = "tcp_keepalive", issue = "155889")]
     pub fn set_keepalive(&self, keepalive: bool) -> io::Result<()> {
         self.0.set_keepalive(keepalive)
@@ -517,7 +517,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// stream.set_keepalive(true).expect("set_keepalive call failed");
+    /// stream.set_keepalive(true).expect("set_keepalive should succeed");
     /// assert_eq!(stream.keepalive().unwrap_or(false), true);
     /// ```
     #[unstable(feature = "tcp_keepalive", issue = "155889")]
@@ -540,7 +540,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// stream.set_nodelay(true).expect("set_nodelay call failed");
+    /// stream.set_nodelay(true).expect("set_nodelay should succeed");
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
@@ -558,7 +558,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// stream.set_nodelay(true).expect("set_nodelay call failed");
+    /// stream.set_nodelay(true).expect("set_nodelay should succeed");
     /// assert_eq!(stream.nodelay().unwrap_or(false), true);
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
@@ -578,7 +578,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// stream.set_ttl(100).expect("set_ttl call failed");
+    /// stream.set_ttl(100).expect("set_ttl should succeed");
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
     pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
@@ -596,7 +596,7 @@ impl TcpStream {
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8080")
     ///                        .expect("Couldn't connect to the server...");
-    /// stream.set_ttl(100).expect("set_ttl call failed");
+    /// stream.set_ttl(100).expect("set_ttl should succeed");
     /// assert_eq!(stream.ttl().unwrap_or(0), 100);
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
@@ -647,7 +647,7 @@ impl TcpStream {
     ///
     /// let mut stream = TcpStream::connect("127.0.0.1:7878")
     ///     .expect("Couldn't connect to the server...");
-    /// stream.set_nonblocking(true).expect("set_nonblocking call failed");
+    /// stream.set_nonblocking(true).expect("set_nonblocking should succeed");
     ///
     /// # fn wait_for_fd() { unimplemented!() }
     /// let mut buf = vec![];
@@ -1006,7 +1006,7 @@ impl TcpListener {
     /// use std::net::TcpListener;
     ///
     /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
-    /// listener.set_ttl(100).expect("could not set TTL");
+    /// listener.set_ttl(100).expect("set_ttl should succeed");
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
     pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
@@ -1023,7 +1023,7 @@ impl TcpListener {
     /// use std::net::TcpListener;
     ///
     /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
-    /// listener.set_ttl(100).expect("could not set TTL");
+    /// listener.set_ttl(100).expect("set_ttl should succeed");
     /// assert_eq!(listener.ttl().unwrap_or(0), 100);
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
@@ -1086,7 +1086,7 @@ impl TcpListener {
     /// use std::net::TcpListener;
     ///
     /// let listener = TcpListener::bind("127.0.0.1:7878").unwrap();
-    /// listener.set_nonblocking(true).expect("Cannot set non-blocking");
+    /// listener.set_nonblocking(true).expect("set_nonblocking should succeed");
     ///
     /// # fn wait_for_fd() { unimplemented!() }
     /// # fn handle_connection(stream: std::net::TcpStream) { unimplemented!() }


### PR DESCRIPTION
Related issue: rust-lang/rust#159751

Rewords the `.expect(...)` messages in the `TcpStream`/`TcpListener` doc examples in `library/std/src/net/tcp.rs` to follow the "expect as precondition" style guide introduced in rust-lang/rust#96033.

Examples of the change:
- `"set_nodelay call failed"` → `"set_nodelay should succeed"`
- `"could not set TTL"` → `"set_ttl should succeed"`
- `"Cannot set non-blocking"` → `"set_nonblocking should succeed"`

19 doc-example messages updated, all in doc comments (`///`). Doc-only change, no behavior change.