### PR TITLE
rustdoc: accept `attribute@` disambiguator for attribute macros

### DIFF
--- a/src/doc/rustdoc/src/write-documentation/linking-to-items-by-name.md
+++ b/src/doc/rustdoc/src/write-documentation/linking-to-items-by-name.md
@@ -89,8 +89,8 @@ fn Foo() {}
 
 These prefixes will be stripped when displayed in the documentation, so `[struct@Foo]` will be
 rendered as `Foo`. The following prefixes are available: `struct`, `enum`, `trait`, `union`,
-`mod`, `module`, `const`, `constant`, `fn`, `function`, `field`, `variant`, `method`, `derive`,
-`type`, `value`, `macro`, `tyalias`, `typealias`, `prim` or `primitive`.
+`mod`, `module`, `const`, `constant`, `fn`, `function`, `field`, `variant`, `method`,
+`attribute`, `derive`, `type`, `value`, `macro`, `tyalias`, `typealias`, `prim` or `primitive`.
 
 You can also disambiguate for functions by adding `()` after the function name,
 or for macros by adding `!` after the macro name. The macro `!` can be followed by `()`, `{}`,

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -116,8 +116,7 @@ impl Res {
 
         let prefix = match kind {
             DefKind::Fn | DefKind::AssocFn => return Suggestion::Function,
-            // FIXME: handle macros with multiple kinds, and attribute/derive macros that aren't
-            // proc macros
+            // FIXME: handle macros with multiple kinds (e.g. bang+attr).
             DefKind::Macro(MacroKinds::ATTR) => "attribute",
             DefKind::Macro(MacroKinds::DERIVE) => "derive",
             DefKind::Macro(_) => return Suggestion::Macro,
@@ -1764,6 +1763,7 @@ impl Disambiguator {
                     safety: Safety::Safe,
                 }),
                 "function" | "fn" | "method" => Kind(DefKind::Fn),
+                "attribute" => Kind(DefKind::Macro(MacroKinds::ATTR)),
                 "derive" => Kind(DefKind::Macro(MacroKinds::DERIVE)),
                 "field" => Kind(DefKind::Field),
                 "variant" => Kind(DefKind::Variant),

--- a/tests/rustdoc-ui/intra-doc/issue-159771-attribute-disambiguator.rs
+++ b/tests/rustdoc-ui/intra-doc/issue-159771-attribute-disambiguator.rs
@@ -1,0 +1,25 @@
+//@ edition:2024
+#![feature(macro_attr)]
+#![deny(rustdoc::broken_intra_doc_links)]
+//~^ NOTE lint level is defined
+
+// Regression test for https://github.com/rust-lang/rust/issues/159771:
+// rustdoc suggested the `attribute@` disambiguator for attribute macros, but did
+// not accept it when parsing links.
+
+mod example {}
+
+#[macro_export]
+macro_rules! example {
+    attr() () => {};
+}
+
+/// Wrong bang disambiguator: [example!]
+//~^ ERROR incompatible link kind for `example`
+//~| NOTE this link resolved to an attribute macro
+//~| HELP prefix with `attribute@`
+
+/// Correct attribute disambiguator: [attribute@example]
+
+/// Macro namespace also works: [macro@example]
+pub fn f() {}

--- a/tests/rustdoc-ui/intra-doc/issue-159771-attribute-disambiguator.stderr
+++ b/tests/rustdoc-ui/intra-doc/issue-159771-attribute-disambiguator.stderr
@@ -1,0 +1,18 @@
+error: incompatible link kind for `example`
+  --> $DIR/issue-159771-attribute-disambiguator.rs:17:32
+   |
+LL | /// Wrong bang disambiguator: [example!]
+   |                                ^^^^^^^^ this link resolved to an attribute macro, which is not a macro
+   |
+note: the lint level is defined here
+  --> $DIR/issue-159771-attribute-disambiguator.rs:3:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: to link to the attribute macro, prefix with `attribute@`
+   |
+LL - /// Wrong bang disambiguator: [example!]
+LL + /// Wrong bang disambiguator: [attribute@example]
+   |
+
+error: aborting due to 1 previous error


### PR DESCRIPTION
### Summary

Rustdoc already *suggested* `attribute@` when an intra-doc link resolved to an attribute macro with the wrong kind (for example `example!`), but `Disambiguator::from_str` did not recognize `attribute`, so applying the suggestion produced `unknown disambiguator \`attribute\``.

This change:
- accepts `attribute@` as a kind disambiguator for `MacroKinds::ATTR` (symmetric with existing `derive@`)
- documents the prefix in the rustdoc book disambiguator list
- adds a rustdoc-ui regression test for rust-lang/rust#159771

### Validation

- Local full bootstrap was not run here (sparse/partial checkout; ~31 GiB free disk; no stage1 rustdoc build available).
- Change is intentionally small (parser + docs + ui test). Please rely on CI `./x.py test tests/rustdoc-ui --stage 1` (or the relevant rustdoc jobs).

Fixes rust-lang/rust#159771

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and prepared the reported local validation notes before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.