### PR TITLE
Reorder the methods in `#[rustc_must_implement_one_of]`

### DIFF
--- a/library/alloc/src/io/read.rs
+++ b/library/alloc/src/io/read.rs
@@ -84,7 +84,7 @@ use crate::vec::Vec;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(notable_trait)]
 #[cfg_attr(not(test), rustc_diagnostic_item = "IoRead")]
-#[rustc_must_implement_one_of(read, read_buf)]
+#[rustc_must_implement_one_of(read_buf, read)] // Keep this order, it's important for rust-analyzer (the preferred-to-implement method should come first).
 pub trait Read {
     /// Pull some bytes from this source into the specified buffer, returning
     /// how many bytes were read.


### PR DESCRIPTION
So that their order will be the preferred order for implementations (assuming implementing `read_buf()` is better), like @joshtriplett said in https://github.com/rust-lang/rust/pull/106643#issuecomment-5187934543.

r? libs

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
