### PR TITLE
rustc: Tweak the effect of `--jobs` on frontend parallelism

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1723,7 +1723,7 @@ fn parse_jobs_all(
                 check_upper_limit(frontend, opt_name);
                 frontend
             }
-            None => jobs.flatten(),
+            None => None, // default to 1 thread irrespectively of `jobs` for now
         },
     };
     let backend = match matches.opt_str("jobs-backend") {

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -498,8 +498,8 @@ more specific `jobs-*` options cannot specify larger values.
 Parallelism used by compilation stages from lexing to generation of backend IR (e.g. LLVM IR).
 
 - If `jobs-frontend` is passed, then it is used as the limit,
-- otherwise if `jobs` is passed, then it is used as the limit,
-- otherwise `1` is used as the limit (parallelism is disabled), this default may change.
+- otherwise `1` is used as the limit (parallelism is disabled), this default may change,
+  but if it's changed to a larger value the limit from `jobs` will still be respected.
 
 In any case the parallelism here may be additionally limited dynamically by jobserver
 passed from a higher level build system like cargo.
@@ -510,8 +510,7 @@ Parallelism used by compilation stages converting backend IR to object files.
 
 - If `jobs-backend` is passed, then it is used as the limit,
 - otherwise if `jobs` is passed, then it is used as the limit,
-- otherwise `32` is used as the limit or there's no limit in case of an inherited jobserver,
-  this default may change.
+- otherwise the number of available logical CPUs is used as the limit, this default may change.
 
 In any case the parallelism here may be additionally limited dynamically by jobserver
 passed from a higher level build system like cargo.


### PR DESCRIPTION
We need to be able to express both of these things for the frontend parallelism:
- "Use exactly `N` threads", `--jobs-frontend=N` does this.
- "Use some default number of threads, but not larger than `N`", `--jobs=N` will do it after this PR.
  The "default number" may be 1 now, or 2 during the upcoming nightly testing, or 4 or 8 after the stabilization if we decide to cap the parallelism.

Part of https://github.com/rust-lang/compiler-team/issues/1005.
r? @bjorn3 