### PR TITLE
bootstrap: Remove `PATH_REMAP` from command-line selector handling 

### DIFF
--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -109,7 +109,10 @@ impl CommandLineStep for Profile {
 
     fn should_run(mut run: ShouldRun<'_>) -> ShouldRun<'_> {
         for choice in Profile::all() {
-            run = run.alias(choice.as_str());
+            // Some of the profile names happen to coincide with actual directory names
+            // ("compiler" and "library"), so avoid the usual assertion that aliases
+            // don't exist on disk.
+            run = run.alias_without_assert(choice.as_str());
         }
         run
     }

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -1107,8 +1107,11 @@ impl CommandLineStep for RustAnalyzerProcMacroSrv {
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         // Allow building `rust-analyzer-proc-macro-srv` both as part of the `rust-analyzer` and as a stand-alone tool.
-        run.path("src/tools/rust-analyzer")
-            .path("src/tools/rust-analyzer/crates/proc-macro-srv-cli")
+        // FIXME(Zalathar): Should we stop registering "src/tools/rust-analyzer" here?
+        run.path("src/tools/rust-analyzer").path_with_alias(
+            "src/tools/rust-analyzer/crates/proc-macro-srv-cli",
+            "rust-analyzer-proc-macro-srv",
+        )
     }
 
     fn is_default_step(builder: &Builder<'_>) -> bool {

--- a/src/bootstrap/src/core/builder/cli_paths.rs
+++ b/src/bootstrap/src/core/builder/cli_paths.rs
@@ -10,63 +10,6 @@ use crate::core::builder::{Builder, CommandLineStepDescription, Kind, PathSet, S
 #[cfg(test)]
 mod tests;
 
-pub(crate) const PATH_REMAP: &[(&str, &[&str])] = &[
-    // bootstrap.toml uses `rust-analyzer-proc-macro-srv`, but the
-    // actual path is `proc-macro-srv-cli`
-    ("rust-analyzer-proc-macro-srv", &["src/tools/rust-analyzer/crates/proc-macro-srv-cli"]),
-    // Make `x test tests` function the same as `x t tests/*`
-    (
-        "tests",
-        &[
-            // tidy-alphabetical-start
-            "tests/assembly-llvm",
-            "tests/build-std",
-            "tests/codegen-llvm",
-            "tests/codegen-units",
-            "tests/coverage",
-            "tests/coverage-run-rustdoc",
-            "tests/crashes",
-            "tests/debuginfo",
-            "tests/incremental",
-            "tests/mir-opt",
-            "tests/pretty",
-            "tests/run-make",
-            "tests/run-make-cargo",
-            "tests/rustdoc-gui",
-            "tests/rustdoc-html",
-            "tests/rustdoc-js",
-            "tests/rustdoc-js-std",
-            "tests/rustdoc-json",
-            "tests/rustdoc-ui",
-            "tests/ui",
-            "tests/ui-fulldeps",
-            // tidy-alphabetical-end
-        ],
-    ),
-];
-
-pub(crate) fn remap_paths(paths: &mut Vec<PathBuf>) {
-    let mut remove = vec![];
-    let mut add = vec![];
-    for (i, path) in paths.iter().enumerate().filter_map(|(i, path)| path.to_str().map(|s| (i, s)))
-    {
-        for &(search, replace) in PATH_REMAP {
-            // Remove leading and trailing slashes so `tests/` and `tests` are equivalent
-            if path.trim_matches(std::path::is_separator) == search {
-                remove.push(i);
-                add.extend(replace.iter().map(PathBuf::from));
-                break;
-            }
-        }
-    }
-    remove.sort();
-    remove.dedup();
-    for idx in remove.into_iter().rev() {
-        paths.remove(idx);
-    }
-    paths.append(&mut add);
-}
-
 #[derive(Clone, PartialEq)]
 pub(crate) struct CLIStepPath {
     pub(crate) path: PathBuf,
@@ -164,8 +107,6 @@ pub(crate) fn match_paths_to_steps_and_run(
             }
         })
         .collect();
-
-    remap_paths(&mut paths);
 
     // Handle all test suite paths.
     // (This is separate from the loop below to avoid having to handle multiple paths in `is_suite_path` somehow.)

--- a/src/bootstrap/src/core/builder/cli_paths.rs
+++ b/src/bootstrap/src/core/builder/cli_paths.rs
@@ -106,10 +106,7 @@ pub(crate) fn match_paths_to_steps_and_run(
     // paths to match it against.
     let steps = step_descs
         .iter()
-        .map(|desc| StepExtra {
-            desc,
-            should_run: (desc.should_run)(ShouldRun::new(builder, desc.kind)),
-        })
+        .map(|desc| StepExtra { desc, should_run: (desc.should_run)(ShouldRun::new(builder)) })
         .collect::<Vec<_>>();
 
     // FIXME(Zalathar): This particular check isn't related to path-to-step

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_proc_macro_srv_cli.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_proc_macro_srv_cli.snap
@@ -1,0 +1,7 @@
+---
+source: src/bootstrap/src/core/builder/cli_paths/tests.rs
+expression: build proc-macro-srv-cli
+---
+[Build] tool::RustAnalyzerProcMacroSrv
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({src/tools/rust-analyzer/crates/proc-macro-srv-cli})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_proc_macro_srv_cli.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_proc_macro_srv_cli.snap
@@ -4,4 +4,4 @@ expression: build proc-macro-srv-cli
 ---
 [Build] tool::RustAnalyzerProcMacroSrv
     targets: [x86_64-unknown-linux-gnu]
-    - Set({src/tools/rust-analyzer/crates/proc-macro-srv-cli})
+    - Set({rust-analyzer-proc-macro-srv, src/tools/rust-analyzer/crates/proc-macro-srv-cli})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_rust_analyzer.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_rust_analyzer.snap
@@ -1,0 +1,10 @@
+---
+source: src/bootstrap/src/core/builder/cli_paths/tests.rs
+expression: build rust-analyzer
+---
+[Build] tool::RustAnalyzer
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({src/tools/rust-analyzer})
+[Build] tool::RustAnalyzerProcMacroSrv
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({src/tools/rust-analyzer})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_rust_analyzer_proc_macro_srv.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_rust_analyzer_proc_macro_srv.snap
@@ -1,0 +1,7 @@
+---
+source: src/bootstrap/src/core/builder/cli_paths/tests.rs
+expression: build rust-analyzer-proc-macro-srv
+---
+[Build] tool::RustAnalyzerProcMacroSrv
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({src/tools/rust-analyzer/crates/proc-macro-srv-cli})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_rust_analyzer_proc_macro_srv.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_rust_analyzer_proc_macro_srv.snap
@@ -4,4 +4,4 @@ expression: build rust-analyzer-proc-macro-srv
 ---
 [Build] tool::RustAnalyzerProcMacroSrv
     targets: [x86_64-unknown-linux-gnu]
-    - Set({src/tools/rust-analyzer/crates/proc-macro-srv-cli})
+    - Set({rust-analyzer-proc-macro-srv, src/tools/rust-analyzer/crates/proc-macro-srv-cli})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_rust_analyzer_proc_macro_srv_plus_full_path.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_rust_analyzer_proc_macro_srv_plus_full_path.snap
@@ -4,4 +4,4 @@ expression: build rust-analyzer-proc-macro-srv src/tools/rust-analyzer/crates/pr
 ---
 [Build] tool::RustAnalyzerProcMacroSrv
     targets: [x86_64-unknown-linux-gnu]
-    - Set({src/tools/rust-analyzer/crates/proc-macro-srv-cli})
+    - Set({rust-analyzer-proc-macro-srv, src/tools/rust-analyzer/crates/proc-macro-srv-cli})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_rust_analyzer_proc_macro_srv_plus_full_path.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_rust_analyzer_proc_macro_srv_plus_full_path.snap
@@ -1,0 +1,7 @@
+---
+source: src/bootstrap/src/core/builder/cli_paths/tests.rs
+expression: build rust-analyzer-proc-macro-srv src/tools/rust-analyzer/crates/proc-macro-srv-cli
+---
+[Build] tool::RustAnalyzerProcMacroSrv
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({src/tools/rust-analyzer/crates/proc-macro-srv-cli})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_src_tools_rust_analyzer.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_src_tools_rust_analyzer.snap
@@ -1,0 +1,11 @@
+---
+source: src/bootstrap/src/core/builder/cli_paths/tests.rs
+expression: build src/tools/rust-analyzer
+---
+[Build] tool::RustAnalyzer
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({src/tools/rust-analyzer})
+[Build] tool::RustAnalyzerProcMacroSrv
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({src/tools/rust-analyzer})
+    - Set({src/tools/rust-analyzer/crates/proc-macro-srv-cli})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_src_tools_rust_analyzer.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_src_tools_rust_analyzer.snap
@@ -7,5 +7,5 @@ expression: build src/tools/rust-analyzer
     - Set({src/tools/rust-analyzer})
 [Build] tool::RustAnalyzerProcMacroSrv
     targets: [x86_64-unknown-linux-gnu]
+    - Set({rust-analyzer-proc-macro-srv, src/tools/rust-analyzer/crates/proc-macro-srv-cli})
     - Set({src/tools/rust-analyzer})
-    - Set({src/tools/rust-analyzer/crates/proc-macro-srv-cli})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_src_tools_rust_analyzer_crates_proc_macro_srv_cli.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_src_tools_rust_analyzer_crates_proc_macro_srv_cli.snap
@@ -1,0 +1,7 @@
+---
+source: src/bootstrap/src/core/builder/cli_paths/tests.rs
+expression: build src/tools/rust-analyzer/crates/proc-macro-srv-cli
+---
+[Build] tool::RustAnalyzerProcMacroSrv
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({src/tools/rust-analyzer/crates/proc-macro-srv-cli})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_src_tools_rust_analyzer_crates_proc_macro_srv_cli.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_src_tools_rust_analyzer_crates_proc_macro_srv_cli.snap
@@ -4,4 +4,4 @@ expression: build src/tools/rust-analyzer/crates/proc-macro-srv-cli
 ---
 [Build] tool::RustAnalyzerProcMacroSrv
     targets: [x86_64-unknown-linux-gnu]
-    - Set({src/tools/rust-analyzer/crates/proc-macro-srv-cli})
+    - Set({rust-analyzer-proc-macro-srv, src/tools/rust-analyzer/crates/proc-macro-srv-cli})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_tests.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_tests.snap
@@ -2,66 +2,69 @@
 source: src/bootstrap/src/core/builder/cli_paths/tests.rs
 expression: test tests
 ---
-[Test] test::AssemblyLlvm
+[Test] test::Ui
     targets: [aarch64-unknown-linux-gnu]
-    - Suite(tests/assembly-llvm)
-[Test] test::BuildStd
+    - Suite(tests/ui)
+[Test] test::Crashes
     targets: [aarch64-unknown-linux-gnu]
-    - Suite(tests/build-std)
+    - Suite(tests/crashes)
+[Test] test::Coverage
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(tests/coverage)
+[Test] test::MirOpt
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(tests/mir-opt)
 [Test] test::CodegenLlvm
     targets: [aarch64-unknown-linux-gnu]
     - Suite(tests/codegen-llvm)
 [Test] test::CodegenUnits
     targets: [aarch64-unknown-linux-gnu]
     - Suite(tests/codegen-units)
-[Test] test::Coverage
+[Test] test::AssemblyLlvm
     targets: [aarch64-unknown-linux-gnu]
-    - Suite(tests/coverage)
-[Test] test::CoverageRunRustdoc
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/coverage-run-rustdoc)
-[Test] test::Crashes
-    targets: [aarch64-unknown-linux-gnu]
-    - Suite(tests/crashes)
-[Test] test::Debuginfo
-    targets: [aarch64-unknown-linux-gnu]
-    - Suite(tests/debuginfo)
+    - Suite(tests/assembly-llvm)
 [Test] test::Incremental
     targets: [aarch64-unknown-linux-gnu]
     - Suite(tests/incremental)
-[Test] test::MirOpt
+[Test] test::Debuginfo
     targets: [aarch64-unknown-linux-gnu]
-    - Suite(tests/mir-opt)
+    - Suite(tests/debuginfo)
+[Test] test::UiFullDeps
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/ui-fulldeps)
+[Test] test::RustdocHtml
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/rustdoc-html)
+[Test] test::CoverageRunRustdoc
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/coverage-run-rustdoc)
 [Test] test::Pretty
     targets: [x86_64-unknown-linux-gnu]
     - Suite(tests/pretty)
