### PR TITLE
rustc_codegen_llvm: handle sm_101* features being an alias

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -252,6 +252,12 @@ pub(crate) fn to_llvm_features<'a>(sess: &Session, s: &'a str) -> Option<LLVMFea
             "allows-misaligned-mem-access" if major < 22 => None,
             s => Some(LLVMFeature::new(s)),
         },
+        Arch::Nvptx64 => match s {
+            "sm_101" if major >= 24 => Some(LLVMFeature::new("sm_110")),
+            "sm_101a" if major >= 24 => Some(LLVMFeature::new("sm_110a")),
+            "sm_101f" if major >= 24 => Some(LLVMFeature::new("sm_110f")),
+            s => Some(LLVMFeature::new(s)),
+        },
         // Filter out features that are not supported by the current LLVM version
         Arch::PowerPC | Arch::PowerPC64 => match s {
             "power8-crypto" => Some(LLVMFeature::new("crypto")),


### PR DESCRIPTION
LLVM 24 [moved sm_101{,a,f} features](https://github.com/llvm/llvm-project/pull/214335) to just be an alias for the matching sm_110 feature. Since the sm_110 feature already exists, we can do the remapping unconditionally rather than gating it on LLVM 24.

<!-- homu-ignore:start -->

- [ ] I did not use an LLM to create a change in this PR.
- [x] I used an LLM to create a change in this PR, and I have explained below how it was used.

An LLM processed the build failure to identify the breaking change. From there the fix was obvious and performed by hand.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

@rustbot label: +llvm-main