### PR TITLE
Add regression test for higher ranked fn pointer impl not general enough

### DIFF
--- a/tests/ui/higher-ranked/hrtb-fn-ptr-impl-not-general-enough-57936.rs
+++ b/tests/ui/higher-ranked/hrtb-fn-ptr-impl-not-general-enough-57936.rs
@@ -1,0 +1,35 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/57936>.
+//!
+//! `X` is only implemented for `fn(&'a ())` for some specific `'a`, so neither the
+//! indirect call through a generic parameter nor the direct call may use it at the
+//! higher-ranked type `for<'a> fn(&'a ())`. Both are rejected now; the indirect one
+//! used to be accepted.
+
+trait X {
+    type G;
+    fn make_g() -> Self::G;
+}
+
+impl<'a> X for fn(&'a ()) {
+    type G = &'a ();
+
+    fn make_g() -> Self::G {
+        &()
+    }
+}
+
+fn indirect<T: X>() {
+    let x = T::make_g();
+}
+
+fn call_indirect() {
+    indirect::<fn(&())>();
+    //~^ ERROR implementation of `X` is not general enough
+}
+
+fn direct() {
+    let x = <fn(&())>::make_g();
+    //~^ ERROR no associated function or constant named `make_g` found for fn pointer `for<'a> fn(&'a ())` in the current scope
+}
+
+fn main() {}

--- a/tests/ui/higher-ranked/hrtb-fn-ptr-impl-not-general-enough-57936.stderr
+++ b/tests/ui/higher-ranked/hrtb-fn-ptr-impl-not-general-enough-57936.stderr
@@ -1,0 +1,25 @@
+error[E0599]: no associated function or constant named `make_g` found for fn pointer `for<'a> fn(&'a ())` in the current scope
+  --> $DIR/hrtb-fn-ptr-impl-not-general-enough-57936.rs:31:24
+   |
+LL |     let x = <fn(&())>::make_g();
+   |                        ^^^^^^ associated function or constant not found in `for<'a> fn(&'a ())`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `X` defines an item `make_g`, perhaps you need to implement it
+  --> $DIR/hrtb-fn-ptr-impl-not-general-enough-57936.rs:8:1
+   |
+LL | trait X {
+   | ^^^^^^^
+
+error: implementation of `X` is not general enough
+  --> $DIR/hrtb-fn-ptr-impl-not-general-enough-57936.rs:26:5
+   |
+LL |     indirect::<fn(&())>();
+   |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `X` is not general enough
+   |
+   = note: `X` would have to be implemented for the type `for<'a> fn(&'a ())`
+   = note: ...but `X` is actually implemented for the type `fn(&'0 ())`, for some specific lifetime `'0`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Closes rust-lang/rust#57936 adds a regression test for higher ranked fn-pointer impl is now correctly rejected