### PR TITLE
renovate: clarify that vulnerability PRs are opened automatically

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,8 +19,13 @@
     "src/doc/book",
     "src/doc/reference"
   ],
-  // Require manual approval from the Dependency Dashboard before opening PRs
+  // Require manual approval from the Dependency Dashboard before opening PRs,
+  // except for the update types explicitly configured below.
   "dependencyDashboardApproval": true,
+  // No dashboard approval necessary for security updates
+  "vulnerabilityAlerts": {
+    "dependencyDashboardApproval": false
+  },
   // Renovate shouldn't update a PR if it is in the bors merge queue.
   "stopUpdatingLabel": "S-waiting-on-bors",
   "packageRules": [


### PR DESCRIPTION
<!-- homu-ignore:start -->

- [ ] I did not use an LLM to create a change in this PR.
- [x] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
As you can see from https://github.com/rust-lang/rust/pull/160602 Renovate already creates security PRs automatically. This PR makes it explicit.
## LLMs
I think my use of LLMs in this case can be categorized under [`“Trivial” code`](https://forge.rust-lang.org/policies/llm-usage.html#-allowed-with-caveats), so I guess it's fine.

I used LLMs to review my renovate config and GPT5.6 suggested this change.
<!-- homu-ignore:end -->
r? @ubiratansoares 