### PR TITLE
delegation: simplify matches on `FnKind`, minor refactorings

### DIFF
--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -71,21 +71,22 @@ enum SelfPositionKind {
     None,
 }
 
-fn create_self_position_kind(
+fn create_self_param_position_kind(
     tcx: TyCtxt<'_>,
-    delegation_id: LocalDefId,
+    def_id: LocalDefId,
     sig_id: DefId,
 ) -> SelfPositionKind {
-    match (fn_kind(tcx, delegation_id), fn_kind(tcx, sig_id)) {
-        (FnKind::AssocInherentImpl, FnKind::AssocTrait)
-        | (FnKind::AssocTraitImpl, FnKind::AssocTrait)
-        | (FnKind::AssocTrait, FnKind::AssocTrait)
-        | (FnKind::AssocTrait, FnKind::Free) => SelfPositionKind::Zero,
-
+    match fn_kinds(tcx, def_id, sig_id) {
         (FnKind::Free, FnKind::AssocTrait) => {
-            let kind = tcx.hir_delegation_info(delegation_id).self_ty_propagation_kind;
+            let kind = tcx.hir_delegation_info(def_id).self_ty_propagation_kind;
             SelfPositionKind::AfterLifetimes(kind)
         }
+
+        (_, FnKind::AssocTraitImpl) => unreachable!(),
+
+        (_, FnKind::AssocTrait) | (FnKind::AssocTrait, _) => SelfPositionKind::Zero,
+
+        (FnKind::AssocTraitImpl, _) => unreachable!(),
 
         _ => SelfPositionKind::None,
     }
@@ -114,6 +115,17 @@ fn fn_kind<'tcx>(tcx: TyCtxt<'tcx>, def_id: impl Into<DefId>) -> FnKind {
         },
         _ => unreachable!("delegation/signature can be either free or associated function"),
     }
+}
+
+fn fn_kinds(tcx: TyCtxt<'_>, def_id: LocalDefId, sig_id: DefId) -> (FnKind, FnKind) {
+    let kinds = (fn_kind(tcx, def_id), fn_kind(tcx, sig_id));
+
+    // For trait impl's `sig_id` is always equal to the corresponding trait method.
+    assert!(!matches!(kinds, (_, FnKind::AssocTraitImpl)));
+    // Delegation to inherent impls is not yet supported.
+    assert!(!matches!(kinds, (_, FnKind::AssocInherentImpl)));
+
+    kinds
 }
 
 /// Given the current context(caller and callee `FnKind`), it specifies
