### PR TITLE
mir: prohibit projection into scalable vec

### DIFF
--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -69,7 +69,9 @@ fn escaping_locals<'tcx>(
             return true;
         }
         if let ty::Adt(def, _args) = ty.kind()
-            && (def.repr().simd() || tcx.is_lang_item(def.did(), LangItem::DynMetadata))
+            && (def.repr().simd()
+                || def.repr().scalable()
+                || tcx.is_lang_item(def.did(), LangItem::DynMetadata))
         {
             // Exclude #[repr(simd)] types so that they are not de-optimized into an array
             // (MCP#838 banned projections into SIMD types, but if the value is unused

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -707,7 +707,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             );
                         }
 
-                        if adt_def.repr().simd() {
+                        if adt_def.repr().simd() || adt_def.repr().scalable() {
                             self.fail(
                                 location,
                                 format!(

--- a/library/stdarch/crates/core_arch/src/aarch64/sve/mod.rs
+++ b/library/stdarch/crates/core_arch/src/aarch64/sve/mod.rs
@@ -39,7 +39,7 @@ impl<T> SveInto<T> for T {
 macro_rules! impl_sve_type {
     ($(($v:vis, $elem_type:ty, $name:ident, $elt:literal))*) => ($(
         #[doc = concat!("Scalable vector of type ", stringify!($elem_type))]
-        #[derive(Clone, Copy, Debug)]
+        #[derive(Clone, Copy)]
         #[rustc_scalable_vector($elt)]
         #[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
         $v struct $name($elem_type);
@@ -52,21 +52,21 @@ macro_rules! impl_sve_tuple_type {
     )*);
     (@ ($v:vis, $vec_type:ty, 2, $name:ident)) => (
         #[doc = concat!("Two-element tuple of scalable vectors of type ", stringify!($vec_type))]
-        #[derive(Clone, Copy, Debug)]
+        #[derive(Clone, Copy)]
         #[rustc_scalable_vector]
         #[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
         $v struct $name($vec_type, $vec_type);
     );
     (@ ($v:vis, $vec_type:ty, 3, $name:ident)) => (
         #[doc = concat!("Three-element tuple of scalable vectors of type ", stringify!($vec_type))]
-        #[derive(Clone, Copy, Debug)]
+        #[derive(Clone, Copy)]
         #[rustc_scalable_vector]
         #[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
         $v struct $name($vec_type, $vec_type, $vec_type);
     );
     (@ ($v:vis, $vec_type:ty, 4, $name:ident)) => (
         #[doc = concat!("Four-element tuple of scalable vectors of type ", stringify!($vec_type))]
-        #[derive(Clone, Copy, Debug)]
+        #[derive(Clone, Copy)]
         #[rustc_scalable_vector]
         #[unstable(feature = "stdarch_aarch64_sve", issue = "145052")]
         $v struct $name($vec_type, $vec_type, $vec_type, $vec_type);

--- a/tests/mir-opt/sroa/scalable_sroa.bar.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/scalable_sroa.bar.ScalarReplacementOfAggregates.diff
@@ -1,0 +1,32 @@
+- // MIR for `bar` before ScalarReplacementOfAggregates
++ // MIR for `bar` after ScalarReplacementOfAggregates
+  
+  fn bar(_1: &[svuint32x2_t], _2: svuint32x2_t) -> () {
+      debug simds => _1;
+      debug _unused => _2;
+      let mut _0: ();
+      let _3: std::arch::aarch64::svuint32x2_t;
+      let _4: usize;
+      let mut _5: usize;
+      let mut _6: bool;
+      scope 1 {
+          debug a => _3;
+      }
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = const 0_usize;
+          _5 = PtrMetadata(copy _1);
+          _6 = Lt(copy _4, copy _5);
+          assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, copy _4) -> [success: bb1, unwind continue];
+      }
+  
+      bb1: {
+          _3 = copy (*_1)[_4];
+          StorageDead(_4);
+          StorageDead(_3);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/sroa/scalable_sroa.foo.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/scalable_sroa.foo.ScalarReplacementOfAggregates.diff
@@ -1,0 +1,32 @@
+- // MIR for `foo` before ScalarReplacementOfAggregates
++ // MIR for `foo` after ScalarReplacementOfAggregates
+  
+  fn foo(_1: &[svuint32_t], _2: svuint32_t) -> () {
+      debug simds => _1;
+      debug _unused => _2;
+      let mut _0: ();
+      let _3: std::arch::aarch64::svuint32_t;
+      let _4: usize;
+      let mut _5: usize;
+      let mut _6: bool;
+      scope 1 {
+          debug a => _3;
+      }
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = const 0_usize;
+          _5 = PtrMetadata(copy _1);
+          _6 = Lt(copy _4, copy _5);
+          assert(move _6, "index out of bounds: the length is {} but the index is {}", move _5, copy _4) -> [success: bb1, unwind continue];
+      }
+  
+      bb1: {
+          _3 = copy (*_1)[_4];
+          StorageDead(_4);
+          StorageDead(_3);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/sroa/scalable_sroa.rs
+++ b/tests/mir-opt/sroa/scalable_sroa.rs
@@ -1,0 +1,30 @@
+//@ only-aarch64
+//@ needs-unwind
+#![feature(stdarch_aarch64_sve)]
+
+// SRoA expands things even if they're unused
+// <https://github.com/rust-lang/rust/issues/144621>
+
+use std::arch::aarch64::{svuint32_t, svuint32x2_t};
+
+// EMIT_MIR scalable_sroa.foo.ScalarReplacementOfAggregates.diff
+pub(crate) fn foo(simds: &[svuint32_t], _unused: svuint32_t) {
+    // CHECK-LABEL: fn foo
+    // CHECK-NOT: u32
+    // CHECK: let [[SIMD:_.+]]: std::arch::aarch64::svuint32_t;
+    // CHECK-NOT: u32
+    // CHECK: [[SIMD]] = copy (*_1)[0 of 1];
+    // CHECK-NOT: u32
+    let a = simds[0];
+}
+
+// EMIT_MIR scalable_sroa.bar.ScalarReplacementOfAggregates.diff
+pub(crate) fn bar(simds: &[svuint32x2_t], _unused: svuint32x2_t) {
+    // CHECK-LABEL: fn bar
+    // CHECK-NOT: { <vscale x u32 x 4>, <vscale x u32 x 4> }
+    // CHECK: let [[SIMD:_.+]]: std::arch::aarch64::svuint32x2_t;
+    // CHECK-NOT: { <vscale x u32 x 4>, <vscale x u32 x 4> }
+    // CHECK: [[SIMD]] = copy (*_1)[0 of 1];
+    // CHECK-NOT: { <vscale x u32 x 4>, <vscale x u32 x 4> }
+    let a = simds[0];
+}

--- a/tests/ui/scalable-vectors/auxiliary/simple.rs
+++ b/tests/ui/scalable-vectors/auxiliary/simple.rs
@@ -1,0 +1,9 @@
+//@ compile-flags: -Copt-level=0
+//@ only-aarch64
+#![allow(internal_features)]
+#![feature(rustc_attrs)]
+#![crate_type = "rlib"]
+
+#[allow(unused)] // Only used on aarch64-unknown-linux-gnu.
+#[rustc_scalable_vector(4)]
+pub struct Sv(f32);

--- a/tests/ui/scalable-vectors/auxiliary/simple.rs
+++ b/tests/ui/scalable-vectors/auxiliary/simple.rs
@@ -1,0 +1,13 @@
+//@ add-minicore
+//@ compile-flags: -Copt-level=0
+//@ only-aarch64
+#![feature(no_core, rustc_attrs)]
+#![no_std]
+#![no_core]
+#![crate_type = "lib"]
+#![allow(internal_features)]
+
+extern crate minicore;
+
+#[rustc_scalable_vector(4)]
+pub struct Sv(f32);

--- a/tests/ui/scalable-vectors/project-into-field-extern.rs
+++ b/tests/ui/scalable-vectors/project-into-field-extern.rs
@@ -1,0 +1,16 @@
+//@ aux-build: simple.rs
+//@ compile-flags: -Copt-level=0
+//@ check-fail
+//@ only-aarch64
+#![allow(internal_features)]
+#![crate_type = "lib"]
+
+extern crate simple;
+
+pub use simple::Sv;
+
+#[target_feature(enable = "sve")]
+pub fn field(x: Sv) -> f32 {
+    x.0
+    //~^ ERROR: field `0` of struct `Sv` is private
+}

--- a/tests/ui/scalable-vectors/project-into-field-extern.rs
+++ b/tests/ui/scalable-vectors/project-into-field-extern.rs
@@ -1,0 +1,21 @@
+//@ add-minicore
+//@ aux-build: simple.rs
+//@ compile-flags: -Copt-level=0
+//@ check-fail
+//@ only-aarch64
+#![feature(no_core, rustc_attrs)]
+#![no_std]
+#![no_core]
+#![crate_type = "lib"]
+#![allow(internal_features)]
+
+extern crate minicore;
+extern crate simple;
+
+pub use simple::Sv;
+
+#[target_feature(enable = "sve")]
+pub fn field(x: Sv) -> f32 {
+    x.0
+    //~^ ERROR: field `0` of struct `Sv` is private
+}

--- a/tests/ui/scalable-vectors/project-into-field-extern.stderr
+++ b/tests/ui/scalable-vectors/project-into-field-extern.stderr
@@ -1,0 +1,9 @@
+error[E0616]: field `0` of struct `Sv` is private
+  --> $DIR/project-into-field-extern.rs:14:7
+   |
+LL |     x.0
+   |       ^ private field
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0616`.

--- a/tests/ui/scalable-vectors/project-into-field-extern.stderr
+++ b/tests/ui/scalable-vectors/project-into-field-extern.stderr
@@ -1,0 +1,9 @@
+error[E0616]: field `0` of struct `Sv` is private
+  --> $DIR/project-into-field-extern.rs:19:7
+   |
+LL |     x.0
+   |       ^ private field
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0616`.

--- a/tests/ui/scalable-vectors/project-into-field.rs
+++ b/tests/ui/scalable-vectors/project-into-field.rs
@@ -1,0 +1,24 @@
+//@ add-minicore
+//@ build-fail
+//@ compile-flags: -Copt-level=0 --target=aarch64-unknown-linux-gnu
+//@ dont-check-compiler-stderr
+//@ failure-status: 101
+//@ ignore-backends: gcc
+//@ needs-llvm-components: aarch64
+#![feature(no_core, rustc_attrs)]
+#![no_std]
+#![no_core]
+#![crate_type = "lib"]
+#![allow(internal_features)]
+
+extern crate minicore;
+
+#[rustc_scalable_vector(4)]
+pub struct Sv(f32);
+
+#[target_feature(enable = "sve")]
+pub fn field(x: Sv) -> f32 {
+    x.0
+    //~^ ERROR broken MIR in Item
+    //~| ERROR Projecting into SIMD type Sv is banned by MCP#838
+}

--- a/tests/ui/scalable-vectors/project-into-field.stderr
+++ b/tests/ui/scalable-vectors/project-into-field.stderr
@@ -1,0 +1,8 @@
+error: cannot project into scalable vector type `Sv`
+  --> $DIR/project-into-field.rs:18:5
+   |
+LL |     x.0
+   |     ^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160642)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#160580. Preventing projections into scalable vectors is an oversight from the initial implementation and something we should fix.

I'm surprised it caused a stdarch CI failure as reported by rust-lang/rust#160580, as nothing in rustc or stdarch seems to have changed that would have caused that to start happening as far as I can tell. This likely won't fix that stdarch CI failure if it keeps happening, because if there is a projection coming from somewhere then that needs to be fixed - nevertheless, preventing them as in this patch is the right thing to do.

I've tested this against the stdarch CI locally.
