### PR TITLE
Add regression test for array type recovery in generic arguments

### DIFF
--- a/tests/ui/parser/recover/array-type-no-semi-turbofish-81097.rs
+++ b/tests/ui/parser/recover/array-type-no-semi-turbofish-81097.rs
@@ -1,0 +1,6 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/81097>.
+
+fn main() {
+    drop::<[(), 0]>([]);
+    //~^ ERROR expected `;` or `]`, found `,`
+}

--- a/tests/ui/parser/recover/array-type-no-semi-turbofish-81097.stderr
+++ b/tests/ui/parser/recover/array-type-no-semi-turbofish-81097.stderr
@@ -1,0 +1,14 @@
+error: expected `;` or `]`, found `,`
+  --> $DIR/array-type-no-semi-turbofish-81097.rs:4:15
+   |
+LL |     drop::<[(), 0]>([]);
+   |               ^ expected `;` or `]`
+   |
+help: you might have meant to use `;` as the separator
+   |
+LL -     drop::<[(), 0]>([]);
+LL +     drop::<[(); 0]>([]);
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Closes rust-lang/rust#81097 adds a regression test. existing covrage was let position only