### PR TITLE
Miri: give the incremental session a chance to finish

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1332,7 +1332,7 @@ pub(crate) fn start_codegen<'tcx>(
                 rustc_monomorphize::write_host_metadata_offload_manifest(tcx);
             }
 
-            // Linker::link will skip join_codegen in case of a CodegenResults Any value.
+            // Linker::link will skip join_codegen in case of a `CompiledModules` Any value.
             Box::new(CompiledModules { modules: vec![], allocator_module: None })
         } else {
             codegen_backend.codegen_crate(tcx)

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1312,7 +1312,7 @@ pub(crate) fn start_codegen<'tcx>(
             // Skip crate items and just output metadata in -Z no-codegen mode.
             tcx.sess.dcx().abort_if_errors();
 
-            // Linker::link will skip join_codegen in case of a CodegenResults Any value.
+            // Linker::link will skip join_codegen in case of a `CompiledModules` Any value.
             Box::new(CompiledModules { modules: vec![], allocator_module: None })
         } else {
             codegen_backend.codegen_crate(tcx)

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -363,7 +363,7 @@ pub fn get_codegen_backend(
             filename if filename.contains('.') => {
                 load_backend_from_dylib(early_dcx, filename.as_ref())
             }
-            "dummy" => || Box::new(DummyCodegenBackend { target_config_override: None }),
+            "dummy" => || Box::new(DummyCodegenBackend),
             #[cfg(feature = "llvm")]
             "llvm" => rustc_codegen_llvm::LlvmCodegenBackend::new,
             backend_name => get_codegen_sysroot(early_dcx, sysroot, backend_name),
@@ -376,9 +376,7 @@ pub fn get_codegen_backend(
     unsafe { load() }
 }
 
-pub struct DummyCodegenBackend {
-    pub target_config_override: Option<Box<dyn Fn(&Session) -> TargetConfig>>,
-}
+pub struct DummyCodegenBackend;
 
 impl CodegenBackend for DummyCodegenBackend {
     fn name(&self) -> &'static str {
@@ -386,10 +384,6 @@ impl CodegenBackend for DummyCodegenBackend {
     }
 
     fn target_config(&self, sess: &Session) -> TargetConfig {
-        if let Some(target_config_override) = &self.target_config_override {
-            return target_config_override(sess);
-        }
-
         let abi_required_features = sess.target.abi_required_features();
         let internal_target_features = internal_target_features::<0>(
             sess,

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -2027,10 +2027,10 @@ rustc_queries! {
     // The hash should not be calculated before the `analysis` pass is complete, specifically
     // until `tcx.untracked().definitions.freeze()` has been called, otherwise if incremental
     // compilation is enabled calculating this hash can freeze this structure too early in
-    // compilation and cause subsequent crashes when attempting to write to `definitions`
+    // compilation and cause subsequent crashes when attempting to write to `definitions`.
     query crate_hash(_: CrateNum) -> Svh {
         eval_always
-        desc { "looking up the hash a crate" }
+        desc { "looking up the hash of a crate" }
         separate_provide_extern
     }
 

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -13,6 +13,7 @@ extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_interface;
 extern crate rustc_log;
+extern crate rustc_metadata;
 extern crate rustc_middle;
 extern crate rustc_session;
 
@@ -21,6 +22,7 @@ rustc_driver::override_c_allocator_in_binary!();
 
 mod log;
 
+use std::any::Any;
 use std::env;
 use std::num::{NonZero, NonZeroI32};
 use std::ops::Range;
@@ -34,6 +36,7 @@ use miri::{
     TreeBorrowsParams, ValidationMode, entry_fn, run_genmc_mode,
 };
 use rustc_codegen_ssa::traits::CodegenBackend;
+use rustc_codegen_ssa::{CompiledModules, CrateInfo, TargetConfig};
 use rustc_data_structures::sync::{self, DynSync};
 use rustc_driver::Compilation;
 use rustc_interface::interface::Config;
@@ -49,6 +52,13 @@ use crate::log::setup::{deinit_loggers, init_early_loggers, init_late_loggers};
 struct MiriCompilerCalls {
     miri_config: Option<MiriConfig>,
     many_seeds: Option<ManySeedsConfig>,
+}
+
+struct MiriCodegenBackend {
+    native: Box<dyn CodegenBackend>,
+    dummy: DummyCodegenBackend,
+    /// Whether we are in a dependency or in the to-be-interpreted binary crate
+    dep: bool,
 }
 
 struct ManySeedsConfig {
@@ -97,39 +107,27 @@ fn run_many_seeds(
 /// Generates the codegen backend for code that Miri will interpret: we basically
 /// use the dummy backend, except that we put the LLVM backend in charge of
 /// target features.
-fn make_miri_codegen_backend(sess: &Session) -> Box<dyn CodegenBackend> {
+fn make_miri_codegen_backend(sess: &Session, dep: bool) -> Box<dyn CodegenBackend> {
     let early_dcx = EarlyDiagCtxt::new(sess.opts.error_format);
 
     // Use the target_config method of the default codegen backend (eg LLVM) to ensure the
     // calculated target features match said backend by respecting eg -Ctarget-cpu.
-    let target_config_backend = rustc_interface::util::get_codegen_backend(
+    let native_codegen_backend = rustc_interface::util::get_codegen_backend(
         &early_dcx,
         &sess.opts.sysroot,
         None,
         &sess.target,
     );
-    target_config_backend.init(sess);
+    native_codegen_backend.init(sess);
 
-    Box::new(DummyCodegenBackend {
-        target_config_override: Some(Box::new(move |sess| {
-            let mut cfg = target_config_backend.target_config(sess);
-            // The basic types and ABI always work.
-            cfg.has_reliable_f16 = true;
-            cfg.has_reliable_f128 = true;
-            // We always provide the f16 intrinsics, but some are provided via the host,
-            // so forward its reliability.
-            cfg.has_reliable_f16_math = cfg!(target_has_reliable_f16_math);
-            // Many f128 operations are still missing.
-            cfg.has_reliable_f128_math = false;
-            cfg
-        })),
-    })
+    Box::new(MiriCodegenBackend { native: native_codegen_backend, dummy: DummyCodegenBackend, dep })
 }
 
 impl rustc_driver::Callbacks for MiriCompilerCalls {
     fn config(&mut self, config: &mut rustc_interface::interface::Config) {
         // We never reach codegen anyway.
-        config.make_codegen_backend = Some(Box::new(make_miri_codegen_backend));
+        config.make_codegen_backend =
+            Some(Box::new(|sess| make_miri_codegen_backend(sess, /* dep */ false)));
 
         // Register our custom extra symbols.
         config.extra_symbols = miri::sym::EXTRA_SYMBOLS.into();
@@ -203,10 +201,71 @@ impl rustc_driver::Callbacks for MiriCompilerCalls {
             tcx.dcx().abort_if_errors();
             exit(return_code.get());
         } else {
-            exit(rustc_driver::EXIT_SUCCESS);
+            // We want to continue here so rustc can do its usual shutdown and finalize the
+            // incremental session. Our custom codegen backend ensures nothing actually happens.
+            return Compilation::Continue;
         }
+    }
+}
 
-        // Unreachable.
+impl CodegenBackend for MiriCodegenBackend {
+    fn name(&self) -> &'static str {
+        "miri"
+    }
+
+    fn target_config(&self, sess: &Session) -> TargetConfig {
+        let native_target_config = self.native.target_config(sess);
+        TargetConfig {
+            internal_target_features: native_target_config.internal_target_features,
+
+            // The basic types and ABI always work.
+            has_reliable_f16: true,
+            has_reliable_f128: true,
+            // We always provide the f16 intrinsics, but some are provided via the host,
+            // so forward its reliability.
+            has_reliable_f16_math: cfg!(target_has_reliable_f16_math),
+            // Many f128 operations are still missing.
+            has_reliable_f128_math: false,
+        }
+    }
+
+    fn target_cpu(&self, _sess: &Session) -> String {
+        String::new()
+    }
+
+    // Everything complicated is forwarded to the dummy backend.
+
+    fn supported_crate_types(&self, sess: &Session) -> Vec<CrateType> {
+        self.dummy.supported_crate_types(sess)
+    }
+
+    fn codegen_crate<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Box<dyn Any> {
+        self.dummy.codegen_crate(tcx)
+    }
+
+    fn join_codegen(
+        &self,
+        ongoing_codegen: Box<dyn Any>,
+        sess: &Session,
+        incr_comp_session: Option<&rustc_session::IncrCompSession>,
+        outputs: &rustc_session::config::OutputFilenames,
+        crate_info: &CrateInfo,
+    ) -> (CompiledModules, rustc_middle::dep_graph::WorkProductMap) {
+        self.dummy.join_codegen(ongoing_codegen, sess, incr_comp_session, outputs, crate_info)
+    }
+
+    fn link(
+        &self,
+        sess: &Session,
+        compiled_modules: CompiledModules,
+        crate_info: CrateInfo,
+        metadata: rustc_metadata::EncodedMetadata,
+        outputs: &rustc_session::config::OutputFilenames,
+    ) {
+        // In the binary this should do nothing.
+        if self.dep {
+            self.dummy.link(sess, compiled_modules, crate_info, metadata, outputs)
+        }
     }
 }
 
@@ -217,7 +276,8 @@ impl rustc_driver::Callbacks for MiriDepCompilerCalls {
     #[allow(rustc::potential_query_instability)] // rustc_codegen_ssa (where this code is copied from) also allows this lint
     fn config(&mut self, config: &mut Config) {
         // We don't need actual codegen, we just emit an rlib that Miri can later consume.
-        config.make_codegen_backend = Some(Box::new(make_miri_codegen_backend));
+        config.make_codegen_backend =
+            Some(Box::new(|sess| make_miri_codegen_backend(sess, /* dep */ true)));
 
         // Avoid warnings about unsupported crate types. However, only do that we we are *not* being
         // queried by cargo about the supported crate types so that cargo still receives the
@@ -683,4 +743,6 @@ fn main() -> ExitCode {
         }
     }
     run_compiler_and_exit(&rustc_args, &mut MiriCompilerCalls::new(miri_config, many_seeds))
+    // Note that we *cannot* just return here, in native-lib mode we have to coordinate
+    // with the supervisor process!
 }

--- a/src/tools/miri/src/diagnostics.rs
+++ b/src/tools/miri/src/diagnostics.rs
@@ -237,7 +237,7 @@ pub fn prune_stacktrace<'tcx>(
 /// Report the result of a Miri execution.
 ///
 /// Returns `Some` if this was regular program termination with a given exit code and a `bool`
-/// indicating whether a leak check should happen; `None` otherwise.
+/// indicating whether a leak check should happen; `None` if execution was aborted with an error.
 pub fn report_result<'tcx>(
     ecx: &InterpCx<'tcx, MiriMachine<'tcx>>,
     res: InterpErrorInfo<'tcx>,

--- a/src/tools/miri/src/eval.rs
+++ b/src/tools/miri/src/eval.rs
@@ -510,8 +510,8 @@ fn call_main<'tcx>(
 }
 
 /// Evaluates the entry function specified by `entry_id`.
-/// Returns `Some(return_code)` if program execution completed.
-/// Returns `None` if an evaluation error occurred.
+/// Returns `Ok(())` if program execution completed with exit code 0.
+/// Returns `Err(code)` if an evaluation error occurred or the program returned a non-0 exit code.
 pub fn eval_entry<'tcx>(
     tcx: TyCtxt<'tcx>,
     entry_id: DefId,

--- a/src/tools/miri/tests/native-lib/pass/ptr_read_access.notrace.stderr
+++ b/src/tools/miri/tests/native-lib/pass/ptr_read_access.notrace.stderr
@@ -14,3 +14,5 @@ LL |     unsafe { print_pointer(&x) };
            1: main
                at tests/native-lib/pass/ptr_read_access.rs:LL:CC
 
+warning: 1 warning emitted
+

--- a/src/tools/miri/tests/native-lib/pass/ptr_read_access.trace.stderr
+++ b/src/tools/miri/tests/native-lib/pass/ptr_read_access.trace.stderr
@@ -15,3 +15,5 @@ LL |     unsafe { print_pointer(&x) };
            1: main
                at tests/native-lib/pass/ptr_read_access.rs:LL:CC
 
+warning: 1 warning emitted
+

--- a/src/tools/miri/tests/native-lib/pass/ptr_write_access.notrace.stderr
+++ b/src/tools/miri/tests/native-lib/pass/ptr_write_access.notrace.stderr
@@ -14,3 +14,5 @@ LL |     unsafe { increment_int(&mut x) };
            1: main
                at tests/native-lib/pass/ptr_write_access.rs:LL:CC
 
+warning: 1 warning emitted
+

--- a/src/tools/miri/tests/native-lib/pass/ptr_write_access.trace.stderr
+++ b/src/tools/miri/tests/native-lib/pass/ptr_write_access.trace.stderr
@@ -15,3 +15,5 @@ LL |     unsafe { increment_int(&mut x) };
            1: main
                at tests/native-lib/pass/ptr_write_access.rs:LL:CC
 
+warning: 1 warning emitted
+

--- a/src/tools/miri/tests/pass-dep/libc/fcntl_f-fullfsync_apple.stderr
+++ b/src/tools/miri/tests/pass-dep/libc/fcntl_f-fullfsync_apple.stderr
@@ -1,2 +1,4 @@
 warning: `fcntl` was made to return an error due to isolation
 
+warning: 1 warning emitted
+

--- a/src/tools/miri/tests/pass-dep/libc/libc-fs-with-isolation.stderr
+++ b/src/tools/miri/tests/pass-dep/libc/libc-fs-with-isolation.stderr
@@ -2,3 +2,5 @@ warning: `readlink` was made to return an error due to isolation
 
 warning: `$STAT` was made to return an error due to isolation
 
+warning: 2 warnings emitted
+

--- a/src/tools/miri/tests/pass-dep/libc/libc-socket-invalid-addr.stderr
+++ b/src/tools/miri/tests/pass-dep/libc/libc-socket-invalid-addr.stderr
@@ -6,3 +6,5 @@ LL |         unsafe { libc::getaddrinfo(node_c_str.as_ptr(), service_c_str.as_pt
    |
    = note: Miri cannot return proper error information from this call; only a generic error code is being returned
 
+warning: 1 warning emitted
+

--- a/src/tools/miri/tests/pass-dep/libc/libc-socket-no-blocking.windows_host.stderr
+++ b/src/tools/miri/tests/pass-dep/libc/libc-socket-no-blocking.windows_host.stderr
@@ -19,3 +19,5 @@ LL |         libc::getsockname(client_sockfd, storage, len)
            4: main
                at tests/pass-dep/libc/libc-socket-no-blocking.rs:LL:CC
 
+warning: 1 warning emitted
+

--- a/src/tools/miri/tests/pass-dep/libc/libc-socket-with-isolation.stderr
+++ b/src/tools/miri/tests/pass-dep/libc/libc-socket-with-isolation.stderr
@@ -1,2 +1,4 @@
 warning: `socket` was made to return an error due to isolation
 
+warning: 1 warning emitted
+

--- a/src/tools/miri/tests/pass-dep/shims/gettid.rs
+++ b/src/tools/miri/tests/pass-dep/shims/gettid.rs
@@ -3,6 +3,7 @@
 //@ [without_isolation] compile-flags: -Zmiri-disable-isolation
 
 #![feature(linkage)]
+#![allow(unused_features)] // only used on some targets
 
 fn gettid() -> u64 {
     cfg_select! {

--- a/src/tools/miri/tests/pass/async-closure-drop.rs
+++ b/src/tools/miri/tests/pass/async-closure-drop.rs
@@ -1,4 +1,4 @@
-#![feature(async_fn_traits, async_trait_bounds)]
+#![feature(async_trait_bounds)]
 
 use std::future::Future;
 use std::pin::pin;

--- a/src/tools/miri/tests/pass/async-closure.rs
+++ b/src/tools/miri/tests/pass/async-closure.rs
@@ -1,5 +1,3 @@
-#![feature(async_fn_traits)]
-
 use std::future::Future;
 use std::ops::{AsyncFn, AsyncFnMut, AsyncFnOnce};
 use std::pin::pin;

--- a/src/tools/miri/tests/pass/async-drop.rs
+++ b/src/tools/miri/tests/pass/async-drop.rs
@@ -7,7 +7,7 @@
 // please consider modifying rustc's async drop test at
 // `tests/ui/async-await/async-drop/async-drop-initial.rs`.
 
-#![feature(async_drop, impl_trait_in_assoc_type)]
+#![feature(async_drop)]
 #![allow(incomplete_features, dead_code)]
 
 // FIXME(zetanumbers): consider AsyncDestruct::async_drop cleanup tests

--- a/src/tools/miri/tests/pass/both_borrows/basic_aliasing_model.rs
+++ b/src/tools/miri/tests/pass/both_borrows/basic_aliasing_model.rs
@@ -1,7 +1,7 @@
 //@revisions: stack tree tree_implicit_writes
 //@[tree_implicit_writes]compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes
 //@[tree]compile-flags: -Zmiri-tree-borrows
-#![feature(allocator_api)]
+
 use std::alloc::{Layout, alloc, dealloc};
 use std::cell::Cell;
 use std::ptr;

--- a/src/tools/miri/tests/pass/extern_types.stack.stderr
+++ b/src/tools/miri/tests/pass/extern_types.stack.stderr
@@ -7,3 +7,5 @@ LL |     let x: &Foo = unsafe { &*(ptr::without_provenance::<()>(16) as *const F
    = help: `extern type` are not compatible with the Stacked Borrows aliasing model implemented by Miri; Miri may miss bugs in this code
    = help: try running with `MIRIFLAGS=-Zmiri-tree-borrows` to use the more permissive but also even more experimental Tree Borrows aliasing checks instead
 
+warning: 1 warning emitted
+

--- a/src/tools/miri/tests/pass/open_a_file_in_proc.stderr
+++ b/src/tools/miri/tests/pass/open_a_file_in_proc.stderr
@@ -30,3 +30,5 @@ LL |         let fd = cvt_r(|| unsafe { open64(path.as_ptr(), flags, opts.mode a
            11: main
                at tests/pass/open_a_file_in_proc.rs:LL:CC
 
+warning: 1 warning emitted
+

--- a/src/tools/miri/tests/pass/shims/env/current_dir_with_isolation.stderr
+++ b/src/tools/miri/tests/pass/shims/env/current_dir_with_isolation.stderr
@@ -2,3 +2,5 @@ warning: `$GETCWD` was made to return an error due to isolation
 
 warning: `$SETCWD` was made to return an error due to isolation
 
+warning: 2 warnings emitted
+

--- a/src/tools/miri/tests/pass/shims/fs-with-isolation.stderr
+++ b/src/tools/miri/tests/pass/shims/fs-with-isolation.stderr
@@ -14,3 +14,5 @@ warning: `rmdir` was made to return an error due to isolation
 
 warning: `opendir` was made to return an error due to isolation
 
+warning: 8 warnings emitted
+

--- a/src/tools/miri/tests/pass/shims/socket-address.stderr
+++ b/src/tools/miri/tests/pass/shims/socket-address.stderr
@@ -23,3 +23,5 @@ LL |             cvt_gai(c::getaddrinfo(c_host.as_ptr(), ptr::null(), &hints, &m
            7: main
                at tests/pass/shims/socket-address.rs:LL:CC
 
+warning: 1 warning emitted
+

--- a/src/tools/miri/tests/pass/shims/x86/intrinsics-x86-pause-without-sse2.stderr
+++ b/src/tools/miri/tests/pass/shims/x86/intrinsics-x86-pause-without-sse2.stderr
@@ -3,3 +3,5 @@ warning: target feature `sse2` must be enabled to ensure that the ABI of the cur
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
 
+warning: 1 warning emitted
+

--- a/src/tools/miri/tests/pass/stacked_borrows/coroutine-self-referential.rs
+++ b/src/tools/miri/tests/pass/stacked_borrows/coroutine-self-referential.rs
@@ -1,6 +1,6 @@
 // See https://github.com/rust-lang/unsafe-code-guidelines/issues/148:
 // this fails when Stacked Borrows is strictly applied even to `!Unpin` types.
-#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#![feature(coroutines, coroutine_trait)]
 
 use std::ops::{Coroutine, CoroutineState};
 use std::pin::Pin;

--- a/src/tools/miri/tests/pass/tree_borrows/tree-borrows.rs
+++ b/src/tools/miri/tests/pass/tree_borrows/tree-borrows.rs
@@ -1,7 +1,6 @@
 //@revisions: tree tree_implicit_writes
 //@[tree_implicit_writes]compile-flags: -Zmiri-tree-borrows-implicit-writes
 //@compile-flags: -Zmiri-tree-borrows
-#![feature(allocator_api)]
 
 use std::{mem, ptr};
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160760)*
<!-- homu-ignore:end -->

This helps with https://github.com/rust-lang/miri/issues/5013. Reruns still aren't as fast as I'd like, but using nextest to run libcore tests shows a big difference:
```
before:
 Nextest run ID 56b7b355-6225-4083-96e3-aeeabbe80523 with nextest profile: default-miri
    Starting 10 tests across 2 binaries (2760 tests skipped)
        PASS [  31.264s] coretests::coretests any::any_downcast_mut
        PASS [  31.287s] coretests::coretests any::distinct_type_names
        PASS [  32.747s] coretests::coretests iter::traits::iterator::test_any
        PASS [  32.758s] coretests::coretests any::any_owning
        PASS [  32.864s] coretests::coretests any::dyn_type_name
        PASS [  32.973s] coretests::coretests any::any_downcast_ref
        PASS [  33.139s] coretests::coretests any::any_unsized
        PASS [  33.719s] coretests::coretests any::any_referenced
        PASS [  35.786s] coretests::coretests any::any_fixed_vec
        PASS [  38.951s] coretests::coretests num::dec2flt::parse::many_digits
────────────
     Summary [  38.955s] 10 tests run: 10 passed, 2760 skipped

after:
 Nextest run ID af603971-e41e-466d-8469-0425057fa325 with nextest profile: default-miri
    Starting 10 tests across 2 binaries (2761 tests skipped)
        PASS [  15.063s] coretests::coretests any::any_unsized
        PASS [  15.176s] coretests::coretests any::distinct_type_names
        PASS [  15.200s] coretests::coretests any::any_referenced
        PASS [  15.550s] coretests::coretests iter::traits::iterator::test_any
        PASS [  15.993s] coretests::coretests any::any_fixed_vec
        PASS [  17.506s] coretests::coretests num::dec2flt::parse::many_digits
        PASS [  17.902s] coretests::coretests any::any_downcast_ref
        PASS [  18.188s] coretests::coretests any::any_owning
        PASS [  19.270s] coretests::coretests any::dyn_type_name
        PASS [  19.702s] coretests::coretests any::any_downcast_mut
────────────
     Summary [  19.705s] 10 tests run: 10 passed, 2761 skipped
```
It still seems to spend at least 10s building the crate before Miri even begins running, no idea what it is doing in that time. But it's 15s less than before so that's good. :)
