### PR TITLE
Ensure that restriction paths are ancestors

### DIFF
--- a/compiler/rustc_ast_lowering/src/diagnostics.rs
+++ b/compiler/rustc_ast_lowering/src/diagnostics.rs
@@ -1,5 +1,5 @@
 use rustc_errors::codes::*;
-use rustc_errors::{DiagArgFromDisplay, DiagSymbolList};
+use rustc_errors::{DiagArgFromDisplay, DiagArgValue, DiagSymbolList, IntoDiagArg};
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Symbol};
 
@@ -578,4 +578,34 @@ pub(crate) struct DelegationInfersMismatch {
 pub(crate) struct DelegationAttemptedBlockWithDefsRelowering {
     #[primary_span]
     pub span: Span,
+}
+
+/// Whether resolving `impl` or `mut` restriction paths
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ResolvingRestrictionKind {
+    Impl,
+    Mut,
+}
+
+impl IntoDiagArg for ResolvingRestrictionKind {
+    fn into_diag_arg(self, _: &mut Option<std::path::PathBuf>) -> DiagArgValue {
+        use std::borrow::Cow;
+        match self {
+            ResolvingRestrictionKind::Impl => DiagArgValue::Str(Cow::Borrowed("impl")),
+            ResolvingRestrictionKind::Mut => DiagArgValue::Str(Cow::Borrowed("mut")),
+        }
+    }
+}
+
+#[derive(Diagnostic)]
+#[diag(
+    "{$kind ->
+    [impl] trait implementation
+    *[mut] field mutation
+} can only be restricted to ancestor modules"
+)]
+pub(crate) struct RestrictionAncestorOnly {
+    #[primary_span]
+    pub(crate) span: Span,
+    pub(crate) kind: ResolvingRestrictionKind,
 }

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -26,7 +26,7 @@ use super::{
     FnDeclKind, GenericArgsMode, ImplTraitContext, ImplTraitPosition, LoweringContext, ParamMode,
     RelaxedBoundForbiddenReason, RelaxedBoundPolicy,
 };
-use crate::diagnostics::ConstComptimeFn;
+use crate::diagnostics::{ConstComptimeFn, ResolvingRestrictionKind, RestrictionAncestorOnly};
 
 pub(super) struct ItemLowerer<'a, 'hir> {
     pub(super) tcx: TyCtxt<'hir>,
@@ -498,7 +498,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 items,
             }) => {
                 let constness = self.lower_constness(attrs, *constness);
-                let impl_restriction = self.lower_impl_restriction(impl_restriction);
+                let impl_restriction = self.lower_impl_restriction(impl_restriction, hir_id);
                 let ident = self.lower_ident(*ident);
                 let (generics, (safety, items, bounds)) = self.lower_generics(
                     generics,
@@ -895,7 +895,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 None => Ident::new(sym::integer(index), self.lower_span(f.span)),
             },
             vis_span: self.lower_span(f.vis.span),
-            mut_restriction: self.lower_mut_restriction(f.mut_restriction()),
+            mut_restriction: self.lower_mut_restriction(f.mut_restriction(), hir_id),
             default: f
                 .default_value()
                 .map(|v| self.lower_anon_const_to_anon_const(v, v.value.span)),
@@ -1797,26 +1797,46 @@ impl<'hir> LoweringContext<'_, 'hir> {
         }
     }
 
