### PR TITLE
rustdoc: Fix invalid CSS classes generated for notable items

### DIFF
--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -23,7 +23,7 @@
         {% if !notable_trait_badges.is_empty() %}
         <div class="notable-trait-badge-container">
             {% for badge in notable_trait_badges.iter() %}
-            <a class="notable-trait-badge notable-trait-badge-{{badge.color_index}}"
+            <a class="badge-{{badge.color_index}}"
                 {% if let Some(href) = badge.href %}href="{{href|safe}}" {%+ endif %}
                 title="{{badge.full_path}}">{{badge.name}}</a>
             {% endfor %}

--- a/tests/rustdoc-gui/notable-traits.goml
+++ b/tests/rustdoc-gui/notable-traits.goml
@@ -1,0 +1,14 @@
+// This test ensures that the notable trait badges are correctly rendered.
+go-to: "file://" + |DOC_PATH| + "/test_docs/notable/struct.Wrapper.html"
+show-text: true
+store-css: (".notable-trait-badge-container", {"background-color": background_color})
+// The background color should be different.
+assert-css-false: (".notable-trait-badge-container > a", {"background-color": |background_color|})
+
+store-css: ("#trait-implementations", {"color": text_color})
+assert-css: (".notable-trait-badge-container > a", {
+    // The color should be the same as the "main color".
+    "color": |text_color|,
+    // Checking some additional CSS values.
+    "border-radius": "12px",
+})

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -13,6 +13,7 @@
 #![feature(macro_attr)]
 #![feature(macro_derive)]
 #![feature(negative_impls)]
+#![feature(doc_notable_trait)]
 
 /*!
 Enable the feature <span class="stab portability"><code>some-feature</code></span> to enjoy
@@ -812,4 +813,12 @@ pub mod tyalias {
     }
 
     pub type Y = X<u8>;
+}
+
+pub mod notable {
+    #[doc(notable_trait)]
+    pub trait Labeled {}
+
+    pub struct Wrapper;
+    impl Labeled for Wrapper {}
 }


### PR DESCRIPTION
Just realized that the background for the notable traits was not set because the jinja template was not wrong:

<img width="306" height="122" alt="Screenshot From 2026-08-11 17-15-34" src="https://github.com/user-attachments/assets/57d6b20d-25bd-4142-9ea7-8c56d7442723" />

With this fix it looks as expected:

<img width="306" height="122" alt="Screenshot From 2026-08-11 17-16-21" src="https://github.com/user-attachments/assets/d3d7ea6f-c562-447f-94bb-91c80b299d90" />

Follow-up of https://github.com/rust-lang/rust/pull/157058.

r? @Urgau 