### PR TITLE
Apply `&[T]` visualizer to `*const [T]`, `*mut [T]` and `Box<[T]>`

### DIFF
--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -194,14 +194,28 @@ def register_providers_compatibility():
     register(
         StdSliceSyntheticProvider,
         SizeSummaryProvider,
-        r"^&(mut )?\[.+\]$",
+        r"^((&(mut )?)|(\*(const|mut) ))\[.+\]$",
+    )
+
+    # Box<[T]> GNU
+    register(
+        StdSliceSyntheticProvider,
+        SizeSummaryProvider,
+        r"^(alloc::([a-z_]+::)+)Box<\[.+\],.*>$",
     )
 
     # slice MSVC
     register(
         MSVCStdSliceSyntheticProvider,
         StdSliceSummaryProvider,
-        r"^ref(_mut)?\$<slice2\$<.+> >",
+        r"^((ref(_mut)?)|(ptr_(const|mut)))\$<slice2\$<.+> >$",
+    )
+
+    # Box<[T]> MSVC
+    register(
+        MSVCStdSliceSyntheticProvider,
+        StdSliceSummaryProvider,
+        r"^(alloc::([a-z_]+::)+)Box<slice2\$<.+>,.*>$",
     )
 
     # OsString

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -908,6 +908,8 @@ class MSVCEnumSyntheticProvider:
 
 
 def MSVCEnumSummaryProvider(valobj: SBValue, _dict: LLDBOpaque) -> str:
+    if valobj.TypeIsPointerType():
+        valobj = valobj.Dereference()
     enum_synth = MSVCEnumSyntheticProvider(valobj.GetNonSyntheticValue(), _dict)
     variant_names: SBType = valobj.target.FindFirstType(
         f"{enum_synth.valobj.GetTypeName()}::VariantNames"
@@ -1127,19 +1129,44 @@ class StdSliceSyntheticProvider:
 
 
 class MSVCStdSliceSyntheticProvider(StdSliceSyntheticProvider):
+    type_name: Optional[str] = None
+
     def get_type_name(self) -> str:
+        if self.type_name is not None:
+            return self.type_name
+
         name = self.valobj.GetTypeName()
 
         if name.startswith("ref_mut"):
-            # remove "ref_mut$<slice2$<" and trailing "> >"
-            name = name[17:-3]
-            ref = "&mut "
-        else:
-            # remove "ref$<slice2$<" and trailing "> >"
-            name = name[13:-3]
-            ref = "&"
+            name = name[len("ref_mut$<slice2$<") :].rstrip("> ")
+            self.type_name = f"&mut [{name}]"
+        elif name.startswith("ref"):
+            name = name[len("ref$<slice2$<") :].rstrip("> ")
+            self.type_name = f"&[{name}]"
+        elif name.startswith("ptr_mut"):
+            name = name[len("ptr_mut$<slice2$<") :].rstrip("> ")
+            self.type_name = f"*mut [{name}]"
+        elif name.startswith("ptr_const"):
+            name = name[len("ptr_const$<slice2$<") :].rstrip("> ")
+            self.type_name = f"*const [{name}]"
+        elif name.startswith("alloc::boxed::Box"):
+            prefix_len = len("alloc::boxed::Box<slice2$<")
+            suffix_len = len(">,alloc::alloc::Global>")
+            if name.endswith(",alloc::alloc::Global>"):
+                name = name[prefix_len : len(name) - suffix_len]
 
-        return "".join([ref, "[", name, "]"])
+                self.type_name = f"Box<[{name}]>"
+            else:
+                [element_name, alloc_name] = name[prefix_len:].split(">", 1)
+
+                name = f"{element_name}{alloc_name}"
+
+                # alloc name contains the trailing ">", so we don't need to add it
+                self.type_name = f"Box<[{element_name}]{alloc_name}"
+        else:
+            self.type_name = name
+
+        return self.type_name
 
 
 def StdSliceSummaryProvider(valobj, dict):


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.
If you do not want your disclosure to be part of the permanent git history, add `<!-- homu-ignore:start` before it.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Same as https://github.com/rust-lang/rust/pull/159834, but for slices instead of `str`.

Once again, msvc is a bit hard to test at the moment so here is how the MSVC changes look:

<img width="605" height="171" alt="image" src="https://github.com/user-attachments/assets/ac4bd27d-bcd1-4e9e-a443-2186d80e9503" />