### PR TITLE
add a test showing polonius alpha is not a subset of datalog polonius

### DIFF
--- a/tests/ui/nll/polonius/nll-legacy-unnecessary-error.legacy.stderr
+++ b/tests/ui/nll/polonius/nll-legacy-unnecessary-error.legacy.stderr
@@ -1,0 +1,14 @@
+error[E0506]: cannot assign to `z` because it is borrowed
+  --> $DIR/nll-legacy-unnecessary-error.rs:20:5
+   |
+LL |     x.0 = &z;
+   |           -- `z` is borrowed here
+LL |     z += 1;
+   |     ^^^^^^ `z` is assigned to here but it was already borrowed
+...
+LL |     dbg!(y.0);
+   |          --- borrow later used here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0506`.

--- a/tests/ui/nll/polonius/nll-legacy-unnecessary-error.nll.stderr
+++ b/tests/ui/nll/polonius/nll-legacy-unnecessary-error.nll.stderr
@@ -1,0 +1,14 @@
+error[E0506]: cannot assign to `z` because it is borrowed
+  --> $DIR/nll-legacy-unnecessary-error.rs:20:5
+   |
+LL |     x.0 = &z;
+   |           -- `z` is borrowed here
+LL |     z += 1;
+   |     ^^^^^^ `z` is assigned to here but it was already borrowed
+...
+LL |     dbg!(y.0);
+   |          --- borrow later used here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0506`.

--- a/tests/ui/nll/polonius/nll-legacy-unnecessary-error.rs
+++ b/tests/ui/nll/polonius/nll-legacy-unnecessary-error.rs
@@ -1,0 +1,25 @@
+// NLLs and legacy polonius emit an unnecessary error here, unlike the alpha. It's not clear
+// *exactly* why the datalog implementation rejects this, but it looks like it propagates the loan
+// from 'x to 'y very eagerly, even though x is dead before the assignment. The loan would thus be
+// live and invalidated by the assignment, AKA an error.
+
+//@ ignore-compare-mode-polonius (explicit revisions)
+//@ revisions: nll polonius legacy
+//@ [nll] compile-flags: -Z polonius=off
+//@ [polonius] check-pass
+//@ [polonius] compile-flags: -Z polonius=next
+//@ [legacy] compile-flags: -Z polonius=legacy
+
+fn main() {
+    let mut x: (&u32,) = (&1,);
+    let mut y: (&u32,) = (&2,);
+    let mut z = 3;
+
+    y.0 = x.0;
+    x.0 = &z;
+    z += 1;
+    //[nll]~^ ERROR: cannot assign to `z` because it is borrowed
+    //[legacy]~^^ ERROR: cannot assign to `z` because it is borrowed
+
+    dbg!(y.0);
+}


### PR DESCRIPTION
This adds a test showing how the datalog and alpha algorithms are not subsets of one another, and are slightly distinct subsets of a platonic ideal borrowck.

r? @jackh726 