### PR TITLE
Rename `bstr` module/feature to `byte_str`

### DIFF
--- a/library/alloc/src/byte_str.rs
+++ b/library/alloc/src/byte_str.rs
@@ -4,9 +4,9 @@
 #![cfg(not(no_global_oom_handling))]
 
 use core::borrow::{Borrow, BorrowMut};
-#[unstable(feature = "bstr", issue = "134915")]
-pub use core::bstr::ByteStr;
-use core::bstr::{impl_partial_eq, impl_partial_eq_n, impl_partial_eq_ord};
+#[unstable(feature = "byte_str", issue = "134915")]
+pub use core::byte_str::ByteStr;
+use core::byte_str::{impl_partial_eq, impl_partial_eq_n, impl_partial_eq_ord};
 use core::cmp::Ordering;
 use core::ops::{
     Deref, DerefMut, DerefPure, Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive,
@@ -32,7 +32,7 @@ use crate::vec::Vec;
 /// need to round-trip whatever data the user provides.
 ///
 /// A `ByteString` owns its contents and can grow and shrink, like a `Vec` or `String`. For a
-/// borrowed byte string, see [`ByteStr`](../../std/bstr/struct.ByteStr.html).
+/// borrowed byte string, see [`ByteStr`](../../std/byte_str/struct.ByteStr.html).
 ///
 /// `ByteString` implements `Deref` to `&Vec<u8>`, so all methods available on `&Vec<u8>` are
 /// available on `ByteString`. Similarly, `ByteString` implements `DerefMut` to `&mut Vec<u8>`,
@@ -40,7 +40,7 @@ use crate::vec::Vec;
 ///
 /// The `Debug` and `Display` implementations for `ByteString` are the same as those for `ByteStr`,
 /// showing invalid UTF-8 as hex escapes or the Unicode replacement character, respectively.
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[repr(transparent)]
 #[derive(Clone, Default)]
 #[doc(alias = "BString")]
@@ -69,7 +69,7 @@ impl ByteString {
     /// implementation for types that implement `Display`, and the trait version
     /// will use the Unicode replacement character rather than returning a
     /// `Result` and allowing for the possibility of the content not being UTF-8.
-    #[unstable(feature = "bstr_to_string", issue = "134915")]
+    #[unstable(feature = "byte_str_to_string", issue = "134915")]
     #[rustc_allow_incoherent_impl]
     pub fn to_string(&self) -> Result<String, Utf8Error> {
         // Avoid allocating a copy of the contents for invalid UTF-8
@@ -81,7 +81,7 @@ impl ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Deref for ByteString {
     type Target = Vec<u8>;
 
@@ -91,7 +91,7 @@ impl Deref for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl DerefMut for ByteString {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
@@ -102,7 +102,7 @@ impl DerefMut for ByteString {
 #[unstable(feature = "deref_pure_trait", issue = "87121")]
 unsafe impl DerefPure for ByteString {}
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl fmt::Debug for ByteString {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -110,7 +110,7 @@ impl fmt::Debug for ByteString {
     }
 }
 
-#[unstable(feature = "bstr_to_string", issue = "134915")]
+#[unstable(feature = "byte_str_to_string", issue = "134915")]
 impl fmt::Display for ByteString {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -118,7 +118,7 @@ impl fmt::Display for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl AsRef<[u8]> for ByteString {
     #[inline]
     fn as_ref(&self) -> &[u8] {
@@ -126,7 +126,7 @@ impl AsRef<[u8]> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl AsRef<ByteStr> for ByteString {
     #[inline]
     fn as_ref(&self) -> &ByteStr {
@@ -134,7 +134,7 @@ impl AsRef<ByteStr> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl AsMut<[u8]> for ByteString {
     #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
@@ -142,7 +142,7 @@ impl AsMut<[u8]> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl AsMut<ByteStr> for ByteString {
     #[inline]
     fn as_mut(&mut self) -> &mut ByteStr {
@@ -150,7 +150,7 @@ impl AsMut<ByteStr> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Borrow<[u8]> for ByteString {
     #[inline]
     fn borrow(&self) -> &[u8] {
@@ -158,7 +158,7 @@ impl Borrow<[u8]> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Borrow<ByteStr> for ByteString {
     #[inline]
     fn borrow(&self) -> &ByteStr {
@@ -169,7 +169,7 @@ impl Borrow<ByteStr> for ByteString {
 // `impl Borrow<ByteStr> for Vec<u8>` omitted to avoid inference failures
 // `impl Borrow<ByteStr> for String` omitted to avoid inference failures
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl BorrowMut<[u8]> for ByteString {
     #[inline]
     fn borrow_mut(&mut self) -> &mut [u8] {
@@ -177,7 +177,7 @@ impl BorrowMut<[u8]> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl BorrowMut<ByteStr> for ByteString {
     #[inline]
     fn borrow_mut(&mut self) -> &mut ByteStr {
@@ -189,7 +189,7 @@ impl BorrowMut<ByteStr> for ByteString {
 
 // Omitted due to inference failures
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a, const N: usize> From<&'a [u8; N]> for ByteString {
 //     #[inline]
 //     fn from(s: &'a [u8; N]) -> Self {
@@ -197,7 +197,7 @@ impl BorrowMut<ByteStr> for ByteString {
 //     }
 // }
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<const N: usize> From<[u8; N]> for ByteString {
 //     #[inline]
 //     fn from(s: [u8; N]) -> Self {
@@ -205,7 +205,7 @@ impl BorrowMut<ByteStr> for ByteString {
 //     }
 // }
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a> From<&'a [u8]> for ByteString {
 //     #[inline]
 //     fn from(s: &'a [u8]) -> Self {
@@ -213,7 +213,7 @@ impl BorrowMut<ByteStr> for ByteString {
 //     }
 // }
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl From<Vec<u8>> for ByteString {
 //     #[inline]
 //     fn from(s: Vec<u8>) -> Self {
@@ -221,7 +221,7 @@ impl BorrowMut<ByteStr> for ByteString {
 //     }
 // }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl From<ByteString> for Vec<u8> {
     #[inline]
     fn from(s: ByteString) -> Self {
@@ -231,7 +231,7 @@ impl From<ByteString> for Vec<u8> {
 
 // Omitted due to inference failures
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a> From<&'a str> for ByteString {
 //     #[inline]
 //     fn from(s: &'a str) -> Self {
@@ -239,7 +239,7 @@ impl From<ByteString> for Vec<u8> {
 //     }
 // }
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl From<String> for ByteString {
 //     #[inline]
 //     fn from(s: String) -> Self {
@@ -247,7 +247,7 @@ impl From<ByteString> for Vec<u8> {
 //     }
 // }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> From<&'a ByteStr> for ByteString {
     #[inline]
     fn from(s: &'a ByteStr) -> Self {
@@ -255,7 +255,7 @@ impl<'a> From<&'a ByteStr> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> From<ByteString> for Cow<'a, ByteStr> {
     #[inline]
     fn from(s: ByteString) -> Self {
@@ -263,7 +263,7 @@ impl<'a> From<ByteString> for Cow<'a, ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> From<&'a ByteString> for Cow<'a, ByteStr> {
     #[inline]
     fn from(s: &'a ByteString) -> Self {
@@ -271,7 +271,7 @@ impl<'a> From<&'a ByteString> for Cow<'a, ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl FromIterator<char> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = char>>(iter: T) -> Self {
@@ -279,7 +279,7 @@ impl FromIterator<char> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl FromIterator<u8> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = u8>>(iter: T) -> Self {
@@ -287,7 +287,7 @@ impl FromIterator<u8> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> FromIterator<&'a str> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
@@ -295,7 +295,7 @@ impl<'a> FromIterator<&'a str> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> FromIterator<&'a [u8]> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = &'a [u8]>>(iter: T) -> Self {
@@ -307,7 +307,7 @@ impl<'a> FromIterator<&'a [u8]> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> FromIterator<&'a ByteStr> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = &'a ByteStr>>(iter: T) -> Self {
@@ -319,7 +319,7 @@ impl<'a> FromIterator<&'a ByteStr> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl FromIterator<ByteString> for ByteString {
     #[inline]
     fn from_iter<T: IntoIterator<Item = ByteString>>(iter: T) -> Self {
@@ -331,7 +331,7 @@ impl FromIterator<ByteString> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl FromStr for ByteString {
     type Err = core::convert::Infallible;
 
@@ -341,7 +341,7 @@ impl FromStr for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<usize> for ByteString {
     type Output = u8;
 
@@ -351,7 +351,7 @@ impl Index<usize> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<RangeFull> for ByteString {
     type Output = ByteStr;
 
@@ -361,7 +361,7 @@ impl Index<RangeFull> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<Range<usize>> for ByteString {
     type Output = ByteStr;
 
@@ -371,7 +371,7 @@ impl Index<Range<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<RangeInclusive<usize>> for ByteString {
     type Output = ByteStr;
 
@@ -381,7 +381,7 @@ impl Index<RangeInclusive<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<RangeFrom<usize>> for ByteString {
     type Output = ByteStr;
 
@@ -391,7 +391,7 @@ impl Index<RangeFrom<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<RangeTo<usize>> for ByteString {
     type Output = ByteStr;
 
@@ -401,7 +401,7 @@ impl Index<RangeTo<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Index<RangeToInclusive<usize>> for ByteString {
     type Output = ByteStr;
 
@@ -411,7 +411,7 @@ impl Index<RangeToInclusive<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<usize> for ByteString {
     #[inline]
     fn index_mut(&mut self, idx: usize) -> &mut u8 {
@@ -419,7 +419,7 @@ impl IndexMut<usize> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<RangeFull> for ByteString {
     #[inline]
     fn index_mut(&mut self, _: RangeFull) -> &mut ByteStr {
@@ -427,7 +427,7 @@ impl IndexMut<RangeFull> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<Range<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: Range<usize>) -> &mut ByteStr {
@@ -435,7 +435,7 @@ impl IndexMut<Range<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<RangeInclusive<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: RangeInclusive<usize>) -> &mut ByteStr {
@@ -443,7 +443,7 @@ impl IndexMut<RangeInclusive<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<RangeFrom<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: RangeFrom<usize>) -> &mut ByteStr {
@@ -451,7 +451,7 @@ impl IndexMut<RangeFrom<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<RangeTo<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: RangeTo<usize>) -> &mut ByteStr {
@@ -459,7 +459,7 @@ impl IndexMut<RangeTo<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl IndexMut<RangeToInclusive<usize>> for ByteString {
     #[inline]
     fn index_mut(&mut self, r: RangeToInclusive<usize>) -> &mut ByteStr {
@@ -467,7 +467,7 @@ impl IndexMut<RangeToInclusive<usize>> for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl hash::Hash for ByteString {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -475,10 +475,10 @@ impl hash::Hash for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Eq for ByteString {}
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl PartialEq for ByteString {
     #[inline]
     fn eq(&self, other: &ByteString) -> bool {
@@ -488,7 +488,7 @@ impl PartialEq for ByteString {
 
 macro_rules! impl_partial_eq_ord_cow {
     ($lhs:ty, $rhs:ty) => {
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl PartialEq<$rhs> for $lhs {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool {
@@ -497,7 +497,7 @@ macro_rules! impl_partial_eq_ord_cow {
             }
         }
 
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
@@ -506,7 +506,7 @@ macro_rules! impl_partial_eq_ord_cow {
             }
         }
 
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl PartialOrd<$rhs> for $lhs {
             #[inline]
             fn partial_cmp(&self, other: &$rhs) -> Option<Ordering> {
@@ -515,7 +515,7 @@ macro_rules! impl_partial_eq_ord_cow {
             }
         }
 
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl PartialOrd<$lhs> for $rhs {
             #[inline]
             fn partial_cmp(&self, other: &$lhs) -> Option<Ordering> {
@@ -548,7 +548,7 @@ impl_partial_eq_ord_cow!(ByteString, Cow<'_, ByteStr>);
 impl_partial_eq_ord_cow!(ByteString, Cow<'_, str>);
 impl_partial_eq_ord_cow!(ByteString, Cow<'_, [u8]>);
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Ord for ByteString {
     #[inline]
     fn cmp(&self, other: &ByteString) -> Ordering {
@@ -556,7 +556,7 @@ impl Ord for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl PartialOrd for ByteString {
     #[inline]
     fn partial_cmp(&self, other: &ByteString) -> Option<Ordering> {
@@ -564,7 +564,7 @@ impl PartialOrd for ByteString {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl ToOwned for ByteStr {
     type Owned = ByteString;
 
@@ -574,7 +574,7 @@ impl ToOwned for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl TryFrom<ByteString> for String {
     type Error = crate::string::FromUtf8Error;
 
@@ -584,7 +584,7 @@ impl TryFrom<ByteString> for String {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> TryFrom<&'a ByteString> for &'a str {
     type Error = crate::str::Utf8Error;
 
@@ -596,7 +596,7 @@ impl<'a> TryFrom<&'a ByteString> for &'a str {
 
 // Additional impls for `ByteStr` that require types from `alloc`:
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Clone for Box<ByteStr> {
     #[inline]
     fn clone(&self) -> Self {
@@ -604,7 +604,7 @@ impl Clone for Box<ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> From<&'a ByteStr> for Cow<'a, ByteStr> {
     #[inline]
     fn from(s: &'a ByteStr) -> Self {
@@ -612,7 +612,7 @@ impl<'a> From<&'a ByteStr> for Cow<'a, ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl From<Box<[u8]>> for Box<ByteStr> {
     #[inline]
     fn from(s: Box<[u8]>) -> Box<ByteStr> {
@@ -621,7 +621,7 @@ impl From<Box<[u8]>> for Box<ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl From<Box<ByteStr>> for Box<[u8]> {
     #[inline]
     fn from(s: Box<ByteStr>) -> Box<[u8]> {
@@ -630,7 +630,7 @@ impl From<Box<ByteStr>> for Box<[u8]> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[cfg(not(no_rc))]
 impl From<Rc<[u8]>> for Rc<ByteStr> {
     #[inline]
@@ -640,7 +640,7 @@ impl From<Rc<[u8]>> for Rc<ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[cfg(not(no_rc))]
 impl From<Rc<ByteStr>> for Rc<[u8]> {
     #[inline]
@@ -650,7 +650,7 @@ impl From<Rc<ByteStr>> for Rc<[u8]> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
 impl From<Arc<[u8]>> for Arc<ByteStr> {
     #[inline]
@@ -660,7 +660,7 @@ impl From<Arc<[u8]>> for Arc<ByteStr> {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[cfg(all(not(no_rc), not(no_sync), target_has_atomic = "ptr"))]
 impl From<Arc<ByteStr>> for Arc<[u8]> {
     #[inline]
@@ -678,7 +678,7 @@ impl_partial_eq_ord_cow!(&ByteStr, Cow<'_, ByteStr>);
 impl_partial_eq_ord_cow!(&ByteStr, Cow<'_, str>);
 impl_partial_eq_ord_cow!(&ByteStr, Cow<'_, [u8]>);
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> TryFrom<&'a ByteStr> for String {
     type Error = core::str::Utf8Error;
 
@@ -697,7 +697,7 @@ impl ByteStr {
     /// implementation for types that implement `Display`, and the trait version
     /// will use the Unicode replacement character rather than returning a
     /// `Result` and allowing for the possibility of the content not being UTF-8.
-    #[unstable(feature = "bstr_to_string", issue = "134915")]
+    #[unstable(feature = "byte_str_to_string", issue = "134915")]
     #[rustc_allow_incoherent_impl]
     pub fn to_string(&self) -> Result<String, Utf8Error> {
         // Avoid allocating a copy of the contents for invalid UTF-8

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -96,8 +96,8 @@
 #![feature(async_fn_traits)]
 #![feature(async_iterator)]
 #![feature(borrowed_buf_init)]
-#![feature(bstr)]
-#![feature(bstr_internals)]
+#![feature(byte_str)]
+#![feature(byte_str_internals)]
 #![feature(can_vector)]
 #![feature(case_ignorable)]
 #![feature(cast_maybe_uninit)]
@@ -246,8 +246,8 @@ pub mod alloc;
 // to allow code to have `use boxed::Box;` declarations.
 pub mod borrow;
 pub mod boxed;
-#[unstable(feature = "bstr", issue = "134915")]
-pub mod bstr;
+#[unstable(feature = "byte_str", issue = "134915")]
+pub mod byte_str;
 pub mod collections;
 #[cfg(all(not(no_rc), not(no_sync), not(no_global_oom_handling)))]
 pub mod ffi;

--- a/library/alloctests/tests/byte_str.rs
+++ b/library/alloctests/tests/byte_str.rs
@@ -1,17 +1,21 @@
-use core::bstr::ByteStr;
+use alloc::byte_str::ByteString;
+use core::assert_matches;
 
 #[test]
 fn test_debug() {
+    let b1 = ByteString(
+        b"\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff".to_vec()
+    );
     assert_eq!(
         r#""\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff""#,
-        format!("{:?}", ByteStr::new(b"\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff")),
+        format!("{:?}", b1),
     );
 }
 
 #[test]
 fn test_display() {
-    let b1 = ByteStr::new("abc");
-    let b2 = ByteStr::new(b"\xf0\x28\x8c\xbc");
+    let b1 = ByteString(b"abc".to_vec());
+    let b2 = ByteString(b"\xf0\x28\x8c\xbc".to_vec());
 
     assert_eq!(&format!("{b1}"), "abc");
     assert_eq!(&format!("{b2}"), "�(��");
@@ -64,4 +68,17 @@ fn test_display() {
     assert_eq!(&format!("{b2:-<6.3}!"), "�(�---!");
     assert_eq!(&format!("{b2:-^6.3}!"), "-�(�--!");
     assert_eq!(&format!("{b2:->6.3}!"), "---�(�!");
+}
+
+#[test]
+fn test_to_string() {
+    let b1 = ByteString(b"abc".to_vec());
+    let b2 = ByteString(b"\xf0\x28\x8c\xbc".to_vec());
+
+    assert_eq!(Ok("abc".to_string()), b1.to_string());
+    assert_matches!(b2.to_string(), Err(core::str::Utf8Error { .. }));
+
+    // Can still directly use the trait
+    assert_eq!("abc".to_string(), ToString::to_string(&b1));
+    assert_eq!("�(��".to_string(), ToString::to_string(&b2));
 }

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -8,9 +8,9 @@
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(binary_heap_pop_if)]
 #![feature(borrowed_buf_init)]
-#![feature(bstr)]
-#![feature(bstr_to_string)]
 #![feature(buf_read_has_data_left)]
+#![feature(byte_str)]
+#![feature(byte_str_to_string)]
 #![feature(can_vector)]
 #![feature(casefold)]
 #![feature(const_btree_len)]
@@ -73,8 +73,8 @@ mod arc;
 mod autotraits;
 mod borrow;
 mod boxed;
-mod bstr;
 mod btree_set_hash;
+mod byte_str;
 mod c_str;
 mod c_str2;
 mod collections;

--- a/library/core/src/byte_str/mod.rs
+++ b/library/core/src/byte_str/mod.rs
@@ -2,7 +2,7 @@
 
 mod traits;
 
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 pub use traits::{impl_partial_eq, impl_partial_eq_n, impl_partial_eq_ord};
 
 use crate::borrow::{Borrow, BorrowMut};
@@ -17,7 +17,7 @@ use crate::ops::{Deref, DerefMut, DerefPure};
 /// need to round-trip whatever data the user provides.
 ///
 /// For an owned, growable byte string buffer, use
-/// [`ByteString`](../../std/bstr/struct.ByteString.html).
+/// [`ByteString`](../../std/byte_str/struct.ByteString.html).
 ///
 /// `ByteStr` implements `Deref` to `[u8]`, so all methods available on `[u8]` are available on
 /// `ByteStr`.
@@ -37,7 +37,7 @@ use crate::ops::{Deref, DerefMut, DerefPure};
 ///
 /// The `Display` implementation behaves as if the `ByteStr` were first lossily converted to a
 /// `str`, with invalid UTF-8 presented as the Unicode replacement character (�).
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_has_incoherent_inherent_impls]
 #[repr(transparent)]
 #[doc(alias = "BStr")]
@@ -53,8 +53,8 @@ impl ByteStr {
     /// You can create a `ByteStr` from a byte array, a byte slice or a string slice:
     ///
     /// ```
-    /// # #![feature(bstr)]
-    /// # use std::bstr::ByteStr;
+    /// # #![feature(byte_str)]
+    /// # use std::byte_str::ByteStr;
     /// let a = ByteStr::new(b"abc");
     /// let b = ByteStr::new(&b"abc"[..]);
     /// let c = ByteStr::new("abc");
@@ -63,7 +63,7 @@ impl ByteStr {
     /// assert_eq!(a, c);
     /// ```
     #[inline]
-    #[unstable(feature = "bstr", issue = "134915")]
+    #[unstable(feature = "byte_str", issue = "134915")]
     #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
     pub const fn new<B: ?Sized + [const] AsRef<[u8]>>(bytes: &B) -> &Self {
         ByteStr::from_bytes(bytes.as_ref())
@@ -76,7 +76,7 @@ impl ByteStr {
     /// for example `Box<ByteStr>` or `Arc<ByteStr>`.
     #[inline]
     // #[unstable(feature = "str_as_str", issue = "130366")]
-    #[unstable(feature = "bstr", issue = "134915")]
+    #[unstable(feature = "byte_str", issue = "134915")]
     pub const fn as_byte_str(&self) -> &ByteStr {
         self
     }
@@ -88,15 +88,15 @@ impl ByteStr {
     /// for example `Box<ByteStr>` or `MutexGuard<ByteStr>`.
     #[inline]
     // #[unstable(feature = "str_as_str", issue = "130366")]
-    #[unstable(feature = "bstr", issue = "134915")]
+    #[unstable(feature = "byte_str", issue = "134915")]
     pub const fn as_mut_byte_str(&mut self) -> &mut ByteStr {
         self
     }
 
     #[doc(hidden)]
-    #[unstable(feature = "bstr_internals", issue = "none")]
+    #[unstable(feature = "byte_str_internals", issue = "none")]
     #[inline]
-    #[rustc_const_unstable(feature = "bstr_internals", issue = "none")]
+    #[rustc_const_unstable(feature = "byte_str_internals", issue = "none")]
     pub const fn from_bytes(slice: &[u8]) -> &Self {
         // SAFETY: `ByteStr` is a transparent wrapper around `[u8]`, so we can turn a reference to
         // the wrapped type into a reference to the wrapper type.
@@ -104,9 +104,9 @@ impl ByteStr {
     }
 
     #[doc(hidden)]
-    #[unstable(feature = "bstr_internals", issue = "none")]
+    #[unstable(feature = "byte_str_internals", issue = "none")]
     #[inline]
-    #[rustc_const_unstable(feature = "bstr_internals", issue = "none")]
+    #[rustc_const_unstable(feature = "byte_str_internals", issue = "none")]
     pub const fn from_bytes_mut(slice: &mut [u8]) -> &mut Self {
         // SAFETY: `ByteStr` is a transparent wrapper around `[u8]`, so we can turn a reference to
         // the wrapped type into a reference to the wrapper type.
@@ -114,23 +114,23 @@ impl ByteStr {
     }
 
     #[doc(hidden)]
-    #[unstable(feature = "bstr_internals", issue = "none")]
+    #[unstable(feature = "byte_str_internals", issue = "none")]
     #[inline]
-    #[rustc_const_unstable(feature = "bstr_internals", issue = "none")]
+    #[rustc_const_unstable(feature = "byte_str_internals", issue = "none")]
     pub const fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 
     #[doc(hidden)]
-    #[unstable(feature = "bstr_internals", issue = "none")]
+    #[unstable(feature = "byte_str_internals", issue = "none")]
     #[inline]
-    #[rustc_const_unstable(feature = "bstr_internals", issue = "none")]
+    #[rustc_const_unstable(feature = "byte_str_internals", issue = "none")]
     pub const fn as_bytes_mut(&mut self) -> &mut [u8] {
         &mut self.0
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl Deref for ByteStr {
     type Target = [u8];
@@ -141,7 +141,7 @@ const impl Deref for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl DerefMut for ByteStr {
     #[inline]
@@ -153,7 +153,7 @@ const impl DerefMut for ByteStr {
 #[unstable(feature = "deref_pure_trait", issue = "87121")]
 unsafe impl DerefPure for ByteStr {}
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl fmt::Debug for ByteStr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "\"")?;
@@ -172,7 +172,7 @@ impl fmt::Debug for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr_to_string", issue = "134915")]
+#[unstable(feature = "byte_str_to_string", issue = "134915")]
 impl fmt::Display for ByteStr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn emit(byte_str: &ByteStr, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -257,7 +257,7 @@ impl fmt::Display for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl AsRef<[u8]> for ByteStr {
     #[inline]
@@ -266,7 +266,7 @@ const impl AsRef<[u8]> for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl AsRef<ByteStr> for ByteStr {
     #[inline]
@@ -277,7 +277,7 @@ const impl AsRef<ByteStr> for ByteStr {
 
 // `impl AsRef<ByteStr> for [u8]` omitted to avoid widespread inference failures
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl AsRef<ByteStr> for str {
     #[inline]
@@ -286,7 +286,7 @@ const impl AsRef<ByteStr> for str {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl AsMut<[u8]> for ByteStr {
     #[inline]
@@ -301,7 +301,7 @@ const impl AsMut<[u8]> for ByteStr {
 
 // `impl Borrow<ByteStr> for str` omitted to avoid widespread inference failures
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl Borrow<[u8]> for ByteStr {
     #[inline]
@@ -312,7 +312,7 @@ const impl Borrow<[u8]> for ByteStr {
 
 // `impl BorrowMut<ByteStr> for [u8]` omitted to avoid widespread inference failures
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl BorrowMut<[u8]> for ByteStr {
     #[inline]
@@ -321,14 +321,14 @@ const impl BorrowMut<[u8]> for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> Default for &'a ByteStr {
     fn default() -> Self {
         ByteStr::from_bytes(b"")
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<'a> Default for &'a mut ByteStr {
     fn default() -> Self {
         ByteStr::from_bytes_mut(&mut [])
@@ -337,7 +337,7 @@ impl<'a> Default for &'a mut ByteStr {
 
 // Omitted due to inference failures
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a, const N: usize> From<&'a [u8; N]> for &'a ByteStr {
 //     #[inline]
 //     fn from(s: &'a [u8; N]) -> Self {
@@ -345,7 +345,7 @@ impl<'a> Default for &'a mut ByteStr {
 //     }
 // }
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a> From<&'a [u8]> for &'a ByteStr {
 //     #[inline]
 //     fn from(s: &'a [u8]) -> Self {
@@ -355,7 +355,7 @@ impl<'a> Default for &'a mut ByteStr {
 
 // Omitted due to slice-from-array-issue-113238:
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a> From<&'a ByteStr> for &'a [u8] {
 //     #[inline]
 //     fn from(s: &'a ByteStr) -> Self {
@@ -363,7 +363,7 @@ impl<'a> Default for &'a mut ByteStr {
 //     }
 // }
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a> From<&'a mut ByteStr> for &'a mut [u8] {
 //     #[inline]
 //     fn from(s: &'a mut ByteStr) -> Self {
@@ -373,7 +373,7 @@ impl<'a> Default for &'a mut ByteStr {
 
 // Omitted due to inference failures
 //
-// #[unstable(feature = "bstr", issue = "134915")]
+// #[unstable(feature = "byte_str", issue = "134915")]
 // impl<'a> From<&'a str> for &'a ByteStr {
 //     #[inline]
 //     fn from(s: &'a str) -> Self {
@@ -381,7 +381,7 @@ impl<'a> Default for &'a mut ByteStr {
 //     }
 // }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl<'a> TryFrom<&'a ByteStr> for &'a str {
     type Error = crate::str::Utf8Error;
@@ -392,7 +392,7 @@ const impl<'a> TryFrom<&'a ByteStr> for &'a str {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl<'a> TryFrom<&'a mut ByteStr> for &'a mut str {
     type Error = crate::str::Utf8Error;

--- a/library/core/src/byte_str/traits.rs
+++ b/library/core/src/byte_str/traits.rs
@@ -1,11 +1,11 @@
 //! Trait implementations for `ByteStr`.
 
-use crate::bstr::ByteStr;
+use crate::byte_str::ByteStr;
 use crate::cmp::Ordering;
 use crate::slice::SliceIndex;
 use crate::{hash, ops, range};
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Ord for ByteStr {
     #[inline]
     fn cmp(&self, other: &ByteStr) -> Ordering {
@@ -13,7 +13,7 @@ impl Ord for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl PartialOrd for ByteStr {
     #[inline]
     fn partial_cmp(&self, other: &ByteStr) -> Option<Ordering> {
@@ -21,7 +21,7 @@ impl PartialOrd for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl PartialEq<ByteStr> for ByteStr {
     #[inline]
     fn eq(&self, other: &ByteStr) -> bool {
@@ -29,10 +29,10 @@ impl PartialEq<ByteStr> for ByteStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl Eq for ByteStr {}
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl hash::Hash for ByteStr {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
@@ -42,7 +42,7 @@ impl hash::Hash for ByteStr {
 
 #[doc(hidden)]
 #[macro_export]
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 macro_rules! impl_partial_eq {
     ($lhs:ty, $rhs:ty) => {
         impl PartialEq<$rhs> for $lhs {
@@ -64,17 +64,17 @@ macro_rules! impl_partial_eq {
 }
 
 #[doc(hidden)]
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 pub use impl_partial_eq;
 
 #[doc(hidden)]
 #[macro_export]
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 macro_rules! impl_partial_eq_ord {
     ($lhs:ty, $rhs:ty) => {
-        $crate::bstr::impl_partial_eq!($lhs, $rhs);
+        $crate::byte_str::impl_partial_eq!($lhs, $rhs);
 
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl PartialOrd<$rhs> for $lhs {
             #[inline]
             fn partial_cmp(&self, other: &$rhs) -> Option<Ordering> {
@@ -83,7 +83,7 @@ macro_rules! impl_partial_eq_ord {
             }
         }
 
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl PartialOrd<$lhs> for $rhs {
             #[inline]
             fn partial_cmp(&self, other: &$lhs) -> Option<Ordering> {
@@ -95,15 +95,15 @@ macro_rules! impl_partial_eq_ord {
 }
 
 #[doc(hidden)]
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 pub use impl_partial_eq_ord;
 
 #[doc(hidden)]
 #[macro_export]
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 macro_rules! impl_partial_eq_n {
     ($lhs:ty, $rhs:ty) => {
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl<const N: usize> PartialEq<$rhs> for $lhs {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool {
@@ -112,7 +112,7 @@ macro_rules! impl_partial_eq_n {
             }
         }
 
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         impl<const N: usize> PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
@@ -124,7 +124,7 @@ macro_rules! impl_partial_eq_n {
 }
 
 #[doc(hidden)]
-#[unstable(feature = "bstr_internals", issue = "none")]
+#[unstable(feature = "byte_str_internals", issue = "none")]
 pub use impl_partial_eq_n;
 
 // PartialOrd with `[u8]` omitted to avoid inference failures
@@ -140,7 +140,7 @@ impl_partial_eq_n!(ByteStr, [u8; N]);
 // PartialOrd with `[u8; N]` omitted to avoid inference failures
 impl_partial_eq_n!(ByteStr, &[u8; N]);
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<I> ops::Index<I> for ByteStr
 where
     I: SliceIndex<ByteStr>,
@@ -153,7 +153,7 @@ where
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 impl<I> ops::IndexMut<I> for ByteStr
 where
     I: SliceIndex<ByteStr>,
@@ -164,7 +164,7 @@ where
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 unsafe impl SliceIndex<ByteStr> for ops::RangeFull {
     type Output = ByteStr;
     #[inline]
@@ -193,7 +193,7 @@ unsafe impl SliceIndex<ByteStr> for ops::RangeFull {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
+#[unstable(feature = "byte_str", issue = "134915")]
 unsafe impl SliceIndex<ByteStr> for usize {
     type Output = u8;
     #[inline]
@@ -226,7 +226,7 @@ unsafe impl SliceIndex<ByteStr> for usize {
 
 macro_rules! impl_slice_index {
     ($index:ty) => {
-        #[unstable(feature = "bstr", issue = "134915")]
+        #[unstable(feature = "byte_str", issue = "134915")]
         unsafe impl SliceIndex<ByteStr> for $index {
             type Output = ByteStr;
             #[inline]

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -686,8 +686,8 @@ unsafe impl CloneToUninit for crate::ffi::CStr {
     }
 }
 
-#[unstable(feature = "bstr", issue = "134915")]
-unsafe impl CloneToUninit for crate::bstr::ByteStr {
+#[unstable(feature = "byte_str", issue = "134915")]
+unsafe impl CloneToUninit for crate::byte_str::ByteStr {
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     unsafe fn clone_to_uninit(&self, dst: *mut u8) {

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -171,7 +171,7 @@ impl fmt::Display for FromBytesUntilNulError {
 #[stable(feature = "cstr_debug", since = "1.3.0")]
 impl fmt::Debug for CStr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(crate::bstr::ByteStr::from_bytes(self.to_bytes()), f)
+        fmt::Debug::fmt(crate::byte_str::ByteStr::from_bytes(self.to_bytes()), f)
     }
 }
 
@@ -652,7 +652,7 @@ impl CStr {
                   it returns an object that can be displayed"]
     #[inline]
     pub fn display(&self) -> impl fmt::Display {
-        crate::bstr::ByteStr::from_bytes(self.to_bytes())
+        crate::byte_str::ByteStr::from_bytes(self.to_bytes())
     }
 
     /// Returns the same string as a string slice `&CStr`.

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -86,7 +86,7 @@
 // Library features:
 // tidy-alphabetical-start
 #![feature(asm_experimental_arch)]
-#![feature(bstr_internals)]
+#![feature(byte_str_internals)]
 #![feature(cfg_target_has_reliable_f16_f128)]
 #![feature(const_carrying_mul_add)]
 #![feature(const_cmp)]
@@ -292,8 +292,8 @@ pub mod ascii;
 pub mod asserting;
 #[unstable(feature = "async_iterator", issue = "79024")]
 pub mod async_iter;
-#[unstable(feature = "bstr", issue = "134915")]
-pub mod bstr;
+#[unstable(feature = "byte_str", issue = "134915")]
+pub mod byte_str;
 pub mod cell;
 pub mod char;
 pub mod ffi;

--- a/library/coretests/tests/byte_str.rs
+++ b/library/coretests/tests/byte_str.rs
@@ -1,21 +1,17 @@
-use alloc::bstr::ByteString;
-use core::assert_matches;
+use core::byte_str::ByteStr;
 
 #[test]
 fn test_debug() {
-    let b1 = ByteString(
-        b"\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff".to_vec()
-    );
     assert_eq!(
         r#""\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff""#,
-        format!("{:?}", b1),
+        format!("{:?}", ByteStr::new(b"\0\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x11\x12\r\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f \x7f\x80\x81\xfe\xff")),
     );
 }
 
 #[test]
 fn test_display() {
-    let b1 = ByteString(b"abc".to_vec());
-    let b2 = ByteString(b"\xf0\x28\x8c\xbc".to_vec());
+    let b1 = ByteStr::new("abc");
+    let b2 = ByteStr::new(b"\xf0\x28\x8c\xbc");
 
     assert_eq!(&format!("{b1}"), "abc");
     assert_eq!(&format!("{b2}"), "�(��");
@@ -68,17 +64,4 @@ fn test_display() {
     assert_eq!(&format!("{b2:-<6.3}!"), "�(�---!");
     assert_eq!(&format!("{b2:-^6.3}!"), "-�(�--!");
     assert_eq!(&format!("{b2:->6.3}!"), "---�(�!");
-}
-
-#[test]
-fn test_to_string() {
-    let b1 = ByteString(b"abc".to_vec());
-    let b2 = ByteString(b"\xf0\x28\x8c\xbc".to_vec());
-
-    assert_eq!(Ok("abc".to_string()), b1.to_string());
-    assert_matches!(b2.to_string(), Err(core::str::Utf8Error { .. }));
-
-    // Can still directly use the trait
-    assert_eq!("abc".to_string(), ToString::to_string(&b1));
-    assert_eq!("�(��".to_string(), ToString::to_string(&b2));
 }

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -9,7 +9,7 @@
 #![feature(async_iter_from_iter)]
 #![feature(async_iterator)]
 #![feature(borrowed_buf_init)]
-#![feature(bstr)]
+#![feature(byte_str)]
 #![feature(casefold)]
 #![feature(cfg_overflow_checks)]
 #![feature(cfg_target_has_reliable_f16_f128)]
@@ -177,7 +177,7 @@ mod asserting;
 mod async_iter;
 mod atomic;
 mod bool;
-mod bstr;
+mod byte_str;
 mod cell;
 mod char;
 mod clone;

--- a/library/std/src/bstr.rs
+++ b/library/std/src/bstr.rs
@@ -1,4 +1,0 @@
-//! The `ByteStr` and `ByteString` types and trait implementations.
-
-#[unstable(feature = "bstr", issue = "134915")]
-pub use alloc::bstr::{ByteStr, ByteString};

--- a/library/std/src/byte_str.rs
+++ b/library/std/src/byte_str.rs
@@ -1,0 +1,4 @@
+//! The `ByteStr` and `ByteString` types and trait implementations.
+
+#[unstable(feature = "byte_str", issue = "134915")]
+pub use alloc::byte_str::{ByteStr, ByteString};

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -319,8 +319,8 @@
 // Library features (core):
 // tidy-alphabetical-start
 #![feature(borrowed_buf_init)]
-#![feature(bstr)]
-#![feature(bstr_internals)]
+#![feature(byte_str)]
+#![feature(byte_str_internals)]
 #![feature(c_size_t)]
 #![feature(can_vector)]
 #![feature(cast_maybe_uninit)]
@@ -628,8 +628,8 @@ pub mod f64;
 pub mod thread;
 pub mod ascii;
 pub mod backtrace;
-#[unstable(feature = "bstr", issue = "134915")]
-pub mod bstr;
+#[unstable(feature = "byte_str", issue = "134915")]
+pub mod byte_str;
 pub mod collections;
 pub mod env;
 pub mod error;

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -1,4 +1,4 @@
-use crate::bstr::ByteStr;
+use crate::byte_str::ByteStr;
 use crate::ffi::OsStr;
 #[cfg(any(doc, target_os = "android", target_os = "linux", target_os = "cygwin"))]
 use crate::os::net::linux_ext;

--- a/library/std/src/os/windows/net/addr.rs
+++ b/library/std/src/os/windows/net/addr.rs
@@ -1,5 +1,5 @@
 #![unstable(feature = "windows_unix_domain_sockets", issue = "150487")]
-use crate::bstr::ByteStr;
+use crate::byte_str::ByteStr;
 use crate::ffi::OsStr;
 use crate::path::Path;
 #[cfg(not(doc))]

--- a/library/std/src/sys/os_str/bytes.rs
+++ b/library/std/src/sys/os_str/bytes.rs
@@ -4,7 +4,7 @@
 use core::clone::CloneToUninit;
 
 use crate::borrow::Cow;
-use crate::bstr::ByteStr;
+use crate::byte_str::ByteStr;
 use crate::collections::TryReserveError;
 use crate::rc::Rc;
 use crate::sync::Arc;

--- a/library/std/src/sys/platform_version/darwin/mod.rs
+++ b/library/std/src/sys/platform_version/darwin/mod.rs
@@ -3,7 +3,7 @@ use self::core_foundation::{
     kCFPropertyListImmutable, kCFStringEncodingUTF8,
 };
 use crate::borrow::Cow;
-use crate::bstr::ByteStr;
+use crate::byte_str::ByteStr;
 use crate::ffi::{CStr, c_char};
 use crate::num::{NonZero, ParseIntError};
 use crate::path::{Path, PathBuf};

--- a/tests/ui/indexing/index-help.stderr
+++ b/tests/ui/indexing/index-help.stderr
@@ -9,7 +9,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<{integer}>` to implement `Index<i32>`

--- a/tests/ui/indexing/indexing-integral-types.stderr
+++ b/tests/ui/indexing/indexing-integral-types.stderr
@@ -9,7 +9,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<u8>`
@@ -25,7 +25,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<i8>`
@@ -41,7 +41,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<u32>`
@@ -57,7 +57,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `Vec<isize>` to implement `Index<i32>`
@@ -73,7 +73,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<u8>`
@@ -89,7 +89,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<i8>`
@@ -105,7 +105,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<u32>`
@@ -121,7 +121,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[u8]` to implement `Index<i32>`

--- a/tests/ui/indexing/indexing-requires-a-uint.stderr
+++ b/tests/ui/indexing/indexing-requires-a-uint.stderr
@@ -9,7 +9,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[{integer}]` to implement `Index<u8>`

--- a/tests/ui/on-unimplemented/slice-index.stderr
+++ b/tests/ui/on-unimplemented/slice-index.stderr
@@ -9,7 +9,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[i32]` to implement `Index<i32>`
@@ -25,10 +25,10 @@ help: `RangeTo<usize>` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
-  ::: $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  ::: $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: in this macro invocation
   --> $SRC_DIR/core/src/str/traits.rs:LL:COL

--- a/tests/ui/str/str-idx.stderr
+++ b/tests/ui/str/str-idx.stderr
@@ -11,7 +11,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `str` to implement `Index<{integer}>`
@@ -31,7 +31,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get`
@@ -52,7 +52,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_unchecked`

--- a/tests/ui/str/str-mut-idx.stderr
+++ b/tests/ui/str/str-mut-idx.stderr
@@ -35,7 +35,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `str` to implement `Index<usize>`
@@ -55,7 +55,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_mut`
@@ -76,7 +76,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
 note: required by a bound in `core::str::<impl str>::get_unchecked_mut`

--- a/tests/ui/suggestions/suggest-dereferencing-index.stderr
+++ b/tests/ui/suggestions/suggest-dereferencing-index.stderr
@@ -9,7 +9,7 @@ help: `usize` implements trait `SliceIndex<T>`
   --> $SRC_DIR/core/src/slice/index.rs:LL:COL
    |
    = note: `SliceIndex<[T]>`
-  --> $SRC_DIR/core/src/bstr/traits.rs:LL:COL
+  --> $SRC_DIR/core/src/byte_str/traits.rs:LL:COL
    |
    = note: `SliceIndex<ByteStr>`
    = note: required for `[{integer}]` to implement `Index<&usize>`


### PR DESCRIPTION
This also renames the various features to use `byte_str` instead of `bstr`.