### PR TITLE
Document and correct assignment order for yield and inline-asm

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -29,7 +29,7 @@ use rustc_middle::ty::{
     self, PredicateKind, RegionExt, Ty, TyCtxt, TypeSuperVisitable, TypeVisitor, Upcast,
     suggest_constraining_type_params,
 };
-use rustc_mir_dataflow::move_paths::{Init, InitKind, InitLocation, MoveOutIndex, MovePathIndex};
+use rustc_mir_dataflow::move_paths::{Init, InitLocation, MoveOutIndex, MovePathIndex};
 use rustc_span::def_id::{DefId, LocalDefId};
 use rustc_span::hygiene::DesugaringKind;
 use rustc_span::{BytePos, ExpnKind, Ident, MacroKind, Span, Symbol, kw, sym};
@@ -3948,25 +3948,12 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
             }
 
             // check for inits
-            let mut any_match = false;
             for ii in &self.move_data.init_loc_map[location] {
                 let init = self.move_data.inits[*ii];
-                match init.kind {
-                    InitKind::Deep | InitKind::NonPanicPathOnly => {
-                        if mpis.contains(&init.path) {
-                            any_match = true;
-                        }
-                    }
-                    InitKind::Shallow => {
-                        if mpi == init.path {
-                            any_match = true;
-                        }
-                    }
+                if mpis.contains(&init.path) {
+                    reinits.push(location);
+                    return true;
                 }
-            }
-            if any_match {
-                reinits.push(location);
-                return true;
             }
             false
         };

--- a/compiler/rustc_borrowck/src/polonius/legacy/mod.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/mod.rs
@@ -90,7 +90,7 @@ fn emit_move_facts(
                 let block_data = &body[location.block];
                 let is_terminator = location.statement_index == block_data.statements.len();
 
-                if is_terminator && init.kind == InitKind::NonPanicPathOnly {
+                if is_terminator && init.kind == InitKind::OnReturn {
                     // We are at the terminator of an init that has a panic path,
                     // and where the init should not happen on panic
 

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -945,6 +945,9 @@ pub enum TerminatorKind<'tcx> {
         template: &'tcx [InlineAsmTemplatePiece],
 
         /// The operands for the inline assembly, as `Operand`s or `Place`s.
+        ///
+        /// For the purposes of MIR analyzes, `out` and `inout` operands are only considered
+        /// written-to when execution continues with `targets`.
         operands: Box<[InlineAsmOperand<'tcx>]>,
 
         /// Miscellaneous options for the inline assembly.

--- a/compiler/rustc_mir_dataflow/src/drop_flag_effects.rs
+++ b/compiler/rustc_mir_dataflow/src/drop_flag_effects.rs
@@ -141,12 +141,8 @@ where
     for ii in &move_data.init_loc_map[loc] {
         let init = move_data.inits[*ii];
         match init.kind {
-            InitKind::Deep => {
-                let path = init.path;
-
-                on_all_children_bits(move_data, path, &mut callback)
-            }
-            InitKind::NonPanicPathOnly => (),
+            InitKind::Unconditional => on_all_children_bits(move_data, init.path, &mut callback),
+            InitKind::OnReturn => (),
         }
     }
 }

--- a/compiler/rustc_mir_dataflow/src/drop_flag_effects.rs
+++ b/compiler/rustc_mir_dataflow/src/drop_flag_effects.rs
@@ -146,10 +146,6 @@ where
 
                 on_all_children_bits(move_data, path, &mut callback)
             }
-            InitKind::Shallow => {
-                let mpi = init.path;
-                callback(mpi);
-            }
             InitKind::NonPanicPathOnly => (),
         }
     }