+[Test] test::Clippy
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(src/tools/clippy/tests)
+[Test] test::RustdocJSStd
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/rustdoc-js-std)
+[Test] test::RustdocJSNotStd
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/rustdoc-js)
+[Test] test::RustdocGUI
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/rustdoc-gui)
+[Test] test::RustdocUi
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/rustdoc-ui)
+[Test] test::RustdocJson
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/rustdoc-json)
 [Test] test::RunMake
     targets: [aarch64-unknown-linux-gnu]
     - Suite(tests/run-make)
 [Test] test::RunMakeCargo
     targets: [aarch64-unknown-linux-gnu]
     - Suite(tests/run-make-cargo)
-[Test] test::RustdocGUI
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/rustdoc-gui)
-[Test] test::RustdocHtml
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/rustdoc-html)
-[Test] test::RustdocJSNotStd
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/rustdoc-js)
-[Test] test::RustdocJSStd
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/rustdoc-js-std)
-[Test] test::RustdocJson
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/rustdoc-json)
-[Test] test::RustdocUi
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/rustdoc-ui)
-[Test] test::Ui
+[Test] test::BuildStd
     targets: [aarch64-unknown-linux-gnu]
-    - Suite(tests/ui)
-[Test] test::UiFullDeps
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/ui-fulldeps)
+    - Suite(tests/build-std)

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_tests_skip_coverage.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_tests_skip_coverage.snap
@@ -2,63 +2,66 @@
 source: src/bootstrap/src/core/builder/cli_paths/tests.rs
 expression: test tests --skip=coverage
 ---