-    fn lower_restriction_kind(&mut self, kind: &RestrictionKind) -> hir::RestrictionKind<'hir> {
-        match kind {
+    fn lower_restriction_kind(
+        &mut self,
+        restriction_kind: &RestrictionKind,
+        hir_id: HirId,
+        resolving_kind: ResolvingRestrictionKind,
+    ) -> hir::RestrictionKind<'hir> {
+        match restriction_kind {
             RestrictionKind::Unrestricted => hir::RestrictionKind::Unrestricted,
             RestrictionKind::Restricted { path, id, shorthand: _ } => {
                 let res = self.get_partial_res(*id);
+                let parent_module = self.tcx.parent_module(hir_id);
                 if let Some(did) = res.and_then(|res| res.expect_full_res().opt_def_id()) {
-                    hir::RestrictionKind::Restricted(self.arena.alloc(hir::Path {
-                        res: did,
-                        segments: self.arena.alloc_from_iter(path.segments.iter().map(|segment| {
-                            self.lower_path_segment(
-                                path.span,
-                                segment,
-                                ParamMode::Explicit,
-                                GenericArgsMode::Err,
-                                ImplTraitContext::Disallowed(ImplTraitPosition::Path),
-                                None,
-                            )
-                        })),
-                        span: self.lower_span(path.span),
-                    }))
+                    if !self.tcx.is_descendant_of(parent_module, did) {
+                        // If the restriction path is not an ancestor of the item,
+                        // emit an error and recover by lowering the restriction to `Unrestricted`.
+                        self.dcx()
+                            .create_err(RestrictionAncestorOnly {
+                                span: path.span,
+                                kind: resolving_kind,
+                            })
+                            .emit();
+                        hir::RestrictionKind::Unrestricted
+                    } else {
+                        hir::RestrictionKind::Restricted(self.arena.alloc(hir::Path {
+                            res: did,
+                            segments: self.arena.alloc_from_iter(path.segments.iter().map(
+                                |segment| {
+                                    self.lower_path_segment(
+                                        path.span,
+                                        segment,
+                                        ParamMode::Explicit,
+                                        GenericArgsMode::Err,
+                                        ImplTraitContext::Disallowed(ImplTraitPosition::Path),
+                                        None,
+                                    )
+                                },
+                            )),
+                            span: self.lower_span(path.span),
+                        }))
+                    }
                 } else {
                     self.dcx().span_delayed_bug(path.span, "should have errored in resolve");
                     hir::RestrictionKind::Unrestricted
@@ -1828,16 +1848,18 @@ impl<'hir> LoweringContext<'_, 'hir> {
     pub(super) fn lower_impl_restriction(
         &mut self,
         r: &ImplRestriction,
+        hir_id: HirId,
     ) -> &'hir hir::ImplRestriction<'hir> {
-        let kind = self.lower_restriction_kind(&r.kind);
+        let kind = self.lower_restriction_kind(&r.kind, hir_id, ResolvingRestrictionKind::Impl);
         self.arena.alloc(hir::ImplRestriction { kind, span: self.lower_span(r.span) })
     }
 
     pub(super) fn lower_mut_restriction(
         &mut self,
         r: &MutRestriction,
+        hir_id: HirId,
     ) -> &'hir hir::MutRestriction<'hir> {
-        let kind = self.lower_restriction_kind(&r.kind);
+        let kind = self.lower_restriction_kind(&r.kind, hir_id, ResolvingRestrictionKind::Mut);
         self.arena.alloc(hir::MutRestriction { kind, span: self.lower_span(r.span) })
     }
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4398,6 +4398,8 @@ pub enum RestrictionKind<'hir> {
     /// The restriction does not affect the item.
     Unrestricted,
     /// The restriction only applies outside of this path.
+    /// The path is guaranteed to resolve to an ancestor module
+    /// of the restricted item.
     Restricted(&'hir Path<'hir, DefId>),
 }
 

--- a/compiler/rustc_resolve/src/diagnostics/mod.rs
+++ b/compiler/rustc_resolve/src/diagnostics/mod.rs
@@ -8,7 +8,7 @@ use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Spanned, Symbol};
 
 use crate::Res;
-use crate::late::{PatternSource, ResolvingRestrictionKind};
+use crate::late::PatternSource;
 
 pub(crate) mod impls;
 
@@ -546,19 +546,6 @@ pub(crate) struct ExpectedModuleFound {
 #[derive(Diagnostic)]
 #[diag("cannot determine resolution for the visibility", code = E0578)]
 pub(crate) struct Indeterminate(#[primary_span] pub(crate) Span);
-
-#[derive(Diagnostic)]
-#[diag(
-    "{$kind ->
-    [impl] trait implementation
-    *[mut] field mutation
-} can only be restricted to ancestor modules"
-)]
-pub(crate) struct RestrictionAncestorOnly {
-    #[primary_span]
-    pub(crate) span: Span,
-    pub(crate) kind: ResolvingRestrictionKind,
-}
 
 #[derive(Diagnostic)]
 #[diag("cannot use a tool module through an import")]

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -426,23 +426,6 @@ pub(crate) enum AliasPossibility {
     Maybe,
 }
 
-/// Whether resolving `impl` or `mut` restriction paths
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum ResolvingRestrictionKind {
-    Impl,
-    Mut,
-}
-
-impl IntoDiagArg for ResolvingRestrictionKind {
-    fn into_diag_arg(self, _: &mut Option<std::path::PathBuf>) -> DiagArgValue {
-        use std::borrow::Cow;
-        match self {
-            ResolvingRestrictionKind::Impl => DiagArgValue::Str(Cow::Borrowed("impl")),
-            ResolvingRestrictionKind::Mut => DiagArgValue::Str(Cow::Borrowed("mut")),
-        }
-    }
-}
-
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum PathSource<'a, 'ast, 'ra> {
     /// Type paths `Path`.
@@ -1502,7 +1485,7 @@ impl<'ast, 'ra, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'ra, 'tc
         let FieldDef { attrs, id: _, span: _, vis, ident, ty, is_placeholder: _, extras: _ } = f;
         walk_list!(self, visit_attribute, attrs);
         try_visit!(self.visit_vis(vis));
-        self.resolve_restriction_path(&f.mut_restriction().kind, ResolvingRestrictionKind::Mut);
+        self.resolve_restriction_path(&f.mut_restriction().kind);
         visit_opt!(self, visit_ident, ident);
         try_visit!(self.visit_ty(ty));
         if let Some(v) = f.default_value() {
@@ -2875,10 +2858,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
             ItemKind::Trait(Trait { generics, bounds, items, impl_restriction, .. }) => {
                 // resolve paths for `impl` restrictions
-                self.resolve_restriction_path(
-                    &impl_restriction.kind,
-                    ResolvingRestrictionKind::Impl,
-                );
+                self.resolve_restriction_path(&impl_restriction.kind);
 
                 // Create a new rib for the trait-wide type parameters.
                 self.with_generic_param_rib(
@@ -4494,31 +4474,11 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         }
     }
 
-    fn resolve_restriction_path(
-        &mut self,
-        restriction: &'ast ast::RestrictionKind,
-        kind: ResolvingRestrictionKind,
-    ) {
+    fn resolve_restriction_path(&mut self, restriction: &'ast ast::RestrictionKind) {
         match &restriction {
             ast::RestrictionKind::Unrestricted => (),
             ast::RestrictionKind::Restricted { path, id, shorthand: _ } => {
                 self.smart_resolve_path(*id, &None, path, PathSource::Module);
-                if let Some(res) = self.r.partial_res_map[&id].full_res()
-                    && let Some(def_id) = res.opt_def_id()
-                {
-                    if !self.r.is_accessible_from(
-                        Visibility::Restricted(def_id),
-                        self.parent_scope.module,
-                    ) {
-                        self.r
-                            .dcx()
-                            .create_err(crate::diagnostics::RestrictionAncestorOnly {
-                                span: path.span,
-                                kind,
-                            })
-                            .emit();
-                    }
-                }
             }
         }
     }

--- a/tests/ui/impl-restriction/restriction_resolution_errors.stderr
+++ b/tests/ui/impl-restriction/restriction_resolution_errors.stderr
@@ -1,74 +1,14 @@
-error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:16:21
-   |
-LL |         pub impl(in ::std) trait T2 {}
-   |                     ^^^^^
-
-error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:18:21
-   |
-LL |         pub impl(in self::c) trait T3 {}
-   |                     ^^^^^^^
-
-error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:20:21
-   |
-LL |         pub impl(in super::d) trait T4 {}
-   |                     ^^^^^^^^
-
 error[E0433]: too many leading `super` keywords within `crate::a::b`
   --> $DIR/restriction_resolution_errors.rs:26:35
    |
 LL |         pub impl(in super::super::super) trait T7 {}
    |                                   ^^^^^ this `super` would go above the crate root
 
-error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:36:21
-   |
-LL |         pub impl(in self::f) trait L1 {}
-   |                     ^^^^^^^
-
-error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:40:21
-   |
-LL |         pub impl(in super::h) trait L3 {}
-   |                     ^^^^^^^^
-
-error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:49:13
-   |
-LL | pub impl(in crate::a) trait T13 {}
-   |             ^^^^^^^^
-
 error[E0433]: too many leading `super` keywords within `crate`
   --> $DIR/restriction_resolution_errors.rs:56:10
    |
 LL | pub impl(super) trait T17 {}
    |          ^^^^^ this `super` would go above the crate root
-
-error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:58:13
-   |
-LL | pub impl(in external) trait T18 {}
-   |             ^^^^^^^^
-
-error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:61:13
-   |
-LL | pub impl(in crate::j) trait L4 {}
-   |             ^^^^^^^^
-
-error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:77:21
-   |
-LL |         pub impl(in crate::m2) trait U2 {}
-   |                     ^^^^^^^^^
-
-error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:79:21
-   |
-LL |         pub impl(in m6::m5) trait U4 {}
-   |                     ^^^^^^
 
 error[E0433]: cannot find module or crate `a` in this scope
   --> $DIR/restriction_resolution_errors.rs:14:21
@@ -139,6 +79,66 @@ error[E0577]: expected module, found enum `m7`
    |
 LL |         pub impl(in m7) trait U5 {}
    |                     ^^ not a module
+
+error: trait implementation can only be restricted to ancestor modules
+  --> $DIR/restriction_resolution_errors.rs:16:21
+   |
+LL |         pub impl(in ::std) trait T2 {}
+   |                     ^^^^^
+
+error: trait implementation can only be restricted to ancestor modules
+  --> $DIR/restriction_resolution_errors.rs:18:21
+   |
+LL |         pub impl(in self::c) trait T3 {}
+   |                     ^^^^^^^
+
+error: trait implementation can only be restricted to ancestor modules
+  --> $DIR/restriction_resolution_errors.rs:20:21
+   |
+LL |         pub impl(in super::d) trait T4 {}
+   |                     ^^^^^^^^
+
+error: trait implementation can only be restricted to ancestor modules
+  --> $DIR/restriction_resolution_errors.rs:36:21
+   |
+LL |         pub impl(in self::f) trait L1 {}
+   |                     ^^^^^^^
+
+error: trait implementation can only be restricted to ancestor modules
+  --> $DIR/restriction_resolution_errors.rs:40:21
+   |
+LL |         pub impl(in super::h) trait L3 {}
+   |                     ^^^^^^^^
+
+error: trait implementation can only be restricted to ancestor modules
+  --> $DIR/restriction_resolution_errors.rs:49:13
+   |
+LL | pub impl(in crate::a) trait T13 {}
+   |             ^^^^^^^^
+
+error: trait implementation can only be restricted to ancestor modules
+  --> $DIR/restriction_resolution_errors.rs:58:13
+   |
+LL | pub impl(in external) trait T18 {}
+   |             ^^^^^^^^
+
+error: trait implementation can only be restricted to ancestor modules
+  --> $DIR/restriction_resolution_errors.rs:61:13
+   |
+LL | pub impl(in crate::j) trait L4 {}
+   |             ^^^^^^^^
+
+error: trait implementation can only be restricted to ancestor modules
+  --> $DIR/restriction_resolution_errors.rs:77:21
+   |
+LL |         pub impl(in crate::m2) trait U2 {}
+   |                     ^^^^^^^^^
+
+error: trait implementation can only be restricted to ancestor modules
+  --> $DIR/restriction_resolution_errors.rs:79:21
+   |
+LL |         pub impl(in m6::m5) trait U4 {}
+   |                     ^^^^^^
 
 error: aborting due to 19 previous errors
 

--- a/tests/ui/mut-restriction/restriction-resolution-errors.stderr
+++ b/tests/ui/mut-restriction/restriction-resolution-errors.stderr
@@ -1,56 +1,14 @@
-error: field mutation can only be restricted to ancestor modules
-  --> $DIR/restriction-resolution-errors.rs:10:24
-   |
-LL |             pub mut(in ::std) i2: i32,
-   |                        ^^^^^
-
-error: field mutation can only be restricted to ancestor modules
-  --> $DIR/restriction-resolution-errors.rs:11:24
-   |
-LL |             pub mut(in self::c) i3: i32,
-   |                        ^^^^^^^
-
-error: field mutation can only be restricted to ancestor modules
-  --> $DIR/restriction-resolution-errors.rs:12:24
-   |
-LL |             pub mut(in super::d) i4: i32,
-   |                        ^^^^^^^^
-
 error[E0433]: too many leading `super` keywords within `crate::a::b`
   --> $DIR/restriction-resolution-errors.rs:15:38
    |
 LL |             pub mut(in super::super::super) i7: i32,
    |                                      ^^^^^ this `super` would go above the crate root
 
-error: field mutation can only be restricted to ancestor modules
-  --> $DIR/restriction-resolution-errors.rs:32:16
-   |
-LL |         mut(in crate::a) e1: i32,
-   |                ^^^^^^^^
-
 error[E0433]: too many leading `super` keywords within `crate`
   --> $DIR/restriction-resolution-errors.rs:36:13
    |
 LL |         mut(super) e5: i32,
    |             ^^^^^ this `super` would go above the crate root
-
-error: field mutation can only be restricted to ancestor modules
-  --> $DIR/restriction-resolution-errors.rs:38:16
-   |
-LL |     Tup(mut(in external) i32),
-   |                ^^^^^^^^
-
-error: field mutation can only be restricted to ancestor modules
-  --> $DIR/restriction-resolution-errors.rs:52:24
-   |
-LL |             pub mut(in crate::m2) i32,
-   |                        ^^^^^^^^^
-
-error: field mutation can only be restricted to ancestor modules
-  --> $DIR/restriction-resolution-errors.rs:54:24
-   |
-LL |             pub mut(in m6::m5) i32,
-   |                        ^^^^^^
 
 error[E0433]: cannot find module or crate `a` in this scope
   --> $DIR/restriction-resolution-errors.rs:9:24
@@ -100,6 +58,48 @@ error[E0577]: expected module, found enum `m7`
    |
 LL |             pub mut(in m7) i32,
    |                        ^^ not a module
+
+error: field mutation can only be restricted to ancestor modules
+  --> $DIR/restriction-resolution-errors.rs:10:24
+   |
+LL |             pub mut(in ::std) i2: i32,
+   |                        ^^^^^
+
+error: field mutation can only be restricted to ancestor modules
+  --> $DIR/restriction-resolution-errors.rs:11:24
+   |
+LL |             pub mut(in self::c) i3: i32,
+   |                        ^^^^^^^
+
+error: field mutation can only be restricted to ancestor modules
+  --> $DIR/restriction-resolution-errors.rs:12:24
+   |
+LL |             pub mut(in super::d) i4: i32,
+   |                        ^^^^^^^^
+
+error: field mutation can only be restricted to ancestor modules
+  --> $DIR/restriction-resolution-errors.rs:32:16
+   |
+LL |         mut(in crate::a) e1: i32,
+   |                ^^^^^^^^
+
+error: field mutation can only be restricted to ancestor modules
+  --> $DIR/restriction-resolution-errors.rs:38:16
+   |
+LL |     Tup(mut(in external) i32),
+   |                ^^^^^^^^
+
+error: field mutation can only be restricted to ancestor modules
+  --> $DIR/restriction-resolution-errors.rs:52:24
+   |
+LL |             pub mut(in crate::m2) i32,
+   |                        ^^^^^^^^^
+
+error: field mutation can only be restricted to ancestor modules
+  --> $DIR/restriction-resolution-errors.rs:54:24
+   |
+LL |             pub mut(in m6::m5) i32,
+   |                        ^^^^^^
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/mut-restriction/stricter-of-non-ancestor-160873.rs
+++ b/tests/ui/mut-restriction/stricter-of-non-ancestor-160873.rs
@@ -1,0 +1,17 @@
+//! Issue: <https://github.com/rust-lang/rust/issues/160873>
+//! This test checks that restricting struct expressions with
+//! non-ancestor mutability restrictions do not cause an ICE.
+
+//@ edition: 2018..
+#![feature(mut_restriction)]
+
+pub mod inner {
+    pub struct InnerS {
+        pub mut(self) x: i32,
+        pub mut(in std) y: i32, //~ ERROR field mutation can only be restricted to ancestor modules
+    }
+}
+
+fn main() {
+    let _ = inner::InnerS { x: 0, y: 0 }; //~ ERROR `InnerS` cannot be constructed using a `struct` expression outside `crate::inner`
+}

--- a/tests/ui/mut-restriction/stricter-of-non-ancestor-160873.stderr
+++ b/tests/ui/mut-restriction/stricter-of-non-ancestor-160873.stderr
@@ -1,0 +1,17 @@
+error: field mutation can only be restricted to ancestor modules
+  --> $DIR/stricter-of-non-ancestor-160873.rs:11:20
+   |
+LL |         pub mut(in std) y: i32,
+   |                    ^^^
+
+error: `InnerS` cannot be constructed using a `struct` expression outside `crate::inner`
+  --> $DIR/stricter-of-non-ancestor-160873.rs:16:13
+   |
+LL |         pub mut(self) x: i32,
+   |             --------- field restricted here
+...
+LL |     let _ = inner::InnerS { x: 0, y: 0 };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

fix: rust-lang/rust#160873

This PR moves the check that `impl` and `mut` restriction paths resolve to ancestor modules from `rustc_resolve` to `rustc_ast_lowering`. This ensures that `RestrictionKind::Restricted` in HIR always refers to an ancestor module.
If a restriction path resolves to a non-ancestor, we emit an error and recover by lowering the restriction as `RestrictionKind::Unrestricted`.

Tracking Issue: rust-lang/rust#105077 

r? @Urgau
cc @jhpratt 