### PR TITLE
Stabilise `abort_immediate`

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -384,7 +384,7 @@ pub fn rustc_peek<T>(_: T) -> T;
 /// process will probably terminate with a signal like `SIGABRT`, `SIGILL`, `SIGTRAP`, `SIGSEGV` or
 /// `SIGBUS`.  The precise behavior is not guaranteed and not stable.
 ///
-/// The stabilization-track version of this intrinsic is [`core::process::abort_immediate`].
+/// The stabilized version of this intrinsic is [`core::process::abort_immediate`].
 #[rustc_nounwind]
 #[rustc_intrinsic]
 pub fn abort() -> !;

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -306,7 +306,7 @@ pub mod panicking;
 #[unstable(feature = "pattern_type_macro", issue = "123646")]
 pub mod pat;
 pub mod pin;
-#[unstable(feature = "abort_immediate", issue = "154601")]
+#[stable(feature = "abort_immediate", since = "CURRENT_RUSTC_VERSION")]
 pub mod process;
 #[unstable(feature = "random", issue = "130703")]
 pub mod random;

--- a/library/core/src/process.rs
+++ b/library/core/src/process.rs
@@ -22,7 +22,8 @@
 ///
 /// `abort_immediate` lowers to a trap instruction on *most* architectures; on
 /// some architectures it simply lowers to call the unmangled `abort` function.
-/// The exact behavior is architecture and system dependent.
+/// The exact behavior is architecture and system dependent, but not explicitly
+/// guaranteed.
 ///
 /// On bare-metal (no OS) systems the trap instruction usually causes a
 /// *hardware* exception to be raised in a *synchronous* fashion; hardware
@@ -34,7 +35,7 @@
 /// corresponds to `SIGILL` or equivalent, *unless* this signal is handled.
 /// Other signals such as `SIGABRT`, `SIGTRAP`, `SIGSEGV`, and `SIGBUS` may be
 /// produced instead, depending on specifics. This is not an exhaustive list.
-#[unstable(feature = "abort_immediate", issue = "154601")]
+#[stable(feature = "abort_immediate", since = "CURRENT_RUSTC_VERSION")]
 #[cold]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 #[doc(alias = "halt")]

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2639,7 +2639,7 @@ pub fn abort() -> ! {
 }
 
 #[doc(inline)]
-#[unstable(feature = "abort_immediate", issue = "154601")]
+#[stable(feature = "abort_immediate", since = "CURRENT_RUSTC_VERSION")]
 pub use core::process::abort_immediate;
 
 /// Returns the OS-assigned process identifier associated with this process.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160766)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!-- homu-ignore:end -->

Closes rust-lang/rust#154601 by stabilising the feature. Explicitly do not promise any particular behaviour beyond aborting in some nonspecific violent fashion.

The ACP for the relevant feature was accepted 2 years ago and the feature has been on nightly for 5 months with the only apparent concerns being related to naming and the possibility of having a version of `abort` in core that guarantees calling the system abort if available, but such an implementation is blocked on EIIs and there is merit to offering this in parallel as well. Additionally, the nonspecific semantics of `abort_immediate` let us change its behaviour to opportunistically call `abort` in the future if so desired.