### PR TITLE
Experiment: Add `core::cmp::smallest` and `core::cmp::largest`

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1873,6 +1873,214 @@ where
     if f(&v2) < f(&v1) { [v2, v1] } else { [v1, v2] }
 }
 
+/// Calls `mac` on lists of arguments from size `0` to `1 + count($y)`.
+macro impl_for_tuples_up_to($mac:ident! { $($x:ident, $($y:ident,)*)? }) {
+    $(impl_for_tuples_up_to! {
+        $mac! { $($y,)* }
+    })?
+    $mac! { $($x, $($y,)*)? }
+}
+
+/// Calls each `mac` on lists of arguments from size zero to twelve.
+macro impl_tuples($($mac:ident,)+) {
+    $(impl_for_tuples_up_to! { $mac! { x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, } })+
+}
+
+/// Implementation detail for [`smallest`] and [`largest`].
+/// Marker indicating that `Self` is a tuple where all members are of the same type.
+#[diagnostic::on_unimplemented(message = "`{Self}` is not a homogeneous tuple")]
+#[unstable(feature = "cmp_splat_internals", issue = "160728")]
+#[rustc_const_unstable(feature = "cmp_splat_internals", issue = "160728")]
+const trait HomogeneousTuple: crate::marker::Tuple {
+    /// The type of each item in this tuple.
+    type Item;
+}
+
+/// Implements [`HomogeneousTuple`] for a provided tuple.
+macro impl_homogeneous_tuple($($($x:ident,)+)?) {
+    $(
+        #[unstable(feature = "cmp_splat_internals", issue = "160728")]
+        #[rustc_const_unstable(feature = "cmp_splat_internals", issue = "160728")]
+        const impl<T> HomogeneousTuple for ($(${ignore($x)}T,)+) {
+            type Item = T;
+        }
+    )?
+}
+
+impl_tuples! {
+    impl_homogeneous_tuple,
+}
+
+/// Compares and returns the minimum of the provided values.
+///
+/// Returns the first argument if the comparison determines them to be equal.
+///
+/// Internally uses [`Ord::min`].
+///
+/// # Examples
+///
+/// ```
+/// #![feature(cmp_splat)]
+/// use std::cmp;
+///
+/// assert_eq!(cmp::smallest(1), 1);
+/// assert_eq!(cmp::smallest(1, 2), 1);
+/// assert_eq!(cmp::smallest(3, 2, 1), 1);
+/// assert_eq!(cmp::smallest(1, 2, 3, 4), 1);
+/// ```
+/// ```
+/// #![feature(cmp_splat)]
+/// use std::cmp::{self, Ordering};
+///
+/// #[derive(Eq)]
+/// struct Equal(&'static str);
+///
+/// impl PartialEq for Equal {
+///     fn eq(&self, other: &Self) -> bool { true }
+/// }
+/// impl PartialOrd for Equal {
+///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(Ordering::Equal) }
+/// }
+/// impl Ord for Equal {
+///     fn cmp(&self, other: &Self) -> Ordering { Ordering::Equal }
+/// }
+///
+/// assert_eq!(cmp::smallest(Equal("v1"), Equal("v2")).0, "v1");
+/// ```
+///
+/// # Stability
+///
+/// This function is added in its current form as an experiment in variadic functions.
+/// In a future iteration of the feature, this function may be removed in favour of
+/// making [`min`] itself variadic instead.
+#[inline]
+#[must_use]
+#[unstable(feature = "cmp_splat", issue = "160728")]
+#[rustc_const_unstable(feature = "cmp_splat", issue = "160728")]
+#[expect(private_bounds, reason = "`SmallestArgs` is an internal implementation detail")]
+#[cfg(not(test))] // FIXME: splat interacts poorly with the double linking of `core` in tests
+pub const fn smallest<T: [const] Ord + [const] Destruct>(
+    #[rustc_splat] args: impl [const] SmallestArgs<Item = T>,
+) -> T {
+    SmallestArgs::smallest(args)
+}
+
+/// Implementation detail for [`smallest`].
+#[diagnostic::on_unimplemented(message = "`{Self}` is not a valid set of arguments for `smallest`")]
+#[unstable(feature = "cmp_splat_internals", issue = "160728")]
+#[rustc_const_unstable(feature = "cmp_splat_internals", issue = "160728")]
+const trait SmallestArgs: HomogeneousTuple {
+    /// Reduces all elements of a homogeneous tuple to its smallest value.
+    fn smallest(self) -> Self::Item;
+}
+
+/// Implements [`SmallestArgs`] for a provided tuple if applicable.
+macro impl_smallest_args($($x:ident, $($($y:ident,)+)?)?) {
+    $(
+        #[unstable(feature = "cmp_splat_internals", issue = "160728")]
+        #[rustc_const_unstable(feature = "cmp_splat_internals", issue = "160728")]
+        const impl<T> SmallestArgs for (T, $($(${ignore($y)}T,)+)?)
+        $(where T: [const] Destruct + [const] Ord, $(${ignore($y)})+)?
+        {
+            #[inline]
+            fn smallest(self) -> Self::Item {
+                let ($x, $($($y,)+)?) = self;
+                $($(let $x = $x.min($y);)+)?
+                $x
+            }
+        }
+    )?
+}
+
+impl_tuples! {
+    impl_smallest_args,
+}
+
+/// Compares and returns the maximum of the provided values.
+///
+/// Returns the last argument if the comparison determines them to be equal.
+///
+/// Internally uses [`Ord::max`].
+///
+/// # Examples
+///
+/// ```
+/// #![feature(cmp_splat)]
+/// use std::cmp;
+///
+/// assert_eq!(cmp::largest(1), 1);
+/// assert_eq!(cmp::largest(1, 2), 2);
+/// assert_eq!(cmp::largest(3, 2, 1), 3);
+/// assert_eq!(cmp::largest(1, 2, 3, 4), 4);
+/// ```
+/// ```
+/// #![feature(cmp_splat)]
+/// use std::cmp::{self, Ordering};
+///
+/// #[derive(Eq)]
+/// struct Equal(&'static str);
+///
+/// impl PartialEq for Equal {
+///     fn eq(&self, other: &Self) -> bool { true }
+/// }
+/// impl PartialOrd for Equal {
+///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(Ordering::Equal) }
+/// }
+/// impl Ord for Equal {
+///     fn cmp(&self, other: &Self) -> Ordering { Ordering::Equal }
+/// }
+///
+/// assert_eq!(cmp::largest(Equal("v1"), Equal("v2")).0, "v2");
+/// ```
+///
+/// # Stability
+///
+/// This function is added in its current form as an experiment in variadic functions.
+/// In a future iteration of the feature, this function may be removed in favour of
+/// making [`max`] itself variadic instead.
+#[inline]
+#[must_use]
+#[unstable(feature = "cmp_splat", issue = "160728")]
+#[rustc_const_unstable(feature = "cmp_splat", issue = "160728")]
+#[expect(private_bounds, reason = "`LargestArgs` is an internal implementation detail")]
+#[cfg(not(test))] // FIXME: splat interacts poorly with the double linking of `core` in tests
+pub const fn largest<T: [const] Ord + [const] Destruct>(
+    #[rustc_splat] args: impl [const] LargestArgs<Item = T>,
+) -> T {
+    LargestArgs::largest(args)
+}
+
+/// Implementation detail for [`largest`].
+#[diagnostic::on_unimplemented(message = "`{Self}` is not a valid set of arguments for `largest`")]
+#[unstable(feature = "cmp_splat_internals", issue = "160728")]
+#[rustc_const_unstable(feature = "cmp_splat_internals", issue = "160728")]
+const trait LargestArgs: HomogeneousTuple {
+    /// Reduces all elements of a homogeneous tuple to its largest value.
+    fn largest(self) -> Self::Item;
+}
+
+/// Implements [`LargestArgs`] for a provided tuple if applicable.
+macro impl_largest_args($($x:ident, $($($y:ident,)+)?)?) {
+    $(
+        #[unstable(feature = "cmp_splat_internals", issue = "160728")]
+        #[rustc_const_unstable(feature = "cmp_splat_internals", issue = "160728")]
+        const impl<T> LargestArgs for (T, $($(${ignore($y)}T,)+)?)
+        $(where T: [const] Destruct + [const] Ord, $(${ignore($y)})+)?
+        {
+            #[inline]
+            fn largest(self) -> Self::Item {
+                let ($x, $($($y,)+)?) = self;
+                $($(let $x = $x.max($y);)+)?
+                $x
+            }
+        }
+    )?
+}
+
+impl_tuples! {
+    impl_largest_args,
+}
+
 // Implementation of PartialEq, Eq, PartialOrd and Ord for primitive types
 mod impls {
     use crate::cmp::Ordering::{self, Equal, Greater, Less};

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1938,6 +1938,12 @@ impl_tuple!(a0:T, a1:T, a2:T, a3:T, a4:T, a5:T, a6:T, a7:T, a8:T, a9:T, a10:T, a
 ///
 /// assert_eq!(cmp::smallest(Equal("v1"), Equal("v2")).0, "v1");
 /// ```
+///
+/// # Stability
+///
+/// This function is added in its current form as an experiment in variadic functions.
+/// In a future iteration of the feature, this function may be removed in favour of
+/// making [`min`] itself variadic instead.
 #[inline]
 #[must_use]
 #[unstable(feature = "cmp_splat", issue = "160728")]
@@ -1982,6 +1988,12 @@ pub const fn smallest<T: [const] Ord + [const] Destruct>(
 ///
 /// assert_eq!(cmp::largest(Equal("v1"), Equal("v2")).0, "v2");
 /// ```
+///
+/// # Stability
+///
+/// This function is added in its current form as an experiment in variadic functions.
+/// In a future iteration of the feature, this function may be removed in favour of
+/// making [`min`] itself variadic instead.
 #[inline]
 #[must_use]
 #[unstable(feature = "cmp_splat", issue = "160728")]

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1873,6 +1873,125 @@ where
     if f(&v2) < f(&v1) { [v2, v1] } else { [v1, v2] }
 }
 
+/// Implementation detail for [`smallest`] and [`largest`].
+#[diagnostic::on_unimplemented(message = "`{Self}` is not a homogeneous tuple of type `{T}`")]
+#[unstable(feature = "cmp_splat", issue = "160728")]
+#[rustc_const_unstable(feature = "cmp_splat", issue = "160728")]
+pub impl(self) const trait TupleReduce<T>: crate::marker::Tuple {
+    /// Reduces all elements of a homogeneous non-empty tuple by repeatedly calling
+    /// the provided function `f` on successive pairs.
+    fn reduce<F: [const] Destruct + [const] FnMut(T, T) -> T>(self, f: F) -> T;
+}
+
+macro_rules! impl_tuple {
+    ($($_:ident: $T:ident, $($y:ident: $U:ident,)*)?) => {$(
+        impl_tuple! { $($y: $U,)* }
+
+        #[unstable(feature = "cmp_splat", issue = "160728")]
+        #[rustc_const_unstable(feature = "cmp_splat", issue = "160728")]
+        const impl<T> TupleReduce<T> for ($T, $($U,)*)
+        where
+            Self: [const] Destruct,
+        {
+            fn reduce<F: [const] Destruct + [const] FnMut(T, T) -> T>(self, mut _f: F) -> T {
+                let (x, $($y,)*) = self;
+                $(let x = _f(x, $y);)*
+                x
+            }
+        }
+    )?};
+}
+
+impl_tuple!(a0:T, a1:T, a2:T, a3:T, a4:T, a5:T, a6:T, a7:T, a8:T, a9:T, a10:T, a11:T,);
+
+/// Compares and returns the minimum of the provided values.
+///
+/// Returns the first argument if the comparison determines them to be equal.
+///
+/// Internally uses [`Ord::min`].
+///
+/// # Examples
+///
+/// ```
+/// #![feature(cmp_splat)]
+/// use std::cmp;
+///
+/// assert_eq!(cmp::smallest(1, 2, 3), 1);
+/// assert_eq!(cmp::smallest(2, 2), 2);
+/// ```
+/// ```
+/// #![feature(cmp_splat)]
+/// use std::cmp::{self, Ordering};
+///
+/// #[derive(Eq)]
+/// struct Equal(&'static str);
+///
+/// impl PartialEq for Equal {
+///     fn eq(&self, other: &Self) -> bool { true }
+/// }
+/// impl PartialOrd for Equal {
+///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(Ordering::Equal) }
+/// }
+/// impl Ord for Equal {
+///     fn cmp(&self, other: &Self) -> Ordering { Ordering::Equal }
+/// }
+///
+/// assert_eq!(cmp::smallest(Equal("v1"), Equal("v2")).0, "v1");
+/// ```
+#[inline]
+#[must_use]
+#[unstable(feature = "cmp_splat", issue = "160728")]
+#[rustc_const_unstable(feature = "cmp_splat", issue = "160728")]
+pub const fn smallest<T: [const] Ord + [const] Destruct>(
+    #[rustc_splat] vals: impl [const] TupleReduce<T>,
+) -> T {
+    vals.reduce(Ord::min)
+}
+
+/// Compares and returns the maximum of the provided values.
+///
+/// Returns the first argument if the comparison determines them to be equal.
+///
+/// Internally uses [`Ord::max`].
+///
+/// # Examples
+///
+/// ```
+/// #![feature(cmp_splat)]
+/// use std::cmp;
+///
+/// assert_eq!(cmp::largest(1, 2, 3), 3);
+/// assert_eq!(cmp::largest(2, 2), 2);
+/// ```
+/// ```
+/// #![feature(cmp_splat)]
+/// use std::cmp::{self, Ordering};
+///
+/// #[derive(Eq)]
+/// struct Equal(&'static str);
+///
+/// impl PartialEq for Equal {
+///     fn eq(&self, other: &Self) -> bool { true }
+/// }
+/// impl PartialOrd for Equal {
+///     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(Ordering::Equal) }
+/// }
+/// impl Ord for Equal {
+///     fn cmp(&self, other: &Self) -> Ordering { Ordering::Equal }
+/// }
+///
+/// assert_eq!(cmp::largest(Equal("v1"), Equal("v2")).0, "v2");
+/// ```
+#[inline]
+#[must_use]
+#[unstable(feature = "cmp_splat", issue = "160728")]
+#[rustc_const_unstable(feature = "cmp_splat", issue = "160728")]
+pub const fn largest<T: [const] Ord + [const] Destruct>(
+    #[rustc_splat] vals: impl [const] TupleReduce<T>,
+) -> T {
+    vals.reduce(Ord::max)
+}
+
 // Implementation of PartialEq, Eq, PartialOrd and Ord for primitive types
 mod impls {
     use crate::cmp::Ordering::{self, Equal, Greater, Less};

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -155,6 +155,7 @@
 #![feature(rustc_attrs)]
 #![feature(rustdoc_internals)]
 #![feature(simd_ffi)]
+#![feature(splat)]
 #![feature(staged_api)]
 #![feature(stmt_expr_attributes)]
 #![feature(strict_provenance_lints)]

--- a/library/coretests/tests/cmp.rs
+++ b/library/coretests/tests/cmp.rs
@@ -280,3 +280,12 @@ mod const_cmp {
     const _: () = assert!(S(0) < S(1));
     const _: () = assert!(S(1) > S(0));
 }
+
+mod const_splat {
+    use super::*;
+
+    const _: () = assert!(cmp::smallest(1, 2, 3, 4) == 1);
+    const _: () = assert!(cmp::smallest(4, 3, 2, 1) == 1);
+    const _: () = assert!(cmp::largest(1, 2, 3, 4) == 4);
+    const _: () = assert!(cmp::largest(4, 3, 2, 1) == 4);
+}

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -15,6 +15,7 @@
 #![feature(char_internals)]
 #![feature(clone_to_uninit)]
 #![feature(cmp_minmax)]
+#![feature(cmp_splat)]
 #![feature(const_array)]
 #![feature(const_bool)]
 #![feature(const_cell_traits)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160687)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->

- [X] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking Issue: rust-lang/rust#160728
Zulip: [#t-libs-api/api-changes > variadic min/max](https://rust-lang.zulipchat.com/#narrow/channel/327149-t-libs-api.2Fapi-changes/topic/variadic.20min.2Fmax/with/570428142)

# Description

Adds variadic alternatives to `cmp::min` and `cmp::max` which use `#[rustc_splat]` to allow anywhere from 1 to 12 arguments to be compared. Twelve chosen as an arbitrary limit. This doesn't have a pre-existing ACP or tracking issue (linking the `splat` issue since it's the most relevant), so I've added these two functions, `smallest` and `largest` under a new feature, `cmp_splat`.

This mostly exists to demonstrate a possible solution to the problem posited in the linked Zulip thread. Happy to close if undesirable, as my current focus is on `no_std` I/O.