### PR TITLE
interpret: treat pattern and unsafe-binder as ABI-transparent

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -101,6 +101,13 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     interp_ok(true)
                 }
             }
+            // Types that are considered transparent in `unfold_transparent` should also act
+            // like transparent types here.
+            ty::Pat(base, _) => self.has_trivial_abi(self.layout_of(base)?),
+            ty::UnsafeBinder(bound_ty) => {
+                let ty = self.tcx.instantiate_bound_regions_with_erased(bound_ty.into());
+                self.has_trivial_abi(self.layout_of(ty)?)
+            }
 
             ty::Alias(..) => panic!("non-normalized type"),
             _ => interp_ok(false),
@@ -116,8 +123,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         layout: TyAndLayout<'tcx>,
         may_unfold: impl Fn(AdtDef<'tcx>) -> bool,
     ) -> InterpResult<'tcx, TyAndLayout<'tcx>> {
-        match layout.ty.kind() {
-            ty::Adt(adt_def, _) if adt_def.repr().transparent() && may_unfold(*adt_def) => {
+        match *layout.ty.kind() {
+            ty::Adt(adt_def, _) if adt_def.repr().transparent() && may_unfold(adt_def) => {
                 assert_matches!(layout.variants, rustc_abi::Variants::Single { .. });
                 // Look for non-trivial-ABI field(s).
                 let mut found = None;
@@ -142,7 +149,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 // Recurse.
                 self.unfold_transparent(field, may_unfold)
             }
-            ty::Pat(base, _) => interp_ok(self.layout_of(*base)?),
+            ty::Pat(base, _) => self.unfold_transparent(self.layout_of(base)?, may_unfold),
+            ty::UnsafeBinder(bound_ty) => {
+                let ty = self.tcx.instantiate_bound_regions_with_erased(bound_ty.into());
+                self.unfold_transparent(self.layout_of(ty)?, may_unfold)
+            }
             // Not a transparent type, no further unfolding.
             _ => interp_ok(layout),
         }


### PR DESCRIPTION
This was suggested by @Jules-Bertholet in https://github.com/rust-lang/rust/pull/160658. I didn't follow all the discussions for those types. Making them transparent makes sense to me though we should make sure this is explicitly discussed as a stable guarantee when it comes to stabilizing those types.

Tracking issues: https://github.com/rust-lang/rust/issues/123646, https://github.com/rust-lang/rust/issues/130516.

r? @oli-obk 