### PR TITLE
Add regression test for cross-crate assoc const private field leak in rustdoc

### DIFF
--- a/tests/rustdoc-html/inline_cross/assoc-const-private-fields-99630.rs
+++ b/tests/rustdoc-html/inline_cross/assoc-const-private-fields-99630.rs
@@ -1,0 +1,14 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/99630>.
+//!
+//! Re-exporting a type from another crate must not leak the private fields used
+//! in the initializer of one of its associated constants.
+
+//@ aux-build:assoc-const-private-fields.rs
+
+#![crate_name = "foo"]
+
+extern crate assoc_const_private_fields;
+
+//@ has foo/struct.HasPrivateFields.html
+//@ matches - '//*[@id="associatedconstant.ASSOC"]' '^pub const ASSOC: HasPrivateFields$'
+pub use assoc_const_private_fields::HasPrivateFields;

--- a/tests/rustdoc-html/inline_cross/assoc-const-private-fields-99630.rs
+++ b/tests/rustdoc-html/inline_cross/assoc-const-private-fields-99630.rs
@@ -1,0 +1,15 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/99630>.
+//!
+//! Re-exporting a type from another crate must not leak the private fields used
+//! in the initializer of one of its associated constants.
+
+//@ aux-build:assoc-const-private-fields.rs
+
+#![crate_name = "foo"]
+
+extern crate assoc_const_private_fields;
+
+//@ has foo/struct.HasPrivateFields.html
+//@ has - '//*[@id="associatedconstant.ASSOC"]' 'pub const ASSOC: HasPrivateFields'
+//@ !has - '//*[@id="associatedconstant.ASSOC"]' '_private'
+pub use assoc_const_private_fields::HasPrivateFields;

--- a/tests/rustdoc-html/inline_cross/auxiliary/assoc-const-private-fields.rs
+++ b/tests/rustdoc-html/inline_cross/auxiliary/assoc-const-private-fields.rs
@@ -1,0 +1,7 @@
+pub struct HasPrivateFields {
+    _private: (),
+}
+
+impl HasPrivateFields {
+    pub const ASSOC: Self = Self { _private: () };
+}


### PR DESCRIPTION
Closes rust-lang/rust#99630 adds a rustdoc test, reexporting a type must not leak the private field