### PR TITLE
Add regression test for cycle error on guaranteed unsized self type

### DIFF
--- a/tests/ui/traits/cycle-guaranteed-unsized-self-type-116914.rs
+++ b/tests/ui/traits/cycle-guaranteed-unsized-self-type-116914.rs
@@ -1,0 +1,27 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/116914>.
+
+trait Filter {
+    type ToMatch;
+}
+
+impl<T> Filter for T //~ ERROR cycle detected when computing whether
+where
+    T: Fn(Self::ToMatch),
+{
+}
+
+trait Rule {}
+
+impl<T> Rule for T
+where
+    T: Filter,
+{
+}
+
+struct JustFilter<F: Filter> {
+    filter: F,
+}
+
+impl<T: Filter> Rule for JustFilter<T> {}
+
+fn main() {}

--- a/tests/ui/traits/cycle-guaranteed-unsized-self-type-116914.stderr
+++ b/tests/ui/traits/cycle-guaranteed-unsized-self-type-116914.stderr
@@ -1,0 +1,16 @@
+error[E0391]: cycle detected when computing whether `<impl at $DIR/cycle-guaranteed-unsized-self-type-116914.rs:7:1: 9:26>` has a guaranteed unsized self type
+  --> $DIR/cycle-guaranteed-unsized-self-type-116914.rs:7:1
+   |
+LL | / impl<T> Filter for T
+LL | | where
+LL | |     T: Fn(Self::ToMatch),
+   | |_________________________^
+   |
+   = note: ...which requires computing normalized predicates of `<impl at $DIR/cycle-guaranteed-unsized-self-type-116914.rs:7:1: 9:26>`...
+   = note: ...which again requires computing whether `<impl at $DIR/cycle-guaranteed-unsized-self-type-116914.rs:7:1: 9:26>` has a guaranteed unsized self type, completing the cycle
+   = note: cycle used when checking that `<impl at $DIR/cycle-guaranteed-unsized-self-type-116914.rs:7:1: 9:26>` is well-formed
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
Closes rust-lang/rust#116914 the solver now detects the cycle and errors, which this pins