### PR TITLE
Move `LateParamRegion` to `rustc_type_ir`

### DIFF
--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -121,7 +121,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     type ScalarInt = ty::ScalarInt;
     type InternedRegionKind = Interned<'tcx, ty::RegionKind<'tcx>>;
     type EarlyParamRegion = ty::EarlyParamRegion;
-    type LateParamRegion = ty::LateParamRegion;
+    type LateParamRegionKind = ty::LateParamRegionKind;
 
     type RegionAssumptions = &'tcx ty::List<ty::ArgOutlivesClause<'tcx>>;
 

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -3,12 +3,15 @@ use rustc_hir::def_id::DefId;
 use rustc_macros::{StableHash, TyDecodable, TyEncodable, extension};
 use rustc_span::{DUMMY_SP, ErrorGuaranteed, Symbol, kw, sym};
 pub use rustc_type_ir::RegionVid;
-use rustc_type_ir::{Region as IrRegion, RegionKind as IrRegionKind};
+use rustc_type_ir::{
+    LateParamRegion as IrLateParamRegion, Region as IrRegion, RegionKind as IrRegionKind,
+};
 
 use crate::ty::{self, BoundVar, TyCtxt};
 
 pub type Region<'tcx> = IrRegion<TyCtxt<'tcx>>;
 pub type RegionKind<'tcx> = IrRegionKind<TyCtxt<'tcx>>;
+pub type LateParamRegion<'tcx> = IrLateParamRegion<TyCtxt<'tcx>>;
 
 #[extension(pub trait RegionExt<'tcx>)]
 impl<'tcx> Region<'tcx> {
@@ -168,21 +171,6 @@ impl std::fmt::Debug for EarlyParamRegion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}/#{}", self.name, self.index)
     }
-}
-
-#[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable, Copy)]
-#[derive(StableHash)]
-/// The parameter representation of late-bound function parameters, "some region
-/// at least as big as the scope `fr.scope`".
-///
-/// Similar to a placeholder region as we create `LateParam` regions when entering a binder
-/// except they are always in the root universe and instead of using a boundvar to distinguish
-/// between others we use the `DefId` of the parameter. For this reason the `bound_region` field
-/// should basically always be `BoundRegionKind::Named` as otherwise there is no way of telling
-/// different parameters apart.
-pub struct LateParamRegion {
-    pub scope: DefId,
-    pub kind: LateParamRegionKind,
 }
 
 /// When liberating bound regions, we map their [`ty::BoundRegionKind`]

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -64,12 +64,6 @@ impl<'tcx> fmt::Debug for ty::adjustment::PatAdjustment<'tcx> {
     }
 }
 
-impl fmt::Debug for ty::LateParamRegion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ReLateParam({:?}, {:?})", self.scope, self.kind)
-    }
-}
-
 impl fmt::Debug for ty::LateParamRegionKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
