### PR TITLE
fix ICE in `suggest_add_reference_to_arg` for non-callable items

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -13,7 +13,7 @@ use rustc_errors::{
     Applicability, Diag, EmissionGuarantee, MultiSpan, Style, SuggestionStyle, pluralize,
     struct_span_code_err,
 };
-use rustc_hir::def::{CtorOf, DefKind, Res};
+use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::{Visitor, VisitorExt};
 use rustc_hir::lang_items::LangItem;
@@ -1764,7 +1764,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         // If we didn't return early here, we would instead suggest `&&str::from("")`.
                         return false;
                     } else if let hir::ExprKind::Call(_, args) = expr.kind {
-                        if let Some(pred) = self
+                        // The `def_id` can point at a struct, which has no fn sig.
+                        if matches!(
+                            self.tcx.def_kind(*def_id),
+                            DefKind::AssocFn | DefKind::Fn | DefKind::Ctor(_, CtorKind::Fn)
+                        ) && let Some(pred) = self
                                 .tcx
                                 .clauses_of(*def_id)
                                 .instantiate_identity(self.tcx)
@@ -1799,6 +1803,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             c @ ObligationCauseCode::WhereClauseInExpr(def_id, _, hir_id, idx)
                 if let hir::Node::Expr(expr) = self.tcx.hir_node(*hir_id)
                     && let hir::ExprKind::MethodCall(_segment, rcvr, args, ..) = expr.kind
+                    // The `def_id` can also point at the impl, which has no fn sig.
+                    && matches!(
+                        self.tcx.def_kind(*def_id),
+                        DefKind::AssocFn | DefKind::Fn | DefKind::Ctor(_, CtorKind::Fn)
+                    )
                     && let Some(pred) = self
                         .tcx
                         .clauses_of(*def_id)

--- a/tests/ui/structs/ice-missing-field-fn-sig.rs
+++ b/tests/ui/structs/ice-missing-field-fn-sig.rs
@@ -1,0 +1,14 @@
+// A struct literal that's missing fields shouldn't ICE when checking the fn sig.
+
+trait Context {}
+struct Wrapper<C: Context + 'static> {
+    container: &'static C,
+}
+fn foobar(_: Wrapper<()>) { //~ ERROR the trait bound `(): Context` is not satisfied
+    foobar(Wrapper { /* missing */ })
+//~^ ERROR the trait bound `(): Context` is not satisfied
+//~^^ ERROR missing field `container` in initializer of `Wrapper<_>`
+//~^^^ ERROR the trait bound `(): Context` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/structs/ice-missing-field-fn-sig.stderr
+++ b/tests/ui/structs/ice-missing-field-fn-sig.stderr
@@ -1,0 +1,61 @@
+error[E0277]: the trait bound `(): Context` is not satisfied
+  --> $DIR/ice-missing-field-fn-sig.rs:7:14
+   |
+LL | fn foobar(_: Wrapper<()>) {
+   |              ^^^^^^^^^^^ the trait `Context` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-missing-field-fn-sig.rs:3:1
+   |
+LL | trait Context {}
+   | ^^^^^^^^^^^^^
+note: required by a bound in `Wrapper`
+  --> $DIR/ice-missing-field-fn-sig.rs:4:19
+   |
+LL | struct Wrapper<C: Context + 'static> {
+   |                   ^^^^^^^ required by this bound in `Wrapper`
+
+error[E0277]: the trait bound `(): Context` is not satisfied
+  --> $DIR/ice-missing-field-fn-sig.rs:8:12
+   |
+LL |     foobar(Wrapper { /* missing */ })
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Context` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-missing-field-fn-sig.rs:3:1
+   |
+LL | trait Context {}
+   | ^^^^^^^^^^^^^
+note: required by a bound in `Wrapper`
+  --> $DIR/ice-missing-field-fn-sig.rs:4:19
+   |
+LL | struct Wrapper<C: Context + 'static> {
+   |                   ^^^^^^^ required by this bound in `Wrapper`
+
+error[E0063]: missing field `container` in initializer of `Wrapper<_>`
+  --> $DIR/ice-missing-field-fn-sig.rs:8:12
+   |
+LL |     foobar(Wrapper { /* missing */ })
+   |            ^^^^^^^ missing `container`
+
+error[E0277]: the trait bound `(): Context` is not satisfied
+  --> $DIR/ice-missing-field-fn-sig.rs:8:12
+   |
+LL |     foobar(Wrapper { /* missing */ })
+   |            ^^^^^^^ the trait `Context` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-missing-field-fn-sig.rs:3:1
+   |
+LL | trait Context {}
+   | ^^^^^^^^^^^^^
+note: required by a bound in `Wrapper`
+  --> $DIR/ice-missing-field-fn-sig.rs:4:19
+   |
+LL | struct Wrapper<C: Context + 'static> {
+   |                   ^^^^^^^ required by this bound in `Wrapper`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0063, E0277.
+For more information about an error, try `rustc --explain E0063`.


### PR DESCRIPTION
`tcx.fn_sig(def_id)` panicked ("unexpected sort of node in fn_sig()") when
the `def_id` in a `WhereClauseInExpr` obligation was the struct being
constructed, not the impl. This happens when a struct literal argument is
missing a field.

Guard both `fn_sig` call sites in `suggest_add_reference_to_arg` so the
suggestion only fires for callable defs.

Fixes rust-lang/rust#160591.