### PR TITLE
ignore tests with the GCC backend if we can't find `libgccjit.so` for the target

### DIFF
--- a/src/tools/compiletest/src/cli.rs
+++ b/src/tools/compiletest/src/cli.rs
@@ -385,6 +385,13 @@ pub(crate) fn parse_config(args: Vec<String>) -> Config {
     let iteration_count = args.iteration_count.unwrap_or(Config::DEFAULT_ITERATION_COUNT);
     assert!(iteration_count > 0, "`--iteration-count` must be a positive integer");
 
+    let gcc_supported_target_tuples = match default_codegen_backend {
+        CodegenBackend::Gcc => {
+            directives::find_gcc_supported_targets(&args.sysroot_base, &args.host)
+        }
+        CodegenBackend::Llvm | CodegenBackend::Cranelift => vec![],
+    };
+
     Config {
         bless: args.bless,
         fail_fast: args.fail_fast || env::var_os("RUSTC_TEST_FAIL_FAST").is_some(),
@@ -493,6 +500,8 @@ pub(crate) fn parse_config(args: Vec<String>) -> Config {
         default_codegen_backend,
         override_codegen_backend: args.override_codegen_backend,
         bypass_ignore_backends: args.bypass_ignore_backends,
+
+        gcc_supported_target_tuples,
 
         jobs: args.jobs,
 

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -754,6 +754,9 @@ pub(crate) struct Config {
     /// Whether to ignore `//@ ignore-backends`.
     pub(crate) bypass_ignore_backends: bool,
 
+    /// Target tuples for which we've found libgccjit.so.
+    pub(crate) gcc_supported_target_tuples: Vec<String>,
+
     /// Number of parallel jobs configured for the build.
     ///
     /// This is forwarded from bootstrap's `jobs` configuration.

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -958,6 +958,7 @@ pub(crate) fn make_test_description(
                 decision!(ignore_llvm(config, ln));
                 decision!(ignore_backends(config, ln));
                 decision!(needs_backends(config, ln));
+                decision!(ignore_unsupported_backend_target(config, ln));
                 decision!(ignore_cdb(config, variant, ln));
                 decision!(ignore_gdb(config, variant, ln));
                 decision!(ignore_lldb(config, variant, ln));
@@ -1210,6 +1211,36 @@ fn needs_backends(config: &Config, line: &DirectiveLine<'_>) -> IgnoreDecision {
         }
     }
     IgnoreDecision::Continue
+}
+
+/// When using the GCC backend, ignore tests for which we did not find a libgccjit.so.
+fn ignore_unsupported_backend_target(config: &Config, line: &DirectiveLine<'_>) -> IgnoreDecision {
+    if config.default_codegen_backend != crate::CodegenBackend::Gcc {
+        return IgnoreDecision::Continue;
+    }
+
+    let Some(compile_flags) = config.parse_name_value_directive(line, "compile-flags") else {
+        return IgnoreDecision::Continue;
+    };
+
+    // See if this line sets a `--target=...`
+    let Some((_, rest)) = compile_flags.split_once("--target") else {
+        return IgnoreDecision::Continue;
+    };
+    let Some(target) = rest.trim_start_matches([' ', '=']).split_whitespace().next() else {
+        return IgnoreDecision::Continue;
+    };
+
+    if target != "x86_64-unknown-linux-gnu" {
+        IgnoreDecision::Ignore {
+            reason: format!(
+                "backend `{}` cannot build for target `{target}`",
+                config.default_codegen_backend.as_str()
+            ),
+        }
+    } else {
+        IgnoreDecision::Continue
+    }
 }
 
 fn ignore_llvm(config: &Config, line: &DirectiveLine<'_>) -> IgnoreDecision {

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -851,6 +851,30 @@ pub(crate) fn extract_llvm_version_from_binary(binary_path: &str) -> Option<Vers
     None
 }
 
+pub(crate) fn find_gcc_supported_targets(sysroot_base: &Utf8Path, host: &str) -> Vec<String> {
+    // E.g. `lib/rustlib/x86_64-unknown-linux-gnu/codegen-backends/lib`.
+    let backends_dir =
+        sysroot_base.join("lib").join("rustlib").join(host).join("codegen-backends").join("lib");
+
+    match std::fs::read_dir(&backends_dir) {
+        Ok(entries) => {
+            // Search for `aarch64-unknown-linux-gnu/libgccjit.so` et cetera.
+            let target_tuples: Vec<_> = entries
+                .filter_map(|entry| entry.ok())
+                .filter(|entry| entry.path().join("libgccjit.so").exists())
+                .filter_map(|entry| entry.file_name().into_string().ok())
+                .collect();
+
+            if target_tuples.is_empty() {
+                panic!("did not find `libgccjit.so` for any target in {backends_dir}");
+            }
+
+            target_tuples
+        }
+        Err(e) => panic!("unable to find `libgccjit.so` for any target in {backends_dir}: {e:?}",),
+    }
+}
+
 /// Takes a directive of the form `"<version1> [- <version2>]"`, returns the numeric representation
 /// of `<version1>` and `<version2>` as tuple: `(<version1>, <version2>)`.
 ///
@@ -1231,7 +1255,7 @@ fn ignore_unsupported_backend_target(config: &Config, line: &DirectiveLine<'_>) 
         return IgnoreDecision::Continue;
     };
 
-    if target != "x86_64-unknown-linux-gnu" {
+    if !config.gcc_supported_target_tuples.iter().any(|t| t == target) {
         IgnoreDecision::Ignore {
             reason: format!(
                 "backend `{}` cannot build for target `{target}`",

--- a/src/tools/compiletest/src/rustdoc_gui_test.rs
+++ b/src/tools/compiletest/src/rustdoc_gui_test.rs
@@ -139,6 +139,7 @@ fn incomplete_config_for_rustdoc_gui_test() -> Config {
         default_codegen_backend: CodegenBackend::Llvm,
         override_codegen_backend: None,
         bypass_ignore_backends: Default::default(),
+        gcc_supported_target_tuples: vec![],
         jobs: Default::default(),
         parallel_frontend_threads: Config::DEFAULT_PARALLEL_FRONTEND_THREADS,
         iteration_count: Config::DEFAULT_ITERATION_COUNT,

--- a/tests/ui/asm/naked-functions/instruction-set.rs
+++ b/tests/ui/asm/naked-functions/instruction-set.rs
@@ -2,7 +2,6 @@
 //@ compile-flags: --target armv5te-unknown-linux-gnueabi
 //@ needs-llvm-components: arm
 //@ build-pass
-//@ ignore-backends: gcc
 
 #![crate_type = "lib"]
 #![feature(no_core)]


### PR DESCRIPTION
<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

Much like we ignore tests on targets that don't support certain properties, ignore a test or revision when the target is not supported by GCC, and GCC is the default codegen backend. 

With this change we can remove many `//@ ignore-backends: gcc` (which I've left for later).

See also the conversation at [#rustc-codegen-gcc > tidy error on building test with GCC on unsupported target](https://rust-lang.zulipchat.com/#narrow/channel/386786-rustc-codegen-gcc/topic/tidy.20error.20on.20building.20test.20with.20GCC.20on.20unsupported.20target/with/615232618).

r? jieyouxu 
cc @GuillaumeGomez @antoyo 