### PR TITLE
Remove target argument from get_proc_macros

### DIFF
--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -970,17 +970,19 @@ fn get_flavor_from_path(path: &Path) -> CrateFlavor {
     }
 }
 
-/// A function to fetch about all macros inside a proc-macro crate.
+/// A function to fetch all macros inside a proc-macro crate.
 ///
 /// Used by rust-analyzer-proc-macro-srv.
 pub fn get_proc_macros(
-    target: &Target,
     path: &Path,
     metadata_loader: &dyn MetadataLoader,
     cfg_version: &'static str,
 ) -> IoResult<Vec<(ProcMacroClient, ProcMacroKind)>> {
+    let host_tuple = TargetTuple::from_tuple(config::host_tuple());
+    let (host, _) = Target::search(&host_tuple, Path::new(""), false).unwrap();
+
     let metadata =
-        get_metadata_section(target, CrateFlavor::Dylib, path, metadata_loader, cfg_version, None)
+        get_metadata_section(&host, CrateFlavor::Dylib, path, metadata_loader, cfg_version, None)
             .map_err(|err| io::Error::other(err.to_string()))?;
     let stable_crate_id = metadata.get_root().stable_crate_id();
 

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
@@ -5,9 +5,6 @@ mod proc_macros;
 use rustc_codegen_ssa::back::metadata::DefaultMetadataLoader;
 use rustc_interface::util::rustc_version_str;
 use rustc_proc_macro::bridge;
-use rustc_session::config::host_tuple;
-use rustc_target::spec::{Target, TargetTuple};
-use std::path::Path;
 use std::{fs, io, time::SystemTime};
 use temp_dir::TempDir;
 
@@ -78,11 +75,7 @@ struct ProcMacroLibrary {
 impl ProcMacroLibrary {
     fn open(path: &Utf8Path) -> io::Result<Self> {
         let proc_macros = rustc_span::create_default_session_globals_then(|| {
-            let (target, _) =
-                Target::search(&TargetTuple::from_tuple(host_tuple()), Path::new(""), false)
-                    .unwrap();
             rustc_metadata::locator::get_proc_macros(
-                &target,
                 path.as_ref(),
                 &DefaultMetadataLoader,
                 rustc_version_str().unwrap_or("unknown"),

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
@@ -21,9 +21,7 @@ extern crate rustc_interface;
 extern crate rustc_lexer;
 extern crate rustc_metadata;
 extern crate rustc_proc_macro;
-extern crate rustc_session;
 extern crate rustc_span;
-extern crate rustc_target;
 
 mod bridge;
 mod dylib;


### PR DESCRIPTION
Currently it will always load proc-macros for the host. In the future it may also start loading wasm proc-macros. This way rust-analyzer doesn't have to pick between both options itself.

Part of https://github.com/rust-lang/rust/issues/160389