### PR TITLE
dogfood `#[diagnostic::unknown]` in the compiler

### DIFF
--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -19,6 +19,7 @@
 #![allow(internal_features)]
 #![cfg_attr(target_arch = "loongarch64", feature(stdarch_loongarch))]
 #![feature(core_io_borrowed_buf)]
+#![feature(diagnostic_on_unknown)]
 #![feature(map_try_insert)]
 #![feature(negative_impls)]
 #![feature(read_buf)]

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2932,8 +2932,8 @@ pub mod kw {
     note = "consider adding `{Unresolved}` to the `symbols!` invocation in compiler/rustc_span/src/symbol.rs"
 )]
 pub mod sym {
-    // Used from a macro in `librustc_feature/accepted.rs`
     use super::Symbol;
+    // Used from a macro in `librustc_feature/accepted.rs`
     pub use super::kw::MacroRules as macro_rules;
     #[doc(inline)]
     pub use super::sym_generated::*;

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2927,6 +2927,10 @@ pub mod kw {
 ///
 /// Given that `sym` is imported, use them like `sym::symbol_name`.
 /// For example `sym::rustfmt` or `sym::u8`.
+#[diagnostic::on_unknown(
+    label = "`{Unresolved}` is not a pre-interned symbol",
+    note = "consider adding `{Unresolved}` to the `symbols!` invocation in compiler/rustc_span/src/symbol.rs"
+)]
 pub mod sym {
     // Used from a macro in `librustc_feature/accepted.rs`
     use super::Symbol;


### PR DESCRIPTION
This makes the error for not-found symbols a lot nicer :)

```
error[E0425]: cannot find value `better_rust` in module `sym`                                                                                                                                                                          
   --> compiler\rustc_feature\src\unstable.rs:799:16
    |
157 |                 name: sym::$feature,
    |                            -------- due to this macro variable
...
799 |     (unstable, better_rust, "2.0.0", Some(42)),
    |                ^^^^^^^^^^^ `better_rust` is not a pre-interned symbol
    |
    = note: consider adding `better_rust` to the `symbols!` invocation in compiler/rustc_span/src/symbol.rs
```

(only works when building stage 2 for now, the necessary changes haven't landed in beta yet)