### PR TITLE
tests/run-make-cargo/thumb-none-cortex-m: bump `cortex-m` dependency

### DIFF
--- a/tests/run-make-cargo/thumb-none-cortex-m/rmake.rs
+++ b/tests/run-make-cargo/thumb-none-cortex-m/rmake.rs
@@ -18,7 +18,7 @@ use run_make_support::{cargo, cmd, env, env_var, target};
 
 const CRATE: &str = "cortex-m";
 const CRATE_URL: &str = "https://github.com/rust-embedded/cortex-m";
-const CRATE_SHA1: &str = "a448e9156e2cb1e556e5441fd65426952ef4b927"; // v0.5.0
+const CRATE_SHA1: &str = "bb4a78208323260a161e68b2498438867f971bc5"; // v0.7.7
 
 fn main() {
     // FIXME: requires an internet connection https://github.com/rust-lang/rust/issues/128733


### PR DESCRIPTION
the previous version, v0.5.0 (from 2018), does not include a Cargo lockfile which makes the test brittle as bugs and unintentional breaking changes in any new release of a dependency can make the test fail

the newly chosen version, v0.7.7, includes a Cargo lockfile

fixes rust-lang/rust#160907

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