@@ -265,7 +259,6 @@ TrivialTypeTraversalAndLiftImpls! {
 TrivialLiftImpls! {
     rustc_span::ErrorGuaranteed,
     ty::EarlyParamRegion,
-    ty::LateParamRegion,
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -5,6 +5,7 @@ use std::ops::Deref;
 
 use rustc_ast_ir::Movability;
 use rustc_ast_ir::visit::VisitorResult;
+use rustc_data_structures::stable_hash::StableHash;
 use rustc_index::bit_set::DenseBitSet;
 
 use crate::fold::TypeFoldable;
@@ -184,8 +185,16 @@ pub trait Interner:
     type ScalarInt: Copy + Debug + Hash + Eq;
 
     // Kinds of regions
+    /// (2026/08/13)
+    /// Do not uplift, the underlying types differ between r-a and rustc.
+    ///
+    /// See <https://github.com/rust-lang/rust/pull/160986#issuecomment-5269817932>.
     type EarlyParamRegion: ParamLike;
-    type LateParamRegion: Copy + Debug + Hash + Eq;
+    /// (2026/08/13)
+    /// Do not uplift, the underlying types differ between r-a and rustc.
+    ///
+    /// See <https://github.com/rust-lang/rust/pull/160986#issuecomment-5269817932>.
+    type LateParamRegionKind: Clone + Copy + Debug + PartialEq + Eq + Hash + StableHash;
 
     type InternedRegionKind: Interned<Self, Value = RegionKind<Self>>;
 
@@ -522,7 +531,6 @@ declare_lift_into! {
     InherentAssocConstId,
     InherentAssocTyId,
     InternedRegionKind,
-    LateParamRegion,
     OpaqueTyId,
     ParamEnv,
     PatList,

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -5,6 +5,7 @@ use std::ops::Deref;
 
 use rustc_ast_ir::Movability;
 use rustc_ast_ir::visit::VisitorResult;
+#[cfg(feature = "nightly")]
 use rustc_data_structures::stable_hash::StableHash;
 use rustc_index::bit_set::DenseBitSet;
 
@@ -194,7 +195,11 @@ pub trait Interner:
     /// Do not uplift, the underlying types differ between r-a and rustc.
     ///
     /// See <https://github.com/rust-lang/rust/pull/160986#issuecomment-5269817932>.
+    #[cfg(feature = "nightly")]
     type LateParamRegionKind: Clone + Copy + Debug + PartialEq + Eq + Hash + StableHash;
+
+    #[cfg(not(feature = "nightly"))]
+    type LateParamRegionKind: Clone + Copy + Debug + PartialEq + Eq + Hash;
 
     type InternedRegionKind: Interned<Self, Value = RegionKind<Self>>;
 

--- a/compiler/rustc_type_ir/src/macros.rs
+++ b/compiler/rustc_type_ir/src/macros.rs
@@ -62,3 +62,20 @@ TrivialTypeTraversalImpls! {
     rustc_ast_ir::Mutability,
     // tidy-alphabetical-end
 }
+
+macro_rules! TrivialLiftImpls {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl<I: $crate::Interner> $crate::lift::Lift<I> for $ty {
+                type Lifted = Self;
+                fn lift_to_interner(self, _: I) -> Self {
+                    self
+                }
+            }
+        )+
+    };
+}
+
+TrivialLiftImpls! {
+    crate::LateParamRegion<I>
+}

--- a/compiler/rustc_type_ir/src/region_kind.rs
+++ b/compiler/rustc_type_ir/src/region_kind.rs
@@ -8,7 +8,7 @@ use rustc_macros::{Decodable_NoContext, Encodable_NoContext};
 use rustc_type_ir_macros::GenericTypeVisitable;
 
 use self::RegionKind::*;
-use crate::{BoundRegion, BoundVarIndexKind, Interner, PlaceholderRegion};
+use crate::{BoundRegion, BoundVarIndexKind, Interner, LateParamRegion, PlaceholderRegion};
 
 rustc_index::newtype_index! {
     /// A **region** **v**ariable **ID**.
@@ -164,7 +164,7 @@ pub enum RegionKind<I: Interner> {
     ///
     /// See <https://rustc-dev-guide.rust-lang.org/early_late_parameters.html> for
     /// more info about early and late bound lifetime parameters.
-    ReLateParam(I::LateParamRegion),
+    ReLateParam(LateParamRegion<I>),
 
     /// Static data that has an "infinite" lifetime. Bottom in the region lattice.
     ReStatic,
@@ -221,7 +221,6 @@ impl<I: Interner> fmt::Debug for RegionKind<I> {
 impl<I: Interner> StableHash for RegionKind<I>
 where
     I::EarlyParamRegion: StableHash,
-    I::LateParamRegion: StableHash,
     I::DefId: StableHash,
     I::Symbol: StableHash,
 {

--- a/compiler/rustc_type_ir/src/sty/mod.rs
+++ b/compiler/rustc_type_ir/src/sty/mod.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use derive_where::derive_where;
 #[cfg(feature = "nightly")]
-use rustc_macros::StableHash_NoContext;
+use rustc_macros::{Decodable_NoContext, Encodable_NoContext, StableHash_NoContext};
 use rustc_type_ir_macros::{GenericTypeVisitable, Lift_Generic};
 use tracing::debug;
 
@@ -211,5 +211,29 @@ impl<I: Interner> TypeFoldable<I> for Region<I> {
 
     fn fold_with<F: TypeFolder<I>>(self, folder: &mut F) -> Self {
         folder.fold_region(self)
+    }
+}
+
+#[derive_where(Clone, Copy, PartialEq, Eq, Hash; I: Interner)]
+#[cfg_attr(
+    feature = "nightly",
+    derive(Encodable_NoContext, Decodable_NoContext, StableHash_NoContext)
+)]
+/// The parameter representation of late-bound function parameters, "some region
+/// at least as big as the scope `fr.scope`".
+///
+/// Similar to a placeholder region as we create `LateParam` regions when entering a binder
+/// except they are always in the root universe and instead of using a boundvar to distinguish
+/// between others we use the `DefId` of the parameter. For this reason the `bound_region` field
+/// should basically always be `BoundRegionKind::Named` as otherwise there is no way of telling
+/// different parameters apart.
+pub struct LateParamRegion<I: Interner> {
+    pub scope: I::DefId,
+    pub kind: I::LateParamRegionKind,
+}
+
+impl<I: Interner> fmt::Debug for LateParamRegion<I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ReLateParam({:?}, {:?})", self.scope, self.kind)
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/160986)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
Move `LateParamRegion` to `rustc_type_ir`. As per feedback, I created a `TrivialLiftImpls!` mirroring `rustc_middle`'s variant which is creates an identity function for `lift_to_interner(...)`.

Spun off from; https://github.com/rust-lang/rust/pull/160509

r? @lcnr 