### PR TITLE
Add regression test for unsized non-last struct field with overlapping impls

### DIFF
--- a/tests/ui/unsized/unsized-non-last-field-overlapping-impls-83097.rs
+++ b/tests/ui/unsized/unsized-non-last-field-overlapping-impls-83097.rs
@@ -1,0 +1,20 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/83097>.
+//!
+//! Only the `E0119` conflicting-implementations error used to be reported here, which hid the
+//! actual mistake: the unsized field is not the last field of the struct. Both errors are now
+//! emitted.
+
+use std::marker::PhantomData;
+
+trait Trait {}
+
+struct Unsized([u8], ());
+//~^ ERROR the size for values of type `[u8]` cannot be known at compilation time
+
+struct Foo<T: ?Sized>(PhantomData<T>);
+
+impl<T> Trait for Foo<T> {}
+impl Trait for Foo<Unsized> {}
+//~^ ERROR conflicting implementations of trait `Trait` for type `Foo<Unsized>`
+
+fn main() {}

--- a/tests/ui/unsized/unsized-non-last-field-overlapping-impls-83097.stderr
+++ b/tests/ui/unsized/unsized-non-last-field-overlapping-impls-83097.stderr
@@ -1,0 +1,30 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/unsized-non-last-field-overlapping-impls-83097.rs:11:16
+   |
+LL | struct Unsized([u8], ());
+   |                ^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: only the last field of a struct may have a dynamically sized type
+   = help: change the field's type to have a statically known size
+help: borrowed types always have a statically known size
+   |
+LL | struct Unsized(&[u8], ());
+   |                +
+help: the `Box` type always has a statically known size and allocates its contents in the heap
+   |
+LL | struct Unsized(Box<[u8]>, ());
+   |                ++++    +
+
+error[E0119]: conflicting implementations of trait `Trait` for type `Foo<Unsized>`
+  --> $DIR/unsized-non-last-field-overlapping-impls-83097.rs:17:1
+   |
+LL | impl<T> Trait for Foo<T> {}
+   | ------------------------ first implementation here
+LL | impl Trait for Foo<Unsized> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Foo<Unsized>`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0119, E0277.
+For more information about an error, try `rustc --explain E0119`.


### PR DESCRIPTION
Closes rust-lang/rust#83097 adds a regresion test locking that  E0277 & E0119 are both emitted