### PR TITLE
Limit compile_error! lookup suppression to its module

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics/impls.rs
+++ b/compiler/rustc_resolve/src/diagnostics/impls.rs
@@ -147,14 +147,22 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         glob_error: bool,
     ) {
         errors.retain(|(_import, err)| match err.module {
-            // Skip `use` errors for `use foo::Bar;` if `foo.rs` has unrecovered parse errors.
-            Some(def_id) if self.mods_with_parse_errors.contains(&def_id) => false,
+            // Skip `use` errors for `use foo::Bar;` if `foo` has unrecovered parse errors or
+            // contains a `compile_error!`.
+            Some(def_id)
+                if self.mods_with_parse_errors.contains(&def_id)
+                    || self.mods_with_compile_errors.contains(&def_id) =>
+            {
+                false
+            }
             // If we've encountered something like `use _;`, we've already emitted an error stating
             // that `_` is not a valid identifier, so we ignore that resolve error.
             _ => err.segment.map(|s| s.name) != Some(kw::Underscore),
         });
         if errors.is_empty() {
-            self.tcx.dcx().delayed_bug("expected a parse or \"`_` can't be an identifier\" error");
+            self.tcx.dcx().delayed_bug(
+                "expected a parse error, `compile_error!`, or \"`_` can't be an identifier\" error",
+            );
             return;
         }
 

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1777,6 +1777,25 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         res
     }
 
+    // Unlike parse errors, `compile_error!` only suppresses failures in the module containing it,
+    // not failures in modules reached from that module.
+    fn module_has_compile_error(
+        &self,
+        module: Option<ModuleOrUniformRoot<'ra>>,
+        parent_scope: &ParentScope<'ra>,
+    ) -> bool {
+        let module = match module {
+            Some(ModuleOrUniformRoot::Module(module))
+            | Some(ModuleOrUniformRoot::ModuleAndExternPrelude(module)) => module,
+            Some(ModuleOrUniformRoot::CurrentScope) | None => parent_scope.module,
+            Some(ModuleOrUniformRoot::ExternPrelude | ModuleOrUniformRoot::OpenModule(_)) => {
+                return false;
+            }
+        };
+        self.mods_with_compile_errors
+            .contains(&module.nearest_parent_mod().to_def_id())
+    }
+
     #[instrument(level = "debug", skip(self))]
     pub(crate) fn maybe_resolve_path<'r>(
         self: CmResolver<'r, 'ra, 'tcx>,
@@ -1883,11 +1902,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     let current_module = self.resolve_self(&mut ctxt, parent_scope.module);
                     let current_module_path = module_to_string(current_module)
                         .map_or_else(|| "crate".to_string(), |path| format!("crate::{path}"));
