### PR TITLE
Add OpenBSD `-current` release version to `target_env`

### DIFF
--- a/compiler/rustc_target/src/spec/base/openbsd.rs
+++ b/compiler/rustc_target/src/spec/base/openbsd.rs
@@ -1,8 +1,9 @@
-use crate::spec::{FramePointer, Os, RelroLevel, TargetOptions, TlsModel, cvs};
+use crate::spec::{Env, FramePointer, Os, RelroLevel, TargetOptions, TlsModel, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
         os: Os::OpenBsd,
+        env: Env::OpenBsdCurrent,
         dynamic_linking: true,
         families: cvs!["unix"],
         has_rpath: true,

--- a/compiler/rustc_target/src/spec/base/openbsd.rs
+++ b/compiler/rustc_target/src/spec/base/openbsd.rs
@@ -1,8 +1,9 @@
-use crate::spec::{FramePointer, Os, RelroLevel, TargetOptions, TlsModel, cvs};
+use crate::spec::{Env, FramePointer, Os, RelroLevel, TargetOptions, TlsModel, cvs};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
         os: Os::OpenBsd,
+        env: Env::OpenBsd,
         dynamic_linking: true,
         families: cvs!["unix"],
         has_rpath: true,

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2045,6 +2045,7 @@ crate::target_spec_enum! {
         Nto71 = "nto71",
         Nto71IoSock = "nto71_iosock",
         Ohos = "ohos",
+        OpenBsd = "openbsd7.9",
         Relibc = "relibc",
         Sgx = "sgx",
         Sim = "sim",

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2045,6 +2045,7 @@ crate::target_spec_enum! {
         Nto71 = "nto71",
         Nto71IoSock = "nto71_iosock",
         Ohos = "ohos",
+        OpenBsdCurrent = "openbsd8.0",
         Relibc = "relibc",
         Sgx = "sgx",
         Sim = "sim",

--- a/src/doc/rustc/src/platform-support/openbsd.md
+++ b/src/doc/rustc/src/platform-support/openbsd.md
@@ -19,6 +19,22 @@ The target names follow this format: `$ARCH-unknown-openbsd`, where `$ARCH` spec
 
 Note that all OS versions are *major* even if using X.Y notation (`6.8` and `6.9` are different major versions) and could be binary incompatibles (with breaking changes).
 
+<!--
+Whenever a new OpenBSD version releases, the following is in order:
+
+- Update `` by updating the `Env` variant used for OpenBSD versions
+    - This may potentially need adding a new variant instead of updating
+      the current one if OpenBSD deprecates support for some target
+      architecture but we want to continue supporting it.
+
+- Update `src/librustdoc/clean.rs` with a formatted string containing
+  the new version.
+-->
+
+> [!IMPORTANT]
+> Note these targets encode the latest OpenBSD version that supported
+> them. In most cases, this means the version to be released once
+> OpenBSD `-current` is made into a new `-release` release.
 
 ## Target Maintainers
 
@@ -29,7 +45,6 @@ Further contacts:
 - [lang/rust](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/rust/Makefile?rev=HEAD&content-type=text/x-cvsweb-markup) maintainer (see MAINTAINER variable)
 
 Fallback to ports@openbsd.org, OpenBSD third parties public mailing-list (with openbsd developers readers)
-
 
 ## Requirements
 

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -723,6 +723,7 @@ fn human_readable_target_env(env: Symbol) -> Option<&'static str> {
         Nto71 => "QNX SDP 7.1",
         Nto71IoSock => "QNX SDP 7.1 with io-sock",
         Ohos => "OpenHarmony",
+        OpenBsd => "OpenBSD -current",
         P1 => "WASIp1",
         P2 => "WASIp2",
         P3 => "WASIp3",

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -723,6 +723,7 @@ fn human_readable_target_env(env: Symbol) -> Option<&'static str> {
         Nto71 => "QNX SDP 7.1",
         Nto71IoSock => "QNX SDP 7.1 with io-sock",
         Ohos => "OpenHarmony",
+        OpenBsdCurrent => "OpenBSD -current (8.0)",
         P1 => "WASIp1",
         P2 => "WASIp2",
         P3 => "WASIp3",

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -156,7 +156,7 @@ warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
 LL |     target_env = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_env` are: ``, `gnu`, `macabi`, `mlibc`, `msvc`, `musl`, `newlib`, `nto70`, `nto71`, `nto71_iosock`, `ohos`, `p1`, `p2`, `p3`, `relibc`, `sgx`, `sim`, `uclibc`, and `v5`
+   = note: expected values for `target_env` are: ``, `gnu`, `macabi`, `mlibc`, `msvc`, `musl`, `newlib`, `nto70`, `nto71`, `nto71_iosock`, `ohos`, `openbsd7.9`, `p1`, `p2`, `p3`, `relibc`, `sgx`, `sim`, `uclibc`, and `v5`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160739)*
<!-- homu-ignore:end -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below
      how it was used.

Draft PR to add support for `target_env` values in OpenBSD to carry their
`-current` release channel version number.

This is meant to be the associated implementation for
rust-lang/compiler-team#1018.

Unlike the proposed implementation plan in the MCP, no specific target specs
have been modified. The base specification currently serves just fine for all
supported OpenBSD targets.

If at some point in the future, some OpenBSD release drops support for a current
Rust target, the target-specific module can be modified to avoid relying on the
default `Env` value.
