### PR TITLE
rustc_parse: suggest removing semicolon before `if` block

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2777,6 +2777,17 @@ impl<'a> Parser<'a> {
                                 "you likely meant to continue parsing the let-chain starting here",
                             );
                         } else {
+                            if self.prev_token == token::Semi
+                                && (self.token == token::OpenBrace || AssocOp::from_token(&self.token).is_some())
+                            {
+                                err.span_suggestion_verbose(
+                                    self.prev_token.span,
+                                    "remove this semicolon",
+                                    "",
+                                    Applicability::MaybeIncorrect,
+                                );
+                            }
+
                             // Look for usages of '=>' where '>=' might be intended
                             if maybe_fatarrow == token::FatArrow {
                                 err.span_suggestion_verbose(

--- a/tests/ui/parser/if-semi-before-block.fixed
+++ b/tests/ui/parser/if-semi-before-block.fixed
@@ -1,0 +1,47 @@
+//@ edition:2024
+//@ run-rustfix
+
+#![allow(dead_code)]
+
+fn block() {
+    if let Some(_) = Some(2) {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn and() {
+    if let Some(x) = Some(2) && x != 1 {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn and_paren_cond() {
+    if let Some(x) = Some(2) && (x > 0 && x != 1) {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn and_some() {
+    if let Some(x) = Some(2) && Some(1) == Some(x) {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn or() {
+    if true || false {
+        //~^ ERROR expected `{`, found `;`
+        //~| NOTE expected `{`
+        //~| HELP remove this semicolon
+        //~| NOTE the `if` expression is missing a block after this condition
+    }
+}
+
+fn main() {}

--- a/tests/ui/parser/if-semi-before-block.rs
+++ b/tests/ui/parser/if-semi-before-block.rs
@@ -1,0 +1,47 @@
+//@ edition:2024
+//@ run-rustfix
+
+#![allow(dead_code)]
+
+fn block() {
+    if let Some(_) = Some(2); {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn and() {
+    if let Some(x) = Some(2); && x != 1 {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn and_paren_cond() {
+    if let Some(x) = Some(2); && (x > 0 && x != 1) {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn and_some() {
+    if let Some(x) = Some(2); && Some(1) == Some(x) {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn or() {
+    if true; || false {
+        //~^ ERROR expected `{`, found `;`
+        //~| NOTE expected `{`
+        //~| HELP remove this semicolon
+        //~| NOTE the `if` expression is missing a block after this condition
+    }
+}
+
+fn main() {}

--- a/tests/ui/parser/if-semi-before-block.stderr
+++ b/tests/ui/parser/if-semi-before-block.stderr
@@ -1,0 +1,87 @@
+error: expected `{`, found `;`
+  --> $DIR/if-semi-before-block.rs:7:29
+   |
+LL |     if let Some(_) = Some(2); {}
+   |                             ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/if-semi-before-block.rs:7:8
+   |
+LL |     if let Some(_) = Some(2); {}
+   |        ^^^^^^^^^^^^^^^^^^^^^
+help: remove this semicolon
+   |
+LL -     if let Some(_) = Some(2); {}
+LL +     if let Some(_) = Some(2) {}
+   |
+
+error: expected `{`, found `;`
+  --> $DIR/if-semi-before-block.rs:15:29
+   |
+LL |     if let Some(x) = Some(2); && x != 1 {}
+   |                             ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/if-semi-before-block.rs:15:8
+   |
+LL |     if let Some(x) = Some(2); && x != 1 {}
+   |        ^^^^^^^^^^^^^^^^^^^^^
+help: remove this semicolon
+   |
+LL -     if let Some(x) = Some(2); && x != 1 {}
+LL +     if let Some(x) = Some(2) && x != 1 {}
+   |
+
+error: expected `{`, found `;`
+  --> $DIR/if-semi-before-block.rs:23:29
+   |
+LL |     if let Some(x) = Some(2); && (x > 0 && x != 1) {}
+   |                             ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/if-semi-before-block.rs:23:8
+   |
+LL |     if let Some(x) = Some(2); && (x > 0 && x != 1) {}
+   |        ^^^^^^^^^^^^^^^^^^^^^
+help: remove this semicolon
+   |
+LL -     if let Some(x) = Some(2); && (x > 0 && x != 1) {}
+LL +     if let Some(x) = Some(2) && (x > 0 && x != 1) {}
+   |
+
+error: expected `{`, found `;`
+  --> $DIR/if-semi-before-block.rs:31:29
+   |
+LL |     if let Some(x) = Some(2); && Some(1) == Some(x) {}
+   |                             ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/if-semi-before-block.rs:31:8
+   |
+LL |     if let Some(x) = Some(2); && Some(1) == Some(x) {}
+   |        ^^^^^^^^^^^^^^^^^^^^^
+help: remove this semicolon
+   |
+LL -     if let Some(x) = Some(2); && Some(1) == Some(x) {}
+LL +     if let Some(x) = Some(2) && Some(1) == Some(x) {}
+   |
+
+error: expected `{`, found `;`
+  --> $DIR/if-semi-before-block.rs:39:12
+   |
+LL |     if true; || false {
+   |            ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/if-semi-before-block.rs:39:8
+   |
+LL |     if true; || false {
+   |        ^^^^
+help: remove this semicolon
+   |
+LL -     if true; || false {
+LL +     if true || false {
+   |
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/parser/semi-in-let-chain.stderr
+++ b/tests/ui/parser/semi-in-let-chain.stderr
@@ -28,6 +28,11 @@ LL |       if let () = ()
    |  ________^
 LL | |         && () == ();
    | |___________________^
+help: remove this semicolon
+   |
+LL -         && () == ();
+LL +         && () == ()
+   |
 
 error: expected `{`, found `;`
   --> $DIR/semi-in-let-chain.rs:22:20


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.
If you do not want your disclosure to be part of the permanent git history, add `<!-- homu-ignore:start` before it.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Closes rust-lang/rust#159812

Suggest removing semicolon before the block in an `if` expression