### PR TITLE
Avoid the std DLL copy alongside rustc

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -2350,17 +2350,13 @@ impl CommandLineStep for Assemble {
             let is_dylib_or_debug = is_dylib(&f.path()) || is_debug_info(&filename);
 
             // If we link statically to stdlib, do not copy the libstd dynamic library file
-            // FIXME: Also do this for Windows once incremental post-optimization stage0 tests
-            // work without std.dll (see https://github.com/rust-lang/rust/pull/131188).
-            let can_be_rustc_dynamic_dep = if builder
-                .link_std_into_rustc_driver(target_compiler.host)
-                && !target_compiler.host.is_windows()
-            {
-                let is_std = filename.starts_with("std-") || filename.starts_with("libstd-");
-                !is_std
-            } else {
-                true
-            };
+            let can_be_rustc_dynamic_dep =
+                if builder.link_std_into_rustc_driver(target_compiler.host) {
+                    let is_std = filename.starts_with("std-") || filename.starts_with("libstd-");
+                    !is_std
+                } else {
+                    true
+                };
 
             if is_dylib_or_debug && can_be_rustc_dynamic_dep && !is_proc_macro {
                 builder.copy_link(&f.path(), &rustc_libdir.join(&filename), FileType::Regular);


### PR DESCRIPTION
This removes the extra the std DLL copy alongside rustc. Fixes https://github.com/rust-lang/rust/issues/131587.