### PR TITLE
std: avoid aliasing violations when wrapping opaque C types

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -393,6 +393,7 @@
 #![feature(temporary_niche_types)]
 #![feature(ub_checks)]
 #![feature(uint_carryless_mul)]
+#![feature(unsafe_pinned)]
 #![feature(used_with_arg)]
 #![feature(write_all_vectored)]
 // tidy-alphabetical-end

--- a/library/std/src/sys/helpers/c_opaque.rs
+++ b/library/std/src/sys/helpers/c_opaque.rs
@@ -1,0 +1,101 @@
+use crate::mem::MaybeUninit;
+use crate::pin::{Pin, UnsafePinned};
+
+/// A wrapper for an opaque C object.
+///
+/// Some libraries like UNIX's pthread have data types that must be treated
+/// as entirely opaque. Soundly wrapping these types is very hard since
+/// Rust's operational semantics are much stricter when it comes to e.g. the
+/// initialization state of data types and pointer aliasing. For instance, a
+/// function like `pthread_mutexattr_init` might not fully initialize the
+/// `libc::pthread_mutexattr_t` passed to it, so doing e.g.
+/// ```ignore (for-illustration-purposes-only)
+/// let mut attr = MaybeUninit::uninit();
+/// pthread_mutexattr_init(attr.as_mut_ptr());
+/// let attr = attr.assume_init();
+/// ```
+/// is unsound. Another example: on platforms like macOS a `pthread_mutex_t`
+/// cannot be moved because the implementation will dynamically align some inner
+/// fields to a higher alignment than required by the definition. And furthermore,
+/// some implementations (e.g. AIX) of `pthread_cond_t` use intrinsically linked
+/// lists, and hence doing
+/// ```ignore (for-illustration-purposes-only)
+/// pub struct Condvar(UnsafeCell<libc::pthread_cont_t>);
+///
+/// /* initialization and usage omitted for brevity */
+///
+/// impl Drop for Condvar {
+///     fn drop(&mut self) {
+///         unsafe { libc::pthread_cond_destroy(self.0.get()) };
+///     }
+/// }
+/// ```
+/// results in undefined behaviour (even when utilizing `Pin` to ensure
+/// immovability) because the creation of the `&mut Condvar` passed to `drop`
+/// invalidates other pointers in the linked list.
+///
+/// `COpaque` helps with avoiding all these caveats:
+/// * it wraps the inner value in `MaybeUninit` and thus is entirely oblivious
+///   of its initialization state.
+/// * [`COpaque::get`] takes a `Pin` and thus prevents accidental moves.
+/// * it utilizes `UnsafePinned` to relax the aliasing guarantees of mutable
+///   references to the `COpaque`.
+///
+/// The only way to access the inner value is via [`COpaque::get`]. It returns
+/// a pointer which should be directly passed to the platform functions.
+///
+/// In effect, a pinned instance of this wrapper acts very much like a C variable.
+pub struct COpaque<T> {
+    inner: UnsafePinned<MaybeUninit<T>>,
+}
+
+impl<T> COpaque<T> {
+    /// Creates an uninitialized C-like storage for `T`.
+    ///
+    /// If you'd write
+    /// ```c
+    /// T var;
+    /// ```
+    /// in C, the equivalent Rust code is
+    /// ```ignore (for-illustration-purposes-only)
+    /// let var = pin!(COpaque::uninit());
+    /// ```
+    pub fn uninit() -> COpaque<T> {
+        COpaque { inner: UnsafePinned::new(MaybeUninit::uninit()) }
+    }
+
+    /// Creates a zero-initialized C-like storage for `T`.
+    ///
+    /// If you'd write
+    /// ```c
+    /// T var = {};
+    /// ```
+    /// in C, the equivalent Rust code is
+    /// ```ignore (for-illustration-purposes-only)
+    /// let var = pin!(COpaque::zeroed());
+    /// ```
+    pub fn zeroed() -> COpaque<T> {
+        COpaque { inner: UnsafePinned::new(MaybeUninit::zeroed()) }
+    }
+
+    /// Creates a pre-initialized C-like storage for `T`.
+    ///
+    /// If you'd write
+    /// ```c
+    /// T var = T_INITIALIZER;
+    /// ```
+    /// in C, the equivalent Rust code is
+    /// ```ignore (for-illustration-purposes-only)
+    /// let var = pin!(COpaque::new(T_INITIALIZER));
+    /// ```
+    pub fn new(initializer: T) -> COpaque<T> {
+        COpaque { inner: UnsafePinned::new(MaybeUninit::new(initializer)) }
+    }
+
+    /// Gets a pointer to the value.
+    ///
+    /// Use this as a replacement for C's ampersand operator.
+    pub fn get(self: Pin<&Self>) -> *mut T {
+        self.inner.get().cast_init()
+    }
+}

