### PR TITLE
No longer mention the removed generic

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -2383,7 +2383,7 @@ pub enum AbiFromStrErr {
     NoExplicitUnwind,
 }
 
-// NOTE: This struct is generic over the FieldIdx and VariantIdx for rust-analyzer usage.
+// NOTE: This struct is generic over the FieldIdx for rust-analyzer usage.
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 #[cfg_attr(feature = "nightly", derive(StableHash))]
 pub struct VariantLayout<FieldIdx: Idx> {


### PR DESCRIPTION
This was added in https://github.com/rust-lang/rust/pull/151742/commits/464dc07de29d58e60ec3a0a9502fa365ab3123bd, and should've been deleted in https://github.com/rust-lang/rust/pull/151742/commits/1162bdc1f3fe4a85f6b1d217578f40669c43aeb5, but wasn't.

cc @moulins