### PR TITLE
Put `{:#?}` into backticks

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -1176,7 +1176,7 @@ pub use macros::Debug;
     ),
     on(
         from_desugaring = "FormatLiteral",
-        note = "in format strings you may be able to use `{{:?}}` (or {{:#?}} for pretty-print) instead",
+        note = "in format strings you may be able to use `{{:?}}` (or `{{:#?}}` for pretty-print) instead",
         label = "`{Self}` cannot be formatted with the default formatter",
     ),
     message = "`{Self}` doesn't implement `{This}`"

--- a/tests/ui/fmt/format-args-argument-span.stderr
+++ b/tests/ui/fmt/format-args-argument-span.stderr
@@ -5,7 +5,7 @@ LL |     println!("{x:?} {x} {x:?}");
    |                     ^^^ `Option<{integer}>` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `Option<{integer}>`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 
 error[E0277]: `Option<{integer}>` doesn't implement `std::fmt::Display`
   --> $DIR/format-args-argument-span.rs:15:37
@@ -16,7 +16,7 @@ LL |     println!("{x:?} {x} {x:?}", x = Some(1));
    |                     required by this formatting parameter
    |
    = help: the trait `std::fmt::Display` is not implemented for `Option<{integer}>`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 
 error[E0277]: `DisplayOnly` doesn't implement `Debug`
   --> $DIR/format-args-argument-span.rs:18:19

--- a/tests/ui/fmt/non-source-literals.stderr
+++ b/tests/ui/fmt/non-source-literals.stderr
@@ -9,7 +9,7 @@ help: the trait `std::fmt::Display` is not implemented for `NonDisplay`
    |
 LL | pub struct NonDisplay;
    | ^^^^^^^^^^^^^^^^^^^^^
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 
 error[E0277]: `NonDisplay` doesn't implement `std::fmt::Display`
   --> $DIR/non-source-literals.rs:10:45
@@ -22,7 +22,7 @@ help: the trait `std::fmt::Display` is not implemented for `NonDisplay`
    |
 LL | pub struct NonDisplay;
    | ^^^^^^^^^^^^^^^^^^^^^
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 
 error[E0277]: `NonDebug` doesn't implement `Debug`
   --> $DIR/non-source-literals.rs:11:42

--- a/tests/ui/macros/macro-expansion-empty-span-147255.stderr
+++ b/tests/ui/macros/macro-expansion-empty-span-147255.stderr
@@ -7,7 +7,7 @@ LL |     println!("{}", x_str);
    |               required by this formatting parameter
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/on-unimplemented/no-debug.stderr
+++ b/tests/ui/on-unimplemented/no-debug.stderr
@@ -36,7 +36,7 @@ help: the trait `std::fmt::Display` is not implemented for `Foo`
    |
 LL | struct Foo;
    | ^^^^^^^^^^
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 
 error[E0277]: `Bar` doesn't implement `std::fmt::Display`
   --> $DIR/no-debug.rs:11:28
@@ -47,7 +47,7 @@ LL |     println!("{} {}", Foo, Bar);
    |                  required by this formatting parameter
    |
    = help: the trait `std::fmt::Display` is not implemented for `Bar`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/suggestions/issue-97760.stderr
+++ b/tests/ui/suggestions/issue-97760.stderr
@@ -5,7 +5,7 @@ LL |         println!("{x}");
    |                   ^^^ `<impl IntoIterator as IntoIterator>::Item` cannot be formatted with the default formatter
    |
    = help: the trait `std::fmt::Display` is not implemented for `<impl IntoIterator as IntoIterator>::Item`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 help: introduce a type parameter with a trait bound instead of using `impl Trait`
    |
 LL ~ pub fn print_values<I: IntoIterator>(values: &I)

--- a/tests/ui/suggestions/path-display.stderr
+++ b/tests/ui/suggestions/path-display.stderr
@@ -8,7 +8,7 @@ LL |     println!("{}", path);
    |
    = help: the trait `std::fmt::Display` is not implemented for `Path`
    = note: call `.display()` or `.to_string_lossy()` to safely print paths, as they may contain non-Unicode data
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
    = note: required for `&Path` to implement `std::fmt::Display`
 
 error[E0277]: `PathBuf` doesn't implement `std::fmt::Display`
@@ -21,7 +21,7 @@ LL |     println!("{}", path);
    |
    = help: the trait `std::fmt::Display` is not implemented for `PathBuf`
    = note: call `.display()` or `.to_string_lossy()` to safely print paths, as they may contain non-Unicode data
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type/binding-assigned-block-without-tail-expression.stderr
+++ b/tests/ui/type/binding-assigned-block-without-tail-expression.stderr
@@ -10,7 +10,7 @@ LL |     println!("{}", x);
    |               required by this formatting parameter
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/binding-assigned-block-without-tail-expression.rs:15:20
@@ -24,7 +24,7 @@ LL |     println!("{}", y);
    |               required by this formatting parameter
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/binding-assigned-block-without-tail-expression.rs:16:20
@@ -38,7 +38,7 @@ LL |     println!("{}", z);
    |               required by this formatting parameter
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/binding-assigned-block-without-tail-expression.rs:17:20
@@ -55,7 +55,7 @@ LL |       println!("{}", s);
    |                 required by this formatting parameter
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 
 error[E0308]: mismatched types
   --> $DIR/binding-assigned-block-without-tail-expression.rs:18:18

--- a/tests/ui/type/recover-from-semicolon-trailing-undefined.stderr
+++ b/tests/ui/type/recover-from-semicolon-trailing-undefined.stderr
@@ -19,7 +19,7 @@ LL |       println!("{}", x_str);
    |                 required by this formatting parameter
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: in format strings you may be able to use `{:?}` (or `{:#?}` for pretty-print) instead
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
For consistency with `{:?}` before it