### PR TITLE
autodiff: Normalize typetree struct field types

### DIFF
--- a/compiler/rustc_middle/src/ty/typetree.rs
+++ b/compiler/rustc_middle/src/ty/typetree.rs
@@ -122,7 +122,16 @@ fn typetree_from_ty_impl_inner<'tcx>(
         ty::Ref(..) | ty::RawPtr(..) => handle_indirection(ty, tcx, depth, visited),
         ty::Adt(def, _) if def.is_box() => handle_indirection(ty, tcx, depth, visited),
         ty::Array(element_ty, len_const) => {
-            let len = len_const.try_to_target_usize(tcx).unwrap_or(0);
+            // Lengths are normalized by callers (struct fields via
+            // `normalize_erasing_regions`); keep a graceful fallback rather
+            // than asserting when evaluation still fails.
+            let len = len_const.try_to_target_usize(tcx).unwrap_or_else(|| {
+                trace!(
+                    "autodiff typetree: array length {len_const:?} not evaluable; \
+                     emitting empty TypeTree"
+                );
+                0
+            });
             if len == 0 {
                 TypeTree::new()
             } else {
@@ -169,20 +178,19 @@ fn typetree_from_ty_impl_inner<'tcx>(
             }
         }
         ty::Adt(adt_def, args) if adt_def.is_struct() => {
-            let struct_layout =
-                tcx.layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(ty));
+            let typing_env = ty::TypingEnv::fully_monomorphized();
+            let struct_layout = tcx.layout_of(typing_env.as_query_input(ty));
             if let Ok(layout) = struct_layout {
                 let mut types = Vec::new();
 
                 for (field_idx, field_def) in adt_def.all_fields().enumerate() {
-                    let field_ty = field_def.ty(tcx, args);
-                    let field_tree = typetree_from_ty_impl_inner(
-                        tcx,
-                        field_ty.skip_norm_wip(),
-                        depth + 1,
-                        visited,
-                        false,
-                    );
+                    // `FieldDef::ty` returns `Unnormalized`; normalize before recursion so
+                    // array lengths / projections are concrete for `struct_tail_for_codegen`
+                    // and `try_to_target_usize` (see #160635).
+                    let field_ty =
+                        tcx.normalize_erasing_regions(typing_env, field_def.ty(tcx, args));
+                    let field_tree =
+                        typetree_from_ty_impl_inner(tcx, field_ty, depth + 1, visited, false);
 
                     let field_offset = layout.fields.offset(field_idx).bytes_usize();
 

--- a/tests/run-make/autodiff/type-trees/array-const-len-typetree/array-const-len.check
+++ b/tests/run-make/autodiff/type-trees/array-const-len-typetree/array-const-len.check
@@ -1,16 +1,14 @@
-; ICE case (#160635): pointer-to-[T; N] field keeps float child metadata after normalizing N.
+; Pointer-to-[T; N]: normalize N, keep a compact [-1] float child under the pointee.
 PTR-LABEL: define{{.*}}@copy_ptr_array(
 PTR-NOT: define
 PTR: call void @llvm.memcpy{{.*}}"enzyme_type"="{[0]:Pointer, [0,0]:Pointer, [0,0,-1]:Float@float, [0,8]:Float@float, [0,12]:Float@float}"
 
-; Silent case: plain [T; N] field produces float metadata (not an empty subtree).
-; Known limitation: the struct arm collapses array element offset -1 to the field
-; byte offset, so only byte 0 of `data: [f32; 8]` is classified as Float; bytes
-; 4..32 stay unclassified (unlike pointer-to-array, which preserves [-1]).
+; Inline [T; N]: first float element plus the distinct `scale: i32` field.
+; Struct flattening currently collapses array `-1` to the field base, so only
+; byte 0 of `data` is classified until Enzyme gains a compact range encoding.
 INLINE-LABEL: define{{.*}}@copy_inline_array(
 INLINE-NOT: define
-INLINE: call void @llvm.memcpy{{.*}}"enzyme_type"="{[0]:Pointer, [0,0]:Float@float, [0,32]:Float@float}"
+INLINE: call void @llvm.memcpy{{.*}}"enzyme_type"="{[0]:Pointer, [0,0]:Float@float, [0,32]:Integer}"
 
-; Enzyme accepts the ICE-shaped PtrArray TypeTree (not just rustc emission).
 ADIFF-LABEL: define{{.*}}@ptr_array_sum(
 ADIFF-SAME: ptr{{.*}}"enzyme_type"="{[-1]:Pointer, [-1,0]:Pointer, [-1,0,-1]:Float@float, [-1,8]:Float@float, [-1,12]:Float@float}"

--- a/tests/run-make/autodiff/type-trees/array-const-len-typetree/array-const-len.check
+++ b/tests/run-make/autodiff/type-trees/array-const-len-typetree/array-const-len.check
@@ -1,0 +1,16 @@
+; ICE case (#160635): pointer-to-[T; N] field keeps float child metadata after normalizing N.
+PTR-LABEL: define{{.*}}@copy_ptr_array(
+PTR-NOT: define
+PTR: call void @llvm.memcpy{{.*}}"enzyme_type"="{[0]:Pointer, [0,0]:Pointer, [0,0,-1]:Float@float, [0,8]:Float@float, [0,12]:Float@float}"
+
+; Silent case: plain [T; N] field produces float metadata (not an empty subtree).
+; Known limitation: the struct arm collapses array element offset -1 to the field
+; byte offset, so only byte 0 of `data: [f32; 8]` is classified as Float; bytes
+; 4..32 stay unclassified (unlike pointer-to-array, which preserves [-1]).
+INLINE-LABEL: define{{.*}}@copy_inline_array(
+INLINE-NOT: define
+INLINE: call void @llvm.memcpy{{.*}}"enzyme_type"="{[0]:Pointer, [0,0]:Float@float, [0,32]:Float@float}"
+
+; Enzyme accepts the ICE-shaped PtrArray TypeTree (not just rustc emission).
+ADIFF-LABEL: define{{.*}}@ptr_array_sum(
+ADIFF-SAME: ptr{{.*}}"enzyme_type"="{[-1]:Pointer, [-1,0]:Pointer, [-1,0,-1]:Float@float, [-1,8]:Float@float, [-1,12]:Float@float}"

--- a/tests/run-make/autodiff/type-trees/array-const-len-typetree/rmake.rs
+++ b/tests/run-make/autodiff/type-trees/array-const-len-typetree/rmake.rs
@@ -1,0 +1,19 @@
+//@ needs-enzyme
+//@ ignore-cross-compile
+
+use run_make_support::{llvm_filecheck, rfs, rustc};
+
+fn main() {
+    rustc()
+        .input("test.rs")
+        .arg("-Zautodiff=Enable,NoPostopt")
+        .opt_level("0")
+        .arg("-Clto=fat")
+        .emit("llvm-ir")
+        .run();
+
+    let ir = rfs::read("test.ll");
+    llvm_filecheck().patterns("array-const-len.check").check_prefix("PTR").stdin_buf(&ir).run();
+    llvm_filecheck().patterns("array-const-len.check").check_prefix("INLINE").stdin_buf(&ir).run();
+    llvm_filecheck().patterns("array-const-len.check").check_prefix("ADIFF").stdin_buf(&ir).run();
+}

--- a/tests/run-make/autodiff/type-trees/array-const-len-typetree/test.rs
+++ b/tests/run-make/autodiff/type-trees/array-const-len-typetree/test.rs
@@ -3,10 +3,13 @@
 
 use std::autodiff::autodiff_reverse;
 
-// Regression test for #160635: non-literal array lengths (anon consts) in struct
-// fields must be normalized before typetree recursion. Without that, `*mut [f32; N]`
-// ICEs in `struct_tail_for_codegen`, and a plain `[f32; N]` field silently yields
-// an empty TypeTree.
+// Regression for #160635: anon-const array lengths in struct fields need
+// normalization before typetree walks. `*mut [f32; N]` used to ICE in
+// `struct_tail_for_codegen` (deepest trailing field / unsizing tail), and a
+// plain `[f32; N]` field used to emit an empty TypeTree.
+//
+// `scale` is `i32` (not `f32`) so a naive `[-1]:Float` over the whole struct
+// would misclassify it. Array metadata has to stay bounded to `data`.
 
 const N: usize = 8;
 
@@ -24,7 +27,6 @@ pub unsafe fn copy_ptr_array(a: &PtrArray, b: &mut PtrArray) {
     *b = *a;
 }
 
-// Run Enzyme over the ICE-shaped type so metadata is not only emitted but accepted.
 #[autodiff_reverse(d_ptr_array_sum, Duplicated, Active)]
 #[no_mangle]
 #[inline(never)]
@@ -41,7 +43,7 @@ pub fn exercise_ptr_array_sum(s: &PtrArray, ds: &mut PtrArray) -> f32 {
 #[repr(C)]
 pub struct InlineArray {
     pub data: [f32; N],
-    pub scale: f32,
+    pub scale: i32,
 }
 
 #[no_mangle]

--- a/tests/run-make/autodiff/type-trees/array-const-len-typetree/test.rs
+++ b/tests/run-make/autodiff/type-trees/array-const-len-typetree/test.rs
@@ -1,0 +1,51 @@
+#![crate_type = "lib"]
+#![feature(autodiff)]
+
+use std::autodiff::autodiff_reverse;
+
+// Regression test for #160635: non-literal array lengths (anon consts) in struct
+// fields must be normalized before typetree recursion. Without that, `*mut [f32; N]`
+// ICEs in `struct_tail_for_codegen`, and a plain `[f32; N]` field silently yields
+// an empty TypeTree.
+
+const N: usize = 8;
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct PtrArray {
+    pub p: *mut [f32; N],
+    pub q: f32,
+    pub r: f32,
+}
+
+#[no_mangle]
+#[inline(never)]
+pub unsafe fn copy_ptr_array(a: &PtrArray, b: &mut PtrArray) {
+    *b = *a;
+}
+
+// Run Enzyme over the ICE-shaped type so metadata is not only emitted but accepted.
+#[autodiff_reverse(d_ptr_array_sum, Duplicated, Active)]
+#[no_mangle]
+#[inline(never)]
+pub fn ptr_array_sum(s: &PtrArray) -> f32 {
+    s.q + s.r
+}
+
+#[no_mangle]
+pub fn exercise_ptr_array_sum(s: &PtrArray, ds: &mut PtrArray) -> f32 {
+    d_ptr_array_sum(s, ds, 1.0)
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct InlineArray {
+    pub data: [f32; N],
+    pub scale: f32,
+}
+
+#[no_mangle]
+#[inline(never)]
+pub unsafe fn copy_inline_array(a: &InlineArray, b: &mut InlineArray) {
+    *b = *a;
+}


### PR DESCRIPTION
Fixes rust-lang/rust#160635

`-Zautodiff=Enable` was ICEing on structs with fields like `*mut [f32; N]`. `FieldDef::ty` returns `Unnormalized`, and we were just calling `skip_norm_wip`, so recursion hit `struct_tail_for_codegen` with an unevaluated anon const length. Same root cause also quietly emptied TypeTrees for plain `[T; N]` fields, fyi.

Now we normalize with `TypingEnv::fully_monomorphized` before walking struct fields. Imo that's the right call here: we're already post-mono in codegen, and it lines up with the Unnormalized WIP migration instead of spreading more `skip_norm_wip` around. Btw I added a run-make regression covering both faces of the bug.

Idk if Enzyme will still choke on murkier shadow-pointer cases irl, but at least rustc stops panicking. Ltm if the FileCheck strings look too layout-locked for other targets and I can loosen them asap.