### PR TITLE
Enable `-Znext-solver` on nightly by default

### DIFF
--- a/compiler/rustc_ast_passes/src/diagnostics.rs
+++ b/compiler/rustc_ast_passes/src/diagnostics.rs
@@ -39,6 +39,14 @@ pub(crate) struct ImplFnConst {
 }
 
 #[derive(Diagnostic)]
+#[diag("`-Znext-solver=globally` is disabled because `generic_const_exprs` is enabled")]
+#[note("the old trait solver will be used globally for this crate")]
+pub(crate) struct NextSolverDisabledForGenericConstExprs {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("functions in {$in_impl ->
         [true] trait impls
         *[false] traits

--- a/compiler/rustc_ast_passes/src/diagnostics.rs
+++ b/compiler/rustc_ast_passes/src/diagnostics.rs
@@ -39,6 +39,17 @@ pub(crate) struct ImplFnConst {
 }
 
 #[derive(Diagnostic)]
+#[diag("`feature(generic_const_exprs)` is not supported with the next-generation trait solver")]
+#[note("`-Znext-solver=globally` is currently enabled by default for testing")]
+#[note("reverted the setting to `-Znext-solver=coherence` for this crate")]
+#[note("the currently stable trait solver will be used for this crate")]
+#[note("see issues #160895 <https://github.com/rust-lang/rust/issues/160895> for more information")]
+pub(crate) struct NextSolverDisabledForGenericConstExprs {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("functions in {$in_impl ->
         [true] trait impls
         *[false] traits

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -6,7 +6,7 @@ use rustc_errors::msg;
 use rustc_feature::Features;
 use rustc_session::Session;
 use rustc_session::diagnostics::{feature_err, feature_warn};
-use rustc_span::{Span, Spanned, Symbol, sym};
+use rustc_span::{Span, Spanned, sym};
 
 use crate::diagnostics;
 
@@ -436,7 +436,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
     maybe_stage_features(sess, features, krate);
     check_incompatible_features(sess, features);
     check_dependent_features(sess, features);
-    check_new_solver_banned_features(sess, features);
+    warn_next_solver_and_gce(sess, features);
     check_features_requiring_new_solver(sess, features);
 
     let mut visitor = PostExpansionVisitor { sess, features };
@@ -721,26 +721,21 @@ fn check_dependent_features(sess: &Session, features: &Features) {
     }
 }
 
-fn check_new_solver_banned_features(sess: &Session, features: &Features) {
+fn warn_next_solver_and_gce(sess: &Session, features: &Features) {
     if !sess.opts.unstable_opts.next_solver.globally {
         return;
     }
 
-    // Ban GCE with the new solver, because it does not implement GCE correctly.
+    // Warn people who uses GCE and -Znext-solver=globally
+    // that their trait solver was downgraded to -Znext-solver=no
     if let Some(gce_span) = features
         .enabled_lang_features()
         .iter()
         .find(|feat| feat.gate_name == sym::generic_const_exprs)
         .map(|feat| feat.attr_sp)
     {
-        // Abort immediately, otherwise GCE can lower to `ConstKind::Expr`,
-        // which the new solver intentionally does not support.
-        #[allow(rustc::symbol_intern_string_literal)]
-        sess.dcx().emit_fatal(diagnostics::IncompatibleFeatures {
-            spans: vec![gce_span],
-            f1: Symbol::intern("-Znext-solver=globally"),
-            f2: sym::generic_const_exprs,
-        });
+        sess.dcx()
+            .emit_warn(diagnostics::NextSolverDisabledForGenericConstExprs { span: gce_span });
     }
 }
 

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -7,7 +7,7 @@ use rustc_hir::Attribute;
 use rustc_hir::attrs::AttributeKind;
 use rustc_session::Session;
 use rustc_session::diagnostics::{feature_err, feature_warn};
-use rustc_span::{Span, Spanned, Symbol, sym};
+use rustc_span::{Span, Spanned, sym};
 
 use crate::diagnostics;
 
@@ -437,7 +437,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
     maybe_stage_features(sess, features, krate);
     check_incompatible_features(sess, features);
     check_dependent_features(sess, features);
-    check_new_solver_banned_features(sess, features);
+    warn_next_solver_and_gce(sess, features);
     check_features_requiring_new_solver(sess, features);
 
     let mut visitor = PostExpansionVisitor { sess, features };
@@ -718,26 +718,21 @@ fn check_dependent_features(sess: &Session, features: &Features) {
     }
 }
 
-fn check_new_solver_banned_features(sess: &Session, features: &Features) {
+fn warn_next_solver_and_gce(sess: &Session, features: &Features) {
     if !sess.opts.unstable_opts.next_solver.globally {
         return;
     }
 
-    // Ban GCE with the new solver, because it does not implement GCE correctly.
+    // Warn people who uses GCE and -Znext-solver=globally
+    // that their trait solver was downgraded to -Znext-solver=no
     if let Some(gce_span) = features
         .enabled_lang_features()
         .iter()
         .find(|feat| feat.gate_name == sym::generic_const_exprs)
         .map(|feat| feat.attr_sp)
     {
-        // Abort immediately, otherwise GCE can lower to `ConstKind::Expr`,
-        // which the new solver intentionally does not support.
-        #[allow(rustc::symbol_intern_string_literal)]
-        sess.dcx().emit_fatal(diagnostics::IncompatibleFeatures {
-            spans: vec![gce_span],
-            f1: Symbol::intern("-Znext-solver=globally"),
-            f2: sym::generic_const_exprs,
-        });
+        sess.dcx()
+            .emit_warn(diagnostics::NextSolverDisabledForGenericConstExprs { span: gce_span });
     }
 }
 

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -851,7 +851,13 @@ fn test_unstable_options_tracking_hash() {
     tracked!(mir_opt_level, Some(4));
     tracked!(mir_preserve_ub, true);
     tracked!(move_size_limit, Some(4096));
-    tracked!(next_solver, NextSolverConfig { coherence: true, globally: false });
+
+    // tidy-alphabetical-end
+    // FIXME(#160895): We don't test this when the next-solver is enabled by default.
+    if option_env!("CFG_DEFAULT_NEXT_SOLVER_GLOBALLY").is_none() {
+        tracked!(next_solver, NextSolverConfig { coherence: true, globally: true });
+    }
+    // tidy-alphabetical-start
     tracked!(no_generate_arange_section, true);
     tracked!(no_link, true);
     tracked!(no_profiler_runtime, true);

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -851,7 +851,7 @@ fn test_unstable_options_tracking_hash() {
     tracked!(mir_opt_level, Some(4));
     tracked!(mir_preserve_ub, true);
     tracked!(move_size_limit, Some(4096));
-    tracked!(next_solver, NextSolverConfig { coherence: true, globally: true });
+    tracked!(next_solver, NextSolverConfig { coherence: true, globally: false });
     tracked!(no_generate_arange_section, true);
     tracked!(no_link, true);
     tracked!(no_profiler_runtime, true);

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2685,7 +2685,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     pub fn next_trait_solver_globally(self) -> bool {
-        self.sess.opts.unstable_opts.next_solver.globally
+        self.sess.opts.unstable_opts.next_solver.globally && !self.features().generic_const_exprs()
     }
 
     pub fn next_trait_solver_in_coherence(self) -> bool {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2686,7 +2686,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     pub fn next_trait_solver_globally(self) -> bool {
-        self.sess.opts.unstable_opts.next_solver.globally
+        self.sess.opts.unstable_opts.next_solver.globally && !self.features().generic_const_exprs()
     }
 
     pub fn next_trait_solver_in_coherence(self) -> bool {

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1011,13 +1011,25 @@ impl ExternEntry {
     }
 }
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Default)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct NextSolverConfig {
     /// Whether the new trait solver should be enabled in coherence.
     pub coherence: bool = true,
     /// Whether the new trait solver should be enabled everywhere.
     /// This is only `true` if `coherence` is also enabled.
     pub globally: bool = false,
+}
+
+// FIXME(#160895): Using -Znext-solver as default on nightly
+// See https://github.com/rust-lang/compiler-team/issues/1014
+impl Default for NextSolverConfig {
+    fn default() -> Self {
+        if option_env!("CFG_DEFAULT_NEXT_SOLVER_GLOBALLY").is_some() {
+            Self { coherence: true, globally: true }
+        } else {
+            Self { coherence: true, globally: false }
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1011,13 +1011,25 @@ impl ExternEntry {
     }
 }
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Default)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct NextSolverConfig {
     /// Whether the new trait solver should be enabled in coherence.
     pub coherence: bool = true,
     /// Whether the new trait solver should be enabled everywhere.
     /// This is only `true` if `coherence` is also enabled.
     pub globally: bool = false,
+}
+
+// Using -Znext-solver as default on nightly
+// See https://github.com/rust-lang/compiler-team/issues/1014
+impl Default for NextSolverConfig {
+    fn default() -> Self {
+        if option_env!("CFG_DEFAULT_NEXT_SOLVER_GLOBALLY").is_some() {
+            Self { coherence: true, globally: true }
+        } else {
+            Self { coherence: true, globally: false }
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1371,8 +1371,9 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
 
     let nightly = builder.config.channel == "nightly" || builder.config.channel == "dev";
     if nightly {
-        // We want to enable Polonius Alpha by default on nighty
+        // We want to enable Polonius Alpha and Next Trait Solver by default on nighty
         cargo.env("CFG_DEFAULT_POLONIUS_NEXT", "1");
+        cargo.env("CFG_DEFAULT_NEXT_SOLVER_GLOBALLY", "1");
     }
 
     // These conditionals represent a tension between three forces:

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3319,6 +3319,7 @@ fn run_cargo_test<'a>(
 
     // FIXME(#160895): While the new solver is enabled by default on nightly,
     // we don't want to use it in our tests for now.
+    cargo.rustflag("-Znext-solver=coherence");
     cargo.rustdocflag("-Znext-solver=coherence");
 
     let mut cargo = prepare_cargo_test(cargo, libtest_args, crates, target, builder);

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3163,6 +3163,9 @@ fn markdown_test(builder: &Builder<'_>, compiler: Compiler, markdown: &Path) -> 
     builder.do_if_verbose(|| println!("doc tests for: {}", markdown.display()));
     let mut cmd = builder.rustdoc_cmd(compiler);
     builder.add_rust_test_threads(&mut cmd);
+    if builder.config.channel == "nightly" || builder.config.channel == "dev" {
+        cmd.arg("-Znext-solver=no");
+    }
     // allow for unstable options such as new editions
     cmd.arg("-Z");
     cmd.arg("unstable-options");
@@ -3235,7 +3238,7 @@ impl CommandLineStep for CrateLibrustc {
 ///
 /// Returns whether the test succeeded.
 fn run_cargo_test<'a>(
-    cargo: builder::Cargo,
+    mut cargo: builder::Cargo,
     libtest_args: &[&str],
     crates: &[String],
     description: impl Into<Option<&'a str>>,
@@ -3248,6 +3251,10 @@ fn run_cargo_test<'a>(
         Mode::Std => compiler.stage,
         _ => compiler.stage + 1,
     };
+
+    if builder.config.channel == "nightly" || builder.config.channel == "dev" {
+        cargo.rustdocflag("-Znext-solver=no");
+    }
 
     let mut cargo = prepare_cargo_test(cargo, libtest_args, crates, target, builder);
     let _time = helpers::timeit(builder);

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3228,6 +3228,9 @@ fn markdown_test(builder: &Builder<'_>, compiler: Compiler, markdown: &Path) -> 
     builder.do_if_verbose(|| println!("doc tests for: {}", markdown.display()));
     let mut cmd = builder.rustdoc_cmd(compiler);
     builder.add_rust_test_threads(&mut cmd);
+    // FIXME(#160895): While the new solver is enabled by default on nightly,
+    // we don't want to use it in our tests for now.
+    cmd.arg("-Znext-solver=coherence");
     // allow for unstable options such as new editions
     cmd.arg("-Z");
     cmd.arg("unstable-options");
@@ -3300,7 +3303,7 @@ impl CommandLineStep for CrateLibrustc {
 ///
 /// Returns whether the test succeeded.
 fn run_cargo_test<'a>(
-    cargo: builder::Cargo,
+    mut cargo: builder::Cargo,
     libtest_args: &[&str],
     crates: &[String],
     description: impl Into<Option<&'a str>>,
@@ -3313,6 +3316,10 @@ fn run_cargo_test<'a>(
         Mode::Std => compiler.stage,
         _ => compiler.stage + 1,
     };
+
+    // FIXME(#160895): While the new solver is enabled by default on nightly,
+    // we don't want to use it in our tests for now.
+    cargo.rustdocflag("-Znext-solver=coherence");
 
     let mut cargo = prepare_cargo_test(cargo, libtest_args, crates, target, builder);
     let _time = helpers::timeit(builder);

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3319,7 +3319,6 @@ fn run_cargo_test<'a>(
 
     // FIXME(#160895): While the new solver is enabled by default on nightly,
     // we don't want to use it in our tests for now.
-    cargo.rustflag("-Znext-solver=coherence");
     cargo.rustdocflag("-Znext-solver=coherence");
 
     let mut cargo = prepare_cargo_test(cargo, libtest_args, crates, target, builder);

--- a/src/tools/clippy/tests/compile-test.rs
+++ b/src/tools/clippy/tests/compile-test.rs
@@ -227,6 +227,7 @@ impl TestContext {
                 "-Ainternal_features",
                 "-Zui-testing",
                 "-Zdeduplicate-diagnostics=no",
+                "-Znext-solver=no",
                 "-Dwarnings",
             ]
             .map(OsString::from),
@@ -333,7 +334,7 @@ fn run_ui_cargo(cx: &TestContext) {
     config.program.out_dir_flag = CommandBuilder::cargo().out_dir_flag;
     config.program.args = vec!["clippy".into(), "--color".into(), "never".into(), "--quiet".into()];
     config.program.envs.extend([
-        ("RUSTFLAGS".into(), Some("-Dwarnings".into())),
+        ("RUSTFLAGS".into(), Some("-Dwarnings -Znext-solver=no".into())),
         ("CARGO_INCREMENTAL".into(), Some("0".into())),
     ]);
     // We need to do this while we still have a rustc in the `program` field.

--- a/src/tools/clippy/tests/compile-test.rs
+++ b/src/tools/clippy/tests/compile-test.rs
@@ -228,6 +228,9 @@ impl TestContext {
                 "-Ainternal_features",
                 "-Zui-testing",
                 "-Zdeduplicate-diagnostics=no",
+                // FIXME(#160895): While the new solver is enabled by default on nightly,
+                // we don't want to use it in our tests for now.
+                "-Znext-solver=coherence",
                 "-Dwarnings",
             ]
             .map(OsString::from),
@@ -334,7 +337,9 @@ fn run_ui_cargo(cx: &TestContext) {
     config.program.out_dir_flag = CommandBuilder::cargo().out_dir_flag;
     config.program.args = vec!["clippy".into(), "--color".into(), "never".into(), "--quiet".into()];
     config.program.envs.extend([
-        ("RUSTFLAGS".into(), Some("-Dwarnings".into())),
+        // FIXME(#160895): While the new solver is enabled by default on nightly,
+        // we don't want to use it in our tests for now.
+        ("RUSTFLAGS".into(), Some("-Dwarnings -Znext-solver=coherence".into())),
         ("CARGO_INCREMENTAL".into(), Some("0".into())),
     ]);
     // We need to do this while we still have a rustc in the `program` field.

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1038,6 +1038,9 @@ impl<'test> TestCx<'test> {
             .arg(file_to_doc)
             .arg("-A")
             .arg("internal_features")
+            // FIXME(#160895): While the new solver is enabled by default on nightly,
+            // we don't want to use it in our tests for now.
+            .arg("-Znext-solver=coherence")
             .args(&self.props.compile_flags)
             .args(&self.props.doc_flags);
 
@@ -1847,6 +1850,10 @@ impl<'test> TestCx<'test> {
                 }
             },
         }
+
+        // FIXME(#160895): While the new solver is enabled by default on nightly,
+        // we don't want to use it in our tests for now.
+        compiler.args(["-Znext-solver=coherence"]);
 
         match self.config.compare_mode {
             Some(CompareMode::Polonius) => {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1038,6 +1038,7 @@ impl<'test> TestCx<'test> {
             .arg(file_to_doc)
             .arg("-A")
             .arg("internal_features")
+            .arg("-Znext-solver=coherence")
             .args(&self.props.compile_flags)
             .args(&self.props.doc_flags);
 
@@ -1850,7 +1851,7 @@ impl<'test> TestCx<'test> {
 
         match self.config.compare_mode {
             Some(CompareMode::Polonius) => {
-                compiler.args(&["-Zpolonius=next"]);
+                compiler.args(&["-Zpolonius=next", "-Znext-solver=coherence"]);
             }
             Some(CompareMode::NextSolver) => {
                 compiler.args(&["-Znext-solver"]);
@@ -1867,7 +1868,9 @@ impl<'test> TestCx<'test> {
             Some(CompareMode::SplitDwarfSingle) => {
                 compiler.args(&["-Csplit-debuginfo=packed"]);
             }
-            None => {}
+            None => {
+                compiler.args(["-Znext-solver=coherence"]);
+            }
         }
 
         // Add `-A unused` before `config` flags and in-test (`props`) flags, so that they can

--- a/src/tools/lint-docs/src/lib.rs
+++ b/src/tools/lint-docs/src/lib.rs
@@ -473,6 +473,9 @@ impl<'a> LintExtractor<'a> {
         cmd.arg(format!("--edition={edition}"));
         // Just in case this is an unstable edition.
         cmd.arg("-Zunstable-options");
+        // FIXME(#160895): While the new solver is enabled by default on nightly,
+        // we don't want to use it in our tests for now.
+        cmd.arg("-Znext-solver=coherence");
         cmd.arg("--error-format=json");
         cmd.arg("--target").arg(self.rustc_target);
         if let Some(target_linker) = self.rustc_linker {

--- a/src/tools/lint-docs/src/lib.rs
+++ b/src/tools/lint-docs/src/lib.rs
@@ -473,6 +473,7 @@ impl<'a> LintExtractor<'a> {
         cmd.arg(format!("--edition={edition}"));
         // Just in case this is an unstable edition.
         cmd.arg("-Zunstable-options");
+        cmd.arg("-Znext-solver=no");
         cmd.arg("--error-format=json");
         cmd.arg("--target").arg(self.rustc_target);
         if let Some(target_linker) = self.rustc_linker {

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -199,4 +199,7 @@ pub const MIRI_DEFAULT_ARGS: &[&str] = &[
     // Deduplicating diagnostics means we miss events when tracking what happens during an
     // execution. Let's not do that.
     "-Zdeduplicate-diagnostics=no",
+    // FIXME(#160895): the new solver is enabled by default on nightly, but we
+    // don't want to use it in Miri for now. Remove once that's reverted.
+    "-Znext-solver=coherence",
 ];

--- a/src/tools/miri/tests/ui.rs
+++ b/src/tools/miri/tests/ui.rs
@@ -300,6 +300,9 @@ fn run_tests(
             )
             .into(),
         );
+
+        config.program.args.push("-Znext-solver=no".into());
+
         if let Ok(extra_flags) = env::var("MIRIFLAGS") {
             for flag in extra_flags.split_whitespace() {
                 config.program.args.push(flag.into());

--- a/src/tools/miri/tests/ui.rs
+++ b/src/tools/miri/tests/ui.rs
@@ -300,6 +300,7 @@ fn run_tests(
             )
             .into(),
         );
+
         if let Ok(extra_flags) = env::var("MIRIFLAGS") {
             for flag in extra_flags.split_whitespace() {
                 config.program.args.push(flag.into());

--- a/tests/ui/const-generics/generic_const_exprs/next-solver-gce-incompatible-issue-158428.rs
+++ b/tests/ui/const-generics/generic_const_exprs/next-solver-gce-incompatible-issue-158428.rs
@@ -3,13 +3,14 @@
 #![feature(min_generic_const_args)]
 #![feature(generic_const_args)]
 #![feature(generic_const_exprs)]
-//~^ ERROR `-Znext-solver=globally` and `generic_const_exprs` are incompatible
+//~^ WARN: `-Znext-solver=globally` is disabled because `generic_const_exprs` is enabled
 //@ normalize-stderr: "(--> ).*/tests/ui/const-generics/generic_const_exprs" -> "$1$$DIR"
 
 use std::mem::size_of;
 
 union AsBytes<T> {
     as_bytes: [u8; const { size_of::<T>() }],
+    //~^ ERROR: overly complex generic constant
 }
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/next-solver-gce-incompatible-issue-158428.rs
+++ b/tests/ui/const-generics/generic_const_exprs/next-solver-gce-incompatible-issue-158428.rs
@@ -1,15 +1,17 @@
+//@ run-pass
 //@ compile-flags: -Znext-solver=globally
 
 #![feature(min_generic_const_args)]
 #![feature(generic_const_args)]
 #![feature(generic_const_exprs)]
-//~^ ERROR `-Znext-solver=globally` and `generic_const_exprs` are incompatible
+//~^ WARN: `feature(generic_const_exprs)` is not supported with the next-generation trait solver
 //@ normalize-stderr: "(--> ).*/tests/ui/const-generics/generic_const_exprs" -> "$1$$DIR"
 
 use std::mem::size_of;
 
 union AsBytes<T> {
-    as_bytes: [u8; const { size_of::<T>() }],
+    //~^ WARN: union `AsBytes` is never used
+    as_bytes: [u8; { size_of::<T>() }],
 }
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/next-solver-gce-incompatible-issue-158428.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/next-solver-gce-incompatible-issue-158428.stderr
@@ -1,10 +1,21 @@
-error: `-Znext-solver=globally` and `generic_const_exprs` are incompatible, using them at the same time is not allowed
-  --> $DIR/next-solver-gce-incompatible-issue-158428.rs:5:12
+warning: `feature(generic_const_exprs)` is not supported with the next-generation trait solver
+  --> $DIR/next-solver-gce-incompatible-issue-158428.rs:6:12
    |
 LL | #![feature(generic_const_exprs)]
    |            ^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove one of these features
+   = note: `-Znext-solver=globally` is currently enabled by default for testing
+   = note: reverted the setting to `-Znext-solver=coherence` for this crate
+   = note: the currently stable trait solver will be used for this crate
+   = note: see issues #160895 <https://github.com/rust-lang/rust/issues/160895> for more information
 
-error: aborting due to 1 previous error
+warning: union `AsBytes` is never used
+  --> $DIR/next-solver-gce-incompatible-issue-158428.rs:12:7
+   |
+LL | union AsBytes<T> {
+   |       ^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+
+warning: 2 warnings emitted
 

--- a/tests/ui/const-generics/generic_const_exprs/next-solver-gce-incompatible-issue-158428.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/next-solver-gce-incompatible-issue-158428.stderr
@@ -1,10 +1,19 @@
-error: `-Znext-solver=globally` and `generic_const_exprs` are incompatible, using them at the same time is not allowed
+warning: `-Znext-solver=globally` is disabled because `generic_const_exprs` is enabled
   --> $DIR/next-solver-gce-incompatible-issue-158428.rs:5:12
    |
 LL | #![feature(generic_const_exprs)]
    |            ^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove one of these features
+   = note: the old trait solver will be used globally for this crate
 
-error: aborting due to 1 previous error
+error: overly complex generic constant
+  --> $DIR/next-solver-gce-incompatible-issue-158428.rs:12:20
+   |
+LL |     as_bytes: [u8; const { size_of::<T>() }],
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^ const blocks are not supported in generic constants
+   |
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
+
+error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.rs
+++ b/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.rs
@@ -1,10 +1,9 @@
-//@ known-bug: unknown
 // This used to ensure that the next solver prints unsatisfied always-const trait bounds as
 // `const Trait`, but no longer does because GCE is incompatible with the next solver.
 //@ compile-flags: -Znext-solver
 
 #![feature(const_trait_impl, generic_const_exprs)]
-#![allow(incomplete_features)]
+//~^ WARN: `feature(generic_const_exprs)` is not supported with the next-generation trait solver
 
 fn require<T: const Trait>() {}
 
@@ -15,11 +14,14 @@ const trait Trait {
 struct Ty;
 
 impl Trait for Ty {
-    fn make() -> u32 { 0 }
+    fn make() -> u32 {
+        0
+    }
 }
 
 fn main() {
     require::<Ty>();
+    //~^ ERROR: the trait bound `Ty: const Trait` is not satisfied
 }
 
 struct Container<const N: u32>;
@@ -27,7 +29,9 @@ struct Container<const N: u32>;
 // FIXME(const_trait_impl): Somehow emit `the trait bound `T: const Trait`
 // is not satisfied` here instead and suggest changing `Trait` to `const Trait`.
 fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
+//~^ ERROR: the trait bound `T: const Trait` is not satisfied
 
 // FIXME(const_trait_impl): Instead of suggesting `+ const Trait`, suggest
 //                 changing `[const] Trait` to `const Trait`.
 const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
+//~^ ERROR: the trait bound `T: const Trait` is not satisfied

--- a/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.rs
+++ b/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.rs
@@ -1,10 +1,9 @@
-//@ known-bug: unknown
 // This used to ensure that the next solver prints unsatisfied always-const trait bounds as
 // `const Trait`, but no longer does because GCE is incompatible with the next solver.
 //@ compile-flags: -Znext-solver
 
 #![feature(const_trait_impl, generic_const_exprs)]
-#![allow(incomplete_features)]
+//~^ WARN: `-Znext-solver=globally` is disabled because `generic_const_exprs` is enabled
 
 fn require<T: const Trait>() {}
 
@@ -15,11 +14,14 @@ const trait Trait {
 struct Ty;
 
 impl Trait for Ty {
-    fn make() -> u32 { 0 }
+    fn make() -> u32 {
+        0
+    }
 }
 
 fn main() {
     require::<Ty>();
+    //~^ ERROR: the trait bound `Ty: const Trait` is not satisfied
 }
 
 struct Container<const N: u32>;
@@ -27,7 +29,9 @@ struct Container<const N: u32>;
 // FIXME(const_trait_impl): Somehow emit `the trait bound `T: const Trait`
 // is not satisfied` here instead and suggest changing `Trait` to `const Trait`.
 fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
+//~^ ERROR: the trait bound `T: const Trait` is not satisfied
 
 // FIXME(const_trait_impl): Instead of suggesting `+ const Trait`, suggest
 //                 changing `[const] Trait` to `const Trait`.
 const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
+//~^ ERROR: the trait bound `T: const Trait` is not satisfied

--- a/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
+++ b/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
@@ -1,10 +1,39 @@
-error: `-Znext-solver=globally` and `generic_const_exprs` are incompatible, using them at the same time is not allowed
-  --> $DIR/unsatisfied-const-trait-bound.rs:6:30
+warning: `-Znext-solver=globally` is disabled because `generic_const_exprs` is enabled
+  --> $DIR/unsatisfied-const-trait-bound.rs:5:30
    |
 LL | #![feature(const_trait_impl, generic_const_exprs)]
    |                              ^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove one of these features
+   = note: the old trait solver will be used globally for this crate
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `T: const Trait` is not satisfied
+  --> $DIR/unsatisfied-const-trait-bound.rs:31:37
+   |
+LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
+   |                                     ^
 
+error[E0277]: the trait bound `T: const Trait` is not satisfied
+  --> $DIR/unsatisfied-const-trait-bound.rs:36:51
+   |
+LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
+   |                                                   ^
+
+error[E0277]: the trait bound `Ty: const Trait` is not satisfied
+  --> $DIR/unsatisfied-const-trait-bound.rs:23:15
+   |
+LL |     require::<Ty>();
+   |               ^^
+   |
+note: required by a bound in `require`
+  --> $DIR/unsatisfied-const-trait-bound.rs:8:15
+   |
+LL | fn require<T: const Trait>() {}
+   |               ^^^^^^^^^^^ required by this bound in `require`
+help: make the `impl` of trait `Trait` `const`
+   |
+LL | const impl Trait for Ty {
+   | +++++
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
+++ b/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
@@ -1,10 +1,42 @@
-error: `-Znext-solver=globally` and `generic_const_exprs` are incompatible, using them at the same time is not allowed
-  --> $DIR/unsatisfied-const-trait-bound.rs:6:30
+warning: `feature(generic_const_exprs)` is not supported with the next-generation trait solver
+  --> $DIR/unsatisfied-const-trait-bound.rs:5:30
    |
 LL | #![feature(const_trait_impl, generic_const_exprs)]
    |                              ^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove one of these features
+   = note: `-Znext-solver=globally` is currently enabled by default for testing
+   = note: reverted the setting to `-Znext-solver=coherence` for this crate
+   = note: the currently stable trait solver will be used for this crate
+   = note: see issues #160895 <https://github.com/rust-lang/rust/issues/160895> for more information
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `T: const Trait` is not satisfied
+  --> $DIR/unsatisfied-const-trait-bound.rs:31:37
+   |
+LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
+   |                                     ^
 
+error[E0277]: the trait bound `T: const Trait` is not satisfied
+  --> $DIR/unsatisfied-const-trait-bound.rs:36:51
+   |
+LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
+   |                                                   ^
+
+error[E0277]: the trait bound `Ty: const Trait` is not satisfied
+  --> $DIR/unsatisfied-const-trait-bound.rs:23:15
+   |
+LL |     require::<Ty>();
+   |               ^^
+   |
+note: required by a bound in `require`
+  --> $DIR/unsatisfied-const-trait-bound.rs:8:15
+   |
+LL | fn require<T: const Trait>() {}
+   |               ^^^^^^^^^^^ required by this bound in `require`
+help: make the `impl` of trait `Trait` `const`
+   |
+LL | const impl Trait for Ty {
+   | +++++
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160619)*
<!-- homu-ignore:end -->

Implementation of https://github.com/rust-lang/compiler-team/issues/1014 cc https://github.com/rust-lang/blog.rust-lang.org/pull/1896 https://github.com/rust-lang/rust/issues/160895

This enables `-Znext-solver=globally` by default in nightly, but keeps `-Znext-solver=coherence` for most tests.