+                    let suppress_error = module_had_parse_errors
+                        || self.module_has_compile_error(module, parent_scope);
                     return PathResult::failed(
                         ident,
                         false,
                         finalize.is_some(),
-                        module_had_parse_errors,
+                        suppress_error,
                         module,
                         || {
                             (
@@ -1940,11 +1961,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
             // Report special messages for path segment keywords in wrong positions.
             if ident.is_path_segment_keyword() && segment_idx != 0 && !allow_trailing_self {
+                let suppress_error =
+                    module_had_parse_errors || self.module_has_compile_error(module, parent_scope);
                 return PathResult::failed(
                     ident,
                     false,
                     finalize.is_some(),
-                    module_had_parse_errors,
+                    suppress_error,
                     module,
                     || {
                         let name_str = if name == kw::PathRoot {
@@ -2080,11 +2103,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             path.len() - segment_idx - 1,
                         ));
                     } else {
+                        let suppress_error = module_had_parse_errors
+                            || self.module_has_compile_error(module, parent_scope);
                         return PathResult::failed(
                             ident,
                             is_last,
                             finalize.is_some(),
-                            module_had_parse_errors,
+                            suppress_error,
                             module,
                             || {
                                 let import_inherent_item_error_flag =
@@ -2147,12 +2172,14 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         ));
                     }
 
+                    let suppress_error = module_had_parse_errors
+                        || self.module_has_compile_error(module, parent_scope);
                     let mut this = self.reborrow();
                     return PathResult::failed(
                         ident,
                         is_last,
                         finalize.is_some(),
-                        module_had_parse_errors,
+                        suppress_error,
                         module,
                         || {
                             let (message, label, suggestion) =

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1534,6 +1534,7 @@ pub struct Resolver<'ra, 'tcx> {
     /// could be a crate that wasn't imported. For diagnostics use only.
     current_crate_outer_attr_insert_span: Span,
 
+    mods_with_compile_errors: FxHashSet<DefId> = default::fx_hash_set(),
     mods_with_parse_errors: FxHashSet<DefId> = default::fx_hash_set(),
 
     /// Whether `Resolver::register_macros_for_all_crates` has been called once already, as we

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -184,7 +184,7 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
         if let Some(id) = self.owners.get(&id).map(|i| i.def_id)
             && self.tcx.def_kind(id).is_module_like()
         {
-            self.mods_with_parse_errors.insert(id.to_def_id());
+            self.mods_with_compile_errors.insert(id.to_def_id());
         }
     }
 

--- a/tests/ui/macros/compile_error_macro-suppress-errors.rs
+++ b/tests/ui/macros/compile_error_macro-suppress-errors.rs
@@ -15,6 +15,9 @@ pub mod some_module {
             error: self::MissingType, //~ ERROR: cannot find type `MissingType` in module `self`
         }
     }
+
+    type Missing = inner_module::MissingType;
+    //~^ ERROR: cannot find type `MissingType` in module `inner_module`
 }
 
 pub mod another_module {

--- a/tests/ui/macros/compile_error_macro-suppress-errors.stderr
+++ b/tests/ui/macros/compile_error_macro-suppress-errors.stderr
@@ -5,7 +5,7 @@ LL |     compile_error!("Error in a module");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Error in a function
-  --> $DIR/compile_error_macro-suppress-errors.rs:23:9
+  --> $DIR/compile_error_macro-suppress-errors.rs:26:9
    |
 LL |         compile_error!("Error in a function");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |         use crate::another_module::NotExist;
    |                                    no `NotExist` in `another_module`
 
 error[E0433]: cannot find `Hello` in `another_module`
-  --> $DIR/compile_error_macro-suppress-errors.rs:37:55
+  --> $DIR/compile_error_macro-suppress-errors.rs:40:55
    |
 LL |     let _: another_module::SomeType = another_module::Hello::new();
    |                                                       ^^^^^ could not find `Hello` in `another_module`
@@ -30,19 +30,25 @@ error[E0425]: cannot find type `MissingType` in module `self`
 LL |             error: self::MissingType,
    |                          ^^^^^^^^^^^ not found in `self`
 
+error[E0425]: cannot find type `MissingType` in module `inner_module`
+  --> $DIR/compile_error_macro-suppress-errors.rs:19:34
+   |
+LL |     type Missing = inner_module::MissingType;
+   |                                  ^^^^^^^^^^^ not found in `inner_module`
+
 error[E0425]: cannot find function `some_function` in module `another_module`
-  --> $DIR/compile_error_macro-suppress-errors.rs:35:29
+  --> $DIR/compile_error_macro-suppress-errors.rs:38:29
    |
 LL |     let _ = another_module::some_function();
    |                             ^^^^^^^^^^^^^ not found in `another_module`
 
 error[E0425]: cannot find type `SomeType` in module `another_module`
-  --> $DIR/compile_error_macro-suppress-errors.rs:37:28
+  --> $DIR/compile_error_macro-suppress-errors.rs:40:28
    |
 LL |     let _: another_module::SomeType = another_module::Hello::new();
    |                            ^^^^^^^^ not found in `another_module`
 
-error: aborting due to 7 previous errors
+error: aborting due to 8 previous errors
 
 Some errors have detailed explanations: E0425, E0432, E0433.
 For more information about an error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes rust-lang/rust#155414.

Modules containing `compile_error!` are currently recorded in `mods_with_parse_errors`. Path resolution intentionally keeps parser-error suppression active after traversing a module, so a `compile_error!` in an outer module can also hide legitimate unresolved-name diagnostics after lookup enters a clean module.

Track modules containing `compile_error!` separately. Keep the existing sticky behavior for actual parser errors, but consult the compile-error set only for the module where lookup fails. Unresolved imports remain suppressed when their target module itself contains `compile_error!`.

Extend the existing UI test with a lookup that starts in a marked module and fails in a clean nested module.

Testing: `git diff --check` and clean patch application succeeded. The full `./x test tests/ui/macros/compile_error_macro-suppress-errors.rs` run was not available because the supplied bundle omits the bootstrap/compiler harness and originally omitted the UI test source and stderr fixture; those fixtures were reconstructed from the supplied Git index.