### PR TITLE
Add regression test for assoc const panic ICE in match

### DIFF
--- a/tests/ui/associated-consts/assoc-const-panic-in-match-91514.rs
+++ b/tests/ui/associated-consts/assoc-const-panic-in-match-91514.rs
@@ -1,0 +1,30 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/91514>.
+//
+// An associated const initialized with `panic!()`, referenced from a `match` arm
+// with arms on both sides, used to ICE during codegen. It now fails const-eval
+// cleanly instead. The failure only surfaces on a full build (not `check`), since
+// the const is evaluated during codegen.
+
+//@ build-fail
+
+#![allow(path_statements)]
+
+struct S;
+
+impl S {
+    const CONST: u8 = panic!(); //~ ERROR evaluation panicked: explicit panic
+}
+
+fn f(_: Option<()>, _: Option<u8>) {}
+
+fn main() {
+    match 0 {
+        0 => {
+            f(None, None);
+        }
+        1 => {
+            S::CONST;
+        }
+        _ => {}
+    };
+}

--- a/tests/ui/associated-consts/assoc-const-panic-in-match-91514.stderr
+++ b/tests/ui/associated-consts/assoc-const-panic-in-match-91514.stderr
@@ -1,0 +1,15 @@
+error[E0080]: evaluation panicked: explicit panic
+  --> $DIR/assoc-const-panic-in-match-91514.rs:15:23
+   |
+LL |     const CONST: u8 = panic!();
+   |                       ^^^^^^^^ evaluation of `S::CONST` failed here
+
+note: erroneous constant encountered
+  --> $DIR/assoc-const-panic-in-match-91514.rs:26:13
+   |
+LL |             S::CONST;
+   |             ^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
Closes rust-lang/rust#91514, The associated const panic!() in a match used to ICE and now fails const eval cleanly