### PR TITLE
Rename parse_delimited_token_tree in cfg_select

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/cfg_select.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg_select.rs
@@ -87,7 +87,7 @@ pub fn parse_cfg_select(
             let underscore = p.prev_token;
             p.expect(exp!(FatArrow)).map_err(|e| e.emit())?;
 
-            let tts = p.parse_delimited_token_tree().map_err(|e| e.emit())?;
+            let tts = p.parse_cfg_select_branch_rhs().map_err(|e| e.emit())?;
             let span = underscore.span.to(p.token.span);
 
             match branches.wildcard {
@@ -126,7 +126,7 @@ pub fn parse_cfg_select(
 
             p.expect(exp!(FatArrow)).map_err(|e| e.emit())?;
 
-            let tts = p.parse_delimited_token_tree().map_err(|e| e.emit())?;
+            let tts = p.parse_cfg_select_branch_rhs().map_err(|e| e.emit())?;
             let span = cfg_span.to(p.token.span);
 
             match branches.wildcard {

--- a/compiler/rustc_parse/src/parser/cfg_select.rs
+++ b/compiler/rustc_parse/src/parser/cfg_select.rs
@@ -14,10 +14,9 @@ pub struct CfgSelectBranchAttrSpans {
 }
 
 impl<'a> Parser<'a> {
-    /// Parses a `TokenTree` consisting either of `{ /* ... */ }` optionally followed by a comma
-    /// (and strip the braces and the optional comma) or an expression followed by a comma
-    /// (and strip the comma).
-    pub fn parse_delimited_token_tree(&mut self) -> PResult<'a, TokenStream> {
+    /// Parses the right-hand side of a `cfg_select!` branch,
+    /// which can be either a braced block or an expression.
+    pub fn parse_cfg_select_branch_rhs(&mut self) -> PResult<'a, TokenStream> {
         if self.token == token::OpenBrace {
             // Strip the outer '{' and '}'.
             match self.parse_token_tree() {


### PR DESCRIPTION
<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

From https://github.com/rust-lang/rust/pull/160303#discussion_r3739253868
The fn `parse_delimited_token_tree` only for parsing `cfg_select`.