### PR TITLE
Require windowed (and exception) for Xtensa ABI

### DIFF
--- a/compiler/rustc_target/src/spec/consistency.rs
+++ b/compiler/rustc_target/src/spec/consistency.rs
@@ -616,6 +616,19 @@ impl Target {
                     "invalid `target_abi` for wasm"
                 );
             }
+            Arch::Xtensa => {
+                check!(
+                    self.llvm_abiname == LlvmAbi::Unspecified,
+                    "`llvm_abiname` is unused on Xtensa"
+                );
+                check!(self.llvm_floatabi.is_none(), "`llvm_floatabi` is unused on Xtensa");
+                check!(self.rustc_abi.is_none(), "`rustc_abi` is unused on Xtensa");
+                check_matches!(
+                    self.cfg_abi,
+                    CfgAbi::Unspecified | CfgAbi::Other(_),
+                    "invalid `target_abi` for Xtensa"
+                );
+            }
             ref arch => {
                 check!(self.rustc_abi.is_none(), "`rustc_abi` is unused on {arch}");
                 // Ensure consistency among built-in targets, but give JSON targets the opportunity

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -1467,6 +1467,17 @@ impl Target {
                 // No ABI-relevant target features have been identified thus far.
                 NOTHING
             }
+            Arch::Xtensa => {
+                // All Rust-supported Xtensa targets use the windowed register ABI
+                // (esp32 and later). Non-windowed (historical esp8266 / CALL0) is not
+                // a supported Rust ABI. Requiring `windowed` here means selecting a
+                // -Ctarget-cpu that does not provide windowed produces an ABI mismatch
+                // warning rather than silent UB when mixed with windowed code.
+                //
+                // `windowed` implies `exception` in XTENSA_FEATURES, so exception is
+                // always enabled for this ABI; list it explicitly for complete constraints.
+                FeatureConstraints { required: &["windowed", "exception"], incompatible: &[] }
+            }
             _ => NOTHING,
         }
     }

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -1426,6 +1426,17 @@ impl Target {
                 // No ABI-relevant target features have been identified thus far.
                 NOTHING
             }
+            Arch::Xtensa => {
+                // All Rust-supported Xtensa targets use the windowed register ABI
+                // (esp32 and later). Non-windowed (historical esp8266 / CALL0) is not
+                // a supported Rust ABI. Requiring `windowed` here means selecting a
+                // -Ctarget-cpu that does not provide windowed produces an ABI mismatch
+                // warning rather than silent UB when mixed with windowed code.
+                //
+                // `windowed` implies `exception` in XTENSA_FEATURES, so exception is
+                // always enabled for this ABI; list it explicitly for complete constraints.
+                FeatureConstraints { required: &["windowed", "exception"], incompatible: &[] }
+            }
             _ => NOTHING,
         }
     }


### PR DESCRIPTION
Rust only supports the windowed Xtensa calling convention on all upstream targets (esp32 family). Mark windowed and exception as ABI-required features so a mismatched -Ctarget-cpu cannot silently change the ABI.

Discussion: https://github.com/rust-lang/rust/pull/160530#discussion_r3720972977

<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


r? @RalfJung 