-[Test] test::AssemblyLlvm
+[Test] test::Ui
     targets: [aarch64-unknown-linux-gnu]
-    - Suite(tests/assembly-llvm)
-[Test] test::BuildStd
+    - Suite(tests/ui)
+[Test] test::Crashes
     targets: [aarch64-unknown-linux-gnu]
-    - Suite(tests/build-std)
+    - Suite(tests/crashes)
+[Test] test::MirOpt
+    targets: [aarch64-unknown-linux-gnu]
+    - Suite(tests/mir-opt)
 [Test] test::CodegenLlvm
     targets: [aarch64-unknown-linux-gnu]
     - Suite(tests/codegen-llvm)
 [Test] test::CodegenUnits
     targets: [aarch64-unknown-linux-gnu]
     - Suite(tests/codegen-units)
-[Test] test::CoverageRunRustdoc
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/coverage-run-rustdoc)
-[Test] test::Crashes
+[Test] test::AssemblyLlvm
     targets: [aarch64-unknown-linux-gnu]
-    - Suite(tests/crashes)
-[Test] test::Debuginfo
-    targets: [aarch64-unknown-linux-gnu]
-    - Suite(tests/debuginfo)
+    - Suite(tests/assembly-llvm)
 [Test] test::Incremental
     targets: [aarch64-unknown-linux-gnu]
     - Suite(tests/incremental)
