### PR TITLE
Optimize PartialOrd for arrays-of-`u8` (and other `UnsignedBytewiseOrd`)

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -410,23 +410,23 @@ where
 const impl<T: [const] PartialOrd, const N: usize> PartialOrd for [T; N] {
     #[inline]
     fn partial_cmp(&self, other: &[T; N]) -> Option<Ordering> {
-        PartialOrd::partial_cmp(&&self[..], &&other[..])
+        <[T] as PartialOrd>::partial_cmp(self, other)
     }
     #[inline]
     fn lt(&self, other: &[T; N]) -> bool {
-        PartialOrd::lt(&&self[..], &&other[..])
+        <[T] as PartialOrd>::lt(self, other)
     }
     #[inline]
     fn le(&self, other: &[T; N]) -> bool {
-        PartialOrd::le(&&self[..], &&other[..])
+        <[T] as PartialOrd>::le(self, other)
     }
     #[inline]
     fn ge(&self, other: &[T; N]) -> bool {
-        PartialOrd::ge(&&self[..], &&other[..])
+        <[T] as PartialOrd>::ge(self, other)
     }
     #[inline]
     fn gt(&self, other: &[T; N]) -> bool {
-        PartialOrd::gt(&&self[..], &&other[..])
+        <[T] as PartialOrd>::gt(self, other)
     }
 }
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -412,6 +412,7 @@ const impl<T: [const] PartialOrd, const N: usize> PartialOrd for [T; N] {
     fn partial_cmp(&self, other: &[T; N]) -> Option<Ordering> {
         SlicePartialOrd::partial_compare_array(self, other)
     }
+
     #[inline]
     fn lt(&self, other: &[T; N]) -> bool {
         SliceChain::lt_array(self, other)
@@ -427,6 +428,23 @@ const impl<T: [const] PartialOrd, const N: usize> PartialOrd for [T; N] {
     #[inline]
     fn gt(&self, other: &[T; N]) -> bool {
         SliceChain::gt_array(self, other)
+    }
+
+    #[inline]
+    fn __chaining_lt(&self, other: &Self) -> ControlFlow<bool> {
+        <[T] as PartialOrd>::__chaining_lt(self, other)
+    }
+    #[inline]
+    fn __chaining_le(&self, other: &Self) -> ControlFlow<bool> {
+        <[T] as PartialOrd>::__chaining_le(self, other)
+    }
+    #[inline]
+    fn __chaining_gt(&self, other: &Self) -> ControlFlow<bool> {
+        <[T] as PartialOrd>::__chaining_gt(self, other)
+    }
+    #[inline]
+    fn __chaining_ge(&self, other: &Self) -> ControlFlow<bool> {
+        <[T] as PartialOrd>::__chaining_ge(self, other)
     }
 }
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -18,7 +18,7 @@ use crate::ops::{
     ChangeOutputType, ControlFlow, FromResidual, Index, IndexMut, NeverShortCircuit, Residual, Try,
 };
 use crate::ptr::{null, null_mut};
-use crate::slice::{Iter, IterMut};
+use crate::slice::{Iter, IterMut, SliceChain, SlicePartialOrd};
 use crate::{fmt, ptr};
 
 mod ascii;
@@ -410,23 +410,23 @@ where
 const impl<T: [const] PartialOrd, const N: usize> PartialOrd for [T; N] {
     #[inline]
     fn partial_cmp(&self, other: &[T; N]) -> Option<Ordering> {
-        <[T] as PartialOrd>::partial_cmp(self, other)
+        SlicePartialOrd::partial_compare_array(self, other)
     }
     #[inline]
     fn lt(&self, other: &[T; N]) -> bool {
-        <[T] as PartialOrd>::lt(self, other)
+        SliceChain::lt_array(self, other)
     }
     #[inline]
     fn le(&self, other: &[T; N]) -> bool {
-        <[T] as PartialOrd>::le(self, other)
+        SliceChain::le_array(self, other)
     }
     #[inline]
     fn ge(&self, other: &[T; N]) -> bool {
-        <[T] as PartialOrd>::ge(self, other)
+        SliceChain::ge_array(self, other)
     }
     #[inline]
     fn gt(&self, other: &[T; N]) -> bool {
-        <[T] as PartialOrd>::gt(self, other)
+        SliceChain::gt_array(self, other)
     }
 }
 

--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -1,13 +1,13 @@
 //! Comparison traits for `[T]`.
 
 use super::{from_raw_parts, memchr};
-use crate::ascii;
 use crate::cmp::{self, BytewiseEq, Ordering};
 use crate::intrinsics::compare_bytes;
 use crate::marker::Destruct;
 use crate::mem::SizedTypeProperties;
 use crate::num::NonZero;
 use crate::ops::ControlFlow;
+use crate::{ascii, ptr};
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
@@ -142,15 +142,20 @@ where
 
 #[doc(hidden)]
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-// intermediate trait for specialization of slice's PartialOrd
-const trait SlicePartialOrd: Sized {
+// intermediate trait for specialization of slices' and arrays' PartialOrd
+pub(crate) const trait SlicePartialOrd: Sized {
     fn partial_compare(left: &[Self], right: &[Self]) -> Option<Ordering>;
+    fn partial_compare_array<const N: usize>(
+        left: &[Self; N],
+        right: &[Self; N],
+    ) -> Option<Ordering>;
 }
 
 #[doc(hidden)]
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-// intermediate trait for specialization of slice's PartialOrd chaining methods
-const trait SliceChain: Sized {
+// intermediate trait for specialization of slices' and arrays' PartialOrd chaining methods,
+// as well as the ordinary versions which use them by default.
+pub(crate) const trait SliceChain: Sized {
     fn chaining_lt(left: &[Self], right: &[Self]) -> ControlFlow<bool>;
     fn chaining_le(left: &[Self], right: &[Self]) -> ControlFlow<bool>;
     fn chaining_gt(left: &[Self], right: &[Self]) -> ControlFlow<bool>;
@@ -160,6 +165,11 @@ const trait SliceChain: Sized {
     fn le(left: &[Self], right: &[Self]) -> bool;
     fn gt(left: &[Self], right: &[Self]) -> bool;
     fn ge(left: &[Self], right: &[Self]) -> bool;
+
+    fn lt_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> bool;
+    fn le_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> bool;
+    fn gt_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> bool;
+    fn ge_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> bool;
 }
 
 type AlwaysBreak<B> = ControlFlow<B, crate::convert::Infallible>;
@@ -176,6 +186,12 @@ const impl<A: [const] PartialOrd> SlicePartialOrd for A {
 
         let AlwaysBreak::Break(b) = chaining_impl(left, right, elem_chain, len_chain);
         b
+    }
+    default fn partial_compare_array<const N: usize>(
+        left: &[Self; N],
+        right: &[Self; N],
+    ) -> Option<Ordering> {
+        Self::partial_compare(left, right)
     }
 }
 
@@ -217,6 +233,23 @@ const impl<A: [const] PartialOrd> SliceChain for A {
     #[inline]
     default fn ge(left: &[Self], right: &[Self]) -> bool {
         as_underlying(left.__chaining_ge(right)) != 0
+    }
+
+    #[inline]
+    default fn lt_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> bool {
+        SliceChain::lt(left, right)
+    }
+    #[inline]
+    default fn le_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> bool {
+        SliceChain::le(left, right)
+    }
+    #[inline]
+    default fn gt_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> bool {
+        SliceChain::gt(left, right)
+    }
+    #[inline]
+    default fn ge_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> bool {
+        SliceChain::ge(left, right)
     }
 }
 
@@ -274,6 +307,12 @@ const impl<A: [const] AlwaysApplicableOrd> SlicePartialOrd for A {
     fn partial_compare(left: &[A], right: &[A]) -> Option<Ordering> {
         Some(SliceOrd::compare(left, right))
     }
+    fn partial_compare_array<const N: usize>(
+        left: &[Self; N],
+        right: &[Self; N],
+    ) -> Option<Ordering> {
+        Some(SliceOrd::compare_array(left, right))
+    }
 }
 
 #[rustc_specialization_trait]
@@ -301,6 +340,7 @@ always_applicable_ord! {
 // intermediate trait for specialization of slice's Ord
 const trait SliceOrd: Sized {
     fn compare(left: &[Self], right: &[Self]) -> Ordering;
+    fn compare_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> Ordering;
 }
 
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
@@ -315,6 +355,9 @@ const impl<A: [const] Ord> SliceOrd for A {
 
         let AlwaysBreak::Break(b) = chaining_impl(left, right, elem_chain, len_chain);
         b
+    }
+    default fn compare_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> Ordering {
+        Self::compare(left, right)
     }
 }
 
@@ -362,6 +405,17 @@ const impl<A: [const] Ord + [const] UnsignedBytewiseOrd> SliceOrd for A {
         if order == 0 {
             order = diff;
         }
+        order.cmp(&0)
+    }
+
+    #[inline]
+    fn compare_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> Ordering {
+        let left = ptr::from_ref(left).cast();
+        let right = ptr::from_ref(right).cast();
+        // SAFETY: `left` and `right` are references and are thus guaranteed to
+        // be valid. `UnsignedBytewiseOrd` is only implemented for types that
+        // are valid u8s and can be compared the same way.
+        let order = unsafe { compare_bytes(left, right, N) };
         order.cmp(&0)
     }
 }
@@ -416,6 +470,23 @@ const impl<A: [const] PartialOrd + [const] UnsignedBytewiseOrd> SliceChain for A
     #[inline]
     fn ge(left: &[Self], right: &[Self]) -> bool {
         SliceOrd::compare(left, right).is_ge()
+    }
+
+    #[inline]
+    fn lt_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> bool {
+        SliceOrd::compare_array(left, right).is_lt()
+    }
+    #[inline]
+    fn le_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> bool {
+        SliceOrd::compare_array(left, right).is_le()
+    }
+    #[inline]
+    fn gt_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> bool {
+        SliceOrd::compare_array(left, right).is_gt()
+    }
+    #[inline]
+    fn ge_array<const N: usize>(left: &[Self; N], right: &[Self; N]) -> bool {
+        SliceOrd::compare_array(left, right).is_ge()
     }
 }
 

--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -41,17 +41,6 @@ const impl<T: [const] Ord> Ord for [T] {
     }
 }
 
-#[inline]
-const fn as_underlying(x: ControlFlow<bool>) -> u8 {
-    // SAFETY: This will only compile if `bool` and `ControlFlow<bool>` have the same
-    // size (which isn't guaranteed but this is libcore). Because they have the same
-    // size, it's a niched implementation, which in one byte means there can't be
-    // any uninitialized memory. The callers then only check for `0` or `1` from this,
-    // which must necessarily match the `Break` variant, and we're fine no matter
-    // what ends up getting picked as the value representing `Continue(())`.
-    unsafe { crate::mem::transmute(x) }
-}
-
 /// Implements comparison of slices [lexicographically](Ord#lexicographical-comparison).
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
@@ -62,27 +51,19 @@ const impl<T: [const] PartialOrd> PartialOrd for [T] {
     }
     #[inline]
     fn lt(&self, other: &Self) -> bool {
-        // This is certainly not the obvious way to implement these methods.
-        // Unfortunately, using anything that looks at the discriminant means that
-        // LLVM sees a check for `2` (aka `ControlFlow<bool>::Continue(())`) and
-        // gets very distracted by that, ending up generating extraneous code.
-        // This should be changed to something simpler once either LLVM is smarter,
-        // see <https://github.com/llvm/llvm-project/issues/132678>, or we generate
-        // niche discriminant checks in a way that doesn't trigger it.
-
-        as_underlying(self.__chaining_lt(other)) == 1
+        SliceChain::lt(self, other)
     }
     #[inline]
     fn le(&self, other: &Self) -> bool {
-        as_underlying(self.__chaining_le(other)) != 0
+        SliceChain::le(self, other)
     }
     #[inline]
     fn gt(&self, other: &Self) -> bool {
-        as_underlying(self.__chaining_gt(other)) == 1
+        SliceChain::gt(self, other)
     }
     #[inline]
     fn ge(&self, other: &Self) -> bool {
-        as_underlying(self.__chaining_ge(other)) != 0
+        SliceChain::ge(self, other)
     }
     #[inline]
     fn __chaining_lt(&self, other: &Self) -> ControlFlow<bool> {
@@ -174,6 +155,11 @@ const trait SliceChain: Sized {
     fn chaining_le(left: &[Self], right: &[Self]) -> ControlFlow<bool>;
     fn chaining_gt(left: &[Self], right: &[Self]) -> ControlFlow<bool>;
     fn chaining_ge(left: &[Self], right: &[Self]) -> ControlFlow<bool>;
+
+    fn lt(left: &[Self], right: &[Self]) -> bool;
+    fn le(left: &[Self], right: &[Self]) -> bool;
+    fn gt(left: &[Self], right: &[Self]) -> bool;
+    fn ge(left: &[Self], right: &[Self]) -> bool;
 }
 
 type AlwaysBreak<B> = ControlFlow<B, crate::convert::Infallible>;
@@ -207,6 +193,42 @@ const impl<A: [const] PartialOrd> SliceChain for A {
     default fn chaining_ge(left: &[Self], right: &[Self]) -> ControlFlow<bool> {
         chaining_impl(left, right, PartialOrd::__chaining_ge, usize::__chaining_ge)
     }
+
+    #[inline]
+    default fn lt(left: &[Self], right: &[Self]) -> bool {
+        // This is certainly not the obvious way to implement these methods.
+        // Unfortunately, using anything that looks at the discriminant means that
+        // LLVM sees a check for `2` (aka `ControlFlow<bool>::Continue(())`) and
+        // gets very distracted by that, ending up generating extraneous code.
+        // This should be changed to something simpler once either LLVM is smarter,
+        // see <https://github.com/llvm/llvm-project/issues/132678>, or we generate
+        // niche discriminant checks in a way that doesn't trigger it.
+
+        as_underlying(left.__chaining_lt(right)) == 1
+    }
+    #[inline]
+    default fn le(left: &[Self], right: &[Self]) -> bool {
+        as_underlying(left.__chaining_le(right)) != 0
+    }
+    #[inline]
+    default fn gt(left: &[Self], right: &[Self]) -> bool {
+        as_underlying(left.__chaining_gt(right)) == 1
+    }
+    #[inline]
+    default fn ge(left: &[Self], right: &[Self]) -> bool {
+        as_underlying(left.__chaining_ge(right)) != 0
+    }
+}
+
+#[inline]
+const fn as_underlying(x: ControlFlow<bool>) -> u8 {
+    // SAFETY: This will only compile if `bool` and `ControlFlow<bool>` have the same
+    // size (which isn't guaranteed but this is libcore). Because they have the same
+    // size, it's a niched implementation, which in one byte means there can't be
+    // any uninitialized memory. The callers then only check for `0` or `1` from this,
+    // which must necessarily match the `Break` variant, and we're fine no matter
+    // what ends up getting picked as the value representing `Continue(())`.
+    unsafe { crate::mem::transmute(x) }
 }
 
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
@@ -375,6 +397,25 @@ const impl<A: [const] PartialOrd + [const] UnsignedBytewiseOrd> SliceChain for A
             Ordering::Equal => ControlFlow::Continue(()),
             ne => ControlFlow::Break(ne.is_ge()),
         }
+    }
+
+    // We don't need the redirect through `ControlFlow` for the non-chaining ones
+
+    #[inline]
+    fn lt(left: &[Self], right: &[Self]) -> bool {
+        SliceOrd::compare(left, right).is_lt()
+    }
+    #[inline]
+    fn le(left: &[Self], right: &[Self]) -> bool {
+        SliceOrd::compare(left, right).is_le()
+    }
+    #[inline]
+    fn gt(left: &[Self], right: &[Self]) -> bool {
+        SliceOrd::compare(left, right).is_gt()
+    }
+    #[inline]
+    fn ge(left: &[Self], right: &[Self]) -> bool {
+        SliceOrd::compare(left, right).is_ge()
     }
 }
 

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -48,6 +48,8 @@ pub use ascii::EscapeAscii;
 #[unstable(feature = "str_internals", issue = "none")]
 #[doc(hidden)]
 pub use ascii::is_ascii_simple;
