### PR TITLE
[rustdoc] Create output file after we checked that the standalone markdown file is valid

### DIFF
--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -69,13 +69,14 @@ pub(crate) fn render_and_write(
     let playground_url = options.markdown_playground_url.or(options.playground_url);
     let playground = playground_url.map(|url| markdown::Playground { crate_name: None, url });
 
-    let mut out =
-        File::create(&output).map_err(|e| format!("{output}: {e}", output = output.display()))?;
-
     let (metadata, text) = extract_leading_metadata(&input_str);
     if metadata.is_empty() {
         return Err("invalid markdown file: no initial lines starting with `# ` or `%`".to_owned());
     }
+
+    let mut out =
+        File::create(&output).map_err(|e| format!("{output}: {e}", output = output.display()))?;
+
     let title = metadata[0];
 
     let error_codes = ErrorCodes::from(options.unstable_features.is_nightly_build());

--- a/tests/run-make/rustdoc/markdown-without-title/rmake.rs
+++ b/tests/run-make/rustdoc/markdown-without-title/rmake.rs
@@ -1,0 +1,45 @@
+// When rustdoc gets a markdown file as input, we want to ensure that if the markdown is invalid,
+// the output file won't be truncated in case this markdown is invalid.
+
+//@ needs-target-std
+
+use run_make_support::{path, rfs, rustdoc};
+
+fn main() {
+    let output_content = "output";
+    let base_file_name = "input";
+
+    let out_dir = path("out");
+    rfs::create_dir(&out_dir);
+
+    // We create the file that should be created by rustdoc and add some content
+    // into it that we will check is still there once rustdoc failed.
+    let output = out_dir.join(format!("{base_file_name}.html"));
+    rfs::write(&output, output_content);
+
+    // We create an "invalid" markdown file (ie no title).
+    let md_file = format!("{base_file_name}.md");
+    rfs::write(&md_file, "Markdown without a title");
+
+    // We run the failing rustdoc.
+    rustdoc()
+        .input(&md_file)
+        .out_dir(&out_dir)
+        .run_fail()
+        .assert_exit_code(1)
+        .assert_stderr_contains(
+            "error: invalid markdown file: no initial lines starting with `# ` or `%`",
+        );
+
+    // Shouldn't have changed.
+    assert_eq!(rfs::read_to_string(&output), output_content);
+
+    // We update the input markdown to make it valid for rustdoc.
+    rfs::write(&md_file, "# a title\n\nMarkdown with a title");
+
+    // We run rustdoc successfully.
+    rustdoc().input(&md_file).out_dir(&out_dir).run();
+
+    // Should have changed.
+    assert_ne!(rfs::read_to_string(output), output_content);
+}


### PR DESCRIPTION
This PR makes the creation of the output (HTML) file after we checked that the input markdown is valid to prevent the output file content to be truncated ([`File::create` doc](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.create)) in any case.

r? @Urgau 