### PR TITLE
rustc: Stabilize the WebAssembly `wide-arithmetic` feature

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -845,7 +845,7 @@ static WASM_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("sign-ext", Stable, &[]),
     ("simd128", Stable, &[]),
     ("tail-call", Stable, &[]),
-    ("wide-arithmetic", Unstable(sym::wasm_target_feature), &[]),
+    ("wide-arithmetic", Stable, &[]),
     // tidy-alphabetical-end
 ];
 

--- a/src/doc/rustc/src/platform-support/wasm32v1-none.md
+++ b/src/doc/rustc/src/platform-support/wasm32v1-none.md
@@ -64,6 +64,8 @@ For reference sake, the set of proposals that LLVM supports at the time of writi
     * [Multiple memories]- `+multimemory`
     * [Relaxed SIMD] - `+relaxed-simd`
     * [Tail call] - `+tail-call`
+* Post-3.0 proposals:
+    * [Wide Arithmetic] - `+wide-arithmetic`
 
 [Bulk memory]: https://github.com/WebAssembly/spec/blob/main/proposals/bulk-memory-operations/Overview.md
 [Sign-extending operations]: https://github.com/WebAssembly/spec/blob/main/proposals/sign-extension-ops/Overview.md
@@ -78,6 +80,7 @@ For reference sake, the set of proposals that LLVM supports at the time of writi
 [Multiple memories]: https://github.com/WebAssembly/multi-memory
 [Relaxed SIMD]: https://github.com/WebAssembly/relaxed-simd
 [Tail call]: https://github.com/WebAssembly/tail-call
+[Wide Arithmetic]: https://github.com/WebAssembly/wide-arithmetic
 
 Additional proposals in the future are, of course, also not enabled by default.
 

--- a/tests/ui/wasm/wasm-stable-target-features.rs
+++ b/tests/ui/wasm/wasm-stable-target-features.rs
@@ -35,6 +35,9 @@ fn foo9() {}
 #[target_feature(enable = "tail-call")]
 fn foo10() {}
 
+#[target_feature(enable = "wide-arithmetic")]
+fn foo11() {}
+
 fn main() {
     foo1();
     foo2();
@@ -46,4 +49,5 @@ fn main() {
     foo8();
     foo9();
     foo10();
+    foo11();
 }


### PR DESCRIPTION
Reference PR:

- https://github.com/rust-lang/reference/pull/2324

This commit stabilizes the `wide-arithmetic` target feature for WebAssembly targets. This [upstream WebAssembly proposal][repo] has [now reached phase 4][phase] in the WebAssembly CG standardization process which means that it's expected to ship shortly in browsers/engines and is considered stable. This is intended to be a sibling PR to rust-lang/rust to reflect the stability of the proposal in LLVM/engines to allow users to enable this in downstream code without warnings.

To recap what `wide-arithmetic` is -- this is a target feature for all WebAssembly targets for Rust. This feature corresponds to the LLVM `wide-arithmetic` target feature and gates generation of four new instructions added in the [wide-arithmetic proposal][repo], primarily centered around 128-bit addition/subtraction and a widening 64x64-bit multiply producing a 128-bit result. This target feature has no library APIs, no impact on the Rust language, nor any impact on ABIs anywhere. The only change is that more efficient codegen is generated for some operations, primarily 128-bit multiplication. Generally speaking it's expected that users should be able to enable this feature, recompile with today's source code, and see speedups if these operations are bottlenecks.

This feature is off-by-default and requires `-Ctarget-feature=...` or similar to enable it. This feature will not be on-by-default for quite some time while engine support percolates and (ideally) becomes pervasive.

[repo]: https://github.com/webassembly/wide-arithmetic
[phase]: https://github.com/WebAssembly/proposals/pull/239

<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.
If you do not want your disclosure to be part of the permanent git history, add `<!-- homu-ignore:start` before it.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
