### PR TITLE
move resolve_path to Session inherent method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4599,7 +4599,6 @@ dependencies = [
  "rustc_crate_store",
  "rustc_data_structures",
  "rustc_errors",
- "rustc_expand",
  "rustc_feature",
  "rustc_hir",
  "rustc_index",

--- a/compiler/rustc_builtin_macros/src/source_util.rs
+++ b/compiler/rustc_builtin_macros/src/source_util.rs
@@ -9,7 +9,7 @@ use rustc_ast::tokenstream::TokenStream;
 use rustc_ast::{join_path_idents, token};
 use rustc_ast_pretty::pprust;
 use rustc_expand::base::{
-    DummyResult, ExpandResult, ExtCtxt, MacEager, MacResult, MacroExpanderResult, resolve_path,
+    DummyResult, ExpandResult, ExtCtxt, MacEager, MacResult, MacroExpanderResult,
 };
 use rustc_expand::module::DirOwnership;
 use rustc_parse::lexer::StripTokens;
@@ -117,7 +117,7 @@ pub(crate) fn expand_include<'cx>(
         Err(guar) => return ExpandResult::Ready(DummyResult::any(sp, guar)),
     };
     // The file will be added to the code map by the parser
-    let path = match resolve_path(&cx.sess, path.as_str(), sp) {
+    let path = match cx.sess.resolve_path(path.as_str(), sp) {
         Ok(path) => path,
         Err(err) => {
             let guar = err.emit();
@@ -267,7 +267,7 @@ fn load_binary_file(
     macro_span: Span,
     path_span: Span,
 ) -> Result<(Arc<[u8]>, Span), Box<dyn MacResult>> {
-    let resolved_path = match resolve_path(&cx.sess, original_path, macro_span) {
+    let resolved_path = match cx.sess.resolve_path(original_path, macro_span) {
         Ok(path) => path,
         Err(err) => {
             let guar = err.emit();

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1,7 +1,6 @@
 use std::any::Any;
 use std::default::Default;
 use std::iter;
-use std::path::Component::Prefix;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -15,7 +14,7 @@ use rustc_attr_ir::{
 };
 use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
 use rustc_data_structures::{Limit, sync};
-use rustc_errors::{BufferedEarlyLint, DiagCtxtHandle, ErrorGuaranteed, PResult};
+use rustc_errors::{BufferedEarlyLint, DiagCtxtHandle, ErrorGuaranteed};
 use rustc_feature::Features;
 use rustc_hir::def::MacroKinds;
 use rustc_lint_defs::RegisteredTools;
@@ -1339,37 +1338,5 @@ impl<'a> ExtCtxt<'a> {
 
     pub fn check_unused_macros(&mut self) {
         self.resolver.check_unused_macros();
-    }
-}
-
-/// Resolves a `path` mentioned inside Rust code, returning an absolute path.
-///
-/// This unifies the logic used for resolving `include_X!`.
-pub fn resolve_path(sess: &Session, path: impl Into<PathBuf>, span: Span) -> PResult<'_, PathBuf> {
-    let path = path.into();
-
-    // Relative paths are resolved relative to the file in which they are found
-    // after macro expansion (that is, they are unhygienic).
-    if !path.is_absolute() {
-        let callsite = span.source_callsite();
-        let source_map = sess.source_map();
-        let Some(mut base_path) = source_map.span_to_filename(callsite).into_local_path() else {
-            return Err(sess.dcx().create_err(diagnostics::ResolveRelativePath {
-                span,
-                path: source_map
-                    .filename_for_diagnostics(&source_map.span_to_filename(callsite))
-                    .to_string(),
-            }));
-        };
-        base_path.pop();
-        base_path.push(path);
-        Ok(base_path)
-    } else {
-        // This ensures that Windows verbatim paths are fixed if mixed path separators are used,
-        // which can happen when `concat!` is used to join paths.
-        match path.components().next() {
-            Some(Prefix(prefix)) if prefix.kind().is_verbatim() => Ok(path.components().collect()),
-            _ => Ok(path),
-        }
     }
 }

--- a/compiler/rustc_expand/src/diagnostics.rs
+++ b/compiler/rustc_expand/src/diagnostics.rs
@@ -125,14 +125,6 @@ pub(crate) struct UnknownMacroVariable {
 }
 
 #[derive(Diagnostic)]
-#[diag("cannot resolve relative path in non-file source `{$path}`")]
-pub(crate) struct ResolveRelativePath {
-    #[primary_span]
-    pub span: Span,
-    pub path: String,
-}
-
-#[derive(Diagnostic)]
 #[diag("macros cannot have body stability attributes")]
 pub(crate) struct MacroBodyStability {
     #[primary_span]

--- a/compiler/rustc_passes/Cargo.toml
+++ b/compiler/rustc_passes/Cargo.toml
@@ -12,7 +12,6 @@ rustc_attr_parsing = { path = "../rustc_attr_parsing" }
 rustc_crate_store = { path = "../rustc_crate_store" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
-rustc_expand = { path = "../rustc_expand" }
 rustc_feature = { path = "../rustc_feature" }
 rustc_hir = { path = "../rustc_hir" }
 rustc_index = { path = "../rustc_index" }

--- a/compiler/rustc_passes/src/debugger_visualizer.rs
+++ b/compiler/rustc_passes/src/debugger_visualizer.rs
@@ -2,7 +2,6 @@
 
 use rustc_ast::{ItemKind, ast};
 use rustc_attr_parsing::AttributeParser;
-use rustc_expand::base::resolve_path;
 use rustc_hir::Attribute;
 use rustc_hir::attrs::{AttributeKind, DebugVisualizer};
 use rustc_middle::middle::debugger_visualizer::DebuggerVisualizerFile;
@@ -19,7 +18,7 @@ impl DebuggerVisualizerCollector<'_> {
             AttributeParser::parse_limited_sym(&self.sess, attrs, &[sym::debugger_visualizer])
         {
             for DebugVisualizer { span, visualizer_type, path } in visualizers {
-                let file = match resolve_path(&self.sess, path.as_str(), span) {
+                let file = match self.sess.resolve_path(path.as_str(), span) {
                     Ok(file) => file,
                     Err(err) => {
                         err.emit();

--- a/compiler/rustc_session/src/diagnostics.rs
+++ b/compiler/rustc_session/src/diagnostics.rs
@@ -721,3 +721,11 @@ pub(crate) struct NativeTargetCpuNotAllowed<'a> {
     pub(crate) target_triple: &'a TargetTuple,
     pub(crate) need_explicit_cpu: bool,
 }
+
+#[derive(Diagnostic)]
+#[diag("cannot resolve relative path in non-file source `{$path}`")]
+pub(crate) struct ResolveRelativePath {
+    #[primary_span]
+    pub span: Span,
+    pub path: String,
+}

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -776,7 +776,7 @@ impl Session {
 
     /// Resolves a `path` mentioned inside Rust code, returning an absolute path.
     ///
-    /// This unifies the logic used for resolving `include_X!`.
+    /// This unifies the logic used for resolving `include_*!` and debugger visualizers.
     pub fn resolve_path(&self, path: impl Into<PathBuf>, span: Span) -> PResult<'_, PathBuf> {
         let path = path.into();
 

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::path::Component::Prefix;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -15,7 +16,7 @@ use rustc_errors::emitter::{DynEmitter, HumanReadableErrorType, OutputTheme, std
 use rustc_errors::json::JsonEmitter;
 use rustc_errors::timings::TimingSectionHandler;
 use rustc_errors::{
-    Diag, DiagCtxt, DiagCtxtHandle, DiagMessage, Diagnostic, ErrorGuaranteed, FatalAbort,
+    Diag, DiagCtxt, DiagCtxtHandle, DiagMessage, Diagnostic, ErrorGuaranteed, FatalAbort, PResult,
     TerminalUrl,
 };
 use rustc_feature::UnstableFeatures;
@@ -770,6 +771,41 @@ impl Session {
         match self.lint_store {
             Some(ref lint_store) => lint_store.lint_groups_iter(),
             None => Box::new(std::iter::empty()),
+        }
+    }
+
+    /// Resolves a `path` mentioned inside Rust code, returning an absolute path.
+    ///
+    /// This unifies the logic used for resolving `include_X!`.
+    pub fn resolve_path(&self, path: impl Into<PathBuf>, span: Span) -> PResult<'_, PathBuf> {
+        let path = path.into();
+
+        // Relative paths are resolved relative to the file in which they are found
+        // after macro expansion (that is, they are unhygienic).
+        if !path.is_absolute() {
+            let callsite = span.source_callsite();
+            let source_map = self.source_map();
+            let Some(mut base_path) = source_map.span_to_filename(callsite).into_local_path()
+            else {
+                return Err(self.dcx().create_err(diagnostics::ResolveRelativePath {
+                    span,
+                    path: source_map
+                        .filename_for_diagnostics(&source_map.span_to_filename(callsite))
+                        .to_string(),
+                }));
+            };
+            base_path.pop();
+            base_path.push(path);
+            Ok(base_path)
+        } else {
+            // This ensures that Windows verbatim paths are fixed if mixed path separators are used,
+            // which can happen when `concat!` is used to join paths.
+            match path.components().next() {
+                Some(Prefix(prefix)) if prefix.kind().is_verbatim() => {
+                    Ok(path.components().collect())
+                }
+                _ => Ok(path),
+            }
         }
     }
 }


### PR DESCRIPTION
rustc_passes depends on rustc_expand just for this, which is imo unnecessary.
