### PR TITLE
Arc: Remove unnecessary fmt::Display use for overflow assertion

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -55,9 +55,12 @@ use crate::vec::Vec;
 /// See comment in `Arc::clone`.
 const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 
-#[inline(always)]
-fn enforce_overflow_limit(n: usize) {
-    assert!(n <= MAX_REFCOUNT, "Arc counter overflow");
+#[cold]
+#[cfg_attr(not(panic = "immediate-abort"), inline(never))]
+#[cfg_attr(panic = "immediate-abort", inline)]
+#[track_caller]
+fn panic_arc_overflow() -> ! {
+    panic!("Arc counter overflow");
 }
 
 #[cfg(not(sanitize = "thread"))]
@@ -1956,8 +1959,9 @@ impl<T: ?Sized, A: Allocator> Arc<T, A> {
             }
 
             // We can't allow the refcount to increase much past `MAX_REFCOUNT`.
-            enforce_overflow_limit(cur);
-
+            if cur > MAX_REFCOUNT {
+                panic_arc_overflow();
+            }
             // NOTE: this code currently ignores the possibility of overflow
             // into usize::MAX; in general both Rc and Arc need to be adjusted
             // to deal with overflow.
@@ -3313,7 +3317,9 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
                 return None;
             }
             // See comments in `Arc::clone` for why we do this (for `mem::forget`).
-            enforce_overflow_limit(n);
+            if n > MAX_REFCOUNT {
+                panic_arc_overflow();
+            }
             Some(n + 1)
         }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -55,8 +55,10 @@ use crate::vec::Vec;
 /// See comment in `Arc::clone`.
 const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 
-/// The error in case either counter reaches above `MAX_REFCOUNT`, and we can `panic` safely.
-const INTERNAL_OVERFLOW_ERROR: &str = "Arc counter overflow";
+#[inline(always)]
+fn enforce_overflow_limit(n: usize) {
+    assert!(n <= MAX_REFCOUNT, "Arc counter overflow");
+}
 
 #[cfg(not(sanitize = "thread"))]
 macro_rules! acquire {
@@ -1954,7 +1956,7 @@ impl<T: ?Sized, A: Allocator> Arc<T, A> {
             }
 
             // We can't allow the refcount to increase much past `MAX_REFCOUNT`.
-            assert!(cur <= MAX_REFCOUNT, "{}", INTERNAL_OVERFLOW_ERROR);
+            enforce_overflow_limit(cur);
 
             // NOTE: this code currently ignores the possibility of overflow
             // into usize::MAX; in general both Rc and Arc need to be adjusted
@@ -3311,7 +3313,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
                 return None;
             }
             // See comments in `Arc::clone` for why we do this (for `mem::forget`).
-            assert!(n <= MAX_REFCOUNT, "{}", INTERNAL_OVERFLOW_ERROR);
+            enforce_overflow_limit(n);
             Some(n + 1)
         }
 


### PR DESCRIPTION
- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

This PR removes unnecessary `fmt::Display` generated assembly because of use of formatting in the overflow check assertion(`assert!(n <= MAX_REFCOUNT, "{}", INTERNAL_OVERFLOW_ERROR);`).

This reduces generated x64 assembly for counter increment(simplified) from:
```asm
increase_counter:
        test    rdi, rdi
        js      .LBB1_2
        inc     rdi
        mov     rax, rdi
        ret
.LBB1_2:
        sub     rsp, 24
        lea     rax, [rip + .Lanon.642d46026bcfa00bfed8baf8cdbf502d.2]
        mov     qword ptr [rsp + 8], rax
        lea     rax, [rip + <&str as core[4e7ceada952a6ea0]::fmt::Display>::fmt]
        mov     qword ptr [rsp + 16], rax
        lea     rdi, [rip + .Lanon.642d46026bcfa00bfed8baf8cdbf502d.0]
        lea     rdx, [rip + .Lanon.642d46026bcfa00bfed8baf8cdbf502d.4]
        lea     rsi, [rsp + 8]
        call    qword ptr [rip + core[4e7ceada952a6ea0]::panicking::panic_fmt@GOTPCREL]

.Lanon.642d46026bcfa00bfed8baf8cdbf502d.0:
        .asciz  "\300"

.Lanon.642d46026bcfa00bfed8baf8cdbf502d.1:
        .ascii  "Arc counter overflow"
```

To:
```asm
increase_counter:
        test    rdi, rdi
        js      .LBB0_2
        inc     rdi
        mov     rax, rdi
        ret
.LBB0_2:
        push    rax
        lea     rdi, [rip + .Lanon.642d46026bcfa00bfed8baf8cdbf502d.0]
        lea     rdx, [rip + .Lanon.642d46026bcfa00bfed8baf8cdbf502d.2]
        mov     esi, 41
        call    qword ptr [rip + core[4e7ceada952a6ea0]::panicking::panic_fmt@GOTPCREL]

.Lanon.642d46026bcfa00bfed8baf8cdbf502d.0:
        .ascii  "Arc counter overflow"
```

Godbolt link:
https://godbolt.org/z/3qjxooYWM

I expect bors to report a binary size reduction for all programs using Arc. There might also be performance improvements as a byproduct of CPU cache hit increase.