### PR TITLE
derive(Diagnostic): link to proper docs

### DIFF
--- a/compiler/rustc_macros/src/lib.rs
+++ b/compiler/rustc_macros/src/lib.rs
@@ -180,7 +180,7 @@ decl_derive!(
 decl_derive!([Lift, attributes(lift)] => lift::lift_derive);
 decl_derive!(
     [Diagnostic, attributes(
-        // struct attributes
+        // struct and field attributes
         diag,
         help,
         help_once,
@@ -194,7 +194,9 @@ decl_derive!(
         suggestion,
         suggestion_short,
         suggestion_hidden,
-        suggestion_verbose)] => diagnostics::diagnostic_derive
+        suggestion_verbose)] =>
+        #[doc = "See <https://rustc-dev-guide.rust-lang.org/diagnostics/diagnostic-structs.html#derivediagnostic>"]
+        diagnostics::diagnostic_derive
 );
 decl_derive!(
     [Subdiagnostic, attributes(


### PR DESCRIPTION
I confirmed that this makes the doc comment show up in RA when hovering a `derive(Diagnostic)`.

Also it's not correct that `note` etc can only be used on the struct, those attributes also work on (some) fields. So also fix the comment.

<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
