### PR TITLE
add regression tests for the fn sig ice

### DIFF
--- a/tests/ui/structs/ice-missing-field-fn-sig-closure.rs
+++ b/tests/ui/structs/ice-missing-field-fn-sig-closure.rs
@@ -1,0 +1,16 @@
+// issue-link: https://github.com/rust-lang/rust/issues/160591
+// A closure call with a struct literal missing a field shouldn't ICE when checking the fn sig.
+
+trait Context {}
+struct Wrapper<C: Context + 'static> {
+    container: &'static C,
+}
+
+fn main() {
+    let c = |_: Wrapper<()>| {}; //~ ERROR the trait bound `(): Context` is not satisfied
+    c(Wrapper { /* missing */ });
+    //~^ ERROR the trait bound `(): Context` is not satisfied
+    //~^^ ERROR missing field `container` in initializer of `Wrapper<_>`
+    //~^^^ ERROR the trait bound `(): Context` is not satisfied
+    //~^^^^ ERROR the trait bound `(): Context` is not satisfied
+}

--- a/tests/ui/structs/ice-missing-field-fn-sig-closure.rs
+++ b/tests/ui/structs/ice-missing-field-fn-sig-closure.rs
@@ -1,0 +1,15 @@
+// A closure call with a struct literal missing a field shouldn't ICE when checking the fn sig.
+
+trait Context {}
+struct Wrapper<C: Context + 'static> {
+    container: &'static C,
+}
+
+fn main() {
+    let c = |_: Wrapper<()>| {}; //~ ERROR the trait bound `(): Context` is not satisfied
+    c(Wrapper { /* missing */ });
+    //~^ ERROR the trait bound `(): Context` is not satisfied
+    //~^^ ERROR missing field `container` in initializer of `Wrapper<_>`
+    //~^^^ ERROR the trait bound `(): Context` is not satisfied
+    //~^^^^ ERROR the trait bound `(): Context` is not satisfied
+}

--- a/tests/ui/structs/ice-missing-field-fn-sig-closure.stderr
+++ b/tests/ui/structs/ice-missing-field-fn-sig-closure.stderr
@@ -1,0 +1,78 @@
+error[E0277]: the trait bound `(): Context` is not satisfied
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:10:17
+   |
+LL |     let c = |_: Wrapper<()>| {};
+   |                 ^^^^^^^^^^^ the trait `Context` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:4:1
+   |
+LL | trait Context {}
+   | ^^^^^^^^^^^^^
+note: required by a bound in `Wrapper`
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:5:19
+   |
+LL | struct Wrapper<C: Context + 'static> {
+   |                   ^^^^^^^ required by this bound in `Wrapper`
+
+error[E0277]: the trait bound `(): Context` is not satisfied
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:11:7
+   |
+LL |     c(Wrapper { /* missing */ });
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Context` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:4:1
+   |
+LL | trait Context {}
+   | ^^^^^^^^^^^^^
+note: required by a bound in `Wrapper`
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:5:19
+   |
+LL | struct Wrapper<C: Context + 'static> {
+   |                   ^^^^^^^ required by this bound in `Wrapper`
+
+error[E0063]: missing field `container` in initializer of `Wrapper<_>`
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:11:7
+   |
+LL |     c(Wrapper { /* missing */ });
+   |       ^^^^^^^ missing `container`
+
+error[E0277]: the trait bound `(): Context` is not satisfied
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:11:7
+   |
+LL |     c(Wrapper { /* missing */ });
+   |       ^^^^^^^ the trait `Context` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:4:1
+   |
+LL | trait Context {}
+   | ^^^^^^^^^^^^^
+note: required by a bound in `Wrapper`
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:5:19
+   |
+LL | struct Wrapper<C: Context + 'static> {
+   |                   ^^^^^^^ required by this bound in `Wrapper`
+
+error[E0277]: the trait bound `(): Context` is not satisfied
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:11:5
+   |
+LL |     c(Wrapper { /* missing */ });
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Context` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:4:1
+   |
+LL | trait Context {}
+   | ^^^^^^^^^^^^^
+note: required by a bound in `Wrapper`
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:5:19
+   |
+LL | struct Wrapper<C: Context + 'static> {
+   |                   ^^^^^^^ required by this bound in `Wrapper`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0063, E0277.
+For more information about an error, try `rustc --explain E0063`.

