### PR TITLE
Remove unneeded `[const] Destruct` bound in `array::from_fn`

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -107,11 +107,20 @@ pub fn repeat<T: Clone, const N: usize>(val: T) -> [T; N] {
 #[inline]
 #[stable(feature = "array_from_fn", since = "1.63.0")]
 #[rustc_const_unstable(feature = "const_array", issue = "147606")]
-pub const fn from_fn<T: [const] Destruct, const N: usize, F>(f: F) -> [T; N]
+pub const fn from_fn<T, const N: usize, F>(mut f: F) -> [T; N]
 where
     F: [const] FnMut(usize) -> T + [const] Destruct,
 {
-    try_from_fn(NeverShortCircuit::wrap_mut_1(f)).0
+    let mut array: [MaybeUninit<T>; N] = [const { MaybeUninit::uninit() }; N];
+
+    let mut i = 0;
+    while i < N {
+        array[i] = MaybeUninit::new(f(i));
+        i += 1;
+    }
+
+    // SAFETY: All N elements were initialized.
+    unsafe { MaybeUninit::array_assume_init(array) }
 }
 
 /// Creates an array `[T; N]` where each fallible array element `T` is returned by the `cb` call.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

relevant tracking issue: https://github.com/rust-lang/rust/issues/147606

Using `array::try_from_fn` introduces an unneeded `T: [const] Destruct` bound.

Given that `try_from_fn` internally uses `try_from_fn_erased`, this change could have negative perf implications.