### PR TITLE
Detect bad number of generics caused by bad derive

### DIFF
--- a/compiler/rustc_hir_analysis/src/diagnostics/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/diagnostics/wrong_number_of_generic_args.rs
@@ -3,7 +3,7 @@ use rustc_errors::codes::*;
 use rustc_errors::{Applicability, Diag, Diagnostic, EmissionGuarantee, MultiSpan, pluralize};
 use rustc_hir as hir;
 use rustc_middle::ty::{self as ty, AssocItem, AssocItems, TyCtxt};
-use rustc_span::def_id::DefId;
+use rustc_span::def_id::{DefId, LocalDefId};
 use tracing::debug;
 
 /// Handles the `wrong number of type / lifetime / ... arguments` family of error messages.
@@ -30,6 +30,9 @@ pub(crate) struct WrongNumberOfGenericArgs<'a, 'tcx> {
 
     /// DefId of the generic type
     pub(crate) def_id: DefId,
+
+    /// DefId of the generic type
+    pub(crate) cx_def_id: LocalDefId,
 }
 
 // Provides information about the kind of arguments that were provided for
@@ -83,6 +86,7 @@ pub(crate) enum GenericArgsInfo {
         // if synthetic type arguments (e.g. `impl Trait`) are specified
         synth_provided: bool,
     },
+    // BadDerive,
 }
 
 impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
@@ -94,6 +98,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         params_offset: usize,
         gen_args: &'a hir::GenericArgs<'a>,
         def_id: DefId,
+        cx_def_id: LocalDefId,
     ) -> Self {
         let angle_brackets = if gen_args.span_ext().is_none() {
             if gen_args.is_empty() { AngleBrackets::Missing } else { AngleBrackets::Implied }
@@ -110,6 +115,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
             params_offset,
             gen_args,
             def_id,
+            cx_def_id,
         }
     }
 
@@ -540,6 +546,25 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         } else {
             format!("missing generics for {def_kind} `{def_path}`")
         }
+    }
+
+    fn bad_derive(&self, err: &mut Diag<'_, impl EmissionGuarantee>) -> bool {
+        if let Some(ident) = self.tcx.opt_item_ident(self.def_id)
+            && self.def_id.is_local()
+            && self.path_segment.ident.span.source_equal(ident.span)
+            && self.tcx.is_automatically_derived(self.cx_def_id.into())
+        {
+            // Very likely this is a botched `derive` which passes the iten name straight
+            // through, but doesn't support type parameters.
+            err.span_label(
+                self.tcx.def_span(self.cx_def_id),
+                "it looks like this derive macro might not support annotating items with type \
+                 parameters",
+            );
+
+            return true;
+        }
+        false
     }
 
     /// Builds the `expected 1 type argument / supplied 2 type arguments` message.
@@ -1157,6 +1182,9 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for WrongNumberOfGenericArgs<'_
         err.code(E0107);
         err.span(self.path_segment.ident.span);
 
+        if self.bad_derive(&mut err) {
+            return err;
+        }
         self.notify(&mut err);
         self.suggest(&mut err);
         self.show_definition(&mut err);

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
@@ -471,6 +471,7 @@ pub(crate) fn check_generic_arg_count(
             has_self as usize,
             gen_args,
             def_id,
+            cx.item_def_id(),
         ));
 
         Err(reported)
@@ -585,6 +586,7 @@ pub(crate) fn check_generic_arg_count(
                     params_offset,
                     gen_args,
                     def_id,
+                    cx.item_def_id(),
                 ))
                 .emit_unless_delay(all_params_are_binded)
         });

--- a/tests/run-make/derive-macro-unsupported-type-params/bar.rs
+++ b/tests/run-make/derive-macro-unsupported-type-params/bar.rs
@@ -1,0 +1,10 @@
+#![no_std]
+#![crate_type = "lib"]
+
+#[macro_use]
+extern crate foo;
+
+#[derive(A)]
+enum A<T> {
+    Variant(T),
+}

--- a/tests/run-make/derive-macro-unsupported-type-params/bar.stderr
+++ b/tests/run-make/derive-macro-unsupported-type-params/bar.stderr
@@ -1,0 +1,26 @@
+error[E0425]: cannot find type `T` in this scope
+ --> bar.rs:9:13
+  |
+9 |     Variant(T),
+  |             ^ not found in this scope
+
+error[E0107]: missing generics for enum `A`
+ --> bar.rs:8:6
+  |
+7 | #[derive(A)]
+  |          - it looks like this derive macro might not support annotating items with type parameters
+8 | enum A<T> {
+  |      ^
+
+error[E0107]: missing generics for enum `A`
+ --> bar.rs:8:6
+  |
+7 | #[derive(A)]
+  |          - it looks like this derive macro might not support annotating items with type parameters
+8 | enum A<T> {
+  |      ^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0425.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/run-make/derive-macro-unsupported-type-params/foo.rs
+++ b/tests/run-make/derive-macro-unsupported-type-params/foo.rs
@@ -1,0 +1,37 @@
+#![crate_type = "proc-macro"]
+#![feature(proc_macro_quote)]
+
+extern crate proc_macro;
+
+use proc_macro::{TokenStream, TokenTree, quote};
+
+#[proc_macro_derive(A)]
+pub fn derive(item: TokenStream) -> TokenStream {
+    let mut tokens = item.into_iter();
+    let _enum = tokens.next();
+    let name = tokens.next().unwrap();
+    let _ = tokens.next().unwrap();
+    let _ = tokens.next().unwrap();
+    let _ = tokens.next().unwrap();
+    let TokenTree::Group(group) = tokens.next().unwrap() else { panic!() };
+    let mut group = group.stream().into_iter();
+    let variant = group.next().unwrap();
+    let TokenTree::Group(args) = group.next().unwrap() else { panic!() };
+    let arg = args.stream().into_iter().next().unwrap();
+    let tokens = quote! {
+        trait X {}
+        #[automatically_derived]
+        impl X for $name {}
+
+        #[automatically_derived]
+        impl $name {
+            fn foo(&self) {
+                if let Self :: $variant(val) = self {
+                    let _: $arg = val;
+                }
+            }
+        }
+
+    };
+    tokens
+}

--- a/tests/run-make/derive-macro-unsupported-type-params/rmake.rs
+++ b/tests/run-make/derive-macro-unsupported-type-params/rmake.rs
@@ -1,0 +1,10 @@
+//@ ignore-cross-compile
+//@ needs-crate-type: proc-macro
+
+use run_make_support::{diff, rustc, target};
+
+fn main() {
+    rustc().input("foo.rs").edition("2024").run();
+    let out = rustc().input("bar.rs").edition("2024").run_fail().stderr_utf8();
+    diff().expected_file("bar.stderr").actual_text("actual-bar-stderr", out).run();
+}


### PR DESCRIPTION
When a derive macro expands the annotated item's name directly using `quote!`, it keep the item's Span context (instead of having a new context). This means that the generic Span context machinery which provides feedback that an error happened due to a derive doesn't kick in.

If a derive macro isn't written to take into account the existence of type parameters, an error for "mismatched number of type parameters" will be emitted. We now detect the case when this happens due to the derive macro, and customize the output to point that out, as well as avoid giving suggestions that will always be wrong.

Partially address rust-lang/rust#160463 (this doesn't detect a nameres error caused by referencing type parameter within a derive).

```
error[E0107]: missing generics for enum `A`
 --> bar.rs:8:6
  |
7 | #[derive(A)]
  |          - it looks like this derive macro might not support items with generic parameters
8 | enum A<T> {
  |      ^
```
<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? @petrochenkov 