### PR TITLE
Helpful suggestions for incorrect address-of mutability

### DIFF
--- a/compiler/rustc_hir_typeck/src/diagnostics.rs
+++ b/compiler/rustc_hir_typeck/src/diagnostics.rs
@@ -679,6 +679,30 @@ pub(crate) struct SuggestPtrNullMut {
     pub span: Span,
 }
 
+#[derive(Subdiagnostic)]
+#[suggestion(
+    "consider using `&mut` instead",
+    applicability = "maybe-incorrect",
+    style = "verbose",
+    code = "&mut "
+)]
+pub(crate) struct SuggestRefMut {
+    #[primary_span]
+    pub ref_span: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(
+    "consider using `&raw mut` instead",
+    applicability = "maybe-incorrect",
+    style = "verbose",
+    code = "&raw mut "
+)]
+pub(crate) struct SuggestRawMut {
+    #[primary_span]
+    pub raw_span: Span,
+}
+
 #[derive(Diagnostic)]
 #[diag(
     "trivial {$numeric ->

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -37,7 +37,7 @@ use crate::Expectation::*;
 use crate::TupleArgumentsFlag::*;
 use crate::callee::SplatLoweringInfo;
 use crate::coercion::CoerceMany;
-use crate::diagnostics::{ExprParenthesesNeeded, SuggestPtrNullMut};
+use crate::diagnostics::{ExprParenthesesNeeded, SuggestPtrNullMut, SuggestRawMut, SuggestRefMut};
 use crate::fn_ctxt::arg_matrix::{ArgMatrix, Compatibility, Error, ExpectedIdx, ProvidedIdx};
 use crate::gather_locals::Declaration;
 use crate::inline_asm::InlineAsmCtxt;
@@ -982,7 +982,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         err.emit()
     }
 
-    fn suggest_ptr_null_mut(
+    fn suggest_mut_addr(
         &self,
         expected_ty: Ty<'tcx>,
         provided_ty: Ty<'tcx>,
@@ -999,6 +999,39 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // The user provided `ptr::null()`, but the function expects
             // `ptr::null_mut()`.
             err.subdiagnostic(SuggestPtrNullMut { span: arg.span });
+        }
+
+        if let ty::RawPtr(expected_ty, hir::Mutability::Mut) = expected_ty.kind()
+            && let ty::RawPtr(provided_ty, hir::Mutability::Not) = provided_ty.kind()
+            && let hir::ExprKind::AddrOf(hir::BorrowKind::Raw, hir::Mutability::Not, expr) =
+                arg.kind
+            && expected_ty == provided_ty
+        {
+            // The user provided `&raw const T`, but the function expects `&raw mut T`.
+            let raw_span = arg.span.until(expr.span);
+            err.subdiagnostic(SuggestRawMut { raw_span });
+        }
+
+        if let ty::Ref(_, expected_ty, hir::Mutability::Mut) = expected_ty.kind()
+            && let ty::Ref(_, provided_ty, hir::Mutability::Not) = provided_ty.kind()
+            && let hir::ExprKind::AddrOf(hir::BorrowKind::Ref, hir::Mutability::Not, expr) =
+                arg.kind
+            && expected_ty == provided_ty
+        {
+            // The user provided `&T`, but the function expects `&mut T`.
+            let ref_span = arg.span.until(expr.span);
+            err.subdiagnostic(SuggestRefMut { ref_span });
+        }
+
+        if let ty::RawPtr(expected_ty, hir::Mutability::Mut) = expected_ty.kind()
+            && let ty::Ref(_, provided_ty, hir::Mutability::Not) = provided_ty.kind()
+            && let hir::ExprKind::AddrOf(hir::BorrowKind::Ref, hir::Mutability::Not, expr) =
+                arg.kind
+            && expected_ty == provided_ty
+        {
+            // The user provided `&T`, but the function expects `&raw mut T`
+            let raw_span = arg.span.until(expr.span);
+            err.subdiagnostic(SuggestRawMut { raw_span });
         }
     }
 
@@ -2491,7 +2524,7 @@ impl<'a, 'tcx> FnCallDiagCtxt<'a, 'tcx> {
                 );
             }
 
-            self.suggest_ptr_null_mut(
+            self.suggest_mut_addr(
                 expected_ty,
                 provided_ty,
                 self.provided_args[provided_idx],

--- a/tests/ui/span/coerce-suggestions.stderr
+++ b/tests/ui/span/coerce-suggestions.stderr
@@ -34,6 +34,10 @@ note: function defined here
    |
 LL | fn test(_x: &mut String) {}
    |    ^^^^ ---------------
+help: consider using `&mut` instead
+   |
+LL |     test(&mut y);
+   |           +++
 
 error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:14:11


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Added suggestions for `&` and `&raw` expressions used as function arguments when the function expects a mutable address.

I also did a small refactor, grouping all 'suggest mut' code into a single function called `suggest_addr_mut`, and removed `suggest_ptr_null_mut`. Its logic was moved into the new  `suggest_addr_mut`.

Fixes rust-lang/rust#159490.

Example:

```rust
fn main() {
    let s = String::new();
    takes_raw(&raw const s);
    takes_ref(&s);
}

fn takes_raw(_: *mut String) {}
fn takes_ref(_: &mut String) {}
```

Diagnostics before:

```Shell
error[E0308]: mismatched types
  |
3 |     takes_raw(&raw const s);
  |     --------- ^^^^^^^^^^^^ types differ in mutability
  |     |
  |     arguments to this function are incorrect
  |
  = note: expected raw pointer `*mut String`
             found raw pointer `*const String`
note: function defined here
 -->..\src\main.rs:7:4
  |
7 | fn takes_raw(_: *mut String) {}
  |    ^^^^^^^^^ --------------

error[E0308]: mismatched types
 --> ..\src\main.rs:4:15
  |
4 |     takes_ref(&s);
  |     --------- ^^ types differ in mutability
  |     |
  |     arguments to this function are incorrect
  |
  = note: expected mutable reference `&mut String`
                     found reference `&String`
note: function defined here
 --> ..\src\main.rs:8:4
  |
8 | fn takes_ref(_: &mut String) {}
  |    ^^^^^^^^^ --------------
```

Diagnostics after:

```Shell
error[E0308]: mismatched types                                                                                                                        
 --> ..\src\main.rs:3:15
  |
3 |     takes_raw(&raw const s);
  |     --------- ^^^^^^^^^^^^ types differ in mutability
  |     |
  |     arguments to this function are incorrect
  |
  = note: expected raw pointer `*mut String`
             found raw pointer `*const String`
note: function defined here
 --> ..\src\main.rs:7:4
  |
7 | fn takes_raw(_: *mut String) {}
  |    ^^^^^^^^^ --------------
help: consider using `&raw mut` instead
  |
3 -     takes_raw(&raw const s);
3 +     takes_raw(&raw mut s);
  |

error[E0308]: mismatched types                                                                                                                        
 --> ..\src\main.rs:4:15
  |
4 |     takes_ref(&s);
  |     --------- ^^ types differ in mutability
  |     |
  |     arguments to this function are incorrect
  |
  = note: expected mutable reference `&mut String`
                     found reference `&String`
note: function defined here
 --> ..\src\main.rs:8:4
  |
8 | fn takes_ref(_: &mut String) {}
  |    ^^^^^^^^^ --------------
help: consider using `&mut` instead
  |
4 |     takes_ref(&mut s);
  |                +++
```