### PR TITLE
Unify E0117 foreign-trait label for ADT/primitive types with existing Slice/Array/Tuple handling

### DIFF
--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -465,13 +465,21 @@ fn emit_orphan_check_error<'tcx>(
                         });
                     }
                     ty::Adt(adt_def, _) => {
-                        diag.subdiagnostic(diagnostics::OnlyCurrentTraitsAdt {
-                            span,
-                            name: tcx.def_path_str(adt_def.did()),
-                        });
+                        if is_foreign {
+                            diag.subdiagnostic(diagnostics::OnlyCurrentTraitsForeign { span });
+                        } else {
+                            diag.subdiagnostic(diagnostics::OnlyCurrentTraitsAdt {
+                                span,
+                                name: tcx.def_path_str(adt_def.did()),
+                            });
+                        }
                     }
                     _ => {
-                        diag.subdiagnostic(diagnostics::OnlyCurrentTraitsTy { span, ty });
+                        if is_foreign {
+                            diag.subdiagnostic(diagnostics::OnlyCurrentTraitsForeign { span });
+                        } else {
+                            diag.subdiagnostic(diagnostics::OnlyCurrentTraitsTy { span, ty });
+                        }
                     }
                 }
             }

--- a/tests/ui/coherence/coherence-orphan-foreign-adt-diagnostic.rs
+++ b/tests/ui/coherence/coherence-orphan-foreign-adt-diagnostic.rs
@@ -1,0 +1,43 @@
+//@ compile-flags: --crate-type=lib
+
+// Test diagnostic output for E0117 when implementing foreign traits
+// with defaulted parameters (like `PartialEq` and `Add`) on foreign types.
+// addresses https://github.com/rust-lang/rust/issues/160648
+
+use std::ops::Add;
+
+// Case 1: Foreign trait, foreign type in Self position, defaulted Rhs (PartialEq)
+impl PartialEq for Option<u32> {
+    //~^ ERROR only traits defined in the current crate can be implemented for types defined outside of the crate
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+// Case 2: Foreign trait, foreign primitive in Self position, defaulted Rhs (Add)
+impl Add for u32 {
+    //~^ ERROR only traits defined in the current crate can be implemented for primitive types
+    type Output = u32;
+    fn add(self, _rhs: u32) -> u32 {
+        self
+    }
+}
+
+// Case 3: Foreign trait with explicit foreign Rhs type on a foreign Self type
+impl PartialEq<String> for Option<u32> {
+    //~^ ERROR only traits defined in the current crate can be implemented for types defined outside of the crate
+    fn eq(&self, _other: &String) -> bool {
+        false
+    }
+}
+
+// Case 4: Foreign trait with explicit foreign array Rhs type on a foreign Self type
+// (control case: Array already used the foreign-trait label before this fix,
+// via the pre-existing `Slice`/`Array`/`Tuple` arms. included here so that
+// behavior is also pinned down as a regression test.)
+impl PartialEq<[i32; 3]> for Option<u32> {
+    //~^ ERROR only traits defined in the current crate can be implemented for types defined outside of the crate
+    fn eq(&self, _other: &[i32; 3]) -> bool {
+        false
+    }
+}

--- a/tests/ui/coherence/coherence-orphan-foreign-adt-diagnostic.stderr
+++ b/tests/ui/coherence/coherence-orphan-foreign-adt-diagnostic.stderr
@@ -1,0 +1,55 @@
+error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
+  --> $DIR/coherence-orphan-foreign-adt-diagnostic.rs:10:1
+   |
+LL | impl PartialEq for Option<u32> {
+   | ^^^^^---------^^^^^-----------
+   |      |             |
+   |      |             `Option` is not defined in the current crate
+   |      this is not defined in the current crate because this is a foreign trait
+   |
+   = note: impl doesn't have any local type before any uncovered type parameters
+   = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
+   = note: define and implement a trait or new type instead
+
+error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
+  --> $DIR/coherence-orphan-foreign-adt-diagnostic.rs:27:1
+   |
+LL | impl PartialEq<String> for Option<u32> {
+   | ^^^^^-----------------^^^^^-----------
+   |      |                     |
+   |      |                     `Option` is not defined in the current crate
+   |      this is not defined in the current crate because this is a foreign trait
+   |
+   = note: impl doesn't have any local type before any uncovered type parameters
+   = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
+   = note: define and implement a trait or new type instead
+
+error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
+  --> $DIR/coherence-orphan-foreign-adt-diagnostic.rs:38:1
+   |
+LL | impl PartialEq<[i32; 3]> for Option<u32> {
+   | ^^^^^-------------------^^^^^-----------
+   |      |                       |
+   |      |                       `Option` is not defined in the current crate
+   |      this is not defined in the current crate because this is a foreign trait
+   |
+   = note: impl doesn't have any local type before any uncovered type parameters
+   = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
+   = note: define and implement a trait or new type instead
+
+error[E0117]: only traits defined in the current crate can be implemented for primitive types
+  --> $DIR/coherence-orphan-foreign-adt-diagnostic.rs:18:1
+   |
+LL | impl Add for u32 {
+   | ^^^^^---^^^^^---
+   |      |       |
+   |      |       `u32` is not defined in the current crate
+   |      this is not defined in the current crate because this is a foreign trait
+   |
+   = note: impl doesn't have any local type before any uncovered type parameters
+   = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
+   = note: define and implement a trait or new type instead
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0117`.

--- a/tests/ui/coherence/coherence-orphan.stderr
+++ b/tests/ui/coherence/coherence-orphan.stderr
@@ -5,7 +5,7 @@ LL | impl TheTrait<usize> for isize {}
    | ^^^^^---------------^^^^^-----
    |      |                   |
    |      |                   `isize` is not defined in the current crate
-   |      `usize` is not defined in the current crate
+   |      this is not defined in the current crate because this is a foreign trait
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules

--- a/tests/ui/coherence/coherence-pair-covered-uncovered-1.stderr
+++ b/tests/ui/coherence/coherence-pair-covered-uncovered-1.stderr
@@ -5,7 +5,7 @@ LL | impl<T, U> Remote1<Pair<T, Local<U>>> for i32 { }
    | ^^^^^^^^^^^--------------------------^^^^^---
    |            |                              |
    |            |                              `i32` is not defined in the current crate
-   |            `Pair` is not defined in the current crate
+   |            this is not defined in the current crate because this is a foreign trait
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules

--- a/tests/ui/coherence/impl-foreign-for-foreign[foreign].stderr
+++ b/tests/ui/coherence/impl-foreign-for-foreign[foreign].stderr
@@ -5,7 +5,7 @@ LL | impl Remote1<Rc<i32>> for i32 {
    | ^^^^^----------------^^^^^---
    |      |                    |
    |      |                    `i32` is not defined in the current crate
-   |      `Rc` is not defined in the current crate
+   |      this is not defined in the current crate because this is a foreign trait
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
@@ -18,7 +18,7 @@ LL | impl Remote1<Rc<Local>> for f64 {
    | ^^^^^------------------^^^^^---
    |      |                      |
    |      |                      `f64` is not defined in the current crate
-   |      `Rc` is not defined in the current crate
+   |      this is not defined in the current crate because this is a foreign trait
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
@@ -31,7 +31,7 @@ LL | impl<T> Remote1<Rc<T>> for f32 {
    | ^^^^^^^^--------------^^^^^---
    |         |                  |
    |         |                  `f32` is not defined in the current crate
-   |         `Rc` is not defined in the current crate
+   |         this is not defined in the current crate because this is a foreign trait
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules

--- a/tests/ui/coherence/impl-foreign[foreign]-for-foreign.stderr
+++ b/tests/ui/coherence/impl-foreign[foreign]-for-foreign.stderr
@@ -5,7 +5,7 @@ LL | impl Remote1<u32> for f64 {
    | ^^^^^------------^^^^^---
    |      |                |
    |      |                `f64` is not defined in the current crate
-   |      `u32` is not defined in the current crate
+   |      this is not defined in the current crate because this is a foreign trait
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules

--- a/tests/ui/coherence/impl-foreign[fundemental[foreign]]-for-foreign.stderr
+++ b/tests/ui/coherence/impl-foreign[fundemental[foreign]]-for-foreign.stderr
@@ -5,7 +5,7 @@ LL | impl Remote1<Box<String>> for i32 {
    | ^^^^^--------------------^^^^^---
    |      |                        |
    |      |                        `i32` is not defined in the current crate
-   |      `String` is not defined in the current crate
+   |      this is not defined in the current crate because this is a foreign trait
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
@@ -18,7 +18,7 @@ LL | impl Remote1<Box<Rc<i32>>> for f64 {
    | ^^^^^---------------------^^^^^---
    |      |                         |
    |      |                         `f64` is not defined in the current crate
-   |      `Rc` is not defined in the current crate
+   |      this is not defined in the current crate because this is a foreign trait
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
@@ -31,7 +31,7 @@ LL | impl<T> Remote1<Box<Rc<T>>> for f32 {
    | ^^^^^^^^-------------------^^^^^---
    |         |                       |
    |         |                       `f32` is not defined in the current crate
-   |         `Rc` is not defined in the current crate
+   |         this is not defined in the current crate because this is a foreign trait
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules

--- a/tests/ui/coherence/orphan-check-error-reporting-ty-var.stderr
+++ b/tests/ui/coherence/orphan-check-error-reporting-ty-var.stderr
@@ -5,7 +5,7 @@ LL | impl<K2> From<Vec<K2>> for <Vec<K2> as MyTrait>::Item {}
    | ^^^^^^^^^-------------^^^^^--------------------------
    |          |                 |
    |          |                 `Vec` is not defined in the current crate
-   |          `Vec` is not defined in the current crate
+   |          this is not defined in the current crate because this is a foreign trait
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules

--- a/tests/ui/traits/const-traits/const-and-non-const-impl.stderr
+++ b/tests/ui/traits/const-traits/const-and-non-const-impl.stderr
@@ -14,7 +14,7 @@ LL | const impl std::ops::Add for i32 {
    | ^^^^^^^^^^^-------------^^^^^---
    |            |                 |
    |            |                 `i32` is not defined in the current crate
-   |            `i32` is not defined in the current crate
+   |            this is not defined in the current crate because this is a foreign trait
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules


### PR DESCRIPTION
### What this does

`emit_orphan_check_error` (in `compiler/rustc_hir_analysis/src/coherence/orphan.rs`) already has an `is_foreign` flag, true whenever a non-local type sits in one of the *trait's own* parameter positions rather than `Self`. The `Slice`, `Array`, and `Tuple` arms already use it to switch their label to a generic "this is not defined in the current crate because this is a foreign trait" message instead of naming the type. The `Adt` arm and the catch-all `_` arm (covering primitives) never checked `is_foreign` and always named the type, even in the same non-Self position.

This PR extends the same `is_foreign` branch to those two arms, so all four are consistent. No new types or subdiagnostics reuses the existing `OnlyCurrentTraitsForeign` struct already used a few lines above.

LLM use :
I used LLM to explore the project and find where code that tags labels

### Before / after

```rust
impl PartialEq for u32 {
    fn eq(&self, _other: &Self) -> bool { todo!() }
}
```
Before :
```Plaintext
   |      |             `u32` is not defined in the current crate
   |      `u32` is not defined in the current crate
```

After :
```Plaintext
   |      |       `u32` is not defined in the current crate
   |      this is not defined in the current crate because this is a foreign trait
```
Addresses rust-lang/rust#160648

r? compiler

<!-- homu-ignore:start -->

- [] I did not use an LLM to create a change in this PR.
- [x] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!-- homu-ignore:end -->