### PR TITLE
c-variadic: use `emit_ptr_va_arg` for `va_arg` on `sparc`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -1233,6 +1233,18 @@ pub(super) fn emit_va_arg<'ll, 'tcx>(
             // sparc64 is a big-endian target and stores variable arguments right-adjusted.
             ForceRightAdjust::Yes,
         ),
+        Arch::Sparc => {
+            std::assert_matches!(stability, CVariadicStatus::Unstable { .. });
+            emit_ptr_va_arg(
+                bx,
+                addr,
+                target_ty,
+                PassMode::Direct,
+                SlotSize::Bytes4,
+                AllowHigherAlign::No,
+                ForceRightAdjust::No,
+            )
+        }
         Arch::Mips | Arch::Mips32r6 | Arch::Mips64 | Arch::Mips64r6 => emit_ptr_va_arg(
             bx,
             addr,
@@ -1256,7 +1268,7 @@ pub(super) fn emit_va_arg<'ll, 'tcx>(
         Arch::Bpf => bug!("bpf does not support c-variadic functions"),
         Arch::SpirV => bug!("spirv does not support c-variadic functions"),
 
-        Arch::Sparc | Arch::Avr | Arch::M68k | Arch::Msp430 => {
+        Arch::Avr | Arch::M68k | Arch::Msp430 => {
             std::assert_matches!(stability, CVariadicStatus::Unstable { .. });
 
             // Clang uses the LLVM implementation for these architectures.

--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -1233,6 +1233,28 @@ pub(super) fn emit_va_arg<'ll, 'tcx>(
             // sparc64 is a big-endian target and stores variable arguments right-adjusted.
             ForceRightAdjust::Yes,
         ),
+        Arch::Sparc => {
+            std::assert_matches!(stability, CVariadicStatus::Unstable { .. });
+
+            // f128 is passed indirectly.
+            let pass_mode = match layout.layout.backend_repr() {
+                BackendRepr::Scalar(scalar) => match scalar.primitive() {
+                    Primitive::Float(Float::F128) => PassMode::Indirect,
+                    _ => PassMode::Direct,
+                },
+                _ => PassMode::Direct,
+            };
+
+            emit_ptr_va_arg(
+                bx,
+                addr,
+                target_ty,
+                pass_mode,
+                SlotSize::Bytes4,
+                AllowHigherAlign::No,
+                ForceRightAdjust::Yes,
+            )
+        }
         Arch::Mips | Arch::Mips32r6 | Arch::Mips64 | Arch::Mips64r6 => emit_ptr_va_arg(
             bx,
             addr,
@@ -1256,7 +1278,7 @@ pub(super) fn emit_va_arg<'ll, 'tcx>(
         Arch::Bpf => bug!("bpf does not support c-variadic functions"),
         Arch::SpirV => bug!("spirv does not support c-variadic functions"),
 
-        Arch::Sparc | Arch::Avr | Arch::M68k | Arch::Msp430 => {
+        Arch::Avr | Arch::M68k | Arch::Msp430 => {
             std::assert_matches!(stability, CVariadicStatus::Unstable { .. });
 
             // Clang uses the LLVM implementation for these architectures.

--- a/tests/assembly-llvm/c-variadic/sparc.rs
+++ b/tests/assembly-llvm/c-variadic/sparc.rs
@@ -90,14 +90,17 @@ unsafe extern "C" fn read_i64(ap: &mut VaList<'_>) -> i64 {
     // CHECK-LABEL: read_i64
     //
     // SPARC: ld [%o0], %o1
-    // SPARC-NEXT: add %o1, 4, %o2
+    // SPARC-NEXT: add %o1, 8, %o2
     // SPARC-NEXT: st %o2, [%o0]
-    // SPARC-NEXT: ld [%o1], %o2
-    // SPARC-NEXT: add %o1, 8, %o3
-    // SPARC-NEXT: st %o3, [%o0]
-    // SPARC-NEXT: ld [%o1+4], %o1
+    // SPARC-NEXT: ld [%o1+4], %o0
+    // SPARC-NEXT: add %sp, 96, %o2
+    // SPARC-NEXT: or %o2, 4, %o2
+    // SPARC-NEXT: st %o0, [%o2]
+    // SPARC-NEXT: ld [%o1], %o0
+    // SPARC-NEXT: st %o0, [%sp+96]
+    // SPARC-NEXT: ldd [%sp+96], %o0
     // SPARC-NEXT: retl
-    // SPARC-NEXT: mov %o2, %o0
+    // SPARC-NEXT: add %sp, 104, %sp
     //
     // SPARC64: ldx [%o0], %o1
     // SPARC64-NEXT: add %o1, 8, %o2

--- a/tests/run-make/c-link-to-rust-va-list-fn/checkrust.rs
+++ b/tests/run-make/c-link-to-rust-va-list-fn/checkrust.rs
@@ -1,5 +1,5 @@
 #![crate_type = "staticlib"]
-#![feature(c_variadic_int128)]
+#![feature(c_variadic_int128, c_variadic_experimental_arch)]
 
 use core::ffi::{CStr, VaList, c_char, c_double, c_int, c_long, c_longlong};
 


### PR DESCRIPTION
<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!-- homu-ignore:end -->

I've built GCC for the target and validated pretty extensively that this works. Using our helper does generate worse code for `i64` unfortunately, I've reported that as https://github.com/llvm/llvm-project/issues/214594. But, given that this is a tier-3 target etc. I don't think it makes sense to go out of our way to do better, we can just wait for LLVM to resolve that issue.