### PR TITLE
Trim `GoalStalledOn::Certainty`

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
@@ -7,7 +7,7 @@
 
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::solve::{
-    Certainty, ComputeGoalFastPathOutcome, Goal, GoalStalledOn, GoalStalledOnOpaques,
+    Certainty, ComputeGoalFastPathOutcome, Goal, GoalStalledOn, GoalStalledOnOpaques, MaybeInfo,
     SucceededInErased,
 };
 use rustc_type_ir::{InferCtxtLike, Interner};
@@ -18,7 +18,7 @@ use crate::solve::{GoalEvaluation, HasChanged};
 
 #[derive(Debug, Clone, Copy)]
 pub(super) enum RerunStalled {
-    WontMakeProgress(Certainty),
+    WontMakeProgress(MaybeInfo),
     MayMakeProgress,
 }
 
@@ -43,7 +43,7 @@ where
     }
 
     // If the goal isn't stalled, we should definitely run it.
-    let Some(&GoalStalledOn { ref opaques, ref stalled_vars, ref sub_roots, stalled_certainty }) =
+    let Some(&GoalStalledOn { ref opaques, ref stalled_vars, ref sub_roots, stalled_maybe_info }) =
         stalled_on
     else {
         return MayMakeProgress;
@@ -105,7 +105,7 @@ where
 
     // Otherwise, we can be sure that this stalled goal cannot make any progress
     // and we can exit early.
-    WontMakeProgress(stalled_certainty)
+    WontMakeProgress(stalled_maybe_info)
 }
 
 /// `compute_goal_fast_path` is complicated enough that outling helps, so it gets optimized

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -181,8 +181,7 @@ pub trait SolverDelegateEvalExt: SolverDelegate {
 
     /// Checks whether a stalled goal would remain stalled if re-evaluated, without consuming
     /// `stalled_on`.
-    fn goal_remains_stalled(&self, stalled_on: &GoalStalledOn<Self::Interner>)
-    -> Option<Certainty>;
+    fn goal_remains_stalled(&self, stalled_on: &GoalStalledOn<Self::Interner>) -> bool;
 
     /// Checks whether evaluating `goal` may hold while treating not-yet-defined
     /// opaque types as being kind of rigid.
@@ -231,12 +230,12 @@ where
         stalled_on: Option<GoalStalledOn<I>>,
     ) -> Result<GoalEvaluation<I>, NoSolution> {
         // Run fast paths *before* building an `EvalCtxt`, saving a little bit of time.
-        if let RerunStalled::WontMakeProgress(stalled_certainty) =
+        if let RerunStalled::WontMakeProgress(stalled_maybe_info) =
             rerunning_stalled_goal_may_make_progress(self, stalled_on.as_ref())
         {
             return Ok(GoalEvaluation {
                 goal,
-                certainty: stalled_certainty,
+                certainty: Certainty::Maybe(stalled_maybe_info),
                 has_changed: HasChanged::No,
                 stalled_on,
             });
@@ -265,13 +264,10 @@ where
         }
     }
 
