### PR TITLE
Implement `Write for Cursor<W: AsMut<[u8]>>`

### DIFF
--- a/library/alloc/src/io/cursor.rs
+++ b/library/alloc/src/io/cursor.rs
@@ -1,9 +1,6 @@
 use crate::alloc::Allocator;
-use crate::boxed::Box;
 use crate::io::{
-    self, BorrowedCursor, BufRead, Cursor, ErrorKind, IoSlice, IoSliceMut, Read,
-    WriteThroughCursor, slice_write, slice_write_all, slice_write_all_vectored,
-    slice_write_vectored,
+    self, BorrowedCursor, BufRead, Cursor, ErrorKind, IoSlice, IoSliceMut, Read, SpecCursorWrite,
 };
 use crate::string::String;
 use crate::vec::Vec;
@@ -254,8 +251,9 @@ where
     Ok(buf_len)
 }
 
+#[doc(hidden)]
 #[stable(feature = "cursor_mut_vec", since = "1.25.0")]
-impl<A> WriteThroughCursor for &mut Vec<u8, A>
+impl<A> SpecCursorWrite for &mut Vec<u8, A>
 where
     A: Allocator,
 {
@@ -268,32 +266,11 @@ where
         let (pos, inner) = this.into_parts_mut();
         vec_write_all_vectored(pos, inner, bufs)
     }
-
-    #[inline]
-    fn is_write_vectored(_this: &Cursor<Self>) -> bool {
-        true
-    }
-
-    fn write_all(this: &mut Cursor<Self>, buf: &[u8]) -> io::Result<()> {
-        let (pos, inner) = this.into_parts_mut();
-        vec_write_all(pos, inner, buf)?;
-        Ok(())
-    }
-
-    fn write_all_vectored(this: &mut Cursor<Self>, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
-        let (pos, inner) = this.into_parts_mut();
-        vec_write_all_vectored(pos, inner, bufs)?;
-        Ok(())
-    }
-
-    #[inline]
-    fn flush(_this: &mut Cursor<Self>) -> io::Result<()> {
-        Ok(())
-    }
 }
 
