### PR TITLE
Add regression test for incremental borrowck ICE with generic const exprs

### DIFF
--- a/tests/ui/const-generics/generic_const_exprs/cannot-convert-erased-region-vid-ice-125564.rs
+++ b/tests/ui/const-generics/generic_const_exprs/cannot-convert-erased-region-vid-ice-125564.rs
@@ -1,0 +1,33 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/125564>.
+
+//@ incremental
+
+#![allow(incomplete_features)]
+#![feature(adt_const_params, unsized_const_params, generic_const_exprs)]
+
+const fn concat_strs() -> &'static str {
+    //~^ ERROR mismatched types
+    const fn concat_arr<const M: usize, const N: usize>(a: [u8; M], b: [u8; N]) -> [u8; M + N] {}
+    //~^ ERROR mismatched types
+
+    impl<const A: &'static str, const B: &'static str> Inner<A, B>
+    //~^ ERROR cannot find type `Inner` in this scope
+    where
+        [(); A.len()]:,
+        [(); B.len()]:,
+        [(); A.len() + B.len()]:,
+    {
+        const ABSTR: &'static str = unsafe {
+            std::str::from_utf8_unchecked(&concat_arr(
+                A.as_ptr().cast().read(),
+                //~^ WARN type annotations needed
+                //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+                B.as_ptr().cast().read(),
+                //~^ WARN type annotations needed
+                //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+            ))
+        };
+    }
+}
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/cannot-convert-erased-region-vid-ice-125564.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/cannot-convert-erased-region-vid-ice-125564.stderr
@@ -1,0 +1,51 @@
+error[E0425]: cannot find type `Inner` in this scope
+  --> $DIR/cannot-convert-erased-region-vid-ice-125564.rs:13:56
+   |
+LL |     impl<const A: &'static str, const B: &'static str> Inner<A, B>
+   |                                                        ^^^^^ not found in this scope
+
+error[E0308]: mismatched types
+  --> $DIR/cannot-convert-erased-region-vid-ice-125564.rs:8:27
+   |
+LL | const fn concat_strs() -> &'static str {
+   |          -----------      ^^^^^^^^^^^^ expected `&str`, found `()`
+   |          |
+   |          implicitly returns `()` as its body has no tail or `return` expression
+
+error[E0308]: mismatched types
+  --> $DIR/cannot-convert-erased-region-vid-ice-125564.rs:10:84
+   |
+LL |     const fn concat_arr<const M: usize, const N: usize>(a: [u8; M], b: [u8; N]) -> [u8; M + N] {}
+   |              ----------                                                            ^^^^^^^^^^^ expected `[u8; M + N]`, found `()`
+   |              |
+   |              implicitly returns `()` as its body has no tail or `return` expression
+   |
+note: consider returning one of these bindings
+  --> $DIR/cannot-convert-erased-region-vid-ice-125564.rs:10:57
+   |
+LL |     const fn concat_arr<const M: usize, const N: usize>(a: [u8; M], b: [u8; N]) -> [u8; M + N] {}
+   |                                                         ^           ^
+
+warning: type annotations needed
+  --> $DIR/cannot-convert-erased-region-vid-ice-125564.rs:22:35
+   |
+LL |                 A.as_ptr().cast().read(),
+   |                                   ^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2018/tyvar-behind-raw-pointer.html>
+   = note: `#[warn(tyvar_behind_raw_pointer)]` (part of `#[warn(rust_2018_compatibility)]`) on by default
+
+warning: type annotations needed
+  --> $DIR/cannot-convert-erased-region-vid-ice-125564.rs:25:35
+   |
+LL |                 B.as_ptr().cast().read(),
+   |                                   ^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2018/tyvar-behind-raw-pointer.html>
+
+error: aborting due to 3 previous errors; 2 warnings emitted
+
+Some errors have detailed explanations: E0308, E0425.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Adds an incremental regression test for rust-lang/rust#125564 for generic-const exprs snippet, now reports errors cleanly

Closes https://github.com/rust-lang/rust/issues/125564