### PR TITLE
Fix swapped documentation lines on `io::Read`

### DIFF
--- a/library/alloc/src/io/read.rs
+++ b/library/alloc/src/io/read.rs
@@ -22,8 +22,8 @@ use crate::vec::Vec;
 /// trait.
 ///
 /// Please note that each call to [`read()`] may involve a system call, and
-/// `BufReader`, will be more efficient.
 /// therefore, using something that implements [`BufRead`], such as
+/// `BufReader`, will be more efficient.
 ///
 /// [`BufRead`]: crate::io::BufRead
 ///


### PR DESCRIPTION
<!-- homu-ignore:start -->

- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.

<!--
Please read our [LLM policy] before opening a PR,
and check one of the boxes above to indicate whether you've used an LLM.
If you do not check a box, a reviewer may ask you whether an LLM was involved.
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
While reading the documentation for the `std::io::Read` trait, I noticed some wording out of order:
> Please note that each call to [read()](https://doc.rust-lang.org/nightly/std/io/trait.Read.html#method.read) may involve a system call, and BufReader, will be more efficient. therefore, using something that implements [BufRead](https://doc.rust-lang.org/nightly/std/io/trait.BufRead.html), such as

It looks like rust-lang/rust#158546 accidentally swapped two lines when inserting an intra-doc link; this PR swaps them back.