### PR TITLE
Ensure inferred let pattern types are well-formed

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1191,6 +1191,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Type check the pattern. Override if necessary to avoid knock-on errors.
         self.check_pat_top(decl.pat, decl_ty, ty_span, origin_expr, Some(decl.origin));
+        if decl.ty.is_none()
+            && decl.init.is_none()
+            && !matches!(decl.pat.kind, hir::PatKind::Binding(.., None) | hir::PatKind::Wild)
+        {
+            self.register_wf_obligation(
+                decl_ty.into(),
+                decl.pat.span,
+                ObligationCauseCode::WellFormed(None),
+            );
+        }
         let pat_ty = self.node_ty(decl.pat.hir_id);
         self.overwrite_local_ty_if_err(decl.hir_id, decl.pat, pat_ty);
 

--- a/tests/crashes/150040.rs
+++ b/tests/crashes/150040.rs
@@ -1,7 +1,0 @@
-//@ known-bug: #150040
-
-fn main() {
-    let [(ref a, b), x];
-    a = "";
-    b = 5;
-}

--- a/tests/ui/wf/let-pat-inferred-non-wf.rs
+++ b/tests/ui/wf/let-pat-inferred-non-wf.rs
@@ -1,0 +1,58 @@
+// Regression test for https://github.com/rust-lang/rust/issues/150040
+// When a `let PAT;` has no explicit type, later assignments can infer a non-well-formed
+// pattern type such as `[str; 2]` or `(str, i32)`. We must reject those array and tuple
+// patterns instead of accepting the invalid type or causing ICE.
+
+#![allow(unused)]
+
+struct S<T: ?Sized>(T);
+
+fn should_fail_1() {
+    let ref y @ [ref x, _]; //~ ERROR E0277
+    x = "";
+}
+
+fn should_fail_2() {
+    let [ref x]; //~ ERROR E0277
+    x = "";
+}
+
+fn should_fail_3() {
+    let [[ref x], [_, y @ ..]]; //~ ERROR E0277
+    x = "";
+    y = [];
+}
+
+fn should_fail_4() {
+    let [(ref a, b), x]; //~ ERROR E0277
+    a = "";
+    b = 5;
+}
+
+fn should_fail_5() {
+    let (ref a, b); //~ ERROR E0277
+    a = "";
+    b = 5;
+}
+
+fn should_fail_6() {
+    let [S(ref x)]; //~ ERROR E0277
+    x = "";
+}
+
+fn should_pass_1() {
+    let ref x;
+    x = "";
+}
+
+fn should_pass_2() {
+    let ref y @ (ref x,);
+    x = "";
+}
+
+fn should_pass_3() {
+    let S(ref x);
+    x = "";
+}
+
+fn main() {}

--- a/tests/ui/wf/let-pat-inferred-non-wf.stderr
+++ b/tests/ui/wf/let-pat-inferred-non-wf.stderr
@@ -1,0 +1,62 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/let-pat-inferred-non-wf.rs:11:9
+   |
+LL |     let ref y @ [ref x, _];
+   |         ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: slice and array elements must have `Sized` type
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/let-pat-inferred-non-wf.rs:16:9
+   |
+LL |     let [ref x];
+   |         ^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: slice and array elements must have `Sized` type
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/let-pat-inferred-non-wf.rs:21:9
+   |
+LL |     let [[ref x], [_, y @ ..]];
+   |         ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: slice and array elements must have `Sized` type
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/let-pat-inferred-non-wf.rs:27:9
+   |
+LL |     let [(ref a, b), x];
+   |         ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: only the last element of a tuple may have a dynamically sized type
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/let-pat-inferred-non-wf.rs:33:9
+   |
+LL |     let (ref a, b);
+   |         ^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: only the last element of a tuple may have a dynamically sized type
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/let-pat-inferred-non-wf.rs:39:9
+   |
+LL |     let [S(ref x)];
+   |         ^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `S<str>`, the trait `Sized` is not implemented for `str`
+note: required because it appears within the type `S<str>`
+  --> $DIR/let-pat-inferred-non-wf.rs:8:8
+   |
+LL | struct S<T: ?Sized>(T);
+   |        ^
+   = note: slice and array elements must have `Sized` type
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes rust-lang/rust#150040

Context: Same as rust-lang/rust#157013, but that PR was merged without a crater run and FCP, so it was reverted and rust-lang/rust#157841 was opened instead. However, there is a snippet that causes an ICE, which I reported in https://github.com/rust-lang/rust/issues/150040#issuecomment-4554031893, specifically in `tests/crashes/150040.rs`. This caused the CI to fail because the root cause was fixed in the original PR and it no longer causes an ICE. This PR removes that crash test case in addition to the previous changes, as it is already covered by the newly added tests.

I don't know how the FCP process works, so if it's problematic to open a different PR from the one where the FCP has finished, please just ignore this and remove `tests/crashes/150040.rs` in https://github.com/rust-lang/rust/pull/157841 instead.

r? lcnr