### PR TITLE
Fix references to unsupported on sys::paths::unix

### DIFF
--- a/library/std/src/sys/paths/unix.rs
+++ b/library/std/src/sys/paths/unix.rs
@@ -47,7 +47,7 @@ pub fn getcwd() -> io::Result<PathBuf> {
 
 #[cfg(target_os = "espidf")]
 pub fn chdir(_p: &path::Path) -> io::Result<()> {
-    crate::sys::pal::unsupported::unsupported()
+    crate::sys::pal::unsupported()
 }
 
 #[cfg(not(target_os = "espidf"))]
@@ -385,7 +385,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
 
 #[cfg(any(target_os = "espidf", target_os = "horizon", target_os = "vita"))]
 pub fn current_exe() -> io::Result<PathBuf> {
-    crate::sys::pal::unsupported::unsupported()
+    crate::sys::pal::unsupported()
 }
 
 #[cfg(target_os = "fuchsia")]


### PR DESCRIPTION
<!-- homu-ignore:start -->

- [X] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!-- homu-ignore:end -->

Compilation was seemingly broken by PR https://github.com/rust-lang/rust/pull/150885, commit f2dd93228abcf29ab85960457df7a6f828eb3cb9, by removing one of the nested `mod`s.

I'm one of the `armv7-sony-vita-newlibeabihf` target maintainers.

Summary of changes for affected targets:

- `armv7-sony-vita-newlibeabihf`: now compiles
- `armv6k-nintendo-3ds`: still doesn't compile, apparently due to an issue introduced in https://github.com/rust-lang/rust/pull/158168, which should be fixed by https://github.com/rust-lang/rust/pull/160170
- all espidf targets: I haven't compiled any of them as I don't have the toolchain installed, but it should be on the same as 3DS. The same errors can be seen in [does-it-build](https://does-it-build.noratrieb.dev/build?nightly=2026-08-09&target=xtensa-esp32s3-espidf&mode=std)