### PR TITLE
resolver diagnostics: don't swallow labels and point out  similar items as a note, not a label

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics/impls.rs
+++ b/compiler/rustc_resolve/src/diagnostics/impls.rs
@@ -1928,9 +1928,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ident,
             is_expected,
         );
-        if !self.add_typo_suggestion(err, suggestion, ident.span) {
-            self.detect_derive_attribute(err, ident, parent_scope, sugg_span);
-        }
+        self.add_typo_suggestion(err, suggestion, ident.span);
+        self.detect_derive_attribute(err, ident, parent_scope, sugg_span);
 
         let import_suggestions =
             self.lookup_import_candidates(ident, Namespace::MacroNS, parent_scope, is_expected);
@@ -2211,11 +2210,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         err: &mut Diag<'_>,
         suggestion: Option<TypoSuggestion>,
         span: Span,
-    ) -> bool {
+    ) {
         let suggestion = match suggestion {
-            None => return false,
+            None => return,
             // We shouldn't suggest underscore.
-            Some(suggestion) if suggestion.candidate == kw::Underscore => return false,
+            Some(suggestion) if suggestion.candidate == kw::Underscore => return,
             Some(suggestion) => suggestion,
         };
 
@@ -2241,7 +2240,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 //    |
                 // LL | const Y: X = Y("ö");
                 //    |              ^
-                return false;
+                return;
             }
             let span = self.tcx.sess.source_map().guess_head_span(def_span);
             let candidate_descr = suggestion.res.descr();
@@ -2271,7 +2270,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 "the leading underscore in `{candidate}` marks it as unused, consider renaming it to `{snippet}`"
             );
             if !did_label_def_span {
-                err.span_label(span, format!("`{candidate}` defined here"));
+                err.span_note(span, format!("`{candidate}` defined here"));
             }
             (span, msg, snippet)
         } else {
@@ -2288,7 +2287,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             (span, msg, suggestion.candidate.to_ident_string())
         };
         err.span_suggestion_verbose(span, msg, sugg, Applicability::MaybeIncorrect);
