### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 github: rustfoundation
-custom: ["rust-lang.org/funding"]
+custom: ["https://rust-lang.org/funding"]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -69,11 +69,11 @@
       "enabled": false
     },
     {
-      // Update yarn.lock in a dedicated PR.
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "groupName": "Yarn lock file maintenance",
-      "commitMessageAction": "Yarn lock file update"
+      // Do not update npm/yarn lockfile, we only use it for internal tests.
+      "matchManagers": [
+        "npm"
+      ],
+      "enabled": false,
     }
   ],
   "ignorePaths": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,6 +73,7 @@
       "matchManagers": [
         "npm"
       ],
+      "matchUpdateTypes": ["lockFileMaintenance"],
       "enabled": false,
     }
   ],

--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -935,6 +935,15 @@
 #
 #rust.parallel-frontend-threads = 1
 
+# Baseline commit SHA for comparing semver breakages in the Rust standard library.
+# The in-tree stdlib API will be evaluated for semver breakages against this commit.
+# Used for the `./x test std-semver-check` command.
+# If unset, the first upstream parent commit will be used.
+#
+# The SHA must point to a merge commit merged into the mainline rust-lang/rust `main` branch,
+# because bootstrap will attempt to download the JSON docs data for this commit from its CI.
+#rust.stdlib-semver-baseline = "<commit-sha>"
+
 # =============================================================================
 # Distribution options
 #

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -803,7 +803,6 @@ pub(crate) struct MirBorrowckCtxt<'a, 'diag, 'tcx> {
 impl<'a, 'tcx> ResultsVisitor<'tcx, Borrowck<'a, 'tcx>> for MirBorrowckCtxt<'a, '_, 'tcx> {
     fn visit_after_early_statement_effect(
         &mut self,
-        _analysis: &Borrowck<'a, 'tcx>,
         state: &BorrowckDomain,
         stmt: &Statement<'tcx>,
         location: Location,
@@ -878,7 +877,6 @@ impl<'a, 'tcx> ResultsVisitor<'tcx, Borrowck<'a, 'tcx>> for MirBorrowckCtxt<'a, 
 
     fn visit_after_early_terminator_effect(
         &mut self,
-        _analysis: &Borrowck<'a, 'tcx>,
         state: &BorrowckDomain,
         term: &Terminator<'tcx>,
         loc: Location,
@@ -991,7 +989,6 @@ impl<'a, 'tcx> ResultsVisitor<'tcx, Borrowck<'a, 'tcx>> for MirBorrowckCtxt<'a, 
 
     fn visit_after_primary_terminator_effect(
         &mut self,
-        _analysis: &Borrowck<'a, 'tcx>,
         state: &BorrowckDomain,
         term: &Terminator<'tcx>,
         loc: Location,

--- a/compiler/rustc_mir_dataflow/src/framework/direction.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/direction.rs
@@ -144,16 +144,16 @@ impl Direction for Backward {
         let loc = Location { block, statement_index: block_data.statements.len() };
         let term = block_data.terminator();
         analysis.apply_early_terminator_effect(state, term, loc);
-        vis.visit_after_early_terminator_effect(analysis, state, term, loc);
+        vis.visit_after_early_terminator_effect(state, term, loc);
         analysis.apply_primary_terminator_effect(state, term, loc);
-        vis.visit_after_primary_terminator_effect(analysis, state, term, loc);
+        vis.visit_after_primary_terminator_effect(state, term, loc);
 
         for (statement_index, stmt) in block_data.statements.iter().enumerate().rev() {
             let loc = Location { block, statement_index };
             analysis.apply_early_statement_effect(state, stmt, loc);
-            vis.visit_after_early_statement_effect(analysis, state, stmt, loc);
+            vis.visit_after_early_statement_effect(state, stmt, loc);
             analysis.apply_primary_statement_effect(state, stmt, loc);
-            vis.visit_after_primary_statement_effect(analysis, state, stmt, loc);
+            vis.visit_after_primary_statement_effect(state, stmt, loc);
         }
     }
 }
@@ -259,16 +259,16 @@ impl Direction for Forward {
         for (statement_index, stmt) in block_data.statements.iter().enumerate() {
             let loc = Location { block, statement_index };
             analysis.apply_early_statement_effect(state, stmt, loc);
-            vis.visit_after_early_statement_effect(analysis, state, stmt, loc);
+            vis.visit_after_early_statement_effect(state, stmt, loc);
             analysis.apply_primary_statement_effect(state, stmt, loc);
-            vis.visit_after_primary_statement_effect(analysis, state, stmt, loc);
+            vis.visit_after_primary_statement_effect(state, stmt, loc);
         }
 
         let loc = Location { block, statement_index: block_data.statements.len() };
         let term = block_data.terminator();
         analysis.apply_early_terminator_effect(state, term, loc);
-        vis.visit_after_early_terminator_effect(analysis, state, term, loc);
+        vis.visit_after_early_terminator_effect(state, term, loc);
         analysis.apply_primary_terminator_effect(state, term, loc);
-        vis.visit_after_primary_terminator_effect(analysis, state, term, loc);
+        vis.visit_after_primary_terminator_effect(state, term, loc);
     }
 }

--- a/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
@@ -287,7 +287,7 @@ where
     fn write_node_label(
         &mut self,
         block: BasicBlock,
-        diffs: StateDiffCollector<A::Domain>,
+        diffs: StateDiffCollector<'_, 'tcx, A>,
     ) -> io::Result<Vec<u8>> {
         use std::io::Write;
 
@@ -527,7 +527,7 @@ where
         &mut self,
         w: &mut impl io::Write,
         block: BasicBlock,
-        diffs: StateDiffCollector<A::Domain>,
+        diffs: StateDiffCollector<'_, 'tcx, A>,
     ) -> io::Result<()> {
         let mut diffs_before = diffs.before.map(|v| v.into_iter());
         let mut diffs_after = diffs.after.into_iter();
@@ -627,24 +627,25 @@ where
     }
 }
 
-struct StateDiffCollector<D> {
-    prev_state: D,
+struct StateDiffCollector<'a, 'tcx, A: Analysis<'tcx>> {
+    analysis: &'a A,
+    prev_state: A::Domain,
     before: Option<Vec<String>>,
     after: Vec<String>,
 }
 
-impl<D: Clone> StateDiffCollector<D> {
-    fn run<'tcx, A>(
+impl<'a, 'tcx, A: Analysis<'tcx>> StateDiffCollector<'a, 'tcx, A> {
+    fn run(
         body: &Body<'tcx>,
         block: BasicBlock,
-        results: &Results<'tcx, A>,
+        results: &'a Results<'tcx, A>,
         style: OutputStyle,
     ) -> Self
     where
-        A: Analysis<'tcx, Domain = D>,
-        D: DebugWithContext<A>,
+        A::Domain: DebugWithContext<A>,
     {
         let mut collector = StateDiffCollector {
+            analysis: &results.analysis,
             prev_state: results.entry_states[block].clone(),
             after: vec![],
             before: (style == OutputStyle::BeforeAndAfter).then_some(vec![]),
@@ -655,56 +656,56 @@ impl<D: Clone> StateDiffCollector<D> {
     }
 }
 
-impl<'tcx, A> ResultsVisitor<'tcx, A> for StateDiffCollector<A::Domain>
+impl<'a, 'tcx, A: Analysis<'tcx>> ResultsVisitor<'tcx, A> for StateDiffCollector<'a, 'tcx, A>
 where
     A: Analysis<'tcx>,
     A::Domain: DebugWithContext<A>,
 {
     fn visit_after_early_statement_effect(
         &mut self,
-        analysis: &A,
+        _analysis: &A,
         state: &A::Domain,
         _statement: &mir::Statement<'tcx>,
         _location: Location,
     ) {
         if let Some(before) = self.before.as_mut() {
-            before.push(diff_pretty(state, &self.prev_state, analysis));
+            before.push(diff_pretty(state, &self.prev_state, self.analysis));
             self.prev_state.clone_from(state)
         }
     }
 
     fn visit_after_primary_statement_effect(
         &mut self,
-        analysis: &A,
+        _analysis: &A,
         state: &A::Domain,
         _statement: &mir::Statement<'tcx>,
         _location: Location,
     ) {
-        self.after.push(diff_pretty(state, &self.prev_state, analysis));
+        self.after.push(diff_pretty(state, &self.prev_state, self.analysis));
         self.prev_state.clone_from(state)
     }
 
     fn visit_after_early_terminator_effect(
         &mut self,
-        analysis: &A,
+        _analysis: &A,
         state: &A::Domain,
         _terminator: &mir::Terminator<'tcx>,
         _location: Location,
     ) {
         if let Some(before) = self.before.as_mut() {
-            before.push(diff_pretty(state, &self.prev_state, analysis));
+            before.push(diff_pretty(state, &self.prev_state, self.analysis));
             self.prev_state.clone_from(state)
         }
     }
 
     fn visit_after_primary_terminator_effect(
         &mut self,
-        analysis: &A,
+        _analysis: &A,
         state: &A::Domain,
         _terminator: &mir::Terminator<'tcx>,
         _location: Location,
     ) {
-        self.after.push(diff_pretty(state, &self.prev_state, analysis));
+        self.after.push(diff_pretty(state, &self.prev_state, self.analysis));
         self.prev_state.clone_from(state)
     }
 }

--- a/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
@@ -663,7 +663,6 @@ where
 {
     fn visit_after_early_statement_effect(
         &mut self,
-        _analysis: &A,
         state: &A::Domain,
         _statement: &mir::Statement<'tcx>,
         _location: Location,
@@ -676,7 +675,6 @@ where
 
     fn visit_after_primary_statement_effect(
         &mut self,
-        _analysis: &A,
         state: &A::Domain,
         _statement: &mir::Statement<'tcx>,
         _location: Location,
@@ -687,7 +685,6 @@ where
 
     fn visit_after_early_terminator_effect(
         &mut self,
-        _analysis: &A,
         state: &A::Domain,
         _terminator: &mir::Terminator<'tcx>,
         _location: Location,
@@ -700,7 +697,6 @@ where
 
     fn visit_after_primary_terminator_effect(
         &mut self,
-        _analysis: &A,
         state: &A::Domain,
         _terminator: &mir::Terminator<'tcx>,
         _location: Location,

--- a/compiler/rustc_mir_dataflow/src/framework/visitor.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/visitor.rs
@@ -37,7 +37,6 @@ where
     /// Called after the "early" effect of the given statement is applied to `state`.
     fn visit_after_early_statement_effect(
         &mut self,
-        _analysis: &A,
         _state: &A::Domain,
         _statement: &mir::Statement<'tcx>,
         _location: Location,
@@ -47,7 +46,6 @@ where
     /// Called after the "primary" effect of the given statement is applied to `state`.
     fn visit_after_primary_statement_effect(
         &mut self,
-        _analysis: &A,
         _state: &A::Domain,
         _statement: &mir::Statement<'tcx>,
         _location: Location,
@@ -57,7 +55,6 @@ where
     /// Called after the "early" effect of the given terminator is applied to `state`.
     fn visit_after_early_terminator_effect(
         &mut self,
-        _analysis: &A,
         _state: &A::Domain,
         _terminator: &mir::Terminator<'tcx>,
         _location: Location,
@@ -69,7 +66,6 @@ where
     /// The `call_return_effect` (if one exists) will *not* be applied to `state`.
     fn visit_after_primary_terminator_effect(
         &mut self,
-        _analysis: &A,
         _state: &A::Domain,
         _terminator: &mir::Terminator<'tcx>,
         _location: Location,

--- a/compiler/rustc_mir_transform/src/coroutine/layout.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/layout.rs
@@ -301,7 +301,6 @@ struct StorageConflictVisitor<'a> {
 impl<'a, 'tcx> ResultsVisitor<'tcx, MaybeRequiresStorage> for StorageConflictVisitor<'a> {
     fn visit_after_early_statement_effect(
         &mut self,
-        _analysis: &MaybeRequiresStorage,
         state: &DenseBitSet<Local>,
         _statement: &Statement<'tcx>,
         _loc: Location,
@@ -311,7 +310,6 @@ impl<'a, 'tcx> ResultsVisitor<'tcx, MaybeRequiresStorage> for StorageConflictVis
 
     fn visit_after_early_terminator_effect(
         &mut self,
-        _analysis: &MaybeRequiresStorage,
         state: &DenseBitSet<Local>,
         _terminator: &Terminator<'tcx>,
         _loc: Location,

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -71,7 +71,7 @@ impl<'tcx> crate::MirPass<'tcx> for DataflowConstProp {
             .in_scope(|| ConstAnalysis::new(tcx, body, map).iterate_to_fixpoint(tcx, body, None));
 
         // Collect results and patch the body afterwards.
-        let mut visitor = Collector::new(tcx, body);
+        let mut visitor = Collector::new(tcx, body, &const_.analysis.map);
         debug_span!("collect").in_scope(|| {
             visit_results(body, traversal::reachable(body).map(|(bb, _)| bb), &const_, &mut visitor)
         });
@@ -767,23 +767,24 @@ struct Collector<'a, 'tcx> {
     patch: Patch<'tcx>,
     local_decls: &'a LocalDecls<'tcx>,
     ecx: InterpCx<'tcx, DummyMachine>,
+    map: &'a Map<'tcx>,
 }
 
 impl<'a, 'tcx> Collector<'a, 'tcx> {
-    pub(crate) fn new(tcx: TyCtxt<'tcx>, body: &'a Body<'tcx>) -> Self {
+    pub(crate) fn new(tcx: TyCtxt<'tcx>, body: &'a Body<'tcx>, map: &'a Map<'tcx>) -> Self {
         Self {
             patch: Patch::new(tcx),
             local_decls: &body.local_decls,
             ecx: InterpCx::new(tcx, DUMMY_SP, body.typing_env(tcx), DummyMachine),
+            map,
         }
     }
 
-    #[instrument(level = "trace", skip(self, map), ret)]
+    #[instrument(level = "trace", skip(self), ret)]
     fn try_make_constant(
         &mut self,
         place: Place<'tcx>,
         state: &State<FlatSet<Scalar>>,
-        map: &Map<'tcx>,
     ) -> Option<Const<'tcx>> {
         let ty = place.ty(self.local_decls, self.patch.tcx).ty;
         let layout = self.ecx.layout_of(ty).ok()?;
@@ -796,9 +797,9 @@ impl<'a, 'tcx> Collector<'a, 'tcx> {
             return None;
         }
 
-        let place = map.find(place.as_ref())?;
+        let place = self.map.find(place.as_ref())?;
         if layout.backend_repr.is_scalar()
-            && let Some(value) = propagatable_scalar(place, state, map)
+            && let Some(value) = propagatable_scalar(place, state, self.map)
         {
             return Some(Const::Val(ConstValue::Scalar(value), ty));
         }
@@ -807,7 +808,7 @@ impl<'a, 'tcx> Collector<'a, 'tcx> {
             let alloc_id = self
                 .ecx
                 .intern_with_temp_alloc(layout, |ecx, dest| {
-                    try_write_constant(ecx, dest, place, ty, state, map)
+                    try_write_constant(ecx, dest, place, ty, state, self.map)
                 })
                 .discard_err()?;
             return Some(Const::Val(ConstValue::Indirect { alloc_id, offset: Size::ZERO }, ty));
@@ -940,27 +941,26 @@ fn try_write_constant<'tcx>(
 }
 
 impl<'tcx> ResultsVisitor<'tcx, ConstAnalysis<'_, 'tcx>> for Collector<'_, 'tcx> {
-    #[instrument(level = "trace", skip(self, analysis, statement))]
+    #[instrument(level = "trace", skip(self, _analysis, statement))]
     fn visit_after_early_statement_effect(
         &mut self,
-        analysis: &ConstAnalysis<'_, 'tcx>,
+        _analysis: &ConstAnalysis<'_, 'tcx>,
         state: &State<FlatSet<Scalar>>,
         statement: &Statement<'tcx>,
         location: Location,
     ) {
         match &statement.kind {
             StatementKind::Assign((_, rvalue)) => {
-                OperandCollector { state, visitor: self, map: &analysis.map }
-                    .visit_rvalue(rvalue, location);
+                OperandCollector { state, visitor: self }.visit_rvalue(rvalue, location);
             }
             _ => (),
         }
     }
 
-    #[instrument(level = "trace", skip(self, analysis, statement))]
+    #[instrument(level = "trace", skip(self, _analysis, statement))]
     fn visit_after_primary_statement_effect(
         &mut self,
-        analysis: &ConstAnalysis<'_, 'tcx>,
+        _analysis: &ConstAnalysis<'_, 'tcx>,
         state: &State<FlatSet<Scalar>>,
         statement: &Statement<'tcx>,
         location: Location,
@@ -970,7 +970,7 @@ impl<'tcx> ResultsVisitor<'tcx, ConstAnalysis<'_, 'tcx>> for Collector<'_, 'tcx>
                 // Don't overwrite the assignment if it already uses a constant (to keep the span).
             }
             StatementKind::Assign((place, _)) => {
-                if let Some(value) = self.try_make_constant(place, state, &analysis.map) {
+                if let Some(value) = self.try_make_constant(place, state) {
                     self.patch.assignments.insert(location, value);
                 }
             }
@@ -980,13 +980,12 @@ impl<'tcx> ResultsVisitor<'tcx, ConstAnalysis<'_, 'tcx>> for Collector<'_, 'tcx>
 
     fn visit_after_early_terminator_effect(
         &mut self,
-        analysis: &ConstAnalysis<'_, 'tcx>,
+        _analysis: &ConstAnalysis<'_, 'tcx>,
         state: &State<FlatSet<Scalar>>,
         terminator: &Terminator<'tcx>,
         location: Location,
     ) {
-        OperandCollector { state, visitor: self, map: &analysis.map }
-            .visit_terminator(terminator, location);
+        OperandCollector { state, visitor: self }.visit_terminator(terminator, location);
     }
 }
 
@@ -1045,7 +1044,6 @@ impl<'tcx> MutVisitor<'tcx> for Patch<'tcx> {
 struct OperandCollector<'a, 'b, 'tcx> {
     state: &'a State<FlatSet<Scalar>>,
     visitor: &'a mut Collector<'b, 'tcx>,
-    map: &'a Map<'tcx>,
 }
 
 impl<'tcx> Visitor<'tcx> for OperandCollector<'_, '_, 'tcx> {
@@ -1057,7 +1055,7 @@ impl<'tcx> Visitor<'tcx> for OperandCollector<'_, '_, 'tcx> {
         location: Location,
     ) {
         if let PlaceElem::Index(local) = elem
-            && let Some(value) = self.visitor.try_make_constant(local.into(), self.state, self.map)
+            && let Some(value) = self.visitor.try_make_constant(local.into(), self.state)
         {
             self.visitor.patch.before_effect.insert((location, local.into()), value);
         }
@@ -1065,7 +1063,7 @@ impl<'tcx> Visitor<'tcx> for OperandCollector<'_, '_, 'tcx> {
 
     fn visit_operand(&mut self, operand: &Operand<'tcx>, location: Location) {
         if let Some(place) = operand.place() {
-            if let Some(value) = self.visitor.try_make_constant(place, self.state, self.map) {
+            if let Some(value) = self.visitor.try_make_constant(place, self.state) {
                 self.visitor.patch.before_effect.insert((location, place), value);
             } else if !place.projection.is_empty() {
                 // Try to propagate into `Index` projections.

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -941,10 +941,9 @@ fn try_write_constant<'tcx>(
 }
 
 impl<'tcx> ResultsVisitor<'tcx, ConstAnalysis<'_, 'tcx>> for Collector<'_, 'tcx> {
-    #[instrument(level = "trace", skip(self, _analysis, statement))]
+    #[instrument(level = "trace", skip(self, statement))]
     fn visit_after_early_statement_effect(
         &mut self,
-        _analysis: &ConstAnalysis<'_, 'tcx>,
         state: &State<FlatSet<Scalar>>,
         statement: &Statement<'tcx>,
         location: Location,
@@ -957,10 +956,9 @@ impl<'tcx> ResultsVisitor<'tcx, ConstAnalysis<'_, 'tcx>> for Collector<'_, 'tcx>
         }
     }
 
-    #[instrument(level = "trace", skip(self, _analysis, statement))]
+    #[instrument(level = "trace", skip(self, statement))]
     fn visit_after_primary_statement_effect(
         &mut self,
-        _analysis: &ConstAnalysis<'_, 'tcx>,
         state: &State<FlatSet<Scalar>>,
         statement: &Statement<'tcx>,
         location: Location,
@@ -980,7 +978,6 @@ impl<'tcx> ResultsVisitor<'tcx, ConstAnalysis<'_, 'tcx>> for Collector<'_, 'tcx>
 
     fn visit_after_early_terminator_effect(
         &mut self,
-        _analysis: &ConstAnalysis<'_, 'tcx>,
         state: &State<FlatSet<Scalar>>,
         terminator: &Terminator<'tcx>,
         location: Location,

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -12,7 +12,7 @@ use rustc_type_ir::search_graph::{CandidateHeadUsages, LowerAvailableDepth, Path
 use rustc_type_ir::solve::{
     AccessedOpaques, ExternalRegionConstraints, FetchEligibleAssocItemResponse, MaybeInfo,
     NoSolutionOrRerunNonErased, OpaqueTypesJank, QueryResultOrRerunNonErased, RerunCondition,
-    RerunNonErased, RerunReason, RerunResultExt, SmallCopyList,
+    RerunNonErased, RerunReason, RerunResultExt, SmallCopySet,
 };
 use rustc_type_ir::{
     self as ty, CanonicalVarValues, ClauseKind, InferCtxtLike, Interner, MayBeErased,
@@ -1732,7 +1732,7 @@ fn should_rerun_after_erased_canonicalization<I: Interner>(
     parent_opaque_types: &[(OpaqueTypeKey<I>, I::Ty)],
 ) -> RerunDecision {
     let parent_opaque_def_ids = parent_opaque_types.iter().map(|(key, _)| key.def_id.into());
-    let opaque_in_storage = |opaques: I::LocalDefIds, def_ids: SmallCopyList<_>| {
+    let opaque_in_storage = |opaques: I::LocalDefIds, def_ids: SmallCopySet<_>| {
         if def_ids.as_ref().is_empty() {
             RerunDecision::No
         } else if opaques

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -79,17 +79,21 @@ impl From<RerunNonErased> for NoSolutionOrRerunNonErased {
     }
 }
 
+/// A small set of up to 3 `Copy` elements, used as an optimization in [`RerunCondition`].
+/// The entire set can be `Copy`ed because of this requirement.
+///
+/// Set properties maintained using [`union`](SmallCopySet::union), which deduplicates values.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 #[derive(TypeVisitable_Generic, TypeFoldable_Generic, GenericTypeVisitable)]
 #[cfg_attr(feature = "nightly", derive(StableHash_NoContext))]
-pub enum SmallCopyList<T: Copy + Debug + Hash + Eq> {
+pub enum SmallCopySet<T: Copy + Debug + Hash + Eq> {
     Empty,
     One([T; 1]),
     Two([T; 2]),
     Three([T; 3]),
 }
 
-impl<T: Copy + Debug + Hash + Eq> SmallCopyList<T> {
+impl<T: Copy + Debug + Hash + Eq> SmallCopySet<T> {
     fn empty() -> Self {
         Self::Empty
     }
@@ -127,7 +131,7 @@ impl<T: Copy + Debug + Hash + Eq> SmallCopyList<T> {
     }
 }
 
-impl<T: Copy + Debug + Hash + Eq> AsRef<[T]> for SmallCopyList<T> {
+impl<T: Copy + Debug + Hash + Eq> AsRef<[T]> for SmallCopySet<T> {
     fn as_ref(&self) -> &[T] {
         match self {
             Self::Empty => &[],
@@ -165,12 +169,12 @@ pub enum RerunCondition<I: Interner> {
     /// Note that this only reruns according to the condition *if* we are in [`TypingMode::Typeck`].
     AnyOpaqueHasInferAsHidden,
     /// Note: unconditionally reruns in postanalysis
-    OpaqueInStorage(SmallCopyList<I::LocalDefId>),
+    OpaqueInStorage(SmallCopySet<I::LocalDefId>),
 
     /// Merges [`Self::AnyOpaqueHasInferAsHidden`] and [`Self::OpaqueInStorage`].
     /// Note that just like the unmerged [`Self::OpaqueInStorage`], that part of the
     /// condition only matters in [`TypingMode::Typeck`]
-    OpaqueInStorageOrAnyOpaqueHasInferAsHidden(SmallCopyList<I::LocalDefId>),
+    OpaqueInStorageOrAnyOpaqueHasInferAsHidden(SmallCopySet<I::LocalDefId>),
 
     Always,
 }
@@ -327,7 +331,7 @@ impl<I: Interner> AccessedOpaques<I> {
         debug!("set rerun if post analysis");
         self.update(AccessedOpaques {
             reason: Some(reason),
-            rerun: RerunCondition::OpaqueInStorage(SmallCopyList::empty()),
+            rerun: RerunCondition::OpaqueInStorage(SmallCopySet::empty()),
         })
     }
 
@@ -339,7 +343,7 @@ impl<I: Interner> AccessedOpaques<I> {
         debug!("set rerun if opaque type {defid:?} in storage");
         self.update(AccessedOpaques {
             reason: Some(reason),
-            rerun: RerunCondition::OpaqueInStorage(SmallCopyList::new(defid.into())),
+            rerun: RerunCondition::OpaqueInStorage(SmallCopySet::new(defid.into())),
         })
     }
 

--- a/library/alloc/src/io/read.rs
+++ b/library/alloc/src/io/read.rs
@@ -22,8 +22,8 @@ use crate::vec::Vec;
 /// trait.
 ///
 /// Please note that each call to [`read()`] may involve a system call, and
-/// `BufReader`, will be more efficient.
 /// therefore, using something that implements [`BufRead`], such as
+/// `BufReader`, will be more efficient.
 ///
 /// [`BufRead`]: crate::io::BufRead
 ///

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -4634,6 +4634,9 @@ fn check_if_cargo_semver_checks_is_installed(builder: &Builder<'_>) -> bool {
 /// If unset, the first upstream parent commit will be used.
 ///
 /// Fails if a semver-breaking change is detected.
+///
+/// If you want to allow a breaking change in a given PR, or if cargo-semver-checks has a false
+/// positive, modify the `src/bootstrap/stdlib-semver-check-stamp` file.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StdSemverCheck {
     build_compiler: Compiler,
@@ -4679,6 +4682,15 @@ impl CommandLineStep for StdSemverCheck {
     }
 
     fn run(self, builder: &Builder<'_>) {
+        const STDLIB_SEMVER_CHECK_STAMP_PATH: &str = "src/bootstrap/stdlib-semver-check-stamp";
+
+        if builder.config.ci_env.is_running_in_ci()
+            && builder.config.has_changes_from_upstream(&[STDLIB_SEMVER_CHECK_STAMP_PATH])
+        {
+            builder.info(&format!("Skipping stdlib semver check, because {STDLIB_SEMVER_CHECK_STAMP_PATH} was modified."));
+            return;
+        }
+
         let Some(docs_dir) = builder.config.download_std_json_docs(self.target, &self.commit)
         else {
             return;

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -4617,7 +4617,7 @@ impl CommandLineStep for RemoteTestClientTests {
 }
 
 fn check_if_cargo_semver_checks_is_installed(builder: &Builder<'_>) -> bool {
-    command("cargo")
+    command(&builder.initial_cargo)
         .allow_failure()
         .arg("semver-checks")
         .arg("--version")
@@ -4693,7 +4693,7 @@ impl CommandLineStep for StdSemverCheck {
 
         for library in ["core", "alloc", "std"] {
             println!("Checking semver compatibility of {library}");
-            let mut cmd = command("cargo");
+            let mut cmd = command(&builder.initial_cargo);
             cmd.arg("semver-checks")
                 .arg("-Z")
                 .arg("unstable-options")

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -4704,7 +4704,41 @@ impl CommandLineStep for StdSemverCheck {
                 .arg(directory.join(format!("{library}.json")))
                 .arg("--baseline-rustdoc")
                 .arg(baseline_dir.join(format!("{library}.json")));
-            cmd.run(builder);
+
+            // We use run_capture to get the exit status
+            let res = cmd.allow_failure().run_capture(builder);
+            match res.status() {
+                Some(status) if status.success() => {
+                    println!("{}\n{}", res.stdout(), res.stderr());
+                }
+                // 101 marks that csc was unable to parse the JSON data, but it did not fail with a
+                // semver breakage.
+                Some(status) if status.code() == Some(101) => {
+                    eprintln!(
+                        "cargo-semver-checks was unable to process {library} (this is not a fatal error)\n{}\n{}",
+                        res.stderr(),
+                        res.stdout()
+                    );
+                }
+                // 100 marks semver breakage
+                Some(status) if status.code() == Some(100) => {
+                    let error = format!(
+                        "cargo-semver-checks found semver breakage in {library}\n{}\n{}",
+                        res.stderr(),
+                        res.stdout()
+                    );
+                    if builder.fail_fast {
+                        eprintln!("{error}",);
+                        exit!(1);
+                    } else {
+                        builder.config.exec_ctx().add_to_delay_failure(error);
+                    }
+                }
+                _ => {
+                    eprintln!("cargo-semver-checks failed.\n{}\n{}", res.stderr(), res.stdout());
+                    exit!(1);
+                }
+            }
         }
     }
 }

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -4630,6 +4630,9 @@ fn check_if_cargo_semver_checks_is_installed(builder: &Builder<'_>) -> bool {
 /// Run cargo-semver-checks on the standard library and compare its API
 /// versus a previous baseline, using rustdoc JSON data.
 ///
+/// The baseline commit can be configured using `rust.stdlib-semver-baseline`.
+/// If unset, the first upstream parent commit will be used.
+///
 /// Fails if a semver-breaking change is detected.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StdSemverCheck {
@@ -4651,19 +4654,22 @@ impl CommandLineStep for StdSemverCheck {
             panic!("cargo-semver-checks was not found, please install it");
         }
 
-        let baseline_commit = match get_closest_upstream_commit(
-            Some(&run.builder.config.src),
-            &run.builder.config.git_config(),
-            run.builder.config.ci_env,
-        ) {
-            Ok(Some(commit)) => commit,
-            Ok(None) => {
-                panic!("No baseline parent commit found for std-semver-check");
-            }
-            Err(error) => {
-                panic!("Cannot get baseline parent commit for std-semver-check: {error:?}");
-            }
-        };
+        let baseline_commit =
+            run.builder.config.stdlib_semver_baseline.clone().unwrap_or_else(|| {
+                match get_closest_upstream_commit(
+                    Some(&run.builder.config.src),
+                    &run.builder.config.git_config(),
+                    run.builder.config.ci_env,
+                ) {
+                    Ok(Some(commit)) => commit,
+                    Ok(None) => {
+                        panic!("No baseline parent commit found for std-semver-check");
+                    }
+                    Err(error) => {
+                        panic!("Cannot get baseline parent commit for std-semver-check: {error:?}");
+                    }
+                }
+            });
 
         run.builder.ensure(Self {
             build_compiler: run.builder.compiler_for_std(run.builder.top_stage),

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -240,6 +240,8 @@ pub struct Config {
     pub rustdoc_pgo: PgoConfig,
     pub cargo_pgo: PgoConfig,
 
+    pub stdlib_semver_baseline: Option<String>,
+
     pub llvm_libunwind_default: Option<LlvmLibunwind>,
     pub enable_bolt_settings: bool,
 
@@ -610,6 +612,7 @@ impl Config {
             std_features: rust_std_features,
             break_on_ice: rust_break_on_ice,
             rustflags: rust_rustflags,
+            stdlib_semver_baseline: rust_stdlib_semver_baseline,
         } = toml_rust.unwrap_or_default();
 
         let Llvm {
@@ -1594,6 +1597,7 @@ NOTE: Please add `--stage 2` to your command line, or if you're sure you want to
                 .or(rust_rustc_debug_assertions)
                 .unwrap_or(rust_debug == Some(true)),
             stderr_is_tty: std::io::stderr().is_terminal(),
+            stdlib_semver_baseline: rust_stdlib_semver_baseline,
             stdout_is_tty: std::io::stdout().is_terminal(),
             submodules: build_submodules,
             sysconfdir: install_sysconfdir.map(PathBuf::from),

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -77,6 +77,7 @@ define_config! {
         std_features: Option<BTreeSet<String>> = "std-features",
         break_on_ice: Option<bool> = "break-on-ice",
         parallel_frontend_threads: Option<u32> = "parallel-frontend-threads",
+        stdlib_semver_baseline: Option<String> = "stdlib-semver-baseline",
     }
 }
 
@@ -384,6 +385,7 @@ pub fn check_incompatible_options_for_ci_rustc(
         parallel_frontend_threads: _,
         bootstrap_override_lld: _,
         rustflags: _,
+        stdlib_semver_baseline: _,
     } = ci_rust_config;
 
     // There are two kinds of checks for CI rustc incompatible options:

--- a/src/bootstrap/stdlib-semver-check-stamp
+++ b/src/bootstrap/stdlib-semver-check-stamp
@@ -1,0 +1,5 @@
+Change this file to explicitly acknowledge making a breaking change to the Rust standard library.
+If this file is modified in the same PR as the breaking change, then CI will not fail due to the
+breaking change being detected by cargo-semver-checks.
+
+Last change is for: https://github.com/rust-lang/rust/pull/160253

--- a/src/ci/docker/host-x86_64/x86_64-gnu-stdlib-semver-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-stdlib-semver-check/Dockerfile
@@ -25,6 +25,7 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu"
+ENV RUSTC_WRAPPER=/usr/local/bin/sccache
 
 COPY /scripts/std-semver-check.sh /tmp/std-semver-check.sh
 ENV SCRIPT="bash /tmp/std-semver-check.sh"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-stdlib-semver-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-stdlib-semver-check/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:26.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  ninja-build \
+  file \
+  curl \
+  ca-certificates \
+  python3 \
+  git \
+  cmake \
+  sudo \
+  gdb \
+  libssl-dev \
+  pkg-config \
+  xz-utils \
+  mingw-w64 \
+  zlib1g-dev \
+  libzstd-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu"
+
+COPY /scripts/std-semver-check.sh /tmp/std-semver-check.sh
+ENV SCRIPT="bash /tmp/std-semver-check.sh"

--- a/src/ci/docker/scripts/std-semver-check.sh
+++ b/src/ci/docker/scripts/std-semver-check.sh
@@ -6,8 +6,11 @@ BUILD_DIR=$(realpath ./build/x86_64-unknown-linux-gnu)
 
 # Install the latest version of cargo-semver-checks, so that once the JSON doc format changes,
 # we will eventually get a csc version that supports it
-RUSTC="${BUILD_DIR}"/stage0/bin/rustc "${BUILD_DIR}"/stage0/bin/cargo install \
-  cargo-semver-checks --locked
+# Speed up compilation by reducing optimizations settings a bit
+RUSTC="${BUILD_DIR}"/stage0/bin/rustc \
+CARGO_PROFILE_RELEASE_LTO=false \
+CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 \
+"${BUILD_DIR}"/stage0/bin/cargo install cargo-semver-checks --locked
 
 # Provide path to cargo-semver-checks
 export PATH=${PATH}:/cargo/bin

--- a/src/ci/docker/scripts/std-semver-check.sh
+++ b/src/ci/docker/scripts/std-semver-check.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+BUILD_DIR=$(realpath ./build/x86_64-unknown-linux-gnu)
+
+# Install the latest version of cargo-semver-checks, so that once the JSON doc format changes,
+# we will eventually get a csc version that supports it
+RUSTC="${BUILD_DIR}"/stage0/bin/rustc "${BUILD_DIR}"/stage0/bin/cargo install \
+  cargo-semver-checks --locked
+
+# Provide path to cargo-semver-checks
+export PATH=${PATH}:/cargo/bin
+
+# Explicitly compute the baseline commit (the first git parent, which is the latest upstream main
+# commit), so that it is shown in the commit log and so that the command can be easily reproduced
+# locally.
+PARENT=$(git rev-parse HEAD^1)
+
+# Run the test
+python3 ../x.py test std-semver-check --set rust.stdlib-semver-baseline=${PARENT}

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -492,6 +492,7 @@ auto:
     <<: *job-linux-4c
 
   - name: x86_64-gnu-stdlib-semver-check
+    doc_url: https://rustc-dev-guide.rust-lang.org/tests/stdlib-semver-check.html
     <<: *job-linux-4c
 
   - name: optional-x86_64-gnu-autodiff

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -491,6 +491,9 @@ auto:
   - name: x86_64-gnu-miri
     <<: *job-linux-4c
 
+  - name: x86_64-gnu-stdlib-semver-check
+    <<: *job-linux-4c
+
   - name: optional-x86_64-gnu-autodiff
     continue_on_error: true
     doc_url: https://rustc-dev-guide.rust-lang.org/tests/autodiff-ci-job.html

--- a/src/doc/rustc-dev-guide/src/SUMMARY.md
+++ b/src/doc/rustc-dev-guide/src/SUMMARY.md
@@ -37,6 +37,7 @@
     - [Performance testing](./tests/perf.md)
     - [Autodiff CI job](./tests/autodiff-ci-job.md)
     - [Pre-stabilization CI job for the next solver and polonius alpha](./tests/x86_64-gnu-next-trait-solver-polonius-ci-job.md)
+    - [Standard library semver breakage test](./tests/stdlib-semver-check.md)
     - [Misc info](./tests/misc.md)
 - [Debugging the compiler](./compiler-debugging.md)
     - [Using the tracing/logging instrumentation](./tracing.md)

--- a/src/doc/rustc-dev-guide/src/tests/stdlib-semver-check.md
+++ b/src/doc/rustc-dev-guide/src/tests/stdlib-semver-check.md
@@ -1,0 +1,21 @@
+# Standard library semantic versioning breakage check
+
+The `x86_64-gnu-stdlib-semver-check` job runs the [`cargo-semver-checks`][csc] (c-s-c) tool on the standard library (`core`, `alloc` and `std`) in order to find potential unintended semantic versioning (semver) breakages. It does so by analyzing the rustdoc JSON output (from the `rust-docs-json` component) of the parent merge commit, and the current commit being merged. When it runs, one of five things can happen:
+
+1. Everything proceeds correctly, c-s-c does not find any breakage.
+2. The rustdoc JSON version was bumped recently, and c-s-c cannot handle it yet. This case will result in the test ending with a success, and printing a warning that c-s-c needs to be updated. Once c-s-c releases a version that supports the new JSON format, it should go to 1. again.
+   - We currently install the latest released version of c-s-c in this job, so its version does not need to be updated manually in the `rust-lang/rust` repository.
+3. c-s-c detects a breakage, but it is a false positive. In this case, please report the false positive to [this][semver-topic] Zulip channel, and [bump the stamp file](#bumping-the-stdlib-semver-stamp-file). 
+4. c-s-c detects a real breakage, and it helped you find unintended beakage. Yay! In this case, please consider reporting the success to [this][semver-topic] Zulip channel.
+5. c-s-c detects a real breakage, but you want to land it anyway (maybe it is an edge case that was FCPed). In that case, [bump the stamp file](#bumping-the-stdlib-semver-stamp-file). 
+
+## Bumping the stdlib semver stamp file
+
+If you want to let CI pass on a PR where c-s-c detects breakage (whether it is real or not), you have to modify the `src/bootstrap/stdlib-semver-check-stamp` file. Please update the PR number in which you modify this file at the bottom of the file. This will ensure that the test will stay green, regardless of what c-s-c detects.
+
+## Running the check manually
+
+You can manually run the semver check locally using `./x test std-semver-check --set rust.stdlib-semver-baseline=${PARENT}`, where `PARENT` is a commit SHA against which you want to compare the in-tree stdlib. If you do not specify it, bootstrap will select the latest upstream commit that it finds in your local git history.
+
+[semver-topic]: https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/Breakages.20detected.20by.20cargo-semver-checks/with/615570111
+[csc]: https://github.com/obi1kenobi/cargo-semver-checks


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#160253 (Add CI job for checking stdlib semver compatibility)
 - rust-lang/rust#160832 (Fix funding link)
 - rust-lang/rust#160833 (Remove `analysis` arg from `ResultsVisitor` methods)
 - rust-lang/rust#160834 (Update Enzyme submodule)
 - rust-lang/rust#160836 (Fix swapped documentation lines on `io::Read`)
 - rust-lang/rust#160839 (Stop updating npm lockfile by Renovatebot)
 - rust-lang/rust#160840 (Rename `SmallCopyList` to `SmallCopySet`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=160253,160832,160833,160834,160836,160839,160840)
<!-- homu-ignore:end -->