-[Test] test::MirOpt
+[Test] test::Debuginfo
     targets: [aarch64-unknown-linux-gnu]
-    - Suite(tests/mir-opt)
+    - Suite(tests/debuginfo)
+[Test] test::UiFullDeps
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/ui-fulldeps)
+[Test] test::RustdocHtml
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/rustdoc-html)
+[Test] test::CoverageRunRustdoc
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/coverage-run-rustdoc)
 [Test] test::Pretty
     targets: [x86_64-unknown-linux-gnu]
     - Suite(tests/pretty)
+[Test] test::Clippy
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(src/tools/clippy/tests)
+[Test] test::RustdocJSStd
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/rustdoc-js-std)
+[Test] test::RustdocJSNotStd
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/rustdoc-js)
+[Test] test::RustdocGUI
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/rustdoc-gui)
+[Test] test::RustdocUi
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/rustdoc-ui)
+[Test] test::RustdocJson
+    targets: [x86_64-unknown-linux-gnu]
+    - Suite(tests/rustdoc-json)
 [Test] test::RunMake
     targets: [aarch64-unknown-linux-gnu]
     - Suite(tests/run-make)
 [Test] test::RunMakeCargo
     targets: [aarch64-unknown-linux-gnu]
     - Suite(tests/run-make-cargo)
