### PR TITLE
Revert "Single-pass ASCII lower/upper case conversion" for benchmark

### DIFF
--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -639,7 +639,9 @@ impl [u8] {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_uppercase(&self) -> Vec<u8> {
-        self.iter().map(|b| b.to_ascii_uppercase()).collect()
+        let mut me = self.to_vec();
+        me.make_ascii_uppercase();
+        me
     }
 
     /// Returns a vector containing a copy of this slice where each byte
@@ -658,7 +660,9 @@ impl [u8] {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_lowercase(&self) -> Vec<u8> {
-        self.iter().map(|b| b.to_ascii_lowercase()).collect()
+        let mut me = self.to_vec();
+        me.make_ascii_lowercase();
+        me
     }
 }
 

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -844,10 +844,9 @@ impl str {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_uppercase(&self) -> String {
-        let bytes = self.as_bytes().to_ascii_uppercase();
-        // SAFETY: ASCII case conversion only maps a-z to A-Z and leaves
-        // all other bytes unchanged as valid UTF-8
-        unsafe { String::from_utf8_unchecked(bytes) }
+        let mut s = self.to_owned();
+        s.make_ascii_uppercase();
+        s
     }
 
     /// Returns a copy of this string where each character is mapped to its
@@ -877,10 +876,9 @@ impl str {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_lowercase(&self) -> String {
-        let bytes = self.as_bytes().to_ascii_lowercase();
-        // SAFETY: ASCII case conversion only maps A-Z to a-z and leaves
-        // all other bytes unchanged as valid UTF-8
-        unsafe { String::from_utf8_unchecked(bytes) }
+        let mut s = self.to_owned();
+        s.make_ascii_lowercase();
+        s
     }
 }
 


### PR DESCRIPTION
PR exists only to do a perf run of https://github.com/rust-lang/rust/pull/160480

<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
