### PR TITLE
Back MoveData's location maps with a shared DenseLocationMap

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -344,7 +344,7 @@ fn borrowck_collect_region_constraints<'tcx>(
     let locals_are_invalidated_at_exit = tcx.hir_body_owner_kind(def).is_fn_or_closure();
     let borrow_set = BorrowSet::build(tcx, body, locals_are_invalidated_at_exit, &move_data);
 
-    let location_map = Rc::new(DenseLocationMap::new(body));
+    let location_map = Rc::clone(move_data.location_map());
 
     let polonius_input = root_cx.consumer.as_ref().map_or(false, |c| c.polonius_input())
         || infcx.tcx.sess.opts.unstable_opts.polonius.is_legacy_enabled();

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -1,4 +1,5 @@
 use std::mem;
+use std::rc::Rc;
 
 use rustc_index::IndexVec;
 use rustc_middle::mir::*;
@@ -11,6 +12,7 @@ use super::{
     Init, InitIndex, InitKind, InitLocation, LocationMap, LookupResult, MoveData, MoveOut,
     MoveOutIndex, MovePath, MovePathIndex, MovePathLookup, MoveSubPath, MoveSubPathResult,
 };
+use crate::points::DenseLocationMap;
 
 struct MoveDataBuilder<'a, 'tcx, F> {
     body: &'a Body<'tcx>,
@@ -47,13 +49,15 @@ impl<'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> MoveDataBuilder<'a, 'tcx, F> {
             })
             .collect();
 
+        let location_map = Rc::new(DenseLocationMap::new(body));
+
         MoveDataBuilder {
             body,
             loc: Location::START,
             tcx,
             data: MoveData {
                 move_outs: IndexVec::new(),
-                move_out_loc_map: LocationMap::new(body),
+                move_out_loc_map: LocationMap::new(Rc::clone(&location_map)),
                 rev_lookup: MovePathLookup {
                     locals,
                     projections: Default::default(),
@@ -62,7 +66,7 @@ impl<'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> MoveDataBuilder<'a, 'tcx, F> {
                 move_paths,
                 move_out_path_map,
                 inits: IndexVec::new(),
-                init_loc_map: LocationMap::new(body),
+                init_loc_map: LocationMap::new(location_map),
                 init_path_map,
             },
             filter,

--- a/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 use std::ops::{Index, IndexMut};
+use std::rc::Rc;
 
 use rustc_abi::{FieldIdx, VariantIdx};
 use rustc_data_structures::fx::FxHashMap;
@@ -11,6 +12,7 @@ use rustc_middle::ty::{Ty, TyCtxt};
 use rustc_span::Span;
 use smallvec::SmallVec;
 
+use crate::points::{DenseLocationMap, PointIndex};
 use crate::un_derefer::UnDerefer;
 
 rustc_index::newtype_index! {
@@ -205,39 +207,22 @@ pub trait HasMoveData<'tcx> {
 
 #[derive(Debug)]
 pub struct LocationMap<T> {
-    /// All per-location entries live in the single flat `data` vector.
-    /// `block_starts[bb]` gives the index in `data` where block `bb`'s entries
-    /// start; each block has one entry per statement plus one for its terminator.
-    data: Vec<T>,
-    block_starts: IndexVec<BasicBlock, usize>,
-}
-
-impl<T> LocationMap<T> {
-    #[inline]
-    fn offset(&self, loc: Location) -> usize {
-        let offset = self.block_starts[loc.block] + loc.statement_index;
-        if cfg!(debug_assertions) {
-            // A block's entries run until the next block's start, or the end of
-            // `data` for the last block.
-            let next = loc.block.as_usize() + 1;
-            let block_end = self.block_starts.raw.get(next).copied().unwrap_or(self.data.len());
-            assert!(offset < block_end, "{loc:?} is out of range for its block");
-        }
-        offset
-    }
+    /// One entry per point: each block has one entry per statement plus one for
+    /// its terminator. The shared `location_map` numbers the points.
+    data: IndexVec<PointIndex, T>,
+    location_map: Rc<DenseLocationMap>,
 }
 
 impl<T> Index<Location> for LocationMap<T> {
     type Output = T;
     fn index(&self, index: Location) -> &Self::Output {
-        &self.data[self.offset(index)]
+        &self.data[self.location_map.point_from_location(index)]
     }
 }
 
 impl<T> IndexMut<Location> for LocationMap<T> {
     fn index_mut(&mut self, index: Location) -> &mut Self::Output {
-        let offset = self.offset(index);
-        &mut self.data[offset]
+        &mut self.data[self.location_map.point_from_location(index)]
     }
 }
 
@@ -245,14 +230,9 @@ impl<T> LocationMap<T>
 where
     T: Default + Clone,
 {
-    fn new(body: &Body<'_>) -> Self {
-        let mut block_starts = IndexVec::with_capacity(body.basic_blocks.len());
-        let mut total = 0;
-        for block in body.basic_blocks.iter() {
-            block_starts.push(total);
-            total += block.statements.len() + 1;
-        }
-        LocationMap { data: vec![T::default(); total], block_starts }
+    fn new(location_map: Rc<DenseLocationMap>) -> Self {
+        let data = IndexVec::from_elem_n(T::default(), location_map.num_points());
+        LocationMap { data, location_map }
     }
 }
 
@@ -402,6 +382,10 @@ impl<'tcx> MoveData<'tcx> {
         filter: impl Fn(Ty<'tcx>) -> bool,
     ) -> MoveData<'tcx> {
         builder::gather_moves(body, tcx, filter)
+    }
+
+    pub fn location_map(&self) -> &Rc<DenseLocationMap> {
+        &self.move_out_loc_map.location_map
     }
 
     /// For the move path `mpi`, returns the root local variable that starts the path.

--- a/compiler/rustc_mir_dataflow/src/points.rs
+++ b/compiler/rustc_mir_dataflow/src/points.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use rustc_index::{Idx, IndexVec};
 use rustc_middle::mir::{BasicBlock, Body, Location};
 
@@ -84,6 +86,15 @@ impl DenseLocationMap {
     #[inline]
     pub fn point_in_range(&self, index: PointIndex) -> bool {
         index.index() < self.num_points
+    }
+}
+
+// The per-point tables would drown any containing struct's debug output.
+impl fmt::Debug for DenseLocationMap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DenseLocationMap")
+            .field("num_points", &self.num_points)
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
cleanup, suggested by @cjgillot in https://github.com/rust-lang/rust/pull/160245#discussion_r3691155114