-[Test] test::RustdocGUI
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/rustdoc-gui)
-[Test] test::RustdocHtml
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/rustdoc-html)
-[Test] test::RustdocJSNotStd
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/rustdoc-js)
-[Test] test::RustdocJSStd
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/rustdoc-js-std)
-[Test] test::RustdocJson
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/rustdoc-json)
-[Test] test::RustdocUi
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/rustdoc-ui)
-[Test] test::Ui
+[Test] test::BuildStd
     targets: [aarch64-unknown-linux-gnu]
-    - Suite(tests/ui)
-[Test] test::UiFullDeps
-    targets: [x86_64-unknown-linux-gnu]
-    - Suite(tests/ui-fulldeps)
+    - Suite(tests/build-std)

--- a/src/bootstrap/src/core/builder/cli_paths/tests.rs
+++ b/src/bootstrap/src/core/builder/cli_paths/tests.rs
@@ -135,9 +135,21 @@ declare_tests!(
     (x_build_compiletest, "build compiletest"),
     (x_build_library, "build library"),
     (x_build_llvm, "build llvm"),
+    (x_build_proc_macro_srv_cli, "build proc-macro-srv-cli"),
+    (x_build_rust_analyzer, "build rust-analyzer"),
+    (x_build_rust_analyzer_proc_macro_srv, "build rust-analyzer-proc-macro-srv"),
+    (
+        x_build_rust_analyzer_proc_macro_srv_plus_full_path,
+        "build rust-analyzer-proc-macro-srv src/tools/rust-analyzer/crates/proc-macro-srv-cli"
+    ),
     (x_build_rustc, "build rustc"),
     (x_build_rustc_llvm, "build rustc_llvm"),
     (x_build_rustdoc, "build rustdoc"),
+    (x_build_src_tools_rust_analyzer, "build src/tools/rust-analyzer"),
+    (
+        x_build_src_tools_rust_analyzer_crates_proc_macro_srv_cli,
+        "build src/tools/rust-analyzer/crates/proc-macro-srv-cli"
+    ),
     (x_build_sysroot, "build sysroot"),
     (x_check, "check"),
     (x_check_bootstrap, "check bootstrap"),

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
-use std::{env, fs};
+use std::{env, fs, iter};
 
 use clap::ValueEnum;
 #[cfg(feature = "tracing")]
@@ -355,6 +355,9 @@ struct CommandLineStepDescription {
     is_default_step_fn: fn(&Builder<'_>) -> bool,
     make_run: fn(RunConfig<'_>),
     name: &'static str,
+
+    /// Kind that was passed to [`CommandLineStepDescription::from`].
+    #[cfg_attr(not(test), expect(dead_code, reason = "currently only needed by tests"))]
     kind: Kind,
 }
 
@@ -520,15 +523,14 @@ impl CommandLineStepDescription {
 /// correspond to.
 pub struct ShouldRun<'a> {
     pub builder: &'a Builder<'a>,
-    kind: Kind,
 
     // use a BTreeSet to maintain sort order
     paths: BTreeSet<PathSet>,
 }
 
 impl<'a> ShouldRun<'a> {
-    fn new(builder: &'a Builder<'_>, kind: Kind) -> ShouldRun<'a> {
-        ShouldRun { builder, kind, paths: BTreeSet::new() }
+    fn new(builder: &'a Builder<'_>) -> ShouldRun<'a> {
+        ShouldRun { builder, paths: BTreeSet::new() }
     }
 
     /// The corresponding step should run if the bootstrap command-line selects
@@ -562,16 +564,25 @@ impl<'a> ShouldRun<'a> {
     }
 
     // single alias, which does not correspond to any on-disk path
-    pub fn alias(mut self, alias: &str) -> Self {
-        // exceptional case for `Kind::Setup` because its `library`
-        // and `compiler` options would otherwise naively match with
-        // `compiler` and `library` folders respectively.
+    pub fn alias(self, alias: &str) -> Self {
+        self.assert_valid_alias(alias);
+        self.alias_without_assert(alias)
+    }
+
+    /// Like [`Self::alias`], but does not assert the absence of a path with the same name.
+    ///
+    /// Needed by [`setup::Profile`], which registers aliases named `compiler` and `library`
+    /// that happen to coincide with directory names.
+    pub fn alias_without_assert(mut self, alias: &str) -> Self {
+        self.paths.insert(PathSet::Set(iter::once(TaskPath { path: alias.into() }).collect()));
+        self
+    }
+
+    fn assert_valid_alias(&self, alias: &str) {
         assert!(
-            self.kind == Kind::Setup || !self.builder.src.join(alias).exists(),
+            !self.builder.src.join(alias).exists(),
             "use `builder.path()` for real paths: {alias}"
         );
-        self.paths.insert(PathSet::Set(std::iter::once(TaskPath { path: alias.into() }).collect()));
-        self
     }
 
     fn assert_valid_path(&self, path: &str) {
@@ -1061,11 +1072,9 @@ impl<'a> Builder<'a> {
 
         let builder = Self::new_internal(build, kind, vec![]);
         let builder = &builder;
-        // The "build" kind here is just a placeholder, it will be replaced with something else in
-        // the following statement.
-        let mut should_run = ShouldRun::new(builder, Kind::Build);
+
+        let mut should_run = ShouldRun::new(builder);
         for desc in step_descriptions {
-            should_run.kind = desc.kind;
             should_run = (desc.should_run)(should_run);
         }
         let mut help = String::from("Available paths:\n");
@@ -1148,7 +1157,7 @@ impl<'a> Builder<'a> {
                 continue;
             }
 
-            let should_run = (desc.should_run)(ShouldRun::new(self, Kind::Doc));
+            let should_run = (desc.should_run)(ShouldRun::new(self));
             let default_pathsets = should_run.default_pathsets();
 
             let targets = if desc.is_host { &self.hosts } else { &self.targets };
@@ -1686,7 +1695,7 @@ Alternatively, you can set `build.local-rebuild=true` and use a stage0 compiler 
         kind: Kind,
     ) -> Option<S::Output> {
         let desc = CommandLineStepDescription::from::<S>(kind);
-        let should_run = (desc.should_run)(ShouldRun::new(self, desc.kind));
+        let should_run = (desc.should_run)(ShouldRun::new(self));
 
         // Avoid running steps contained in --skip
         for pathset in &should_run.paths {
@@ -1702,7 +1711,7 @@ Alternatively, you can set `build.local-rebuild=true` and use a stage0 compiler 
     /// Checks if any of the "should_run" paths is in the `Builder` paths.
     pub(crate) fn was_invoked_explicitly<S: CommandLineStep>(&'a self, kind: Kind) -> bool {
         let desc = CommandLineStepDescription::from::<S>(kind);
-        let should_run = (desc.should_run)(ShouldRun::new(self, desc.kind));
+        let should_run = (desc.should_run)(ShouldRun::new(self));
 
         for path in &self.paths {
             if should_run.paths.iter().any(|s| s.has(path))

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -609,6 +609,19 @@ impl<'a> ShouldRun<'a> {
         self
     }
 
+    /// Registers a path, and an alias that is treated as equivalent to that path.
+    pub fn path_with_alias(mut self, path: &str, alias: &str) -> Self {
+        self.assert_valid_path(path);
+        self.assert_valid_alias(alias);
+
+        let set = [path, alias]
+            .into_iter()
+            .map(|p| TaskPath { path: PathBuf::from(p) })
+            .collect::<BTreeSet<_>>();
+        self.paths.insert(PathSet::Set(set));
+        self
+    }
+
     /// Multiple on-disk paths that should select the same unit of work.
     pub fn multi_path(mut self, paths: &[&str]) -> Self {
         let mut set = BTreeSet::new();

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -5,7 +5,6 @@ use build_helper::stage0_parser::parse_stage0_file;
 use llvm::prebuilt_llvm_config;
 
 use super::*;
-use crate::core::builder::cli_paths::PATH_REMAP;
 use crate::core::config::Config;
 use crate::utils::cache::ExecutedStep;
 use crate::utils::helpers::get_host_target;
@@ -48,43 +47,6 @@ fn test_valid() {
 fn test_invalid() {
     // make sure that invalid paths are caught, even when combined with valid paths
     check_cli(["test", "library/std", "x"]);
-}
-
-#[test]
-fn validate_path_remap() {
-    let build = Build::new(configure("test", &[TEST_TRIPLE_1], &[TEST_TRIPLE_1]));
-
-    PATH_REMAP
-        .iter()
-        .flat_map(|(_, paths)| paths.iter())
-        .map(|path| build.src.join(path))
-        .for_each(|path| {
-            assert!(path.exists(), "{} should exist.", path.display());
-        });
-}
-
-#[test]
-fn check_missing_paths_for_x_test_tests() {
-    let build = Build::new(configure("test", &[TEST_TRIPLE_1], &[TEST_TRIPLE_1]));
-
-    let (_, tests_remap_paths) =
-        PATH_REMAP.iter().find(|(target_path, _)| *target_path == "tests").unwrap();
-
-    let tests_dir = fs::read_dir(build.src.join("tests")).unwrap();
-    for dir in tests_dir {
-        let path = dir.unwrap().path();
-
-        // Skip if not a test directory.
-        if path.ends_with("tests/auxiliary") || !path.is_dir() {
-            continue;
-        }
-
-        assert!(
-            tests_remap_paths.iter().any(|item| path.ends_with(*item)),
-            "{} is missing in PATH_REMAP tests list.",
-            path.display()
-        );
-    }
 }
 
 #[test]


### PR DESCRIPTION
Remapping of "rust-analyzer-proc-macro-srv" can be avoided by registering it as an alias attached to the real path.

Remapping of "test" is not necessary at all, since `./x test tests` naturally selects all of the test suites in `tests`.

(This changes the order of steps listed in the relevant snapshot tests, but the set of steps is unchanged.)

---

The removal of `ShouldRun::kind` is not essential to this PR, but I included it because it would have conflicted with changes to ShouldRun's alias-related methods.