### PR TITLE
Add offload component on nightly

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -39,7 +39,8 @@ fn is_nightly_only(pkg: &PkgType) -> bool {
         | PkgType::RustcCodegenCranelift
         | PkgType::RustcCodegenGcc
         | PkgType::Gcc { .. }
-        | PkgType::Enzyme => true,
+        | PkgType::Enzyme
+        | PkgType::Offload => true,
         PkgType::Rust
         | PkgType::RustSrc
         | PkgType::Rustc
@@ -331,7 +332,8 @@ impl Builder {
                 | PkgType::RustcCodegenGcc
                 | PkgType::Gcc { .. }
                 | PkgType::LlvmBitcodeLinker
-                | PkgType::Enzyme => {
+                | PkgType::Enzyme
+                | PkgType::Offload => {
                     extensions.push(host_component(pkg));
                 }
                 PkgType::RustcDev => {

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -89,6 +89,7 @@ pkg_type! {
         "x86_64-unknown-linux-gnu"
     ],
     Enzyme = "enzyme"; preview = true,
+    Offload = "offload"; preview = true,
 }
 
 impl PkgType {
@@ -128,6 +129,7 @@ impl PkgType {
             PkgType::RustAnalysis => true,
             PkgType::LlvmBitcodeLinker => true,
             PkgType::Enzyme => true,
+            PkgType::Offload => true,
         }
     }
 
@@ -165,6 +167,7 @@ impl PkgType {
             LlvmTools => TARGETS,
             LlvmBitcodeLinker => HOSTS,
             Enzyme => HOSTS,
+            Offload => HOSTS,
         }
     }
 


### PR DESCRIPTION
I forgot to add offload to build-manifest in https://github.com/rust-lang/rust/pull/159064 ...
I noticed when I tried running rustup +nightly component add offload

r? @ZuseZ4

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
