### PR TITLE
Derive `GenericTypeVisitable` for `RegionConstraint` _correctly_

### DIFF
--- a/compiler/rustc_type_ir/src/generic_visit.rs
+++ b/compiler/rustc_type_ir/src/generic_visit.rs
@@ -20,29 +20,35 @@ use crate::Interner;
 /// This trait is implemented for every type that can be visited,
 /// providing the skeleton of the traversal.
 ///
-/// To implement this conveniently, use the derive macro located in
-/// `rustc_macros`.
-pub trait GenericTypeVisitable<V> {
+/// ## Safety
+///
+/// A manual implementation **must visit** every field.
+///
+/// Therefore, it is advised to instead derive this using the derive
+/// macro located in `rustc_macros`.
+pub unsafe trait GenericTypeVisitable<V> {
     fn generic_visit_with(&self, visitor: &mut V);
 }
 
 ///////////////////////////////////////////////////////////////////////////
 // Traversal implementations.
 
-impl<V, T: ?Sized + GenericTypeVisitable<V>> GenericTypeVisitable<V> for &T {
+unsafe impl<V, T: ?Sized + GenericTypeVisitable<V>> GenericTypeVisitable<V> for &T {
     fn generic_visit_with(&self, visitor: &mut V) {
         T::generic_visit_with(*self, visitor)
     }
 }
 
-impl<V, T: GenericTypeVisitable<V>, U: GenericTypeVisitable<V>> GenericTypeVisitable<V> for (T, U) {
+unsafe impl<V, T: GenericTypeVisitable<V>, U: GenericTypeVisitable<V>> GenericTypeVisitable<V>
+    for (T, U)
+{
     fn generic_visit_with(&self, visitor: &mut V) {
         self.0.generic_visit_with(visitor);
         self.1.generic_visit_with(visitor);
     }
 }
 
-impl<V, A: GenericTypeVisitable<V>, B: GenericTypeVisitable<V>, C: GenericTypeVisitable<V>>
+unsafe impl<V, A: GenericTypeVisitable<V>, B: GenericTypeVisitable<V>, C: GenericTypeVisitable<V>>
     GenericTypeVisitable<V> for (A, B, C)
 {
     fn generic_visit_with(&self, visitor: &mut V) {
@@ -52,7 +58,7 @@ impl<V, A: GenericTypeVisitable<V>, B: GenericTypeVisitable<V>, C: GenericTypeVi
     }
 }
 
-impl<V, T: GenericTypeVisitable<V>> GenericTypeVisitable<V> for Option<T> {
+unsafe impl<V, T: GenericTypeVisitable<V>> GenericTypeVisitable<V> for Option<T> {
     fn generic_visit_with(&self, visitor: &mut V) {
         match self {
             Some(v) => v.generic_visit_with(visitor),
@@ -61,7 +67,7 @@ impl<V, T: GenericTypeVisitable<V>> GenericTypeVisitable<V> for Option<T> {
     }
 }
 
-impl<V, T: GenericTypeVisitable<V>, E: GenericTypeVisitable<V>> GenericTypeVisitable<V>
+unsafe impl<V, T: GenericTypeVisitable<V>, E: GenericTypeVisitable<V>> GenericTypeVisitable<V>
     for Result<T, E>
 {
     fn generic_visit_with(&self, visitor: &mut V) {
@@ -72,54 +78,56 @@ impl<V, T: GenericTypeVisitable<V>, E: GenericTypeVisitable<V>> GenericTypeVisit
     }
 }
 
-impl<V, T: ?Sized + GenericTypeVisitable<V>> GenericTypeVisitable<V> for Arc<T> {
+unsafe impl<V, T: ?Sized + GenericTypeVisitable<V>> GenericTypeVisitable<V> for Arc<T> {
     fn generic_visit_with(&self, visitor: &mut V) {
         (**self).generic_visit_with(visitor)
     }
 }
 
-impl<V, T: ?Sized + GenericTypeVisitable<V>> GenericTypeVisitable<V> for Box<T> {
+unsafe impl<V, T: ?Sized + GenericTypeVisitable<V>> GenericTypeVisitable<V> for Box<T> {
     fn generic_visit_with(&self, visitor: &mut V) {
         (**self).generic_visit_with(visitor)
     }
 }
 
-impl<V, T: GenericTypeVisitable<V>> GenericTypeVisitable<V> for Vec<T> {
+unsafe impl<V, T: GenericTypeVisitable<V>> GenericTypeVisitable<V> for Vec<T> {
     fn generic_visit_with(&self, visitor: &mut V) {
         self.iter().for_each(|it| it.generic_visit_with(visitor));
     }
 }
 
-impl<V, T: GenericTypeVisitable<V>> GenericTypeVisitable<V> for ThinVec<T> {
+unsafe impl<V, T: GenericTypeVisitable<V>> GenericTypeVisitable<V> for ThinVec<T> {
     fn generic_visit_with(&self, visitor: &mut V) {
         self.iter().for_each(|it| it.generic_visit_with(visitor));
     }
 }
 
-impl<V, T: GenericTypeVisitable<V>, const N: usize> GenericTypeVisitable<V> for SmallVec<[T; N]> {
+unsafe impl<V, T: GenericTypeVisitable<V>, const N: usize> GenericTypeVisitable<V>
+    for SmallVec<[T; N]>
+{
     fn generic_visit_with(&self, visitor: &mut V) {
         self.iter().for_each(|it| it.generic_visit_with(visitor));
     }
 }
 
-impl<V, T: GenericTypeVisitable<V>> GenericTypeVisitable<V> for [T] {
+unsafe impl<V, T: GenericTypeVisitable<V>> GenericTypeVisitable<V> for [T] {
     fn generic_visit_with(&self, visitor: &mut V) {
         self.iter().for_each(|it| it.generic_visit_with(visitor));
     }
 }
 
-impl<V, T: GenericTypeVisitable<V>, Ix: Idx> GenericTypeVisitable<V> for IndexVec<Ix, T> {
+unsafe impl<V, T: GenericTypeVisitable<V>, Ix: Idx> GenericTypeVisitable<V> for IndexVec<Ix, T> {
     fn generic_visit_with(&self, visitor: &mut V) {
         self.iter().for_each(|it| it.generic_visit_with(visitor));
     }
 }
 
-impl<S, V> GenericTypeVisitable<V> for std::hash::BuildHasherDefault<S> {
+unsafe impl<S, V> GenericTypeVisitable<V> for std::hash::BuildHasherDefault<S> {
     fn generic_visit_with(&self, _visitor: &mut V) {}
 }
 
 #[expect(rustc::default_hash_types, rustc::potential_query_instability)]
-impl<
+unsafe impl<
     Visitor,
     Key: GenericTypeVisitable<Visitor>,
     Value: GenericTypeVisitable<Visitor>,
@@ -133,7 +141,7 @@ impl<
 }
 
 #[expect(rustc::default_hash_types, rustc::potential_query_instability)]
-impl<V, T: GenericTypeVisitable<V>, S: GenericTypeVisitable<V>> GenericTypeVisitable<V>
+unsafe impl<V, T: GenericTypeVisitable<V>, S: GenericTypeVisitable<V>> GenericTypeVisitable<V>
     for std::collections::HashSet<T, S>
 {
     fn generic_visit_with(&self, visitor: &mut V) {
@@ -142,7 +150,7 @@ impl<V, T: GenericTypeVisitable<V>, S: GenericTypeVisitable<V>> GenericTypeVisit
     }
 }
 
-impl<
+unsafe impl<
     Visitor,
     Key: GenericTypeVisitable<Visitor>,
     Value: GenericTypeVisitable<Visitor>,
@@ -155,7 +163,7 @@ impl<
     }
 }
 
-impl<V, T: GenericTypeVisitable<V>, S: GenericTypeVisitable<V>> GenericTypeVisitable<V>
+unsafe impl<V, T: GenericTypeVisitable<V>, S: GenericTypeVisitable<V>> GenericTypeVisitable<V>
     for indexmap::IndexSet<T, S>
 {
     fn generic_visit_with(&self, visitor: &mut V) {
@@ -167,7 +175,7 @@ impl<V, T: GenericTypeVisitable<V>, S: GenericTypeVisitable<V>> GenericTypeVisit
 macro_rules! trivial_impls {
     ( $($ty:ty),* $(,)? ) => {
         $(
-            impl<V>
+            unsafe impl<V>
                 GenericTypeVisitable<V> for $ty
             {
                 fn generic_visit_with(&self, _visitor: &mut V) {}
@@ -176,7 +184,7 @@ macro_rules! trivial_impls {
     };
 }
 
-impl<T: ?Sized, V> GenericTypeVisitable<V> for std::marker::PhantomData<T> {
+unsafe impl<T: ?Sized, V> GenericTypeVisitable<V> for std::marker::PhantomData<T> {
     fn generic_visit_with(&self, _visitor: &mut V) {}
 }
 
@@ -215,6 +223,7 @@ trivial_impls!(
     rustc_abi::ExternAbi,
 );
 
-impl<I: Interner, V> GenericTypeVisitable<V> for crate::FnSigKind<I> {
+// SAFETY: `FnSigKind` is a packed representation, therefore visiting its fields doesn't make sense
+unsafe impl<I: Interner, V> GenericTypeVisitable<V> for crate::FnSigKind<I> {
     fn generic_visit_with(&self, _visitor: &mut V) {}
 }

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -66,7 +66,6 @@ mod const_kind;
 mod flags;
 mod fold;
 mod generic_arg;
-#[cfg(not(feature = "nightly"))]
 mod generic_visit;
 mod infer_ctxt;
 mod interner;
@@ -97,7 +96,6 @@ pub use const_kind::*;
 pub use flags::*;
 pub use fold::*;
 pub use generic_arg::*;
-#[cfg(not(feature = "nightly"))]
 pub use generic_visit::*;
 pub use infer_ctxt::*;
 pub use interner::*;

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -117,8 +117,8 @@ pub enum RegionConstraint<I: Interner, S = ()> {
     /// and there may wind up being assumptions we can use to prove this when we're in a smaller universe.
     PlaceholderTyOutlives(I::Ty, Region<I>, S),
 
-    And(Box<[RegionConstraint<I, S>]>),
-    Or(Box<[RegionConstraint<I, S>]>),
+    And(#[generic_type_visitable(bounds())] Box<[RegionConstraint<I, S>]>),
+    Or(#[generic_type_visitable(bounds())] Box<[RegionConstraint<I, S>]>),
 }
 
 /// A solver region constraint together with the span that caused each leaf constraint.

--- a/compiler/rustc_type_ir_macros/src/lib.rs
+++ b/compiler/rustc_type_ir_macros/src/lib.rs
@@ -1,3 +1,5 @@
+use std::ops::ControlFlow;
+
 use indexmap::IndexSet;
 use quote::{ToTokens, quote};
 use syn::visit_mut::VisitMut;
@@ -28,13 +30,8 @@ enum TypeParameterPath {
     GenericParameter(syn::Ident),
 }
 
-enum TypeParameterTransform {
-    Continue,
-    Stop,
-}
-
 type TypeParameterVisitor =
-    fn(TypeParameterPath, &mut syn::TypePath, &mut IndexSet<syn::Ident>) -> TypeParameterTransform;
+    fn(TypeParameterPath, &mut syn::TypePath, &mut IndexSet<syn::Ident>) -> ControlFlow<()>;
 
 fn has_ignore_attr(attrs: &[Attribute], name: &'static str, meta: &'static str) -> bool {
     let mut ignored = false;
@@ -183,7 +180,7 @@ fn type_foldable_generic_parameters(
         if let TypeParameterPath::GenericParameter(param) = path {
             generic_parameter_bounds.insert(param);
         }
-        TypeParameterTransform::Continue
+        ControlFlow::Continue(())
     })
     .generic_parameter_bounds
 }
@@ -295,12 +292,12 @@ fn lift(ty: syn::Type, generic_parameters: &[syn::Ident]) -> TransformedTy {
         match path {
             TypeParameterPath::Interner => {
                 *ty.path.segments.first_mut().unwrap() = parse_quote! { J };
-                TypeParameterTransform::Continue
+                ControlFlow::Continue(())
             }
             TypeParameterPath::GenericParameter(param) => {
                 generic_parameter_bounds.insert(param.clone());
                 *ty = parse_quote! { <#param as ::rustc_type_ir::lift::Lift<J>>::Lifted };
-                TypeParameterTransform::Stop
+                ControlFlow::Break(())
             }
         }
     })
@@ -338,9 +335,7 @@ fn transform_type_parameters(
             };
 
             if let Some(path) = path {
-                if let TypeParameterTransform::Stop =
-                    (self.visit)(path, i, &mut self.generic_parameter_bounds)
-                {
+                if (self.visit)(path, i, &mut self.generic_parameter_bounds).is_break() {
                     return;
                 }
             }

--- a/compiler/rustc_type_ir_macros/src/lib.rs
+++ b/compiler/rustc_type_ir_macros/src/lib.rs
@@ -15,7 +15,6 @@ decl_derive!(
 decl_derive!(
     [Lift_Generic, attributes(lift)] => lift_derive
 );
-#[cfg(not(feature = "nightly"))]
 decl_derive!(
     [GenericTypeVisitable] => customizable_type_visitable_derive
 );
@@ -353,7 +352,6 @@ fn transform_type_parameters(
     TransformedTy { ty, generic_parameter_bounds: visitor.generic_parameter_bounds }
 }
 
-#[cfg(not(feature = "nightly"))]
 fn customizable_type_visitable_derive(
     mut s: synstructure::Structure<'_>,
 ) -> proc_macro2::TokenStream {
@@ -381,10 +379,4 @@ fn customizable_type_visitable_derive(
             }
         },
     )
-}
-
-#[cfg(feature = "nightly")]
-#[proc_macro_derive(GenericTypeVisitable)]
-pub fn customizable_type_visitable_derive(_: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    proc_macro::TokenStream::new()
 }

--- a/compiler/rustc_type_ir_macros/src/lib.rs
+++ b/compiler/rustc_type_ir_macros/src/lib.rs
@@ -368,7 +368,7 @@ fn customizable_type_visitable_derive(
     });
     s.bind_with(|_| synstructure::BindStyle::Move);
 
-    s.bound_impl(
+    s.unsafe_bound_impl(
         quote!(::rustc_type_ir::GenericTypeVisitable<__V>),
         quote! {
             fn generic_visit_with(

--- a/compiler/rustc_type_ir_macros/src/lib.rs
+++ b/compiler/rustc_type_ir_macros/src/lib.rs
@@ -2,6 +2,7 @@ use std::ops::ControlFlow;
 
 use indexmap::IndexSet;
 use quote::{ToTokens, quote};
+use syn::parse::Parse;
 use syn::visit_mut::VisitMut;
 use syn::{Attribute, parse_quote};
 use synstructure::decl_derive;
@@ -16,7 +17,43 @@ decl_derive!(
     [Lift_Generic, attributes(lift)] => lift_derive
 );
 decl_derive!(
-    [GenericTypeVisitable] => customizable_type_visitable_derive
+    [ GenericTypeVisitable, attributes(generic_type_visitable)] =>
+        /// By default, `#[derive(GenericTypeVisitable)]` will add `GenericTypeVisitable`
+        /// bounds to every field of the item. However, this results in infinite recursion
+        /// for types whose fields mention `Self`, such as:
+        ///
+        /// ```
+        /// struct List {
+        ///     next: Option<Box<Self>>
+        /// }
+        /// ```
+        ///
+        /// The `#[generic_type_visitable(bounds(...))]` attribute provides an escape
+        /// hatch: it allows you to override the list of trait bounds added to the field's type.
+        /// Namely, it should contain `GenericTypeVisitable` bounds for all the non-`Self`
+        /// types present in the field.
+        ///
+        /// For the example above, that list will be empty:
+        /// ```ignore (would need to import GenericTypeVisitable to get this to compile)
+        /// #[derive(GenericTypeVisitable)]
+        /// struct List {
+        ///     #[generic_type_visitable(bounds())]
+        ///     next: Option<Box<Self>>
+        /// }
+        /// ```
+        ///
+        /// For a more complicated type:
+        /// ```ignore (would need to import GenericTypeVisitable to get this to compile)
+        /// #[derive(GenericTypeVisitable)]
+        /// struct Foo {
+        ///     #[generic_type_visitable(bounds())]
+        ///     just_self: Box<Self>,
+        ///     #[generic_type_visitable(bounds(Bar: GenericTypeVisitable))]
+        ///     contains_self: (Box<Self>, Bar),
+        /// }
+        /// struct Bar;
+        /// ```
+        customizable_type_visitable_derive
 );
 
 struct TransformedTy {
@@ -360,13 +397,30 @@ fn customizable_type_visitable_derive(
     }
 
     s.add_impl_generic(parse_quote!(__V));
-    s.add_bounds(synstructure::AddBounds::Fields);
+    s.add_bounds(synstructure::AddBounds::None);
+
+    let mut wc = vec![];
     let body_visit = s.each(|bind| {
+        let field = bind.ast();
+        let ty = field.ty.clone();
+
+        match field_generic_type_visitable_bound(field) {
+            Ok(Some(bounds)) => wc.extend(bounds),
+            Ok(None) => {
+                // no overridden bounds, add the default one
+                wc.push(parse_quote! { #ty: ::rustc_type_ir::GenericTypeVisitable::<__V> });
+            }
+            Err(err) => return err.into_compile_error(),
+        }
+
         quote! {
             ::rustc_type_ir::GenericTypeVisitable::<__V>::generic_visit_with(#bind, __visitor);
         }
     });
     s.bind_with(|_| synstructure::BindStyle::Move);
+    for wc in wc {
+        s.add_where_predicate(wc);
+    }
 
     s.unsafe_bound_impl(
         quote!(::rustc_type_ir::GenericTypeVisitable<__V>),
@@ -379,4 +433,47 @@ fn customizable_type_visitable_derive(
             }
         },
     )
+}
+
+fn field_generic_type_visitable_bound(
+    field: &syn::Field,
+) -> syn::Result<Option<impl Iterator<Item = syn::WherePredicate>>> {
+    let mut attrs =
+        field.attrs.iter().filter(|attr| attr.path().is_ident("generic_type_visitable"));
+    let Some(attr) = attrs.next() else {
+        return Ok(None);
+    };
+
+    if attrs.next().is_some() {
+        return Err(syn::Error::new_spanned(
+            field,
+            "multiple `generic_type_visitable` attributes on field",
+        ));
+    }
+
+    parse_generic_type_visitable_bound(attr).map(Some)
+}
+
+mod kw {
+    syn::custom_keyword!(bounds);
+}
+
+/// Parses a bound like:
+///
+/// ```ignore (would need to import GenericTypeVisitable to get this to compile)
+/// #[generic_type_visitable(bounds(Foo: GenericTypeVisitable, Bar: GenericTypeVisitable))]
+/// ```
+fn parse_generic_type_visitable_bound(
+    attr: &Attribute,
+) -> syn::Result<impl Iterator<Item = syn::WherePredicate>> {
+    attr.parse_args_with(|input: syn::parse::ParseStream<'_>| {
+        input.parse::<kw::bounds>()?;
+        let predicates;
+        syn::parenthesized!(predicates in input);
+
+        let proof =
+            predicates.parse_terminated(syn::WherePredicate::parse, syn::Token![,])?.into_iter();
+
+        if input.is_empty() { Ok(proof) } else { Err(input.error("unexpected token")) }
+    })
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160914)*
<!-- homu-ignore:end -->

The derive added in https://github.com/rust-lang/rust/pull/160164 was incorrect -- it resulted in an overflow during trait solving. This is because `#[derive(GenericTypeVisitable)]` automatically adds a `: GenericTypeVisitable` bound to every field of a type -- in this case, `Box<[RegionConstraint<I>]>: GenericTypeVisitable<V>`.

To fix this, I added a `#[generic_type_visitable(bounds(..))]` attribute to the derive macro, which allows overriding the added bounds.

I also made the derive macro no longer a no-op in rustc, so that errors like this can be caught on r-l/r CI in the future.

Best reviewed commit-by-commit.

cc @ChayimFriedman2