### PR TITLE
Default `RawOsError` to `i16` for 16-bit targets

### DIFF
--- a/library/core/src/io/error.rs
+++ b/library/core/src/io/error.rs
@@ -714,13 +714,16 @@ impl CustomOwner {
 ///
 /// This is an [`i32`] on all currently supported platforms, but platforms
 /// added in the future (such as UEFI) may use a different primitive type like
-/// [`usize`]. Use `as` or [`into`] conversions where applicable to ensure maximum
-/// portability.
+/// [`usize`] or [`i16`]. Use `as` or [`into`] conversions where applicable to
+/// ensure maximum portability.
 ///
 /// [`into`]: Into::into
 #[unstable(feature = "raw_os_error_ty", issue = "107792")]
 pub type RawOsError = cfg_select! {
     target_os = "uefi" => usize,
+    // For 16-bit AVR and MSP430, i16 is equivalent to c_int.
+    // Using i16 to be explicit.
+    target_pointer_width = "16" => i16,
     _ => i32,
 };
 

--- a/library/coretests/tests/io/error.rs
+++ b/library/coretests/tests/io/error.rs
@@ -1,0 +1,11 @@
+use core::io::RawOsError;
+
+/// On all targets to date, [`RawOsError`] is equivalent to a `c_int`, with the
+/// notable exception of UEFI, where it is instead defined as `usize`.
+#[test]
+fn raw_os_error_ffi_guarantees() {
+    let _: RawOsError = cfg_select! {
+        target_os = "uefi" => 0 as usize,
+        _ => 0 as core::ffi::c_int,
+    };
+}

--- a/library/coretests/tests/io/mod.rs
+++ b/library/coretests/tests/io/mod.rs
@@ -1,2 +1,3 @@
 mod borrowed_buf;
+mod error;
 mod io_slice;

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -97,6 +97,7 @@
 #![feature(pointer_is_aligned_to)]
 #![feature(portable_simd)]
 #![feature(ptr_metadata)]
+#![feature(raw_os_error_ty)]
 #![feature(rustc_attrs)]
 #![feature(signed_bigint_helpers)]
 #![feature(slice_from_ptr_range)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

ACP: https://github.com/rust-lang/libs-team/issues/755
Tracking issue: rust-lang/rust#154046 & rust-lang/rust#107792
Fixes rust-lang/rust#160541

# Description

As noted by @tgross35, it's likely desirable for `RawOsError` to default to `i16` for 16-bit platforms. Practically, this only affects AVR and MSP430. Since `c_int` is defined as:

```rust
crate::cfg_select! {
    any(target_arch = "avr", target_arch = "msp430") => {
        pub(super) type c_int = i16;
        pub(super) type c_uint = u16;
    }
    _ => {
        pub(super) type c_int = i32;
        pub(super) type c_uint = u32;
    }
}
```

This also ensures for all platforms (excluding UEFI), `RawOsError` is equivalent to `c_int`. Since neither sets of targets had an implementation of `std`, this hasn't yet been litigated. While `RawOsError` is unstable, it seems reasonable to choose a default more likely to align with the underlying OS (if any).

---

## Notes

- No AI tooling of any kind was used during the creation of this PR.