### PR TITLE
[perf] Reuse existing trait reference instead of recreating it.

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to.rs
@@ -261,10 +261,9 @@ where
         let alias_def_id = goal.predicate.alias.expect_projection_def_id();
         let goal_trait_ref = goal.predicate.alias.trait_ref(cx);
         let impl_trait_ref = cx.impl_trait_ref(impl_def_id);
-        if !DeepRejectCtxt::relate_rigid_infer(ecx.cx()).args_may_unify(
-            goal.predicate.alias.trait_ref(cx).args,
-            impl_trait_ref.skip_binder().args,
-        ) {
+        if !DeepRejectCtxt::relate_rigid_infer(ecx.cx())
+            .args_may_unify(goal_trait_ref.args, impl_trait_ref.skip_binder().args)
+        {
             return Err(NoSolution.into());
         }
 


### PR DESCRIPTION
Effectively, do one step of common subexpression elimination, manually. We can reuse the existing interned reference made a few lines prior, without needing to recreate it.

r? @lcnr

**AI disclosure:** The optimization opportunity here was discovered as part of a systematic probe for missed optimizations using a combination of both traditional and AI tools. The code here was initially prototyped and vetted by AI tools, followed by additional manual work. I stand behind the quality of the code I'm submitting, and I vouch it's as good or better than if no AI tools were in the loop.