### PR TITLE
Implement missing TrustedLen for core and alloc types

### DIFF
--- a/library/alloc/src/boxed/iter.rs
+++ b/library/alloc/src/boxed/iter.rs
@@ -77,6 +77,9 @@ impl<I: ExactSizeIterator + ?Sized, A: Allocator> ExactSizeIterator for Box<I, A
     }
 }
 
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl<I: TrustedLen + ?Sized, A: Allocator> TrustedLen for Box<I, A> {}
+
 #[stable(feature = "fused", since = "1.26.0")]
 impl<I: FusedIterator + ?Sized, A: Allocator> FusedIterator for Box<I, A> {}
 

--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -1666,6 +1666,9 @@ impl<T> ExactSizeIterator for Iter<'_, T> {
     }
 }
 
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl<T> TrustedLen for Iter<'_, T> {}
+
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for Iter<'_, T> {}
 
@@ -1728,6 +1731,9 @@ impl<T, A: Allocator> ExactSizeIterator for IntoIter<T, A> {
         self.iter.is_empty()
     }
 }
+
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl<T, A: Allocator> TrustedLen for IntoIter<T, A> {}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T, A: Allocator> FusedIterator for IntoIter<T, A> {}
@@ -1875,6 +1881,9 @@ impl<T, A: Allocator> ExactSizeIterator for Drain<'_, T, A> {
         self.iter.is_empty()
     }
 }
+
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl<T, A: Allocator> TrustedLen for Drain<'_, T, A> {}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T, A: Allocator> FusedIterator for Drain<'_, T, A> {}

--- a/library/alloc/src/collections/vec_deque/drain.rs
+++ b/library/alloc/src/collections/vec_deque/drain.rs
@@ -1,4 +1,4 @@
-use core::iter::FusedIterator;
+use core::iter::{FusedIterator, TrustedLen};
 use core::marker::PhantomData;
 use core::mem::{self, SizedTypeProperties};
 use core::ptr::NonNull;
@@ -270,6 +270,9 @@ impl<T, A: Allocator> DoubleEndedIterator for Drain<'_, T, A> {
 
 #[stable(feature = "drain", since = "1.6.0")]
 impl<T, A: Allocator> ExactSizeIterator for Drain<'_, T, A> {}
+
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl<T, A: Allocator> TrustedLen for Drain<'_, T, A> {}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T, A: Allocator> FusedIterator for Drain<'_, T, A> {}

--- a/library/alloc/src/collections/vec_deque/splice.rs
+++ b/library/alloc/src/collections/vec_deque/splice.rs
@@ -1,4 +1,5 @@
 use core::alloc::Allocator;
+use core::iter::TrustedLen;
 
 use crate::alloc::Global;
 use crate::collections::vec_deque::Drain;
@@ -52,6 +53,9 @@ impl<I: Iterator, A: Allocator> DoubleEndedIterator for Splice<'_, I, A> {
 
 #[unstable(feature = "deque_extend_front", issue = "146975")]
 impl<I: Iterator, A: Allocator> ExactSizeIterator for Splice<'_, I, A> {}
+
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl<I: Iterator, A: Allocator> TrustedLen for Splice<'_, I, A> {}
 
 // See also: [`crate::vec::Splice`].
 #[unstable(feature = "deque_extend_front", issue = "146975")]

--- a/library/alloc/src/vec/splice.rs
+++ b/library/alloc/src/vec/splice.rs
@@ -1,3 +1,4 @@
+use core::iter::TrustedLen;
 use core::ptr;
 
 use super::{Drain, Vec};
@@ -48,6 +49,9 @@ impl<I: Iterator, A: Allocator> DoubleEndedIterator for Splice<'_, I, A> {
 
 #[stable(feature = "vec_splice", since = "1.21.0")]
 impl<I: Iterator, A: Allocator> ExactSizeIterator for Splice<'_, I, A> {}
+
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl<I: Iterator, A: Allocator> TrustedLen for Splice<'_, I, A> {}
 
 // See also: [`crate::collections::vec_deque::Splice`].
 #[stable(feature = "vec_splice", since = "1.21.0")]

--- a/library/core/src/ascii.rs
+++ b/library/core/src/ascii.rs
@@ -11,7 +11,7 @@
 
 use crate::escape::{AlwaysEscaped, EscapeIterInner};
 use crate::fmt;
-use crate::iter::FusedIterator;
+use crate::iter::{FusedIterator, TrustedLen};
 use crate::num::NonZero;
 
 mod ascii_char;
@@ -158,6 +158,9 @@ impl ExactSizeIterator for EscapeDefault {
         self.0.len()
     }
 }
+
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl TrustedLen for EscapeDefault {}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl FusedIterator for EscapeDefault {}

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -212,6 +212,9 @@ impl ExactSizeIterator for EscapeUnicode {
     }
 }
 
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl TrustedLen for EscapeUnicode {}
+
 #[stable(feature = "fused", since = "1.26.0")]
 impl FusedIterator for EscapeUnicode {}
 
