### PR TITLE
expand: Feature gate AST-based attribute macros on expressions and statements

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -858,6 +858,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                         Err(guar) => return ExpandResult::Ready(fragment_kind.dummy(span, guar)),
                     }
                 } else if let SyntaxExtensionKind::LegacyAttr(expander) = ext {
+                    self.gate_proc_macro_attr_item(span, &item);
                     // `LegacyAttr` is only used for builtin attribute macros, which have their
                     // safety checked by `check_builtin_meta_item`, so we don't need to check
                     // `unsafety` here.

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1046,7 +1046,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             self.cx.sess,
             sym::proc_macro_hygiene,
             span,
-            format!("custom attributes cannot be applied to {kind}"),
+            format!("macro attributes on {kind} are unstable"),
         )
         .emit();
     }

--- a/tests/ui/cfg/cfg-stmt-recovery.rs
+++ b/tests/ui/cfg/cfg-stmt-recovery.rs
@@ -1,7 +1,7 @@
 // Verify that we do not ICE when failing to parse a statement in `cfg_eval`.
 
 #![feature(cfg_eval)]
-#![feature(stmt_expr_attributes)]
+#![feature(stmt_expr_attributes, proc_macro_hygiene)]
 
 #[cfg_eval]
 fn main() {

--- a/tests/ui/conditional-compilation/invalid-node-range-issue-129166.rs
+++ b/tests/ui/conditional-compilation/invalid-node-range-issue-129166.rs
@@ -3,7 +3,7 @@
 //@ check-pass
 
 #![feature(cfg_eval)]
-#![feature(stmt_expr_attributes)]
+#![feature(stmt_expr_attributes, proc_macro_hygiene)]
 
 fn f() -> u32 {
     #[cfg_eval] #[cfg(not(FALSE))] 0

--- a/tests/ui/eii/errors.rs
+++ b/tests/ui/eii/errors.rs
@@ -8,7 +8,7 @@
 #[eii_declaration(bar)] //~ ERROR `#[eii_declaration(...)]` is only valid on macros
 fn hello() {
     #[eii_declaration(bar)] //~ ERROR `#[eii_declaration(...)]` is only valid on macros
-    let x = 3 + 3;          //~| ERROR custom attributes cannot be applied to statements
+    let x = 3 + 3;          //~| ERROR macro attributes on statements are unstable
 }
 
 #[eii_declaration] //~ ERROR `#[eii_declaration(...)]` expects a list of one or two elements

--- a/tests/ui/eii/errors.rs
+++ b/tests/ui/eii/errors.rs
@@ -8,7 +8,7 @@
 #[eii_declaration(bar)] //~ ERROR `#[eii_declaration(...)]` is only valid on macros
 fn hello() {
     #[eii_declaration(bar)] //~ ERROR `#[eii_declaration(...)]` is only valid on macros
-    let x = 3 + 3;
+    let x = 3 + 3;          //~| ERROR custom attributes cannot be applied to statements
 }
 
 #[eii_declaration] //~ ERROR `#[eii_declaration(...)]` expects a list of one or two elements

--- a/tests/ui/eii/errors.stderr
+++ b/tests/ui/eii/errors.stderr
@@ -4,7 +4,7 @@ error: `#[eii_declaration(...)]` is only valid on macros
 LL | #[eii_declaration(bar)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0658]: custom attributes cannot be applied to statements
+error[E0658]: macro attributes on statements are unstable
   --> $DIR/errors.rs:10:5
    |
 LL |     #[eii_declaration(bar)]

--- a/tests/ui/eii/errors.stderr
+++ b/tests/ui/eii/errors.stderr
@@ -4,6 +4,16 @@ error: `#[eii_declaration(...)]` is only valid on macros
 LL | #[eii_declaration(bar)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
 
+error[E0658]: custom attributes cannot be applied to statements
+  --> $DIR/errors.rs:10:5
+   |
+LL |     #[eii_declaration(bar)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error: `#[eii_declaration(...)]` is only valid on macros
   --> $DIR/errors.rs:10:5
    |
@@ -88,5 +98,6 @@ error: `#[foo]` expected no arguments or a single argument: `#[foo(default)]`
 LL | #[foo = "default"]
    | ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 14 previous errors
+error: aborting due to 15 previous errors
 
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/macros/issue-111749.rs
+++ b/tests/ui/macros/issue-111749.rs
@@ -9,5 +9,5 @@ fn main() {
     //~^ ERROR the `test` attribute may only be used on a free function
     //~| ERROR attribute must be of the form `#[test]`
     //~| WARNING this was previously accepted by the compiler but is being phased out
-    //~| ERROR custom attributes cannot be applied to expressions
+    //~| ERROR macro attributes on expressions are unstable
 }

--- a/tests/ui/macros/issue-111749.rs
+++ b/tests/ui/macros/issue-111749.rs
@@ -9,4 +9,5 @@ fn main() {
     //~^ ERROR the `test` attribute may only be used on a free function
     //~| ERROR attribute must be of the form `#[test]`
     //~| WARNING this was previously accepted by the compiler but is being phased out
+    //~| ERROR custom attributes cannot be applied to expressions
 }

--- a/tests/ui/macros/issue-111749.stderr
+++ b/tests/ui/macros/issue-111749.stderr
@@ -1,3 +1,13 @@
+error[E0658]: custom attributes cannot be applied to expressions
+  --> $DIR/issue-111749.rs:8:17
+   |
+LL |     cbor_map! { #[test(test)] 4i32};
+   |                 ^^^^^^^^^^^^^
+   |
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error: the `test` attribute may only be used on a free function
   --> $DIR/issue-111749.rs:8:17
    |
@@ -20,8 +30,9 @@ LL |     cbor_map! { #[test(test)] 4i32};
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
    = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0658`.
 Future incompatibility report: Future breakage diagnostic:
 error: attribute must be of the form `#[test]`
   --> $DIR/issue-111749.rs:8:17

--- a/tests/ui/macros/issue-111749.stderr
+++ b/tests/ui/macros/issue-111749.stderr
@@ -1,4 +1,4 @@
-error[E0658]: custom attributes cannot be applied to expressions
+error[E0658]: macro attributes on expressions are unstable
   --> $DIR/issue-111749.rs:8:17
    |
 LL |     cbor_map! { #[test(test)] 4i32};

--- a/tests/ui/proc-macro/cfg-eval-fail.rs
+++ b/tests/ui/proc-macro/cfg-eval-fail.rs
@@ -4,5 +4,5 @@
 fn main() {
     let _ = #[cfg_eval] #[cfg(false)] 0;
     //~^ ERROR removing an expression is not supported in this position
-    //~| ERROR custom attributes cannot be applied to expressions
+    //~| ERROR macro attributes on expressions are unstable
 }

--- a/tests/ui/proc-macro/cfg-eval-fail.rs
+++ b/tests/ui/proc-macro/cfg-eval-fail.rs
@@ -4,4 +4,5 @@
 fn main() {
     let _ = #[cfg_eval] #[cfg(false)] 0;
     //~^ ERROR removing an expression is not supported in this position
+    //~| ERROR custom attributes cannot be applied to expressions
 }

--- a/tests/ui/proc-macro/cfg-eval-fail.stderr
+++ b/tests/ui/proc-macro/cfg-eval-fail.stderr
@@ -4,7 +4,7 @@ error: removing an expression is not supported in this position
 LL |     let _ = #[cfg_eval] #[cfg(false)] 0;
    |                         ^^^^^^^^^^^^^
 
-error[E0658]: custom attributes cannot be applied to expressions
+error[E0658]: macro attributes on expressions are unstable
   --> $DIR/cfg-eval-fail.rs:5:13
    |
 LL |     let _ = #[cfg_eval] #[cfg(false)] 0;

--- a/tests/ui/proc-macro/cfg-eval-fail.stderr
+++ b/tests/ui/proc-macro/cfg-eval-fail.stderr
@@ -4,5 +4,16 @@ error: removing an expression is not supported in this position
 LL |     let _ = #[cfg_eval] #[cfg(false)] 0;
    |                         ^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0658]: custom attributes cannot be applied to expressions
+  --> $DIR/cfg-eval-fail.rs:5:13
+   |
+LL |     let _ = #[cfg_eval] #[cfg(false)] 0;
+   |             ^^^^^^^^^^^
+   |
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/proc-macro/derive-macro-invalid-placement.rs
+++ b/tests/ui/proc-macro/derive-macro-invalid-placement.rs
@@ -1,6 +1,6 @@
 //! regression test for <https://github.com/rust-lang/rust/issues/49934>
 
-#![feature(stmt_expr_attributes)]
+#![feature(stmt_expr_attributes, proc_macro_hygiene)]
 
 fn foo<#[derive(Debug)] T>() { //~ ERROR expected non-macro attribute, found attribute macro
     match 0 {

--- a/tests/ui/proc-macro/proc-macro-gates.rs
+++ b/tests/ui/proc-macro/proc-macro-gates.rs
@@ -23,26 +23,26 @@ fn attrs() {
     struct S;
 
     // Statement, macro
-    #[empty_attr] //~ ERROR: custom attributes cannot be applied to statements
+    #[empty_attr] //~ ERROR: macro attributes on statements are unstable
     println!();
 
     // Statement, semi
-    #[empty_attr] //~ ERROR: custom attributes cannot be applied to statements
+    #[empty_attr] //~ ERROR: macro attributes on statements are unstable
     S;
 
     // Statement, local
-    #[empty_attr] //~ ERROR: custom attributes cannot be applied to statements
+    #[empty_attr] //~ ERROR: macro attributes on statements are unstable
     let _x = 2;
 
     // Expr
-    let _x = #[identity_attr] 2; //~ ERROR: custom attributes cannot be applied to expressions
+    let _x = #[identity_attr] 2; //~ ERROR: macro attributes on expressions are unstable
 
     // Opt expr
-    let _x = [#[identity_attr] 2]; //~ ERROR: custom attributes cannot be applied to expressions
+    let _x = [#[identity_attr] 2]; //~ ERROR: macro attributes on expressions are unstable
 
     // Expr macro
     let _x = #[identity_attr] println!();
-    //~^ ERROR: custom attributes cannot be applied to expressions
+    //~^ ERROR: macro attributes on expressions are unstable
 }
 
 fn test_case() {

--- a/tests/ui/proc-macro/proc-macro-gates.stderr
+++ b/tests/ui/proc-macro/proc-macro-gates.stderr
@@ -24,7 +24,7 @@ error: key-value macro attributes are not supported
 LL | #[empty_attr = "y"]
    | ^^^^^^^^^^^^^^^^^^^
 
-error[E0658]: custom attributes cannot be applied to statements
+error[E0658]: macro attributes on statements are unstable
   --> $DIR/proc-macro-gates.rs:26:5
    |
 LL |     #[empty_attr]
@@ -34,7 +34,7 @@ LL |     #[empty_attr]
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: custom attributes cannot be applied to statements
+error[E0658]: macro attributes on statements are unstable
   --> $DIR/proc-macro-gates.rs:30:5
    |
 LL |     #[empty_attr]
@@ -44,7 +44,7 @@ LL |     #[empty_attr]
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: custom attributes cannot be applied to statements
+error[E0658]: macro attributes on statements are unstable
   --> $DIR/proc-macro-gates.rs:34:5
    |
 LL |     #[empty_attr]
@@ -54,7 +54,7 @@ LL |     #[empty_attr]
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: custom attributes cannot be applied to expressions
+error[E0658]: macro attributes on expressions are unstable
   --> $DIR/proc-macro-gates.rs:38:14
    |
 LL |     let _x = #[identity_attr] 2;
@@ -64,7 +64,7 @@ LL |     let _x = #[identity_attr] 2;
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: custom attributes cannot be applied to expressions
+error[E0658]: macro attributes on expressions are unstable
   --> $DIR/proc-macro-gates.rs:41:15
    |
 LL |     let _x = [#[identity_attr] 2];
@@ -74,7 +74,7 @@ LL |     let _x = [#[identity_attr] 2];
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: custom attributes cannot be applied to expressions
+error[E0658]: macro attributes on expressions are unstable
   --> $DIR/proc-macro-gates.rs:44:14
    |
 LL |     let _x = #[identity_attr] println!();


### PR DESCRIPTION
Right now all of these macros happen to either be unstable or to produce errors when used on expressions and (non-item) statements, but it is safer to feature gate them anyway to avoid unexpected stability holes in the future, because all token-based macros are already feature-gated in these positions.