### PR TITLE
fix: handle OOM gracefully in check_validity_requirement_strict [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
+++ b/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
@@ -54,8 +54,11 @@ fn check_validity_requirement_strict<'tcx>(
     let mut cx = InterpCx::new(cx.tcx(), DUMMY_SP, cx.typing_env, machine);
 
     // It doesn't really matter which `MemoryKind` we use here, `Stack` is the least wrong.
-    let allocated =
-        cx.allocate(ty, MemoryKind::Stack).expect("OOM: failed to allocate for uninit check");
+    // If the allocation fails (e.g. for very large types), conservatively treat the type
+    // as not permitting raw initialization rather than ICEing.
+    let Ok(allocated) = cx.allocate(ty, MemoryKind::Stack) else {
+        return false;
+    };
 
     if kind == ValidityRequirement::Zero {
         cx.write_bytes_ptr(


### PR DESCRIPTION
## Description

When `-Zstrict-init-checks=yes` is enabled and the compiler encounters a type that is too large to allocate (e.g. `[[[bool; 9999999]; 777777777]; 239]`), `check_validity_requirement_strict` calls `cx.allocate()` which returns `Err(ResourceExhaustion(MemoryExhausted))`. The `.expect("OOM: failed to allocate for uninit check")` then panics, producing an ICE.

This fix replaces the `.expect()` with a `let Ok(allocated) = ... else { return false; }` pattern, handling the OOM gracefully by conservatively returning `false` (the type does not permit raw initialization) instead of ICEing.

## Testing

- The ICE is triggered by `-Zalways-encode-mir -Zstrict-init-checks=yes` on a file containing:
  ```rust
  //@compile-flags: -Zalways-encode-mir -Zstrict-init-checks=yes
  fn overflow() -> [[[bool; 9999999]; 777777777]; 239] {
      unsafe { core::mem::zeroed() }
  }
  fn main() {
      let _ = overflow();
  }
  ```
- After the fix, the compiler will no longer panic with OOM. Instead, it will conservatively report that the type does not allow raw initialization.

Closes rust-lang/rust#160769