@@ -288,6 +291,9 @@ impl ExactSizeIterator for EscapeDefault {
     }
 }
 
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl TrustedLen for EscapeDefault {}
+
 #[stable(feature = "fused", since = "1.26.0")]
 impl FusedIterator for EscapeDefault {}
 
@@ -353,6 +359,9 @@ impl ExactSizeIterator for EscapeDebug {
         self.0.len()
     }
 }
+
+#[unstable(feature = "trusted_len", issue = "37572")]
+unsafe impl TrustedLen for EscapeDebug {}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl FusedIterator for EscapeDebug {}


### PR DESCRIPTION
While working on https://github.com/rust-lang/rust/pull/160813 I noticed TrustedLen is missing for the LinkedList, I suspected that other modules are missing the implementation too, so I wrote a small script to scan the project and found these candidates which implement ExactSizeIterator but not the TrustedLen, Reviewed the code just to make sure they are actually meet TrustedLen requirement and then I've added missing implementations.

While editting I found out there are instances of FusedIterator missing too, ~~So I've added them too~~.

I think most important missing one is the `impl<I: TrustedLen + ?Sized, A: Allocator> TrustedLen for Box<I, A>` which inherits `TrustedLen` for a `Box` to a `TrustedLen` implementer.

I did this only for `core` and `alloc`, I ignored script reports for the `std` but I think it worth looking into, specially for the `HashMap`:
```
FusedIterator::missing CommandArgs in library/std/src/process.rs
TrustedLen::missing CommandArgs in library/std/src/process.rs
FusedIterator::missing CommandEnvs in library/std/src/process.rs
TrustedLen::missing CommandEnvs in library/std/src/process.rs
FusedIterator::missing Args in library/std/src/env.rs
TrustedLen::missing Args in library/std/src/env.rs
FusedIterator::missing ArgsOs in library/std/src/env.rs
TrustedLen::missing ArgsOs in library/std/src/env.rs
TrustedLen::missing Iter in library/std/src/collections/hash/set.rs
TrustedLen::missing IntoIter in library/std/src/collections/hash/set.rs
TrustedLen::missing Drain in library/std/src/collections/hash/set.rs
TrustedLen::missing Iter in library/std/src/collections/hash/map.rs
TrustedLen::missing IterMut in library/std/src/collections/hash/map.rs
TrustedLen::missing IntoIter in library/std/src/collections/hash/map.rs
TrustedLen::missing Keys in library/std/src/collections/hash/map.rs
TrustedLen::missing Values in library/std/src/collections/hash/map.rs
TrustedLen::missing ValuesMut in library/std/src/collections/hash/map.rs
TrustedLen::missing IntoKeys in library/std/src/collections/hash/map.rs
TrustedLen::missing IntoValues in library/std/src/collections/hash/map.rs
TrustedLen::missing Drain in library/std/src/collections/hash/map.rs
FusedIterator::missing CommandArgs in library/std/src/sys/process/unsupported.rs
TrustedLen::missing CommandArgs in library/std/src/sys/process/unsupported.rs
FusedIterator::missing CommandArgs in library/std/src/sys/process/windows.rs
TrustedLen::missing CommandArgs in library/std/src/sys/process/windows.rs
FusedIterator::missing CommandArgs in library/std/src/sys/process/uefi.rs
TrustedLen::missing CommandArgs in library/std/src/sys/process/uefi.rs
FusedIterator::missing CommandArgs in library/std/src/sys/process/motor.rs
TrustedLen::missing CommandArgs in library/std/src/sys/process/motor.rs
FusedIterator::missing CommandEnvs in library/std/src/sys/process/env.rs
TrustedLen::missing CommandEnvs in library/std/src/sys/process/env.rs
FusedIterator::missing CommandArgs in library/std/src/sys/process/unix/common.rs
TrustedLen::missing CommandArgs in library/std/src/sys/process/unix/common.rs
FusedIterator::missing CStringIter in library/std/src/sys/process/unix/common/cstring_array.rs
TrustedLen::missing CStringIter in library/std/src/sys/process/unix/common/cstring_array.rs
FusedIterator::missing Args in library/std/src/sys/args/common.rs
TrustedLen::missing Args in library/std/src/sys/args/common.rs
FusedIterator::missing Args in library/std/src/sys/args/unsupported.rs
TrustedLen::missing Args in library/std/src/sys/args/unsupported.rs
FusedIterator::missing Args in library/std/src/sys/args/sgx.rs
TrustedLen::missing Args in library/std/src/sys/args/sgx.rs
FusedIterator::missing Args in library/std/src/sys/args/zkvm.rs
TrustedLen::missing Args in library/std/src/sys/args/zkvm.rs
````

This is related to rust-lang/rust#37572

<!-- homu-ignore:start -->
- [x] I did not use an LLM to create a change in this PR.
- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.
<!-- homu-ignore:end -->
