### PR TITLE
MaybeDangling: ensure references fit inside the address space

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -647,6 +647,25 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
                 None
             }
         } else {
+            // We are not checking dereferenceability, but we still want to ensure that the pointer
+            // *could* be dereferenceable in *some* memory: we have to be able to compute the
+            // address at the end of this range without overflowing..
+            let scalar = Scalar::from_maybe_pointer(place.ptr(), self.ecx);
+            // Skip this if we don't know the absolute address (during CTFE).
+            if let Ok(addr) = scalar.try_to_scalar_int() {
+                // Try to compute the end address.
+                let addr = Size::from_bytes(addr.to_target_usize(*self.ecx.tcx));
+                if addr.checked_add(size, self.ecx).is_none() {
+                    throw_validation_failure!(
+                        self.path,
+                        format!(
+                            "encountered a {ptr_kind} that is too close to the end of the address space for a pointee of {} bytes",
+                            size.bytes(),
+                        )
+                    )
+                }
+            }
+
             // Pointer remains unchanged.
             None
         };
@@ -657,20 +676,6 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
         } else if self.reset_provenance_and_padding {
             self.reset_pointer_provenance(value, &ptr)?;
         }
-
-        // Check alignment after dereferenceable (if both are violated, trigger the error above).
-        try_validation!(
-            self.ecx.check_ptr_align(
-                place.ptr(),
-                align,
-            ),
-            self.path,
-            Ub(AlignmentCheckFailed(Misalignment { required, has }, _msg)) => format!(
-                "encountered an unaligned {ptr_kind} (required {required_bytes} byte alignment but found {found_bytes})",
-                required_bytes = required.bytes(),
-                found_bytes = has.bytes()
-            ),
-        );
 
         // Make sure this is non-null. This is obviously needed when `may_dangle` is set,
         // but even if we did check dereferenceability above that would still allow null
@@ -686,6 +691,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
                 )
             )
         }
+
         // Do not allow references to uninhabited types.
         if !place.layout.ty.is_opsem_inhabited(*self.ecx.tcx, self.ecx.typing_env) {
             let ty = place.layout.ty;
@@ -694,6 +700,20 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
                 format!("encountered a {ptr_kind} pointing to uninhabited type `{ty}`")
             )
         }
+
+        // Check alignment after dereferenceable (if both are violated, trigger the error above).
+        try_validation!(
+            self.ecx.check_ptr_align(
+                place.ptr(),
+                align,
+            ),
+            self.path,
+            Ub(AlignmentCheckFailed(Misalignment { required, has }, _msg)) => format!(
+                "encountered an unaligned {ptr_kind} (required {required_bytes} byte alignment but found {found_bytes})",
+                required_bytes = required.bytes(),
+                found_bytes = has.bytes()
+            ),
+        );
 
         // Recursive checking (but not inside `MaybeDangling` of course).
         if let Some(ref_tracking) = self.ref_tracking.as_deref_mut()

--- a/src/tools/miri/tests/fail/validity/maybe_dangling_ref_too_big.rs
+++ b/src/tools/miri/tests/fail/validity/maybe_dangling_ref_too_big.rs
@@ -1,0 +1,7 @@
+#![feature(maybe_dangling)]
+use std::mem::{transmute, MaybeDangling};
+
+fn main() {
+    let _x: MaybeDangling<&i8> = unsafe { transmute(usize::MAX) };
+    //~^ERROR: too close to the end of the address space
+}

--- a/src/tools/miri/tests/fail/validity/maybe_dangling_ref_too_big.stderr
+++ b/src/tools/miri/tests/fail/validity/maybe_dangling_ref_too_big.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: constructing invalid value of type std::mem::MaybeDangling<&i8>: encountered a reference that is too close to the end of the address space for a pointee of 1 bytes
+  --> tests/fail/validity/maybe_dangling_ref_too_big.rs:LL:CC
+   |
+LL |     let _x: MaybeDangling<&i8> = unsafe { transmute(usize::MAX) };
+   |                                           ^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
In the RFC we left open the question of the exact validity invariant for references inside `MaybeDangling`. This PR implements the strictest invariant I can think of: we already require references to be aligned, now we also require "addr + size" to be computable without overflow. This ensures that whatever niches we add to references in the future, `MaybeDangling` preserves those niches.

Cc @rust-lang/opsem @WaffleLapkin 

Tracking issue: https://github.com/rust-lang/rust/issues/118166
r? @oli-obk 
<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
