### PR TITLE
Allow CodegenBackend to borrow from invoker of rustc_driver

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -117,15 +117,15 @@ pub const EXIT_FAILURE: i32 = 1;
 pub const DEFAULT_BUG_REPORT_URL: &str = "https://github.com/rust-lang/rust/issues/new\
     ?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md";
 
-pub trait Callbacks {
+pub trait Callbacks<'a> {
     /// Called before creating the compiler instance
-    fn config(&mut self, _config: &mut interface::Config) {}
+    fn config(&mut self, _config: &mut interface::Config<'a>) {}
     /// Called after parsing the crate root. Submodules are not yet parsed when
     /// this callback is called. Return value instructs the compiler whether to
     /// continue the compilation afterwards (defaults to `Compilation::Continue`)
     fn after_crate_root_parsing(
         &mut self,
-        _compiler: &interface::Compiler,
+        _compiler: &interface::Compiler<'_>,
         _krate: &mut ast::Crate,
     ) -> Compilation {
         Compilation::Continue
@@ -134,7 +134,7 @@ pub trait Callbacks {
     /// continue the compilation afterwards (defaults to `Compilation::Continue`)
     fn after_expansion<'tcx>(
         &mut self,
-        _compiler: &interface::Compiler,
+        _compiler: &interface::Compiler<'_>,
         _tcx: TyCtxt<'tcx>,
     ) -> Compilation {
         Compilation::Continue
@@ -143,7 +143,7 @@ pub trait Callbacks {
     /// continue the compilation afterwards (defaults to `Compilation::Continue`)
     fn after_analysis<'tcx>(
         &mut self,
-        _compiler: &interface::Compiler,
+        _compiler: &interface::Compiler<'_>,
         _tcx: TyCtxt<'tcx>,
     ) -> Compilation {
         Compilation::Continue
@@ -155,10 +155,10 @@ pub struct TimePassesCallbacks {
     time_passes: Option<TimePassesFormat>,
 }
 
-impl Callbacks for TimePassesCallbacks {
+impl Callbacks<'_> for TimePassesCallbacks {
     // JUSTIFICATION: the session doesn't exist at this point.
     #[allow(rustc::bad_opt_access)]
-    fn config(&mut self, config: &mut interface::Config) {
+    fn config(&mut self, config: &mut interface::Config<'_>) {
         // If a --print=... option has been given, we don't print the "total"
         // time because it will mess up the --print output. See #64339.
         //
@@ -169,7 +169,7 @@ impl Callbacks for TimePassesCallbacks {
 }
 
 /// This is the primary entry point for rustc.
-pub fn run_compiler(at_args: &[String], callbacks: &mut (dyn Callbacks + Send)) {
+pub fn run_compiler(at_args: &[String], callbacks: &mut (dyn Callbacks<'_> + Send)) {
     let mut default_early_dcx = EarlyDiagCtxt::new(ErrorOutputType::default());
 
     // Throw away the first argument, the name of the binary.
@@ -543,7 +543,7 @@ fn show_colored_md_content(content: &str) {
     safe_print!("{content}");
 }
 
-fn process_rlink(sess: &Session, compiler: &interface::Compiler) {
+fn process_rlink(sess: &Session, compiler: &interface::Compiler<'_>) {
     assert!(sess.opts.unstable_opts.link_only);
     let dcx = sess.dcx();
     if let Input::File(file) = &sess.io.input {

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -33,9 +33,9 @@ pub type Result<T> = result::Result<T, ErrorGuaranteed>;
 ///
 /// Can be used to run `rustc_interface` queries.
 /// Created by passing [`Config`] to [`run_compiler`].
-pub struct Compiler {
+pub struct Compiler<'a> {
     pub sess: Session,
-    pub codegen_backend: Box<dyn CodegenBackend>,
+    pub codegen_backend: Box<dyn CodegenBackend + 'a>,
     pub(crate) override_queries: Option<fn(&Session, &mut Providers)>,
 
     /// A reference to the current `GlobalCtxt` which we pass on to `GlobalCtxt`.
@@ -307,7 +307,7 @@ pub(crate) fn parse_check_cfg(dcx: DiagCtxtHandle<'_>, specs: Vec<String>) -> Ch
 }
 
 /// The compiler configuration
-pub struct Config {
+pub struct Config<'a> {
     /// Command line options
     pub opts: config::Options,
 
@@ -357,7 +357,8 @@ pub struct Config {
     /// hotswapping branch of cg_clif" for "setting the codegen backend from a
     /// custom driver where the custom codegen backend has arbitrary data."
     /// (See #102759.)
-    pub make_codegen_backend: Option<Box<dyn FnOnce(&Session) -> Box<dyn CodegenBackend> + Send>>,
+    pub make_codegen_backend:
+        Option<Box<dyn FnOnce(&Session) -> Box<dyn CodegenBackend + 'a> + Send + 'a>>,
 
     /// The inner atomic value is set to true when a feature marked as `internal` is
     /// enabled. Makes it so that "please report a bug" is hidden, as ICEs with
@@ -367,7 +368,10 @@ pub struct Config {
 
 // JUSTIFICATION: before session exists, only config
 #[allow(rustc::bad_opt_access)]
-pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Send) -> R {
+pub fn run_compiler<R: Send>(
+    config: Config<'_>,
+    f: impl for<'a> FnOnce(&Compiler<'a>) -> R + Send,
+) -> R {
     trace!("run_compiler");
 
     // Set parallel mode before thread pool creation, which will create `Lock`s.

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -927,7 +927,7 @@ pub static DEFAULT_QUERY_PROVIDERS: LazyLock<Providers> = LazyLock::new(|| {
 });
 
 pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
-    compiler: &Compiler,
+    compiler: &Compiler<'_>,
     krate: rustc_ast::Crate,
     f: F,
 ) -> (T, Option<IncrCompSession>) {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -231,7 +231,7 @@ pub(crate) fn create_config(
         ..
     }: RustdocOptions,
     render_options: &RenderOptions,
-) -> rustc_interface::Config {
+) -> rustc_interface::Config<'static> {
     // Add the doc cfg into the doc build.
     cfgs.push("doc".to_string());
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -766,7 +766,7 @@ fn run_renderer<
 /// discovered via `--read-doc-meta-dir` are combined and written to the doc root.
 fn run_merge_finalize(
     render_options: config::RenderOptions,
-    compiler: &interface::Compiler,
+    compiler: &interface::Compiler<'_>,
 ) -> Result<(), error::Error> {
     assert!(
         render_options.should_merge.write_rendered_cci,

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -127,7 +127,7 @@ fn make_miri_codegen_backend(sess: &Session) -> Box<dyn CodegenBackend> {
 }
 
 impl rustc_driver::Callbacks for MiriCompilerCalls {
-    fn config(&mut self, config: &mut rustc_interface::interface::Config) {
+    fn config(&mut self, config: &mut Config<'_>) {
         // We never reach codegen anyway.
         config.make_codegen_backend = Some(Box::new(make_miri_codegen_backend));
 
@@ -137,7 +137,7 @@ impl rustc_driver::Callbacks for MiriCompilerCalls {
 
     fn after_analysis<'tcx>(
         &mut self,
-        _: &rustc_interface::interface::Compiler,
+        _: &rustc_interface::interface::Compiler<'_>,
         tcx: TyCtxt<'tcx>,
     ) -> Compilation {
         // Compilation is done, interpretation is starting. Deal with diagnostics from the
@@ -215,7 +215,7 @@ struct MiriDepCompilerCalls;
 
 impl rustc_driver::Callbacks for MiriDepCompilerCalls {
     #[allow(rustc::potential_query_instability)] // rustc_codegen_ssa (where this code is copied from) also allows this lint
-    fn config(&mut self, config: &mut Config) {
+    fn config(&mut self, config: &mut Config<'_>) {
         // We don't need actual codegen, we just emit an rlib that Miri can later consume.
         config.make_codegen_backend = Some(Box::new(make_miri_codegen_backend));
 
@@ -257,7 +257,7 @@ impl rustc_driver::Callbacks for MiriDepCompilerCalls {
 
     fn after_analysis<'tcx>(
         &mut self,
-        _: &rustc_interface::interface::Compiler,
+        _: &rustc_interface::interface::Compiler<'_>,
         tcx: TyCtxt<'tcx>,
     ) -> Compilation {
         // While the dummy codegen backend doesn't do any codegen, we are still emulating


### PR DESCRIPTION
I authored this change almost 6 years ago, but never had a good reason to submit it. I'm probably going to need it soon for some experiments on the cg_clif side, so I decided to upstream it now.

<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!-- homu-ignore:end -->
