### PR TITLE
delegation: fix determining wrong `FnKind` when delegation is inside const arg

### DIFF
--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -2,8 +2,6 @@
 //!
 //! For more information about delegation design, see the tracking issue #118212.
 
-use std::debug_assert_matches;
-
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
@@ -104,14 +102,17 @@ enum FnKind {
 fn fn_kind<'tcx>(tcx: TyCtxt<'tcx>, def_id: impl Into<DefId>) -> FnKind {
     let def_id = def_id.into();
 
-    debug_assert_matches!(tcx.def_kind(def_id), DefKind::Fn | DefKind::AssocFn);
-
-    let parent = tcx.parent(def_id);
-    match tcx.def_kind(parent) {
-        DefKind::Trait => FnKind::AssocTrait,
-        DefKind::Impl { of_trait: true } => FnKind::AssocTraitImpl,
-        DefKind::Impl { of_trait: false } => FnKind::AssocInherentImpl,
-        _ => FnKind::Free,
+    match tcx.def_kind(def_id) {
+        DefKind::Fn => FnKind::Free,
+        DefKind::AssocFn => match tcx.def_kind(tcx.parent(def_id)) {
+            DefKind::Trait => FnKind::AssocTrait,
+            DefKind::Impl { of_trait } => match of_trait {
+                true => FnKind::AssocTraitImpl,
+                false => FnKind::AssocInherentImpl,
+            },
+            _ => unreachable!("associated function can only be in trait or impl"),
+        },
+        _ => unreachable!("delegation/signature can be either free or associated function"),
     }
 }
 

--- a/tests/ui/delegation/wrong-fn-kind-ice-159127.rs
+++ b/tests/ui/delegation/wrong-fn-kind-ice-159127.rs
@@ -1,0 +1,15 @@
+#![feature(fn_delegation)]
+#![feature(min_generic_const_args)]
+
+impl
+    core::direct_const_arg!({
+    //~^ ERROR: expected type, found `direct_const_arg!()` constant
+        fn foo() {}
+        reuse foo::<>as bar;
+        reuse bar;
+        //~^ ERROR: the name `bar` is defined multiple times
+    })
+{
+}
+
+fn main() {}

--- a/tests/ui/delegation/wrong-fn-kind-ice-159127.stderr
+++ b/tests/ui/delegation/wrong-fn-kind-ice-159127.stderr
@@ -1,0 +1,24 @@
+error[E0428]: the name `bar` is defined multiple times
+  --> $DIR/wrong-fn-kind-ice-159127.rs:9:9
+   |
+LL |         reuse foo::<>as bar;
+   |         -------------------- previous definition of the value `bar` here
+LL |         reuse bar;
+   |         ^^^^^^^^^^ `bar` redefined here
+   |
+   = note: `bar` must be defined only once in the value namespace of this block
+
+error: expected type, found `direct_const_arg!()` constant
+  --> $DIR/wrong-fn-kind-ice-159127.rs:5:5
+   |
+LL | /     core::direct_const_arg!({
+LL | |
+LL | |         fn foo() {}
+LL | |         reuse foo::<>as bar;
+...  |
+LL | |     })
+   | |______^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0428`.


### PR DESCRIPTION
Fixes rust-lang/rust#159127. Part of rust-lang/rust#118212.
r? @petrochenkov