--- a/compiler/rustc_mir_dataflow/src/impls/initialized.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/initialized.rs
@@ -663,10 +663,9 @@ impl<'tcx> Analysis<'tcx> for EverInitializedPlaces<'_, 'tcx> {
         // Record inits of locals. Projections can be ignored.
         state.gen_all(init_loc_map[location].iter().copied().filter_map(|ii| {
             let init = &move_data.inits[ii];
-            if init.kind != InitKind::NonPanicPathOnly {
-                move_data.move_paths[init.path].place.as_local()
-            } else {
-                None
+            match init.kind {
+                InitKind::Unconditional => move_data.move_paths[init.path].place.as_local(),
+                InitKind::OnReturn => None,
             }
         }));
     }
@@ -684,10 +683,9 @@ impl<'tcx> Analysis<'tcx> for EverInitializedPlaces<'_, 'tcx> {
         let call_loc = self.body.terminator_loc(block);
         state.gen_all(init_loc_map[call_loc].iter().copied().filter_map(|ii| {
             let init = &move_data.inits[ii];
-            if init.kind == InitKind::NonPanicPathOnly {
-                move_data.move_paths[init.path].place.as_local()
-            } else {
-                None
+            match init.kind {
+                InitKind::Unconditional => None,
+                InitKind::OnReturn => move_data.move_paths[init.path].place.as_local(),
             }
         }));
     }
@@ -717,7 +715,7 @@ impl EverInitializedPlaces<'_, '_> {
         if init_loc.statement_index < init_block_data.statements.len() {
             // This case mirrors `apply_primary_statement_effect`.
             queue.push(init_loc.successor_within_block());
-        } else if init.kind == InitKind::NonPanicPathOnly {
+        } else if init.kind == InitKind::OnReturn {
             // This case mirrors `apply_call_return_effect`.
             let TerminatorEdges::AssignOnReturn { return_, .. } =
                 init_block_data.terminator().edges()

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -365,7 +365,7 @@ impl<'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> MoveDataBuilder<'a, 'tcx, F> {
             if let Some(path) = self.data.rev_lookup.find_local(arg) {
                 let init = self.data.inits.push(Init {
                     path,
-                    kind: InitKind::Deep,
+                    kind: InitKind::Unconditional,
                     location: InitLocation::Argument(arg),
                 });
 
@@ -391,7 +391,7 @@ impl<'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> MoveDataBuilder<'a, 'tcx, F> {
             }
             StatementKind::Assign((place, rval)) => {
                 self.create_move_path(*place);
-                self.gather_init(place.as_ref(), InitKind::Deep);
+                self.gather_init(place.as_ref(), InitKind::Unconditional);
                 self.gather_rvalue(rval);
             }
             StatementKind::FakeRead((_, place)) => {
@@ -473,7 +473,7 @@ impl<'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> MoveDataBuilder<'a, 'tcx, F> {
             TerminatorKind::Yield { ref value, resume_arg: place, .. } => {
                 self.gather_operand(value);
                 self.create_move_path(place);
-                self.gather_init(place.as_ref(), InitKind::Deep);
+                self.gather_init(place.as_ref(), InitKind::Unconditional);
             }
             TerminatorKind::Call {
                 ref func,
@@ -490,7 +490,7 @@ impl<'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> MoveDataBuilder<'a, 'tcx, F> {
                 }
                 if let Some(_bb) = target {
                     self.create_move_path(destination);
-                    self.gather_init(destination.as_ref(), InitKind::NonPanicPathOnly);
+                    self.gather_init(destination.as_ref(), InitKind::OnReturn);
                 }
             }
             TerminatorKind::TailCall { ref func, ref args, .. } => {
@@ -516,14 +516,14 @@ impl<'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> MoveDataBuilder<'a, 'tcx, F> {
                         InlineAsmOperand::Out { reg: _, late: _, place, .. } => {
                             if let Some(place) = place {
                                 self.create_move_path(place);
-                                self.gather_init(place.as_ref(), InitKind::Deep);
+                                self.gather_init(place.as_ref(), InitKind::Unconditional);
                             }
                         }
                         InlineAsmOperand::InOut { reg: _, late: _, ref in_value, out_place } => {
                             self.gather_operand(in_value);
                             if let Some(out_place) = out_place {
                                 self.create_move_path(out_place);
-                                self.gather_init(out_place.as_ref(), InitKind::Deep);
+                                self.gather_init(out_place.as_ref(), InitKind::Unconditional);
                             }
                         }
                         InlineAsmOperand::Const { value: _ }

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -473,7 +473,7 @@ impl<'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> MoveDataBuilder<'a, 'tcx, F> {
             TerminatorKind::Yield { ref value, resume_arg: place, .. } => {
                 self.gather_operand(value);
                 self.create_move_path(place);
-                self.gather_init(place.as_ref(), InitKind::Unconditional);
+                self.gather_init(place.as_ref(), InitKind::OnReturn);
             }
             TerminatorKind::Call {
                 ref func,
@@ -516,14 +516,14 @@ impl<'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> MoveDataBuilder<'a, 'tcx, F> {
                         InlineAsmOperand::Out { reg: _, late: _, place, .. } => {
                             if let Some(place) = place {
                                 self.create_move_path(place);
-                                self.gather_init(place.as_ref(), InitKind::Unconditional);
+                                self.gather_init(place.as_ref(), InitKind::OnReturn);
                             }
                         }
                         InlineAsmOperand::InOut { reg: _, late: _, ref in_value, out_place } => {
                             self.gather_operand(in_value);
                             if let Some(out_place) = out_place {
                                 self.create_move_path(out_place);
-                                self.gather_init(out_place.as_ref(), InitKind::Unconditional);
+                                self.gather_init(out_place.as_ref(), InitKind::OnReturn);
                             }
                         }
                         InlineAsmOperand::Const { value: _ }

--- a/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
@@ -298,10 +298,10 @@ pub enum InitLocation {
 /// Additional information about the initialization.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum InitKind {
-    /// Deep init, even on panic
-    Deep,
-    /// This doesn't initialize the variable on panic (and a panic is possible).
-    NonPanicPathOnly,
+    /// Always initialize the variable.
+    Unconditional,
+    /// Only initializes the variable on the terminator "return" path, excluding panics.
+    OnReturn,
 }
 
 impl fmt::Debug for Init {

--- a/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
@@ -300,8 +300,6 @@ pub enum InitLocation {
 pub enum InitKind {
     /// Deep init, even on panic
     Deep,
-    /// Only does a shallow init
-    Shallow,
     /// This doesn't initialize the variable on panic (and a panic is possible).
     NonPanicPathOnly,
 }


### PR DESCRIPTION
The first two commits cleanup and rename the variants of `InitKind`.

The third commit attempts to make several parts of MIR analyses a bit more consistent.

For calls, we correctly model assignments to happen on the return edge.

For yields, assignments also happen on the return edge according to dataflow analyses (see `TerminatorEdges`), but were considered unconditional. This should not change anything, as nobody uses droppable types as coroutine resume argument.

For  `inline_asm`, same thing, dataflow analyses consider assignments to happen on `targets` and not on unwind. This is also corrected. I have no idea what's the impact of this. I suppose user wisely avoid to assign droppable types in inline asm that may unwind.

<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!-- homu-ignore:end -->
