### PR TITLE
rustdoc: fix auto trait synthesis ICE with higher-ranked GAT bounds

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -8,7 +8,7 @@ use rustc_data_structures::fx::{FxIndexMap, FxIndexSet, IndexEntry};
 use rustc_data_structures::unord::UnordSet;
 use rustc_hir::def_id::CRATE_DEF_ID;
 use rustc_infer::infer::DefineOpaqueTypes;
-use rustc_middle::ty::{Region, RegionVid};
+use rustc_middle::ty::{BottomUpFolder, Region, RegionVid, TypeFoldable, TypeVisitable};
 use rustc_span::DUMMY_SP;
 use tracing::debug;
 
@@ -445,6 +445,33 @@ impl<'tcx> AutoTraitFinder<'tcx> {
         user_computed_clauses: &mut FxIndexSet<ty::Clause<'tcx>>,
         new_clause: ty::Clause<'tcx>,
     ) {
+        // Collects every region -- free or bound -- in visit order.
+        #[derive(Default)]
+        struct CollectAllRegions<'tcx> {
+            regions: Vec<ty::Region<'tcx>>,
+        }
+        impl<'tcx> ty::TypeVisitor<TyCtxt<'tcx>> for CollectAllRegions<'tcx> {
+            fn visit_region(&mut self, r: ty::Region<'tcx>) {
+                self.regions.push(r);
+            }
+        }
+
+        let tcx = self.tcx;
+
+        // Replaces every region -- free or bound -- with `'erased`, in order
+        // to compare two sets of generic arguments modulo regions. Note that
+        // `fold_regions` and `erase_and_anonymize_regions` don't touch regions
+        // bound within the value, so they can't be used here: erasing *every*
+        // region ensures that a walk over the regions of two values that
+        // compare equal after erasure visits the same positions.
+        let erase_all_regions = |args: ty::GenericArgsRef<'tcx>| {
+            args.fold_with(&mut BottomUpFolder {
+                tcx,
+                ty_op: |ty| ty,
+                lt_op: |_| tcx.lifetimes.re_erased,
+                ct_op: |ct| ct,
+            })
+        };
         let mut should_add_new = true;
         user_computed_clauses.retain(|&old_clause| {
             if let (ty::ClauseKind::Trait(new_trait), ty::ClauseKind::Trait(old_trait)) =
@@ -454,14 +481,32 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                     let new_args = new_trait.trait_ref.args;
                     let old_args = old_trait.trait_ref.args;
 
-                    if !new_args.types().eq(old_args.types()) {
-                        // We can't compare lifetimes if the types are different,
-                        // so skip checking `old_clause`.
+                    // The two clauses can only be merged if they differ solely in
+                    // their regions. Note that regions don't just show up as
+                    // direct generic arguments of the trait ref: with generic
+                    // associated types, a region can also sit *inside* a type
+                    // argument, e.g. `for<'w> <A as Alloc>::Wired<'w>: Send` vs.
+                    // `<A as Alloc>::Wired<'static>: Send`. Therefore the
+                    // arguments are compared with *all* regions erased, and the
+                    // region comparison below walks the regions of both argument
+                    // lists in lockstep.
+                    if erase_all_regions(new_args) != erase_all_regions(old_args) {
+                        // The clauses differ in more than their regions, so both
+                        // must be kept: skip checking `old_clause`.
                         return true;
                     }
 
+                    let mut new_regions = CollectAllRegions::default();
+                    new_args.visit_with(&mut new_regions);
+                    let mut old_regions = CollectAllRegions::default();
+                    old_args.visit_with(&mut old_regions);
+
+                    // Equal modulo regions implies the same region positions
+                    // on both sides.
+                    debug_assert_eq!(new_regions.regions.len(), old_regions.regions.len());
+
                     for (new_region, old_region) in
-                        iter::zip(new_args.regions(), old_args.regions())
+                        iter::zip(new_regions.regions, old_regions.regions)
                     {
                         match (new_region.kind(), old_region.kind()) {
                             // If both predicates have an `ReBound` (a HRTB) in the

--- a/tests/rustdoc-html/synthetic_auto/gat-hrtb-dedup-144918.rs
+++ b/tests/rustdoc-html/synthetic_auto/gat-hrtb-dedup-144918.rs
@@ -1,0 +1,31 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/144918>.
+//
+// Synthesizing auto trait impls used to ICE ("Unable to fulfill trait ...:
+// [Ambiguity]") when a manual `unsafe impl` carried a higher-ranked bound on a
+// generic associated type (`for<'w> A::Wired<'w>: Send`) while a field of the
+// type being documented mentioned the same GAT with a concrete lifetime
+// (`A::Wired<'static>`). The two discovered bounds differ only in a region
+// *inside* a type argument, which `add_user_clause` failed to deduplicate,
+// leaving an ambiguous `ParamEnv`.
+
+pub trait Alloc {
+    type Wired<'w>;
+}
+
+pub struct Slot<A>(A);
+
+unsafe impl<A: Alloc> Send for Slot<A> where for<'w> A::Wired<'w>: Send {}
+
+//@ has gat_hrtb_dedup_144918/struct.Custody.html
+//
+// The two discovered `Send` bounds collapse into the stricter, higher-ranked
+// one.
+// FIXME: `for<'w>` is rendered on the bound rather than before the self type;
+// this is a pre-existing rendering quirk.
+//@ has - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]//h3[@class="code-header"]' \
+// "impl<A> Send for Custody<A>where <A as Alloc>::Wired<'w>: for<'w> Send,"
+//
+// `Sync` discovers no higher-ranked bound, so the concrete one is kept.
+//@ has - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]//h3[@class="code-header"]' \
+// "impl<A> Sync for Custody<A>where <A as Alloc>::Wired<'static>: Sync, A: Sync,"
+pub struct Custody<A: Alloc>(Slot<A>, A::Wired<'static>);


### PR DESCRIPTION
rustdoc's auto trait impl synthesis deduplicates discovered clauses that differ only in their regions (`AutoTraitFinder::add_user_clause`), keeping the stricter (higher-ranked) one, because a `ParamEnv` containing both confuses `SelectionContext`: both candidates apply, selection reports ambiguity, and the sanity check in `find_auto_trait_generics` turns that into an ICE:

```
Unable to fulfill trait DefId(... ~ core[...]::marker::Send) for '...': [Ambiguity]
```

The dedup only compared regions appearing as *direct* generic arguments of the trait ref (`T: Trait<'a>` vs. `for<'b> T: Trait<'b>`). With generic associated types the differing region can instead sit *inside* a type argument: `for<'w> <A as Alloc>::Wired<'w>: Send` and `<A as Alloc>::Wired<'static>: Send` have unequal self types, so the dedup bailed out ("we can't compare lifetimes if the types are different"), both clauses landed in the `ParamEnv`, and the final fulfillment check panicked.

This PR compares the argument lists with all regions erased instead, and, when they are equal modulo regions, walks the regions of both argument lists in lockstep so the existing preference rules (keep the higher-ranked bound, drop region variables) also apply to regions nested inside type arguments.

Minimal reproduction (ICEs on stable and nightly before this change):

```rust
pub trait Alloc {
    type Wired<'w>;
}

pub struct Slot<A>(A);

unsafe impl<A: Alloc> Send for Slot<A> where for<'w> A::Wired<'w>: Send {}

pub struct Custody<A: Alloc>(Slot<A>, A::Wired<'static>);
```

Synthesizing `Custody<A>: Send` discovers `for<'w> A::Wired<'w>: Send` (from `Slot`'s manual impl) and `A::Wired<'static>: Send` (from the second field); with this change the latter is subsumed by the former and the synthesized impl is rendered with the higher-ranked bound.

Fixes rust-lang/rust#144918.

rust-lang/rust#149019 rewrites the synthesis on the next solver and would also fix this; this PR is a targeted fix for the current implementation in the meantime.

The related rust-lang/rust#110741 hits the same panic through an ambiguous *projection* clause (`FnOnce::Output`), which `add_user_clause` does not deduplicate at all; that flavor is not addressed here.
