### PR TITLE
Do not pass `-no-pie` on Windows

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -536,7 +536,8 @@ impl<'a> Linker for GccLinker<'a> {
             LinkOutputKind::StaticNoPicExe => {
                 // `-static` works for both gcc wrapper and ld.
                 self.link_or_cc_arg("-static");
-                if !self.is_ld && self.is_gnu {
+                // noop on windows w/ gcc, warning w/ clang
+                if !self.is_ld && self.is_gnu && !self.sess.target.is_like_windows {
                     self.cc_arg("-no-pie");
                 }
             }


### PR DESCRIPTION
The warning can be seen with a simple example:
```
❯ cargo new /tmp/hello -q
❯ cargo rustc --target x86_64-pc-windows-gnullvm -q -- -C target-feature=+crt-static
warning: linker stderr: clang: argument unused during compilation: '-no-pie' [-Wunused-command-line-argument]
  |
  = note: `#[warn(linker_messages)]` on by default
```