-    fn goal_remains_stalled(
-        &self,
-        stalled_on: &GoalStalledOn<Self::Interner>,
-    ) -> Option<Certainty> {
+    fn goal_remains_stalled(&self, stalled_on: &GoalStalledOn<Self::Interner>) -> bool {
         match rerunning_stalled_goal_may_make_progress(self, Some(stalled_on)) {
-            RerunStalled::WontMakeProgress(certainty) => Some(certainty),
-            RerunStalled::MayMakeProgress => None,
+            RerunStalled::WontMakeProgress(_) => true,
+            RerunStalled::MayMakeProgress => false,
         }
     }
 
@@ -608,12 +604,12 @@ where
         goal: Goal<I, I::Predicate>,
         stalled_on: Option<GoalStalledOn<I>>,
     ) -> Result<GoalEvaluation<I>, NoSolutionOrRerunNonErased> {
-        if let RerunStalled::WontMakeProgress(stalled_certainty) =
+        if let RerunStalled::WontMakeProgress(stalled_maybe_info) =
             rerunning_stalled_goal_may_make_progress(self.delegate, stalled_on.as_ref())
         {
             return Ok(GoalEvaluation {
                 goal,
-                certainty: stalled_certainty,
+                certainty: Certainty::Maybe(stalled_maybe_info),
                 has_changed: HasChanged::No,
                 stalled_on,
             });
@@ -814,7 +810,7 @@ where
 
         let stalled_on = match certainty {
             Certainty::Yes => None,
-            Certainty::Maybe { .. } => match has_changed {
+            Certainty::Maybe(maybe_info) => match has_changed {
                 // FIXME: We could recompute a *new* set of stalled variables by walking
                 // through the orig values, resolving, and computing the root vars of anything
                 // that is not resolved. Only when *these* have changed is it meaningful
@@ -822,7 +818,7 @@ where
                 HasChanged::Yes => None,
                 HasChanged::No => Some(self.build_stalled_on(
                     canonical_goal,
-                    certainty,
+                    maybe_info,
                     orig_values,
                     succeeded_in_erased,
                 )),
@@ -838,7 +834,7 @@ where
     fn build_stalled_on(
         &self,
         canonical_goal: CanonicalInput<I>,
-        certainty: Certainty,
+        maybe_info: MaybeInfo,
         stalled_vars: ThinVec<I::GenericArg>,
         previously_succeeded_in_erased: SucceededInErased<I>,
     ) -> GoalStalledOn<I> {
@@ -872,7 +868,7 @@ where
         GoalStalledOn {
             stalled_vars,
             sub_roots,
-            stalled_certainty: certainty,
+            stalled_maybe_info: maybe_info,
             opaques: GoalStalledOnOpaques::Yes {
                 num_opaques_in_storage: canonical_goal
                     .canonical

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -14,7 +14,7 @@ use rustc_infer::traits::solve::{
     ComputeGoalFastPathOutcome, FetchEligibleAssocItemResponse, Goal, SucceededInErased,
 };
 use rustc_middle::traits::query::NoSolution;
-use rustc_middle::traits::solve::Certainty;
+use rustc_middle::traits::solve::{Certainty, MaybeInfo};
 use rustc_middle::ty::{
     self, MayBeErased, Ty, TyCtxt, TypeFlags, TypeFoldable, TypeSuperVisitable, TypeVisitable,
     TypeVisitableExt, TypeVisitor, TypingMode,
@@ -61,7 +61,7 @@ fn goal_stalled_on_args<'tcx>(
         stalled_on: GoalStalledOn {
             stalled_vars,
             sub_roots: ThinVec::new(),
-            stalled_certainty: Certainty::AMBIGUOUS,
+            stalled_maybe_info: MaybeInfo::AMBIGUOUS,
             opaques: GoalStalledOnOpaques::No,
         },
     }
@@ -77,7 +77,7 @@ fn goal_stalled_on_args_or_nonempty_opaques<'tcx>(
         stalled_on: GoalStalledOn {
             stalled_vars,
             sub_roots: ThinVec::new(),
-            stalled_certainty: Certainty::AMBIGUOUS,
+            stalled_maybe_info: MaybeInfo::AMBIGUOUS,
             opaques: GoalStalledOnOpaques::Yes {
                 num_opaques_in_storage: 0,
                 // This function should only be called when not in erased mode,

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -9,8 +9,7 @@ use rustc_infer::traits::{
 use rustc_middle::ty::{self, TyCtxt, TypeVisitableExt, TypingMode};
 use rustc_next_trait_solver::solve::fast_path::compute_goal_fast_path;
 use rustc_next_trait_solver::solve::{
-    GoalEvaluation, GoalStalledOn, HasChanged, MaybeInfo, SolverDelegateEvalExt as _,
-    StalledOnCoroutines,
+    GoalEvaluation, GoalStalledOn, HasChanged, SolverDelegateEvalExt as _, StalledOnCoroutines,
 };
 use thin_vec::ThinVec;
 use tracing::instrument;
@@ -208,8 +207,7 @@ where
                 // Common case: still stalled; keep the obligation. This path is extremely hot in
                 // some cases; there can be thousands of pending obligations.
                 if let Some(stalled_on) = opt_stalled_on
-                    && let Some(certainty) = delegate.goal_remains_stalled(stalled_on)
-                    && matches!(certainty, Certainty::Maybe(_))
+                    && delegate.goal_remains_stalled(stalled_on)
                 {
                     return true;
                 }
@@ -378,13 +376,11 @@ where
 
         self.obligations
             .drain_pending(|_, stalled_on| {
-                stalled_on.as_ref().is_some_and(|s| match s.stalled_certainty {
-                    Certainty::Maybe(MaybeInfo {
-                        cause: _,
-                        opaque_types_jank: _,
-                        stalled_on_coroutines: StalledOnCoroutines::Yes,
-                    }) => true,
-                    Certainty::Maybe(_) | Certainty::Yes => false,
+                stalled_on.as_ref().is_some_and(|s| {
+                    match s.stalled_maybe_info.stalled_on_coroutines {
+                        StalledOnCoroutines::Yes => true,
+                        StalledOnCoroutines::No => false,
+                    }
                 })
             })
             .into_iter()

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -993,9 +993,9 @@ pub struct GoalStalledOn<I: Interner> {
     pub stalled_vars: ThinVec<TyOrConstInferVar>,
     // `ThinVec` is important for performance. See #160005.
     pub sub_roots: ThinVec<TyVid>,
-    /// The certainty that will be returned on subsequent evaluations if this
+    /// The `MaybeInfo` that will be returned on subsequent evaluations if this
     /// goal remains stalled.
-    pub stalled_certainty: Certainty,
+    pub stalled_maybe_info: MaybeInfo,
     pub opaques: GoalStalledOnOpaques<I>,
 }
 


### PR DESCRIPTION
It's always `Certainty::Maybe`, so we can trim it down to just the `MaybeInfo` that is within `Certainty::Maybe`.

r? @lcnr