### PR TITLE
Ensure TLS accesses don't call the global allocator through panic

### DIFF
--- a/library/std/src/sys/thread_local/key/unix.rs
+++ b/library/std/src/sys/thread_local/key/unix.rs
@@ -33,8 +33,16 @@ pub fn create(dtor: Option<unsafe extern "C" fn(*mut u8)>) -> Key {
 
 #[inline]
 pub unsafe fn set(key: Key, value: *mut u8) {
+    #[cold]
+    fn fail() -> ! {
+        rtabort!("Failed to set value of thread local")
+    }
+
     let r = unsafe { libc::pthread_setspecific(key, value as *mut _) };
-    debug_assert_eq!(r, 0);
+    // May happen on memory exhaustion
+    if r != 0 {
+        fail()
+    }
 }
 
 #[inline]

--- a/library/std/src/sys/thread_local/key/windows.rs
+++ b/library/std/src/sys/thread_local/key/windows.rs
@@ -138,8 +138,15 @@ unsafe impl Sync for LazyKey {}
 
 #[inline]
 pub unsafe fn set(key: Key, val: *mut u8) {
+    #[cold]
+    fn fail() -> ! {
+        rtabort!("Failed to set value of thread local")
+    }
     let r = unsafe { c::TlsSetValue(key, val.cast()) };
-    debug_assert_eq!(r, c::TRUE);
+    // According to MS documentation, `TlsSetValue` returns zero "if it fails"
+    if r != c::TRUE {
+        fail()
+    }
 }
 
 #[inline]

--- a/library/std/src/sys/thread_local/key/xous.rs
+++ b/library/std/src/sys/thread_local/key/xous.rs
@@ -134,14 +134,14 @@ pub fn create(dtor: Option<Dtor>) -> Key {
 
 #[inline]
 pub unsafe fn set(key: Key, value: *mut u8) {
-    assert!((key < 1022) && (key >= 1));
+    rtassert!((key < 1022) && (key >= 1));
     let table = tls_table();
     table[key] = value;
 }
 
 #[inline]
 pub unsafe fn get(key: Key) -> *mut u8 {
-    assert!((key < 1022) && (key >= 1));
+    rtassert!((key < 1022) && (key >= 1));
     tls_table()[key]
 }
 


### PR DESCRIPTION
cc rust-lang/rust#160930

That issue is much more simple to fix than the other reentrancy issues, since only thread locals
use the TLS code. We can just replace all the assertions with their `rt` versions that do not 
call the global allocator.

r? libs