### PR TITLE
Clarify `str::split_at` docs

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -823,13 +823,13 @@ impl str {
         unsafe { &mut *(begin..end).get_unchecked_mut(self) }
     }
 
-    /// Divides one string slice into two at an index.
+    /// Divides one string slice into two at a byte offset.
     ///
     /// The argument, `mid`, should be a byte offset from the start of the
     /// string. It must also be on the boundary of a UTF-8 code point.
     ///
-    /// The two slices returned go from the start of the string slice to `mid`,
-    /// and from `mid` to the end of the string slice.
+    /// The first returned slice contains exactly the first `mid` bytes, and the
+    /// second contains all remaining bytes.
     ///
     /// To get mutable string slices instead, see the [`split_at_mut`]
     /// method.
@@ -863,13 +863,13 @@ impl str {
         }
     }
 
-    /// Divides one mutable string slice into two at an index.
+    /// Divides one mutable string slice into two at a byte offset.
     ///
     /// The argument, `mid`, should be a byte offset from the start of the
     /// string. It must also be on the boundary of a UTF-8 code point.
     ///
-    /// The two slices returned go from the start of the string slice to `mid`,
-    /// and from `mid` to the end of the string slice.
+    /// The first returned slice contains exactly the first `mid` bytes, and the
+    /// second contains all remaining bytes.
     ///
     /// To get immutable string slices instead, see the [`split_at`] method.
     ///
@@ -907,14 +907,14 @@ impl str {
         }
     }
 
-    /// Divides one string slice into two at an index.
+    /// Divides one string slice into two at a byte offset.
     ///
     /// The argument, `mid`, should be a valid byte offset from the start of the
     /// string. It must also be on the boundary of a UTF-8 code point. The
     /// method returns `None` if that’s not the case.
     ///
-    /// The two slices returned go from the start of the string slice to `mid`,
-    /// and from `mid` to the end of the string slice.
+    /// The first returned slice contains exactly the first `mid` bytes, and the
+    /// second contains all remaining bytes.
     ///
     /// To get mutable string slices instead, see the [`split_at_mut_checked`]
     /// method.
@@ -947,14 +947,14 @@ impl str {
         }
     }
 
-    /// Divides one mutable string slice into two at an index.
+    /// Divides one mutable string slice into two at a byte offset.
     ///
     /// The argument, `mid`, should be a valid byte offset from the start of the
     /// string. It must also be on the boundary of a UTF-8 code point. The
     /// method returns `None` if that’s not the case.
     ///
-    /// The two slices returned go from the start of the string slice to `mid`,
-    /// and from `mid` to the end of the string slice.
+    /// The first returned slice contains exactly the first `mid` bytes, and the
+    /// second contains all remaining bytes.
     ///
     /// To get immutable string slices instead, see the [`split_at_checked`] method.
     ///
@@ -988,7 +988,7 @@ impl str {
         }
     }
 
-    /// Divides one string slice into two at an index.
+    /// Divides one string slice into two at a byte offset.
     ///
     /// # Safety
     ///
@@ -1007,7 +1007,7 @@ impl str {
         }
     }
 
-    /// Divides one string slice into two at an index.
+    /// Divides one mutable string slice into two at a byte offset.
     ///
     /// # Safety
     ///


### PR DESCRIPTION
<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes https://github.com/rust-lang/rust/issues/158990

The documentation currently describes the split position as an "index", which can be confusing because `mid` is a byte offset rather than an element index.

This change clarifies the relationship between `mid` and the returned slices by describing the length of the first slice. The first returned slice contains exactly `mid` bytes from the start of the string slice, and the second slice contains the remaining bytes.