--- a/library/std/src/sys/helpers/mod.rs
+++ b/library/std/src/sys/helpers/mod.rs
@@ -3,6 +3,8 @@
 //! If any of these have uses outside of `sys`, please move them to a different
 //! module.
 
+#[cfg_attr(not(target_os = "netbsd"), allow(unused))] // Not used on all platforms.
+mod c_opaque;
 #[cfg_attr(not(target_os = "linux"), allow(unused))] // Not used on all platforms.
 mod small_c_string;
 #[cfg_attr(not(target_os = "windows"), allow(unused))] // Not used on all platforms.
@@ -11,6 +13,8 @@ mod wstr;
 #[cfg(test)]
 mod tests;
 
+#[cfg_attr(not(target_os = "netbsd"), allow(unused))] // Not used on all platforms.
+pub use c_opaque::COpaque;
 #[cfg_attr(not(target_os = "linux"), allow(unused))] // Not used on all platforms.
 pub use small_c_string::{run_path_with_cstr, run_with_cstr};
 #[cfg_attr(not(target_os = "windows"), allow(unused))] // Not used on all platforms.

--- a/library/std/src/sys/pal/unix/stack_overflow.rs
+++ b/library/std/src/sys/pal/unix/stack_overflow.rs
@@ -359,28 +359,32 @@ mod imp {
         target_os = "l4re"
     ))]
     unsafe fn get_stack_start() -> Option<*mut libc::c_void> {
+        use crate::pin::pin;
+        use crate::sys::helpers::COpaque;
+
         let mut ret = None;
-        let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = mem::MaybeUninit::uninit();
+        let mut attr: COpaque<libc::pthread_attr_t> = COpaque::uninit();
         if !cfg!(target_os = "freebsd") {
-            attr = mem::MaybeUninit::zeroed();
+            attr = COpaque::zeroed();
         }
+        let attr = pin!(attr);
+        // FIXME(pin-ergonomics): remove the next line.
+        let attr = attr.into_ref();
+
         #[cfg(target_os = "freebsd")]
-        assert_eq!(libc::pthread_attr_init(attr.as_mut_ptr()), 0);
+        assert_eq!(libc::pthread_attr_init(attr.get()), 0);
         #[cfg(target_os = "freebsd")]
-        let e = libc::pthread_attr_get_np(libc::pthread_self(), attr.as_mut_ptr());
+        let e = libc::pthread_attr_get_np(libc::pthread_self(), attr.get());
         #[cfg(not(target_os = "freebsd"))]
-        let e = libc::pthread_getattr_np(libc::pthread_self(), attr.as_mut_ptr());
+        let e = libc::pthread_getattr_np(libc::pthread_self(), attr.get());
         if e == 0 {
             let mut stackaddr = crate::ptr::null_mut();
             let mut stacksize = 0;
-            assert_eq!(
-                libc::pthread_attr_getstack(attr.as_ptr(), &mut stackaddr, &mut stacksize),
-                0
-            );
+            assert_eq!(libc::pthread_attr_getstack(attr.get(), &mut stackaddr, &mut stacksize), 0);
             ret = Some(stackaddr);
         }
         if e == 0 || cfg!(target_os = "freebsd") {
-            assert_eq!(libc::pthread_attr_destroy(attr.as_mut_ptr()), 0);
+            assert_eq!(libc::pthread_attr_destroy(attr.get()), 0);
         }
         ret
     }
