### PR TITLE
Add missing reverse PartialEq impls for Cow

### DIFF
--- a/library/alloc/src/vec/partial_eq.rs
+++ b/library/alloc/src/vec/partial_eq.rs
@@ -32,6 +32,12 @@ __impl_slice_eq1! { [A: Allocator] Cow<'_, [T]>, Vec<U, A> where T: Clone, #[sta
 __impl_slice_eq1! { [] Cow<'_, [T]>, &[U] where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
 #[cfg(not(no_global_oom_handling))]
 __impl_slice_eq1! { [] Cow<'_, [T]>, &mut [U] where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
+#[cfg(not(no_global_oom_handling))]
+__impl_slice_eq1! { [A: Allocator] Vec<T, A>, Cow<'_, [U]> where U: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
+#[cfg(not(no_global_oom_handling))]
+__impl_slice_eq1! { [] &[T], Cow<'_, [U]> where U: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
+#[cfg(not(no_global_oom_handling))]
+__impl_slice_eq1! { [] &mut [T], Cow<'_, [U]> where U: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
 __impl_slice_eq1! { const, [A: Allocator, const N: usize] Vec<T, A>, [U; N], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
 __impl_slice_eq1! { const, [A: Allocator, const N: usize] Vec<T, A>, &[U; N], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
 

--- a/library/alloctests/tests/vec.rs
+++ b/library/alloctests/tests/vec.rs
@@ -2198,6 +2198,16 @@ fn partialeq_vec_full() {
     assert_partial_eq_valid!(vec2,vec3; array2,array3);
     assert_partial_eq_valid!(vec2,vec3; arrayref2,arrayref3);
     assert_partial_eq_valid!(vec2,vec3; arrayref2[..],arrayref3[..]);
+
+    let cow2: Cow<'_, [i32]> = Cow::from(vec![1, 2]);
+    let cow3: Cow<'_, [i32]> = Cow::from(vec![1, 2, 3]);
+
+    assert_partial_eq_valid!(vec2,vec3; cow2,cow3);
+    assert_partial_eq_valid!(slice2,slice3; cow2,cow3);
+    assert_partial_eq_valid!(slicemut2,slicemut3; cow2,cow3);
+    assert_partial_eq_valid!(cow2,cow3; vec2,vec3);
+    assert_partial_eq_valid!(cow2,cow3; slice2,slice3);
+    assert_partial_eq_valid!(cow2,cow3; slicemut2,slicemut3);
 }
 
 #[test]

--- a/tests/ui/consts/too_generic_eval_ice.current.stderr
+++ b/tests/ui/consts/too_generic_eval_ice.current.stderr
@@ -30,15 +30,15 @@ LL |         [5; Self::HOST_SIZE] == [6; 0]
    |
    = help: the trait `PartialEq<[{integer}; 0]>` is not implemented for `[{integer}; Self::HOST_SIZE]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             `&[T]` implements `PartialEq<Cow<'_, [U]>>`
              `&[T]` implements `PartialEq<Vec<U, A>>`
              `&[T]` implements `PartialEq<[U; N]>`
              `&[u8; N]` implements `PartialEq<ByteStr>`
              `&[u8; N]` implements `PartialEq<ByteString>`
              `&[u8]` implements `PartialEq<ByteStr>`
              `&[u8]` implements `PartialEq<ByteString>`
-             `&mut [T]` implements `PartialEq<Vec<U, A>>`
-             `&mut [T]` implements `PartialEq<[U; N]>`
-           and 11 others
+             `&mut [T]` implements `PartialEq<Cow<'_, [U]>>`
+           and 13 others
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/macros/assert-ne-no-invalid-help-issue-146204.stderr
+++ b/tests/ui/macros/assert-ne-no-invalid-help-issue-146204.stderr
@@ -6,15 +6,15 @@ LL |     assert_ne!(buf, b"----");
    |
    = help: the trait `PartialEq<&[u8; 4]>` is not implemented for `[u8; 4]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             `&[T]` implements `PartialEq<Cow<'_, [U]>>`
              `&[T]` implements `PartialEq<Vec<U, A>>`
              `&[T]` implements `PartialEq<[U; N]>`
              `&[u8; N]` implements `PartialEq<ByteStr>`
              `&[u8; N]` implements `PartialEq<ByteString>`
              `&[u8]` implements `PartialEq<ByteStr>`
              `&[u8]` implements `PartialEq<ByteString>`
-             `&mut [T]` implements `PartialEq<Vec<U, A>>`
-             `&mut [T]` implements `PartialEq<[U; N]>`
-           and 11 others
+             `&mut [T]` implements `PartialEq<Cow<'_, [U]>>`
+           and 13 others
 
 error[E0277]: can't compare `[u8; 4]` with `&[u8; 4]`
   --> $DIR/assert-ne-no-invalid-help-issue-146204.rs:19:5
@@ -24,15 +24,15 @@ LL |     assert_eq!(buf, b"----");
    |
    = help: the trait `PartialEq<&[u8; 4]>` is not implemented for `[u8; 4]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             `&[T]` implements `PartialEq<Cow<'_, [U]>>`
              `&[T]` implements `PartialEq<Vec<U, A>>`
              `&[T]` implements `PartialEq<[U; N]>`
              `&[u8; N]` implements `PartialEq<ByteStr>`
              `&[u8; N]` implements `PartialEq<ByteString>`
              `&[u8]` implements `PartialEq<ByteStr>`
              `&[u8]` implements `PartialEq<ByteString>`
-             `&mut [T]` implements `PartialEq<Vec<U, A>>`
-             `&mut [T]` implements `PartialEq<[U; N]>`
-           and 11 others
+             `&mut [T]` implements `PartialEq<Cow<'_, [U]>>`
+           and 13 others
 
 error[E0277]: can't compare `[u8; 4]` with `&[u8; 4]`
   --> $DIR/assert-ne-no-invalid-help-issue-146204.rs:5:30


### PR DESCRIPTION
Closes rust-lang/rust#152830

Implements the Cow-related cases that rust-lang/rust#152972 doesn't cover:

- impl PartialEq<Cow<'_, [U]>> for Vec<T, A>
- impl PartialEq<Cow<'_, [U]>> for &[T]
- impl PartialEq<Cow<'_, [U]>> for &mut [T]

Without these, expressions like `vec == cow` or `slice == cow` fail to compile.