### PR TITLE
Fix UB from &mut-derived pointer in Thread::new

### DIFF
--- a/library/std/src/sys/pal/unix/sync/condvar.rs
+++ b/library/std/src/sys/pal/unix/sync/condvar.rs
@@ -1,6 +1,7 @@
 use super::Mutex;
 use crate::cell::UnsafeCell;
 use crate::pin::Pin;
+use crate::ptr;
 #[cfg(not(any(target_os = "nto", target_os = "qnx")))]
 use crate::sys::pal::time::TIMESPEC_MAX;
 #[cfg(any(target_os = "nto", target_os = "qnx"))]
@@ -149,7 +150,7 @@ impl Condvar {
 
     /// # Safety
     /// May only be called once per instance of `Self`.
-    pub unsafe fn init(self: Pin<&mut Self>) {
+    pub unsafe fn init(this: *mut Self) {
         use crate::mem::MaybeUninit;
 
         struct AttrGuard<'a>(pub &'a mut MaybeUninit<libc::pthread_condattr_t>);
@@ -169,7 +170,8 @@ impl Condvar {
             let attr = AttrGuard(&mut attr);
             let r = libc::pthread_condattr_setclock(attr.0.as_mut_ptr(), Self::CLOCK);
             assert_eq!(r, 0);
-            let r = libc::pthread_cond_init(self.raw(), attr.0.as_ptr());
+            let r =
+                libc::pthread_cond_init(ptr::addr_of_mut!((*this).inner).cast(), attr.0.as_ptr());
             assert_eq!(r, 0);
         }
     }
@@ -183,7 +185,7 @@ impl Condvar {
 
     /// # Safety
     /// May only be called once per instance of `Self`.
-    pub unsafe fn init(self: Pin<&mut Self>) {
+    pub unsafe fn init(_this: *mut Self) {
         // `PTHREAD_COND_INITIALIZER` is fully supported and we don't need to
         // change clocks, so there's nothing to do here.
     }
@@ -204,13 +206,15 @@ impl Condvar {
 
     /// # Safety
     /// May only be called once per instance of `Self`.
-    pub unsafe fn init(self: Pin<&mut Self>) {
+    pub unsafe fn init(this: *mut Self) {
         if cfg!(any(target_os = "espidf", target_os = "horizon", target_os = "teeos")) {
             // NOTE: ESP-IDF's PTHREAD_COND_INITIALIZER support is not released yet
             // So on that platform, init() should always be called.
             //
             // Similar story for the 3DS (horizon) and for TEEOS.
-            let r = unsafe { libc::pthread_cond_init(self.raw(), crate::ptr::null()) };
+            let r = unsafe {
+                libc::pthread_cond_init(ptr::addr_of_mut!((*this).inner).cast(), crate::ptr::null())
+            };
             assert_eq!(r, 0);
         }
     }

--- a/library/std/src/sys/pal/unix/sync/mutex.rs
+++ b/library/std/src/sys/pal/unix/sync/mutex.rs
@@ -3,6 +3,7 @@ use crate::cell::UnsafeCell;
 use crate::io::Error;
 use crate::mem::MaybeUninit;
 use crate::pin::Pin;
+use crate::ptr;
 
 pub struct Mutex {
     inner: UnsafeCell<libc::pthread_mutex_t>,
@@ -19,7 +20,7 @@ impl Mutex {
 
     /// # Safety
     /// May only be called once per instance of `Self`.
-    pub unsafe fn init(self: Pin<&mut Self>) {
+    pub unsafe fn init(this: *mut Self) {
         // Issue #33770
         //
         // A pthread mutex initialized with PTHREAD_MUTEX_INITIALIZER will have
@@ -53,7 +54,11 @@ impl Mutex {
                 libc::PTHREAD_MUTEX_NORMAL,
             ))
             .unwrap();
-            cvt_nz(libc::pthread_mutex_init(self.raw(), attr.0.as_ptr())).unwrap();
+            cvt_nz(libc::pthread_mutex_init(
+                ptr::addr_of_mut!((*this).inner).cast(),
+                attr.0.as_ptr(),
+            ))
+            .unwrap();
         }
     }
 

--- a/library/std/src/sys/sync/condvar/pthread.rs
+++ b/library/std/src/sys/sync/condvar/pthread.rs
@@ -23,7 +23,7 @@ impl Condvar {
         self.cvar.get_or_init(|| {
             let mut cvar = Box::pin(pal::Condvar::new());
             // SAFETY: we only call `init` once per `pal::Condvar`, namely here.
-            unsafe { cvar.as_mut().init() };
+            unsafe { pal::Condvar::init(&raw mut *cvar) };
             cvar
         })
     }

--- a/library/std/src/sys/sync/mutex/pthread.rs
+++ b/library/std/src/sys/sync/mutex/pthread.rs
@@ -22,7 +22,7 @@ impl Mutex {
         self.pal.get_or_init(|| {
             let mut pal = Box::pin(pal::Mutex::new());
             // SAFETY: we only call `init` once per `pal::Mutex`, namely here.
-            unsafe { pal.as_mut().init() };
+            unsafe { pal::Mutex::init(&raw mut *pal) };
             pal
         })
     }

--- a/library/std/src/sys/sync/thread_parking/pthread.rs
+++ b/library/std/src/sys/sync/thread_parking/pthread.rs
@@ -28,7 +28,7 @@ impl Parker {
             cvar: Condvar::new(),
         });
 
-        Pin::new_unchecked(&mut (*parker).cvar).init();
+        unsafe { Condvar::init(&raw mut (*parker).cvar) };
     }
 
     fn lock(self: Pin<&Self>) -> Pin<&Mutex> {

--- a/library/std/src/thread/thread.rs
+++ b/library/std/src/thread/thread.rs
@@ -96,11 +96,10 @@ impl Thread {
         // We have to use `unsafe` here to construct the `Parker` in-place,
         // which is required for the UNIX implementation.
         //
-        // SAFETY: We pin the Arc immediately after creation, so its address never
-        // changes.
+        // safety: the pointer comes from Arc::as_ptr so it is not tied to a &mut
         let inner = unsafe {
-            let mut arc = Arc::<Inner, _>::new_uninit_in(System);
-            let ptr = Arc::get_mut_unchecked(&mut arc).as_mut_ptr();
+            let arc = Arc::<Inner, _>::new_uninit_in(System);
+            let ptr = Arc::as_ptr(&arc).cast_mut().cast::<Inner>();
             (&raw mut (*ptr).name).write(name);
             (&raw mut (*ptr).id).write(id);
             Parker::new_in_place(&raw mut (*ptr).parker);


### PR DESCRIPTION
fix_approach: Take the pointer from the raw allocation `(Arc::as_ptr)` instead of from a `&mut`,
and pass libc the address straight from the allocation `(addr_of_mut)`. It stays
valid no matter how the thread is used later.