### PR TITLE
Get rid of LLM disclosure checkboxes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,11 @@
-<!-- homu-ignore:start -->
-
-- [ ] I did not use an LLM to create a change in this PR.
-- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.
-
 <!--
 Please read our [LLM policy] before opening a PR,
-and check one of the boxes above to indicate whether you've used an LLM.
-If you do not check a box, a reviewer may ask you whether an LLM was involved.
+If you used an LLM to generate code, please disclose that according to our [guidelines][disclosure guidelines].
 LLM contributions are not banned, but are held to a higher standard of review and correctness.
+If you do not want your disclosure to be part of the permanent git history, add `<!-- homu-ignore:start` before it.
 
 [LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
+[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines
 
 If this PR is related to an unstable feature or an otherwise tracked effort,
 please link to the relevant tracking issue here. If you don't know of a related
@@ -20,4 +16,3 @@ a specific user to review your work, you can assign it to them by using
 
     r? <reviewer name>
 -->
-<!-- homu-ignore:end -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!--
 Please read our [LLM policy] before opening a PR,
-If you used an LLM to generate code, please disclose that according to our [guidelines][disclosure guidelines].
+If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
 LLM contributions are not banned, but are held to a higher standard of review and correctness.
 If you do not want your disclosure to be part of the permanent git history, add `<!-- homu-ignore:start` before it.
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160785)*
<!-- homu-ignore:end -->

These had a bunch of issues:
- They're extra work every time someone opens a PR
- They didn't show up at all if people used `gh pr create`
- They had "bad vibes" -- reviewers often don't want to think about LLMs, and adding a checkbox makes them very "in-your-face" for the reviewer.
- Every PR now shows "1 of 2 tasks", which is useless noise.
- The hovered PR description is now useless.

Replace them with an HTML comment that says "remember to disclose if you used an LLM". This seems ok and low-noise for now.
If we find that people are ignoring the comment,
we could edit the triagebot welcome message to include a reminder and a link to the policy (cc @Kobzol, i believe you'd planned to do this already).

<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