+// Exposed for arrays
+pub(crate) use cmp::{SliceChain, SlicePartialOrd};
 #[stable(feature = "slice_get_slice", since = "1.28.0")]
 pub use index::SliceIndex;
 #[unstable(feature = "slice_range", issue = "76393")]

--- a/tests/mir-opt/pre-codegen/array_ord.lt_ipv4.runtime-optimized.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/array_ord.lt_ipv4.runtime-optimized.after.panic-abort.mir
@@ -6,38 +6,15 @@ fn lt_ipv4(_1: &[u8; 4], _2: &[u8; 4]) -> bool {
     let mut _0: bool;
     scope 1 (inlined std::cmp::impls::<impl PartialOrd for &[u8; 4]>::lt) {
         scope 2 (inlined array::<impl PartialOrd for [u8; 4]>::lt) {
-            scope 3 (inlined #[track_caller] array::<impl Index<RangeFull> for [u8; 4]>::index) {
-                let _3: &[u8];
-                scope 4 (inlined #[track_caller] core::slice::index::<impl Index<RangeFull> for [u8]>::index) {
-                    scope 5 (inlined #[track_caller] <RangeFull as SliceIndex<[u8]>>::index) {
-                    }
-                }
-            }
-            scope 6 (inlined #[track_caller] array::<impl Index<RangeFull> for [u8; 4]>::index) {
-                let _4: &[u8];
-                scope 7 (inlined #[track_caller] core::slice::index::<impl Index<RangeFull> for [u8]>::index) {
-                    scope 8 (inlined #[track_caller] <RangeFull as SliceIndex<[u8]>>::index) {
-                    }
-                }
-            }
-            scope 9 (inlined std::cmp::impls::<impl PartialOrd for &[u8]>::lt) {
-                scope 10 (inlined core::slice::cmp::<impl PartialOrd for [u8]>::lt) {
-                    let mut _7: std::ops::ControlFlow<bool>;
-                    let mut _9: u8;
-                    scope 11 (inlined core::slice::cmp::<impl PartialOrd for [u8]>::__chaining_lt) {
-                        scope 13 (inlined <u8 as core::slice::cmp::SliceChain>::chaining_lt) {
-                            let mut _5: std::cmp::Ordering;
-                            let mut _6: i8;
-                            let mut _8: bool;
-                            scope 14 {
-                                scope 15 (inlined std::cmp::Ordering::is_lt) {
-                                    scope 16 (inlined std::cmp::Ordering::as_raw) {
-                                    }
-                                }
-                            }
+            let mut _3: &[u8];
+            let mut _4: &[u8];
+            scope 3 (inlined core::slice::cmp::<impl PartialOrd for [u8]>::lt) {
+                scope 4 (inlined <u8 as core::slice::cmp::SliceChain>::lt) {
+                    let mut _5: std::cmp::Ordering;
+                    scope 5 (inlined std::cmp::Ordering::is_lt) {
+                        let mut _6: i8;
+                        scope 6 (inlined std::cmp::Ordering::as_raw) {
                         }
-                    }
-                    scope 12 (inlined core::slice::cmp::as_underlying) {
                     }
                 }
             }
@@ -46,41 +23,19 @@ fn lt_ipv4(_1: &[u8; 4], _2: &[u8; 4]) -> bool {
 
     bb0: {
         StorageLive(_3);
+        _3 = copy _1 as &[u8] (PointerCoercion(Unsize, Implicit));
         StorageLive(_4);
-        _3 = copy _1 as &[u8] (PointerCoercion(Unsize, AsCast));
-        _4 = copy _2 as &[u8] (PointerCoercion(Unsize, AsCast));
-        StorageLive(_9);
-        StorageLive(_7);
-        StorageLive(_6);
+        _4 = copy _2 as &[u8] (PointerCoercion(Unsize, Implicit));
         StorageLive(_5);
         _5 = <u8 as core::slice::cmp::SliceOrd>::compare(move _3, move _4) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
+        StorageLive(_6);
         _6 = discriminant(_5);
-        switchInt(copy _6) -> [0: bb2, otherwise: bb3];
-    }
-
-    bb2: {
-        _7 = const ControlFlow::<bool>::Continue(());
-        goto -> bb4;
-    }
-
-    bb3: {
-        StorageLive(_8);
-        _8 = Lt(copy _6, const 0_i8);
-        _7 = ControlFlow::<bool>::Break(move _8);
-        StorageDead(_8);
-        goto -> bb4;
-    }
-
-    bb4: {
-        StorageDead(_5);
+        _0 = Lt(move _6, const 0_i8);
         StorageDead(_6);
-        _9 = copy _7 as u8 (Transmute);
-        StorageDead(_7);
-        _0 = Eq(move _9, const 1_u8);
-        StorageDead(_9);
+        StorageDead(_5);
         StorageDead(_4);
         StorageDead(_3);
         return;

--- a/tests/mir-opt/pre-codegen/array_ord.lt_ipv4.runtime-optimized.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/array_ord.lt_ipv4.runtime-optimized.after.panic-abort.mir
@@ -6,15 +6,34 @@ fn lt_ipv4(_1: &[u8; 4], _2: &[u8; 4]) -> bool {
     let mut _0: bool;
     scope 1 (inlined std::cmp::impls::<impl PartialOrd for &[u8; 4]>::lt) {
         scope 2 (inlined array::<impl PartialOrd for [u8; 4]>::lt) {
-            let mut _3: &[u8];
-            let mut _4: &[u8];
-            scope 3 (inlined core::slice::cmp::<impl PartialOrd for [u8]>::lt) {
-                scope 4 (inlined <u8 as core::slice::cmp::SliceChain>::lt) {
-                    let mut _5: std::cmp::Ordering;
-                    scope 5 (inlined std::cmp::Ordering::is_lt) {
-                        let mut _6: i8;
-                        scope 6 (inlined std::cmp::Ordering::as_raw) {
+            scope 3 (inlined <u8 as core::slice::cmp::SliceChain>::lt_array::<4>) {
+                let mut _8: std::cmp::Ordering;
+                scope 4 (inlined <u8 as core::slice::cmp::SliceOrd>::compare_array::<4>) {
+                    let mut _3: *const [u8; 4];
+                    let _4: *const u8;
+                    let mut _5: *const [u8; 4];
+                    scope 5 {
+                        let _6: *const u8;
+                        scope 6 {
+                            let _7: i32;
+                            scope 7 {
+                                scope 12 (inlined std::cmp::impls::<impl Ord for i32>::cmp) {
+                                }
+                            }
                         }
+                        scope 10 (inlined std::ptr::from_ref::<[u8; 4]>) {
+                        }
+                        scope 11 (inlined std::ptr::const_ptr::<impl *const [u8; 4]>::cast::<u8>) {
+                        }
+                    }
+                    scope 8 (inlined std::ptr::from_ref::<[u8; 4]>) {
+                    }
+                    scope 9 (inlined std::ptr::const_ptr::<impl *const [u8; 4]>::cast::<u8>) {
+                    }
+                }
+                scope 13 (inlined std::cmp::Ordering::is_lt) {
+                    let mut _9: i8;
+                    scope 14 (inlined std::cmp::Ordering::as_raw) {
                     }
                 }
             }
@@ -22,22 +41,31 @@ fn lt_ipv4(_1: &[u8; 4], _2: &[u8; 4]) -> bool {
     }
 
     bb0: {
-        StorageLive(_3);
-        _3 = copy _1 as &[u8] (PointerCoercion(Unsize, Implicit));
+        StorageLive(_8);
         StorageLive(_4);
-        _4 = copy _2 as &[u8] (PointerCoercion(Unsize, Implicit));
+        StorageLive(_3);
+        _3 = &raw const (*_1);
+        _4 = copy _3 as *const u8 (PtrToPtr);
+        StorageDead(_3);
+        StorageLive(_6);
         StorageLive(_5);
-        _5 = <u8 as core::slice::cmp::SliceOrd>::compare(move _3, move _4) -> [return: bb1, unwind unreachable];
+        _5 = &raw const (*_2);
+        _6 = copy _5 as *const u8 (PtrToPtr);
+        StorageDead(_5);
+        StorageLive(_7);
+        _7 = compare_bytes(move _4, move _6, const 4_usize) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
-        StorageLive(_6);
-        _6 = discriminant(_5);
-        _0 = Lt(move _6, const 0_i8);
+        _8 = Cmp(copy _7, const 0_i32);
+        StorageDead(_7);
         StorageDead(_6);
-        StorageDead(_5);
         StorageDead(_4);
-        StorageDead(_3);
+        StorageLive(_9);
+        _9 = discriminant(_8);
+        _0 = Lt(move _9, const 0_i8);
+        StorageDead(_9);
+        StorageDead(_8);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/array_ord.lt_ipv4.runtime-optimized.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/array_ord.lt_ipv4.runtime-optimized.after.panic-abort.mir
@@ -1,0 +1,88 @@
+// MIR for `lt_ipv4` after runtime-optimized
+
+fn lt_ipv4(_1: &[u8; 4], _2: &[u8; 4]) -> bool {
+    debug a => _1;
+    debug b => _2;
+    let mut _0: bool;
+    scope 1 (inlined std::cmp::impls::<impl PartialOrd for &[u8; 4]>::lt) {
+        scope 2 (inlined array::<impl PartialOrd for [u8; 4]>::lt) {
+            scope 3 (inlined #[track_caller] array::<impl Index<RangeFull> for [u8; 4]>::index) {
+                let _3: &[u8];
+                scope 4 (inlined #[track_caller] core::slice::index::<impl Index<RangeFull> for [u8]>::index) {
+                    scope 5 (inlined #[track_caller] <RangeFull as SliceIndex<[u8]>>::index) {
+                    }
+                }
+            }
+            scope 6 (inlined #[track_caller] array::<impl Index<RangeFull> for [u8; 4]>::index) {
+                let _4: &[u8];
+                scope 7 (inlined #[track_caller] core::slice::index::<impl Index<RangeFull> for [u8]>::index) {
+                    scope 8 (inlined #[track_caller] <RangeFull as SliceIndex<[u8]>>::index) {
+                    }
+                }
+            }
+            scope 9 (inlined std::cmp::impls::<impl PartialOrd for &[u8]>::lt) {
+                scope 10 (inlined core::slice::cmp::<impl PartialOrd for [u8]>::lt) {
+                    let mut _7: std::ops::ControlFlow<bool>;
+                    let mut _9: u8;
+                    scope 11 (inlined core::slice::cmp::<impl PartialOrd for [u8]>::__chaining_lt) {
+                        scope 13 (inlined <u8 as core::slice::cmp::SliceChain>::chaining_lt) {
+                            let mut _5: std::cmp::Ordering;
+                            let mut _6: i8;
+                            let mut _8: bool;
+                            scope 14 {
+                                scope 15 (inlined std::cmp::Ordering::is_lt) {
+                                    scope 16 (inlined std::cmp::Ordering::as_raw) {
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    scope 12 (inlined core::slice::cmp::as_underlying) {
+                    }
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_3);
+        StorageLive(_4);
+        _3 = copy _1 as &[u8] (PointerCoercion(Unsize, AsCast));
+        _4 = copy _2 as &[u8] (PointerCoercion(Unsize, AsCast));
+        StorageLive(_9);
+        StorageLive(_7);
+        StorageLive(_6);
+        StorageLive(_5);
+        _5 = <u8 as core::slice::cmp::SliceOrd>::compare(move _3, move _4) -> [return: bb1, unwind unreachable];
+    }
+
+    bb1: {
+        _6 = discriminant(_5);
+        switchInt(copy _6) -> [0: bb2, otherwise: bb3];
+    }
+
+    bb2: {
+        _7 = const ControlFlow::<bool>::Continue(());
+        goto -> bb4;
+    }
+
+    bb3: {
+        StorageLive(_8);
+        _8 = Lt(copy _6, const 0_i8);
+        _7 = ControlFlow::<bool>::Break(move _8);
+        StorageDead(_8);
+        goto -> bb4;
+    }
+
+    bb4: {
+        StorageDead(_5);
+        StorageDead(_6);
+        _9 = copy _7 as u8 (Transmute);
+        StorageDead(_7);
+        _0 = Eq(move _9, const 1_u8);
+        StorageDead(_9);
+        StorageDead(_4);
+        StorageDead(_3);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/array_ord.lt_ipv4.runtime-optimized.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/array_ord.lt_ipv4.runtime-optimized.after.panic-unwind.mir
@@ -6,15 +6,34 @@ fn lt_ipv4(_1: &[u8; 4], _2: &[u8; 4]) -> bool {
     let mut _0: bool;
     scope 1 (inlined std::cmp::impls::<impl PartialOrd for &[u8; 4]>::lt) {
         scope 2 (inlined array::<impl PartialOrd for [u8; 4]>::lt) {
-            let mut _3: &[u8];
-            let mut _4: &[u8];
-            scope 3 (inlined core::slice::cmp::<impl PartialOrd for [u8]>::lt) {
-                scope 4 (inlined <u8 as core::slice::cmp::SliceChain>::lt) {
-                    let mut _5: std::cmp::Ordering;
-                    scope 5 (inlined std::cmp::Ordering::is_lt) {
-                        let mut _6: i8;
-                        scope 6 (inlined std::cmp::Ordering::as_raw) {
+            scope 3 (inlined <u8 as core::slice::cmp::SliceChain>::lt_array::<4>) {
+                let mut _8: std::cmp::Ordering;
+                scope 4 (inlined <u8 as core::slice::cmp::SliceOrd>::compare_array::<4>) {
+                    let mut _3: *const [u8; 4];
+                    let _4: *const u8;
+                    let mut _5: *const [u8; 4];
+                    scope 5 {
+                        let _6: *const u8;
+                        scope 6 {
+                            let _7: i32;
+                            scope 7 {
+                                scope 12 (inlined std::cmp::impls::<impl Ord for i32>::cmp) {
+                                }
+                            }
                         }
+                        scope 10 (inlined std::ptr::from_ref::<[u8; 4]>) {
+                        }
+                        scope 11 (inlined std::ptr::const_ptr::<impl *const [u8; 4]>::cast::<u8>) {
+                        }
+                    }
+                    scope 8 (inlined std::ptr::from_ref::<[u8; 4]>) {
+                    }
+                    scope 9 (inlined std::ptr::const_ptr::<impl *const [u8; 4]>::cast::<u8>) {
+                    }
+                }
+                scope 13 (inlined std::cmp::Ordering::is_lt) {
+                    let mut _9: i8;
+                    scope 14 (inlined std::cmp::Ordering::as_raw) {
                     }
                 }
             }
@@ -22,22 +41,31 @@ fn lt_ipv4(_1: &[u8; 4], _2: &[u8; 4]) -> bool {
     }
 
     bb0: {
-        StorageLive(_3);
-        _3 = copy _1 as &[u8] (PointerCoercion(Unsize, Implicit));
+        StorageLive(_8);
         StorageLive(_4);
-        _4 = copy _2 as &[u8] (PointerCoercion(Unsize, Implicit));
+        StorageLive(_3);
+        _3 = &raw const (*_1);
+        _4 = copy _3 as *const u8 (PtrToPtr);
+        StorageDead(_3);
+        StorageLive(_6);
         StorageLive(_5);
-        _5 = <u8 as core::slice::cmp::SliceOrd>::compare(move _3, move _4) -> [return: bb1, unwind continue];
+        _5 = &raw const (*_2);
+        _6 = copy _5 as *const u8 (PtrToPtr);
+        StorageDead(_5);
+        StorageLive(_7);
+        _7 = compare_bytes(move _4, move _6, const 4_usize) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {
-        StorageLive(_6);
-        _6 = discriminant(_5);
-        _0 = Lt(move _6, const 0_i8);
+        _8 = Cmp(copy _7, const 0_i32);
+        StorageDead(_7);
         StorageDead(_6);
-        StorageDead(_5);
         StorageDead(_4);
-        StorageDead(_3);
+        StorageLive(_9);
+        _9 = discriminant(_8);
+        _0 = Lt(move _9, const 0_i8);
+        StorageDead(_9);
+        StorageDead(_8);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/array_ord.lt_ipv4.runtime-optimized.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/array_ord.lt_ipv4.runtime-optimized.after.panic-unwind.mir
@@ -6,38 +6,15 @@ fn lt_ipv4(_1: &[u8; 4], _2: &[u8; 4]) -> bool {
     let mut _0: bool;
     scope 1 (inlined std::cmp::impls::<impl PartialOrd for &[u8; 4]>::lt) {
         scope 2 (inlined array::<impl PartialOrd for [u8; 4]>::lt) {
-            scope 3 (inlined #[track_caller] array::<impl Index<RangeFull> for [u8; 4]>::index) {
-                let _3: &[u8];
-                scope 4 (inlined #[track_caller] core::slice::index::<impl Index<RangeFull> for [u8]>::index) {
-                    scope 5 (inlined #[track_caller] <RangeFull as SliceIndex<[u8]>>::index) {
-                    }
-                }
-            }
-            scope 6 (inlined #[track_caller] array::<impl Index<RangeFull> for [u8; 4]>::index) {
-                let _4: &[u8];
-                scope 7 (inlined #[track_caller] core::slice::index::<impl Index<RangeFull> for [u8]>::index) {
-                    scope 8 (inlined #[track_caller] <RangeFull as SliceIndex<[u8]>>::index) {
-                    }
-                }
-            }
-            scope 9 (inlined std::cmp::impls::<impl PartialOrd for &[u8]>::lt) {
-                scope 10 (inlined core::slice::cmp::<impl PartialOrd for [u8]>::lt) {
-                    let mut _7: std::ops::ControlFlow<bool>;
-                    let mut _9: u8;
-                    scope 11 (inlined core::slice::cmp::<impl PartialOrd for [u8]>::__chaining_lt) {
-                        scope 13 (inlined <u8 as core::slice::cmp::SliceChain>::chaining_lt) {
-                            let mut _5: std::cmp::Ordering;
-                            let mut _6: i8;
-                            let mut _8: bool;
-                            scope 14 {
-                                scope 15 (inlined std::cmp::Ordering::is_lt) {
-                                    scope 16 (inlined std::cmp::Ordering::as_raw) {
-                                    }
-                                }
-                            }
+            let mut _3: &[u8];
+            let mut _4: &[u8];
+            scope 3 (inlined core::slice::cmp::<impl PartialOrd for [u8]>::lt) {
+                scope 4 (inlined <u8 as core::slice::cmp::SliceChain>::lt) {
+                    let mut _5: std::cmp::Ordering;
+                    scope 5 (inlined std::cmp::Ordering::is_lt) {
+                        let mut _6: i8;
+                        scope 6 (inlined std::cmp::Ordering::as_raw) {
                         }
-                    }
-                    scope 12 (inlined core::slice::cmp::as_underlying) {
                     }
                 }
             }
@@ -46,41 +23,19 @@ fn lt_ipv4(_1: &[u8; 4], _2: &[u8; 4]) -> bool {
 
     bb0: {
         StorageLive(_3);
+        _3 = copy _1 as &[u8] (PointerCoercion(Unsize, Implicit));
         StorageLive(_4);
-        _3 = copy _1 as &[u8] (PointerCoercion(Unsize, AsCast));
-        _4 = copy _2 as &[u8] (PointerCoercion(Unsize, AsCast));
-        StorageLive(_9);
-        StorageLive(_7);
-        StorageLive(_6);
+        _4 = copy _2 as &[u8] (PointerCoercion(Unsize, Implicit));
         StorageLive(_5);
         _5 = <u8 as core::slice::cmp::SliceOrd>::compare(move _3, move _4) -> [return: bb1, unwind continue];
     }
 
     bb1: {
+        StorageLive(_6);
         _6 = discriminant(_5);
-        switchInt(copy _6) -> [0: bb2, otherwise: bb3];
-    }
-
-    bb2: {
-        _7 = const ControlFlow::<bool>::Continue(());
-        goto -> bb4;
-    }
-
-    bb3: {
-        StorageLive(_8);
-        _8 = Lt(copy _6, const 0_i8);
-        _7 = ControlFlow::<bool>::Break(move _8);
-        StorageDead(_8);
-        goto -> bb4;
-    }
-
-    bb4: {
-        StorageDead(_5);
+        _0 = Lt(move _6, const 0_i8);
         StorageDead(_6);
-        _9 = copy _7 as u8 (Transmute);
-        StorageDead(_7);
-        _0 = Eq(move _9, const 1_u8);
-        StorageDead(_9);
+        StorageDead(_5);
         StorageDead(_4);
         StorageDead(_3);
         return;

--- a/tests/mir-opt/pre-codegen/array_ord.lt_ipv4.runtime-optimized.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/array_ord.lt_ipv4.runtime-optimized.after.panic-unwind.mir
@@ -1,0 +1,88 @@
+// MIR for `lt_ipv4` after runtime-optimized
+
+fn lt_ipv4(_1: &[u8; 4], _2: &[u8; 4]) -> bool {
+    debug a => _1;
+    debug b => _2;
+    let mut _0: bool;
+    scope 1 (inlined std::cmp::impls::<impl PartialOrd for &[u8; 4]>::lt) {
+        scope 2 (inlined array::<impl PartialOrd for [u8; 4]>::lt) {
+            scope 3 (inlined #[track_caller] array::<impl Index<RangeFull> for [u8; 4]>::index) {
+                let _3: &[u8];
+                scope 4 (inlined #[track_caller] core::slice::index::<impl Index<RangeFull> for [u8]>::index) {
+                    scope 5 (inlined #[track_caller] <RangeFull as SliceIndex<[u8]>>::index) {
+                    }
+                }
+            }
+            scope 6 (inlined #[track_caller] array::<impl Index<RangeFull> for [u8; 4]>::index) {
+                let _4: &[u8];
+                scope 7 (inlined #[track_caller] core::slice::index::<impl Index<RangeFull> for [u8]>::index) {
+                    scope 8 (inlined #[track_caller] <RangeFull as SliceIndex<[u8]>>::index) {
+                    }
+                }
+            }
+            scope 9 (inlined std::cmp::impls::<impl PartialOrd for &[u8]>::lt) {
+                scope 10 (inlined core::slice::cmp::<impl PartialOrd for [u8]>::lt) {
+                    let mut _7: std::ops::ControlFlow<bool>;
+                    let mut _9: u8;
+                    scope 11 (inlined core::slice::cmp::<impl PartialOrd for [u8]>::__chaining_lt) {
+                        scope 13 (inlined <u8 as core::slice::cmp::SliceChain>::chaining_lt) {
+                            let mut _5: std::cmp::Ordering;
+                            let mut _6: i8;
+                            let mut _8: bool;
+                            scope 14 {
+                                scope 15 (inlined std::cmp::Ordering::is_lt) {
+                                    scope 16 (inlined std::cmp::Ordering::as_raw) {
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    scope 12 (inlined core::slice::cmp::as_underlying) {
+                    }
+                }
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_3);
+        StorageLive(_4);
+        _3 = copy _1 as &[u8] (PointerCoercion(Unsize, AsCast));
+        _4 = copy _2 as &[u8] (PointerCoercion(Unsize, AsCast));
+        StorageLive(_9);
+        StorageLive(_7);
+        StorageLive(_6);
+        StorageLive(_5);
+        _5 = <u8 as core::slice::cmp::SliceOrd>::compare(move _3, move _4) -> [return: bb1, unwind continue];
+    }
+
+    bb1: {
+        _6 = discriminant(_5);
+        switchInt(copy _6) -> [0: bb2, otherwise: bb3];
+    }
+
+    bb2: {
+        _7 = const ControlFlow::<bool>::Continue(());
+        goto -> bb4;
+    }
+
+    bb3: {
+        StorageLive(_8);
+        _8 = Lt(copy _6, const 0_i8);
+        _7 = ControlFlow::<bool>::Break(move _8);
+        StorageDead(_8);
+        goto -> bb4;
+    }
+
+    bb4: {
+        StorageDead(_5);
+        StorageDead(_6);
+        _9 = copy _7 as u8 (Transmute);
+        StorageDead(_7);
+        _0 = Eq(move _9, const 1_u8);
+        StorageDead(_9);
+        StorageDead(_4);
+        StorageDead(_3);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/array_ord.rs
+++ b/tests/mir-opt/pre-codegen/array_ord.rs
@@ -6,10 +6,13 @@
 // EMIT_MIR array_ord.lt_ipv4.runtime-optimized.after.mir
 pub unsafe fn lt_ipv4<T: Copy>(a: &[u8; 4], b: &[u8; 4]) -> bool {
     // CHECK-LABEL: fn lt_ipv4(_1: &[u8; 4], _2: &[u8; 4]) -> bool
-    // CHECK: [[A:_.+]] = copy _1 as &[u8] (PointerCoercion(Unsize, Implicit));
-    // CHECK: [[B:_.+]] = copy _2 as &[u8] (PointerCoercion(Unsize, Implicit));
-    // CHECK: [[C:_.+]] = <u8 as core::slice::cmp::SliceOrd>::compare(move [[A]], move [[B]])
-    // CHECK: [[D:_.+]] = discriminant(_5);
+    // CHECK: [[A1:_.+]] = &raw const (*_1);
+    // CHECK: [[A2:_.+]] = copy [[A1]] as *const u8 (PtrToPtr);
+    // CHECK: [[B1:_.+]] = &raw const (*_2);
+    // CHECK: [[B2:_.+]] = copy [[B1]] as *const u8 (PtrToPtr);
+    // CHECK: [[C1:_.+]] = compare_bytes(move [[A2]], move [[B2]], const 4_usize)
+    // CHECK: [[C2:_.+]] = Cmp(copy [[C1]], const 0_i32);
+    // CHECK: [[D:_.+]] = discriminant([[C2]]);
     // CHECK: _0 = Lt(move [[D]], const 0_i8);
     a < b
 }

--- a/tests/mir-opt/pre-codegen/array_ord.rs
+++ b/tests/mir-opt/pre-codegen/array_ord.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -O -Zmir-opt-level=2
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+
+#![crate_type = "lib"]
+
+// EMIT_MIR array_ord.lt_ipv4.runtime-optimized.after.mir
+pub unsafe fn lt_ipv4<T: Copy>(a: &[u8; 4], b: &[u8; 4]) -> bool {
+    // CHECK-LABEL: fn lt_ipv4(_1: &[u8; 4], _2: &[u8; 4]) -> bool
+    // CHECK: [[A:_.+]] = copy _1 as &[u8] (PointerCoercion(Unsize, AsCast));
+    // CHECK: [[B:_.+]] = copy _2 as &[u8] (PointerCoercion(Unsize, AsCast));
+    // CHECK: <u8 as core::slice::cmp::SliceOrd>::compare(move [[A]], move [[B]])
+    a < b
+}

--- a/tests/mir-opt/pre-codegen/array_ord.rs
+++ b/tests/mir-opt/pre-codegen/array_ord.rs
@@ -6,8 +6,10 @@
 // EMIT_MIR array_ord.lt_ipv4.runtime-optimized.after.mir
 pub unsafe fn lt_ipv4<T: Copy>(a: &[u8; 4], b: &[u8; 4]) -> bool {
     // CHECK-LABEL: fn lt_ipv4(_1: &[u8; 4], _2: &[u8; 4]) -> bool
-    // CHECK: [[A:_.+]] = copy _1 as &[u8] (PointerCoercion(Unsize, AsCast));
-    // CHECK: [[B:_.+]] = copy _2 as &[u8] (PointerCoercion(Unsize, AsCast));
-    // CHECK: <u8 as core::slice::cmp::SliceOrd>::compare(move [[A]], move [[B]])
+    // CHECK: [[A:_.+]] = copy _1 as &[u8] (PointerCoercion(Unsize, Implicit));
+    // CHECK: [[B:_.+]] = copy _2 as &[u8] (PointerCoercion(Unsize, Implicit));
+    // CHECK: [[C:_.+]] = <u8 as core::slice::cmp::SliceOrd>::compare(move [[A]], move [[B]])
+    // CHECK: [[D:_.+]] = discriminant(_5);
+    // CHECK: _0 = Lt(move [[D]], const 0_i8);
     a < b
 }


### PR DESCRIPTION
@thomcc had an example [in discord](https://discord.com/channels/273534239310479360/490356824420122645/1536945433195315210) that made me realize that since before 1.0 there's been excessive `&`s in the array-to-slice delegation for array `PartialEq`.

I went to just fix that, but then ended up finding more things to clean up.  Let's see if that's worth bothering -- it cleans up the MIR a whole bunch, but whether that's necessary is less clear.

<!-- homu-ignore:start -->
---

*No LLM used*
<!-- homu-ignore:end -->
