### PR TITLE
Fix improper stability of `Write for Cursor<W: WriteThroughCursor>`

### DIFF
--- a/library/core/src/io/cursor.rs
+++ b/library/core/src/io/cursor.rs
@@ -486,6 +486,7 @@ pub trait WriteThroughCursor: Sized {
 }
 
 #[doc(hidden)]
+#[stable(feature = "rust1", since = "1.0.0")]
 impl<W: WriteThroughCursor> Write for Cursor<W> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {


### PR DESCRIPTION
Was already stable when using explicit types (e.g. `Vec<u8>`). `WriteThroughCursor` is still unstable/hidden.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Tracking Issue: rust-lang/rust#154046
Zulip Discussion: [#general > ✔ CI Failure With and Without Stability Attribute](https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/.E2.9C.94.20CI.20Failure.20With.20and.20Without.20Stability.20Attribute/with/615974133)

# Description

Fixes an oversight in how the `Write for Cursor<W: WriteThroughCursor>` implementation was written. While `core::io` was unstable, a stability attribute for this implementation was not required. However, once that module is marked as stable (even when `Cursor` and `Write` are not publicly stably exported), a stability attribute is required. Since `Write` and `Cursor` are both stable items (just not stable to access via `core::io`), the implementation must be marked as stable.

While it is possible to use [#[unstable_feature_bound(core_io)]](https://rustc-dev-guide.rust-lang.org/stability.html#unstable_feature_bound) to allow that implementation to be unstable, we do need users to have access to it stably, since it is how implementations such as `Write for Cursor<Vec<u8>>` are accessed. This is also why this implementation is marked as stable since `1.0.0`, since that is the earliest downstream implementation we must permit.

---

## Notes

- No AI tooling of any kind was used during the creation of this PR.