@@ -152,7 +164,7 @@ fn create_mapping<'tcx>(
 ) -> FxHashMap<u32, u32> {
     let mut mapping: FxHashMap<u32, u32> = Default::default();
 
-    let self_pos_kind = create_self_position_kind(tcx, def_id, sig_id);
+    let self_pos_kind = create_self_param_position_kind(tcx, def_id, sig_id);
     let is_self_at_zero = matches!(self_pos_kind, SelfPositionKind::Zero);
 
     // Is self at zero? If so insert mapping, self in sig parent is always at 0.
@@ -215,30 +227,24 @@ fn create_mapping<'tcx>(
 
 fn get_delegation_parent_args_count_without_self<'tcx>(
     tcx: TyCtxt<'tcx>,
-    delegation_id: LocalDefId,
+    def_id: LocalDefId,
     sig_id: DefId,
 ) -> usize {
-    let delegation_parent_args_count = tcx.generics_of(delegation_id).parent_count;
+    let kinds @ (def_kind, _) = fn_kinds(tcx, def_id, sig_id);
 
-    match (fn_kind(tcx, delegation_id), fn_kind(tcx, sig_id)) {
-        (FnKind::Free, FnKind::Free)
-        | (FnKind::Free, FnKind::AssocTrait)
-        | (FnKind::AssocTraitImpl, FnKind::AssocTrait) => 0,
+    match kinds {
+        (FnKind::AssocTraitImpl, FnKind::AssocTrait) => 0,
 
-        (FnKind::AssocInherentImpl, FnKind::Free)
-        | (FnKind::AssocInherentImpl, FnKind::AssocTrait) => {
-            delegation_parent_args_count /* No Self in AssocInherentImpl */
+        (FnKind::AssocTraitImpl, _) | (_, FnKind::AssocTraitImpl) => unreachable!(),
+
+        (FnKind::Free, _) => 0,
+
+        (_, _) => {
+            let delegation_parent_args_count = tcx.generics_of(def_id).parent_count;
+            let has_self = def_kind == FnKind::AssocTrait;
+
+            delegation_parent_args_count - usize::from(has_self)
         }
-
-        (FnKind::AssocTrait, FnKind::Free) | (FnKind::AssocTrait, FnKind::AssocTrait) => {
-            delegation_parent_args_count - 1 /* Without Self */
-        }
-
-        // For trait impl's `sig_id` is always equal to the corresponding trait method.
-        // For inherent methods delegation is not yet supported.
-        (FnKind::AssocTraitImpl, _)
-        | (_, FnKind::AssocTraitImpl)
-        | (_, FnKind::AssocInherentImpl) => unreachable!(),
     }
 }
 
@@ -247,75 +253,57 @@ fn get_parent_and_inheritance_kind<'tcx>(
     def_id: LocalDefId,
     sig_id: DefId,
 ) -> (Option<DefId>, InheritanceKind) {
-    match (fn_kind(tcx, def_id), fn_kind(tcx, sig_id)) {
-        (FnKind::Free, FnKind::Free) | (FnKind::Free, FnKind::AssocTrait) => {
-            (None, InheritanceKind::WithParent(true))
-        }
+    let kinds @ (_, sig_kind) = fn_kinds(tcx, def_id, sig_id);
 
+    match kinds {
         (FnKind::AssocTraitImpl, FnKind::AssocTrait) => {
             (Some(tcx.parent(def_id.to_def_id())), InheritanceKind::Own)
         }
 
-        (FnKind::AssocInherentImpl, FnKind::AssocTrait)
-        | (FnKind::AssocTrait, FnKind::AssocTrait)
-        | (FnKind::AssocInherentImpl, FnKind::Free)
-        | (FnKind::AssocTrait, FnKind::Free) => {
-            (Some(tcx.parent(def_id.to_def_id())), InheritanceKind::WithParent(false))
+        (FnKind::AssocTraitImpl, _) | (_, FnKind::AssocTraitImpl) => unreachable!(),
+
+        (FnKind::Free, _) => {
+            let copy_self_clauses = sig_kind == FnKind::AssocTrait;
+            (None, InheritanceKind::WithParent(copy_self_clauses))
         }
 
-        // For trait impl's `sig_id` is always equal to the corresponding trait method.
-        // For inherent methods delegation is not yet supported.
-        (FnKind::AssocTraitImpl, _)
-        | (_, FnKind::AssocTraitImpl)
-        | (_, FnKind::AssocInherentImpl) => unreachable!(),
+        (_, _) => (Some(tcx.parent(def_id.to_def_id())), InheritanceKind::WithParent(false)),
     }
 }
 
-fn get_delegation_self_ty<'tcx>(tcx: TyCtxt<'tcx>, delegation_id: LocalDefId) -> Option<Ty<'tcx>> {
-    let sig_id = tcx.hir_opt_delegation_sig_id(delegation_id).expect("Delegation must have sig_id");
-    let (caller_kind, callee_kind) = (fn_kind(tcx, delegation_id), fn_kind(tcx, sig_id));
+fn get_delegation_self_ty<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Option<Ty<'tcx>> {
+    let sig_id = tcx.hir_opt_delegation_sig_id(def_id).expect("processing delegation");
+    let (caller_kind, callee_kind) = fn_kinds(tcx, def_id, sig_id);
 
     match (caller_kind, callee_kind) {
-        (FnKind::Free, FnKind::AssocTrait)
-        | (FnKind::AssocInherentImpl, FnKind::Free)
-        | (FnKind::Free, FnKind::Free)
-        | (FnKind::AssocTrait, FnKind::Free)
-        | (FnKind::AssocTrait, FnKind::AssocTrait) => {
-            match create_self_position_kind(tcx, delegation_id, sig_id) {
-                SelfPositionKind::None => None,
-                SelfPositionKind::AfterLifetimes(propagation_kind) => {
-                    Some(match propagation_kind {
-                        Some(kind) => match kind {
-                            DelegationSelfTyPropagationKind::SelfTy(self_ty_id) => {
-                                let ctx = ItemCtxt::new(tcx, delegation_id);
-                                ctx.lower_ty(tcx.hir_node(self_ty_id).expect_ty())
-                            }
-                            DelegationSelfTyPropagationKind::SelfParam => {
-                                let index = tcx.generics_of(delegation_id).own_counts().lifetimes;
-                                Ty::new_param(tcx, index as u32, kw::SelfUpper)
-                            }
-                        },
-                        None => Ty::new_error_with_message(
-                            tcx,
-                            tcx.def_span(delegation_id),
-                            "self propagation kind must be specified for `AfterLifetimes` variant",
-                        ),
-                    })
-                }
-                SelfPositionKind::Zero => Some(Ty::new_param(tcx, 0, kw::SelfUpper)),
-            }
+        (FnKind::AssocTraitImpl, FnKind::AssocTrait) | (FnKind::AssocInherentImpl, _) => {
+            Some(tcx.type_of(tcx.local_parent(def_id)).instantiate_identity().skip_norm_wip())
         }
 
-        (FnKind::AssocTraitImpl, FnKind::AssocTrait)
-        | (FnKind::AssocInherentImpl, FnKind::AssocTrait) => Some(
-            tcx.type_of(tcx.local_parent(delegation_id)).instantiate_identity().skip_norm_wip(),
-        ),
-
         // For trait impl's `sig_id` is always equal to the corresponding trait method.
-        // For inherent methods delegation is not yet supported.
-        (FnKind::AssocTraitImpl, _)
-        | (_, FnKind::AssocTraitImpl)
-        | (_, FnKind::AssocInherentImpl) => unreachable!(),
+        (FnKind::AssocTraitImpl, _) | (_, FnKind::AssocTraitImpl) => unreachable!(),
+
+        (_, _) => match create_self_param_position_kind(tcx, def_id, sig_id) {
+            SelfPositionKind::None => None,
+            SelfPositionKind::AfterLifetimes(propagation_kind) => Some(match propagation_kind {
+                Some(kind) => match kind {
+                    DelegationSelfTyPropagationKind::SelfTy(self_ty_id) => {
+                        let ctx = ItemCtxt::new(tcx, def_id);
+                        ctx.lower_ty(tcx.hir_node(self_ty_id).expect_ty())
+                    }
+                    DelegationSelfTyPropagationKind::SelfParam => {
+                        let index = tcx.generics_of(def_id).own_counts().lifetimes;
+                        Ty::new_param(tcx, index as u32, kw::SelfUpper)
+                    }
+                },
+                None => Ty::new_error_with_message(
+                    tcx,
+                    tcx.def_span(def_id),
+                    "self propagation kind must be specified for `AfterLifetimes` variant",
+                ),
+            }),
+            SelfPositionKind::Zero => Some(Ty::new_param(tcx, 0, kw::SelfUpper)),
+        },
     }
 }
 
@@ -337,12 +325,12 @@ fn get_delegation_self_ty<'tcx>(tcx: TyCtxt<'tcx>, delegation_id: LocalDefId) ->
 fn create_generic_args<'tcx>(
     tcx: TyCtxt<'tcx>,
     sig_id: DefId,
-    delegation_id: LocalDefId,
+    def_id: LocalDefId,
     mut parent_args: &[ty::GenericArg<'tcx>],
     mut child_args: &[ty::GenericArg<'tcx>],
 ) -> (Vec<ty::GenericArg<'tcx>>, &'tcx [ty::GenericArg<'tcx>]) {
-    let delegation_generics = tcx.generics_of(delegation_id);
-    let delegation_args = ty::GenericArgs::identity_for_item(tcx, delegation_id);
+    let delegation_generics = tcx.generics_of(def_id);
+    let delegation_args = ty::GenericArgs::identity_for_item(tcx, def_id);
 
     let real_args_count = delegation_args.len() - delegation_generics.own_synthetic_params_count();
     let synth_args = &delegation_args[real_args_count..];
@@ -352,12 +340,12 @@ fn create_generic_args<'tcx>(
 
     let delegation_args = &delegation_args[delegation_generics.parent_count..];
 
-    let kinds = (fn_kind(tcx, delegation_id), fn_kind(tcx, sig_id));
+    let kinds = fn_kinds(tcx, def_id, sig_id);
     if matches!(kinds, (FnKind::AssocTraitImpl, FnKind::AssocTrait)) {
         // Special case, as user specifies Trait args in trait impl header, we want to treat
         // them as parent args. We always generate a function whose generics match
         // child generics in trait.
-        let parent = tcx.local_parent(delegation_id);
+        let parent = tcx.local_parent(def_id);
 
         parent_args =
             tcx.impl_trait_header(parent).trait_ref.instantiate_identity().skip_norm_wip().args;
@@ -368,7 +356,7 @@ fn create_generic_args<'tcx>(
         delegation_parent_args = &[];
     }
 
-    let self_type = get_delegation_self_ty(tcx, delegation_id).map(|t| t.into());
+    let self_type = get_delegation_self_ty(tcx, def_id).map(ty::GenericArg::from);
 
     // Remove `Self` from parent args (it is always at the `0th` index) as it is
     // added manually.
@@ -377,7 +365,7 @@ fn create_generic_args<'tcx>(
     }
 
     let (zero_self, after_lifetimes_self) =
-        match create_self_position_kind(tcx, delegation_id, sig_id) {
+        match create_self_param_position_kind(tcx, def_id, sig_id) {
             SelfPositionKind::AfterLifetimes(_) => {
                 assert!(self_type.is_some());
                 (None, self_type)
@@ -505,7 +493,7 @@ pub(crate) fn inherit_clauses_for_delegation_item<'tcx>(
 
     let (parent_args, child_args) = tcx.delegation_user_specified_args(def_id);
     let (folder, args) = create_folder_and_args(tcx, def_id, sig_id, parent_args, child_args);
-    let self_pos_kind = create_self_position_kind(tcx, def_id, sig_id);
+    let self_pos_kind = create_self_param_position_kind(tcx, def_id, sig_id);
     let filter_self_clauses = matches!(
         self_pos_kind,
         SelfPositionKind::AfterLifetimes(Some(DelegationSelfTyPropagationKind::SelfTy(..)))
@@ -584,7 +572,6 @@ pub(crate) fn inherit_sig_for_delegation_item<'tcx>(
 ) -> &'tcx [Ty<'tcx>] {
     let sig_id = tcx.hir_opt_delegation_sig_id(def_id).expect("Delegation must have sig_id");
     let caller_sig = tcx.fn_sig(sig_id);
-
     if let Err(err) = check_constraints(tcx, def_id, sig_id) {
         let sig_len = caller_sig.instantiate_identity().skip_binder().inputs().len() + 1;
         let err_type = Ty::new_error(tcx, err);
@@ -606,23 +593,24 @@ pub(crate) fn inherit_sig_for_delegation_item<'tcx>(
 // we want to extract [Self, 'static, i32, 1] for parent and [A, B] for child.
 pub(crate) fn delegation_user_specified_args<'tcx>(
     tcx: TyCtxt<'tcx>,
-    delegation_id: LocalDefId,
+    def_id: LocalDefId,
 ) -> (&'tcx [ty::GenericArg<'tcx>], &'tcx [ty::GenericArg<'tcx>]) {
-    let info = tcx.hir_delegation_info(delegation_id);
+    let info = tcx.hir_delegation_info(def_id);
 
     let get_segment = |hir_id| -> Option<(&'tcx PathSegment<'tcx>, DefId)> {
         let segment = tcx.hir_node(hir_id).expect_path_segment();
         segment.res.opt_def_id().map(|def_id| (segment, def_id))
     };
 
-    let ctx = ItemCtxt::new_for_delegation(tcx, delegation_id);
+    let ctx = ItemCtxt::new_for_delegation(tcx, def_id);
     let lowerer = ctx.lowerer();
     let parent_args = info
         .parent_seg_id_for_sig
         .and_then(get_segment)
         .filter(|(_, def_id)| matches!(tcx.def_kind(*def_id), DefKind::Trait))
         .map(|(segment, def_id)| {
-            let self_ty = get_delegation_self_ty(tcx, delegation_id);
+            let self_ty = (tcx.def_kind(def_id) == DefKind::Trait)
+                .then(|| Ty::new_param(tcx, 0, kw::SelfUpper));
 
             lowerer
                 .lower_generic_args_of_path(segment.ident.span, def_id, &[], segment, self_ty)


### PR DESCRIPTION
This PR refactors matches on `FnKind` making them smaller and more concise, next in all matches except `fn_kinds` function we no longer panic on delegation to inherent impls. And some minor renamings/refactorings. First step for rust-lang/rust#160505.

Part of rust-lang/rust#118212.
r? @petrochenkov