### PR TITLE
Use recognizer functions for enums and tuple structs

### DIFF
--- a/src/etc/lldb_batchmode/runner.py
+++ b/src/etc/lldb_batchmode/runner.py
@@ -117,6 +117,7 @@ def execute_command(command_interpreter: lldb.SBCommandInterpreter, command: str
                         + str(res.GetError())
                     )
     else:
+        print(res.GetOutput())
         print(res.GetError())
 
 

--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -126,17 +126,6 @@ def register_providers_compatibility():
     global RUST_CATEGORY
 
     if LLDBFeature.TypeRecognizers in FEATURE_FLAGS:
-        # FIXME: this can be removed once full support for type recognizers is added.
-        # This prevents a semi-unfixable regression for CodeLLDB
-        register_synth(
-            synthetic_lookup,
-            lldb.SBTypeNameSpecifier(
-                MOD_PREFIX + is_udt.__name__,
-                lldb.eFormatterMatchCallback,
-            ),
-            lldb.eTypeOptionCascade,
-        )
-
         # enforce uniform aggregate formatting
         register_summary(
             StructSummaryProvider,
@@ -147,6 +136,34 @@ def register_providers_compatibility():
             lldb.eTypeOptionCascade
             | lldb.eTypeOptionHideEmptyAggregates
             | lldb.eTypeOptionHideChildren,
+        )
+
+        # Tuple-structs
+        register_synth(
+            TupleSyntheticProvider,
+            lldb.SBTypeNameSpecifier(
+                MOD_PREFIX + is_tuple_type.__name__, lldb.eFormatterMatchCallback
+            ),
+            lldb.eTypeOptionCascade,
+        )
+
+        # Gnu Sum-type Enums
+        register_synth(
+            ClangEncodedEnumProvider,
+            lldb.SBTypeNameSpecifier(
+                MOD_PREFIX + is_gnu_enum.__name__,
+                lldb.eFormatterMatchCallback,
+            ),
+            lldb.eTypeOptionCascade,
+        )
+
+        register_summary(
+            ClangEncodedEnumSummaryProvider,
+            lldb.SBTypeNameSpecifier(
+                MOD_PREFIX + is_gnu_enum.__name__,
+                lldb.eFormatterMatchCallback,
+            ),
+            lldb.eTypeOptionCascade,
         )
     else:
         # Need to toss any remaining types through this so that GNU enums are caught
@@ -393,6 +410,18 @@ def is_udt(type: lldb.SBType, _dict: LLDBOpaque) -> bool:
         and not type.IsPointerType()
         and not type.IsArrayType()
     )
+
+
+def is_gnu_enum(type: lldb.SBType, _dict: LLDBOpaque) -> bool:
+    return (
+        type.GetNumberOfFields() == 1
+        and type.GetFieldAtIndex(0).GetName() == "$variants$"
+    )
+
+
+def is_tuple_type(type: lldb.SBType, _dict: LLDBOpaque) -> bool:
+    fields = type.fields
+    return len(fields) != 0 and is_tuple_fields(fields)
 
 
 def classify_rust_type(type: lldb.SBType, is_msvc: bool) -> RustType:


### PR DESCRIPTION
<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Non-urgent, but related to https://github.com/rust-lang/rust/pull/160331

We currently shove most user defined types through `synthetic_lookup` as I hadn't gotten around to using type recognizers yet. If we want tests to skip outputting types when the type doesn't have a visualizer, we should also not attach a (useless) visualizer to most UDTs. 

The only things `synthetic_lookup` catches that aren't already caught by the regexes are tuple-structs and sum-type enums. This patch adds targeted type recognizers for those, and no longer sends types through `synthetic_lookup` at all on LLDB 19+

this doesn't affect `pretty-std.rs` since all those types have visualizers, but it will affect other tests if/when they're converted (e.g. `tests/debuginfo/struct-in-struct.rs`)

r? @Kobzol, @jieyouxu 