### PR TITLE
2026/08/12 -- hrsraiden -- bootstrap: warn when download-ci-llvm is unavailable with assertions

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2495,6 +2495,7 @@ pub fn parse_download_ci_llvm<'a>(
     asserts: bool,
 ) -> bool {
     let dwn_ctx = dwn_ctx.as_ref();
+    let is_explicit = download_ci_llvm.is_some();
     let download_ci_llvm = download_ci_llvm.unwrap_or(StringOrBool::Bool(true));
 
     let if_unchanged = || {
@@ -2539,8 +2540,18 @@ pub fn parse_download_ci_llvm<'a>(
                 );
             }
 
-            // If download-ci-llvm=true we also want to check that CI llvm is available
-            b && llvm::is_ci_llvm_available_for_target(&dwn_ctx.host_target, asserts)
+            let available = llvm::is_ci_llvm_available_for_target(&dwn_ctx.host_target, asserts);
+            if b && !available && is_explicit {
+                println!(
+                    "WARNING: `llvm.download-ci-llvm = true` was specified, but CI LLVM \
+                    (assertions={asserts}) is unavailable for target triple `{}`.",
+                    dwn_ctx.host_target.triple
+                );
+                println!(
+                    "HELP: `download-ci-llvm` will be disabled and LLVM will be built from source."
+                );
+            }
+            b && available
         }
         StringOrBool::String(s) if s == "if-unchanged" => if_unchanged(),
         StringOrBool::String(other) => {

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -50,6 +50,15 @@ fn download_ci_llvm() {
     }
 }
 
+use crate::core::download::is_download_ci_available;
+
+#[test]
+fn download_ci_llvm_unsupported_assertions() {
+    assert!(!is_download_ci_available("i686-pc-windows-msvc", true));
+    assert!(is_download_ci_available("x86_64-pc-windows-msvc", true));
+    assert!(!is_download_ci_available("aarch64-apple-darwin", true));
+}
+
 #[test]
 fn clap_verify() {
     Flags::command().debug_assert();


### PR DESCRIPTION
Fixes rust-lang/rust#160919.

When `llvm.download-ci-llvm = true` and `llvm.assertions = true` are set in `config.toml`, but no assertion-enabled alt CI LLVM binary exists for the host triple, `bootstrap` previously built LLVM from source silently without any notification.

This PR adds a `WARNING` and `HELP` message when `download-ci-llvm = true` is explicitly requested on an unsupported target.

### Verification
- `cargo test --manifest-path src/bootstrap/Cargo.toml download_ci_llvm_unsupported_assertions` (1 passed, 0.00s)
- `python x.py check` (Passed)
- `python x.py fmt --check` (Passed)

r? @jieyouxu
@rustbot label +A-bootstrap

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines
-->
<!-- homu-ignore:end -->