### PR TITLE
platform-support/netbsd.md: No longer mention 8.x, due to EoL.

### DIFF
--- a/src/doc/rustc/src/platform-support/netbsd.md
+++ b/src/doc/rustc/src/platform-support/netbsd.md
@@ -24,10 +24,11 @@ are currently defined running NetBSD:
 | 3                   | `sparc64-unknown-netbsd`      | [Sun UltraSPARC systems](https://wiki.netbsd.org/ports/sparc64/)                     |
 
 All use the "native" `stdc++` library which goes along with the natively
-supplied GNU C++ compiler for the given OS version.  Many of the bootstraps
-are built for NetBSD 9.x, although some exceptions exist (some
-are built for NetBSD 8.x but also work on newer OS versions).
-`x86_64-unknown-netbsd` is built for NetBSD 10.x to access a newer gcc.
+supplied GNU C++ compiler for the given OS version.  Most of the bootstraps
+are built for NetBSD 9.x, although some exceptions exist (some are
+built for newer NetBSD versions, due to target becoming usable first
+with newer versions).  `x86_64-unknown-netbsd` is built for NetBSD
+10.x to access a newer gcc.
 
 
 ## Target Maintainers
@@ -37,7 +38,7 @@ are built for NetBSD 8.x but also work on newer OS versions).
 
 Further contacts:
 
-- [NetBSD/pkgsrc-wip's rust](https://github.com/NetBSD/pkgsrc-wip/blob/master/rust188/Makefile) maintainer (see MAINTAINER variable). This package is part of "pkgsrc work-in-progress" and is used for deployment and testing of new versions of rust.  Note that we have the convention of having multiple rust versions active in pkgsrc-wip at any one time, so the version number is part of the directory name, and from time to time old versions are culled so this is not a fully "stable" link.
+- [NetBSD/pkgsrc-wip's rust](https://github.com/NetBSD/pkgsrc-wip/blob/master/rust197/Makefile) maintainer (see MAINTAINER variable). This package is part of "pkgsrc work-in-progress" and is used for deployment and testing of new versions of rust.  Note that we have the convention of having multiple rust versions active in pkgsrc-wip at any one time, so the version number is part of the directory name, and from time to time old versions are culled so this is not a fully "stable" link.
 - [NetBSD's pkgsrc lang/rust](https://github.com/NetBSD/pkgsrc/tree/trunk/lang/rust) for the "proper" package in pkgsrc.
 - [NetBSD's pkgsrc lang/rust-bin](https://github.com/NetBSD/pkgsrc/tree/trunk/lang/rust-bin) which re-uses the bootstrap kit as a binary distribution and therefore avoids the rather protracted native build time of rust itself
 


### PR DESCRIPTION
Also change the pkgsrc-wip link to indicate a more current rust version.

To be re-visited again once 9.x reaches end of maintnance and EoL by the end of the current month.

<!-- homu-ignore:start -->

- [ x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.
