### PR TITLE
bootstrap: Enable rustdoc mergeable CCI for std docs

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -839,6 +839,10 @@ fn doc_std(
         .arg("--no-deps")
         .arg("--target-dir")
         .arg(&*target_dir.to_string_lossy())
+        // Will be stabilized soon -> let's dogfood it.
+        // Generally provides significant perf improvements, though not noticeable
+        // for std.
+        .arg("-Zrustdoc-mergeable-info")
         .arg("-Zskip-rustdoc-fingerprint")
         .arg("-Zrustdoc-map")
         .rustdocflag("--extern-html-root-url")


### PR DESCRIPTION
Ideally we'd enable it for the compiler docs too, though that's blocked on fixing some hacks in bootstrap related to shared build directories.

<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
