### PR TITLE
arm64ec: `f128` is supported since LLVM 23

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -392,8 +392,7 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
     cfg.has_reliable_f128 = match (target_arch, target_os) {
         // Unsupported https://github.com/llvm/llvm-project/issues/121122
         (Arch::AmdGpu, _) => false,
-        // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
-        (Arch::Arm64EC, _) => false,
+        (Arch::Arm64EC, _) if major < 23 => false, // (fixed in llvm23)
         // Selection bug <https://github.com/llvm/llvm-project/issues/95471>. This issue is closed
         // but basic math still does not work.
         (Arch::Nvptx64, _) => false,


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/116909

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

Related

- https://github.com/llvm/llvm-project/issues/94434
- https://github.com/llvm/llvm-project/pull/206980

cc @dpaoliello (feel free to approve also, and maybe you can validate this in practice?)
r? tgross35