--- a/tests/ui/structs/ice-missing-field-fn-sig-closure.stderr
+++ b/tests/ui/structs/ice-missing-field-fn-sig-closure.stderr
@@ -1,0 +1,78 @@
+error[E0277]: the trait bound `(): Context` is not satisfied
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:9:17
+   |
+LL |     let c = |_: Wrapper<()>| {};
+   |                 ^^^^^^^^^^^ the trait `Context` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:3:1
+   |
+LL | trait Context {}
+   | ^^^^^^^^^^^^^
+note: required by a bound in `Wrapper`
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:4:19
+   |
+LL | struct Wrapper<C: Context + 'static> {
+   |                   ^^^^^^^ required by this bound in `Wrapper`
+
+error[E0277]: the trait bound `(): Context` is not satisfied
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:10:7
+   |
+LL |     c(Wrapper { /* missing */ });
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Context` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:3:1
+   |
+LL | trait Context {}
+   | ^^^^^^^^^^^^^
+note: required by a bound in `Wrapper`
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:4:19
+   |
+LL | struct Wrapper<C: Context + 'static> {
+   |                   ^^^^^^^ required by this bound in `Wrapper`
+
+error[E0063]: missing field `container` in initializer of `Wrapper<_>`
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:10:7
+   |
+LL |     c(Wrapper { /* missing */ });
+   |       ^^^^^^^ missing `container`
+
+error[E0277]: the trait bound `(): Context` is not satisfied
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:10:7
+   |
+LL |     c(Wrapper { /* missing */ });
+   |       ^^^^^^^ the trait `Context` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:3:1
+   |
+LL | trait Context {}
+   | ^^^^^^^^^^^^^
+note: required by a bound in `Wrapper`
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:4:19
+   |
+LL | struct Wrapper<C: Context + 'static> {
+   |                   ^^^^^^^ required by this bound in `Wrapper`
+
+error[E0277]: the trait bound `(): Context` is not satisfied
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:10:5
+   |
+LL |     c(Wrapper { /* missing */ });
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Context` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:3:1
+   |
+LL | trait Context {}
+   | ^^^^^^^^^^^^^
+note: required by a bound in `Wrapper`
+  --> $DIR/ice-missing-field-fn-sig-closure.rs:4:19
+   |
+LL | struct Wrapper<C: Context + 'static> {
+   |                   ^^^^^^^ required by this bound in `Wrapper`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0063, E0277.
+For more information about an error, try `rustc --explain E0063`.

--- a/tests/ui/structs/ice-missing-field-fn-sig-method.rs
+++ b/tests/ui/structs/ice-missing-field-fn-sig-method.rs
@@ -1,0 +1,14 @@
+// issue-link: https://github.com/rust-lang/rust/issues/160591
+// A method call whose where-clause fails shouldn't ICE when checking the fn sig.
+
+trait Context {}
+struct Foo;
+impl Foo {
+    fn take<T: Context>(&self, _: T) {}
+}
+
+fn main() {
+    let f = Foo;
+    f.take(());
+    //~^ ERROR the trait bound `(): Context` is not satisfied
+}

--- a/tests/ui/structs/ice-missing-field-fn-sig-method.rs
+++ b/tests/ui/structs/ice-missing-field-fn-sig-method.rs
@@ -1,0 +1,13 @@
+// A method call whose where-clause fails shouldn't ICE when checking the fn sig.
+
+trait Context {}
+struct Foo;
+impl Foo {
+    fn take<T: Context>(&self, _: T) {}
+}
+
+fn main() {
+    let f = Foo;
+    f.take(());
+    //~^ ERROR the trait bound `(): Context` is not satisfied
+}

--- a/tests/ui/structs/ice-missing-field-fn-sig-method.stderr
+++ b/tests/ui/structs/ice-missing-field-fn-sig-method.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the trait bound `(): Context` is not satisfied
+  --> $DIR/ice-missing-field-fn-sig-method.rs:12:12
+   |
+LL |     f.take(());
+   |       ---- ^^ the trait `Context` is not implemented for `()`
+   |       |
+   |       required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-missing-field-fn-sig-method.rs:4:1
+   |
+LL | trait Context {}
+   | ^^^^^^^^^^^^^
+note: required by a bound in `Foo::take`
+  --> $DIR/ice-missing-field-fn-sig-method.rs:7:16
+   |
+LL |     fn take<T: Context>(&self, _: T) {}
+   |                ^^^^^^^ required by this bound in `Foo::take`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/structs/ice-missing-field-fn-sig-method.stderr
+++ b/tests/ui/structs/ice-missing-field-fn-sig-method.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the trait bound `(): Context` is not satisfied
+  --> $DIR/ice-missing-field-fn-sig-method.rs:11:12
+   |
+LL |     f.take(());
+   |       ---- ^^ the trait `Context` is not implemented for `()`
+   |       |
+   |       required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-missing-field-fn-sig-method.rs:3:1
+   |
+LL | trait Context {}
+   | ^^^^^^^^^^^^^
+note: required by a bound in `Foo::take`
+  --> $DIR/ice-missing-field-fn-sig-method.rs:6:16
+   |
+LL |     fn take<T: Context>(&self, _: T) {}
+   |                ^^^^^^^ required by this bound in `Foo::take`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
follow-up to rust-lang/rust#160628 which fixed the `suggest_add_reference_to_arg` fn_sig ice

adds the regression tests @teor2345 asked for in review
- closure call with a missing-field struct literal (iced without the guard)
- method call whose where-clause fails (covers the method-call branch)

the impl def_id case cant be constructed, those obligations get dropped during probing and turn into e0599 instead