### PR TITLE
std: map ERROR_NEGATIVE_SEEK to ErrorKind::InvalidInput on Windows

### DIFF
--- a/library/std/src/sys/io/error/windows.rs
+++ b/library/std/src/sys/io/error/windows.rs
@@ -65,6 +65,7 @@ pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
         c::ERROR_FILENAME_EXCED_RANGE => return InvalidFilename,
         c::ERROR_CANT_RESOLVE_FILENAME => return FilesystemLoop,
         c::ERROR_IO_DEVICE => return InputOutputError,
+        c::ERROR_NEGATIVE_SEEK => return InvalidInput,
         _ => {}
     }
 


### PR DESCRIPTION
Windows error mapping doesn't have an arm for `ERROR_NEGATIVE_SEEK`, the code returned when using negative seek position, so it decodes to `ErrorKind::Uncategorized`.

On unix negative seek is `EINVAL`:
[> EINVAL whence is not valid.  Or: the resulting file offset would be negative, or beyond the end of a seekable device.](https://www.man7.org/linux/man-pages/man2/lseek.2.html) 
And is mapped to [InvalidInput](https://github.com/rust-lang/rust/blob/e64c8a664d9da54fc239cd4404cbf67f0d624326/library/std/src/sys/io/error/unix.rs#L154) error.

On Windows there is `ERROR_NEGATIVE_SEEK` [windows_sys.rs#L1829](https://github.com/rust-lang/rust/blob/e64c8a664d9da54fc239cd4404cbf67f0d624326/library/std/src/sys/pal/windows/c/windows_sys.rs#L1829).

The message on Windows would still be more specific and detailed for this error. Both messages come from the OS itself, so not sure if it could be addressed somehow. Looks like Unix has more coarse error codes than Windows, which uses more granular ones with more precise messages: `EINVAL` is shared across many syscalls, so its message is more general.

Windows:
`kind: InvalidInput, message: "An attempt was made to move the file pointer before the beginning of the file."`
Unix:
`kind: InvalidInput, message: "Invalid argument" `

Fixes rust-lang/rust#158246

r? libs
