### PR TITLE
Add back homu-ignore markers around the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
+<!-- homu-ignore:start -->
 <!--
 Please read our [LLM policy] before opening a PR,
 If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
 LLM contributions are not banned, but are held to a higher standard of review and correctness.
-If you do not want your disclosure to be part of the permanent git history, add `<!-- homu-ignore:start` before it.
 
 [LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
 [disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines
@@ -15,4 +15,9 @@ This PR will get automatically assigned to a reviewer. In case you would like
 a specific user to review your work, you can assign it to them by using
 
     r? <reviewer name>
+
+When merged, your PR's description becomes part of the commit message of a merge commit.
+If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
+surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
 -->
+<!-- homu-ignore:end -->


### PR DESCRIPTION
Besides reinstantiating the `homu-ignore` markers from rust-lang/rust#126501, this PR also adds better clarification how the homu-ignore markers actually work; I've then also moved that section further down as it seems less important than the other parts of the PR template message. (We shouldn't forget that this is a *general PR template message*, not a LLM-policy-specific message.)

The disclosure markers appear to have been accidentally removed together with the checkboxes in rust-lang/rust#160785.

In the future, if support for ignoring HTML comments in places such as markdown code blocks was added, the new description about how `<!-- homu-ignore:end -->`/`<!-- homu-ignore:start -->` can be used could be further simplified[^1], but I'd like to address the immediate issues first before considering any more involved improvements (there already *exist* [currently ~~6~~ 8] new PRs now that contain the whole template comment without `homu-ignore` markers).

[^1]: actually it may always stay non-ideal given that HTML comments don't nest 🫠