### PR TITLE
Add a suggestion to MissingUnsafeOnExtern diagnostic

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1531,7 +1531,10 @@ impl Visitor<'_> for AstValidator<'_> {
 
                 if &Safety::Default == safety {
                     if item.span.at_least_rust_2024() {
-                        self.dcx().emit_err(diagnostics::MissingUnsafeOnExtern { span: item.span });
+                        self.dcx().emit_err(diagnostics::MissingUnsafeOnExtern {
+                            span: item.span,
+                            unsafe_span: item.span.shrink_to_lo(),
+                        });
                     } else {
                         self.lint_buffer.buffer_lint(
                             MISSING_UNSAFE_ON_EXTERN,

--- a/compiler/rustc_ast_passes/src/diagnostics.rs
+++ b/compiler/rustc_ast_passes/src/diagnostics.rs
@@ -737,6 +737,13 @@ pub(crate) struct UnsafeItem {
 pub(crate) struct MissingUnsafeOnExtern {
     #[primary_span]
     pub span: Span,
+
+    #[suggestion(
+        "needs `unsafe` before the extern keyword",
+        code = "unsafe ",
+        applicability = "machine-applicable"
+    )]
+    pub unsafe_span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/tests/ui/rust-2024/unsafe-extern-blocks/extern-items.edition2024.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/extern-items.edition2024.stderr
@@ -1,7 +1,11 @@
 error: extern blocks must be unsafe
   --> $DIR/extern-items.rs:6:1
    |
-LL | / extern "C" {
+LL |   extern "C" {
+   |   ^
+   |   |
+   |  _help: needs `unsafe` before the extern keyword: `unsafe`
+   | |
 LL | |
 LL | |     static TEST1: i32;
 LL | |     fn test1(i: i32);

--- a/tests/ui/rust-2024/unsafe-extern-blocks/safe-unsafe-on-unadorned-extern-block.edition2024.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/safe-unsafe-on-unadorned-extern-block.edition2024.stderr
@@ -1,7 +1,11 @@
 error: extern blocks must be unsafe
   --> $DIR/safe-unsafe-on-unadorned-extern-block.rs:5:1
    |
-LL | / extern "C" {
+LL |   extern "C" {
+   |   ^
+   |   |
+   |  _help: needs `unsafe` before the extern keyword: `unsafe`
+   | |
 LL | |
 LL | |     safe static TEST1: i32;
 ...  |


### PR DESCRIPTION
`MissingUnsafeOnExtern` diagnostic doesn't have a suggestion, unlike `MissingUnsafeOnExternLint`, which is quite strange. I couldn't find a justification for this in https://github.com/rust-lang/rust/pull/124482, so I assume it's an oversight.

<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
