### PR TITLE
report improper_ctypes lints from external macros

### DIFF
--- a/compiler/rustc_lint/src/types/improper_ctypes.rs
+++ b/compiler/rustc_lint/src/types/improper_ctypes.rs
@@ -47,7 +47,8 @@ declare_lint! {
     /// to resolve it.
     IMPROPER_CTYPES,
     Warn,
-    "proper use of libc types in foreign modules"
+    "proper use of libc types in foreign modules",
+    report_in_external_macro
 }
 
 declare_lint! {
@@ -74,7 +75,8 @@ declare_lint! {
     /// on how to resolve it.
     IMPROPER_CTYPES_DEFINITIONS,
     Warn,
-    "proper use of libc types in foreign item definitions"
+    "proper use of libc types in foreign item definitions",
+    report_in_external_macro
 }
 
 declare_lint! {

--- a/tests/ui/lint/improper-ctypes/auxiliary/cross_crate_macro.rs
+++ b/tests/ui/lint/improper-ctypes/auxiliary/cross_crate_macro.rs
@@ -1,0 +1,6 @@
+#[macro_export]
+macro_rules! make_extern_fn {
+    () => {
+        extern "C" fn bad(p: ::std::string::String) {}
+    };
+}

--- a/tests/ui/lint/improper-ctypes/external-macro.rs
+++ b/tests/ui/lint/improper-ctypes/external-macro.rs
@@ -1,0 +1,12 @@
+// issue-link: https://github.com/rust-lang/rust/issues/160862
+// The improper_ctypes lint should fire even when the extern fn comes from a cross-crate macro.
+
+//@ aux-build: cross_crate_macro.rs
+//@ check-pass
+
+extern crate cross_crate_macro;
+
+cross_crate_macro::make_extern_fn!();
+//~^ WARN `extern` fn uses type `String`, which is not FFI-safe
+
+fn main() {}

--- a/tests/ui/lint/improper-ctypes/external-macro.stderr
+++ b/tests/ui/lint/improper-ctypes/external-macro.stderr
@@ -1,0 +1,13 @@
+warning: `extern` fn uses type `String`, which is not FFI-safe
+  --> $DIR/external-macro.rs:9:1
+   |
+LL | cross_crate_macro::make_extern_fn!();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
+   = note: this struct has unspecified layout
+   = note: `#[warn(improper_ctypes_definitions)]` on by default
+   = note: this warning originates in the macro `cross_crate_macro::make_extern_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
FFI safety belongs to the types being defined, not the macro generating the extern function. Currently, cross-crate macros trigger a heuristic that silently drops these warnings.

This PR enables `report_in_external_macro` for `improper_ctypes` and `improper_ctypes_definitions`. Warnings now emit as expected, while code suggestions stay suppressed for external spans.

uses_power_alignment is untouched as it follows a separate emission path.

Fixes rust-lang/rust#160862