### PR TITLE
std: Adjust cfgs again for TLS on WASI

### DIFF
--- a/library/std/src/sys/thread_local/mod.rs
+++ b/library/std/src/sys/thread_local/mod.rs
@@ -25,7 +25,7 @@
 
 cfg_select! {
     any(
-        all(target_family = "wasm", not(target_feature = "atomics"), not(target_os = "wasi")),
+        all(target_family = "wasm", not(target_feature = "atomics"), not(target_env = "p3")),
         target_os = "uefi",
         target_os = "zkvm",
         target_os = "trusty",
@@ -56,7 +56,7 @@ cfg_select! {
 /// single callback that runs all of the destructors in the list.
 #[cfg(all(
     target_thread_local,
-    not(all(target_family = "wasm", not(target_feature = "atomics"), not(target_os = "wasi")))
+    not(all(target_family = "wasm", not(target_feature = "atomics"), not(target_env = "p3")))
 ))]
 pub(crate) mod destructors {
     cfg_select! {
@@ -96,7 +96,7 @@ pub(crate) mod guard {
             pub(crate) use windows::enable;
         }
         any(
-            all(target_family = "wasm", not(target_os = "wasi")),
+            all(target_family = "wasm", not(target_env = "p3")),
             target_os = "uefi",
             target_os = "zkvm",
             target_os = "trusty",
@@ -151,7 +151,7 @@ pub(crate) mod key {
             ),
             all(not(target_thread_local), target_vendor = "apple"),
             target_os = "teeos",
-            target_os = "wasi",
+            all(target_os = "wasi", target_env = "p3"),
         ) => {
             mod racy;
             mod unix;


### PR DESCRIPTION
This commit adjusts the changes made in rust-lang/rust#159733. A wasi-libc bug was discovered in rust-lang/rust#160828 which is present in certain situations which means that the changes in rust-lang/rust#159733 expose this bug. The purpose of this PR is to get wasip1/wasip2 targets fixed again while preserving a working implementation for wasip3. This upstream bug is already fixed in wasi-libc meaning that this PR won't be necessary once wasi-sdk-34 is published and used in rust-lang/rust. Until that time, however, this effectively reverts rust-lang/rust#159733 for wasip1/wasip2. The wasip3 target is Tier 3 still and requires wasi-sdk-34 anyway which is why that's left unchanged.

Closes rust-lang/rust#160828

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.
If you do not want your disclosure to be part of the permanent git history, add `<!-- homu-ignore:start` before it.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->