### PR TITLE
bootstrap: Avoid some unnecessary imports from the crate root

### DIFF
--- a/src/bootstrap/src/cli_main.rs
+++ b/src/bootstrap/src/cli_main.rs
@@ -13,10 +13,14 @@ use std::sync::Once;
 use std::time::Instant;
 use std::{env, process};
 
-use crate::{
-    Build, CONFIG_CHANGE_HISTORY, ChangeId, Config, Flags, StepStack, Subcommand, debug,
-    find_recent_config_change_ids, human_readable_changes, t,
+use crate::core::builder::StepStack;
+use crate::core::config::flags::Flags;
+use crate::core::config::{ChangeId, Config, Subcommand};
+use crate::utils::change_tracker::{
+    CONFIG_CHANGE_HISTORY, find_recent_config_change_ids, human_readable_changes,
 };
+use crate::utils::helpers::t;
+use crate::{Build, debug};
 
 fn is_tracing_enabled() -> bool {
     cfg!(feature = "tracing")

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -16,9 +16,10 @@ use crate::core::builder::{
     self, Alias, Builder, Cargo, CommandLineStep, Kind, RunConfig, ShouldRun, Step, StepMetadata,
     crate_description,
 };
-use crate::core::config::TargetSelection;
+use crate::core::config::{Subcommand, TargetSelection};
 use crate::utils::build_stamp::{self, BuildStamp};
-use crate::{CodegenBackendKind, Compiler, Mode, Subcommand, t};
+use crate::utils::helpers::t;
+use crate::{CodegenBackendKind, Compiler, Mode};
 
 /// Allows individual check-step instances to keep track of whether they
 /// represent `cargo check` or `cargo fix`, independently of [`Builder::kind`].

--- a/src/bootstrap/src/core/build_steps/clean.rs
+++ b/src/bootstrap/src/core/build_steps/clean.rs
@@ -9,10 +9,13 @@ use std::fs;
 use std::io::{self, ErrorKind};
 use std::path::Path;
 
-use crate::core::builder::{Builder, CommandLineStep, RunConfig, ShouldRun, crate_description};
+use crate::core::builder::{
+    Builder, CommandLineStep, Kind, RunConfig, ShouldRun, crate_description,
+};
+use crate::core::config::Subcommand;
 use crate::utils::build_stamp::BuildStamp;
 use crate::utils::helpers::t;
-use crate::{Build, Compiler, Kind, Mode, Subcommand};
+use crate::{Build, Compiler, Mode};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CleanAll {}

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -14,17 +14,17 @@
 //! (as usual) a massive undertaking/refactoring.
 
 use super::tool::{SourceType, prepare_tool_cargo};
-use crate::builder::{Builder, ShouldRun};
 use crate::core::build_steps::check::{CompilerForCheck, prepare_compiler_for_check};
 use crate::core::build_steps::compile::{
     ArtifactKeepMode, run_cargo, rustc_cargo, std_cargo, std_crates_for_make_run,
 };
 use crate::core::builder;
 use crate::core::builder::{
-    Alias, CommandLineStep, Kind, RunConfig, StepMetadata, crate_description,
+    Alias, Builder, CommandLineStep, Kind, RunConfig, ShouldRun, StepMetadata, crate_description,
 };
+use crate::core::config::{Subcommand, TargetSelection};
 use crate::utils::build_stamp::{self, BuildStamp};
-use crate::{Compiler, Mode, Subcommand, TargetSelection, exit};
+use crate::{Compiler, Mode, exit};
 
 /// Disable the most spammy clippy lints
 const IGNORED_RULES_FOR_STD_AND_RUSTC: &[&str] = &[

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -20,7 +20,7 @@ use crate::core::builder::{
     crate_description,
 };
 use crate::core::config::{Config, TargetSelection};
-use crate::helpers::{submodule_path_of, symlink_dir, t, up_to_date};
+use crate::utils::helpers::{submodule_path_of, symlink_dir, t, up_to_date};
 use crate::{FileType, Mode};
 
 macro_rules! book {

--- a/src/bootstrap/src/core/build_steps/gcc.rs
+++ b/src/bootstrap/src/core/build_steps/gcc.rs
@@ -16,7 +16,7 @@ use std::sync::OnceLock;
 use build_helper::git::PathFreshness;
 
 use crate::core::builder::{Builder, Cargo, CommandLineStep, Kind, RunConfig, ShouldRun};
-use crate::core::config::TargetSelection;
+use crate::core::config::{Config, TargetSelection};
 use crate::utils::build_stamp::{BuildStamp, generate_smart_stamp_hash};
 use crate::utils::exec::command;
 use crate::utils::helpers::{self, t};
@@ -366,12 +366,12 @@ pub fn add_cg_gcc_cargo_flags(cargo: &mut Cargo, gcc: &GccOutput) {
 }
 
 /// The absolute path to the downloaded GCC artifacts.
-fn ci_gcc_root(config: &crate::Config, target: TargetSelection) -> PathBuf {
+fn ci_gcc_root(config: &Config, target: TargetSelection) -> PathBuf {
     config.out.join(target).join("ci-gcc")
 }
 
 /// Detect whether GCC sources have been modified locally or not.
-fn detect_gcc_freshness(config: &crate::Config, is_git: bool) -> build_helper::git::PathFreshness {
+fn detect_gcc_freshness(config: &Config, is_git: bool) -> build_helper::git::PathFreshness {
     assert!(cfg!(not(test)), "unit tests shouldn't care about GCC freshness");
 
     if is_git {

--- a/src/bootstrap/src/core/build_steps/install.rs
+++ b/src/bootstrap/src/core/build_steps/install.rs
@@ -6,14 +6,14 @@
 use std::path::{Component, Path, PathBuf};
 use std::{env, fs};
 
+use crate::Compiler;
 use crate::core::build_steps::dist;
 use crate::core::build_steps::tool::RustcPrivateCompilers;
-use crate::core::builder::{Builder, CommandLineStep, RunConfig, ShouldRun};
+use crate::core::builder::{Builder, CommandLineStep, Kind, RunConfig, ShouldRun};
 use crate::core::config::{Config, TargetSelection};
 use crate::utils::exec::command;
 use crate::utils::helpers::t;
 use crate::utils::tarball::GeneratedTarball;
-use crate::{Compiler, Kind};
 
 #[cfg(target_os = "illumos")]
 const SHELL: &str = "bash";

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -17,14 +17,16 @@ use std::{env, fs};
 use build_helper::git::PathFreshness;
 
 use crate::core::build_steps::llvm;
-use crate::core::builder::{Builder, CommandLineStep, RunConfig, ShouldRun, Step, StepMetadata};
+use crate::core::builder::{
+    Builder, CommandLineStep, Kind, RunConfig, ShouldRun, Step, StepMetadata,
+};
 use crate::core::config::{Config, LlvmPgoGenerationMode, TargetSelection};
 use crate::utils::build_stamp::{BuildStamp, generate_smart_stamp_hash};
 use crate::utils::exec::command;
 use crate::utils::helpers::{
     self, exe, get_clang_cl_resource_dir, libdir, t, unhashed_basename, up_to_date,
 };
-use crate::{CLang, GitRepo, Kind, exit, trace};
+use crate::{CLang, GitRepo, exit, trace};
 
 /// Result of building or downloading LLVM artifacts.
 #[derive(Clone)]

--- a/src/bootstrap/src/core/build_steps/run.rs
+++ b/src/bootstrap/src/core/build_steps/run.rs
@@ -16,7 +16,8 @@ use crate::core::builder::{Builder, CommandLineStep, Kind, RunConfig, ShouldRun,
 use crate::core::config::TargetSelection;
 use crate::core::config::flags::{get_completion, top_level_help};
 use crate::utils::exec::command;
-use crate::{Mode, exit, t};
+use crate::utils::helpers::t;
+use crate::{Mode, exit};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct BuildManifest;

--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -20,10 +20,10 @@ use sha2::Digest;
 
 use crate::core::build_steps::format;
 use crate::core::builder::{Builder, CommandLineStep, RunConfig, ShouldRun};
+use crate::core::config::Config;
 use crate::utils::change_tracker::CONFIG_CHANGE_HISTORY;
 use crate::utils::exec::command;
-use crate::utils::helpers::{self, hex_encode};
-use crate::{Config, t};
+use crate::utils::helpers::{self, hex_encode, t};
 
 #[cfg(test)]
 mod tests;

--- a/src/bootstrap/src/core/build_steps/test/failed_tests.rs
+++ b/src/bootstrap/src/core/build_steps/test/failed_tests.rs
@@ -4,7 +4,7 @@ use std::io::{BufRead, BufReader, ErrorKind};
 use std::path::{Path, PathBuf};
 
 use crate::core::builder::{Builder, Step};
-use crate::t;
+use crate::utils::helpers::t;
 
 #[derive(Clone)]
 pub struct RecordFailedTests {

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -16,15 +16,14 @@ use std::{env, fs};
 use crate::core::build_steps::compile::is_lto_stage;
 use crate::core::build_steps::toolstate::ToolState;
 use crate::core::build_steps::{compile, llvm};
-use crate::core::builder;
 use crate::core::builder::{
-    Builder, Cargo as CargoCommand, CommandLineStep, RunConfig, ShouldRun, Step, StepMetadata,
-    apply_pgo, cargo_profile_var,
+    self, Builder, Cargo as CargoCommand, CommandLineStep, Kind, RunConfig, ShouldRun, Step,
+    StepMetadata, apply_pgo, cargo_profile_var,
 };
 use crate::core::config::{Allocator, DebuginfoLevel, RustcLto, TargetSelection};
 use crate::utils::exec::{BootstrapCommand, command};
 use crate::utils::helpers::{add_dylib_path, exe, t};
-use crate::{Compiler, FileType, Kind, Mode};
+use crate::{Compiler, FileType, Mode};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum SourceType {

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -7,12 +7,12 @@ use crate::core::build_steps::test;
 use crate::core::build_steps::tool::SourceType;
 use crate::core::config::flags::Color;
 use crate::core::config::toml::pgo::PgoConfig;
-use crate::core::config::{CompressDebuginfo, SplitDebuginfo};
+use crate::core::config::{CompressDebuginfo, Config, DryRun, SplitDebuginfo, TargetSelection};
 use crate::utils::build_stamp;
-use crate::utils::helpers::{self, LldThreads, check_cfg_arg, linker_flags};
+use crate::utils::exec::{BootstrapCommand, command};
+use crate::utils::helpers::{self, LldThreads, check_cfg_arg, linker_flags, t};
 use crate::{
-    BootstrapCommand, CLang, Compiler, Config, DryRun, EXTRA_CHECK_CFGS, GitRepo, Mode,
-    RemapScheme, TargetSelection, command, prepare_behaviour_dump_dir, t,
+    CLang, Compiler, EXTRA_CHECK_CFGS, GitRepo, Mode, RemapScheme, prepare_behaviour_dump_dir,
 };
 
 /// Represents flag values in `String` form with a `\x1f` delimiter to pass to the compiler later.

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -13,12 +13,13 @@
 //! and the `bootstrap.toml` file—merging them, applying defaults, and performing
 //! cross-component validation. The main `parse_inner` function and its supporting
 //! helpers reside here, transforming raw `Toml` data into the structured `Config` type.
+
 use std::cell::Cell;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf, absolute};
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::{cmp, env, fs};
 
 use build_helper::ci::CiEnv;
@@ -51,15 +52,13 @@ use crate::core::config::toml::target::{
 use crate::core::config::{
     Allocator, CompilerBuiltins, CompressDebuginfo, DebuggerPath, DebuginfoLevel, DryRun,
     GccCiMode, LlvmLibunwind, Merge, ReplaceOpt, RustcLto, SplitDebuginfo, StringOrBool,
-    threads_from_config,
+    TargetSelection, threads_from_config,
 };
 use crate::core::download::{DownloadContext, download_beta_toolchain, is_download_ci_available};
-use crate::utils::channel;
+use crate::utils::channel::{self, GitInfo};
 use crate::utils::exec::{ExecutionContext, command};
-use crate::utils::helpers::{exe, fail, get_host_target};
-use crate::{
-    CodegenBackendKind, GitInfo, OnceLock, TargetSelection, check_ci_llvm, exit, helpers, t,
-};
+use crate::utils::helpers::{self, exe, fail, get_host_target, t};
+use crate::{CodegenBackendKind, check_ci_llvm, exit};
 
 /// Each path in this list is considered "allowed" in the `download-rustc="if-unchanged"` logic.
 /// This means they can be modified and changes to these paths should never trigger a compiler build

--- a/src/bootstrap/src/core/config/mod.rs
+++ b/src/bootstrap/src/core/config/mod.rs
@@ -28,7 +28,9 @@ mod tests;
 pub mod toml;
 
 use std::collections::HashSet;
+use std::fmt::Display;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 pub use config::*;
 use serde::de::Unexpected;
@@ -40,8 +42,7 @@ pub use toml::change_id::ChangeId;
 pub use toml::rust::BootstrapOverrideLld;
 pub use toml::target::Target;
 
-use crate::str::FromStr;
-use crate::{Display, exit};
+use crate::exit;
 
 // We are using a decl macro instead of a derive proc macro here to reduce the compile time of bootstrap.
 #[macro_export]
@@ -63,8 +64,8 @@ macro_rules! define_config {
         impl Merge for $name {
             fn merge(
                 &mut self,
-                _parent_config_path: Option<PathBuf>,
-                _included_extensions: &mut HashSet<PathBuf>,
+                _parent_config_path: Option<std::path::PathBuf>,
+                _included_extensions: &mut std::collections::HashSet<std::path::PathBuf>,
                 other: Self,
                 replace: ReplaceOpt
             ) {
@@ -87,7 +88,7 @@ macro_rules! define_config {
                                         panic!("overriding existing option")
                                     } else {
                                         eprintln!("overriding existing option: `{}`", stringify!($field));
-                                        exit!(2);
+                                        $crate::exit!(2);
                                     }
                                 } else {
                                     self.$field = other.$field;

--- a/src/bootstrap/src/core/config/target_selection.rs
+++ b/src/bootstrap/src/core/config/target_selection.rs
@@ -1,8 +1,8 @@
-use std::fmt;
+use std::path::Path;
+use std::{env, fmt};
 
 use crate::core::config::SplitDebuginfo;
 use crate::utils::cache::{INTERNER, Interned};
-use crate::{Path, env};
 
 #[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // N.B.: This type is used everywhere, and the entire codebase relies on it being Copy.

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -12,10 +12,11 @@ use super::flags::Flags;
 use super::toml::change_id::ChangeIdWrapper;
 use super::toml::rust::parse_codegen_backends;
 use super::{Config, DebuggerPath, RUSTC_IF_UNCHANGED_ALLOWED_PATHS};
-use crate::ChangeId;
 use crate::core::build_steps::clippy::{LintConfig, get_clippy_rules_in_order};
 use crate::core::build_steps::llvm::LLVM_INVALIDATION_PATHS;
-use crate::core::config::{BootstrapOverrideLld, CompilerBuiltins, Target, TargetSelection};
+use crate::core::config::{
+    BootstrapOverrideLld, ChangeId, CompilerBuiltins, Target, TargetSelection,
+};
 use crate::utils::tests::TestCtx;
 use crate::utils::tests::git::git_test;
 

--- a/src/bootstrap/src/core/config/toml/build.rs
+++ b/src/bootstrap/src/core/config/toml/build.rs
@@ -6,13 +6,14 @@
 //! various feature flags. These options apply across different stages and components
 //! unless specifically overridden by other configuration sections or command-line flags.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 
 use serde::{Deserialize, Deserializer};
 
 use crate::core::config::toml::ReplaceOpt;
 use crate::core::config::{Allocator, CompilerBuiltins, DebuggerPath, Merge, StringOrBool};
-use crate::{HashSet, PathBuf, define_config, exit};
+use crate::define_config;
 
 define_config! {
     /// TOML representation of various global build decisions.

--- a/src/bootstrap/src/core/config/toml/dist.rs
+++ b/src/bootstrap/src/core/config/toml/dist.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Deserializer};
 
 use crate::core::config::Merge;
 use crate::core::config::toml::ReplaceOpt;
-use crate::{HashSet, PathBuf, define_config, exit};
+use crate::define_config;
 
 define_config! {
     #[derive(Default)]

--- a/src/bootstrap/src/core/config/toml/gcc.rs
+++ b/src/bootstrap/src/core/config/toml/gcc.rs
@@ -4,11 +4,13 @@
 //! The `[gcc]` table contains options specifically related to building or
 //! acquiring the GCC compiler for use within the Rust build process.
 
+use std::path::PathBuf;
+
 use serde::{Deserialize, Deserializer};
 
 use crate::core::config::Merge;
 use crate::core::config::toml::ReplaceOpt;
-use crate::{HashSet, PathBuf, define_config, exit};
+use crate::define_config;
 
 define_config! {
     /// TOML representation of how the GCC build is configured.

--- a/src/bootstrap/src/core/config/toml/install.rs
+++ b/src/bootstrap/src/core/config/toml/install.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Deserializer};
 
 use crate::core::config::Merge;
 use crate::core::config::toml::ReplaceOpt;
-use crate::{HashSet, PathBuf, define_config, exit};
+use crate::define_config;
 
 define_config! {
     /// TOML representation of various global install decisions.

--- a/src/bootstrap/src/core/config/toml/llvm.rs
+++ b/src/bootstrap/src/core/config/toml/llvm.rs
@@ -1,11 +1,13 @@
 //! This module defines the `Llvm` struct, which represents the `[llvm]` table
 //! in the `bootstrap.toml` configuration file.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Deserializer};
 
 use crate::core::config::StringOrBool;
 use crate::core::config::toml::{Merge, ReplaceOpt, TomlConfig};
-use crate::{HashMap, HashSet, PathBuf, define_config, exit};
+use crate::define_config;
 
 define_config! {
     /// TOML representation of how the LLVM build is configured.

--- a/src/bootstrap/src/core/config/toml/mod.rs
+++ b/src/bootstrap/src/core/config/toml/mod.rs
@@ -19,6 +19,10 @@ pub mod pgo;
 pub mod rust;
 pub mod target;
 
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
 use build::Build;
 use change_id::{ChangeId, ChangeIdWrapper};
 use dist::Dist;
@@ -29,8 +33,10 @@ use rust::Rust;
 use target::TomlTarget;
 
 use crate::core::config::toml::pgo::Pgo;
-use crate::core::config::{Merge, ReplaceOpt};
-use crate::{Config, HashMap, HashSet, Path, PathBuf, exit, fs, t};
+use crate::core::config::{Config, Merge, ReplaceOpt};
+use crate::exit;
+use crate::utils::change_tracker::{find_recent_config_change_ids, human_readable_changes};
+use crate::utils::helpers::t;
 
 /// Structure of the `bootstrap.toml` file that configuration is read from.
 ///
@@ -183,11 +189,11 @@ impl Config {
                     toml::from_str::<toml::Value>(&contents)
                         .and_then(|table: toml::Value| ChangeIdWrapper::deserialize(table))
                 {
-                    let changes = crate::find_recent_config_change_ids(id);
+                    let changes = find_recent_config_change_ids(id);
                     if !changes.is_empty() {
                         println!(
                             "WARNING: There have been changes to x.py since you last updated:\n{}",
-                            crate::human_readable_changes(changes)
+                            human_readable_changes(changes)
                         );
                     }
                 }

--- a/src/bootstrap/src/core/config/toml/pgo.rs
+++ b/src/bootstrap/src/core/config/toml/pgo.rs
@@ -4,11 +4,13 @@
 //! The `[pgo]` table contains options related PGO (Profile-Guided Optimization) of various
 //! components built by bootstrap.
 
+use std::path::PathBuf;
+
 use serde::{Deserialize, Deserializer};
 
 use crate::core::config::Merge;
 use crate::core::config::toml::ReplaceOpt;
-use crate::{HashSet, PathBuf, define_config, exit};
+use crate::define_config;
 
 #[derive(Clone, Default, Debug, serde_derive::Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -1,12 +1,17 @@
 //! This module defines the `Rust` struct, which represents the `[rust]` table
 //! in the `bootstrap.toml` configuration file.
 
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
 use build_helper::ci::CiEnv;
 use serde::{Deserialize, Deserializer};
 
 use crate::core::config::toml::TomlConfig;
-use crate::core::config::{CompressDebuginfo, DebuginfoLevel, Merge, ReplaceOpt, StringOrBool};
-use crate::{BTreeSet, CodegenBackendKind, HashSet, PathBuf, TargetSelection, define_config, exit};
+use crate::core::config::{
+    CompressDebuginfo, DebuginfoLevel, Merge, ReplaceOpt, StringOrBool, TargetSelection,
+};
+use crate::{CodegenBackendKind, define_config, exit};
 
 define_config! {
     /// TOML representation of how the Rust build is configured.

--- a/src/bootstrap/src/core/config/toml/target.rs
+++ b/src/bootstrap/src/core/config/toml/target.rs
@@ -10,6 +10,7 @@
 //!   build target, which is is stored in the main `Config` structure.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use serde::de::Error;
 use serde::{Deserialize, Deserializer};
@@ -18,7 +19,7 @@ use crate::core::config::{
     Allocator, CompilerBuiltins, CompressDebuginfo, LlvmLibunwind, Merge, ReplaceOpt,
     SplitDebuginfo, StringOrBool,
 };
-use crate::{CodegenBackendKind, HashSet, PathBuf, define_config, exit};
+use crate::{CodegenBackendKind, define_config};
 
 define_config! {
     /// TOML representation of how each build target is configured.

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -13,11 +13,11 @@ use xz2::bufread::XzDecoder;
 
 use crate::core::build_steps::llvm::detect_llvm_freshness;
 use crate::core::config::toml::llvm::check_incompatible_options_for_ci_llvm;
-use crate::core::config::{BUILDER_CONFIG_FILENAME, TargetSelection};
+use crate::core::config::{BUILDER_CONFIG_FILENAME, Config, TargetSelection};
+use crate::exit;
 use crate::utils::build_stamp::BuildStamp;
 use crate::utils::exec::{ExecutionContext, command};
-use crate::utils::helpers::{exe, hex_encode, move_file};
-use crate::{Config, exit, t};
+use crate::utils::helpers::{exe, hex_encode, move_file, t};
 
 static SHOULD_FIX_BINS_AND_DYLIBS: OnceLock<bool> = OnceLock::new();
 

--- a/src/bootstrap/src/core/metadata.rs
+++ b/src/bootstrap/src/core/metadata.rs
@@ -11,7 +11,8 @@ use std::path::PathBuf;
 use serde_derive::Deserialize;
 
 use crate::utils::exec::command;
-use crate::{Build, Crate, t};
+use crate::utils::helpers::t;
+use crate::{Build, Crate};
 
 /// For more information, see the output of
 /// <https://doc.rust-lang.org/nightly/cargo/commands/cargo-metadata.html>

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -14,11 +14,12 @@ use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::{env, fs};
 
-use crate::builder::Builder;
+use crate::Build;
 use crate::core::build_steps::tool;
-use crate::core::config::{CompilerBuiltins, DebuggerPath, Target};
+use crate::core::builder::Builder;
+use crate::core::config::{CompilerBuiltins, DebuggerPath, Subcommand, Target};
 use crate::utils::exec::command;
-use crate::{Build, Subcommand, t};
+use crate::utils::helpers::t;
 
 pub struct Finder {
     cache: HashMap<OsString, Option<PathBuf>>,

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -33,21 +33,14 @@ use tracing::{instrument, span};
 
 use crate::core::build_steps::format::InternalRustfmt;
 use crate::core::build_steps::vendor::VENDOR_DIR;
-#[cfg(feature = "tracing")]
-use crate::core::builder::STEP_SPAN_TARGET;
-use crate::core::builder::{self, Kind, StepStack};
-use crate::core::config::flags::{Flags, Subcommand};
-use crate::core::config::{
-    BootstrapOverrideLld, ChangeId, Config, DryRun, LlvmLibunwind, TargetSelection, flags,
-};
+use crate::core::builder::{self, Kind};
+use crate::core::config::flags::{self, Subcommand};
+use crate::core::config::{BootstrapOverrideLld, Config, DryRun, LlvmLibunwind, TargetSelection};
 use crate::utils::build_stamp::BuildStamp;
-use crate::utils::change_tracker::{
-    CONFIG_CHANGE_HISTORY, find_recent_config_change_ids, human_readable_changes,
-};
 use crate::utils::channel::GitInfo;
 use crate::utils::exec::{BootstrapCommand, ExecutionContext, command};
 use crate::utils::helpers::{
-    self, PanicTracker, dir_is_empty, exe, libdir, set_file_times, split_debuginfo, symlink_dir,
+    self, dir_is_empty, exe, libdir, set_file_times, split_debuginfo, symlink_dir, t,
 };
 
 pub mod cli_main;

--- a/src/bootstrap/src/utils/build_stamp.rs
+++ b/src/bootstrap/src/utils/build_stamp.rs
@@ -9,8 +9,8 @@ use sha2::digest::Digest;
 
 use crate::core::builder::Builder;
 use crate::core::config::TargetSelection;
-use crate::utils::helpers::{hex_encode, mtime};
-use crate::{CodegenBackendKind, Compiler, Mode, helpers, t};
+use crate::utils::helpers::{self, hex_encode, mtime, t};
+use crate::{CodegenBackendKind, Compiler, Mode};
 
 #[cfg(test)]
 mod tests;

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -25,7 +25,7 @@ use std::collections::HashSet;
 use std::iter;
 use std::path::{Path, PathBuf};
 
-use crate::core::config::{CompressDebuginfo, TargetSelection};
+use crate::core::config::{CompressDebuginfo, Subcommand, TargetSelection};
 use crate::utils::exec::{BootstrapCommand, command};
 use crate::{Build, CLang, GitRepo};
 
@@ -70,10 +70,10 @@ fn new_cc_build(build: &Build, target: TargetSelection) -> cc::Build {
 pub fn fill_compilers(build: &mut Build) {
     let targets: HashSet<_> = match build.config.cmd {
         // We don't need to check cross targets for these commands.
-        crate::Subcommand::Clean { .. }
-        | crate::Subcommand::Check { .. }
-        | crate::Subcommand::Format { .. }
-        | crate::Subcommand::Setup { .. } => {
+        Subcommand::Clean { .. }
+        | Subcommand::Check { .. }
+        | Subcommand::Format { .. }
+        | Subcommand::Setup { .. } => {
             build.hosts.iter().cloned().chain(iter::once(build.host_target)).collect()
         }
 

--- a/src/bootstrap/src/utils/change_tracker/tests.rs
+++ b/src/bootstrap/src/utils/change_tracker/tests.rs
@@ -1,4 +1,4 @@
-use crate::{CONFIG_CHANGE_HISTORY, find_recent_config_change_ids};
+use super::{CONFIG_CHANGE_HISTORY, find_recent_config_change_ids};
 
 #[test]
 fn test_find_recent_config_change_ids() {

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -15,7 +15,7 @@ use std::fs::File;
 use std::hash::Hash;
 use std::io::{BufWriter, Write};
 use std::panic::Location;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{
     Child, ChildStderr, ChildStdout, Command, CommandArgs, CommandEnvs, ExitStatus, Output, Stdio,
 };
@@ -25,7 +25,8 @@ use std::time::{Duration, Instant};
 use build_helper::drop_bomb::DropBomb;
 
 use crate::core::config::DryRun;
-use crate::{PathBuf, exit, t};
+use crate::exit;
+use crate::utils::helpers::t;
 
 /// What should be done when the command fails.
 #[derive(Debug, Copy, Clone)]

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -14,10 +14,10 @@ use build_helper::ci::CiEnv;
 use object::read::archive::ArchiveFile;
 pub(crate) use shim_utils::{dylib_path, dylib_path_var};
 
-use crate::core::builder::Builder;
-use crate::core::config::{Config, TargetSelection};
+pub(crate) use self::macros::t;
+use crate::core::builder::{Builder, StepStack};
+use crate::core::config::{BootstrapOverrideLld, Config, TargetSelection};
 use crate::utils::exec::{BootstrapCommand, command};
-use crate::{BootstrapOverrideLld, StepStack};
 
 #[cfg(test)]
 mod tests;
@@ -39,34 +39,36 @@ impl Drop for PanicTracker<'_> {
     }
 }
 
-/// A helper macro to `unwrap` a result except also print out details like:
-///
-/// * The file/line of the panic
-/// * The expression that failed
-/// * The error itself
-///
-/// This is currently used judiciously throughout the build system rather than
-/// using a `Result` with `try!`, but this may change one day...
-#[macro_export]
-macro_rules! t {
-    ($e:expr) => {{
-        let _panic_guard = $crate::PanicTracker(std::panic::Location::caller());
-        match $e {
-            Ok(e) => e,
-            Err(e) => panic!("{} failed with {}", stringify!($e), e),
-        }
-    }};
-    // it can show extra info in the second parameter
-    ($e:expr, $extra:expr) => {{
-        let _panic_guard = $crate::PanicTracker(std::panic::Location::caller());
-        match $e {
-            Ok(e) => e,
-            Err(e) => panic!("{} failed with {} ({:?})", stringify!($e), e, $extra),
-        }
-    }};
+mod macros {
+    /// A helper macro to `unwrap` a result except also print out details like:
+    ///
+    /// * The file/line of the panic
+    /// * The expression that failed
+    /// * The error itself
+    ///
+    /// This is currently used judiciously throughout the build system rather than
+    /// using a `Result` with `try!`, but this may change one day...
+    macro_rules! t {
+        ($e:expr) => {{
+            let _panic_guard = $crate::utils::helpers::PanicTracker(std::panic::Location::caller());
+            match $e {
+                Ok(e) => e,
+                Err(e) => panic!("{} failed with {}", stringify!($e), e),
+            }
+        }};
+        // it can show extra info in the second parameter
+        ($e:expr, $extra:expr) => {{
+            let _panic_guard = $crate::utils::helpers::PanicTracker(std::panic::Location::caller());
+            match $e {
+                Ok(e) => e,
+                Err(e) => panic!("{} failed with {} ({:?})", stringify!($e), e, $extra),
+            }
+        }};
+    }
+
+    pub(crate) use t;
 }
 
-pub use t;
 pub fn exe(name: &str, target: TargetSelection) -> String {
     shim_utils::exe(name, &target.triple)
 }

--- a/src/bootstrap/src/utils/tests/mod.rs
+++ b/src/bootstrap/src/utils/tests/mod.rs
@@ -4,7 +4,8 @@ use std::path::{Path, PathBuf};
 
 use tempfile::TempDir;
 
-use crate::{Config, Flags};
+use crate::core::config::Config;
+use crate::core::config::flags::Flags;
 
 pub mod git;
 mod shim_utils_tests;

--- a/src/bootstrap/src/utils/tracing.rs
+++ b/src/bootstrap/src/utils/tracing.rs
@@ -117,7 +117,7 @@ mod inner {
     use tracing_subscriber::{EnvFilter, Layer};
 
     use super::{COMMAND_SPAN_TARGET, IO_SPAN_TARGET};
-    use crate::STEP_SPAN_TARGET;
+    use crate::core::builder::STEP_SPAN_TARGET;
 
     pub fn setup_tracing(env_name: &str) -> TracingGuard {
         let filter = EnvFilter::from_env(env_name);


### PR DESCRIPTION
One of the unfortunate side-effects of having non-trivial code in the crate root is that any imports they need also function as crate-wide re-exports, gunking up import paths throughout the crate.

---

There is more import cleanup that could be done, along with related tasks like moving items out of `lib.rs` or reducing item visibility. I decided to stop here to avoid cramming too much into one PR.

There should be no changes to bootstrap's behaviour.