### PR TITLE
diagnostics: reject sanitizer compiles of proc-macro

### DIFF
--- a/compiler/rustc_interface/src/diagnostics.rs
+++ b/compiler/rustc_interface/src/diagnostics.rs
@@ -97,6 +97,10 @@ pub(crate) struct FailedWritingFile<'a> {
 pub(crate) struct ProcMacroCratePanicAbort;
 
 #[derive(Diagnostic)]
+#[diag("building proc macro crate with sanitizers enabled is not supported")]
+pub(crate) struct CannotSanitizeProcMacro;
+
+#[derive(Diagnostic)]
 #[diag(
     "due to multiple output types requested, the explicitly specified output file name will be adapted for each output type"
 )]

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -279,6 +279,10 @@ fn configure_and_expand(
         feature_err(sess, sym::export_stable, DUMMY_SP, "`sdylib` crate type is unstable").emit();
     }
 
+    if is_proc_macro_crate && !sess.sanitizers().is_empty() {
+        sess.dcx().emit_err(diagnostics::CannotSanitizeProcMacro);
+    }
+
     if is_proc_macro_crate && !sess.panic_strategy().unwinds() {
         sess.dcx().emit_warn(diagnostics::ProcMacroCratePanicAbort);
     }

--- a/tests/ui/proc-macro/proc-macro-sanitizer-attr.rs
+++ b/tests/ui/proc-macro/proc-macro-sanitizer-attr.rs
@@ -1,0 +1,7 @@
+//@ compile-flags: -Z sanitizer=address
+//@ force-host
+//@ needs-sanitizer-support
+
+#![crate_type = "proc-macro"]
+
+//~? ERROR building proc macro crate with sanitizers enabled is not supported

--- a/tests/ui/proc-macro/proc-macro-sanitizer-attr.stderr
+++ b/tests/ui/proc-macro/proc-macro-sanitizer-attr.stderr
@@ -1,0 +1,4 @@
+error: building proc macro crate with sanitizers enabled is not supported
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/proc-macro/proc-macro-sanitizer.rs
+++ b/tests/ui/proc-macro/proc-macro-sanitizer.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: --crate-type proc-macro -Z sanitizer=address
+//@ force-host
+//@ needs-sanitizer-support
+
+//~? ERROR building proc macro crate with sanitizers enabled is not supported

--- a/tests/ui/proc-macro/proc-macro-sanitizer.stderr
+++ b/tests/ui/proc-macro/proc-macro-sanitizer.stderr
@@ -1,0 +1,4 @@
+error: building proc macro crate with sanitizers enabled is not supported
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
We discussed this at the project all hands way back in May, and I'm only just now getting to it. Since proc-macros get loaded into rustc, it's not helpful to try and compile them in a sanitizer mode because you'll most likely end up with incompatible uses of things like the sanitizer runtimes.

<!-- homu-ignore:start -->

- [ ] I did not use an LLM to create a change in this PR.
- [x] I used an LLM to create a change in this PR, and I have explained below how it was used.

I used an LLM to figure out where to plug this logic in, but I either hand-wrote or scrutinized every line before even committing it, and then self-reviewed again in the web UI before submitting the pull request.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
