### PR TITLE
resolve: fix stack overflow on cyclic ambiguous glob reexports

### DIFF
--- a/compiler/rustc_resolve/src/effective_visibilities.rs
+++ b/compiler/rustc_resolve/src/effective_visibilities.rs
@@ -92,10 +92,14 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
         };
 
         visitor.def_effective_visibilities.update_root();
-        visitor.set_bindings_effective_visibilities(CRATE_DEF_ID);
 
         while visitor.changed {
             visitor.changed = false;
+            // The crate root walks in every iteration like any other module
+            // (`visit_item` re-walks nested modules): `update_decl_chain` visits
+            // each declaration at most once per walk, so anything it skips in
+            // one iteration must be re-attempted until nothing changes.
+            visitor.set_bindings_effective_visibilities(CRATE_DEF_ID);
             visit::walk_crate(&mut visitor, krate);
         }
         visitor.r.effective_visibilities = visitor.def_effective_visibilities;
@@ -137,12 +141,29 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
     /// Set the given effective visibility level to `Level::Direct` and
     /// sets the rest of the `use` chain to `Level::Reexported` until
     /// we hit the actual exported item.
-    fn update_decl_chain(&mut self, mut decl: Decl<'ra>, mut parent_id: ParentId<'ra>) {
+    fn update_decl_chain(&mut self, decl: Decl<'ra>, parent_id: ParentId<'ra>) {
+        self.update_decl_chain_inner(decl, parent_id, &mut Default::default());
+    }
+
+    fn update_decl_chain_inner(
+        &mut self,
+        mut decl: Decl<'ra>,
+        mut parent_id: ParentId<'ra>,
+        visited: &mut FxHashSet<Decl<'ra>>,
+    ) {
         let priv_vis = |this: &Self, parent_id, decl| match parent_id {
             ParentId::Def(_) => this.current_private_vis,
             ParentId::Import(_) => this.r.private_vis_decl(decl),
         };
         while let DeclKind::Import { source_decl, .. } = decl.kind {
+            // Ambiguous glob imports can form cyclic reexport chains: following
+            // `ambiguity_vis_max` below may lead back to a declaration this walk
+            // has already updated. Visit each declaration at most once
+            // per walk — any update a skip leaves behind is picked up by the
+            // next `changed` iteration in `compute_effective_visibilities`.
+            if !visited.insert(decl) {
+                return;
+            }
             self.update_import(decl, parent_id, priv_vis(self, parent_id, decl));
             if let Some(max_vis_decl) = decl.ambiguity_vis_max.get() {
                 // The name is exported with the visibility of the most visible declaration
@@ -154,7 +175,7 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
                 // `ambiguous-import-visibility-globglob-mir.rs`).
                 // This also avoids the most visible import in an ambiguous glob set
                 // being reported as unused.
-                self.update_decl_chain(max_vis_decl, parent_id);
+                self.update_decl_chain_inner(max_vis_decl, parent_id, visited);
             }
             parent_id = ParentId::Import(decl);
             decl = source_decl;

--- a/tests/ui/imports/ambiguous-import-visibility-globglob-cycle.rs
+++ b/tests/ui/imports/ambiguous-import-visibility-globglob-cycle.rs
@@ -1,0 +1,32 @@
+// Regression test for #160685: ambiguous glob imports whose reexport chains
+// form a cycle (`axiomatic` and `own` glob-import each other, and the same
+// item also arrives through `orphan`) sent `update_decl_chain` into infinite
+// recursion through `ambiguity_vis_max`, overflowing the stack. Each
+// declaration is now visited at most once per chain walk; the effective
+// visibility fixpoint loop picks up anything a skipped revisit would have
+// contributed. Minimized from the `reflect_tools` crate by @theemathas.
+
+//@ check-pass
+//@ edition: 2024
+
+pub mod axiomatic {
+    use super::*; // not pub
+    pub use own::*;
+
+    pub mod own {
+        pub use super::*;
+        pub use orphan::*;
+    }
+
+    pub mod orphan {
+        pub use super::private::CollectionDescriptor;
+    }
+
+    pub mod private {
+        pub struct CollectionDescriptor;
+    }
+}
+
+pub use axiomatic::orphan::*;
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#160685 (1.98 beta regression from rust-lang/rust#159039, found by the crater run).

rust-lang/rust#159039 made `update_decl_chain` follow `ambiguity_vis_max` recursively, so the most visible declaration's whole reexport chain gets its effective visibility. But ambiguous glob imports can form cycles, in the minimized example two modules glob-import each other and the same item also arrives through a third, and on such a cycle the recursion never terminates, so rustc overflows its stack.

Fix, two parts that belong together:

- Each chain walk now visits a declaration at most once (a visited set threaded through the recursion). This breaks the cycle.
- Skipping a revisit can leave one update behind within that single walk, so the crate root's bindings now walk inside the `changed` fixpoint loop like every other module's bindings already do. Anything a walk skips is re-attempted until nothing changes, so the final table is unchanged for code that compiled before.

The minimized reproducer from the issue is added as a `check-pass` test. `tests/ui/{imports,privacy,resolve}` pass with the rust-lang/rust#159039 regression tests unmodified, and a crate depending on `reflect_tools 0.4.0` (the crater trigger) compiles again.

Since the regression ships in 1.98 otherwise, nominating for beta backport.

@rustbot label +A-resolve +A-visibility +T-compiler +beta-nominated
