### PR TITLE
Remove `OnDuplicate::Custom`

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -223,13 +223,6 @@ pub(crate) enum OnDuplicate {
 
     /// Ignore duplicates
     Ignore,
-
-    /// Custom function called when a duplicate attribute is found.
-    ///
-    /// - `unused` is the span of the attribute that was unused or bad because of some
-    ///   duplicate reason
-    /// - `used` is the span of the attribute that was used in favor of the unused attribute
-    Custom(fn(cx: &AcceptContext<'_, '_>, used: Span, unused: Span)),
 }
 
 impl OnDuplicate {
@@ -252,7 +245,6 @@ impl OnDuplicate {
                 });
             }
             OnDuplicate::Ignore => {}
-            OnDuplicate::Custom(f) => f(cx, used, unused),
         }
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/transparency.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/transparency.rs
@@ -7,9 +7,7 @@ pub(crate) struct RustcMacroTransparencyParser;
 
 impl SingleAttributeParser for RustcMacroTransparencyParser {
     const PATH: &[Symbol] = &[sym::rustc_macro_transparency];
-    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Custom(|cx, used, unused| {
-        cx.dcx().span_err(vec![used, unused], "multiple macro transparency attributes");
-    });
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Error;
     const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const ALLOWED_TARGETS: AllowedTargets<'_> =
         AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);


### PR DESCRIPTION
It was only used for one attribute, where it was not particularly helpful