@@ -572,21 +576,28 @@ mod imp {
     ))]
     // FIXME: I am probably not unsafe.
     unsafe fn current_guard() -> Option<Range<usize>> {
+        use crate::pin::pin;
+        use crate::sys::helpers::COpaque;
+
         let mut ret = None;
 
-        let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = mem::MaybeUninit::uninit();
+        let mut attr: COpaque<libc::pthread_attr_t> = COpaque::uninit();
         if !cfg!(target_os = "freebsd") {
-            attr = mem::MaybeUninit::zeroed();
+            attr = COpaque::zeroed();
         }
+        let attr = pin!(attr);
+        // FIXME(pin-ergonomics): remove the next line.
+        let attr = attr.into_ref();
+
         #[cfg(target_os = "freebsd")]
-        assert_eq!(libc::pthread_attr_init(attr.as_mut_ptr()), 0);
+        assert_eq!(libc::pthread_attr_init(attr.get()), 0);
         #[cfg(target_os = "freebsd")]
-        let e = libc::pthread_attr_get_np(libc::pthread_self(), attr.as_mut_ptr());
+        let e = libc::pthread_attr_get_np(libc::pthread_self(), attr.get());
         #[cfg(not(target_os = "freebsd"))]
-        let e = libc::pthread_getattr_np(libc::pthread_self(), attr.as_mut_ptr());
+        let e = libc::pthread_getattr_np(libc::pthread_self(), attr.get());
         if e == 0 {
             let mut guardsize = 0;
-            assert_eq!(libc::pthread_attr_getguardsize(attr.as_ptr(), &mut guardsize), 0);
+            assert_eq!(libc::pthread_attr_getguardsize(attr.get(), &mut guardsize), 0);
             if guardsize == 0 {
                 if cfg!(all(target_os = "linux", target_env = "musl")) {
                     // musl versions before 1.1.19 always reported guard
@@ -599,7 +610,7 @@ mod imp {
             }
             let mut stackptr = crate::ptr::null_mut::<libc::c_void>();
             let mut size = 0;
-            assert_eq!(libc::pthread_attr_getstack(attr.as_ptr(), &mut stackptr, &mut size), 0);
+            assert_eq!(libc::pthread_attr_getstack(attr.get(), &mut stackptr, &mut size), 0);
 
             let stackaddr = stackptr.addr();
             ret = if cfg!(any(target_os = "freebsd", target_os = "netbsd", target_os = "hurd")) {
@@ -620,7 +631,7 @@ mod imp {
             };
         }
         if e == 0 || cfg!(target_os = "freebsd") {
-            assert_eq!(libc::pthread_attr_destroy(attr.as_mut_ptr()), 0);
+            assert_eq!(libc::pthread_attr_destroy(attr.get()), 0);
         }
         ret
     }

--- a/library/std/src/sys/pal/unix/sync/condvar.rs
+++ b/library/std/src/sys/pal/unix/sync/condvar.rs
@@ -1,6 +1,6 @@
 use super::Mutex;
-use crate::cell::UnsafeCell;
 use crate::pin::Pin;
+use crate::sys::helpers::COpaque;
 #[cfg(not(any(target_os = "nto", target_os = "qnx")))]
 use crate::sys::pal::time::TIMESPEC_MAX;
 #[cfg(any(target_os = "nto", target_os = "qnx"))]
@@ -8,17 +8,18 @@ use crate::sys::pal::time::TIMESPEC_MAX_CAPPED;
 use crate::time::Duration;
 
 pub struct Condvar {
-    inner: UnsafeCell<libc::pthread_cond_t>,
+    inner: COpaque<libc::pthread_cond_t>,
 }
 
 impl Condvar {
     pub fn new() -> Condvar {
-        Condvar { inner: UnsafeCell::new(libc::PTHREAD_COND_INITIALIZER) }
+        Condvar { inner: COpaque::new(libc::PTHREAD_COND_INITIALIZER) }
     }
 
     #[inline]
-    fn raw(&self) -> *mut libc::pthread_cond_t {
-        self.inner.get()
+    fn raw(self: Pin<&Self>) -> *mut libc::pthread_cond_t {
+        let inner = unsafe { self.map_unchecked(|c| &c.inner) };
+        inner.get()
     }
 
     /// # Safety
@@ -54,7 +55,7 @@ impl Condvar {
     /// * `init` must have been called on this instance.
     /// * `mutex` must be locked by the current thread.
     /// * This condition variable may only be used with the same mutex.
-    pub unsafe fn wait_timeout(&self, mutex: Pin<&Mutex>, dur: Duration) -> bool {
+    pub unsafe fn wait_timeout(self: Pin<&Self>, mutex: Pin<&Mutex>, dur: Duration) -> bool {
         use crate::sys::pal::time::Timespec;
 
         let mutex = mutex.raw();
@@ -91,7 +92,7 @@ impl Condvar {
     /// * `init` must have been called on this instance.
     /// * `mutex` must be locked by the current thread.
     /// * This condition variable may only be used with the same mutex.
-    pub unsafe fn wait_timeout(&self, mutex: Pin<&Mutex>, dur: Duration) -> bool {
+    pub unsafe fn wait_timeout(self: Pin<&Self>, mutex: Pin<&Mutex>, dur: Duration) -> bool {
         let mutex = mutex.raw();
 
         // The macOS implementation of `pthread_cond_timedwait` internally
@@ -150,26 +151,28 @@ impl Condvar {
     /// # Safety
     /// May only be called once per instance of `Self`.
     pub unsafe fn init(self: Pin<&mut Self>) {
-        use crate::mem::MaybeUninit;
+        use crate::pin::pin;
 
-        struct AttrGuard<'a>(pub &'a mut MaybeUninit<libc::pthread_condattr_t>);
+        struct AttrGuard<'a>(Pin<&'a COpaque<libc::pthread_condattr_t>>);
         impl Drop for AttrGuard<'_> {
             fn drop(&mut self) {
                 unsafe {
-                    let result = libc::pthread_condattr_destroy(self.0.as_mut_ptr());
+                    let result = libc::pthread_condattr_destroy(self.0.get());
                     assert_eq!(result, 0);
                 }
             }
         }
 
         unsafe {
-            let mut attr = MaybeUninit::<libc::pthread_condattr_t>::uninit();
-            let r = libc::pthread_condattr_init(attr.as_mut_ptr());
+            let attr = pin!(COpaque::<libc::pthread_condattr_t>::uninit());
+            // FIXME(pin-ergonomics): remove the next line.
+            let attr = attr.into_ref();
+            let r = libc::pthread_condattr_init(attr.get());
             assert_eq!(r, 0);
-            let attr = AttrGuard(&mut attr);
-            let r = libc::pthread_condattr_setclock(attr.0.as_mut_ptr(), Self::CLOCK);
+            let attr = AttrGuard(attr);
+            let r = libc::pthread_condattr_setclock(attr.0.get(), Self::CLOCK);
             assert_eq!(r, 0);
-            let r = libc::pthread_cond_init(self.raw(), attr.0.as_ptr());
+            let r = libc::pthread_cond_init(self.as_ref().raw(), attr.0.get());
             assert_eq!(r, 0);
         }
     }
@@ -210,7 +213,7 @@ impl Condvar {
             // So on that platform, init() should always be called.
             //
             // Similar story for the 3DS (horizon) and for TEEOS.
-            let r = unsafe { libc::pthread_cond_init(self.raw(), crate::ptr::null()) };
+            let r = unsafe { libc::pthread_cond_init(self.as_ref().raw(), crate::ptr::null()) };
             assert_eq!(r, 0);
         }
     }
@@ -224,7 +227,8 @@ unsafe impl Send for Condvar {}
 impl Drop for Condvar {
     #[inline]
     fn drop(&mut self) {
-        let r = unsafe { libc::pthread_cond_destroy(self.raw()) };
+        let inner = unsafe { Pin::new_unchecked(&self.inner) };
+        let r = unsafe { libc::pthread_cond_destroy(inner.get()) };
         if cfg!(target_os = "dragonfly") {
             // On DragonFly pthread_cond_destroy() returns EINVAL if called on
             // a condvar that was just initialized with

--- a/library/std/src/sys/pal/unix/sync/mutex.rs
+++ b/library/std/src/sys/pal/unix/sync/mutex.rs
@@ -1,20 +1,20 @@
 use super::super::cvt_nz;
-use crate::cell::UnsafeCell;
 use crate::io::Error;
-use crate::mem::MaybeUninit;
-use crate::pin::Pin;
+use crate::pin::{Pin, pin};
+use crate::sys::helpers::COpaque;
 
 pub struct Mutex {
-    inner: UnsafeCell<libc::pthread_mutex_t>,
+    inner: COpaque<libc::pthread_mutex_t>,
 }
 
 impl Mutex {
     pub fn new() -> Mutex {
-        Mutex { inner: UnsafeCell::new(libc::PTHREAD_MUTEX_INITIALIZER) }
+        Mutex { inner: COpaque::new(libc::PTHREAD_MUTEX_INITIALIZER) }
     }
 
-    pub(super) fn raw(&self) -> *mut libc::pthread_mutex_t {
-        self.inner.get()
+    pub(super) fn raw(self: Pin<&Self>) -> *mut libc::pthread_mutex_t {
+        let inner = unsafe { self.map_unchecked(|m| &m.inner) };
+        inner.get()
     }
 
     /// # Safety
@@ -45,15 +45,14 @@ impl Mutex {
         // PTHREAD_MUTEX_NORMAL which is guaranteed to deadlock if we try to
         // re-lock it from the same thread, thus avoiding undefined behavior.
         unsafe {
-            let mut attr = MaybeUninit::<libc::pthread_mutexattr_t>::uninit();
-            cvt_nz(libc::pthread_mutexattr_init(attr.as_mut_ptr())).unwrap();
-            let attr = AttrGuard(&mut attr);
-            cvt_nz(libc::pthread_mutexattr_settype(
-                attr.0.as_mut_ptr(),
-                libc::PTHREAD_MUTEX_NORMAL,
-            ))
-            .unwrap();
-            cvt_nz(libc::pthread_mutex_init(self.raw(), attr.0.as_ptr())).unwrap();
+            let attr = pin!(COpaque::<libc::pthread_mutexattr_t>::uninit());
+            // FIXME(pin-ergonomics): remove the next line.
+            let attr = attr.into_ref();
+            cvt_nz(libc::pthread_mutexattr_init(attr.get())).unwrap();
+            let attr = AttrGuard(attr);
+            cvt_nz(libc::pthread_mutexattr_settype(attr.0.get(), libc::PTHREAD_MUTEX_NORMAL))
+                .unwrap();
+            cvt_nz(libc::pthread_mutex_init(self.as_ref().raw(), attr.0.get())).unwrap();
         }
     }
 
@@ -105,12 +104,13 @@ unsafe impl Sync for Mutex {}
 
 impl Drop for Mutex {
     fn drop(&mut self) {
+        let inner = unsafe { Pin::new_unchecked(&self.inner) };
         // SAFETY:
         // If `lock` or `init` was called, the mutex must have been pinned, so
         // it is still at the same location. Otherwise, `inner` must contain
         // `PTHREAD_MUTEX_INITIALIZER`, which is valid at all locations. Thus,
         // this call always destroys a valid mutex.
-        let r = unsafe { libc::pthread_mutex_destroy(self.raw()) };
+        let r = unsafe { libc::pthread_mutex_destroy(inner.get()) };
         if cfg!(any(target_os = "aix", target_os = "dragonfly")) {
             // On AIX and DragonFly pthread_mutex_destroy() returns EINVAL if called
             // on a mutex that was just initialized with libc::PTHREAD_MUTEX_INITIALIZER.
@@ -123,12 +123,12 @@ impl Drop for Mutex {
     }
 }
 
-struct AttrGuard<'a>(pub &'a mut MaybeUninit<libc::pthread_mutexattr_t>);
+struct AttrGuard<'a>(pub Pin<&'a COpaque<libc::pthread_mutexattr_t>>);
 
 impl Drop for AttrGuard<'_> {
     fn drop(&mut self) {
         unsafe {
-            let result = libc::pthread_mutexattr_destroy(self.0.as_mut_ptr());
+            let result = libc::pthread_mutexattr_destroy(self.0.get());
             assert_eq!(result, 0);
         }
     }

--- a/library/std/src/sys/process/unix/unix.rs
+++ b/library/std/src/sys/process/unix/unix.rs
@@ -462,6 +462,8 @@ impl Command {
         use core::sync::atomic::{Atomic, AtomicU8, Ordering};
 
         use crate::mem::MaybeUninit;
+        use crate::pin::{Pin, pin};
+        use crate::sys::helpers::COpaque;
         use crate::sys::{self, cvt_nz, on_broken_pipe_used};
 
         if self.get_gid().is_some()
@@ -670,65 +672,68 @@ impl Command {
 
         let pgroup = self.get_pgroup();
 
-        struct PosixSpawnFileActions<'a>(&'a mut MaybeUninit<libc::posix_spawn_file_actions_t>);
+        struct PosixSpawnFileActions<'a>(Pin<&'a COpaque<libc::posix_spawn_file_actions_t>>);
 
         impl Drop for PosixSpawnFileActions<'_> {
             fn drop(&mut self) {
                 unsafe {
-                    libc::posix_spawn_file_actions_destroy(self.0.as_mut_ptr());
+                    libc::posix_spawn_file_actions_destroy(self.0.get());
                 }
             }
         }
 
-        struct PosixSpawnattr<'a>(&'a mut MaybeUninit<libc::posix_spawnattr_t>);
+        struct PosixSpawnattr<'a>(Pin<&'a COpaque<libc::posix_spawnattr_t>>);
 
         impl Drop for PosixSpawnattr<'_> {
             fn drop(&mut self) {
                 unsafe {
-                    libc::posix_spawnattr_destroy(self.0.as_mut_ptr());
+                    libc::posix_spawnattr_destroy(self.0.get());
                 }
             }
         }
 
         unsafe {
-            let mut attrs = MaybeUninit::uninit();
-            cvt_nz(libc::posix_spawnattr_init(attrs.as_mut_ptr()))?;
-            let attrs = PosixSpawnattr(&mut attrs);
+            let attrs = pin!(COpaque::uninit());
+            // FIXME(pin-ergonomics): remove the next line.
+            let attrs = attrs.into_ref();
+            cvt_nz(libc::posix_spawnattr_init(attrs.get()))?;
+            let attrs = PosixSpawnattr(attrs);
 
             let mut flags = 0;
 
-            let mut file_actions = MaybeUninit::uninit();
-            cvt_nz(libc::posix_spawn_file_actions_init(file_actions.as_mut_ptr()))?;
-            let file_actions = PosixSpawnFileActions(&mut file_actions);
+            let file_actions = pin!(COpaque::uninit());
+            let file_actions = file_actions.into_ref();
+            cvt_nz(libc::posix_spawn_file_actions_init(file_actions.get()))?;
+            let file_actions = PosixSpawnFileActions(file_actions);
 
             if let Some(fd) = stdio.stdin.fd() {
                 cvt_nz(libc::posix_spawn_file_actions_adddup2(
-                    file_actions.0.as_mut_ptr(),
+                    file_actions.0.get(),
                     fd,
                     libc::STDIN_FILENO,
                 ))?;
             }
             if let Some(fd) = stdio.stdout.fd() {
                 cvt_nz(libc::posix_spawn_file_actions_adddup2(
-                    file_actions.0.as_mut_ptr(),
+                    file_actions.0.get(),
                     fd,
                     libc::STDOUT_FILENO,
                 ))?;
             }
             if let Some(fd) = stdio.stderr.fd() {
                 cvt_nz(libc::posix_spawn_file_actions_adddup2(
-                    file_actions.0.as_mut_ptr(),
+                    file_actions.0.get(),
                     fd,
                     libc::STDERR_FILENO,
                 ))?;
             }
             if let Some((f, cwd)) = addchdir {
-                cvt_nz(f(file_actions.0.as_mut_ptr(), cwd.as_ptr()))?;
+                cvt_nz(f(file_actions.0.get(), cwd.as_ptr()))?;
             }
 
             if let Some(pgroup) = pgroup {
                 flags |= libc::POSIX_SPAWN_SETPGROUP;
-                cvt_nz(libc::posix_spawnattr_setpgroup(attrs.0.as_mut_ptr(), pgroup))?;
+                cvt_nz(libc::posix_spawnattr_setpgroup(attrs.0.get(), pgroup))?;
             }
 
             // Inherit the signal mask from this process rather than resetting it (i.e. do not call
@@ -746,10 +751,7 @@ impl Command {
                 {
                     cvt(sigaddset(default_set.as_mut_ptr(), libc::SIGLOST))?;
                 }
-                cvt_nz(libc::posix_spawnattr_setsigdefault(
-                    attrs.0.as_mut_ptr(),
-                    default_set.as_ptr(),
-                ))?;
+                cvt_nz(libc::posix_spawnattr_setsigdefault(attrs.0.get(), default_set.as_ptr()))?;
                 flags |= libc::POSIX_SPAWN_SETSIGDEF;
             }
 
@@ -764,7 +766,7 @@ impl Command {
                 }
             }
 
-            cvt_nz(libc::posix_spawnattr_setflags(attrs.0.as_mut_ptr(), flags as _))?;
+            cvt_nz(libc::posix_spawnattr_setflags(attrs.0.get(), flags as _))?;
 
             // Make sure we synchronize access to the global `environ` resource
             let _env_lock = sys::env::env_read_lock();
@@ -781,8 +783,8 @@ impl Command {
                 let spawn_res = pidfd_spawnp.get().unwrap()(
                     &mut pidfd,
                     self.get_program_cstr().as_ptr(),
-                    file_actions.0.as_ptr(),
-                    attrs.0.as_ptr(),
+                    file_actions.0.get(),
+                    attrs.0.get(),
                     self.get_argv().as_ptr() as *const _,
                     envp as *const _,
                 );
@@ -823,8 +825,8 @@ impl Command {
             let spawn_res = spawn_fn(
                 &mut p.pid,
                 self.get_program_cstr().as_ptr(),
-                file_actions.0.as_ptr(),
-                attrs.0.as_ptr(),
+                file_actions.0.get(),
+                attrs.0.get(),
                 self.get_argv().as_ptr() as *const _,
                 envp as *const _,
             );

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -10,6 +10,8 @@
 use crate::ffi::CStr;
 use crate::mem::{self, DropGuard, ManuallyDrop};
 use crate::num::NonZero;
+use crate::pin::pin;
+use crate::sys::helpers::COpaque;
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 use crate::sys::weak::dlsym;
 #[cfg(any(
@@ -50,11 +52,13 @@ impl Thread {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub unsafe fn new(stack: usize, init: Box<ThreadInit>) -> io::Result<Thread> {
         let data = init;
-        let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = mem::MaybeUninit::uninit();
-        assert_eq!(libc::pthread_attr_init(attr.as_mut_ptr()), 0);
-        let mut attr = DropGuard::new(&mut attr, |attr| {
-            assert_eq!(libc::pthread_attr_destroy(attr.as_mut_ptr()), 0)
-        });
+        let attr = pin!(COpaque::<libc::pthread_attr_t>::uninit());
+        // FIXME(pin-ergonomics): remove the next line.
+        let attr = attr.into_ref();
+
+        assert_eq!(libc::pthread_attr_init(attr.get()), 0);
+        let attr =
+            DropGuard::new(attr, |attr| assert_eq!(libc::pthread_attr_destroy(attr.get()), 0));
 
         #[cfg(any(target_os = "espidf", target_os = "nuttx"))]
         if stack > 0 {
@@ -62,7 +66,7 @@ impl Thread {
             // 0 is used as an indication that the default stack size configured in the ESP-IDF/NuttX menuconfig system should be used
             assert_eq!(
                 libc::pthread_attr_setstacksize(
-                    attr.as_mut_ptr(),
+                    attr.get(),
                     cmp::max(stack, min_stack_size(attr.as_ptr()))
                 ),
                 0
@@ -71,9 +75,9 @@ impl Thread {
 
         #[cfg(not(any(target_os = "espidf", target_os = "nuttx")))]
         {
-            let stack_size = cmp::max(stack, min_stack_size(attr.as_ptr()));
+            let stack_size = cmp::max(stack, min_stack_size(attr.get()));
 
-            match libc::pthread_attr_setstacksize(attr.as_mut_ptr(), stack_size) {
+            match libc::pthread_attr_setstacksize(attr.get(), stack_size) {
                 0 => {}
                 n => {
                     assert_eq!(n, libc::EINVAL);
@@ -88,7 +92,7 @@ impl Thread {
                     // Some libc implementations, e.g. musl, place an upper bound
                     // on the stack size, in which case we can only gracefully return
                     // an error here.
-                    if libc::pthread_attr_setstacksize(attr.as_mut_ptr(), stack_size) != 0 {
+                    if libc::pthread_attr_setstacksize(attr.get(), stack_size) != 0 {
                         return Err(io::const_error!(
                             io::ErrorKind::InvalidInput,
                             "invalid stack size"
@@ -100,7 +104,7 @@ impl Thread {
 
         let data = Box::into_raw(data);
         let mut native: libc::pthread_t = mem::zeroed();
-        let ret = libc::pthread_create(&mut native, attr.as_ptr(), thread_start, data as *mut _);
+        let ret = libc::pthread_create(&mut native, attr.get(), thread_start, data as *mut _);
         return if ret == 0 {
             Ok(Thread { id: native })
         } else {


### PR DESCRIPTION
Fixes rust-lang/rust#160815 (and some other instances of the same problem)

See the new documentation of `COpaque` for a detailed description of the kinds of issues solved by this. In short: creating mutable references to the opaque types from pthread is unsound since some platforms (at least AIX) store an intrinsically list of these types and the creation of the mutable reference (e.g. in the drop glue) invalidates the other pointers to the type.

This doesn't just apply to the internal pthread `Condvar` and `Mutex` abstraction as described in the issue, but also to all other opaque types – nobody is promising us that these are not internally aliased. Hence this PR adds an internal `COpaque` helper type which uses a combination of `UnsafePinned` and `MaybeUninit` to relax all relevant requirements added by Rust's operational semantics.

CC @RalfJung I'd love to hear your opinion on this
r? libs