### PR TITLE
Clean up some manual debug impls

### DIFF
--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -315,6 +315,7 @@ impl MetaItemOrLitParser {
 ///   `= value` part
 ///
 /// The syntax of `MetaItems` can be found at <https://doc.rust-lang.org/reference/attributes.html>
+#[derive(Debug)]
 pub struct MetaItemParser {
     path: OwnedPathParser,
     args: ArgParser,
@@ -323,15 +324,6 @@ pub struct MetaItemParser {
     /// This is tracked because if the arguments of a `MetaItemParser` are ignored, this is probably a mistake
     #[cfg(debug_assertions)]
     args_checked: AtomicBool,
-}
-
-impl Debug for MetaItemParser {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MetaItemParser")
-            .field("path", &self.path)
-            .field("args", &self.args)
-            .finish()
-    }
 }
 
 impl MetaItemParser {
@@ -385,21 +377,11 @@ impl MetaItemParser {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct NameValueParser {
     pub eq_span: Span,
     value: MetaItemLit,
     pub value_span: Span,
-}
-
-impl Debug for NameValueParser {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("NameValueParser")
-            .field("eq_span", &self.eq_span)
-            .field("value", &self.value)
-            .field("value_span", &self.value_span)
-            .finish()
-    }
 }
 
 impl NameValueParser {

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -42,7 +42,6 @@ pub struct AnnotateSnippetEmitter {
     ui_testing: bool,
     ignored_directories_in_source_blocks: Vec<String>,
     diagnostic_width: Option<usize>,
-
     macro_backtrace: bool,
     track_diagnostics: bool,
     terminal_url: TerminalUrl,
@@ -51,18 +50,30 @@ pub struct AnnotateSnippetEmitter {
 
 impl Debug for AnnotateSnippetEmitter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let AnnotateSnippetEmitter {
+            dst,
+            sm,
+            short_message,
+            ui_testing,
+            ignored_directories_in_source_blocks,
+            diagnostic_width,
+            macro_backtrace,
+            track_diagnostics,
+            terminal_url,
+            theme,
+        } = self;
+
         f.debug_struct("AnnotateSnippetEmitter")
-            .field("short_message", &self.short_message)
-            .field("ui_testing", &self.ui_testing)
-            .field(
-                "ignored_directories_in_source_blocks",
-                &self.ignored_directories_in_source_blocks,
-            )
-            .field("diagnostic_width", &self.diagnostic_width)
-            .field("macro_backtrace", &self.macro_backtrace)
-            .field("track_diagnostics", &self.track_diagnostics)
-            .field("terminal_url", &self.terminal_url)
-            .field("theme", &self.theme)
+            .field("dst", &format_args!("<writer@{dst:p}>"))
+            .field("sm", sm)
+            .field("short_message", short_message)
+            .field("ui_testing", ui_testing)
+            .field("ignored_directories_in_source_blocks", ignored_directories_in_source_blocks)
+            .field("diagnostic_width", diagnostic_width)
+            .field("macro_backtrace", macro_backtrace)
+            .field("track_diagnostics", track_diagnostics)
+            .field("terminal_url", terminal_url)
+            .field("theme", theme)
             .finish()
     }
 }

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -174,6 +174,18 @@ struct SourceMapFiles {
     stable_id_to_source_file: UnhashMap<StableSourceFileId, Arc<SourceFile>>,
 }
 
+impl std::fmt::Debug for SourceMapFiles {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let SourceMapFiles { source_files, stable_id_to_source_file: _ } = self;
+
+        f.debug_list()
+            .entries(
+                source_files.iter().map(|f| f.name.prefer_remapped_unconditionally().to_string()),
+            )
+            .finish()
+    }
+}
+
 /// Used to construct a `SourceMap` with `SourceMap::with_inputs`.
 pub struct SourceMapInputs {
     pub file_loader: Box<dyn FileLoader + Send + Sync>,
@@ -201,6 +213,28 @@ pub struct SourceMap {
     ///
     /// If this is equal to `hash_kind` then the checksum won't be computed twice.
     checksum_hash_kind: Option<SourceFileHashAlgorithm>,
+}
+
+impl std::fmt::Debug for SourceMap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let SourceMap {
+            files,
+            file_loader,
+            path_mapping,
+            working_dir,
+            hash_kind,
+            checksum_hash_kind,
+        } = self;
+
+        f.debug_struct("SourceMap")
+            .field("files", files)
+            .field("file_loader", &format_args!("<file_loader@{file_loader:p}>"))
+            .field("path_mapping", path_mapping)
+            .field("working_dir", working_dir)
+            .field("hash_kind", hash_kind)
+            .field("checksum_hash_kind", checksum_hash_kind)
+            .finish()
+    }
 }
 
 impl SourceMap {
@@ -1117,7 +1151,7 @@ pub fn get_source_map() -> Option<Arc<SourceMap>> {
     with_session_globals(|session_globals| session_globals.source_map.clone())
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FilePathMapping {
     mapping: Vec<(PathBuf, PathBuf)>,
     filename_remapping_scopes: RemapPathScopeComponents,


### PR DESCRIPTION
Some of these can just be derives. Others omitted fields, deliberately or not.

For example, the annotate emitter debug now looks like:
```rust
AnnotateSnippetEmitter {
    dst: <writer@0x9069b55c60>,
    sm: Some(
        SourceMap {
            files: RwLock(
                RwLock {
                    data: [
                        "C:\\Users\\bruno\\Rust\\rust\\tests\\ui\\consts\\bad-array-size-in-type-err.rs",
                        "/rustc/FAKE_PREFIX\\library\\std\\src\\lib.rs",
                        "/rustc/FAKE_PREFIX\\library\\std\\src\\../../core/src/attribute_docs.rs",
                        "/rustc/FAKE_PREFIX\\library\\std\\src\\../../core/src/keyword_docs.rs",
                        "/rustc/FAKE_PREFIX\\library\\std\\src\\../../core/src/primitive_docs.rs",
                        "/rustc/FAKE_PREFIX\\library\\std\\src\\macros.rs",
                        "/rustc/FAKE_PREFIX\\library\\std\\src\\thread\\local.rs",
                        "/rustc/FAKE_PREFIX\\library\\std\\src\\prelude\\mod.rs",
                        "/rustc/FAKE_PREFIX\\library\\std\\src\\prelude\\v1.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\lib.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\clone.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\marker.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\default.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\cmp.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\ops\\mod.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\ops\\drop.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\ops\\function.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\ops\\async_function.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\convert\\mod.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\iter\\mod.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\iter\\traits\\mod.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\iter\\traits\\double_ended.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\iter\\traits\\exact_size.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\iter\\traits\\collect.rs",
                        "/rustc/FAKE_PREFIX\\library\\core\\src\\iter\\traits\\iterator.rs",
                        "/rustc/FAKE_PREFIX\\library\\alloc\\src\\lib.rs",
                        "/rustc/FAKE_PREFIX\\library\\alloc\\src\\borrow.rs",
                        "/rustc/FAKE_PREFIX\\library\\alloc\\src\\string.rs",
                    ],
                },
            ),
            file_loader: <file_loader@0x1f813386448>,
            path_mapping: FilePathMapping {
                mapping: [],
                filename_remapping_scopes: RemapPathScopeComponents(
                    MACRO | DIAGNOSTICS | DEBUGINFO | COVERAGE | DOCUMENTATION,
                ),
            },
            working_dir: RealFileName {
                local: Some(
                    InnerRealFileName {
                        name: "C:\\Users\\bruno\\Rust\\rust",
                        working_directory: "",
                        embeddable_name: "C:\\Users\\bruno\\Rust\\rust",
                    },
                ),
                maybe_remapped: InnerRealFileName {
                    name: "C:\\Users\\bruno\\Rust\\rust",
                    working_directory: "",
                    embeddable_name: "C:\\Users\\bruno\\Rust\\rust",
                },
                scopes: RemapPathScopeComponents(
                    0x0,
                ),
            },
            hash_kind: Sha256,
            checksum_hash_kind: None,
        },
    ),
    short_message: false,
    ui_testing: true,
    ignored_directories_in_source_blocks: [
        "C:\\Users\\bruno\\.cargo",
        "C:\\Users\\bruno\\Rust\\rust\\vendor",
    ],
    diagnostic_width: None,
    macro_backtrace: false,
    track_diagnostics: false,
    terminal_url: No,
    theme: Ascii,
}
```