### PR TITLE
re-equate the object bound's trait ref with the goal's when considering object bounds

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -85,7 +85,15 @@ where
         goal: Goal<I, Self>,
         assumption: I::Clause,
     ) -> Result<Candidate<I>, NoSolutionOrRerunNonErased> {
-        Self::probe_and_match_goal_against_assumption(ecx, source, goal, assumption, |ecx| {
+        // We inline much of `probe_and_match_goal_against_assumption` and
+        // `TraitPredicate::match_assumption` here, as we never encounter
+        // `Sized` or `MetaSized` goals here, and we need to equate `goal`
+        // and `assumption`'s trait refs directly inside this function in
+        // order to prevent unsoundness (see below).
+
+        Self::fast_reject_assumption(ecx, goal, assumption)?;
+
+        ecx.probe_trait_candidate(source).enter(|ecx| {
             let cx = ecx.cx();
             let ty::Dynamic(bounds, _) = goal.predicate.self_ty().kind() else {
                 panic!("expected object type in `probe_and_consider_object_bound_candidate`");
@@ -105,6 +113,37 @@ where
                     unreachable!("expected trait or projection predicate as an assumption")
                 }
             });
+
+            // If we need to prove `dyn for<'x> Trait<'x> + '?temp: Trait<'static>` with
+            //
+            // ```rs
+            // trait Trait<'a>: 'a {}
+            // ```
+            //
+            // we have the goal's trait ref as `Trait<'static>` and a theoretical impl
+            // resembling:
+            //
+            // ```rs
+            // impl<'s, 'hr> Trait<'hr> for dyn for<'x> Trait<'x> + 's
+            // where
+            //     dyn for<'a> Trait<'a> + 's: 'hr
+            // {}
+            // ```
+            //
+            // where 'hr is our bound var. The where-clause elaborates to `'s: 'hr`;
+            // in this case we have 's := '?temp. Instantiating the binder gives us
+            // 'hr := '?infer, and our goal has 'hr := 'static, so we need to equate
+            // the instantiated trait ref to the goal in order to get '?infer := 'static,
+            // since what we want is the constraint `'?temp: 'static`.
+            //
+            // If we instead passed the binder to predicates_for_object_candidate and let
+            // it instantiate the binder itself, we would lose '?infer := 'static, since
+            // predicates_for_object_candidate has no way of equating the trait ref with
+            // the goal. We would simply have 'hr := '?infer, giving us the constraint
+            // `?temp: '?infer`, which is satisfiable for any lifetime, leading to
+            // unsoundness: trait-system-refactor-initiative#295.
+            let trait_ref = ecx.instantiate_binder_with_infer(trait_ref);
+            ecx.eq(goal.param_env, goal.predicate.trait_ref(cx), trait_ref)?;
 
             match structural_traits::predicates_for_object_candidate(
                 ecx,

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -8,7 +8,7 @@ use rustc_type_ir::lang_items::{SolverProjectionLangItem, SolverTraitLangItem};
 use rustc_type_ir::solve::SizedTraitKind;
 use rustc_type_ir::solve::inspect::ProbeKind;
 use rustc_type_ir::{
-    self as ty, Binder, FallibleTypeFolder, Interner, Movability, Mutability, Region, TypeFoldable,
+    self as ty, FallibleTypeFolder, Interner, Movability, Mutability, Region, TypeFoldable,
     TypeSuperFoldable, Unnormalized, Upcast as _, elaborate,
 };
 use rustc_type_ir_macros::{TypeFoldable_Generic, TypeVisitable_Generic};
@@ -889,7 +889,7 @@ pub(in crate::solve) fn const_conditions_for_destruct<I: Interner>(
 pub(in crate::solve) fn predicates_for_object_candidate<D, I>(
     ecx: &mut EvalCtxt<'_, D>,
     param_env: I::ParamEnv,
-    trait_ref: Binder<I, ty::TraitRef<I>>,
+    trait_ref: ty::TraitRef<I>,
     object_bounds: I::BoundExistentialPredicates,
 ) -> Result<Vec<Goal<I, I::Predicate>>, Ambiguous>
 where
@@ -897,7 +897,6 @@ where
     I: Interner,
 {
     let cx = ecx.cx();
-    let trait_ref = ecx.instantiate_binder_with_infer(trait_ref);
     let mut requirements = vec![];
     // Elaborating all supertrait outlives obligations here is not soundness critical,
     // since if we just used the unelaborated set, then the transitive supertraits would

--- a/tests/ui/traits/next-solver/assoc-type-static-lifetime-object-bound.rs
+++ b/tests/ui/traits/next-solver/assoc-type-static-lifetime-object-bound.rs
@@ -1,0 +1,27 @@
+//! regression test for https://github.com/rust-lang/trait-system-refactor-initiative/issues/295
+
+//@ compile-flags: -Znext-solver
+
+#![forbid(unsafe_code)]
+
+trait Tr<'a> {
+    type A: 'a;
+}
+
+fn f<X: ?Sized + Tr<'static>>(a: <X as Tr<'static>>::A) -> Box<dyn std::any::Any> {
+    Box::new(a)
+}
+
+fn launder<'b>(r: &'b u8) -> &'static u8 {
+    *f::<dyn for<'a> Tr<'a, A = &'b u8>>(r).downcast_ref::<&'static u8>().unwrap()
+    //~^ ERROR lifetime may not live long enough
+}
+
+fn main() {
+    let p;
+    {
+        let x = Box::new(42u8);
+        p = launder(&x);
+    }
+    println!("{}", *p);
+}

--- a/tests/ui/traits/next-solver/assoc-type-static-lifetime-object-bound.stderr
+++ b/tests/ui/traits/next-solver/assoc-type-static-lifetime-object-bound.stderr
@@ -1,0 +1,10 @@
+error: lifetime may not live long enough
+  --> $DIR/assoc-type-static-lifetime-object-bound.rs:16:6
+   |
+LL | fn launder<'b>(r: &'b u8) -> &'static u8 {
+   |            -- lifetime `'b` defined here
+LL |     *f::<dyn for<'a> Tr<'a, A = &'b u8>>(r).downcast_ref::<&'static u8>().unwrap()
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'static`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/traits/next-solver/gat-static-in-trait-object.rs
+++ b/tests/ui/traits/next-solver/gat-static-in-trait-object.rs
@@ -1,0 +1,24 @@
+//! regression test from https://github.com/rust-lang/rust/pull/160831/changes#r3852248101
+//! once we allow GATs in object types, we want to make sure this isn't unsound.
+
+//@ compile-flags: -Znext-solver
+
+use std::any::Any;
+
+trait Trait {
+    type Assoc<'a>: 'a;
+}
+
+fn tr<T: Trait>(x: T::Assoc<'static>) -> Box<dyn Any> { Box::new(x) }
+
+fn foo<'s>(x: &'s str) -> Box<dyn Any>
+where
+    dyn for<'hr> Trait<Assoc<'hr> = &'s str>: Trait<Assoc<'static> = &'s str>,
+    //~^ ERROR the trait `Trait` is not dyn compatible
+    //~| ERROR the trait `Trait` is not dyn compatible
+{
+    tr::<dyn for<'hr> Trait<Assoc<'hr> = &'s str>>(x)
+    //~^ ERROR the trait `Trait` is not dyn compatible
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/gat-static-in-trait-object.stderr
+++ b/tests/ui/traits/next-solver/gat-static-in-trait-object.stderr
@@ -1,0 +1,51 @@
+error[E0038]: the trait `Trait` is not dyn compatible
+  --> $DIR/gat-static-in-trait-object.rs:16:47
+   |
+LL |     dyn for<'hr> Trait<Assoc<'hr> = &'s str>: Trait<Assoc<'static> = &'s str>,
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Trait` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/gat-static-in-trait-object.rs:9:10
+   |
+LL | trait Trait {
+   |       ----- this trait is not dyn compatible...
+LL |     type Assoc<'a>: 'a;
+   |          ^^^^^ ...because it contains generic associated type `Assoc`
+   = help: consider moving `Assoc` to another trait
+
+error[E0038]: the trait `Trait` is not dyn compatible
+  --> $DIR/gat-static-in-trait-object.rs:16:53
+   |
+LL |     dyn for<'hr> Trait<Assoc<'hr> = &'s str>: Trait<Assoc<'static> = &'s str>,
+   |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^ `Trait` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/gat-static-in-trait-object.rs:9:10
+   |
+LL | trait Trait {
+   |       ----- this trait is not dyn compatible...
+LL |     type Assoc<'a>: 'a;
+   |          ^^^^^ ...because it contains generic associated type `Assoc`
+   = help: consider moving `Assoc` to another trait
+
+error[E0038]: the trait `Trait` is not dyn compatible
+  --> $DIR/gat-static-in-trait-object.rs:20:14
+   |
+LL |     tr::<dyn for<'hr> Trait<Assoc<'hr> = &'s str>>(x)
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Trait` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/gat-static-in-trait-object.rs:9:10
+   |
+LL | trait Trait {
+   |       ----- this trait is not dyn compatible...
+LL |     type Assoc<'a>: 'a;
+   |          ^^^^^ ...because it contains generic associated type `Assoc`
+   = help: consider moving `Assoc` to another trait
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/traits/next-solver/supertrait-static-lifetime-object-bound.rs
+++ b/tests/ui/traits/next-solver/supertrait-static-lifetime-object-bound.rs
@@ -1,0 +1,20 @@
+//! regression test for https://github.com/rust-lang/trait-system-refactor-initiative/issues/295
+
+//@ compile-flags: -Znext-solver
+
+#![forbid(unsafe_code)]
+
+trait Trait<'a>: 'a {}
+
+fn g<'s>(s: &'s String) -> &'static String
+where
+    dyn for<'x> Trait<'x> + 's: Trait<'static>,
+{
+    s
+}
+
+fn main() {
+    let r = g(&String::from("freed"));
+    //~^ ERROR temporary value dropped while borrowed
+    println!("{r}");
+}

--- a/tests/ui/traits/next-solver/supertrait-static-lifetime-object-bound.stderr
+++ b/tests/ui/traits/next-solver/supertrait-static-lifetime-object-bound.stderr
@@ -1,0 +1,18 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/supertrait-static-lifetime-object-bound.rs:17:16
+   |
+LL |     let r = g(&String::from("freed"));
+   |             ---^^^^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
+   |             |  |
+   |             |  creates a temporary value which is freed while still in use
+   |             argument requires that borrow lasts for `'static`
+   |
+note: requirement that the value outlives `'static` introduced here
+  --> $DIR/supertrait-static-lifetime-object-bound.rs:11:33
+   |
+LL |     dyn for<'x> Trait<'x> + 's: Trait<'static>,
+   |                                 ^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0716`.


### PR DESCRIPTION
https://github.com/rust-lang/trait-system-refactor-initiative/issues/295 bisects to rust-lang/rust#152859, which changed `probe_and_consider_object_bound_candidate` to pass the trait object's trait ref in a binder to `predicates_for_object_candidate`, which calls `instantiate_binder_with_infer` on the binder.

Re-instantiating the binder like this, however, loses the constraint that `'x: 'static`, even though earlier in `match_assumption` we actually did equate the object trait ref with the goal's trait ref, which gave us the `eq('x, 'static)` relationship we needed. However, the new inference var has no relationship with the equality we established; hence we lose `'x: 'static` and therefore `Self: 'static` and `'s: 'static`.

We therefore inline `match_assumption` and directly equate the assumption's trait ref with the goal's before passing the assumption to `predicates_for_object_candidate` instead and remove the re-instantiation.

fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/295

cc @lcnr

<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->