### PR TITLE
Add regression test for unknown feaeture name reported with other errors

### DIFF
--- a/tests/ui/feature-gates/unknown-feature-with-other-errors-58390.rs
+++ b/tests/ui/feature-gates/unknown-feature-with-other-errors-58390.rs
@@ -1,0 +1,16 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/58390>.
+//!
+//! An unknown `#![feature(..)]` name used to be silently ignored whenever the crate had any
+//! other error, because the check only ran during stability checking. Both errors must be
+//! reported.
+
+#![feature(this_feature_does_not_exist)] //~ ERROR unknown feature `this_feature_does_not_exist`
+
+struct Foo;
+
+trait Bar {}
+
+impl Bar for Foo {}
+impl Bar for Foo {} //~ ERROR conflicting implementations of trait `Bar` for type `Foo`
+
+fn main() {}

--- a/tests/ui/feature-gates/unknown-feature-with-other-errors-58390.stderr
+++ b/tests/ui/feature-gates/unknown-feature-with-other-errors-58390.stderr
@@ -1,0 +1,18 @@
+error[E0635]: unknown feature `this_feature_does_not_exist`
+  --> $DIR/unknown-feature-with-other-errors-58390.rs:7:12
+   |
+LL | #![feature(this_feature_does_not_exist)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0119]: conflicting implementations of trait `Bar` for type `Foo`
+  --> $DIR/unknown-feature-with-other-errors-58390.rs:14:1
+   |
+LL | impl Bar for Foo {}
+   | ---------------- first implementation here
+LL | impl Bar for Foo {}
+   | ^^^^^^^^^^^^^^^^ conflicting implementation for `Foo`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0119, E0635.
+For more information about an error, try `rustc --explain E0119`.


### PR DESCRIPTION
Closes rust-lang/rust#58390 adds a regression test for unknown feature error fires even when a error aborts compilation first