### PR TITLE
Disable some tests for ohos target

### DIFF
--- a/src/tools/compiletest/src/directives/directive_names.rs
+++ b/src/tools/compiletest/src/directives/directive_names.rs
@@ -104,6 +104,7 @@ pub(crate) const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-nto",
     "ignore-nvptx64",
     "ignore-nvptx64-nvidia-cuda",
+    "ignore-ohos",
     "ignore-openbsd",
     "ignore-parallel-frontend",
     "ignore-pauthtest",

--- a/tests/codegen-llvm/thread-local.rs
+++ b/tests/codegen-llvm/thread-local.rs
@@ -6,6 +6,7 @@
 //@ ignore-android does not use #[thread_local]
 //@ ignore-nto does not use #[thread_local]
 //@ ignore-qnx does not use #[thread_local]
+//@ ignore-ohos does not use #[thread_local]
 
 #![crate_type = "lib"]
 

--- a/tests/debuginfo/pretty-huge-vec.rs
+++ b/tests/debuginfo/pretty-huge-vec.rs
@@ -1,5 +1,6 @@
 //@ ignore-windows-gnu: #128981
 //@ ignore-android: FIXME(#10381)
+//@ ignore-ohos: similiar to android
 //@ ignore-aix: FIXME(#137965)
 //@ compile-flags:-g
 //@ ignore-backends: gcc

--- a/tests/ui/asm/aarch64/sym.rs
+++ b/tests/ui/asm/aarch64/sym.rs
@@ -1,5 +1,6 @@
 //@ only-aarch64
 //@ only-linux
+//@ ignore-ohos does not use #[thread_local]
 //@ needs-asm-support
 //@ run-pass
 

--- a/tests/ui/runtime/out-of-stack.rs
+++ b/tests/ui/runtime/out-of-stack.rs
@@ -5,6 +5,7 @@
 //@ ignore-android: FIXME (#20004)
 //@ needs-subprocess
 //@ ignore-fuchsia must translate zircon signal to SIGABRT, FIXME (#58590)
+//@ ignore-ohos musl libc returns SIGSEGV for stack overflow rather than SIGABRT
 //@ ignore-nto no stack overflow handler used (no alternate stack available)
 //@ ignore-qnx no stack overflow handler used (no alternate stack available)
 //@ ignore-ios stack overflow handlers aren't enabled


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.
If you do not want your disclosure to be part of the permanent git history, add `<!-- homu-ignore:start` before it.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
I ran into some test failures when trying to run the full test suite for ohos target. 
There're a few more but I'm not certain of those yet.
