### PR TITLE
Inline some hot new-solver functions

### DIFF
--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -346,6 +346,7 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
     }
 
     type OpaqueTypeStorageEntries = OpaqueTypeStorageEntries;
+    #[inline]
     fn opaque_types_storage_num_entries(&self) -> OpaqueTypeStorageEntries {
         self.inner.borrow_mut().opaque_types().num_entries()
     }

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/fast_path.rs
@@ -26,8 +26,21 @@ pub(super) enum RerunStalled {
 /// args have changed. This is a cheap way to determine that if we were to rerun this goal now,
 /// it will remain stalled since it'll canonicalize the same way and evaluation is pure.
 /// Therefore, we can skip this rerun
-#[inline]
+#[inline(never)]
 pub(super) fn rerunning_stalled_goal_may_make_progress<D, I>(
+    delegate: &D,
+    stalled_on: Option<&GoalStalledOn<I>>,
+) -> RerunStalled
+where
+    D: SolverDelegate<Interner = I>,
+    I: Interner,
+{
+    inlined_rerunning_stalled_goal_may_make_progress(delegate, stalled_on)
+}
+
+// Always-inlined variant for the one hot call site.
+#[inline(always)]
+pub(super) fn inlined_rerunning_stalled_goal_may_make_progress<D, I>(
     delegate: &D,
     stalled_on: Option<&GoalStalledOn<I>>,
 ) -> RerunStalled

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -32,7 +32,8 @@ use crate::delegate::SolverDelegate;
 use crate::normalize::{NormalizationFolder, NormalizationWasAmbiguous};
 use crate::placeholder::BoundVarReplacer;
 use crate::solve::eval_ctxt::fast_path::{
-    RerunStalled, compute_goal_fast_path, rerunning_stalled_goal_may_make_progress,
+    RerunStalled, compute_goal_fast_path, inlined_rerunning_stalled_goal_may_make_progress,
+    rerunning_stalled_goal_may_make_progress,
 };
 use crate::solve::fast_path::compute_goal_fast_path_cold;
 use crate::solve::search_graph::SearchGraph;
@@ -264,8 +265,10 @@ where
         }
     }
 
+    // This function is very hot and has a single call site.
+    #[inline(always)]
     fn goal_remains_stalled(&self, stalled_on: &GoalStalledOn<Self::Interner>) -> bool {
-        match rerunning_stalled_goal_may_make_progress(self, Some(stalled_on)) {
+        match inlined_rerunning_stalled_goal_may_make_progress(self, Some(stalled_on)) {
             RerunStalled::WontMakeProgress(_) => true,
             RerunStalled::MayMakeProgress => false,
         }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160892)*
<!-- homu-ignore:end -->

`rerunning_stalled_goal_may_make_progress` is split into always-inline and never-inline variants, because it's biggish and has multiple call sites but only one is hot. The other are easy, being either very small or having a single call site.

r? @jdonszelmann 