+#[doc(hidden)]
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A> WriteThroughCursor for Vec<u8, A>
+impl<A> SpecCursorWrite for Vec<u8, A>
 where
     A: Allocator,
 {
@@ -305,67 +282,5 @@ where
     fn write_vectored(this: &mut Cursor<Self>, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let (pos, inner) = this.into_parts_mut();
         vec_write_all_vectored(pos, inner, bufs)
-    }
-
-    #[inline]
-    fn is_write_vectored(_this: &Cursor<Self>) -> bool {
-        true
-    }
-
-    fn write_all(this: &mut Cursor<Self>, buf: &[u8]) -> io::Result<()> {
-        let (pos, inner) = this.into_parts_mut();
-        vec_write_all(pos, inner, buf)?;
-        Ok(())
-    }
-
-    fn write_all_vectored(this: &mut Cursor<Self>, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
-        let (pos, inner) = this.into_parts_mut();
-        vec_write_all_vectored(pos, inner, bufs)?;
-        Ok(())
-    }
-
-    #[inline]
-    fn flush(_this: &mut Cursor<Self>) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-#[stable(feature = "cursor_box_slice", since = "1.5.0")]
-impl<A> WriteThroughCursor for Box<[u8], A>
-where
-    A: Allocator,
-{
-    #[inline]
-    fn write(this: &mut Cursor<Self>, buf: &[u8]) -> io::Result<usize> {
-        let (pos, inner) = this.into_parts_mut();
-        slice_write(pos, inner, buf)
-    }
-
-    #[inline]
-    fn write_vectored(this: &mut Cursor<Self>, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        let (pos, inner) = this.into_parts_mut();
-        slice_write_vectored(pos, inner, bufs)
-    }
-
-    #[inline]
-    fn is_write_vectored(_this: &Cursor<Self>) -> bool {
-        true
-    }
-
-    #[inline]
-    fn write_all(this: &mut Cursor<Self>, buf: &[u8]) -> io::Result<()> {
-        let (pos, inner) = this.into_parts_mut();
-        slice_write_all(pos, inner, buf)
-    }
-
-    #[inline]
-    fn write_all_vectored(this: &mut Cursor<Self>, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
-        let (pos, inner) = this.into_parts_mut();
-        slice_write_all_vectored(pos, inner, bufs)
-    }
-
-    #[inline]
-    fn flush(_this: &mut Cursor<Self>) -> io::Result<()> {
-        Ok(())
     }
 }

--- a/library/alloc/src/io/mod.rs
+++ b/library/alloc/src/io/mod.rs
@@ -202,10 +202,7 @@ pub use core::io::{
 #[doc(hidden)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 pub use core::io::{IoHandle, OsFunctions, default_write_vectored, stream_len_default};
-use core::io::{
-    SizeHint, WriteThroughCursor, chain, slice_write, slice_write_all, slice_write_all_vectored,
-    slice_write_vectored, take,
-};
+use core::io::{SizeHint, SpecCursorWrite, chain, take};
 
 use self::read::{append_to_string, default_read_buf_exact, default_read_exact};
 use self::util::{bytes, lines, split, uninlined_slow_read_byte};

--- a/library/core/src/io/cursor.rs
+++ b/library/core/src/io/cursor.rs
@@ -296,11 +296,8 @@ where
 }
 
 /// Non-resizing [`Write::write`] implementation for slices.
-/// Exported for `Cursor<Box<[u8], A>>`'s implementation of [`Write`].
 #[inline]
-#[doc(hidden)]
-#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-pub fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<usize> {
+fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<usize> {
     let pos = cmp::min(*pos_mut, slice.len() as u64);
     let dst = &mut slice[(pos as usize)..];
     let amt = cmp::min(buf.len(), dst.len());
@@ -310,11 +307,8 @@ pub fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Resul
 }
 
 /// Non-resizing [`Write::write_vectored`] implementation for slices.
-/// Exported for `Cursor<Box<[u8], A>>`'s implementation of [`Write`].
 #[inline]
-#[doc(hidden)]
-#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-pub fn slice_write_vectored(
+fn slice_write_vectored(
     pos_mut: &mut u64,
     slice: &mut [u8],
     bufs: &[IoSlice<'_>],
@@ -331,21 +325,15 @@ pub fn slice_write_vectored(
 }
 
 /// Non-resizing [`Write::write_all`] implementation for slices.
-/// Exported for `Cursor<Box<[u8], A>>`'s implementation of [`Write`].
 #[inline]
-#[doc(hidden)]
-#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-pub fn slice_write_all(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<()> {
+fn slice_write_all(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<()> {
     let n = slice_write(pos_mut, slice, buf)?;
     if n < buf.len() { Err(io::Error::WRITE_ALL_EOF) } else { Ok(()) }
 }
 
 /// Non-resizing [`Write::write_all_vectored`] implementation for slices.
-/// Exported for `Cursor<Box<[u8], A>>`'s implementation of [`Write`].
 #[inline]
-#[doc(hidden)]
-#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-pub fn slice_write_all_vectored(
+fn slice_write_all_vectored(
     pos_mut: &mut u64,
     slice: &mut [u8],
     bufs: &[IoSlice<'_>],
@@ -357,80 +345,6 @@ pub fn slice_write_all_vectored(
         }
     }
     Ok(())
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl Write for Cursor<&mut [u8]> {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let (pos, inner) = self.into_parts_mut();
-        slice_write(pos, inner, buf)
-    }
-
-    #[inline]
-    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        let (pos, inner) = self.into_parts_mut();
-        slice_write_vectored(pos, inner, bufs)
-    }
-
-    #[inline]
-    fn is_write_vectored(&self) -> bool {
-        true
-    }
-
-    #[inline]
-    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        let (pos, inner) = self.into_parts_mut();
-        slice_write_all(pos, inner, buf)
-    }
-
-    #[inline]
-    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
-        let (pos, inner) = self.into_parts_mut();
-        slice_write_all_vectored(pos, inner, bufs)
-    }
-
-    #[inline]
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-#[stable(feature = "cursor_array", since = "1.61.0")]
-impl<const N: usize> Write for Cursor<[u8; N]> {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let (pos, inner) = self.into_parts_mut();
-        slice_write(pos, inner, buf)
-    }
-
-    #[inline]
-    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        let (pos, inner) = self.into_parts_mut();
-        slice_write_vectored(pos, inner, bufs)
-    }
-
-    #[inline]
-    fn is_write_vectored(&self) -> bool {
-        true
-    }
-
-    #[inline]
-    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        let (pos, inner) = self.into_parts_mut();
-        slice_write_all(pos, inner, buf)
-    }
-
-    #[inline]
-    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
-        let (pos, inner) = self.into_parts_mut();
-        slice_write_all_vectored(pos, inner, bufs)
-    }
-
-    #[inline]
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -468,53 +382,95 @@ where
     }
 }
 
