### PR TITLE
Remove unused `#[non_exhaustive]` in library

### DIFF
--- a/library/core/src/escape.rs
+++ b/library/core/src/escape.rs
@@ -167,13 +167,11 @@ union MaybeEscapedCharacter<const N: usize> {
 /// Marker type to indicate that the character is always escaped,
 /// used to optimize the iterator implementation.
 #[derive(Clone, Copy)]
-#[non_exhaustive]
 pub(crate) struct AlwaysEscaped;
 
 /// Marker type to indicate that the character may be escaped,
 /// used to optimize the iterator implementation.
 #[derive(Clone, Copy)]
-#[non_exhaustive]
 pub(crate) struct MaybeEscaped;
 
 /// An iterator over a possibly escaped character.

--- a/library/core/src/mem/type_info.rs
+++ b/library/core/src/mem/type_info.rs
@@ -20,7 +20,6 @@ pub struct Type {
 /// Info of a trait implementation, you can retrieve the vtable with [Self::get_vtable]
 #[derive(Debug, PartialEq, Eq)]
 #[unstable(feature = "type_info", issue = "146922")]
-#[non_exhaustive]
 pub struct TraitImpl<T: PointeeSized> {
     pub(crate) vtable: DynMetadata<T>,
 }

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -245,7 +245,6 @@ impl !Sync for TokenStream {}
 /// The contained error message is explicitly not guaranteed to be stable in any way,
 /// and may change between Rust versions or across compilations.
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
-#[non_exhaustive]
 #[derive(Debug)]
 pub struct LexError(String);
 

--- a/library/std/src/sys/process/unsupported.rs
+++ b/library/std/src/sys/process/unsupported.rs
@@ -199,7 +199,6 @@ impl fmt::Debug for Command {
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Default)]
-#[non_exhaustive]
 pub struct ExitStatus();
 
 impl ExitStatus {


### PR DESCRIPTION
Extracted from https://github.com/rust-lang/rust/pull/160918