### PR TITLE
Fix `visible_parent_map` fallback map merging perf regression

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::mem;
 use std::sync::Arc;
 
-use rustc_data_structures::unord::ExtendUnord;
+use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::attrs::Deprecation;
 use rustc_hir::def::{CtorKind, DefKind};
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LOCAL_CRATE};
@@ -473,7 +473,7 @@ pub(in crate::rmeta) fn provide(providers: &mut Providers) {
             // the former.
             // This is a rudimentary check that does not catch all cases,
             // just the easiest.
-            let mut fallback_map: DefIdMap<DefId> = Default::default();
+            let mut fallback_map: FxHashMap<DefId, DefId> = Default::default();
 
             // Issue 46112: We want the map to prefer the shortest
             // paths when reporting the path to an item. Therefore we
@@ -574,10 +574,16 @@ pub(in crate::rmeta) fn provide(providers: &mut Providers) {
             // We must extend the fallback map with items from the visible parent map
             // as the extend call overrides existing entries from the latter map,
             // which we prefer over fallback entries.
-            let mut merged_visible_parent_map = fallback_map;
-            merged_visible_parent_map.extend_unord(visible_parent_map.into_items());
+            // FIXME: The Unord* APIs lack an efficient way of merging
+            //        the values of one map for only the missing keys of the other map,
+            //        which is required to merge the fallback map into the visible parent map.
+            //        In the meantime, use an "ordered" map internally for fallback entries.
+            #[allow(rustc::potential_query_instability)]
+            for (child, parent) in fallback_map {
+                visible_parent_map.entry(child).or_insert(parent);
+            }
 
-            merged_visible_parent_map
+            visible_parent_map
         },
 
         dependency_formats: |tcx, ()| Arc::new(crate::dependency_format::calculate(tcx)),


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160811)*
<!-- homu-ignore:end -->

This PR attempts to fix the `visible_parent_map` perf regression introduced in rust-lang/rust#160464, which was found in a [post-merge perf run](https://github.com/rust-lang/rust/pull/160464#issuecomment-5231136940).

Because the original PR fixes unnecessary iterations in the breadth-first search (BFS), meaning that it only reduces the amount of work during the BFS, the likely cause of the perf regression is the changed merging of the fallback map into the final visible parent map after the BFS.

The goal of this PR is to determine whether this is the case through a perf try run. The change itself works around the Unord* APIs, but might be worth it to work around the perf regression.

<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
