### PR TITLE
cargotest: replace Servo with standalone Stylo

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -269,8 +269,8 @@ impl CommandLineStep for HtmlCheck {
 }
 
 /// Builds cargo and then runs the `src/tools/cargotest` tool, which checks out
-/// some representative crate repositories and runs `cargo test` on them, in
-/// order to test cargo.
+/// some representative crate repositories and runs Cargo commands on them, in
+/// order to test Cargo.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Cargotest {
     build_compiler: Compiler,
@@ -303,8 +303,8 @@ impl CommandLineStep for Cargotest {
 
     /// Runs the `cargotest` tool as compiled in `stage` by the `host` compiler.
     ///
-    /// This tool in `src/tools` will check out a few Rust projects and run `cargo
-    /// test` to ensure that we don't regress the test suites there.
+    /// This tool in `src/tools` will check out a few Rust projects and run Cargo
+    /// commands to ensure that we don't regress them.
     fn run(self, builder: &Builder<'_>) {
         // cargotest's staging has several pieces:
         // consider ./x test cargotest --stage=2.

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -269,8 +269,8 @@ impl CommandLineStep for HtmlCheck {
 }
 
 /// Builds cargo and then runs the `src/tools/cargotest` tool, which checks out
-/// some representative crate repositories and runs Cargo commands on them, in
-/// order to test Cargo.
+/// some representative crate repositories and runs `cargo test` on them, in
+/// order to test cargo.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Cargotest {
     build_compiler: Compiler,
@@ -303,8 +303,8 @@ impl CommandLineStep for Cargotest {
 
     /// Runs the `cargotest` tool as compiled in `stage` by the `host` compiler.
     ///
-    /// This tool in `src/tools` will check out a few Rust projects and run Cargo
-    /// commands to ensure that we don't regress them.
+    /// This tool in `src/tools` will check out a few Rust projects and run `cargo
+    /// test` to ensure that we don't regress the test suites there.
     fn run(self, builder: &Builder<'_>) {
         // cargotest's staging has several pieces:
         // consider ./x test cargotest --stage=2.

--- a/src/doc/rustc-dev-guide/src/tests/ecosystem.md
+++ b/src/doc/rustc-dev-guide/src/tests/ecosystem.md
@@ -14,7 +14,7 @@ CI. See the [Crater chapter](crater.md) for more details.
 ### `cargotest`
 
 `cargotest` is a small tool which runs `cargo test` on a few sample projects
-(such as `servo`, `ripgrep`, `tokei`, etc.). This runs as part of CI and ensures
+(such as `stylo`, `ripgrep`, `tokei`, etc.). This runs as part of CI and ensures
 there aren't any significant regressions:
 
 ```console

--- a/src/doc/rustc-dev-guide/src/tests/ecosystem.md
+++ b/src/doc/rustc-dev-guide/src/tests/ecosystem.md
@@ -13,8 +13,8 @@ CI. See the [Crater chapter](crater.md) for more details.
 
 ### `cargotest`
 
-`cargotest` is a small tool which runs `cargo test` on a few sample projects
-(such as `servo`, `ripgrep`, `tokei`, etc.). This runs as part of CI and ensures
+`cargotest` is a small tool which runs Cargo commands on a few sample projects
+(such as `stylo`, `ripgrep`, `tokei`, etc.). This runs as part of CI and ensures
 there aren't any significant regressions:
 
 ```console

--- a/src/doc/rustc-dev-guide/src/tests/ecosystem.md
+++ b/src/doc/rustc-dev-guide/src/tests/ecosystem.md
@@ -13,7 +13,7 @@ CI. See the [Crater chapter](crater.md) for more details.
 
 ### `cargotest`
 
-`cargotest` is a small tool which runs Cargo commands on a few sample projects
+`cargotest` is a small tool which runs `cargo test` on a few sample projects
 (such as `stylo`, `ripgrep`, `tokei`, etc.). This runs as part of CI and ensures
 there aren't any significant regressions:
 

--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -70,13 +70,11 @@ const TEST_REPOS: &[Test] = &[
         ],
     },
     Test {
-        name: "servo",
-        repo: "https://github.com/servo/servo",
-        sha: "785a344e32db58d4e631fd3cae17fd1f29a721ab",
+        name: "stylo",
+        repo: "https://github.com/servo/stylo",
+        sha: "127b0b5cab6a6927552e889debb20beb031b79d1",
         lock: None,
-        // Only test Stylo a.k.a. Quantum CSS, the parts of Servo going into Firefox.
-        // This takes much less time to build than all of Servo and supports stable Rust.
-        packages: &["selectors"],
+        packages: &["selectors", "stylo"],
         features: None,
         manifest_path: None,
         filters: &[],
@@ -213,10 +211,6 @@ fn run_cargo_test(
         .env("CFG_DISABLE_CROSS_TESTS", "1")
         // Relax #![deny(warnings)] in some crates
         .env("RUSTFLAGS", "--cap-lints warn")
-        // servo tries to use 'lld-link.exe' on windows, but we don't
-        // have lld on our PATH in CI. Override it to use 'link.exe'
-        .env("CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER", "link.exe")
-        .env("CARGO_TARGET_I686_PC_WINDOWS_MSVC_LINKER", "link.exe")
         .current_dir(crate_path)
         .status()
         .unwrap();

--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -7,7 +7,9 @@ struct Test {
     name: &'static str,
     sha: &'static str,
     lock: Option<&'static str>,
-    packages: &'static [&'static str],
+    test_packages: &'static [&'static str],
+    /// Additional packages to check after running the tests.
+    check_packages: &'static [&'static str],
     features: Option<&'static [&'static str]>,
     manifest_path: Option<&'static str>,
     /// `filters` are passed to libtest (i.e., after a `--` in the `cargo test` invocation).
@@ -20,7 +22,8 @@ const TEST_REPOS: &[Test] = &[
         repo: "https://github.com/iron/iron",
         sha: "cf056ea5e8052c1feea6141e40ab0306715a2c33",
         lock: None,
-        packages: &[],
+        test_packages: &[],
+        check_packages: &[],
         features: None,
         manifest_path: None,
         filters: &[],
@@ -30,7 +33,8 @@ const TEST_REPOS: &[Test] = &[
         repo: "https://github.com/BurntSushi/ripgrep",
         sha: "ced5b92aa93eb47e892bd2fd26ab454008721730",
         lock: None,
-        packages: &[],
+        test_packages: &[],
+        check_packages: &[],
         features: None,
         manifest_path: None,
         filters: &[],
@@ -40,7 +44,8 @@ const TEST_REPOS: &[Test] = &[
         repo: "https://github.com/XAMPPRocky/tokei",
         sha: "fdf3f8cb279a7aeac0696c87e5d8b0cd946e4f9e",
         lock: None,
-        packages: &[],
+        test_packages: &[],
+        check_packages: &[],
         features: None,
         manifest_path: None,
         filters: &[],
@@ -50,7 +55,8 @@ const TEST_REPOS: &[Test] = &[
         repo: "https://github.com/BurntSushi/xsv",
         sha: "3de6c04269a7d315f7e9864b9013451cd9580a08",
         lock: None,
-        packages: &[],
+        test_packages: &[],
+        check_packages: &[],
         features: None,
         manifest_path: None,
         // Many tests here use quickcheck and some of them can fail randomly, so only run deterministic tests.
@@ -70,13 +76,14 @@ const TEST_REPOS: &[Test] = &[
         ],
     },
     Test {
-        name: "servo",
-        repo: "https://github.com/servo/servo",
-        sha: "785a344e32db58d4e631fd3cae17fd1f29a721ab",
+        name: "stylo",
+        repo: "https://github.com/servo/stylo",
+        sha: "2d289c14fdf46952d52cabce63b1f0dc55b2ccde",
         lock: None,
-        // Only test Stylo a.k.a. Quantum CSS, the parts of Servo going into Firefox.
-        // This takes much less time to build than all of Servo and supports stable Rust.
-        packages: &["selectors"],
+        test_packages: &["selectors"],
+        // Stylo's unit tests currently fail to compile under the default Servo configuration,
+        // so only check the library for now.
+        check_packages: &["stylo"],
         features: None,
         manifest_path: None,
         filters: &[],
@@ -86,7 +93,8 @@ const TEST_REPOS: &[Test] = &[
         repo: "https://github.com/diesel-rs/diesel",
         sha: "3db7c17c5b069656ed22750e84d6498c8ab5b81d",
         lock: None,
-        packages: &[],
+        test_packages: &[],
+        check_packages: &[],
         // Test the embedded sqlite variant of diesel
         // This does not require any dependency to be present,
         // sqlite will be compiled as part of the build process
@@ -118,9 +126,28 @@ fn test_repo(cargo: &Path, out_dir: &Path, test: &Test) {
     if let Some(lockfile) = test.lock {
         fs::write(&dir.join("Cargo.lock"), lockfile).unwrap();
     }
-    if !run_cargo_test(cargo, &dir, test.packages, test.features, test.manifest_path, test.filters)
-    {
+    if !run_cargo_test(
+        cargo,
+        &dir,
+        test.test_packages,
+        test.features,
+        test.manifest_path,
+        test.filters,
+    ) {
         panic!("tests failed for {}", test.repo);
+    }
+    if !test.check_packages.is_empty()
+        && !run_cargo(
+            cargo,
+            &dir,
+            "check",
+            test.check_packages,
+            test.features,
+            test.manifest_path,
+            None,
+        )
+    {
+        panic!("checks failed for {}", test.repo);
     }
 }
 
@@ -179,8 +206,20 @@ fn run_cargo_test(
     manifest_path: Option<&str>,
     filters: &[&str],
 ) -> bool {
+    run_cargo(cargo_path, crate_path, "test", packages, features, manifest_path, Some(filters))
+}
+
+fn run_cargo(
+    cargo_path: &Path,
+    crate_path: &Path,
+    subcommand: &str,
+    packages: &[&str],
+    features: Option<&[&str]>,
+    manifest_path: Option<&str>,
+    filters: Option<&[&str]>,
+) -> bool {
     let mut command = Command::new(cargo_path);
-    command.arg("test");
+    command.arg(subcommand);
 
     if let Some(path) = manifest_path {
         command.arg(format!("--manifest-path={}", path));
@@ -197,8 +236,10 @@ fn run_cargo_test(
         command.arg("-p").arg(name);
     }
 
-    command.arg("--");
-    command.args(filters);
+    if let Some(filters) = filters {
+        command.arg("--");
+        command.args(filters);
+    }
 
     let status = command
         // `xsv` locates binaries relative to `current_exe()`
@@ -213,10 +254,6 @@ fn run_cargo_test(
         .env("CFG_DISABLE_CROSS_TESTS", "1")
         // Relax #![deny(warnings)] in some crates
         .env("RUSTFLAGS", "--cap-lints warn")
-        // servo tries to use 'lld-link.exe' on windows, but we don't
-        // have lld on our PATH in CI. Override it to use 'link.exe'
-        .env("CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER", "link.exe")
-        .env("CARGO_TARGET_I686_PC_WINDOWS_MSVC_LINKER", "link.exe")
         .current_dir(crate_path)
         .status()
         .unwrap();

--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -7,9 +7,7 @@ struct Test {
     name: &'static str,
     sha: &'static str,
     lock: Option<&'static str>,
-    test_packages: &'static [&'static str],
-    /// Additional packages to check after running the tests.
-    check_packages: &'static [&'static str],
+    packages: &'static [&'static str],
     features: Option<&'static [&'static str]>,
     manifest_path: Option<&'static str>,
     /// `filters` are passed to libtest (i.e., after a `--` in the `cargo test` invocation).
@@ -22,8 +20,7 @@ const TEST_REPOS: &[Test] = &[
         repo: "https://github.com/iron/iron",
         sha: "cf056ea5e8052c1feea6141e40ab0306715a2c33",
         lock: None,
-        test_packages: &[],
-        check_packages: &[],
+        packages: &[],
         features: None,
         manifest_path: None,
         filters: &[],
@@ -33,8 +30,7 @@ const TEST_REPOS: &[Test] = &[
         repo: "https://github.com/BurntSushi/ripgrep",
         sha: "ced5b92aa93eb47e892bd2fd26ab454008721730",
         lock: None,
-        test_packages: &[],
-        check_packages: &[],
+        packages: &[],
         features: None,
         manifest_path: None,
         filters: &[],
@@ -44,8 +40,7 @@ const TEST_REPOS: &[Test] = &[
         repo: "https://github.com/XAMPPRocky/tokei",
         sha: "fdf3f8cb279a7aeac0696c87e5d8b0cd946e4f9e",
         lock: None,
-        test_packages: &[],
-        check_packages: &[],
+        packages: &[],
         features: None,
         manifest_path: None,
         filters: &[],
@@ -55,8 +50,7 @@ const TEST_REPOS: &[Test] = &[
         repo: "https://github.com/BurntSushi/xsv",
         sha: "3de6c04269a7d315f7e9864b9013451cd9580a08",
         lock: None,
-        test_packages: &[],
-        check_packages: &[],
+        packages: &[],
         features: None,
         manifest_path: None,
         // Many tests here use quickcheck and some of them can fail randomly, so only run deterministic tests.
@@ -78,12 +72,9 @@ const TEST_REPOS: &[Test] = &[
     Test {
         name: "stylo",
         repo: "https://github.com/servo/stylo",
-        sha: "2d289c14fdf46952d52cabce63b1f0dc55b2ccde",
+        sha: "127b0b5cab6a6927552e889debb20beb031b79d1",
         lock: None,
-        test_packages: &["selectors"],
-        // Stylo's unit tests currently fail to compile under the default Servo configuration,
-        // so only check the library for now.
-        check_packages: &["stylo"],
+        packages: &["selectors", "stylo"],
         features: None,
         manifest_path: None,
         filters: &[],
@@ -93,8 +84,7 @@ const TEST_REPOS: &[Test] = &[
         repo: "https://github.com/diesel-rs/diesel",
         sha: "3db7c17c5b069656ed22750e84d6498c8ab5b81d",
         lock: None,
-        test_packages: &[],
-        check_packages: &[],
+        packages: &[],
         // Test the embedded sqlite variant of diesel
         // This does not require any dependency to be present,
         // sqlite will be compiled as part of the build process
@@ -126,28 +116,9 @@ fn test_repo(cargo: &Path, out_dir: &Path, test: &Test) {
     if let Some(lockfile) = test.lock {
         fs::write(&dir.join("Cargo.lock"), lockfile).unwrap();
     }
-    if !run_cargo_test(
-        cargo,
-        &dir,
-        test.test_packages,
-        test.features,
-        test.manifest_path,
-        test.filters,
-    ) {
-        panic!("tests failed for {}", test.repo);
-    }
-    if !test.check_packages.is_empty()
-        && !run_cargo(
-            cargo,
-            &dir,
-            "check",
-            test.check_packages,
-            test.features,
-            test.manifest_path,
-            None,
-        )
+    if !run_cargo_test(cargo, &dir, test.packages, test.features, test.manifest_path, test.filters)
     {
-        panic!("checks failed for {}", test.repo);
+        panic!("tests failed for {}", test.repo);
     }
 }
 
@@ -206,20 +177,8 @@ fn run_cargo_test(
     manifest_path: Option<&str>,
     filters: &[&str],
 ) -> bool {
-    run_cargo(cargo_path, crate_path, "test", packages, features, manifest_path, Some(filters))
-}
-
-fn run_cargo(
-    cargo_path: &Path,
-    crate_path: &Path,
-    subcommand: &str,
-    packages: &[&str],
-    features: Option<&[&str]>,
-    manifest_path: Option<&str>,
-    filters: Option<&[&str]>,
-) -> bool {
     let mut command = Command::new(cargo_path);
-    command.arg(subcommand);
+    command.arg("test");
 
     if let Some(path) = manifest_path {
         command.arg(format!("--manifest-path={}", path));
@@ -236,10 +195,8 @@ fn run_cargo(
         command.arg("-p").arg(name);
     }
 
-    if let Some(filters) = filters {
-        command.arg("--");
-        command.args(filters);
-    }
+    command.arg("--");
+    command.args(filters);
 
     let status = command
         // `xsv` locates binaries relative to `current_exe()`


### PR DESCRIPTION
The Servo entry in `cargotest` pins a 2019 checkout and only tests the
`selectors` package. Cargo still has to resolve the old Servo workspace,
including its large graph of Git dependencies, even though most of that
workspace is not covered by the test.

Both `selectors` and the `stylo` CSS engine now live in the standalone
[`servo/stylo`](https://github.com/servo/stylo) repository. This PR replaces
the old Servo checkout with a recent Stylo revision and runs both
`cargo test -p selectors` and `cargo test -p stylo` from the same checkout.

Stylo's unit tests previously failed under the default Servo configuration
because shared tests used pseudo-elements that were only available in Gecko.
This was fixed in [`servo/stylo#436`](https://github.com/servo/stylo/pull/436),
and this PR pins the resulting revision.

The `cargotest` documentation is updated to list Stylo instead of Servo.

Tests:

- `cargo test --manifest-path src/tools/cargotest/Cargo.toml`
- `target/debug/cargotest "$(command -v cargo)" /tmp/cargotest-stylo stylo`
- `./x test tidy --set build.submodules=false`

Closes rust-lang/rust#79404.
