### PR TITLE
Make tidy::Version public

### DIFF
--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -16,6 +16,8 @@ use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 use std::{fmt, fs};
 
+use regex::Regex;
+
 use crate::diagnostics::{RunningCheck, TidyCtx};
 use crate::walk::{filter_dirs, filter_not_rust, walk, walk_many};
 
@@ -23,7 +25,8 @@ use crate::walk::{filter_dirs, filter_not_rust, walk, walk_many};
 mod tests;
 
 mod version;
-use regex::Regex;
+// Re-export Version. This means other crates can construct Versions from [u32;3] and from &str.
+// This is useful for filtering for features older/newer than a user-provided value.
 pub use version::Version;
 
 const FEATURE_GROUP_START_PREFIX: &str = "// feature-group-start";

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -24,7 +24,7 @@ mod tests;
 
 mod version;
 use regex::Regex;
-use version::Version;
+pub use version::Version;
 
 const FEATURE_GROUP_START_PREFIX: &str = "// feature-group-start";
 const FEATURE_GROUP_END_PREFIX: &str = "// feature-group-end";


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
The tidy library in `src/tools/tidy` is used to implement the `tidy` tool, but is also used by other in-tree crates like `feature-status-dump` to analyze which features are defined in the project. This PR makes the `Version` struct public. This has the effect of being able to construct a version using `Version::from_str("1.80.0").unwrap()`. This can then be used to compare (via the already implemented PartialEq trait) the version where a feature was introduced against a user-provided value, rather than only against other features' versions.

I would like this change because I am working on a tool to filter features for several metrics (stability, first version, activity of tracking issue, etc) to help find abandoned features that need someone to push to stabilize them.

This is my first PR here. I hope it is welcome.