### PR TITLE
Handle multiple action records in EH personality function

### DIFF
--- a/library/std/src/sys/personality/dwarf/eh.rs
+++ b/library/std/src/sys/personality/dwarf/eh.rs
@@ -48,9 +48,20 @@ pub struct EHContext<'a> {
 type LPad = *const u8;
 pub enum EHAction {
     None,
+    /// Destructors should be executed when stack unwinds.
     Cleanup(LPad),
+    /// Stack unwind should be stopped as the exception is going to be caught by `catch_unwind`.
     Catch(LPad),
+    /// Stack unwind should be stopped for termination (`UnwindAction::Terminate`).
+    ///
+    /// Note that due to inlining the landing pad can execute destructors before terminating. So
+    /// this is different from `Terminate`.
+    ///
+    /// Handling of this is mostly identical to `Catch`; except that Rust frames that have no
+    /// destructors but only `UnwindAction::Terminate` is considered as plain-old-frame (POF) and
+    /// forced unwind is allowed to unwind past it; so this is treated as `None` during forced unwind.
     Filter(LPad),
+    /// Process should be terminated as the call site does not permit unwinding.
     Terminate,
 }
 
@@ -160,7 +171,19 @@ unsafe fn interpret_cs_action(
         let action_record = unsafe { action_table.offset(cs_action_entry as isize - 1) };
         let mut action_reader = DwarfReader::new(action_record);
         let ttype_index = unsafe { action_reader.read_sleb128() };
-        if ttype_index == 0 {
+        let next_action = unsafe { action_reader.read_sleb128() };
+        if next_action != 0 {
+            // We observed multiple actions. Action records contain no duplicates (at least that is
+            // true for both LLVM/GCC), and as Rust does not have exception specification, this
+            // indicates that we have at least 2 of "cleanup", "catch" and "filter", so we should
+            // catch all exceptions.
+            //
+            // Note that even for the case of "cleanup" + "filter", decoding them as "catch" is
+            // fine: "filter" behaves identically to "catch" except for forced unwind; in case of
+            // forced unwind, hitting a "cleanup" landing pad is UB as it indicates that we're
+            // unwinding past a non-POF Rust frame.
+            EHAction::Catch(lpad)
+        } else if ttype_index == 0 {
             EHAction::Cleanup(lpad)
         } else if ttype_index > 0 {
             // Stop unwinding Rust panics at catch_unwind.

--- a/tests/ui/panics/lsda-multiple-action.rs
+++ b/tests/ui/panics/lsda-multiple-action.rs
@@ -1,0 +1,29 @@
+//@ run-pass
+//@ needs-unwind
+//@ ignore-backends: gcc
+//@ compile-flags: -Copt-level=3
+
+struct Guard;
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        core::hint::black_box(());
+    }
+}
+
+#[inline(never)]
+fn unwind() {
+    if core::hint::black_box(true) {
+        std::panic::resume_unwind(Box::new(()));
+    }
+}
+
+fn main() {
+    // The `catch_unwind` will generate `landingpad catch` and the destructor will generate
+    // `landingpad cleanup`; after LLVM inlining it will become `landingpad cleanup catch`, and this
+    // is translated to action record chains in LSDA.
+    let _ = std::panic::catch_unwind(|| {
+        let _guard = Guard;
+        unwind();
+    });
+}


### PR DESCRIPTION
LSDA encodes actions are a linked list, we currently only decode the first one. Action records are used for catching specific exception types and for exception specifications, and none of these are present in Rust. However we can still have of multiple of them being present due to LLVM inlining. When this happens, "Catch" is the correct action to execute.

We haven't had issues with this because LLVM orders cleanup record last; however GCC doesn't use the same order, so we do need to explicitly handle this case to support both LLVM and GCC codegen.

See https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/Possible.20bug.20in.20unwind.20function.20in.20std/with/615883393