### PR TITLE
bootstrap: always build llvm's dylib when linking to it

### DIFF
--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -408,11 +408,11 @@ impl CommandLineStep for Llvm {
         // which saves both memory during parallel links and overall disk space
         // for the tools. We don't do this on every platform as it doesn't work
         // equally well everywhere.
-        if builder.llvm_link_shared() {
-            cfg.define("LLVM_LINK_LLVM_DYLIB", "ON");
-            // Keep the pre-LLVM23 behavior for now.
-            cfg.define("LLVM_VERSIONED_DYLIB_NAME_ON_DARWIN", "OFF");
-        }
+        let llvm_link_shared = if builder.llvm_link_shared() { "ON" } else { "OFF" };
+        cfg.define("LLVM_LINK_LLVM_DYLIB", llvm_link_shared);
+        cfg.define("LLVM_BUILD_LLVM_DYLIB", llvm_link_shared);
+        // Keep the pre-LLVM23 behavior for now.
+        cfg.define("LLVM_VERSIONED_DYLIB_NAME_ON_DARWIN", "OFF");
 
         if (target.starts_with("csky")
             || target.starts_with("riscv")


### PR DESCRIPTION
The bootstrap example says that LLVM's dynamic library will be built when llvm.link-shared is true. It actually only set the flag that enables linking against the library (LLVM_LINK_LLVM_DYLIB). It should also set LLVM_BUILD_LLVM_DYLIB.

On clean builds, LLVM's configuration helpfully sets the BUILD flag to true if the LINK flag is true. If a dev toggles link-shared from false to true after an initial build, LINK will be "ON" (given by bootstrap) and BUILD will be "OFF" (from the cmake cache). The library to link will not be built, causing the build to fail at link time.

With this change, the library is always built when it's to be linked. Conversely, it is not built if it is not to be linked.

<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
