### PR TITLE
Optimize new solver unification table ops

### DIFF
--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -108,6 +108,16 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         self.sub_unification_table_root_var(var)
     }
 
+    #[inline]
+    fn is_sub_unification_table_root_var(&self, vid: ty::TyVid) -> bool {
+        self.inner
+            .borrow()
+            .type_variable_storage
+            .sub_unification_table_ref()
+            .try_probe_value(vid)
+            .is_some()
+    }
+
     fn root_const_var(&self, var: ty::ConstVid) -> ty::ConstVid {
         self.root_const_var(var)
     }

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -147,25 +147,18 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
             ty::GenericArgKind::Type(ty) => {
                 if let ty::Infer(infer_ty) = *ty.kind() {
                     match infer_ty {
-                        ty::InferTy::TyVar(vid) => {
-                            !self.try_resolve_ty_var(vid).is_err_and(|_| self.root_var(vid) == vid)
-                        }
-                        ty::InferTy::IntVar(vid) => {
-                            let mut inner = self.inner.borrow_mut();
-                            !matches!(
-                                inner.int_unification_table().probe_value(vid),
-                                ty::IntVarValue::Unknown
-                                    if inner.int_unification_table().find(vid) == vid
-                            )
-                        }
-                        ty::InferTy::FloatVar(vid) => {
-                            let mut inner = self.inner.borrow_mut();
-                            !matches!(
-                                inner.float_unification_table().probe_value(vid),
-                                ty::FloatVarValue::Unknown
-                                    if inner.float_unification_table().find(vid) == vid
-                            )
-                        }
+                        ty::InferTy::TyVar(vid) => !matches!(
+                            self.inner.borrow().try_type_variables_probe_ref(vid),
+                            Some(TypeVariableValue::Unknown { .. })
+                        ),
+                        ty::InferTy::IntVar(vid) => !matches!(
+                            self.inner.borrow().int_unification_storage.try_probe_value(vid),
+                            Some(ty::IntVarValue::Unknown)
+                        ),
+                        ty::InferTy::FloatVar(vid) => !matches!(
+                            self.inner.borrow().float_unification_storage.try_probe_value(vid),
+                            Some(ty::FloatVarValue::Unknown)
+                        ),
                         ty::InferTy::FreshTy(_)
                         | ty::InferTy::FreshIntTy(_)
                         | ty::InferTy::FreshFloatTy(_) => true,
@@ -177,9 +170,10 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
             ty::GenericArgKind::Const(ct) => {
                 if let ty::ConstKind::Infer(infer_ct) = ct.kind() {
                     match infer_ct {
-                        ty::InferConst::Var(vid) => !self
-                            .try_resolve_const_var(vid)
-                            .is_err_and(|_| self.root_const_var(vid) == vid),
+                        ty::InferConst::Var(vid) => !matches!(
+                            self.inner.borrow().const_unification_storage.try_probe_value(vid),
+                            Some(ConstVariableValue::Unknown { .. })
+                        ),
                         ty::InferConst::Fresh(_) => true,
                     }
                 } else {

--- a/compiler/rustc_infer/src/infer/type_variable.rs
+++ b/compiler/rustc_infer/src/infer/type_variable.rs
@@ -157,6 +157,10 @@ impl<'tcx> TypeVariableStorage<'tcx> {
         debug_assert!(self.values.len() >= self.eq_relations.len());
         self.values.truncate(self.eq_relations.len());
     }
+
+    pub(crate) fn sub_unification_table_ref(&self) -> &ut::UnificationTableStorage<TyVidSubKey> {
+        &self.sub_unification_table
+    }
 }
 
 impl<'tcx> TypeVariableTable<'_, 'tcx> {

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
@@ -57,7 +57,7 @@ where
 
     // If some inference took place in any of the sub roots,
     // rerunning might make progress so we should rerun.
-    if sub_roots.iter().any(|&vid| delegate.sub_unification_table_root_var(vid) != vid) {
+    if sub_roots.iter().any(|&vid| !delegate.is_sub_unification_table_root_var(vid)) {
         return MayMakeProgress;
     }
 

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -407,6 +407,7 @@ pub trait InferCtxtLike: Sized {
 
     fn root_ty_var(&self, var: ty::TyVid) -> ty::TyVid;
     fn sub_unification_table_root_var(&self, var: ty::TyVid) -> ty::TyVid;
+    fn is_sub_unification_table_root_var(&self, var: ty::TyVid) -> bool;
     fn root_const_var(&self, var: ty::ConstVid) -> ty::ConstVid;
 
     fn opportunistic_resolve_ty_var(&self, vid: ty::TyVid) -> <Self::Interner as Interner>::Ty;


### PR DESCRIPTION
The current code uses the `ena` crate in sub-optimal ways. Improving this gives big speed wins for the new trait solver on some benchmarks. Details in individual commits.

r? @lcnr