### PR TITLE
Switch try jobs to c8a.8xlarge

### DIFF
--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -83,7 +83,19 @@ runner_group_id = 8
 label_prefix = "ec2"
 region = "us-east-2"
 images = {
-    "ubuntu26.04" = "/aws/service/canonical/ubuntu/server/26.04/stable/current/amd64/hvm/ebs-gp3/ami-id"
+    "x86_64ami" = "latest-gha-runner-ami"
 }
 jit_runner = "organization"
-allowed_instances = ["c8a.12xlarge"]
+# Prices per hour of on-demand compute in us-east-2 (as of Aug 2026)
+# See rough assessment of build speed for dist-x86_64-quick in https://github.com/rust-lang/simpleinfra/issues/1132
+# m8a.2x     8 vCPU, 32 GB   $0.48688/hr
+# c8a.4x    16 vCPU, 32 GB   $0.86216/hr
+# c8a.8x    32 vCPU, 64 GB   $1.72432/hr
+# c8a.12x   48 vCPU, 96 GB   $2.58648/hr
+# CodeBuild 36 vCPU          $4.78799/hr
+allowed_instances = [
+    "m8a.2xlarge",
+    "c8a.4xlarge",
+    "c8a.8xlarge",
+    "c8a.12xlarge",
+]

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -71,8 +71,8 @@ runners:
     os: codebuild-ubuntu-22-8c-$github.run_id-$github.run_attempt
     <<: *base-job
 
-  - &job-linux-48c-ec2
-    os: ec2-ubuntu26.04-c8a.12xlarge-x64-linux-$github.run_id-$github.run_attempt
+  - &job-linux-32c-ec2
+    os: ec2-x86_64ami-c8a.8xlarge-x64-linux-$github.run_id-$github.run_attempt
     <<: *base-job
 
 envs:
@@ -179,7 +179,7 @@ pr:
 # These jobs automatically inherit envs.try, to avoid repeating
 # it in each job definition.
 try:
-  - <<: [*job-dist-x86_64-linux, *job-linux-48c-ec2]
+  - <<: [*job-dist-x86_64-linux, *job-linux-32c-ec2]
     name: dist-x86_64-linux-quick
 
 # Jobs that only run when explicitly invoked in one of the following ways:
@@ -203,7 +203,7 @@ optional:
       DIST_TRY_BUILD: 1
   # We repeat the try job here so that it can be explicitly executed using `@bors try jobs`, to test
   # full x64 Linux dist try builds on EC2.
-  - <<: [*job-dist-x86_64-linux, *job-linux-48c-ec2]
+  - <<: [*job-dist-x86_64-linux, *job-linux-32c-ec2]
     name: dist-x86_64-linux-quick
 
 # Main CI jobs that have to be green to merge a commit into the default branch.


### PR DESCRIPTION
This also expands the instance type list. Our current selection (12xlarge) is at best 2-3 minutes faster than 8xlarge based on rough benchmarks, which isn't worth the extra ~$0.72/build. See description of https://github.com/rust-lang/simpleinfra/issues/1132 for those results.

We expand the instance list to include even smaller instances because we might experiment with using those smaller instances for non-try jobs (e.g., auto and unrolled perf builds) because latency matters less there. That's not done in this commit though.

Unfortunately I think we cannot easily test this before landing it, since AFAICT bors will read the configuration only once it's actually on main. https://github.com/rust-lang/bors-kindergarten/pull/59 (once merged) should give us some test experience with this before we proceed with things in rust-lang/rust.

r? Kobzol