-/// Trait used to allow indirect implementation of `Write` for `Cursor<Self>`.
-/// Since [`Cursor`] is not a foundational type, it is not possible to implement
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T> Write for Cursor<T>
+where
+    T: AsMut<[u8]>,
+{
+    #[inline]
+    default fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let (pos, inner) = self.into_parts_mut();
+        slice_write(pos, inner.as_mut(), buf)
+    }
+
+    #[inline]
+    default fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        let (pos, inner) = self.into_parts_mut();
+        slice_write_vectored(pos, inner.as_mut(), bufs)
+    }
+
+    #[inline]
+    default fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        let (pos, inner) = self.into_parts_mut();
+        slice_write_all(pos, inner.as_mut(), buf)
+    }
+
+    #[inline]
+    default fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        let (pos, inner) = self.into_parts_mut();
+        slice_write_all_vectored(pos, inner.as_mut(), bufs)
+    }
+
+    #[inline]
+    default fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    default fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Trait used to allow indirect implementation of [`Write`] for [`Cursor<Self>`](Cursor).
+/// Since [`Cursor`] is not a fundamental type, it is not possible to implement
 /// `Write` for `Cursor<T>` if `Write` is defined in `libcore` and `T` is in a
 /// downstream crate (e.g., `liballoc` or `libstd`).
 ///
 /// Methods are identical in purpose and meaning to their `Write` namesakes.
 #[doc(hidden)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-pub trait WriteThroughCursor: Sized {
+#[rustc_specialization_trait]
+pub trait SpecCursorWrite: Sized + AsMut<[u8]> {
     fn write(this: &mut Cursor<Self>, buf: &[u8]) -> io::Result<usize>;
     fn write_vectored(this: &mut Cursor<Self>, bufs: &[IoSlice<'_>]) -> io::Result<usize>;
-    fn is_write_vectored(this: &Cursor<Self>) -> bool;
-    fn write_all(this: &mut Cursor<Self>, buf: &[u8]) -> io::Result<()>;
-    fn write_all_vectored(this: &mut Cursor<Self>, bufs: &mut [IoSlice<'_>]) -> io::Result<()>;
-    fn flush(this: &mut Cursor<Self>) -> io::Result<()>;
 }
 
 #[doc(hidden)]
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<W: WriteThroughCursor> Write for Cursor<W> {
+impl<W> Write for Cursor<W>
+where
+    W: SpecCursorWrite,
+{
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        WriteThroughCursor::write(self, buf)
+        SpecCursorWrite::write(self, buf)
     }
 
     #[inline]
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        WriteThroughCursor::write_vectored(self, bufs)
-    }
-
-    #[inline]
-    fn is_write_vectored(&self) -> bool {
-        WriteThroughCursor::is_write_vectored(self)
+        SpecCursorWrite::write_vectored(self, bufs)
     }
 
     #[inline]
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        WriteThroughCursor::write_all(self, buf)
+        SpecCursorWrite::write(self, buf)?;
+        Ok(())
     }
 
     #[inline]
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
-        WriteThroughCursor::write_all_vectored(self, bufs)
+        SpecCursorWrite::write_vectored(self, bufs)?;
+        Ok(())
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        true
     }
 
     #[inline]
     fn flush(&mut self) -> io::Result<()> {
-        WriteThroughCursor::flush(self)
+        Ok(())
     }
 }

--- a/library/core/src/io/mod.rs
+++ b/library/core/src/io/mod.rs
@@ -32,10 +32,7 @@ pub use self::{
 #[doc(hidden)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 pub use self::{
-    cursor::{
-        WriteThroughCursor, slice_write, slice_write_all, slice_write_all_vectored,
-        slice_write_vectored,
-    },
+    cursor::SpecCursorWrite,
     error::{Custom, CustomOwner, OsFunctions},
     seek::stream_len_default,
     size_hint::SizeHint,


### PR DESCRIPTION
Change `WriteThroughCursor` into a specialization which allows `Vec` and `&mut Vec` to extend their allocation for writing. This makes discoverability of the `Write` implementation better.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

ACP: https://github.com/rust-lang/libs-team/issues/853
Tracking Issue: rust-lang/rust#154046
Follow Up To: rust-lang/rust#160952 & rust-lang/rust#158537

# Description

Currently, `Write` is implemented for `Cursor<W>`, where `W` is one of:

* `&mut [u8]`
* `for<const N: usize> [u8; N]`
* `for<A: Allocator> Box<[u8], A>`
* `for<A: Allocator> Vec<u8, A>`
* `for<A: Allocator> &mut Vec<u8, A>`

When moving `Write` into `core::io`, it was noted [here](https://github.com/rust-lang/rust/pull/158537#discussion_r3516982697) that the documentation of `Cursor` would be degraded due to the introduction of `WriteThroughCursor`, an indirection trait to allow `Cursor` and `Write` in `core`, while `Box` and `Vec` exist in `alloc`.

To resolve this documentation regression, and add additional functionality as well, I'm proposing we instead implement `Write for Cursor<W>` where `W: AsMut<[u8]>`. All 5 of the original types above implement `AsMut<[u8]>`, so we'll correctly document the breadth of support.

However, for `Vec` and `&mut Vec`, I use specialization to allow their implementation to extend, rather than only writing to the existing slice. While this still uses an indirection trait (`SpecCursorWrite`), but now this is purely for specialization, and therefore doesn't need to be documented publicly.

I'm opening a PR directly as a reference point, but I suspect this will need an ACP since this changes the public API.

---

## Notes

- No AI tooling of any kind was used during the creation of this PR.