### PR TITLE
Remove d32 feature from 32-bit Arm targets

### DIFF
--- a/compiler/rustc_target/src/spec/targets/armv6_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv6_none_eabihf.rs
@@ -18,7 +18,7 @@ pub(crate) fn target() -> Target {
             cfg_abi: CfgAbi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             asm_args: cvs!["-mthumb-interwork", "-march=armv6", "-mlittle-endian",],
-            features: "+strict-align,+v6k,+vfp2,-d32".into(),
+            features: "+strict-align,+v6k,+vfp2".into(),
             atomic_cas: true,
             has_thumb_interworking: true,
             // LDREXD/STREXD available as of ARMv6K

--- a/compiler/rustc_target/src/spec/targets/armv7_linux_androideabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_linux_androideabi.rs
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::android::opts();
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-march=armv7-a"]);
     Target {
-        llvm_target: "armv7-none-linux-android".into(),
+        llvm_target: "arm-none-linux-android".into(),
         metadata: TargetMetadata {
             description: Some("Armv7-A Android".into()),
             tier: Some(2),
@@ -28,7 +28,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             cfg_abi: CfgAbi::Eabi,
             llvm_floatabi: Some(FloatAbi::Soft),
-            features: "+v7,+thumb-mode,+thumb2,+vfp3d16,-neon".into(),
+            features: "+v7,+db,+dsp,+aclass,+perfmon,+thumb-mode,+thumb2,+vfp3d16".into(),
             supported_sanitizers: SanitizerSet::ADDRESS,
             max_atomic_width: Some(64),
             ..base

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_freebsd.rs
@@ -2,7 +2,7 @@ use crate::spec::{Arch, CfgAbi, FloatAbi, Target, TargetMetadata, TargetOptions,
 
 pub(crate) fn target() -> Target {
     Target {
-        llvm_target: "armv7-unknown-freebsd-gnueabihf".into(),
+        llvm_target: "arm-unknown-freebsd-gnueabihf".into(),
         metadata: TargetMetadata {
             description: Some("Armv7-A FreeBSD".into()),
             tier: Some(3),
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             cfg_abi: CfgAbi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
+            features: "+v7,+db,+dsp,+aclass,+perfmon,+vfp3d16,+thumb2".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}__gnu_mcount_nc".into(),
             ..base::freebsd::opts()

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_gnueabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_gnueabihf.rs
@@ -7,7 +7,7 @@ use crate::spec::{
 
 pub(crate) fn target() -> Target {
     Target {
-        llvm_target: "armv7-unknown-linux-gnueabihf".into(),
+        llvm_target: "arm-unknown-linux-gnueabihf".into(),
         metadata: TargetMetadata {
             description: Some("Armv7-A Linux, hardfloat (kernel 3.2, glibc 2.17)".into()),
             tier: Some(2),
@@ -21,7 +21,7 @@ pub(crate) fn target() -> Target {
             cfg_abi: CfgAbi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
-            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
+            features: "+v7,+db,+dsp,+aclass,+perfmon,+vfp3d16,+thumb2".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}__gnu_mcount_nc".into(),
             llvm_mcount_intrinsic: Some("llvm.arm.gnu.eabi.mcount".into()),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_musleabihf.rs
@@ -4,7 +4,7 @@ use crate::spec::{Arch, CfgAbi, FloatAbi, Target, TargetMetadata, TargetOptions,
 
 pub(crate) fn target() -> Target {
     Target {
-        llvm_target: "armv7-unknown-linux-musleabihf".into(),
+        llvm_target: "arm-unknown-linux-musleabihf".into(),
         metadata: TargetMetadata {
             description: Some("Armv7-A Linux with musl 1.2.5, hardfloat".into()),
             tier: Some(2),
@@ -20,7 +20,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             cfg_abi: CfgAbi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
+            features: "+v7,+db,+dsp,+aclass,+perfmon,+vfp3d16,+thumb2".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}mcount".into(),
             // FIXME(compiler-team#422): musl targets should be dynamically linked by default.

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_uclibceabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_uclibceabihf.rs
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
 
         options: TargetOptions {
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
-            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
+            features: "+v7,+db,+dsp,+aclass,+perfmon,+vfp3d16,+thumb2".into(),
             cpu: "generic".into(),
             max_atomic_width: Some(64),
             mcount: "_mcount".into(),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_netbsd_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_netbsd_eabihf.rs
@@ -2,7 +2,7 @@ use crate::spec::{Arch, CfgAbi, FloatAbi, Target, TargetMetadata, TargetOptions,
 
 pub(crate) fn target() -> Target {
     Target {
-        llvm_target: "armv7-unknown-netbsdelf-eabihf".into(),
+        llvm_target: "arm-unknown-netbsdelf-eabihf".into(),
         metadata: TargetMetadata {
             description: Some("Armv7-A NetBSD w/hard-float".into()),
             tier: Some(3),
@@ -15,7 +15,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             cfg_abi: CfgAbi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
+            features: "+v7,+db,+dsp,+aclass,+perfmon,+vfp3d16,+thumb2".into(),
             max_atomic_width: Some(64),
             mcount: "__mcount".into(),
             ..base::netbsd::opts()

--- a/compiler/rustc_target/src/spec/targets/armv7_wrs_vxworks_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_wrs_vxworks_eabihf.rs
@@ -2,7 +2,7 @@ use crate::spec::{Arch, CfgAbi, FloatAbi, Target, TargetMetadata, TargetOptions,
 
 pub(crate) fn target() -> Target {
     Target {
-        llvm_target: "armv7-unknown-linux-gnueabihf".into(),
+        llvm_target: "arm-unknown-linux-gnueabihf".into(),
         metadata: TargetMetadata {
             description: Some("Armv7-A for VxWorks".into()),
             tier: Some(3),
@@ -16,7 +16,7 @@ pub(crate) fn target() -> Target {
             cfg_abi: CfgAbi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             // Info about features at https://wiki.debian.org/ArmHardFloatPort
-            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
+            features: "+v7,+db,+dsp,+aclass,+perfmon,+vfp3d16,+thumb2".into(),
             max_atomic_width: Some(64),
             ..base::vxworks::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabihf.rs
@@ -5,7 +5,7 @@ use crate::spec::{
 pub(crate) fn target() -> Target {
     let base = base::solid::opts();
     Target {
-        llvm_target: "armv7a-none-eabihf".into(),
+        llvm_target: "arm-none-eabihf".into(),
         metadata: TargetMetadata {
             description: Some("Arm SOLID with TOPPERS/ASP3, hardfloat".into()),
             tier: Some(3),
@@ -19,7 +19,7 @@ pub(crate) fn target() -> Target {
             cfg_abi: CfgAbi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
             linker: Some("arm-kmc-eabi-gcc".into()),
-            features: "+v7,+vfp3d16,+thumb2,-neon".into(),
+            features: "+v7,+db,+dsp,+aclass,+perfmon,+vfp3d16,+thumb2".into(),
             relocation_model: RelocModel::Static,
             disable_redzone: true,
             max_atomic_width: Some(64),

--- a/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_none_eabihf.rs
@@ -4,7 +4,7 @@ use crate::spec::{Arch, CfgAbi, FloatAbi, Target, TargetMetadata, TargetOptions,
 
 pub(crate) fn target() -> Target {
     Target {
-        llvm_target: "armv7a-none-eabihf".into(),
+        llvm_target: "arm-none-eabihf".into(),
         metadata: TargetMetadata {
             description: Some("Bare Armv7-A, hardfloat".into()),
             tier: Some(2),
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             cfg_abi: CfgAbi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+vfp3d16,-neon,+strict-align".into(),
+            features: "+v7,+db,+dsp,+aclass,+perfmon,+vfp3d16,+strict-align".into(),
             max_atomic_width: Some(64),
             has_thumb_interworking: true,
             ..base::arm_none::opts()

--- a/compiler/rustc_target/src/spec/targets/thumbv7a_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7a_none_eabihf.rs
@@ -4,7 +4,7 @@ use crate::spec::{Arch, CfgAbi, FloatAbi, Target, TargetMetadata, TargetOptions,
 
 pub(crate) fn target() -> Target {
     Target {
-        llvm_target: "thumbv7a-none-eabihf".into(),
+        llvm_target: "thumb-none-eabihf".into(),
         metadata: TargetMetadata {
             description: Some("Thumb-mode Bare Armv7-A, hardfloat".into()),
             tier: Some(2),
@@ -17,7 +17,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             cfg_abi: CfgAbi::EabiHf,
             llvm_floatabi: Some(FloatAbi::Hard),
-            features: "+vfp3d16,-neon,+strict-align".into(),
+            features: "+v7,+db,+dsp,+aclass,+perfmon,+vfp3d16,+strict-align".into(),
             max_atomic_width: Some(64),
             has_thumb_interworking: true,
             ..base::arm_none::opts()

--- a/src/doc/rustc/src/platform-support/armv7a-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv7a-none-eabi.md
@@ -49,10 +49,10 @@ disabled as needed with `-C target-feature=(+/-)`.
 
 In general, the following four combinations are possible:
 
-- VFPv3-D16, target feature `+vfp3` and `-d32`
-- VFPv3-D32, target feature `+vfp3` and `+d32`
-- VFPv4-D16, target feature `+vfp4` and `-d32`
-- VFPv4-D32, target feature `+vfp4` and `+d32`
+- VFPv3-D16, target default
+- VFPv3-D32, target feature `+d32`
+- VFPv4-D16, llvm target feature `+vfp4d16`
+- VFPv4-D32, target feature `+vfp4`
 
 An Armv7-A processor may optionally include a NEON hardware unit which
 provides Single Instruction Multiple Data (SIMD) operations. The

--- a/tests/ui/asm/arm-high-dregs.baseline.stderr
+++ b/tests/ui/asm/arm-high-dregs.baseline.stderr
@@ -1,0 +1,8 @@
+error: register class `dreg` requires at least one of the following target features: d32, neon
+  --> $DIR/arm-high-dregs.rs:23:42
+   |
+LL |     asm!("vmov.f64 d16, d0", in("d0") x, out("d16") y);
+   |                                          ^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/asm/arm-high-dregs.rs
+++ b/tests/ui/asm/arm-high-dregs.rs
@@ -1,0 +1,25 @@
+//@ add-minicore
+//@ only-arm
+//@ only-eabihf
+//@ ignore-backends: gcc
+//@ revisions: baseline target-cpu
+//@ [baseline] check-fail
+//@ [target-cpu] check-pass
+//@ [target-cpu] compile-flags: -Ctarget-cpu=cortex-a5
+
+// As well as the error message, this also tests that d32 is not enabled by default on arm hardfloat
+// targets and that it can be re-enabled by target-cpu.
+
+#![feature(f16, no_core)]
+#![crate_type = "rlib"]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+#[no_mangle]
+pub unsafe fn high(x: f64) {
+    let y: f64;
+    asm!("vmov.f64 d16, d0", in("d0") x, out("d16") y);
+    //[baseline]~^ ERROR register class `dreg` requires at least one of the following target features: d32, neon
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160911)*
<!-- homu-ignore:end -->

Fixes https://github.com/rust-lang/rust/issues/159973

In https://github.com/rust-lang/rust/pull/149512/ I removed `-d32` from some specs, but since LLVM enables `neon` by default for v7 targets `d32` was left enabled while it should be optional on this target. For a similar reason `-d32` was removed from some armv6 targets and has been readded.

This PR adds a test to ensure this specific instance does not happen again and has been tested locally on armv7-unknown-linux-gnueabihf, armv7a-none-eabihf and arm-unknown-linux-gnueabihf.

It might be a good idea in general to have a test that runs `--print cfg` and captures the set of rust target features enabled to show when PRs change them, but most of these targets are not run in Rust's CI so it's out of scope for this issue.

For reference, here is the manually-expanded LLVM features and their implications - necessary as these targets rely on a feature from LLVM that Rust doesn't yet expose:

```
vfp4 -> vfp3 + fp16 + vfp4d16 + vfp4sp
vfp4d16 -> vfp3d16 + fp16 + fp64 + vfp4d16sp
vfp4sp -> vfp3sp + fp16 + d32 + vfp4d16sp
vfp4d16sp -> vfp3d16sp + fp16
vfp3 -> vfp2 + vfp3d16 + vfp3sp
vfp3d16 -> vfp2 + fp64 + vfp3d16sp
vfp3sp -> vfp2 + d32 + vfp3d16sp
vfp3d16sp -> vfp2sp
vfp2 -> vfp2sp + fp64
vfp2sp -> fpregs
```