-        true
     }
 
     fn decl_description(&self, b: Decl<'_>, ident: Ident, scope: Scope<'_>) -> String {

--- a/compiler/rustc_resolve/src/diagnostics/mod.rs
+++ b/compiler/rustc_resolve/src/diagnostics/mod.rs
@@ -1219,14 +1219,14 @@ pub(crate) struct CannotFindBuiltinMacroWithName {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum DefinedHere {
-    #[label("similarly named {$candidate_descr} `{$candidate}` defined here")]
+    #[note("similarly named {$candidate_descr} `{$candidate}` defined here")]
     SimilarlyNamed {
         #[primary_span]
         span: Span,
         candidate_descr: &'static str,
         candidate: Symbol,
     },
-    #[label("{$candidate_descr} `{$candidate}` defined here")]
+    #[note("{$candidate_descr} `{$candidate}` defined here")]
     SingleItem {
         #[primary_span]
         span: Span,

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1319,30 +1319,29 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
 
         let typo_sugg =
             self.lookup_typo_candidate(path, following_seg, source.namespace(), is_expected);
-        let mut fallback = false;
+        let mut fallback = true;
         let typo_sugg = typo_sugg
             .to_opt_suggestion()
             .filter(|sugg| !suggested_candidates.contains(sugg.candidate.as_str()));
-        if !self.r.add_typo_suggestion(err, typo_sugg, ident_span) {
-            fallback = true;
-            match self.diag_metadata.current_let_binding {
-                Some((pat_sp, Some(ty_sp), None))
-                    if ty_sp.contains(base_error.span) && base_error.could_be_expr =>
-                {
-                    err.span_suggestion_verbose(
-                        pat_sp.between(ty_sp),
-                        "use `=` if you meant to assign",
-                        " = ",
-                        Applicability::MaybeIncorrect,
-                    );
-                }
-                _ => {}
-            }
+        self.r.add_typo_suggestion(err, typo_sugg, ident_span);
 
-            // If the trait has a single item (which wasn't matched by the algorithm), suggest it
-            let suggestion = self.get_single_associated_item(path, &source, is_expected);
-            self.r.add_typo_suggestion(err, suggestion, ident_span);
+        match self.diag_metadata.current_let_binding {
+            Some((pat_sp, Some(ty_sp), None))
+                if ty_sp.contains(base_error.span) && base_error.could_be_expr =>
+            {
+                err.span_suggestion_verbose(
+                    pat_sp.between(ty_sp),
+                    "use `=` if you meant to assign",
+                    " = ",
+                    Applicability::MaybeIncorrect,
+                );
+            }
+            _ => {}
         }
+
+        // If the trait has a single item (which wasn't matched by the algorithm), suggest it
+        let suggestion = self.get_single_associated_item(path, &source, is_expected);
+        self.r.add_typo_suggestion(err, suggestion, ident_span);
 
         if self.let_binding_suggestion(err, ident_span) {
             fallback = false;

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-inline.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-inline.stderr
@@ -541,6 +541,11 @@ help: a built-in attribute with a similar name exists
 LL - #[lint("this is an example message", code = E0123)]
 LL + #[link("this is an example message", code = E0123)]
    |
+help: the derive macros `Lift` and `Lift_Generic` accept the similarly named `lift` attribute
+   |
+LL - #[lint("this is an example message", code = E0123)]
+LL + #[lift("this is an example message", code = E0123)]
+   |
 
 error: cannot find attribute `multipart_suggestion` in this scope
   --> $DIR/diagnostic-derive-inline.rs:565:3

--- a/tests/ui/argument-suggestions/disjoint-spans-issue-151607.stderr
+++ b/tests/ui/argument-suggestions/disjoint-spans-issue-151607.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find type `E` in this scope
   --> $DIR/disjoint-spans-issue-151607.rs:8:24
    |
-LL | struct B;
-   | --------- similarly named struct `B` defined here
-...
 LL | fn foo(g: F, y: F, e: &E) {
-   |                        ^
+   |                        ^ not found in this scope
    |
+note: similarly named struct `B` defined here
+  --> $DIR/disjoint-spans-issue-151607.rs:5:1
+   |
+LL | struct B;
+   | ^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - fn foo(g: F, y: F, e: &E) {
@@ -21,7 +23,7 @@ error[E0425]: cannot find value `E` in this scope
   --> $DIR/disjoint-spans-issue-151607.rs:10:18
    |
 LL |     foo(B, g, D, E, F, G)
-   |                  ^
+   |                  ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -43,7 +45,7 @@ error[E0425]: cannot find value `G` in this scope
   --> $DIR/disjoint-spans-issue-151607.rs:10:24
    |
 LL |     foo(B, g, D, E, F, G)
-   |                        ^
+   |                        ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/argument-suggestions/issue-109831.stderr
+++ b/tests/ui/argument-suggestions/issue-109831.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find type `C` in this scope
   --> $DIR/issue-109831.rs:4:24
    |
-LL | struct A;
-   | --------- similarly named struct `A` defined here
-...
 LL | fn f(b1: B, b2: B, a2: C) {}
-   |                        ^
+   |                        ^ not found in this scope
    |
+note: similarly named struct `A` defined here
+  --> $DIR/issue-109831.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - fn f(b1: B, b2: B, a2: C) {}
@@ -20,12 +22,14 @@ LL | fn f<C>(b1: B, b2: B, a2: C) {}
 error[E0425]: cannot find value `C` in this scope
   --> $DIR/issue-109831.rs:7:16
    |
-LL | struct A;
-   | --------- similarly named unit struct `A` defined here
-...
 LL |     f(A, A, B, C);
-   |                ^
+   |                ^ not found in this scope
    |
+note: similarly named unit struct `A` defined here
+  --> $DIR/issue-109831.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^
 help: a unit struct with a similar name exists
    |
 LL -     f(A, A, B, C);

--- a/tests/ui/associated-item/issue-87638.stderr
+++ b/tests/ui/associated-item/issue-87638.stderr
@@ -1,12 +1,14 @@
 error[E0576]: cannot find associated type `Output` in trait `Trait`
   --> $DIR/issue-87638.rs:17:26
    |
-LL |     type Target;
-   |     ------------ associated type `Target` defined here
-...
 LL |     let _: <S as Trait>::Output;
    |                          ^^^^^^ not found in `Trait`
    |
+note: associated type `Target` defined here
+  --> $DIR/issue-87638.rs:6:5
+   |
+LL |     type Target;
+   |     ^^^^^^^^^^^^
 help: maybe you meant this associated type
    |
 LL -     let _: <S as Trait>::Output;
@@ -16,12 +18,14 @@ LL +     let _: <S as Trait>::Target;
 error[E0576]: cannot find method or associated constant `BAR` in trait `Trait`
   --> $DIR/issue-87638.rs:20:27
    |
-LL |     const FOO: usize;
-   |     ----------------- associated constant `FOO` defined here
-...
 LL |     let _ = <S as Trait>::BAR;
    |                           ^^^ not found in `Trait`
    |
+note: associated constant `FOO` defined here
+  --> $DIR/issue-87638.rs:4:5
+   |
+LL |     const FOO: usize;
+   |     ^^^^^^^^^^^^^^^^^
 help: maybe you meant this associated constant
    |
 LL -     let _ = <S as Trait>::BAR;

--- a/tests/ui/associated-types/issue-19883.stderr
+++ b/tests/ui/associated-types/issue-19883.stderr
@@ -1,12 +1,14 @@
 error[E0576]: cannot find associated type `Dst` in trait `From`
   --> $DIR/issue-19883.rs:9:30
    |
-LL |     type Output;
-   |     ------------ associated type `Output` defined here
-...
 LL |         <Dst as From<Self>>::Dst
    |                              ^^^ not found in `From`
    |
+note: associated type `Output` defined here
+  --> $DIR/issue-19883.rs:2:5
+   |
+LL |     type Output;
+   |     ^^^^^^^^^^^^
 help: maybe you meant this associated type
    |
 LL -         <Dst as From<Self>>::Dst

--- a/tests/ui/associated-types/issue-22037.stderr
+++ b/tests/ui/associated-types/issue-22037.stderr
@@ -1,11 +1,14 @@
 error[E0576]: cannot find associated type `X` in trait `A`
   --> $DIR/issue-22037.rs:3:33
    |
-LL |     type Output;
-   |     ------------ associated type `Output` defined here
 LL |     fn a(&self) -> <Self as A>::X;
    |                                 ^ not found in `A`
    |
+note: associated type `Output` defined here
+  --> $DIR/issue-22037.rs:2:5
+   |
+LL |     type Output;
+   |     ^^^^^^^^^^^^
 help: maybe you meant this associated type
    |
 LL -     fn a(&self) -> <Self as A>::X;

--- a/tests/ui/attributes/align-on-fields-143987.stderr
+++ b/tests/ui/attributes/align-on-fields-143987.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find type `usize8` in this scope
   --> $DIR/align-on-fields-143987.rs:17:8
    |
 LL |     x: usize8,
-   |        ^^^^^^
+   |        ^^^^^^ not found in this scope
    |
 help: a builtin type with a similar name exists
    |

--- a/tests/ui/c-variadic/issue-86053-1.stderr
+++ b/tests/ui/c-variadic/issue-86053-1.stderr
@@ -58,11 +58,10 @@ error[E0425]: cannot find type `F` in this scope
   --> $DIR/issue-86053-1.rs:10:54
    |
 LL |     self , _: ... ,   self ,   self , _: ... ) where F : FnOnce ( & 'a & 'b usize ) {
-   |                                                      ^
+   |                                                      ^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL |     self , _: ... ,   self ,   self , _: ... ) where Fn : FnOnce ( & 'a & 'b usize ) {

--- a/tests/ui/closures/issue-78720.stderr
+++ b/tests/ui/closures/issue-78720.stderr
@@ -8,11 +8,10 @@ error[E0425]: cannot find type `F` in this scope
   --> $DIR/issue-78720.rs:14:12
    |
 LL |     _func: F,
-   |            ^
+   |            ^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL |     _func: Fn,

--- a/tests/ui/closures/issue-90871.stderr
+++ b/tests/ui/closures/issue-90871.stderr
@@ -2,11 +2,10 @@ error[E0425]: cannot find type `n` in this scope
   --> $DIR/issue-90871.rs:4:22
    |
 LL |     type_ascribe!(2, n([u8; || 1]))
-   |                      ^
+   |                      ^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL |     type_ascribe!(2, Fn([u8; || 1]))

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
@@ -7,11 +7,14 @@ LL |     f1: extern "cmse-nonsecure-call" fn<U: Copy>(U, u32, u32, u32) -> u64,
 error[E0425]: cannot find type `U` in this scope
   --> $DIR/generics.rs:15:50
    |
-LL | struct Test<T: Copy> {
-   |             - similarly named type parameter `T` defined here
 LL |     f1: extern "cmse-nonsecure-call" fn<U: Copy>(U, u32, u32, u32) -> u64,
-   |                                                  ^
+   |                                                  ^ not found in this scope
    |
+note: similarly named type parameter `T` defined here
+  --> $DIR/generics.rs:14:13
+   |
+LL | struct Test<T: Copy> {
+   |             ^
 help: a type parameter with a similar name exists
    |
 LL -     f1: extern "cmse-nonsecure-call" fn<U: Copy>(U, u32, u32, u32) -> u64,

--- a/tests/ui/compiletest-self-test/ui-testing-optout.stderr
+++ b/tests/ui/compiletest-self-test/ui-testing-optout.stderr
@@ -7,12 +7,14 @@ error[E0425]: cannot find type `B` in this scope
 error[E0425]: cannot find type `D` in this scope
  --> $DIR/ui-testing-optout.rs:7:10
   |
-4 | type A = B;
-  | ----------- similarly named type alias `A` defined here
-...
 7 | type C = D;
-  |          ^
+  |          ^ not found in this scope
   |
+note: similarly named type alias `A` defined here
+ --> $DIR/ui-testing-optout.rs:4:1
+  |
+4 | type A = B;
+  | ^^^^^^^^^^^
 help: a type alias with a similar name exists
   |
 7 - type C = D;
@@ -22,12 +24,14 @@ help: a type alias with a similar name exists
 error[E0425]: cannot find type `F` in this scope
   --> $DIR/ui-testing-optout.rs:92:10
    |
- 4 | type A = B;
-   | ----------- similarly named type alias `A` defined here
-...
 92 | type E = F;
-   |          ^
+   |          ^ not found in this scope
    |
+note: similarly named type alias `A` defined here
+  --> $DIR/ui-testing-optout.rs:4:1
+   |
+ 4 | type A = B;
+   | ^^^^^^^^^^^
 help: a type alias with a similar name exists
    |
 92 - type E = F;

--- a/tests/ui/const-generics/generic_const_exprs/error_in_ty.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/error_in_ty.stderr
@@ -2,10 +2,13 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/error_in_ty.rs:6:31
    |
 LL | pub struct A<const z: [usize; x]> {}
-   |                    -          ^
-   |                    |
-   |                    similarly named const parameter `z` defined here
+   |                               ^ not found in this scope
    |
+note: similarly named const parameter `z` defined here
+  --> $DIR/error_in_ty.rs:6:20
+   |
+LL | pub struct A<const z: [usize; x]> {}
+   |                    ^
 help: a const parameter with a similar name exists
    |
 LL - pub struct A<const z: [usize; x]> {}

--- a/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
@@ -2,11 +2,10 @@ error[E0425]: cannot find type `F` in this scope
   --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:11:17
    |
 LL |          let f: F = async { 1 };
-   |                 ^
+   |                 ^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL |          let f: Fn = async { 1 };

--- a/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
@@ -19,12 +19,14 @@ LL |     const v0: [[usize; v4]; v4] = v6(v8);
 error[E0425]: cannot find type `v18` in this scope
   --> $DIR/unevaluated-const-ice-119731.rs:23:31
    |
-LL |     pub type v11 = [[usize; v4]; v4];
-   |     --------------------------------- similarly named type alias `v11` defined here
-...
 LL |         pub const fn v21() -> v18 {}
-   |                               ^^^
+   |                               ^^^ not found in this scope
    |
+note: similarly named type alias `v11` defined here
+  --> $DIR/unevaluated-const-ice-119731.rs:9:5
+   |
+LL |     pub type v11 = [[usize; v4]; v4];
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a type alias with a similar name exists
    |
 LL -         pub const fn v21() -> v18 {}
@@ -34,12 +36,14 @@ LL +         pub const fn v21() -> v11 {}
 error[E0425]: cannot find type `v18` in this scope
   --> $DIR/unevaluated-const-ice-119731.rs:35:31
    |
-LL |     pub type v11 = [[usize; v4]; v4];
-   |     --------------------------------- similarly named type alias `v11` defined here
-...
 LL |         pub const fn v21() -> v18 {
-   |                               ^^^
+   |                               ^^^ not found in this scope
    |
+note: similarly named type alias `v11` defined here
+  --> $DIR/unevaluated-const-ice-119731.rs:9:5
+   |
+LL |     pub type v11 = [[usize; v4]; v4];
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a type alias with a similar name exists
    |
 LL -         pub const fn v21() -> v18 {
@@ -49,12 +53,14 @@ LL +         pub const fn v21() -> v11 {
 error[E0422]: cannot find struct, variant or union type `v18` in this scope
   --> $DIR/unevaluated-const-ice-119731.rs:37:13
    |
-LL |     pub type v11 = [[usize; v4]; v4];
-   |     --------------------------------- similarly named type alias `v11` defined here
-...
 LL |             v18 { _p: () }
-   |             ^^^
+   |             ^^^ not found in this scope
    |
+note: similarly named type alias `v11` defined here
+  --> $DIR/unevaluated-const-ice-119731.rs:9:5
+   |
+LL |     pub type v11 = [[usize; v4]; v4];
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a type alias with a similar name exists
    |
 LL -             v18 { _p: () }

--- a/tests/ui/const-generics/mgca/adt_expr_erroneuous_inits.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_erroneuous_inits.stderr
@@ -1,12 +1,14 @@
 error[E0422]: cannot find struct, variant or union type `Fooo` in this scope
   --> $DIR/adt_expr_erroneuous_inits.rs:20:17
    |
-LL | struct Foo<T> { field: T }
-   | ------------- similarly named struct `Foo` defined here
-...
 LL |     accepts::<{ Fooo::<u8> { field: const { 1 } }}>();
-   |                 ^^^^
+   |                 ^^^^ not found in this scope
    |
+note: similarly named struct `Foo` defined here
+  --> $DIR/adt_expr_erroneuous_inits.rs:9:1
+   |
+LL | struct Foo<T> { field: T }
+   | ^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL -     accepts::<{ Fooo::<u8> { field: const { 1 } }}>();

--- a/tests/ui/const-generics/mgca/projection-error.stderr
+++ b/tests/ui/const-generics/mgca/projection-error.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find type `T` in this scope
   --> $DIR/projection-error.rs:12:17
    |
-LL | pub trait Tr<A> {
-   | --------------- similarly named trait `Tr` defined here
-...
 LL | fn mk_array(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
-   |                 ^
+   |                 ^ not found in this scope
    |
+note: similarly named trait `Tr` defined here
+  --> $DIR/projection-error.rs:8:1
+   |
+LL | pub trait Tr<A> {
+   | ^^^^^^^^^^^^^^^
 help: a trait with a similar name exists
    |
 LL | fn mk_array(_x: Tr) -> [(); <T as Tr<bool>>::SIZE] {}
@@ -19,12 +21,14 @@ LL | fn mk_array<T>(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
 error[E0425]: cannot find type `T` in this scope
   --> $DIR/projection-error.rs:12:29
    |
-LL | pub trait Tr<A> {
-   | --------------- similarly named trait `Tr` defined here
-...
 LL | fn mk_array(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
-   |                             ^
+   |                             ^ not found in this scope
    |
+note: similarly named trait `Tr` defined here
+  --> $DIR/projection-error.rs:8:1
+   |
+LL | pub trait Tr<A> {
+   | ^^^^^^^^^^^^^^^
 help: a trait with a similar name exists
    |
 LL | fn mk_array(_x: T) -> [(); <Tr as Tr<bool>>::SIZE] {}

--- a/tests/ui/const-generics/mgca/unused_speculative_def_id.stderr
+++ b/tests/ui/const-generics/mgca/unused_speculative_def_id.stderr
@@ -2,11 +2,10 @@ error[E0425]: cannot find value `ERR` in this scope
   --> $DIR/unused_speculative_def_id.rs:20:16
    |
 LL |     field: A<{ ERR::<const { 1 }> }>,
-   |                ^^^
+   |                ^^^ not found in this scope
    |
+note: similarly named tuple variant `Err` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named tuple variant `Err` defined here
 help: a tuple variant with a similar name exists
    |
 LL -     field: A<{ ERR::<const { 1 }> }>,

--- a/tests/ui/const-generics/parent_generics_of_nested_in_default.stderr
+++ b/tests/ui/const-generics/parent_generics_of_nested_in_default.stderr
@@ -8,10 +8,13 @@ error[E0425]: cannot find value `B` in this scope
   --> $DIR/parent_generics_of_nested_in_default.rs:1:30
    |
 LL | impl<const A: i32 = { || [0; B] }> Tr {}
-   |            -                 ^
-   |            |
-   |            similarly named const parameter `A` defined here
+   |                              ^ not found in this scope
    |
+note: similarly named const parameter `A` defined here
+  --> $DIR/parent_generics_of_nested_in_default.rs:1:12
+   |
+LL | impl<const A: i32 = { || [0; B] }> Tr {}
+   |            ^
 help: a const parameter with a similar name exists
    |
 LL - impl<const A: i32 = { || [0; B] }> Tr {}

--- a/tests/ui/consts/const-eval/ice-unhandled-type-122191.stderr
+++ b/tests/ui/consts/const-eval/ice-unhandled-type-122191.stderr
@@ -22,11 +22,13 @@ error[E0425]: cannot find function `value` in this scope
   --> $DIR/ice-unhandled-type-122191.rs:9:5
    |
 LL |     value()
-   |     ^^^^^
-...
-LL | const VALUE: Foo = foo();
-   | ------------------------- similarly named constant `VALUE` defined here
+   |     ^^^^^ not found in this scope
    |
+note: similarly named constant `VALUE` defined here
+  --> $DIR/ice-unhandled-type-122191.rs:13:1
+   |
+LL | const VALUE: Foo = foo();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists
    |
 LL -     value()

--- a/tests/ui/consts/const-pattern-rewrite-error-32086.stderr
+++ b/tests/ui/consts/const-pattern-rewrite-error-32086.stderr
@@ -1,12 +1,14 @@
 error[E0532]: expected tuple struct or tuple variant, found constant `C`
   --> $DIR/const-pattern-rewrite-error-32086.rs:6:9
    |
-LL | struct S(u8);
-   | ------------- similarly named tuple struct `S` defined here
-...
 LL |     let C(a) = S(11);
-   |         ^
+   |         ^ not a tuple struct or tuple variant
    |
+note: similarly named tuple struct `S` defined here
+  --> $DIR/const-pattern-rewrite-error-32086.rs:2:1
+   |
+LL | struct S(u8);
+   | ^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL -     let C(a) = S(11);
@@ -16,12 +18,14 @@ LL +     let S(a) = S(11);
 error[E0532]: expected tuple struct or tuple variant, found constant `C`
   --> $DIR/const-pattern-rewrite-error-32086.rs:7:9
    |
-LL | struct S(u8);
-   | ------------- similarly named tuple struct `S` defined here
-...
 LL |     let C(..) = S(11);
-   |         ^
+   |         ^ not a tuple struct or tuple variant
    |
+note: similarly named tuple struct `S` defined here
+  --> $DIR/const-pattern-rewrite-error-32086.rs:2:1
+   |
+LL | struct S(u8);
+   | ^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL -     let C(..) = S(11);

--- a/tests/ui/consts/ice-bad-input-type-for-cast-83056.stderr
+++ b/tests/ui/consts/ice-bad-input-type-for-cast-83056.stderr
@@ -1,11 +1,14 @@
 error[E0425]: cannot find type `T` in this scope
   --> $DIR/ice-bad-input-type-for-cast-83056.rs:5:11
    |
-LL | struct S([bool; f as usize]);
-   | ----------------------------- similarly named struct `S` defined here
 LL | fn f() -> T {}
-   |           ^
+   |           ^ not found in this scope
    |
+note: similarly named struct `S` defined here
+  --> $DIR/ice-bad-input-type-for-cast-83056.rs:4:1
+   |
+LL | struct S([bool; f as usize]);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - fn f() -> T {}

--- a/tests/ui/consts/ice-extra-args-fn-abi-issue-127423.stderr
+++ b/tests/ui/consts/ice-extra-args-fn-abi-issue-127423.stderr
@@ -25,7 +25,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:8:11
    |
 LL |     Qux + y
-   |           ^
+   |           ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/delegation/bad-resolve.stderr
+++ b/tests/ui/delegation/bad-resolve.stderr
@@ -51,12 +51,14 @@ LL |     reuse <F as Trait>::Type;
 error[E0576]: cannot find method or associated constant `baz` in trait `Trait`
   --> $DIR/bad-resolve.rs:29:25
    |
-LL |     fn bar() {}
-   |     -------- similarly named associated function `bar` defined here
-...
 LL |     reuse <F as Trait>::baz;
-   |                         ^^^
+   |                         ^^^ not found in `Trait`
    |
+note: similarly named associated function `bar` defined here
+  --> $DIR/bad-resolve.rs:6:5
+   |
+LL |     fn bar() {}
+   |     ^^^^^^^^
 help: an associated function with a similar name exists
    |
 LL -     reuse <F as Trait>::baz;
@@ -72,12 +74,14 @@ LL |     reuse foo { &self.0 }
 error[E0425]: cannot find function `foo2` in trait `Trait`
   --> $DIR/bad-resolve.rs:37:18
    |
-LL |     fn foo(&self, x: i32) -> i32 { x }
-   |     ---------------------------- similarly named associated function `foo` defined here
-...
 LL |     reuse Trait::foo2 { self.0 }
-   |                  ^^^^
+   |                  ^^^^ not found in `Trait`
    |
+note: similarly named associated function `foo` defined here
+  --> $DIR/bad-resolve.rs:7:5
+   |
+LL |     fn foo(&self, x: i32) -> i32 { x }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: an associated function with a similar name exists
    |
 LL -     reuse Trait::foo2 { self.0 }

--- a/tests/ui/derives/deriving-meta-unknown-trait.stderr
+++ b/tests/ui/derives/deriving-meta-unknown-trait.stderr
@@ -4,9 +4,8 @@ error: cannot find derive macro `Eqr` in this scope
 LL | #[derive(Eqr)]
    |          ^^^
    |
+note: similarly named derive macro `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named derive macro `Eq` defined here
 help: a derive macro with a similar name exists
    |
 LL - #[derive(Eqr)]
@@ -19,10 +18,8 @@ error: cannot find derive macro `Eqr` in this scope
 LL | #[derive(Eqr)]
    |          ^^^
    |
+note: similarly named derive macro `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named derive macro `Eq` defined here
-   |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: a derive macro with a similar name exists
    |

--- a/tests/ui/diagnostic_namespace/on_unknown/late_res.rs
+++ b/tests/ui/diagnostic_namespace/on_unknown/late_res.rs
@@ -12,16 +12,40 @@ fn stuff(x: u32) {
     match x {
         empty::blah => {}
         //~^ ERROR it works `empty` `blah` [E0531]
+        //~| NOTE cannot find unit struct, unit variant or constant `blah` in module `empty`
+        //~| NOTE label it works
+        //~| NOTE note it works
         _ => {}
     }
 
     println!("{}", empty::blah);
     //~^ ERROR it works `empty` `blah` [E0425]
+    //~| NOTE cannot find value `blah` in module `empty`
+    //~| NOTE label it works
+    //~| NOTE note it works
 
     let x = [
         empty::blah,
         //~^ ERROR it works `empty` `blah` [E0425]
+        //~| NOTE cannot find value `blah` in module `empty`
+        //~| NOTE label it works
+        //~| NOTE note it works
         empty::blah2,
         //~^ ERROR it works `empty` `blah2` [E0425]
+        //~| NOTE cannot find value `blah2` in module `empty`
+        //~| NOTE label it works
+        //~| NOTE note it works
     ];
 }
+
+#[diagnostic::on_unknown(message = "message", label = "label", note = "note")]
+mod x {
+    const WHAT: u32 = 1;
+    //~^ NOTE similarly named constant `WHAT` defined here
+
+}
+const X: u32 = x::WAHT;
+//~^ ERROR message
+//~| NOTE note
+//~| NOTE label
+//~| NOTE cannot find value `WAHT` in module `x`

--- a/tests/ui/diagnostic_namespace/on_unknown/late_res.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/late_res.stderr
@@ -8,7 +8,7 @@ LL |         empty::blah => {}
    = note: note it works
 
 error[E0425]: it works `empty` `blah`
-  --> $DIR/late_res.rs:18:27
+  --> $DIR/late_res.rs:21:27
    |
 LL |     println!("{}", empty::blah);
    |                           ^^^^ label it works
@@ -17,7 +17,7 @@ LL |     println!("{}", empty::blah);
    = note: note it works
 
 error[E0425]: it works `empty` `blah`
-  --> $DIR/late_res.rs:22:16
+  --> $DIR/late_res.rs:28:16
    |
 LL |         empty::blah,
    |                ^^^^ label it works
@@ -26,7 +26,7 @@ LL |         empty::blah,
    = note: note it works
 
 error[E0425]: it works `empty` `blah2`
-  --> $DIR/late_res.rs:24:16
+  --> $DIR/late_res.rs:33:16
    |
 LL |         empty::blah2,
    |                ^^^^^ label it works
@@ -34,7 +34,26 @@ LL |         empty::blah2,
    = note: cannot find value `blah2` in module `empty`
    = note: note it works
 
-error: aborting due to 4 previous errors
+error[E0425]: message
+  --> $DIR/late_res.rs:47:19
+   |
+LL | const X: u32 = x::WAHT;
+   |                   ^^^^ label
+   |
+   = note: cannot find value `WAHT` in module `x`
+   = note: note
+note: similarly named constant `WHAT` defined here
+  --> $DIR/late_res.rs:43:5
+   |
+LL |     const WHAT: u32 = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^
+help: a constant with a similar name exists
+   |
+LL - const X: u32 = x::WAHT;
+LL + const X: u32 = x::WHAT;
+   |
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0425, E0531.
 For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/did_you_mean/println-typo.stderr
+++ b/tests/ui/did_you_mean/println-typo.stderr
@@ -4,9 +4,8 @@ error: cannot find macro `prinltn` in this scope
 LL |     prinltn!();
    |     ^^^^^^^
    |
+note: similarly named macro `println` defined here
   --> $SRC_DIR/std/src/macros.rs:LL:COL
-   |
-   = note: similarly named macro `println` defined here
 help: a macro with a similar name exists
    |
 LL -     prinltn!();

--- a/tests/ui/did_you_mean/typo-suggestion-improvement-46332.stderr
+++ b/tests/ui/did_you_mean/typo-suggestion-improvement-46332.stderr
@@ -1,12 +1,14 @@
 error[E0422]: cannot find struct, variant or union type `TyUInt` in this scope
   --> $DIR/typo-suggestion-improvement-46332.rs:10:5
    |
-LL | struct TyUint {}
-   | ------------- similarly named struct `TyUint` defined here
-...
 LL |     TyUInt {};
-   |     ^^^^^^
+   |     ^^^^^^ not found in this scope
    |
+note: similarly named struct `TyUint` defined here
+  --> $DIR/typo-suggestion-improvement-46332.rs:5:1
+   |
+LL | struct TyUint {}
+   | ^^^^^^^^^^^^^
 help: a struct with a similar name exists (notice the capitalization)
    |
 LL -     TyUInt {};

--- a/tests/ui/error-codes/E0423.stderr
+++ b/tests/ui/error-codes/E0423.stderr
@@ -46,11 +46,13 @@ LL |     struct Foo { a: bool };
 LL |
 LL |     let f = Foo();
    |             ^^^^^
-...
-LL | fn foo() {
-   | -------- similarly named function `foo` defined here
    |
    = note: a struct named `Foo` exists in another namespace
+note: similarly named function `foo` defined here
+  --> $DIR/E0423.rs:19:1
+   |
+LL | fn foo() {
+   | ^^^^^^^^
 help: use struct literal syntax instead
    |
 LL -     let f = Foo();

--- a/tests/ui/expr/if/bad-if-let-suggestion.stderr
+++ b/tests/ui/expr/if/bad-if-let-suggestion.stderr
@@ -17,12 +17,14 @@ LL |     if let x = 1 && i == 2 {}
 error[E0425]: cannot find value `i` in this scope
   --> $DIR/bad-if-let-suggestion.rs:7:9
    |
-LL | fn a() {
-   | ------ similarly named function `a` defined here
-...
 LL |     if (i + j) = i {}
-   |         ^
+   |         ^ not found in this scope
    |
+note: similarly named function `a` defined here
+  --> $DIR/bad-if-let-suggestion.rs:1:1
+   |
+LL | fn a() {
+   | ^^^^^^
 help: a function with a similar name exists
    |
 LL -     if (i + j) = i {}
@@ -32,12 +34,14 @@ LL +     if (a + j) = i {}
 error[E0425]: cannot find value `j` in this scope
   --> $DIR/bad-if-let-suggestion.rs:7:13
    |
-LL | fn a() {
-   | ------ similarly named function `a` defined here
-...
 LL |     if (i + j) = i {}
-   |             ^
+   |             ^ not found in this scope
    |
+note: similarly named function `a` defined here
+  --> $DIR/bad-if-let-suggestion.rs:1:1
+   |
+LL | fn a() {
+   | ^^^^^^
 help: a function with a similar name exists
    |
 LL -     if (i + j) = i {}
@@ -47,12 +51,14 @@ LL +     if (i + a) = i {}
 error[E0425]: cannot find value `i` in this scope
   --> $DIR/bad-if-let-suggestion.rs:7:18
    |
-LL | fn a() {
-   | ------ similarly named function `a` defined here
-...
 LL |     if (i + j) = i {}
-   |                  ^
+   |                  ^ not found in this scope
    |
+note: similarly named function `a` defined here
+  --> $DIR/bad-if-let-suggestion.rs:1:1
+   |
+LL | fn a() {
+   | ^^^^^^
 help: a function with a similar name exists
    |
 LL -     if (i + j) = i {}
@@ -62,12 +68,14 @@ LL +     if (i + j) = a {}
 error[E0425]: cannot find value `x` in this scope
   --> $DIR/bad-if-let-suggestion.rs:14:8
    |
-LL | fn a() {
-   | ------ similarly named function `a` defined here
-...
 LL |     if x[0] = 1 {}
-   |        ^
+   |        ^ not found in this scope
    |
+note: similarly named function `a` defined here
+  --> $DIR/bad-if-let-suggestion.rs:1:1
+   |
+LL | fn a() {
+   | ^^^^^^
 help: a function with a similar name exists
    |
 LL -     if x[0] = 1 {}

--- a/tests/ui/fmt/format-args-capture-issue-102057.stderr
+++ b/tests/ui/fmt/format-args-capture-issue-102057.stderr
@@ -14,7 +14,7 @@ error[E0425]: cannot find value `b` in this scope
   --> $DIR/format-args-capture-issue-102057.rs:9:22
    |
 LL |     format!("\x7Ba} {b}");
-   |                      ^
+   |                      ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -26,7 +26,7 @@ error[E0425]: cannot find value `b` in this scope
   --> $DIR/format-args-capture-issue-102057.rs:11:25
    |
 LL |     format!("\x7Ba\x7D {b}");
-   |                         ^
+   |                         ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -38,7 +38,7 @@ error[E0425]: cannot find value `b` in this scope
   --> $DIR/format-args-capture-issue-102057.rs:13:25
    |
 LL |     format!("\x7Ba} \x7Bb}");
-   |                         ^
+   |                         ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -50,7 +50,7 @@ error[E0425]: cannot find value `b` in this scope
   --> $DIR/format-args-capture-issue-102057.rs:15:28
    |
 LL |     format!("\x7Ba\x7D \x7Bb}");
-   |                            ^
+   |                            ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -62,7 +62,7 @@ error[E0425]: cannot find value `b` in this scope
   --> $DIR/format-args-capture-issue-102057.rs:17:28
    |
 LL |     format!("\x7Ba\x7D \x7Bb\x7D");
-   |                            ^
+   |                            ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/fmt/format-args-capture-issue-94010.stderr
+++ b/tests/ui/fmt/format-args-capture-issue-94010.stderr
@@ -1,11 +1,14 @@
 error[E0425]: cannot find value `foo` in this scope
   --> $DIR/format-args-capture-issue-94010.rs:3:16
    |
-LL |     const FOO: i32 = 123;
-   |     --------------------- similarly named constant `FOO` defined here
 LL |     println!("{foo:X}");
-   |                ^^^
+   |                ^^^ not found in this scope
    |
+note: similarly named constant `FOO` defined here
+  --> $DIR/format-args-capture-issue-94010.rs:2:5
+   |
+LL |     const FOO: i32 = 123;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists (notice the capitalization)
    |
 LL -     println!("{foo:X}");
@@ -15,12 +18,14 @@ LL +     println!("{FOO:X}");
 error[E0425]: cannot find value `foo` in this scope
   --> $DIR/format-args-capture-issue-94010.rs:5:18
    |
-LL |     const FOO: i32 = 123;
-   |     --------------------- similarly named constant `FOO` defined here
-...
 LL |     println!("{:.foo$}", 0);
-   |                  ^^^
+   |                  ^^^ not found in this scope
    |
+note: similarly named constant `FOO` defined here
+  --> $DIR/format-args-capture-issue-94010.rs:2:5
+   |
+LL |     const FOO: i32 = 123;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists (notice the capitalization)
    |
 LL -     println!("{:.foo$}", 0);

--- a/tests/ui/fn/fn-ptr-pattern.stderr
+++ b/tests/ui/fn/fn-ptr-pattern.stderr
@@ -198,11 +198,13 @@ error[E0425]: cannot find type `NoThing` in this scope
   --> $DIR/fn-ptr-pattern.rs:19:32
    |
 LL |     pat4: fn(NoThing { a, b }: NoThing),
-   |                                ^^^^^^^
-...
-LL | struct Thing { a: bool, b: bool }
-   | ------------ similarly named struct `Thing` defined here
+   |                                ^^^^^^^ not found in this scope
    |
+note: similarly named struct `Thing` defined here
+  --> $DIR/fn-ptr-pattern.rs:75:1
+   |
+LL | struct Thing { a: bool, b: bool }
+   | ^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL -     pat4: fn(NoThing { a, b }: NoThing),

--- a/tests/ui/hygiene/globs.stderr
+++ b/tests/ui/hygiene/globs.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find function `f` in this scope
   --> $DIR/globs.rs:23:9
    |
-LL |     pub fn g() {}
-   |     ---------- similarly named function `g` defined here
-...
 LL |         f();
-   |         ^
+   |         ^ not found in this scope
    |
+note: similarly named function `g` defined here
+  --> $DIR/globs.rs:9:5
+   |
+LL |     pub fn g() {}
+   |     ^^^^^^^^^^
 help: a function with a similar name exists
    |
 LL -         f();
@@ -20,11 +22,8 @@ LL + use foo::f;
 error[E0425]: cannot find function `g` in this scope
   --> $DIR/globs.rs:16:5
    |
-LL |       pub fn f() {}
-   |       ---------- similarly named function `f` defined here
-...
 LL |       g();
-   |       ^
+   |       ^ not found in this scope
 ...
 LL | /     m! {
 LL | |         use bar::*;
@@ -33,6 +32,11 @@ LL | |         f();
 LL | |     }
    | |_____- in this macro invocation
    |
+note: similarly named function `f` defined here
+  --> $DIR/globs.rs:5:5
+   |
+LL |     pub fn f() {}
+   |     ^^^^^^^^^^
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a function with a similar name exists
    |

--- a/tests/ui/hygiene/rustc-macro-transparency.stderr
+++ b/tests/ui/hygiene/rustc-macro-transparency.stderr
@@ -7,13 +7,19 @@ LL |     Opaque;
 error[E0423]: cannot find value `semiopaque` in this scope
   --> $DIR/rustc-macro-transparency.rs:29:5
    |
-LL |     struct SemiOpaque;
-   |     ------------------ similarly named unit struct `SemiOpaque` defined here
-...
 LL |     semiopaque;
    |     ^^^^^^^^^^ not found in this scope
    |
    = note: a macro named `semiopaque` exists in another namespace
+note: similarly named unit struct `SemiOpaque` defined here
+  --> $DIR/rustc-macro-transparency.rs:10:5
+   |
+LL |     struct SemiOpaque;
+   |     ^^^^^^^^^^^^^^^^^^
+...
+LL |     semiopaque!();
+   |     ------------- in this macro invocation
+   = note: this error originates in the macro `semiopaque` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a unit struct with a similar name exists (notice the capitalization)
    |
 LL -     semiopaque;

--- a/tests/ui/impl-restriction/restriction_resolution_errors.stderr
+++ b/tests/ui/impl-restriction/restriction_resolution_errors.stderr
@@ -47,12 +47,14 @@ LL |         pub impl(in super::G) trait L2 {}
 error[E0577]: expected module, found enum `crate::a::E`
   --> $DIR/restriction_resolution_errors.rs:51:13
    |
-LL |     pub mod b {
-   |     --------- similarly named module `b` defined here
-...
 LL | pub impl(in crate::a::E) trait T14 {}
-   |             ^^^^^^^^^^^
+   |             ^^^^^^^^^^^ not a module
    |
+note: similarly named module `b` defined here
+  --> $DIR/restriction_resolution_errors.rs:9:5
+   |
+LL |     pub mod b {
+   |     ^^^^^^^^^
 help: a module with a similar name exists
    |
 LL - pub impl(in crate::a::E) trait T14 {}
@@ -62,12 +64,14 @@ LL + pub impl(in crate::a::b) trait T14 {}
 error[E0577]: expected module, found enum `crate::I`
   --> $DIR/restriction_resolution_errors.rs:63:13
    |
-LL | pub mod a {
-   | --------- similarly named module `a` defined here
-...
 LL | pub impl(in crate::I) trait L5 {}
-   |             ^^^^^^^^
+   |             ^^^^^^^^ not a module
    |
+note: similarly named module `a` defined here
+  --> $DIR/restriction_resolution_errors.rs:6:1
+   |
+LL | pub mod a {
+   | ^^^^^^^^^
 help: a module with a similar name exists
    |
 LL - pub impl(in crate::I) trait L5 {}

--- a/tests/ui/imports/glob-resolve1.stderr
+++ b/tests/ui/imports/glob-resolve1.stderr
@@ -72,12 +72,14 @@ LL + use other::import;
 error[E0425]: cannot find type `A` in this scope
   --> $DIR/glob-resolve1.rs:33:11
    |
-LL |     pub enum B {
-   |     ---------- similarly named enum `B` defined here
-...
 LL |     foo::<A>();
-   |           ^
+   |           ^ not found in this scope
    |
+note: similarly named enum `B` defined here
+  --> $DIR/glob-resolve1.rs:15:5
+   |
+LL |     pub enum B {
+   |     ^^^^^^^^^^
 note: enum `bar::A` exists but is inaccessible
   --> $DIR/glob-resolve1.rs:12:5
    |
@@ -92,12 +94,14 @@ LL +     foo::<B>();
 error[E0425]: cannot find type `C` in this scope
   --> $DIR/glob-resolve1.rs:34:11
    |
-LL |     pub enum B {
-   |     ---------- similarly named enum `B` defined here
-...
 LL |     foo::<C>();
-   |           ^
+   |           ^ not found in this scope
    |
+note: similarly named enum `B` defined here
+  --> $DIR/glob-resolve1.rs:15:5
+   |
+LL |     pub enum B {
+   |     ^^^^^^^^^^
 note: struct `bar::C` exists but is inaccessible
   --> $DIR/glob-resolve1.rs:19:5
    |
@@ -112,12 +116,14 @@ LL +     foo::<B>();
 error[E0425]: cannot find type `D` in this scope
   --> $DIR/glob-resolve1.rs:35:11
    |
-LL |     pub enum B {
-   |     ---------- similarly named enum `B` defined here
-...
 LL |     foo::<D>();
-   |           ^
+   |           ^ not found in this scope
    |
+note: similarly named enum `B` defined here
+  --> $DIR/glob-resolve1.rs:15:5
+   |
+LL |     pub enum B {
+   |     ^^^^^^^^^^
 note: type alias `bar::D` exists but is inaccessible
   --> $DIR/glob-resolve1.rs:21:5
    |

--- a/tests/ui/lint/recommend-literal.stderr
+++ b/tests/ui/lint/recommend-literal.stderr
@@ -29,7 +29,7 @@ error[E0425]: cannot find type `Bool` in this scope
   --> $DIR/recommend-literal.rs:15:13
    |
 LL |     let v2: Bool = true;
-   |             ^^^^
+   |             ^^^^ not found in this scope
    |
 help: a builtin type with a similar name exists
    |

--- a/tests/ui/macros/expand-full-no-resolution.stderr
+++ b/tests/ui/macros/expand-full-no-resolution.stderr
@@ -1,12 +1,18 @@
 error: cannot find macro `a` in this scope
   --> $DIR/expand-full-no-resolution.rs:18:18
    |
-LL |         macro_rules! _a {
-   |         --------------- similarly named macro `_a` defined here
-...
 LL |     format_args!(a!());
    |                  ^
    |
+note: similarly named macro `_a` defined here
+  --> $DIR/expand-full-no-resolution.rs:7:9
+   |
+LL |         macro_rules! _a {
+   |         ^^^^^^^^^^^^^^^
+...
+LL | wrap!();
+   | ------- in this macro invocation
+   = note: this error originates in the macro `wrap` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: the leading underscore in `_a` marks it as unused, consider renaming it to `a`
    |
 LL -         macro_rules! _a {
@@ -16,12 +22,18 @@ LL +         macro_rules! a {
 error: cannot find macro `a` in this scope
   --> $DIR/expand-full-no-resolution.rs:19:10
    |
-LL |         macro_rules! _a {
-   |         --------------- similarly named macro `_a` defined here
-...
 LL |     env!(a!());
    |          ^
    |
+note: similarly named macro `_a` defined here
+  --> $DIR/expand-full-no-resolution.rs:7:9
+   |
+LL |         macro_rules! _a {
+   |         ^^^^^^^^^^^^^^^
+...
+LL | wrap!();
+   | ------- in this macro invocation
+   = note: this error originates in the macro `wrap` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: the leading underscore in `_a` marks it as unused, consider renaming it to `a`
    |
 LL -         macro_rules! _a {

--- a/tests/ui/macros/macro-context.stderr
+++ b/tests/ui/macros/macro-context.stderr
@@ -46,7 +46,7 @@ error[E0425]: cannot find type `i` in this scope
   --> $DIR/macro-context.rs:3:13
    |
 LL |     () => ( i ; typeof );
-   |             ^
+   |             ^ not found in this scope
 ...
 LL |     let a: m!();
    |            ---- in this macro invocation

--- a/tests/ui/macros/macro-name-typo.stderr
+++ b/tests/ui/macros/macro-name-typo.stderr
@@ -4,9 +4,8 @@ error: cannot find macro `printlx` in this scope
 LL |     printlx!("oh noes!");
    |     ^^^^^^^
    |
+note: similarly named macro `println` defined here
   --> $SRC_DIR/std/src/macros.rs:LL:COL
-   |
-   = note: similarly named macro `println` defined here
 help: a macro with a similar name exists
    |
 LL -     printlx!("oh noes!");

--- a/tests/ui/macros/macro-path-prelude-fail-3.stderr
+++ b/tests/ui/macros/macro-path-prelude-fail-3.stderr
@@ -4,10 +4,8 @@ error: cannot find macro `inline` in this scope
 LL |     inline!();
    |     ^^^^^^
    |
+note: similarly named macro `line` defined here
   --> $SRC_DIR/core/src/macros/mod.rs:LL:COL
-   |
-   = note: similarly named macro `line` defined here
-   |
    = note: `inline` is in scope, but it is an attribute: `#[inline]`
 help: a macro with a similar name exists
    |

--- a/tests/ui/macros/macro-use-wrong-name.stderr
+++ b/tests/ui/macros/macro-use-wrong-name.stderr
@@ -4,11 +4,11 @@ error: cannot find macro `macro_two` in this scope
 LL |     macro_two!();
    |     ^^^^^^^^^
    |
-  ::: $DIR/auxiliary/two_macros.rs:2:1
+note: similarly named macro `macro_one` defined here
+  --> $DIR/auxiliary/two_macros.rs:2:1
    |
 LL | macro_rules! macro_one { () => ("one") }
-   | ---------------------- similarly named macro `macro_one` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^
 help: a macro with a similar name exists
    |
 LL -     macro_two!();

--- a/tests/ui/macros/macro_undefined.stderr
+++ b/tests/ui/macros/macro_undefined.stderr
@@ -1,12 +1,14 @@
 error: cannot find macro `k` in this scope
   --> $DIR/macro_undefined.rs:11:5
    |
-LL |     macro_rules! kl {
-   |     --------------- similarly named macro `kl` defined here
-...
 LL |     k!();
    |     ^
    |
+note: similarly named macro `kl` defined here
+  --> $DIR/macro_undefined.rs:5:5
+   |
+LL |     macro_rules! kl {
+   |     ^^^^^^^^^^^^^^^
 help: a macro with a similar name exists
    |
 LL |     kl!();

--- a/tests/ui/missing/missing-items/missing-const-parameter.stderr
+++ b/tests/ui/missing/missing-items/missing-const-parameter.stderr
@@ -46,10 +46,13 @@ error[E0425]: cannot find value `C` in this scope
   --> $DIR/missing-const-parameter.rs:19:37
    |
 LL | struct Image<const R: usize>([[u32; C]; R]);
-   |                    -                ^
-   |                    |
-   |                    similarly named const parameter `R` defined here
+   |                                     ^ not found in this scope
    |
+note: similarly named const parameter `R` defined here
+  --> $DIR/missing-const-parameter.rs:19:20
+   |
+LL | struct Image<const R: usize>([[u32; C]; R]);
+   |                    ^
 help: a const parameter with a similar name exists
    |
 LL - struct Image<const R: usize>([[u32; C]; R]);

--- a/tests/ui/missing/missing-items/missing-type-parameter2.stderr
+++ b/tests/ui/missing/missing-items/missing-type-parameter2.stderr
@@ -29,12 +29,14 @@ LL | impl<T, const A: u8 = 2, const N: u8> X<N> {}
 error[E0425]: cannot find type `T` in this scope
   --> $DIR/missing-type-parameter2.rs:11:20
    |
-LL | struct X<const N: u8>();
-   | ------------------------ similarly named struct `X` defined here
-...
 LL | fn foo(_: T) where T: Send {}
-   |                    ^
+   |                    ^ not found in this scope
    |
+note: similarly named struct `X` defined here
+  --> $DIR/missing-type-parameter2.rs:1:1
+   |
+LL | struct X<const N: u8>();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - fn foo(_: T) where T: Send {}
@@ -48,12 +50,14 @@ LL | fn foo<T>(_: T) where T: Send {}
 error[E0425]: cannot find type `T` in this scope
   --> $DIR/missing-type-parameter2.rs:11:11
    |
-LL | struct X<const N: u8>();
-   | ------------------------ similarly named struct `X` defined here
-...
 LL | fn foo(_: T) where T: Send {}
-   |           ^
+   |           ^ not found in this scope
    |
+note: similarly named struct `X` defined here
+  --> $DIR/missing-type-parameter2.rs:1:1
+   |
+LL | struct X<const N: u8>();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - fn foo(_: T) where T: Send {}
@@ -67,12 +71,14 @@ LL | fn foo<T>(_: T) where T: Send {}
 error[E0425]: cannot find type `A` in this scope
   --> $DIR/missing-type-parameter2.rs:15:24
    |
-LL | struct X<const N: u8>();
-   | ------------------------ similarly named struct `X` defined here
-...
 LL | fn bar<const N: u8>(_: A) {}
-   |                        ^
+   |                        ^ not found in this scope
    |
+note: similarly named struct `X` defined here
+  --> $DIR/missing-type-parameter2.rs:1:1
+   |
+LL | struct X<const N: u8>();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - fn bar<const N: u8>(_: A) {}

--- a/tests/ui/missing/undeclared-generic-parameter.stderr
+++ b/tests/ui/missing/undeclared-generic-parameter.stderr
@@ -1,11 +1,14 @@
 error[E0425]: cannot find type `B` in this scope
   --> $DIR/undeclared-generic-parameter.rs:2:8
    |
-LL | struct A;
-   | --------- similarly named struct `A` defined here
 LL | impl A<B> {}
-   |        ^
+   |        ^ not found in this scope
    |
+note: similarly named struct `A` defined here
+  --> $DIR/undeclared-generic-parameter.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - impl A<B> {}

--- a/tests/ui/mut-restriction/restriction-resolution-errors.stderr
+++ b/tests/ui/mut-restriction/restriction-resolution-errors.stderr
@@ -41,12 +41,14 @@ LL |             pub mut(in super::E) i6: i32,
 error[E0577]: expected module, found enum `crate::a::E`
   --> $DIR/restriction-resolution-errors.rs:33:16
    |
-LL |     pub mod b {
-   |     --------- similarly named module `b` defined here
-...
 LL |         mut(in crate::a::E) e2: i32,
-   |                ^^^^^^^^^^^
+   |                ^^^^^^^^^^^ not a module
    |
+note: similarly named module `b` defined here
+  --> $DIR/restriction-resolution-errors.rs:7:5
+   |
+LL |     pub mod b {
+   |     ^^^^^^^^^
 help: a module with a similar name exists
    |
 LL -         mut(in crate::a::E) e2: i32,

--- a/tests/ui/namespace/namespace-mix.stderr
+++ b/tests/ui/namespace/namespace-mix.stderr
@@ -1,13 +1,15 @@
 error[E0423]: cannot find value `S` in module `m1`
   --> $DIR/namespace-mix.rs:35:15
    |
-LL |     pub struct TS();
-   |     ---------------- similarly named tuple struct `TS` defined here
-...
 LL |     check(m1::S);
-   |               ^
+   |               ^ not found in `m1`
    |
    = note: a type alias named `m1::S` exists in another namespace
+note: similarly named tuple struct `TS` defined here
+  --> $DIR/namespace-mix.rs:9:5
+   |
+LL |     pub struct TS();
+   |     ^^^^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL |     check(m1::TS);
@@ -28,14 +30,14 @@ error[E0423]: cannot find value `S` in module `xm1`
   --> $DIR/namespace-mix.rs:41:16
    |
 LL |     check(xm1::S);
-   |                ^
-   |
-  ::: $DIR/auxiliary/namespace-mix.rs:5:5
-   |
-LL |     pub struct TS();
-   |     ------------- similarly named tuple struct `TS` defined here
+   |                ^ not found in `xm1`
    |
    = note: a type alias named `xm1::S` exists in another namespace
+note: similarly named tuple struct `TS` defined here
+  --> $DIR/auxiliary/namespace-mix.rs:5:5
+   |
+LL |     pub struct TS();
+   |     ^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL |     check(xm1::TS);
@@ -55,13 +57,15 @@ LL +     check(S);
 error[E0423]: cannot find value `V` in module `m7`
   --> $DIR/namespace-mix.rs:101:15
    |
-LL |         TV(),
-   |         ---- similarly named tuple variant `TV` defined here
-...
 LL |     check(m7::V);
-   |               ^
+   |               ^ not found in `m7`
    |
    = note: a type alias named `m7::V` exists in another namespace
+note: similarly named tuple variant `TV` defined here
+  --> $DIR/namespace-mix.rs:13:9
+   |
+LL |         TV(),
+   |         ^^^^
 help: a tuple variant with a similar name exists
    |
 LL |     check(m7::TV);
@@ -82,14 +86,14 @@ error[E0423]: cannot find value `V` in module `xm7`
   --> $DIR/namespace-mix.rs:107:16
    |
 LL |     check(xm7::V);
-   |                ^
-   |
-  ::: $DIR/auxiliary/namespace-mix.rs:9:9
-   |
-LL |         TV(),
-   |         -- similarly named tuple variant `TV` defined here
+   |                ^ not found in `xm7`
    |
    = note: a type alias named `xm7::V` exists in another namespace
+note: similarly named tuple variant `TV` defined here
+  --> $DIR/auxiliary/namespace-mix.rs:9:9
+   |
+LL |         TV(),
+   |         ^^
 help: a tuple variant with a similar name exists
    |
 LL |     check(xm7::TV);

--- a/tests/ui/parser/emoji-identifiers.stderr
+++ b/tests/ui/parser/emoji-identifiers.stderr
@@ -87,12 +87,14 @@ LL |     👀::full_of_✨()
 error[E0425]: cannot find function `i_like_to_😄_a_lot` in this scope
   --> $DIR/emoji-identifiers.rs:13:13
    |
-LL | fn i_like_to_😅_a_lot() -> 👀 {
-   | ----------------------------- similarly named function `i_like_to_😅_a_lot` defined here
-...
 LL |     let _ = i_like_to_😄_a_lot() ➖ 4;
-   |             ^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^ not found in this scope
    |
+note: similarly named function `i_like_to_😅_a_lot` defined here
+  --> $DIR/emoji-identifiers.rs:8:1
+   |
+LL | fn i_like_to_😅_a_lot() -> 👀 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a function with a similar name exists
    |
 LL -     let _ = i_like_to_😄_a_lot() ➖ 4;

--- a/tests/ui/parser/kw-in-trait-bounds.stderr
+++ b/tests/ui/parser/kw-in-trait-bounds.stderr
@@ -94,11 +94,13 @@ error[E0405]: cannot find trait `r#struct` in this scope
   --> $DIR/kw-in-trait-bounds.rs:16:10
    |
 LL | fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
-   |          ^^^^^^
-...
-LL | trait Struct {}
-   | ------------ similarly named trait `Struct` defined here
+   |          ^^^^^^ not found in this scope
    |
+note: similarly named trait `Struct` defined here
+  --> $DIR/kw-in-trait-bounds.rs:37:1
+   |
+LL | trait Struct {}
+   | ^^^^^^^^^^^^
 help: a trait with a similar name exists (notice the capitalization)
    |
 LL - fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
@@ -109,11 +111,13 @@ error[E0405]: cannot find trait `r#struct` in this scope
   --> $DIR/kw-in-trait-bounds.rs:30:8
    |
 LL |     B: struct,
-   |        ^^^^^^
-...
-LL | trait Struct {}
-   | ------------ similarly named trait `Struct` defined here
+   |        ^^^^^^ not found in this scope
    |
+note: similarly named trait `Struct` defined here
+  --> $DIR/kw-in-trait-bounds.rs:37:1
+   |
+LL | trait Struct {}
+   | ^^^^^^^^^^^^
 help: a trait with a similar name exists (notice the capitalization)
    |
 LL -     B: struct,
@@ -124,11 +128,13 @@ error[E0405]: cannot find trait `r#struct` in this scope
   --> $DIR/kw-in-trait-bounds.rs:16:29
    |
 LL | fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
-   |                             ^^^^^^
-...
-LL | trait Struct {}
-   | ------------ similarly named trait `Struct` defined here
+   |                             ^^^^^^ not found in this scope
    |
+note: similarly named trait `Struct` defined here
+  --> $DIR/kw-in-trait-bounds.rs:37:1
+   |
+LL | trait Struct {}
+   | ^^^^^^^^^^^^
 help: a trait with a similar name exists (notice the capitalization)
    |
 LL - fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
@@ -139,11 +145,13 @@ error[E0405]: cannot find trait `r#struct` in this scope
   --> $DIR/kw-in-trait-bounds.rs:16:45
    |
 LL | fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
-   |                                             ^^^^^^
-...
-LL | trait Struct {}
-   | ------------ similarly named trait `Struct` defined here
+   |                                             ^^^^^^ not found in this scope
    |
+note: similarly named trait `Struct` defined here
+  --> $DIR/kw-in-trait-bounds.rs:37:1
+   |
+LL | trait Struct {}
+   | ^^^^^^^^^^^^
 help: a trait with a similar name exists (notice the capitalization)
    |
 LL - fn _g<A: struct, B>(_: impl struct, _: &dyn struct)

--- a/tests/ui/parser/recover/raw-no-const-mut.stderr
+++ b/tests/ui/parser/recover/raw-no-const-mut.stderr
@@ -71,12 +71,14 @@ LL |     x = &raw mut 1;
 error[E0425]: cannot find function `f` in this scope
   --> $DIR/raw-no-const-mut.rs:17:5
    |
-LL | fn a() {
-   | ------ similarly named function `a` defined here
-...
 LL |     f(&raw 2);
-   |     ^
+   |     ^ not found in this scope
    |
+note: similarly named function `a` defined here
+  --> $DIR/raw-no-const-mut.rs:1:1
+   |
+LL | fn a() {
+   | ^^^^^^
 help: a function with a similar name exists
    |
 LL -     f(&raw 2);

--- a/tests/ui/pattern/constructor-type-mismatch.stderr
+++ b/tests/ui/pattern/constructor-type-mismatch.stderr
@@ -3,12 +3,15 @@ error[E0532]: expected unit struct, unit variant or constant, found tuple varian
    |
 LL |     Bar(i32),
    |     -------- `Foo::Bar` defined here
-LL |     Baz
-   |     --- similarly named unit variant `Baz` defined here
 ...
 LL |         Foo::Bar => {}
    |         ^^^^^^^^
    |
+note: similarly named unit variant `Baz` defined here
+  --> $DIR/constructor-type-mismatch.rs:4:5
+   |
+LL |     Baz
+   |     ^^^
 help: use the tuple variant pattern syntax instead
    |
 LL |         Foo::Bar(_) => {}

--- a/tests/ui/pattern/pat-tuple-field-count-cross.stderr
+++ b/tests/ui/pattern/pat-tuple-field-count-cross.stderr
@@ -20,9 +20,12 @@ LL |         Z0() => {}
    |
 LL | pub struct Z0;
    | ------------- `Z0` defined here
-LL | pub struct Z1();
-   | ------------- similarly named tuple struct `Z1` defined here
    |
+note: similarly named tuple struct `Z1` defined here
+  --> $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:2:1
+   |
+LL | pub struct Z1();
+   | ^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Z0() => {}
@@ -44,9 +47,12 @@ LL |         Z0(x) => {}
    |
 LL | pub struct Z0;
    | ------------- `Z0` defined here
-LL | pub struct Z1();
-   | ------------- similarly named tuple struct `Z1` defined here
    |
+note: similarly named tuple struct `Z1` defined here
+  --> $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:2:1
+   |
+LL | pub struct Z1();
+   | ^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Z0(x) => {}
@@ -67,10 +73,13 @@ LL |         E1::Z0() => {}
   ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:15
    |
 LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
-   |               --  -- similarly named tuple variant `Z1` defined here
-   |               |
-   |               `E1::Z0` defined here
+   |               -- `E1::Z0` defined here
    |
+note: similarly named tuple variant `Z1` defined here
+  --> $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:19
+   |
+LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
+   |                   ^^
 help: use this syntax instead
    |
 LL -         E1::Z0() => {}
@@ -91,10 +100,13 @@ LL |         E1::Z0(x) => {}
   ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:15
    |
 LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
-   |               --  -- similarly named tuple variant `Z1` defined here
-   |               |
-   |               `E1::Z0` defined here
+   |               -- `E1::Z0` defined here
    |
+note: similarly named tuple variant `Z1` defined here
+  --> $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:19
+   |
+LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
+   |                   ^^
 help: use this syntax instead
    |
 LL -         E1::Z0(x) => {}
@@ -115,10 +127,13 @@ LL |         E1::Z1 => {}
   ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:19
    |
 LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
-   |               --  -- `E1::Z1` defined here
-   |               |
-   |               similarly named unit variant `Z0` defined here
+   |                   -- `E1::Z1` defined here
    |
+note: similarly named unit variant `Z0` defined here
+  --> $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:15
+   |
+LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
+   |               ^^
 help: use the tuple variant pattern syntax instead
    |
 LL |         E1::Z1() => {}

--- a/tests/ui/pattern/pat-tuple-overfield.stderr
+++ b/tests/ui/pattern/pat-tuple-overfield.stderr
@@ -15,12 +15,15 @@ error[E0532]: expected tuple struct or tuple variant, found unit struct `Z0`
    |
 LL | struct Z0;
    | ---------- `Z0` defined here
-LL | struct Z1();
-   | ------------ similarly named tuple struct `Z1` defined here
 ...
 LL |         Z0() => {}
    |         ^^^^
    |
+note: similarly named tuple struct `Z1` defined here
+  --> $DIR/pat-tuple-overfield.rs:11:1
+   |
+LL | struct Z1();
+   | ^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Z0() => {}
@@ -37,12 +40,15 @@ error[E0532]: expected tuple struct or tuple variant, found unit struct `Z0`
    |
 LL | struct Z0;
    | ---------- `Z0` defined here
-LL | struct Z1();
-   | ------------ similarly named tuple struct `Z1` defined here
 ...
 LL |         Z0(_) => {}
    |         ^^^^^
    |
+note: similarly named tuple struct `Z1` defined here
+  --> $DIR/pat-tuple-overfield.rs:11:1
+   |
+LL | struct Z1();
+   | ^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Z0(_) => {}
@@ -59,12 +65,15 @@ error[E0532]: expected tuple struct or tuple variant, found unit struct `Z0`
    |
 LL | struct Z0;
    | ---------- `Z0` defined here
-LL | struct Z1();
-   | ------------ similarly named tuple struct `Z1` defined here
 ...
 LL |         Z0(_, _) => {}
    |         ^^^^^^^^
    |
+note: similarly named tuple struct `Z1` defined here
+  --> $DIR/pat-tuple-overfield.rs:11:1
+   |
+LL | struct Z1();
+   | ^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Z0(_, _) => {}
@@ -81,12 +90,15 @@ error[E0532]: expected tuple struct or tuple variant, found unit variant `E1::Z0
    |
 LL |     Z0,
    |     -- `E1::Z0` defined here
-LL |     Z1(),
-   |     ---- similarly named tuple variant `Z1` defined here
 ...
 LL |         E1::Z0() => {}
    |         ^^^^^^^^
    |
+note: similarly named tuple variant `Z1` defined here
+  --> $DIR/pat-tuple-overfield.rs:14:5
+   |
+LL |     Z1(),
+   |     ^^^^
 help: use this syntax instead
    |
 LL -         E1::Z0() => {}
@@ -103,12 +115,15 @@ error[E0532]: expected tuple struct or tuple variant, found unit variant `E1::Z0
    |
 LL |     Z0,
    |     -- `E1::Z0` defined here
-LL |     Z1(),
-   |     ---- similarly named tuple variant `Z1` defined here
 ...
 LL |         E1::Z0(_) => {}
    |         ^^^^^^^^^
    |
+note: similarly named tuple variant `Z1` defined here
+  --> $DIR/pat-tuple-overfield.rs:14:5
+   |
+LL |     Z1(),
+   |     ^^^^
 help: use this syntax instead
    |
 LL -         E1::Z0(_) => {}
@@ -125,12 +140,15 @@ error[E0532]: expected tuple struct or tuple variant, found unit variant `E1::Z0
    |
 LL |     Z0,
    |     -- `E1::Z0` defined here
-LL |     Z1(),
-   |     ---- similarly named tuple variant `Z1` defined here
 ...
 LL |         E1::Z0(_, _) => {}
    |         ^^^^^^^^^^^^
    |
+note: similarly named tuple variant `Z1` defined here
+  --> $DIR/pat-tuple-overfield.rs:14:5
+   |
+LL |     Z1(),
+   |     ^^^^
 help: use this syntax instead
    |
 LL -         E1::Z0(_, _) => {}
@@ -145,14 +163,17 @@ LL +         E1::Z1(_, _) => {}
 error[E0532]: expected unit struct, unit variant or constant, found tuple variant `E1::Z1`
   --> $DIR/pat-tuple-overfield.rs:69:9
    |
-LL |     Z0,
-   |     -- similarly named unit variant `Z0` defined here
 LL |     Z1(),
    |     ---- `E1::Z1` defined here
 ...
 LL |         E1::Z1 => {}
    |         ^^^^^^
    |
+note: similarly named unit variant `Z0` defined here
+  --> $DIR/pat-tuple-overfield.rs:13:5
+   |
+LL |     Z0,
+   |     ^^
 help: use the tuple variant pattern syntax instead
    |
 LL |         E1::Z1() => {}

--- a/tests/ui/pattern/pattern-error-continue.stderr
+++ b/tests/ui/pattern/pattern-error-continue.stderr
@@ -1,15 +1,17 @@
 error[E0532]: expected tuple struct or tuple variant, found unit variant `A::D`
   --> $DIR/pattern-error-continue.rs:20:9
    |
-LL |     B(isize, isize),
-   |     --------------- similarly named tuple variant `B` defined here
-LL |     C(isize, isize, isize),
 LL |     D
    |     - `A::D` defined here
 ...
 LL |         A::D(_) => (),
    |         ^^^^^^^
    |
+note: similarly named tuple variant `B` defined here
+  --> $DIR/pattern-error-continue.rs:6:5
+   |
+LL |     B(isize, isize),
+   |     ^^^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         A::D(_) => (),

--- a/tests/ui/pattern/rfc-3637-guard-patterns/name-resolution.stderr
+++ b/tests/ui/pattern/rfc-3637-guard-patterns/name-resolution.stderr
@@ -38,7 +38,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:11:34
    |
 LL | fn bad_fn_item_1(x: bool, ((y if x) | y): bool) {}
-   |                                  ^
+   |                                  ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -50,7 +50,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:13:25
    |
 LL | fn bad_fn_item_2(((x if y) | x): bool, y: bool) {}
-   |                         ^
+   |                         ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -62,7 +62,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:21:18
    |
 LL |         (x, y if x) => x && y,
-   |                  ^
+   |                  ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -74,7 +74,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:23:15
    |
 LL |         (x if y, y) => x && y,
-   |               ^
+   |               ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -86,7 +86,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:30:20
    |
 LL |         (x @ (y if x),) => x && y,
-   |                    ^
+   |                    ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -98,7 +98,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:38:20
    |
 LL |         ((Ok(x) if y) | (Err(y) if x),) => x && y,
-   |                    ^
+   |                    ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -110,7 +110,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:38:36
    |
 LL |         ((Ok(x) if y) | (Err(y) if x),) => x && y,
-   |                                    ^
+   |                                    ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -128,7 +128,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:47:22
    |
 LL |     if let ((x, y if x) | (x if y, y)) = (true, true) { x && y; }
-   |                      ^
+   |                      ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -140,7 +140,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:47:33
    |
 LL |     if let ((x, y if x) | (x if y, y)) = (true, true) { x && y; }
-   |                                 ^
+   |                                 ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -152,7 +152,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:50:25
    |
 LL |     while let ((x, y if x) | (x if y, y)) = (true, true) { x && y; }
-   |                         ^
+   |                         ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -164,7 +164,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:50:36
    |
 LL |     while let ((x, y if x) | (x if y, y)) = (true, true) { x && y; }
-   |                                    ^
+   |                                    ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -176,7 +176,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:53:19
    |
 LL |     for ((x, y if x) | (x if y, y)) in [(true, true)] { x && y; }
-   |                   ^
+   |                   ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -188,7 +188,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:53:30
    |
 LL |     for ((x, y if x) | (x if y, y)) in [(true, true)] { x && y; }
-   |                              ^
+   |                              ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -200,7 +200,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:58:13
    |
 LL |     (|(x if y), (y if x)| x && y)(true, true);
-   |             ^
+   |             ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -212,7 +212,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:58:23
    |
 LL |     (|(x if y), (y if x)| x && y)(true, true);
-   |                       ^
+   |                       ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/pattern/struct-pattern-with-missing-fields-resolve-error.rs
+++ b/tests/ui/pattern/struct-pattern-with-missing-fields-resolve-error.rs
@@ -25,6 +25,9 @@ fn main() {
 
     let x = Foo::Bar { a: 1 };
     if let Foo::Bar { .. } = x { //~ NOTE this pattern
-        println!("{a}"); //~ ERROR cannot find value `a` in this scope
+        println!("{a}");
+        //~^ ERROR cannot find value `a` in this scope
+        //~| NOTE not found in this scope
+
     }
 }

--- a/tests/ui/pattern/struct-pattern-with-missing-fields-resolve-error.stderr
+++ b/tests/ui/pattern/struct-pattern-with-missing-fields-resolve-error.stderr
@@ -20,7 +20,7 @@ error[E0425]: cannot find value `a` in this scope
 LL |     if let Foo::Bar { .. } = x {
    |            --------------- this pattern doesn't include `a`, which is available in `Bar`
 LL |         println!("{a}");
-   |                    ^
+   |                    ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/privacy/privacy-ns1.stderr
+++ b/tests/ui/privacy/privacy-ns1.stderr
@@ -1,13 +1,15 @@
 error[E0423]: cannot find function, tuple struct or tuple variant `Bar` in this scope
   --> $DIR/privacy-ns1.rs:21:5
    |
-LL |     pub struct Baz;
-   |     --------------- similarly named unit struct `Baz` defined here
-...
 LL |     Bar();
-   |     ^^^
+   |     ^^^ not found in this scope
    |
    = note: a trait named `Bar` exists in another namespace
+note: similarly named unit struct `Baz` defined here
+  --> $DIR/privacy-ns1.rs:13:5
+   |
+LL |     pub struct Baz;
+   |     ^^^^^^^^^^^^^^^
 note: these functions exist but are inaccessible
   --> $DIR/privacy-ns1.rs:15:5
    |
@@ -29,12 +31,14 @@ LL + use foo2::Bar;
 error[E0425]: cannot find function, tuple struct or tuple variant `Bar` in this scope
   --> $DIR/privacy-ns1.rs:52:5
    |
-LL |     pub struct Baz;
-   |     --------------- similarly named unit struct `Baz` defined here
-...
 LL |     Bar();
-   |     ^^^
+   |     ^^^ not found in this scope
    |
+note: similarly named unit struct `Baz` defined here
+  --> $DIR/privacy-ns1.rs:44:5
+   |
+LL |     pub struct Baz;
+   |     ^^^^^^^^^^^^^^^
 note: these functions exist but are inaccessible
   --> $DIR/privacy-ns1.rs:15:5
    |
@@ -56,12 +60,14 @@ LL + use foo2::Bar;
 error[E0425]: cannot find type `Bar` in this scope
   --> $DIR/privacy-ns1.rs:53:17
    |
-LL |     pub struct Baz;
-   |     --------------- similarly named struct `Baz` defined here
-...
 LL |     let _x: Box<Bar>;
-   |                 ^^^
+   |                 ^^^ not found in this scope
    |
+note: similarly named struct `Baz` defined here
+  --> $DIR/privacy-ns1.rs:44:5
+   |
+LL |     pub struct Baz;
+   |     ^^^^^^^^^^^^^^^
 note: these traits exist but are inaccessible
   --> $DIR/privacy-ns1.rs:26:5
    |

--- a/tests/ui/privacy/privacy-ns2.stderr
+++ b/tests/ui/privacy/privacy-ns2.stderr
@@ -21,13 +21,15 @@ LL + use foo2::Bar;
 error[E0423]: cannot find function, tuple struct or tuple variant `Bar` in this scope
   --> $DIR/privacy-ns2.rs:27:5
    |
-LL |     pub struct Baz;
-   |     --------------- similarly named unit struct `Baz` defined here
-...
 LL |     Bar();
-   |     ^^^
+   |     ^^^ not found in this scope
    |
    = note: a trait named `Bar` exists in another namespace
+note: similarly named unit struct `Baz` defined here
+  --> $DIR/privacy-ns2.rs:13:5
+   |
+LL |     pub struct Baz;
+   |     ^^^^^^^^^^^^^^^
 note: these functions exist but are inaccessible
   --> $DIR/privacy-ns2.rs:15:5
    |

--- a/tests/ui/privacy/sysroot-private.default.stderr
+++ b/tests/ui/privacy/sysroot-private.default.stderr
@@ -1,17 +1,20 @@
 error[E0405]: cannot find trait `Equivalent` in this scope
-  --> $DIR/sysroot-private.rs:27:18
+  --> $DIR/sysroot-private.rs:29:18
    |
 LL | trait Trait2<K>: Equivalent<K> {}
    |                  ^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `K` in this scope
-  --> $DIR/sysroot-private.rs:32:35
+  --> $DIR/sysroot-private.rs:34:35
    |
 LL | fn trait_member<T>(val: &T, key: &K) -> bool {
-   |                 -                 ^
-   |                 |
-   |                 similarly named type parameter `T` defined here
+   |                                   ^ not found in this scope
    |
+note: similarly named type parameter `T` defined here
+  --> $DIR/sysroot-private.rs:34:17
+   |
+LL | fn trait_member<T>(val: &T, key: &K) -> bool {
+   |                 ^
 help: a type parameter with a similar name exists
    |
 LL - fn trait_member<T>(val: &T, key: &K) -> bool {
@@ -29,7 +32,7 @@ LL | type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
    |                               ^^^^^^^^^^^^^^^ help: `Trait` has the following associated type: `Bar`
 
 error[E0425]: cannot find function `memchr2` in this scope
-  --> $DIR/sysroot-private.rs:40:5
+  --> $DIR/sysroot-private.rs:47:5
    |
 LL |     memchr2(b'a', b'b', buf)
    |     ^^^^^^^ not found in this scope

--- a/tests/ui/privacy/sysroot-private.rs
+++ b/tests/ui/privacy/sysroot-private.rs
@@ -21,6 +21,8 @@ trait Trait { type Bar; }
 // present in diagnostics (it is a dependency of the compiler).
 type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
 //~^ ERROR associated type `ExpressionStack` not found
+//[default]~| HELP `Trait` has the following associated type
+//[default]~| SUGGESTION Bar
 //[rustc_private_enabled]~| NOTE there is an associated type `ExpressionStack` in the trait `gimli::read::op::EvaluationStorage`
 
 // Attempt to get a suggestion for `hashbrown::Equivalent`
@@ -31,6 +33,11 @@ trait Trait2<K>: Equivalent<K> {}
 // Attempt to get a suggestion for `hashbrown::Equivalent::equivalent`
 fn trait_member<T>(val: &T, key: &K) -> bool {
     //~^ ERROR cannot find type `K`
+    //~| NOTE not found in this scope
+    //~| SUGGESTION K
+    //~| SUGGESTION T
+    //~| HELP you might be missing a type parameter
+    //~| HELP a type parameter with a similar name exists
     //~| NOTE similarly named
     val.equivalent(key)
 }
@@ -40,4 +47,5 @@ fn free_function(buf: &[u8]) -> Option<usize> {
     memchr2(b'a', b'b', buf)
     //~^ ERROR cannot find function
     //~| NOTE not found
+
 }

--- a/tests/ui/privacy/sysroot-private.rustc_private_enabled.stderr
+++ b/tests/ui/privacy/sysroot-private.rustc_private_enabled.stderr
@@ -1,17 +1,20 @@
 error[E0405]: cannot find trait `Equivalent` in this scope
-  --> $DIR/sysroot-private.rs:27:18
+  --> $DIR/sysroot-private.rs:29:18
    |
 LL | trait Trait2<K>: Equivalent<K> {}
    |                  ^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `K` in this scope
-  --> $DIR/sysroot-private.rs:32:35
+  --> $DIR/sysroot-private.rs:34:35
    |
 LL | fn trait_member<T>(val: &T, key: &K) -> bool {
-   |                 -                 ^
-   |                 |
-   |                 similarly named type parameter `T` defined here
+   |                                   ^ not found in this scope
    |
+note: similarly named type parameter `T` defined here
+  --> $DIR/sysroot-private.rs:34:17
+   |
+LL | fn trait_member<T>(val: &T, key: &K) -> bool {
+   |                 ^
 help: a type parameter with a similar name exists
    |
 LL - fn trait_member<T>(val: &T, key: &K) -> bool {
@@ -29,7 +32,7 @@ LL | type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
    |                               ^^^^^^^^^^^^^^^ there is an associated type `ExpressionStack` in the trait `gimli::read::op::EvaluationStorage`
 
 error[E0425]: cannot find function `memchr2` in this scope
-  --> $DIR/sysroot-private.rs:40:5
+  --> $DIR/sysroot-private.rs:47:5
    |
 LL |     memchr2(b'a', b'b', buf)
    |     ^^^^^^^ not found in this scope

--- a/tests/ui/proc-macro/gen-macro-rules-hygiene.stderr
+++ b/tests/ui/proc-macro/gen-macro-rules-hygiene.stderr
@@ -13,7 +13,7 @@ error[E0425]: cannot find value `local_use` in this scope
   --> $DIR/gen-macro-rules-hygiene.rs:13:1
    |
 LL | gen_macro_rules!();
-   | ^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^ not found in this scope
 ...
 LL |         generated!();
    |         ------------ in this macro invocation
@@ -34,7 +34,7 @@ error[E0425]: cannot find value `local_def` in this scope
   --> $DIR/gen-macro-rules-hygiene.rs:22:9
    |
 LL |         local_def;
-   |         ^^^^^^^^^
+   |         ^^^^^^^^^ not found in this scope
    |
 help: an identifier with the same name is defined here, but is not accessible due to macro hygiene
   --> $DIR/gen-macro-rules-hygiene.rs:13:1

--- a/tests/ui/proc-macro/lints_in_proc_macros.stderr
+++ b/tests/ui/proc-macro/lints_in_proc_macros.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `foobar2` in this scope
   --> $DIR/lints_in_proc_macros.rs:10:5
    |
 LL |     bang_proc_macro2!();
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
    = note: this error originates in the macro `bang_proc_macro2` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a local variable with a similar name exists

--- a/tests/ui/proc-macro/mixed-site-span.stderr
+++ b/tests/ui/proc-macro/mixed-site-span.stderr
@@ -714,7 +714,7 @@ error[E0425]: cannot find value `local_use` in this scope
   --> $DIR/mixed-site-span.rs:23:9
    |
 LL |         proc_macro_rules!();
-   |         ^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
 help: an identifier with the same name exists, but is not accessible due to macro hygiene
   --> $DIR/mixed-site-span.rs:22:13
@@ -732,7 +732,7 @@ error[E0425]: cannot find value `local_def` in this scope
   --> $DIR/mixed-site-span.rs:28:9
    |
 LL |         local_def;
-   |         ^^^^^^^^^
+   |         ^^^^^^^^^ not found in this scope
    |
 help: an identifier with the same name is defined here, but is not accessible due to macro hygiene
   --> $DIR/mixed-site-span.rs:23:9

--- a/tests/ui/proc-macro/parent-source-spans.stderr
+++ b/tests/ui/proc-macro/parent-source-spans.stderr
@@ -140,15 +140,13 @@ error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:30:5
    |
 LL |     parent_source_spans!($($tokens)*);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
 ...
 LL |     one!("hello", "world");
    |     ---------------------- in this macro invocation
    |
+note: similarly named tuple variant `Ok` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named tuple variant `Ok` defined here
-   |
    = note: this error originates in the macro `parent_source_spans` which comes from the expansion of the macro `one` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a tuple variant with a similar name exists
    |
@@ -160,15 +158,13 @@ error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:30:5
    |
 LL |     parent_source_spans!($($tokens)*);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
 ...
 LL |     two!("yay", "rust");
    |     ------------------- in this macro invocation
    |
+note: similarly named tuple variant `Ok` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named tuple variant `Ok` defined here
-   |
    = note: this error originates in the macro `parent_source_spans` which comes from the expansion of the macro `two` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a tuple variant with a similar name exists
    |
@@ -180,15 +176,13 @@ error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:30:5
    |
 LL |     parent_source_spans!($($tokens)*);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
 ...
 LL |     three!("hip", "hop");
    |     -------------------- in this macro invocation
    |
+note: similarly named tuple variant `Ok` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named tuple variant `Ok` defined here
-   |
    = note: this error originates in the macro `parent_source_spans` which comes from the expansion of the macro `three` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a tuple variant with a similar name exists
    |

--- a/tests/ui/proc-macro/resolve-error.stderr
+++ b/tests/ui/proc-macro/resolve-error.stderr
@@ -4,11 +4,11 @@ error: cannot find macro `bang_proc_macrp` in this scope
 LL |     bang_proc_macrp!();
    |     ^^^^^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/test-macros.rs:10:1
+note: similarly named macro `bang_proc_macro` defined here
+  --> $DIR/auxiliary/test-macros.rs:10:1
    |
 LL | pub fn empty(_: TokenStream) -> TokenStream {
-   | ------------------------------------------- similarly named macro `bang_proc_macro` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a macro with a similar name exists
    |
 LL -     bang_proc_macrp!();
@@ -24,12 +24,14 @@ LL |     Dlona!();
 error: cannot find macro `attr_proc_macra` in this scope
   --> $DIR/resolve-error.rs:54:5
    |
-LL | macro_rules! attr_proc_mac {
-   | -------------------------- similarly named macro `attr_proc_mac` defined here
-...
 LL |     attr_proc_macra!();
    |     ^^^^^^^^^^^^^^^
    |
+note: similarly named macro `attr_proc_mac` defined here
+  --> $DIR/resolve-error.rs:18:1
+   |
+LL | macro_rules! attr_proc_mac {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a macro with a similar name exists
    |
 LL -     attr_proc_macra!();
@@ -39,12 +41,14 @@ LL +     attr_proc_mac!();
 error: cannot find macro `FooWithLongNama` in this scope
   --> $DIR/resolve-error.rs:51:5
    |
-LL | macro_rules! FooWithLongNam {
-   | --------------------------- similarly named macro `FooWithLongNam` defined here
-...
 LL |     FooWithLongNama!();
    |     ^^^^^^^^^^^^^^^
    |
+note: similarly named macro `FooWithLongNam` defined here
+  --> $DIR/resolve-error.rs:14:1
+   |
+LL | macro_rules! FooWithLongNam {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a macro with a similar name exists
    |
 LL -     FooWithLongNama!();
@@ -71,11 +75,11 @@ error: cannot find derive macro `Dlona` in this scope
 LL | #[derive(Dlona)]
    |          ^^^^^
    |
-  ::: $DIR/auxiliary/derive-clona.rs:6:1
+note: similarly named derive macro `Clona` defined here
+  --> $DIR/auxiliary/derive-clona.rs:6:1
    |
 LL | pub fn derive_clonea(input: TokenStream) -> TokenStream {
-   | ------------------------------------------------------- similarly named derive macro `Clona` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a derive macro with a similar name exists
    |
 LL - #[derive(Dlona)]
@@ -88,11 +92,11 @@ error: cannot find derive macro `Dlona` in this scope
 LL | #[derive(Dlona)]
    |          ^^^^^
    |
-  ::: $DIR/auxiliary/derive-clona.rs:6:1
+note: similarly named derive macro `Clona` defined here
+  --> $DIR/auxiliary/derive-clona.rs:6:1
    |
 LL | pub fn derive_clonea(input: TokenStream) -> TokenStream {
-   | ------------------------------------------------------- similarly named derive macro `Clona` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: a derive macro with a similar name exists
    |
@@ -106,9 +110,8 @@ error: cannot find derive macro `Dlone` in this scope
 LL | #[derive(Dlone)]
    |          ^^^^^
    |
+note: similarly named derive macro `Clone` defined here
   --> $SRC_DIR/core/src/clone.rs:LL:COL
-   |
-   = note: similarly named derive macro `Clone` defined here
 help: a derive macro with a similar name exists
    |
 LL - #[derive(Dlone)]
@@ -121,10 +124,8 @@ error: cannot find derive macro `Dlone` in this scope
 LL | #[derive(Dlone)]
    |          ^^^^^
    |
+note: similarly named derive macro `Clone` defined here
   --> $SRC_DIR/core/src/clone.rs:LL:COL
-   |
-   = note: similarly named derive macro `Clone` defined here
-   |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: a derive macro with a similar name exists
    |
@@ -144,11 +145,11 @@ error: cannot find attribute `attr_proc_macra` in this scope
 LL | #[attr_proc_macra]
    |   ^^^^^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/test-macros.rs:15:1
+note: similarly named attribute macro `attr_proc_macro` defined here
+  --> $DIR/auxiliary/test-macros.rs:15:1
    |
 LL | pub fn empty_attr(_: TokenStream, _: TokenStream) -> TokenStream {
-   | ---------------------------------------------------------------- similarly named attribute macro `attr_proc_macro` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: an attribute macro with a similar name exists
    |
 LL - #[attr_proc_macra]
@@ -161,11 +162,11 @@ error: cannot find derive macro `FooWithLongNan` in this scope
 LL | #[derive(FooWithLongNan)]
    |          ^^^^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/derive-foo.rs:6:1
+note: similarly named derive macro `FooWithLongName` defined here
+  --> $DIR/auxiliary/derive-foo.rs:6:1
    |
 LL | pub fn derive_foo(input: TokenStream) -> TokenStream {
-   | ---------------------------------------------------- similarly named derive macro `FooWithLongName` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a derive macro with a similar name exists
    |
 LL - #[derive(FooWithLongNan)]
@@ -178,11 +179,11 @@ error: cannot find derive macro `FooWithLongNan` in this scope
 LL | #[derive(FooWithLongNan)]
    |          ^^^^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/derive-foo.rs:6:1
+note: similarly named derive macro `FooWithLongName` defined here
+  --> $DIR/auxiliary/derive-foo.rs:6:1
    |
 LL | pub fn derive_foo(input: TokenStream) -> TokenStream {
-   | ---------------------------------------------------- similarly named derive macro `FooWithLongName` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: a derive macro with a similar name exists
    |

--- a/tests/ui/regions/outlives-with-missing.stderr
+++ b/tests/ui/regions/outlives-with-missing.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find type `T` in this scope
   --> $DIR/outlives-with-missing.rs:10:9
    |
-LL | impl<H: HandlerFamily> HandlerWrapper<H> {
-   |      - similarly named type parameter `H` defined here
-...
 LL |         T: Send + Sync + 'static,
-   |         ^
+   |         ^ not found in this scope
    |
+note: similarly named type parameter `H` defined here
+  --> $DIR/outlives-with-missing.rs:7:6
+   |
+LL | impl<H: HandlerFamily> HandlerWrapper<H> {
+   |      ^
 help: a type parameter with a similar name exists
    |
 LL -         T: Send + Sync + 'static,

--- a/tests/ui/resolve/builtin-attribute-not-value.stderr
+++ b/tests/ui/resolve/builtin-attribute-not-value.stderr
@@ -10,7 +10,7 @@ error[E0423]: cannot find value `path` in this scope
   --> $DIR/builtin-attribute-not-value.rs:13:5
    |
 LL |     path;
-   |     ^^^^
+   |     ^^^^ not found in this scope
    |
    = note: a built-in attribute named `path` exists in another namespace
 help: a local variable with a similar name exists

--- a/tests/ui/resolve/empty-struct-braces-expr.stderr
+++ b/tests/ui/resolve/empty-struct-braces-expr.stderr
@@ -7,12 +7,12 @@ LL | struct Empty1 {}
 LL |     let e1 = Empty1;
    |              ^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:2:1
+   = note: a struct named `Empty1` exists in another namespace
+note: similarly named unit struct `XEmpty2` defined here
+  --> $DIR/auxiliary/empty-struct.rs:2:1
    |
 LL | pub struct XEmpty2;
-   | ------------------ similarly named unit struct `XEmpty2` defined here
-   |
-   = note: a struct named `Empty1` exists in another namespace
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct literal syntax instead
    |
 LL |     let e1 = Empty1 {};
@@ -33,10 +33,13 @@ LL |     let xe1 = XEmpty1;
    |
 LL | pub struct XEmpty1 {}
    | ------------------ `XEmpty1` defined here
-LL | pub struct XEmpty2;
-   | ------------------ similarly named unit struct `XEmpty2` defined here
    |
    = note: a struct named `XEmpty1` exists in another namespace
+note: similarly named unit struct `XEmpty2` defined here
+  --> $DIR/auxiliary/empty-struct.rs:2:1
+   |
+LL | pub struct XEmpty2;
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct literal syntax instead
    |
 LL |     let xe1 = XEmpty1 {};
@@ -56,12 +59,12 @@ LL | struct Empty1 {}
 LL |     let e1 = Empty1();
    |              ^^^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:2:1
+   = note: a struct named `Empty1` exists in another namespace
+note: similarly named unit struct `XEmpty2` defined here
+  --> $DIR/auxiliary/empty-struct.rs:2:1
    |
 LL | pub struct XEmpty2;
-   | ------------------ similarly named unit struct `XEmpty2` defined here
-   |
-   = note: a struct named `Empty1` exists in another namespace
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct literal syntax instead
    |
 LL -     let e1 = Empty1();
@@ -106,10 +109,13 @@ LL |     let xe1 = XEmpty1();
    |
 LL | pub struct XEmpty1 {}
    | ------------------ `XEmpty1` defined here
-LL | pub struct XEmpty2;
-   | ------------------ similarly named unit struct `XEmpty2` defined here
    |
    = note: a struct named `XEmpty1` exists in another namespace
+note: similarly named unit struct `XEmpty2` defined here
+  --> $DIR/auxiliary/empty-struct.rs:2:1
+   |
+LL | pub struct XEmpty2;
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct literal syntax instead
    |
 LL -     let xe1 = XEmpty1();

--- a/tests/ui/resolve/empty-struct-braces-pat-2.stderr
+++ b/tests/ui/resolve/empty-struct-braces-pat-2.stderr
@@ -7,12 +7,12 @@ LL | struct Empty1 {}
 LL |         Empty1() => ()
    |         ^^^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:3:1
+   = note: a struct named `Empty1` exists in another namespace
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
    |
 LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
-   |
-   = note: a struct named `Empty1` exists in another namespace
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct pattern syntax instead
    |
 LL -         Empty1() => ()
@@ -34,11 +34,13 @@ LL |         XEmpty1() => ()
    |
 LL | pub struct XEmpty1 {}
    | ------------------ `XEmpty1` defined here
-LL | pub struct XEmpty2;
-LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
    |
    = note: a struct named `XEmpty1` exists in another namespace
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
+   |
+LL | pub struct XEmpty6();
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct pattern syntax instead
    |
 LL -         XEmpty1() => ()
@@ -59,12 +61,12 @@ LL | struct Empty1 {}
 LL |         Empty1(..) => ()
    |         ^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:3:1
+   = note: a struct named `Empty1` exists in another namespace
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
    |
 LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
-   |
-   = note: a struct named `Empty1` exists in another namespace
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct pattern syntax instead
    |
 LL -         Empty1(..) => ()
@@ -86,11 +88,13 @@ LL |         XEmpty1(..) => ()
    |
 LL | pub struct XEmpty1 {}
    | ------------------ `XEmpty1` defined here
-LL | pub struct XEmpty2;
-LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
    |
    = note: a struct named `XEmpty1` exists in another namespace
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
+   |
+LL | pub struct XEmpty6();
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct pattern syntax instead
    |
 LL -         XEmpty1(..) => ()

--- a/tests/ui/resolve/empty-struct-tuple-pat.stderr
+++ b/tests/ui/resolve/empty-struct-tuple-pat.stderr
@@ -37,13 +37,16 @@ error[E0532]: expected unit struct, unit variant or constant, found tuple varian
 LL |         XE::XEmpty5 => (),
    |         ^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:7:5
+  ::: $DIR/auxiliary/empty-struct.rs:8:5
    |
-LL |     XEmpty4,
-   |     ------- similarly named unit variant `XEmpty4` defined here
 LL |     XEmpty5(),
    |     ------- `XE::XEmpty5` defined here
    |
+note: similarly named unit variant `XEmpty4` defined here
+  --> $DIR/auxiliary/empty-struct.rs:7:5
+   |
+LL |     XEmpty4,
+   |     ^^^^^^^
 help: use the tuple variant pattern syntax instead
    |
 LL |         XE::XEmpty5() => (),

--- a/tests/ui/resolve/empty-struct-unit-pat.stderr
+++ b/tests/ui/resolve/empty-struct-unit-pat.stderr
@@ -7,11 +7,11 @@ LL | struct Empty2;
 LL |         Empty2() => ()
    |         ^^^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:3:1
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
    |
 LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Empty2() => ()
@@ -33,9 +33,12 @@ LL |         XEmpty2() => ()
    |
 LL | pub struct XEmpty2;
    | ------------------ `XEmpty2` defined here
-LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
    |
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
+   |
+LL | pub struct XEmpty6();
+   | ^^^^^^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         XEmpty2() => ()
@@ -56,11 +59,11 @@ LL | struct Empty2;
 LL |         Empty2(..) => ()
    |         ^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:3:1
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
    |
 LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Empty2(..) => ()
@@ -82,9 +85,12 @@ LL |         XEmpty2(..) => ()
    |
 LL | pub struct XEmpty2;
    | ------------------ `XEmpty2` defined here
-LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
    |
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
+   |
+LL | pub struct XEmpty6();
+   | ^^^^^^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         XEmpty2(..) => ()
@@ -115,9 +121,12 @@ LL |         XE::XEmpty4() => (),
    |
 LL |     XEmpty4,
    |     ------- `XE::XEmpty4` defined here
-LL |     XEmpty5(),
-   |     ------- similarly named tuple variant `XEmpty5` defined here
    |
+note: similarly named tuple variant `XEmpty5` defined here
+  --> $DIR/auxiliary/empty-struct.rs:8:5
+   |
+LL |     XEmpty5(),
+   |     ^^^^^^^
 help: use this syntax instead
    |
 LL -         XE::XEmpty4() => (),
@@ -148,9 +157,12 @@ LL |         XE::XEmpty4(..) => (),
    |
 LL |     XEmpty4,
    |     ------- `XE::XEmpty4` defined here
-LL |     XEmpty5(),
-   |     ------- similarly named tuple variant `XEmpty5` defined here
    |
+note: similarly named tuple variant `XEmpty5` defined here
+  --> $DIR/auxiliary/empty-struct.rs:8:5
+   |
+LL |     XEmpty5(),
+   |     ^^^^^^^
 help: use this syntax instead
    |
 LL -         XE::XEmpty4(..) => (),

--- a/tests/ui/resolve/issue-10200.stderr
+++ b/tests/ui/resolve/issue-10200.stderr
@@ -1,13 +1,15 @@
 error[E0532]: expected a pattern, found a function call
   --> $DIR/issue-10200.rs:6:9
    |
-LL | struct Foo(bool);
-   | ----------------- similarly named tuple struct `Foo` defined here
-...
 LL |         foo(x)
-   |         ^^^
+   |         ^^^ not a tuple struct or tuple variant
    |
    = note: function calls are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
+note: similarly named tuple struct `Foo` defined here
+  --> $DIR/issue-10200.rs:1:1
+   |
+LL | struct Foo(bool);
+   | ^^^^^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists (notice the capitalization)
    |
 LL -         foo(x)

--- a/tests/ui/resolve/issue-5035.stderr
+++ b/tests/ui/resolve/issue-5035.stderr
@@ -9,12 +9,14 @@ LL | use crate::ImportError;
 error[E0404]: expected trait, found type alias `K`
   --> $DIR/issue-5035.rs:5:6
    |
-LL | trait I {}
-   | ------- similarly named trait `I` defined here
-LL | type K = dyn I;
 LL | impl K for isize {}
    |      ^ type aliases cannot be used as traits
    |
+note: similarly named trait `I` defined here
+  --> $DIR/issue-5035.rs:3:1
+   |
+LL | trait I {}
+   | ^^^^^^^
 help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
    |
 LL - type K = dyn I;

--- a/tests/ui/resolve/levenshtein.stderr
+++ b/tests/ui/resolve/levenshtein.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find type `esize` in this scope
   --> $DIR/levenshtein.rs:5:11
    |
 LL | fn foo(c: esize) {} // Misspelled primitive type name.
-   |           ^^^^^
+   |           ^^^^^ not found in this scope
    |
 help: a builtin type with a similar name exists
    |
@@ -13,12 +13,14 @@ LL + fn foo(c: isize) {} // Misspelled primitive type name.
 error[E0425]: cannot find type `Baz` in this scope
   --> $DIR/levenshtein.rs:10:10
    |
-LL | enum Bar { }
-   | -------- similarly named enum `Bar` defined here
-LL |
 LL | type A = Baz; // Misspelled type name.
-   |          ^^^
+   |          ^^^ not found in this scope
    |
+note: similarly named enum `Bar` defined here
+  --> $DIR/levenshtein.rs:8:1
+   |
+LL | enum Bar { }
+   | ^^^^^^^^
 help: an enum with a similar name exists
    |
 LL - type A = Baz; // Misspelled type name.
@@ -29,11 +31,10 @@ error[E0425]: cannot find type `Opiton` in this scope
   --> $DIR/levenshtein.rs:12:10
    |
 LL | type B = Opiton<u8>; // Misspelled type name from the prelude.
-   |          ^^^^^^
+   |          ^^^^^^ not found in this scope
    |
+note: similarly named enum `Option` defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
-   |
-   = note: similarly named enum `Option` defined here
 help: an enum with a similar name exists
    |
 LL - type B = Opiton<u8>; // Misspelled type name from the prelude.
@@ -49,12 +50,14 @@ LL |     type A = Baz; // No suggestion here, Bar is not visible
 error[E0425]: cannot find value `MAXITEM` in this scope
   --> $DIR/levenshtein.rs:24:20
    |
-LL | const MAX_ITEM: usize = 10;
-   | --------------------------- similarly named constant `MAX_ITEM` defined here
-...
 LL |     let v = [0u32; MAXITEM]; // Misspelled constant name.
-   |                    ^^^^^^^
+   |                    ^^^^^^^ not found in this scope
    |
+note: similarly named constant `MAX_ITEM` defined here
+  --> $DIR/levenshtein.rs:1:1
+   |
+LL | const MAX_ITEM: usize = 10;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists
    |
 LL |     let v = [0u32; MAX_ITEM]; // Misspelled constant name.
@@ -63,12 +66,14 @@ LL |     let v = [0u32; MAX_ITEM]; // Misspelled constant name.
 error[E0425]: cannot find type `first` in module `m`
   --> $DIR/levenshtein.rs:28:15
    |
-LL |     pub struct First;
-   |     ----------------- similarly named struct `First` defined here
-...
 LL |     let b: m::first = m::second; // Misspelled item in module.
-   |               ^^^^^
+   |               ^^^^^ not found in `m`
    |
+note: similarly named struct `First` defined here
+  --> $DIR/levenshtein.rs:19:5
+   |
+LL |     pub struct First;
+   |     ^^^^^^^^^^^^^^^^^
 help: a struct with a similar name exists (notice the capitalization)
    |
 LL -     let b: m::first = m::second; // Misspelled item in module.
@@ -78,12 +83,14 @@ LL +     let b: m::First = m::second; // Misspelled item in module.
 error[E0425]: cannot find value `second` in module `m`
   --> $DIR/levenshtein.rs:28:26
    |
-LL |     pub struct Second;
-   |     ------------------ similarly named unit struct `Second` defined here
-...
 LL |     let b: m::first = m::second; // Misspelled item in module.
-   |                          ^^^^^^
+   |                          ^^^^^^ not found in `m`
    |
+note: similarly named unit struct `Second` defined here
+  --> $DIR/levenshtein.rs:20:5
+   |
+LL |     pub struct Second;
+   |     ^^^^^^^^^^^^^^^^^^
 help: a unit struct with a similar name exists (notice the capitalization)
    |
 LL -     let b: m::first = m::second; // Misspelled item in module.
@@ -93,12 +100,14 @@ LL +     let b: m::first = m::Second; // Misspelled item in module.
 error[E0425]: cannot find function `foobar` in this scope
   --> $DIR/levenshtein.rs:26:5
    |
-LL | fn foo_bar() {}
-   | ------------ similarly named function `foo_bar` defined here
-...
 LL |     foobar(); // Misspelled function name.
-   |     ^^^^^^
+   |     ^^^^^^ not found in this scope
    |
+note: similarly named function `foo_bar` defined here
+  --> $DIR/levenshtein.rs:3:1
+   |
+LL | fn foo_bar() {}
+   | ^^^^^^^^^^^^
 help: a function with a similar name exists
    |
 LL |     foo_bar(); // Misspelled function name.

--- a/tests/ui/resolve/privacy-enum-ctor.stderr
+++ b/tests/ui/resolve/privacy-enum-ctor.stderr
@@ -59,9 +59,6 @@ LL +         (m::Z::Fn(/* fields */));
 error[E0423]: cannot find value `E` in module `m`
   --> $DIR/privacy-enum-ctor.rs:42:19
    |
-LL |     fn f() {
-   |     ------ similarly named function `f` defined here
-...
 LL |     let _: E = m::E;
    |                   ^
    |
@@ -77,6 +74,11 @@ LL | |         },
 LL | |         Unit,
 LL | |     }
    | |_____^
+note: similarly named function `f` defined here
+  --> $DIR/privacy-enum-ctor.rs:23:5
+   |
+LL |     fn f() {
+   |     ^^^^^^
 help: you might have meant to use the following enum variant
    |
 LL -     let _: E = m::E;
@@ -149,12 +151,14 @@ LL + use std::f64::consts::E;
 error[E0425]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:58:12
    |
-LL |     pub enum E {
-   |     ---------- similarly named enum `E` defined here
-...
 LL |     let _: Z = m::n::Z;
-   |            ^
+   |            ^ not found in this scope
    |
+note: similarly named enum `E` defined here
+  --> $DIR/privacy-enum-ctor.rs:3:5
+   |
+LL |     pub enum E {
+   |     ^^^^^^^^^^
 note: enum `m::Z` exists but is inaccessible
   --> $DIR/privacy-enum-ctor.rs:12:9
    |
@@ -198,12 +202,14 @@ LL +     let _: Z = (m::Z::Fn(/* fields */));
 error[E0425]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:62:12
    |
-LL |     pub enum E {
-   |     ---------- similarly named enum `E` defined here
-...
 LL |     let _: Z = m::n::Z::Fn;
-   |            ^
+   |            ^ not found in this scope
    |
+note: similarly named enum `E` defined here
+  --> $DIR/privacy-enum-ctor.rs:3:5
+   |
+LL |     pub enum E {
+   |     ^^^^^^^^^^
 note: enum `m::Z` exists but is inaccessible
   --> $DIR/privacy-enum-ctor.rs:12:9
    |
@@ -218,12 +224,14 @@ LL +     let _: E = m::n::Z::Fn;
 error[E0425]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:65:12
    |
-LL |     pub enum E {
-   |     ---------- similarly named enum `E` defined here
-...
 LL |     let _: Z = m::n::Z::Struct;
-   |            ^
+   |            ^ not found in this scope
    |
+note: similarly named enum `E` defined here
+  --> $DIR/privacy-enum-ctor.rs:3:5
+   |
+LL |     pub enum E {
+   |     ^^^^^^^^^^
 note: enum `m::Z` exists but is inaccessible
   --> $DIR/privacy-enum-ctor.rs:12:9
    |
@@ -238,12 +246,14 @@ LL +     let _: E = m::n::Z::Struct;
 error[E0425]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:69:12
    |
-LL |     pub enum E {
-   |     ---------- similarly named enum `E` defined here
-...
 LL |     let _: Z = m::n::Z::Unit {};
-   |            ^
+   |            ^ not found in this scope
    |
+note: similarly named enum `E` defined here
+  --> $DIR/privacy-enum-ctor.rs:3:5
+   |
+LL |     pub enum E {
+   |     ^^^^^^^^^^
 note: enum `m::Z` exists but is inaccessible
   --> $DIR/privacy-enum-ctor.rs:12:9
    |

--- a/tests/ui/resolve/privacy-struct-ctor.stderr
+++ b/tests/ui/resolve/privacy-struct-ctor.stderr
@@ -1,13 +1,15 @@
 error[E0423]: cannot find value `Z` in this scope
   --> $DIR/privacy-struct-ctor.rs:21:9
    |
-LL |     pub struct S(u8);
-   |     ----------------- similarly named tuple struct `S` defined here
-...
 LL |         Z;
    |         ^ constructor is not visible here due to private fields
    |
    = note: a struct named `Z` exists in another namespace
+note: similarly named tuple struct `S` defined here
+  --> $DIR/privacy-struct-ctor.rs:7:5
+   |
+LL |     pub struct S(u8);
+   |     ^^^^^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL -         Z;

--- a/tests/ui/resolve/suggestions/suggest-path-instead-of-mod-dot-item.stderr
+++ b/tests/ui/resolve/suggestions/suggest-path-instead-of-mod-dot-item.stderr
@@ -40,13 +40,15 @@ LL +     a::b.J
 error[E0423]: cannot find value `b` in module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:35:8
    |
-LL |     pub const I: i32 = 1;
-   |     --------------------- similarly named constant `I` defined here
-...
 LL |     a::b.J
    |        ^
    |
    = note: a module named `a::b` exists in another namespace
+note: similarly named constant `I` defined here
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:5:5
+   |
+LL |     pub const I: i32 = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: use the path separator to refer to an item
    |
 LL -     a::b.J
@@ -74,13 +76,15 @@ LL +     a::b.f();
 error[E0423]: cannot find value `b` in module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:46:15
    |
-LL |     pub const I: i32 = 1;
-   |     --------------------- similarly named constant `I` defined here
-...
 LL |     v.push(a::b);
-   |               ^
+   |               ^ not found in `a`
    |
    = note: a module named `a::b` exists in another namespace
+note: similarly named constant `I` defined here
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:5:5
+   |
+LL |     pub const I: i32 = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists
    |
 LL -     v.push(a::b);
@@ -90,13 +94,15 @@ LL +     v.push(a::I);
 error[E0423]: cannot find value `b` in module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:52:8
    |
-LL |     pub const I: i32 = 1;
-   |     --------------------- similarly named constant `I` defined here
-...
 LL |     a::b.f()
    |        ^
    |
    = note: a module named `a::b` exists in another namespace
+note: similarly named constant `I` defined here
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:5:5
+   |
+LL |     pub const I: i32 = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: use the path separator to refer to an item
    |
 LL -     a::b.f()
@@ -111,13 +117,15 @@ LL +     a::I.f()
 error[E0423]: cannot find value `b` in module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:59:8
    |
-LL |     pub const I: i32 = 1;
-   |     --------------------- similarly named constant `I` defined here
-...
 LL |     a::b
-   |        ^
+   |        ^ not found in `a`
    |
    = note: a module named `a::b` exists in another namespace
+note: similarly named constant `I` defined here
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:5:5
+   |
+LL |     pub const I: i32 = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists
    |
 LL -     a::b
@@ -127,13 +135,15 @@ LL +     a::I
 error[E0423]: cannot find function `b` in module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:65:8
    |
-LL |     pub const I: i32 = 1;
-   |     --------------------- similarly named constant `I` defined here
-...
 LL |     a::b()
-   |        ^
+   |        ^ not found in `a`
    |
    = note: a module named `a::b` exists in another namespace
+note: similarly named constant `I` defined here
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:5:5
+   |
+LL |     pub const I: i32 = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists
    |
 LL -     a::b()

--- a/tests/ui/resolve/tuple-struct-alias.stderr
+++ b/tests/ui/resolve/tuple-struct-alias.stderr
@@ -1,13 +1,15 @@
 error[E0532]: cannot find tuple struct or tuple variant `A` in this scope
   --> $DIR/tuple-struct-alias.rs:7:9
    |
-LL | struct S(u8, u16);
-   | ------------------ similarly named tuple struct `S` defined here
-...
 LL |         A(..) => {}
-   |         ^
+   |         ^ not found in this scope
    |
    = note: a type alias named `A` exists in another namespace
+note: similarly named tuple struct `S` defined here
+  --> $DIR/tuple-struct-alias.rs:1:1
+   |
+LL | struct S(u8, u16);
+   | ^^^^^^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL -         A(..) => {}
@@ -17,13 +19,15 @@ LL +         S(..) => {}
 error[E0423]: cannot find function, tuple struct or tuple variant `A` in this scope
   --> $DIR/tuple-struct-alias.rs:5:13
    |
-LL | struct S(u8, u16);
-   | ------------------ similarly named tuple struct `S` defined here
-...
 LL |     let s = A(0, 1);
    |             ^
    |
    = note: a type alias named `A` exists in another namespace
+note: similarly named tuple struct `S` defined here
+  --> $DIR/tuple-struct-alias.rs:1:1
+   |
+LL | struct S(u8, u16);
+   | ^^^^^^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL -     let s = A(0, 1);

--- a/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
+++ b/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
@@ -49,10 +49,12 @@ error[E0425]: cannot find value `bah` in this scope
    |
 LL |         bah;
    |         ^^^
-...
-LL | fn ba() {}
-   | ------- similarly named function `ba` defined here
    |
+note: similarly named function `ba` defined here
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:42:1
+   |
+LL | fn ba() {}
+   | ^^^^^^^
 help: you might have meant to refer to the associated function
    |
 LL |         Self::bah;
@@ -68,10 +70,12 @@ error[E0425]: cannot find value `BAR` in this scope
    |
 LL |         BAR;
    |         ^^^
-...
-LL | const BARR: u32 = 3;
-   | -------------------- similarly named constant `BARR` defined here
    |
+note: similarly named constant `BARR` defined here
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:43:1
+   |
+LL | const BARR: u32 = 3;
+   | ^^^^^^^^^^^^^^^^^^^^
 help: you might have meant to use the associated `const`
    |
 LL |         Self::BAR;
@@ -86,10 +90,12 @@ error[E0425]: cannot find type `Baz` in this scope
    |
 LL |         let foo: Baz = "".to_string();
    |                  ^^^
-...
-LL | type Bar = String;
-   | ------------------ similarly named type alias `Bar` defined here
    |
+note: similarly named type alias `Bar` defined here
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:44:1
+   |
+LL | type Bar = String;
+   | ^^^^^^^^^^^^^^^^^^
 help: you might have meant to use the associated type
    |
 LL |         let foo: Self::Baz = "".to_string();
@@ -105,10 +111,12 @@ error[E0425]: cannot find function `baz` in this scope
    |
 LL |         baz();
    |         ^^^
-...
-LL | fn ba() {}
-   | ------- similarly named function `ba` defined here
    |
+note: similarly named function `ba` defined here
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:42:1
+   |
+LL | fn ba() {}
+   | ^^^^^^^
 help: you might have meant to call the method
    |
 LL |         self.baz();

--- a/tests/ui/span/suggestion-raw-68962.stderr
+++ b/tests/ui/span/suggestion-raw-68962.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `fina` in this scope
   --> $DIR/suggestion-raw-68962.rs:7:5
    |
 LL |     fina;
-   |     ^^^^
+   |     ^^^^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -13,12 +13,14 @@ LL +     r#final;
 error[E0425]: cannot find function `f` in this scope
   --> $DIR/suggestion-raw-68962.rs:10:5
    |
-LL | fn r#fn() {}
-   | --------- similarly named function `r#fn` defined here
-...
 LL |     f();
-   |     ^
+   |     ^ not found in this scope
    |
+note: similarly named function `r#fn` defined here
+  --> $DIR/suggestion-raw-68962.rs:1:1
+   |
+LL | fn r#fn() {}
+   | ^^^^^^^^^
 help: a function with a similar name exists
    |
 LL -     f();

--- a/tests/ui/span/typo-suggestion.stderr
+++ b/tests/ui/span/typo-suggestion.stderr
@@ -8,7 +8,7 @@ error[E0425]: cannot find value `fob` in this scope
   --> $DIR/typo-suggestion.rs:8:26
    |
 LL |     println!("Hello {}", fob);
-   |                          ^^^
+   |                          ^^^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/stability-attribute/issue-109177.stderr
+++ b/tests/ui/stability-attribute/issue-109177.stderr
@@ -2,13 +2,13 @@ error[E0425]: cannot find function `foo1` in crate `similar_unstable_method`
   --> $DIR/issue-109177.rs:7:30
    |
 LL |     similar_unstable_method::foo1();
-   |                              ^^^^
+   |                              ^^^^ not found in `similar_unstable_method`
    |
-  ::: $DIR/auxiliary/similar-unstable-method.rs:5:1
+note: similarly named function `foo` defined here
+  --> $DIR/auxiliary/similar-unstable-method.rs:5:1
    |
 LL | pub fn foo() {}
-   | ------------ similarly named function `foo` defined here
-   |
+   | ^^^^^^^^^^^^
 help: a function with a similar name exists
    |
 LL -     similar_unstable_method::foo1();

--- a/tests/ui/structs/struct-fields-shorthand-unresolved.stderr
+++ b/tests/ui/structs/struct-fields-shorthand-unresolved.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/struct-fields-shorthand-unresolved.rs:10:9
    |
 LL |         y
-   |         ^
+   |         ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/suggestions/attribute-typos.stderr
+++ b/tests/ui/suggestions/attribute-typos.stderr
@@ -33,9 +33,8 @@ error: cannot find attribute `tests` in this scope
 LL | #[tests]
    |   ^^^^^
    |
+note: similarly named attribute macro `test` defined here
   --> $SRC_DIR/core/src/macros/mod.rs:LL:COL
-   |
-   = note: similarly named attribute macro `test` defined here
 help: an attribute macro with a similar name exists
    |
 LL - #[tests]

--- a/tests/ui/suggestions/case-difference-suggestions.stderr
+++ b/tests/ui/suggestions/case-difference-suggestions.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `Hello` in this scope
   --> $DIR/case-difference-suggestions.rs:5:20
    |
 LL |     println!("{}", Hello);
-   |                    ^^^^^
+   |                    ^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -14,7 +14,7 @@ error[E0425]: cannot find value `myvariable` in this scope
   --> $DIR/case-difference-suggestions.rs:9:20
    |
 LL |     println!("{}", myvariable);
-   |                    ^^^^^^^^^^
+   |                    ^^^^^^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the capitalization)
    |
@@ -26,7 +26,7 @@ error[E0425]: cannot find value `User_Name` in this scope
   --> $DIR/case-difference-suggestions.rs:13:20
    |
 LL |     println!("{}", User_Name);
-   |                    ^^^^^^^^^
+   |                    ^^^^^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -38,7 +38,7 @@ error[E0425]: cannot find value `foo` in this scope
   --> $DIR/case-difference-suggestions.rs:17:20
    |
 LL |     println!("{}", foo);
-   |                    ^^^
+   |                    ^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the capitalization)
    |
@@ -50,7 +50,7 @@ error[E0425]: cannot find value `FFOO` in this scope
   --> $DIR/case-difference-suggestions.rs:22:20
    |
 LL |     println!("{}", FFOO);
-   |                    ^^^^
+   |                    ^^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -62,7 +62,7 @@ error[E0425]: cannot find value `list` in this scope
   --> $DIR/case-difference-suggestions.rs:25:20
    |
 LL |     println!("{}", list);
-   |                    ^^^^
+   |                    ^^^^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -74,7 +74,7 @@ error[E0425]: cannot find value `SS` in this scope
   --> $DIR/case-difference-suggestions.rs:28:20
    |
 LL |     println!("{}", SS);
-   |                    ^^
+   |                    ^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -86,7 +86,7 @@ error[E0425]: cannot find value `a55` in this scope
   --> $DIR/case-difference-suggestions.rs:31:20
    |
 LL |     println!("{}", a55);
-   |                    ^^^
+   |                    ^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -98,7 +98,7 @@ error[E0425]: cannot find value `BB` in this scope
   --> $DIR/case-difference-suggestions.rs:34:20
    |
 LL |     println!("{}", BB);
-   |                    ^^
+   |                    ^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -110,7 +110,7 @@ error[E0425]: cannot find value `gg` in this scope
   --> $DIR/case-difference-suggestions.rs:37:20
    |
 LL |     println!("{}", gg);
-   |                    ^^
+   |                    ^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -122,7 +122,7 @@ error[E0425]: cannot find value `old` in this scope
   --> $DIR/case-difference-suggestions.rs:40:20
    |
 LL |     println!("{}", old);
-   |                    ^^^
+   |                    ^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -134,7 +134,7 @@ error[E0425]: cannot find value `newl` in this scope
   --> $DIR/case-difference-suggestions.rs:43:20
    |
 LL |     println!("{}", newl);
-   |                    ^^^^
+   |                    ^^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -146,7 +146,7 @@ error[E0425]: cannot find value `app1e` in this scope
   --> $DIR/case-difference-suggestions.rs:46:20
    |
 LL |     println!("{}", app1e);
-   |                    ^^^^^
+   |                    ^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -158,7 +158,7 @@ error[E0425]: cannot find value `A` in this scope
   --> $DIR/case-difference-suggestions.rs:49:20
    |
 LL |     println!("{}", A);
-   |                    ^
+   |                    ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -170,7 +170,7 @@ error[E0425]: cannot find value `world1U` in this scope
   --> $DIR/case-difference-suggestions.rs:52:20
    |
 LL |     println!("{}", world1U);
-   |                    ^^^^^^^
+   |                    ^^^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the capitalization and digit/letter confusion)
    |
@@ -182,7 +182,7 @@ error[E0425]: cannot find value `myv4r1able` in this scope
   --> $DIR/case-difference-suggestions.rs:55:20
    |
 LL |     println!("{}", myv4r1able);
-   |                    ^^^^^^^^^^
+   |                    ^^^^^^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the capitalization and digit/letter confusion)
    |

--- a/tests/ui/suggestions/do-not-attempt-to-add-suggestions-with-no-changes.stderr
+++ b/tests/ui/suggestions/do-not-attempt-to-add-suggestions-with-no-changes.stderr
@@ -2,11 +2,10 @@ error[E0573]: expected type, found module `result`
   --> $DIR/do-not-attempt-to-add-suggestions-with-no-changes.rs:3:6
    |
 LL | impl result {
-   |      ^^^^^^
+   |      ^^^^^^ not a type
    |
+note: similarly named enum `Result` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named enum `Result` defined here
 help: an enum with a similar name exists
    |
 LL - impl result {

--- a/tests/ui/suggestions/issue-66968-suggest-sorted-words.stderr
+++ b/tests/ui/suggestions/issue-66968-suggest-sorted-words.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `a_variable_longer_name` in this scope
   --> $DIR/issue-66968-suggest-sorted-words.rs:3:20
    |
 LL |     println!("{}", a_variable_longer_name);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
@@ -63,17 +63,24 @@ LL |     let x: bar;
 error[E0573]: cannot find type `x` in this scope
   --> $DIR/let-binding-init-expr-as-ty.rs:40:12
    |
-LL | struct K(S::new(()));
-   | --------------------- similarly named struct `K` defined here
-...
 LL |     let x: x;
-   |            ^
+   |            ^ not found in this scope
    |
    = note: a local variable named `x` exists in another namespace
+note: similarly named struct `K` defined here
+  --> $DIR/let-binding-init-expr-as-ty.rs:18:1
+   |
+LL | struct K(S::new(()));
+   | ^^^^^^^^^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL -     let x: x;
 LL +     let x: K;
+   |
+help: use `=` if you meant to assign
+   |
+LL -     let x: x;
+LL +     let x = x;
    |
 
 error[E0658]: return type notation is experimental

--- a/tests/ui/suggestions/silenced-binding-typo.stderr
+++ b/tests/ui/suggestions/silenced-binding-typo.stderr
@@ -1,11 +1,14 @@
 error[E0425]: cannot find value `x` in this scope
   --> $DIR/silenced-binding-typo.rs:4:14
    |
-LL |     let _x = 42;
-   |         -- `_x` defined here
 LL |     let _y = x;
-   |              ^
+   |              ^ not found in this scope
    |
+note: `_x` defined here
+  --> $DIR/silenced-binding-typo.rs:3:9
+   |
+LL |     let _x = 42;
+   |         ^^
 help: the leading underscore in `_x` marks it as unused, consider renaming it to `x`
    |
 LL -     let _x = 42;

--- a/tests/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
+++ b/tests/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
@@ -4,9 +4,8 @@ error[E0404]: expected trait, found struct `String`
 LL | struct Foo<T> where T: Bar, <T as Bar>::Baz: String {
    |                                              ^^^^^^ not a trait
    |
+note: similarly named trait `ToString` defined here
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
-   |
-   = note: similarly named trait `ToString` defined here
 help: constrain the associated type to `String`
    |
 LL - struct Foo<T> where T: Bar, <T as Bar>::Baz: String {
@@ -23,9 +22,8 @@ error[E0404]: expected trait, found struct `String`
 LL | struct Qux<'a, T> where T: Bar, <&'a T as Bar>::Baz: String {
    |                                                      ^^^^^^ not a trait
    |
+note: similarly named trait `ToString` defined here
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
-   |
-   = note: similarly named trait `ToString` defined here
 help: constrain the associated type to `String`
    |
 LL - struct Qux<'a, T> where T: Bar, <&'a T as Bar>::Baz: String {
@@ -42,9 +40,8 @@ error[E0404]: expected trait, found struct `String`
 LL | fn foo<T: Bar>(_: T) where <T as Bar>::Baz: String {
    |                                             ^^^^^^ not a trait
    |
+note: similarly named trait `ToString` defined here
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
-   |
-   = note: similarly named trait `ToString` defined here
 help: constrain the associated type to `String`
    |
 LL - fn foo<T: Bar>(_: T) where <T as Bar>::Baz: String {
@@ -61,9 +58,8 @@ error[E0404]: expected trait, found struct `String`
 LL | fn qux<'a, T: Bar>(_: &'a T) where <&'a T as Bar>::Baz: String {
    |                                                         ^^^^^^ not a trait
    |
+note: similarly named trait `ToString` defined here
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
-   |
-   = note: similarly named trait `ToString` defined here
 help: constrain the associated type to `String`
    |
 LL - fn qux<'a, T: Bar>(_: &'a T) where <&'a T as Bar>::Baz: String {
@@ -84,11 +80,10 @@ error[E0404]: expected trait, found struct `String`
   --> $DIR/assoc_type_bound_with_struct.rs:19:51
    |
 LL | fn issue_95327() where <u8 as Unresolved>::Assoc: String {}
-   |                                                   ^^^^^^
+   |                                                   ^^^^^^ not a trait
    |
+note: similarly named trait `ToString` defined here
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
-   |
-   = note: similarly named trait `ToString` defined here
 help: a trait with a similar name exists
    |
 LL | fn issue_95327() where <u8 as Unresolved>::Assoc: ToString {}

--- a/tests/ui/traits/bound/not-on-struct.stderr
+++ b/tests/ui/traits/bound/not-on-struct.stderr
@@ -147,8 +147,6 @@ LL + fn f<'a,T,E>(iter: Iterator<Item=Result<T,E>>) {
 error[E0404]: expected trait, found struct `Traitor`
   --> $DIR/not-on-struct.rs:36:11
    |
-LL | trait Trait {}
-   | ----------- similarly named trait `Trait` defined here
 LL | fn g() -> Traitor + 'static {
    |           ^^^^^^^ not a trait
    |
@@ -159,6 +157,11 @@ LL | fn g() -> Traitor + 'static {
    |           -------   ^^^^^^^ ...because of this bound
    |           |
    |           expected this type to be a trait...
+note: similarly named trait `Trait` defined here
+  --> $DIR/not-on-struct.rs:35:1
+   |
+LL | trait Trait {}
+   | ^^^^^^^^^^^
 help: if you meant to use a type and not a trait here, remove the bounds
    |
 LL - fn g() -> Traitor + 'static {

--- a/tests/ui/traits/const-traits/ice-120503-async-const-method.stderr
+++ b/tests/ui/traits/const-traits/ice-120503-async-const-method.stderr
@@ -44,11 +44,13 @@ error[E0425]: cannot find function `main8` in this scope
   --> $DIR/ice-120503-async-const-method.rs:11:9
    |
 LL |         main8().await;
-   |         ^^^^^
-...
-LL | fn main() {}
-   | --------- similarly named function `main` defined here
+   |         ^^^^^ not found in this scope
    |
+note: similarly named function `main` defined here
+  --> $DIR/ice-120503-async-const-method.rs:16:1
+   |
+LL | fn main() {}
+   | ^^^^^^^^^
 help: a function with a similar name exists
    |
 LL -         main8().await;

--- a/tests/ui/traits/const-traits/mismatched_generic_args.stderr
+++ b/tests/ui/traits/const-traits/mismatched_generic_args.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find value `y` in this scope
   --> $DIR/mismatched_generic_args.rs:19:9
    |
-LL | pub fn add<const U: Dimension>(x: Quantity<f32, U>) -> Quantity<f32, U> {
-   |                  - similarly named const parameter `U` defined here
-LL |
 LL |     x + y
-   |         ^
+   |         ^ not found in this scope
    |
+note: similarly named const parameter `U` defined here
+  --> $DIR/mismatched_generic_args.rs:17:18
+   |
+LL | pub fn add<const U: Dimension>(x: Quantity<f32, U>) -> Quantity<f32, U> {
+   |                  ^
 help: a const parameter with a similar name exists
    |
 LL -     x + y

--- a/tests/ui/traits/impl-for-module.stderr
+++ b/tests/ui/traits/impl-for-module.stderr
@@ -1,12 +1,14 @@
 error[E0573]: expected type, found module `a`
   --> $DIR/impl-for-module.rs:7:12
    |
-LL | trait A {
-   | ------- similarly named trait `A` defined here
-...
 LL | impl A for a {
-   |            ^
+   |            ^ not a type
    |
+note: similarly named trait `A` defined here
+  --> $DIR/impl-for-module.rs:4:1
+   |
+LL | trait A {
+   | ^^^^^^^
 help: a trait with a similar name exists
    |
 LL - impl A for a {

--- a/tests/ui/traits/issue-50480.stderr
+++ b/tests/ui/traits/issue-50480.stderr
@@ -41,10 +41,13 @@ error[E0425]: cannot find type `N` in this scope
   --> $DIR/issue-50480.rs:12:18
    |
 LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
-   |            -     ^
-   |            |
-   |            similarly named type parameter `T` defined here
+   |                  ^ not found in this scope
    |
+note: similarly named type parameter `T` defined here
+  --> $DIR/issue-50480.rs:12:12
+   |
+LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
+   |            ^
 help: a type parameter with a similar name exists
    |
 LL - struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);

--- a/tests/ui/traits/issue-78372.stderr
+++ b/tests/ui/traits/issue-78372.stderr
@@ -13,10 +13,13 @@ error[E0425]: cannot find type `U` in this scope
   --> $DIR/issue-78372.rs:3:31
    |
 LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}
-   |      -                        ^
-   |      |
-   |      similarly named type parameter `T` defined here
+   |                               ^ not found in this scope
    |
+note: similarly named type parameter `T` defined here
+  --> $DIR/issue-78372.rs:3:6
+   |
+LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}
+   |      ^
 help: a type parameter with a similar name exists
    |
 LL - impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}

--- a/tests/ui/traits/late-bound-type-method-probe.stderr
+++ b/tests/ui/traits/late-bound-type-method-probe.stderr
@@ -2,11 +2,10 @@ error[E0425]: cannot find type `F` in this scope
   --> $DIR/late-bound-type-method-probe.rs:8:26
    |
 LL |     fn t<Tail>(&self, _: F) {}
-   |                          ^
+   |                          ^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL |     fn t<Tail>(&self, _: Fn) {}

--- a/tests/ui/type-alias-impl-trait/type-error-drop-elaboration.stderr
+++ b/tests/ui/type-alias-impl-trait/type-error-drop-elaboration.stderr
@@ -2,11 +2,13 @@ error[E0425]: cannot find function `value` in this scope
   --> $DIR/type-error-drop-elaboration.rs:12:5
    |
 LL |     value()
-   |     ^^^^^
-...
-LL | const VALUE: Foo = foo();
-   | ------------------------- similarly named constant `VALUE` defined here
+   |     ^^^^^ not found in this scope
    |
+note: similarly named constant `VALUE` defined here
+  --> $DIR/type-error-drop-elaboration.rs:16:1
+   |
+LL | const VALUE: Foo = foo();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists
    |
 LL -     value()

--- a/tests/ui/type/issue-7607-1.stderr
+++ b/tests/ui/type/issue-7607-1.stderr
@@ -2,11 +2,10 @@ error[E0425]: cannot find type `Fo` in this scope
   --> $DIR/issue-7607-1.rs:5:6
    |
 LL | impl Fo {
-   |      ^^
+   |      ^^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL - impl Fo {

--- a/tests/ui/typeck/issue-114423-ice-regression-in-suggestion.stderr
+++ b/tests/ui/typeck/issue-114423-ice-regression-in-suggestion.stderr
@@ -14,7 +14,7 @@ error[E0425]: cannot find value `g` in this scope
   --> $DIR/issue-114423-ice-regression-in-suggestion.rs:11:22
    |
 LL |     let _ = RGB { r, g, b };
-   |                      ^
+   |                      ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/typeck/issue-83693.stderr
+++ b/tests/ui/typeck/issue-83693.stderr
@@ -2,11 +2,10 @@ error[E0425]: cannot find type `F` in this scope
   --> $DIR/issue-83693.rs:6:6
    |
 LL | impl F {
-   |      ^
+   |      ^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL | impl Fn {

--- a/tests/ui/typeck/issue-88844.rs
+++ b/tests/ui/typeck/issue-88844.rs
@@ -5,6 +5,7 @@ struct Struct { value: i32 }
 
 impl Stuct {
 //~^ ERROR: cannot find type `Stuct` in this scope [E0425]
+//~| NOTE not found in this scope
 //~| HELP: a struct with a similar name exists
     fn new() -> Self {
         Self { value: 42 }

--- a/tests/ui/typeck/issue-88844.stderr
+++ b/tests/ui/typeck/issue-88844.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find type `Stuct` in this scope
   --> $DIR/issue-88844.rs:6:6
    |
-LL | struct Struct { value: i32 }
-   | ------------- similarly named struct `Struct` defined here
-...
 LL | impl Stuct {
-   |      ^^^^^
+   |      ^^^^^ not found in this scope
    |
+note: similarly named struct `Struct` defined here
+  --> $DIR/issue-88844.rs:3:1
+   |
+LL | struct Struct { value: i32 }
+   | ^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL | impl Struct {

--- a/tests/ui/ufcs/ufcs-partially-resolved.stderr
+++ b/tests/ui/ufcs/ufcs-partially-resolved.stderr
@@ -1,13 +1,25 @@
 error[E0576]: cannot find associated type `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:19:24
    |
-LL |     type Y = u16;
-   |     ------------- similarly named associated type `Y` defined here
-...
 LL |     let _: <u8 as Tr>::N;
-   |                        ^
+   |                        ^ not found in `Tr`
    |
+note: similarly named associated type `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:4:5
+   |
+LL |     type Y = u16;
+   |     ^^^^^^^^^^^^^
+note: associated type `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:4:5
+   |
+LL |     type Y = u16;
+   |     ^^^^^^^^^^^^^
 help: an associated type with a similar name exists
+   |
+LL -     let _: <u8 as Tr>::N;
+LL +     let _: <u8 as Tr>::Y;
+   |
+help: maybe you meant this associated type
    |
 LL -     let _: <u8 as Tr>::N;
 LL +     let _: <u8 as Tr>::Y;
@@ -17,11 +29,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:20:19
    |
 LL |     let _: <u8 as E>::N;
-   |                   ^
+   |                   ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     let _: <u8 as Eq>::N;
@@ -42,13 +53,25 @@ LL + trait A = u32;
 error[E0576]: cannot find method or associated constant `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:22:17
    |
-LL |     fn Y() {}
-   |     ------ similarly named associated function `Y` defined here
-...
 LL |     <u8 as Tr>::N;
-   |                 ^
+   |                 ^ not found in `Tr`
    |
+note: similarly named associated function `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:5:5
+   |
+LL |     fn Y() {}
+   |     ^^^^^^
+note: associated function `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:5:5
+   |
+LL |     fn Y() {}
+   |     ^^^^^^
 help: an associated function with a similar name exists
+   |
+LL -     <u8 as Tr>::N;
+LL +     <u8 as Tr>::Y;
+   |
+help: maybe you meant this associated function
    |
 LL -     <u8 as Tr>::N;
 LL +     <u8 as Tr>::Y;
@@ -58,11 +81,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:23:12
    |
 LL |     <u8 as E>::N;
-   |            ^
+   |            ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     <u8 as Eq>::N;
@@ -84,11 +106,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:26:19
    |
 LL |     let _: <u8 as E>::Y;
-   |                   ^
+   |                   ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     let _: <u8 as Eq>::Y;
@@ -98,11 +119,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:28:12
    |
 LL |     <u8 as E>::Y;
-   |            ^
+   |            ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     <u8 as Eq>::Y;
@@ -111,13 +131,25 @@ LL |     <u8 as Eq>::Y;
 error[E0576]: cannot find associated type `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:30:24
    |
-LL |     type Y = u16;
-   |     ------------- similarly named associated type `Y` defined here
-...
 LL |     let _: <u8 as Tr>::N::NN;
-   |                        ^
+   |                        ^ not found in `Tr`
    |
+note: similarly named associated type `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:4:5
+   |
+LL |     type Y = u16;
+   |     ^^^^^^^^^^^^^
+note: associated type `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:4:5
+   |
+LL |     type Y = u16;
+   |     ^^^^^^^^^^^^^
 help: an associated type with a similar name exists
+   |
+LL -     let _: <u8 as Tr>::N::NN;
+LL +     let _: <u8 as Tr>::Y::NN;
+   |
+help: maybe you meant this associated type
    |
 LL -     let _: <u8 as Tr>::N::NN;
 LL +     let _: <u8 as Tr>::Y::NN;
@@ -127,11 +159,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:31:19
    |
 LL |     let _: <u8 as E>::N::NN;
-   |                   ^
+   |                   ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     let _: <u8 as Eq>::N::NN;
@@ -152,13 +183,25 @@ LL + trait A = u32;
 error[E0576]: cannot find associated type `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:33:17
    |
-LL |     type Y = u16;
-   |     ------------- similarly named associated type `Y` defined here
-...
 LL |     <u8 as Tr>::N::NN;
-   |                 ^
+   |                 ^ not found in `Tr`
    |
+note: similarly named associated type `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:4:5
+   |
+LL |     type Y = u16;
+   |     ^^^^^^^^^^^^^
+note: associated type `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:4:5
+   |
+LL |     type Y = u16;
+   |     ^^^^^^^^^^^^^
 help: an associated type with a similar name exists
+   |
+LL -     <u8 as Tr>::N::NN;
+LL +     <u8 as Tr>::Y::NN;
+   |
+help: maybe you meant this associated type
    |
 LL -     <u8 as Tr>::N::NN;
 LL +     <u8 as Tr>::Y::NN;
@@ -168,11 +211,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:34:12
    |
 LL |     <u8 as E>::N::NN;
-   |            ^
+   |            ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     <u8 as Eq>::N::NN;
@@ -194,11 +236,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:37:19
    |
 LL |     let _: <u8 as E>::Y::NN;
-   |                   ^
+   |                   ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     let _: <u8 as Eq>::Y::NN;
@@ -208,11 +249,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:39:12
    |
 LL |     <u8 as E>::Y::NN;
-   |            ^
+   |            ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     <u8 as Eq>::Y::NN;
@@ -281,14 +321,26 @@ LL |     <u8 as E::Y>::NN;
 error[E0575]: cannot find associated type `Z` in trait `Dr`
   --> $DIR/ufcs-partially-resolved.rs:52:24
    |
-LL |     type X = u16;
-   |     ------------- similarly named associated type `X` defined here
-...
 LL |     let _: <u8 as Dr>::Z;
-   |                        ^
+   |                        ^ not found in `Dr`
    |
    = note: an associated function named `Dr::Z` exists in another namespace
+note: similarly named associated type `X` defined here
+  --> $DIR/ufcs-partially-resolved.rs:10:5
+   |
+LL |     type X = u16;
+   |     ^^^^^^^^^^^^^
+note: associated type `X` defined here
+  --> $DIR/ufcs-partially-resolved.rs:10:5
+   |
+LL |     type X = u16;
+   |     ^^^^^^^^^^^^^
 help: an associated type with a similar name exists
+   |
+LL -     let _: <u8 as Dr>::Z;
+LL +     let _: <u8 as Dr>::X;
+   |
+help: maybe you meant this associated type
    |
 LL -     let _: <u8 as Dr>::Z;
 LL +     let _: <u8 as Dr>::X;
@@ -297,14 +349,26 @@ LL +     let _: <u8 as Dr>::X;
 error[E0575]: cannot find method or associated constant `X` in trait `Dr`
   --> $DIR/ufcs-partially-resolved.rs:53:17
    |
-LL |     fn Z() {}
-   |     ------ similarly named associated function `Z` defined here
-...
 LL |     <u8 as Dr>::X;
-   |                 ^
+   |                 ^ not found in `Dr`
    |
    = note: an associated type named `Dr::X` exists in another namespace
+note: similarly named associated function `Z` defined here
+  --> $DIR/ufcs-partially-resolved.rs:11:5
+   |
+LL |     fn Z() {}
+   |     ^^^^^^
+note: associated function `Z` defined here
+  --> $DIR/ufcs-partially-resolved.rs:11:5
+   |
+LL |     fn Z() {}
+   |     ^^^^^^
 help: an associated function with a similar name exists
+   |
+LL -     <u8 as Dr>::X;
+LL +     <u8 as Dr>::Z;
+   |
+help: maybe you meant this associated function
    |
 LL -     <u8 as Dr>::X;
 LL +     <u8 as Dr>::Z;
@@ -313,14 +377,26 @@ LL +     <u8 as Dr>::Z;
 error[E0575]: cannot find associated type `Z` in trait `Dr`
   --> $DIR/ufcs-partially-resolved.rs:54:24
    |
-LL |     type X = u16;
-   |     ------------- similarly named associated type `X` defined here
-...
 LL |     let _: <u8 as Dr>::Z::N;
-   |                        ^
+   |                        ^ not found in `Dr`
    |
    = note: an associated function named `Dr::Z` exists in another namespace
+note: similarly named associated type `X` defined here
+  --> $DIR/ufcs-partially-resolved.rs:10:5
+   |
+LL |     type X = u16;
+   |     ^^^^^^^^^^^^^
+note: associated type `X` defined here
+  --> $DIR/ufcs-partially-resolved.rs:10:5
+   |
+LL |     type X = u16;
+   |     ^^^^^^^^^^^^^
 help: an associated type with a similar name exists
+   |
+LL -     let _: <u8 as Dr>::Z::N;
+LL +     let _: <u8 as Dr>::X::N;
+   |
+help: maybe you meant this associated type
    |
 LL -     let _: <u8 as Dr>::Z::N;
 LL +     let _: <u8 as Dr>::X::N;

--- a/tests/ui/unboxed-closures/unboxed-closures-type-mismatch-closure-from-another-scope.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-type-mismatch-closure-from-another-scope.stderr
@@ -8,7 +8,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/unboxed-closures-type-mismatch-closure-from-another-scope.rs:9:26
    |
 LL |         closure(&mut p, &y);
-   |                          ^
+   |                          ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/variants/variant-result-noresult-used-as-type.stderr
+++ b/tests/ui/variants/variant-result-noresult-used-as-type.stderr
@@ -2,11 +2,10 @@ error[E0573]: expected type, found variant `NoResult`
   --> $DIR/variant-result-noresult-used-as-type.rs:16:17
    |
 LL |     fn new() -> NoResult<MyEnum, String> {
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ not a type
    |
+note: similarly named enum `Result` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named enum `Result` defined here
 help: try using the variant's enum
    |
 LL -     fn new() -> NoResult<MyEnum, String> {
@@ -56,11 +55,10 @@ error[E0573]: expected type, found variant `NoResult`
   --> $DIR/variant-result-noresult-used-as-type.rs:37:15
    |
 LL | fn newer() -> NoResult<foo::MyEnum, String> {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a type
    |
+note: similarly named enum `Result` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named enum `Result` defined here
 help: try using the variant's enum
    |
 LL - fn newer() -> NoResult<foo::MyEnum, String> {


### PR DESCRIPTION
This was also swallowing labels from `diagnostic:on_unknown`; a typo suggestion would override it.