### PR TITLE
mir: validate `Move` call arguments are locals or box derefs

### DIFF
--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -431,6 +431,26 @@ impl<'a, 'tcx> Visitor<'tcx> for CfgChecker<'a, 'tcx> {
                                 ),
                             );
                         }
+
+                        // Call arguments are moved by reference, so they must be plain locals
+                        // or the contents of a box; other moved places violate MIR invariants.
+                        if self.tcx.sess.opts.unstable_opts.validate_mir
+                            && self.body.phase < MirPhase::Runtime(RuntimePhase::Initial)
+                        {
+                            let is_plain_local = place.projection.is_empty();
+                            let is_box_deref =
+                                matches!(place.projection.as_ref(), [ProjectionElem::Deref])
+                                    && self.body.local_decls[place.local].ty.is_box();
+                            if !is_plain_local && !is_box_deref {
+                                self.fail(
+                                    location,
+                                    format!(
+                                        "encountered `Move` of a non-local, non-box place in `Call` terminator: {:?}",
+                                        terminator.kind,
+                                    ),
+                                );
+                            }
+                        }
                     }
                 }
 

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -430,6 +430,26 @@ impl<'a, 'tcx> Visitor<'tcx> for CfgChecker<'a, 'tcx> {
                                 ),
                             );
                         }
+
+                        // Call arguments are moved by reference, so they must be plain locals
+                        // or the contents of a box; other moved places violate MIR invariants.
+                        if self.tcx.sess.opts.unstable_opts.validate_mir
+                            && self.body.phase < MirPhase::Runtime(RuntimePhase::Initial)
+                        {
+                            let is_plain_local = place.projection.is_empty();
+                            let is_box_deref =
+                                matches!(place.projection.as_ref(), [ProjectionElem::Deref])
+                                    && self.body.local_decls[place.local].ty.is_box();
+                            if !is_plain_local && !is_box_deref {
+                                self.fail(
+                                    location,
+                                    format!(
+                                        "encountered `Move` of a non-local, non-box place in `Call` terminator: {:?}",
+                                        terminator.kind,
+                                    ),
+                                );
+                            }
+                        }
                     }
                 }
 

--- a/tests/ui/mir/validate/call-move-arg.rs
+++ b/tests/ui/mir/validate/call-move-arg.rs
@@ -1,0 +1,28 @@
+// Check that validation rejects moving a non-local, non-box place as a
+// `Call` argument.
+//
+//@ failure-status: 101
+//@ dont-check-compiler-stderr
+//@ compile-flags: -Zvalidate-mir
+
+#![feature(custom_mir, core_intrinsics)]
+extern crate core;
+use core::intrinsics::mir::*;
+
+fn bar(_x: i32) {}
+
+#[custom_mir(dialect = "built")]
+pub fn main() {
+    mir! {
+        let a: (i32, i32);
+        {
+            a = (1, 2);
+            Call(RET = bar(Move(a.0)), ReturnTo(retblock), UnwindContinue())
+            //~^ ERROR broken MIR in
+            //~| ERROR encountered `Move` of a non-local, non-box place in `Call` terminator
+        }
+        retblock = {
+            Return()
+        }
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160651)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#103362.

This PR adds a MIR validation check for `Move` arguments passed to `Call` and `TailCall` terminators.
A moved argument should be either a local or the contents of the `Box`. Other places can deinitialize memory that codegen does not track correctly. The check is only enabled with `-Zvalidate-mir`, using the same phase restriction as the existing `Copy` check.
Added a regression test covering the invalid case.