### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -7,10 +7,7 @@ use rustc_ast::token::{Delimiter, Token, TokenKind};
 use rustc_ast::tokenstream::{
     AttrTokenStream, AttrTokenTree, LazyAttrTokenStream, Spacing, TokenTree, WithTokens,
 };
-use rustc_ast::{
-    self as ast, AttrStyle, Attribute, HasAttrs, HasTokens, MetaItem, MetaItemInner, NodeId,
-    SyntheticAttr,
-};
+use rustc_ast::{self as ast, AttrStyle, Attribute, HasAttrs, HasTokens, NodeId, SyntheticAttr};
 use rustc_attr_ir::target::Target;
 use rustc_attr_ir::{self as attrs, AttributeKind};
 use rustc_attr_parsing::parser::AllowExprMetavar;
@@ -32,7 +29,7 @@ use tracing::instrument;
 
 use crate::diagnostics::{
     CrateNameInCfgAttr, CrateTypeInCfgAttr, FeatureNotAllowed, FeatureRemoved,
-    FeatureRemovedReason, InvalidCfg, RemoveExprNotSupported,
+    FeatureRemovedReason, RemoveExprNotSupported,
 };
 
 /// A folder that strips out items that do not belong in the current configuration.
@@ -439,32 +436,6 @@ impl<'a> StripUnconfigured<'a> {
 
         self.process_cfg_attrs(expr);
         self.try_configure_tokens(&mut *expr);
-    }
-}
-
-/// FIXME: Still used by Rustdoc, should be removed after
-pub fn parse_cfg_old<'a>(meta_item: &'a MetaItem, sess: &Session) -> Option<&'a MetaItemInner> {
-    let span = meta_item.span;
-    match meta_item.meta_item_list() {
-        None => {
-            sess.dcx().emit_err(InvalidCfg::NotFollowedByParens { span });
-            None
-        }
-        Some([]) => {
-            sess.dcx().emit_err(InvalidCfg::NoPredicate { span });
-            None
-        }
-        Some([_, .., l]) => {
-            sess.dcx().emit_err(InvalidCfg::MultiplePredicates { span: l.span() });
-            None
-        }
-        Some([single]) => match single.meta_item_or_bool() {
-            Some(meta_item) => Some(meta_item),
-            None => {
-                sess.dcx().emit_err(InvalidCfg::PredicateLiteral { span: single.span() });
-                None
-            }
-        },
     }
 }
 

--- a/compiler/rustc_expand/src/diagnostics.rs
+++ b/compiler/rustc_expand/src/diagnostics.rs
@@ -190,40 +190,6 @@ pub(crate) struct RemoveExprNotSupported {
 }
 
 #[derive(Diagnostic)]
-pub(crate) enum InvalidCfg {
-    #[diag("`cfg` is not followed by parentheses")]
-    NotFollowedByParens {
-        #[primary_span]
-        #[suggestion(
-            "expected syntax is",
-            code = "cfg(/* predicate */)",
-            applicability = "has-placeholders"
-        )]
-        span: Span,
-    },
-    #[diag("`cfg` predicate is not specified")]
-    NoPredicate {
-        #[primary_span]
-        #[suggestion(
-            "expected syntax is",
-            code = "cfg(/* predicate */)",
-            applicability = "has-placeholders"
-        )]
-        span: Span,
-    },
-    #[diag("multiple `cfg` predicates are specified")]
-    MultiplePredicates {
-        #[primary_span]
-        span: Span,
-    },
-    #[diag("`cfg` predicate key cannot be a literal")]
-    PredicateLiteral {
-        #[primary_span]
-        span: Span,
-    },
-}
-
-#[derive(Diagnostic)]
 #[diag("non-{$kind} macro in {$kind} position: {$name}")]
 pub(crate) struct WrongFragmentKind<'a> {
     #[primary_span]

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -970,17 +970,19 @@ fn get_flavor_from_path(path: &Path) -> CrateFlavor {
     }
 }
 
-/// A function to fetch about all macros inside a proc-macro crate.
+/// A function to fetch all macros inside a proc-macro crate.
 ///
 /// Used by rust-analyzer-proc-macro-srv.
 pub fn get_proc_macros(
-    target: &Target,
     path: &Path,
     metadata_loader: &dyn MetadataLoader,
     cfg_version: &'static str,
 ) -> IoResult<Vec<(ProcMacroClient, ProcMacroKind)>> {
+    let host_tuple = TargetTuple::from_tuple(config::host_tuple());
+    let (host, _) = Target::search(&host_tuple, Path::new(""), false).unwrap();
+
     let metadata =
-        get_metadata_section(target, CrateFlavor::Dylib, path, metadata_loader, cfg_version, None)
+        get_metadata_section(&host, CrateFlavor::Dylib, path, metadata_loader, cfg_version, None)
             .map_err(|err| io::Error::other(err.to_string()))?;
     let stable_crate_id = metadata.get_root().stable_crate_id();
 

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2777,6 +2777,17 @@ impl<'a> Parser<'a> {
                                 "you likely meant to continue parsing the let-chain starting here",
                             );
                         } else {
+                            if self.prev_token == token::Semi
+                                && (self.token == token::OpenBrace || AssocOp::from_token(&self.token).is_some())
+                            {
+                                err.span_suggestion_verbose(
+                                    self.prev_token.span,
+                                    "remove this semicolon",
+                                    "",
+                                    Applicability::MaybeIncorrect,
+                                );
+                            }
+
                             // Look for usages of '=>' where '>=' might be intended
                             if maybe_fatarrow == token::FatArrow {
                                 err.span_suggestion_verbose(

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -196,6 +196,13 @@ declare_rustdoc_lint! {
     "detects redundant explicit links in doc comments"
 }
 
+declare_rustdoc_lint! {
+    /// This lint checks for uses of footnote references without definition.
+    BROKEN_FOOTNOTE,
+    Warn,
+    "footnote reference with no associated definition"
+}
+
 pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
     vec![
         BROKEN_INTRA_DOC_LINKS,
@@ -209,6 +216,7 @@ pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
         MISSING_CRATE_LEVEL_DOCS,
         UNESCAPED_BACKTICKS,
         REDUNDANT_EXPLICIT_LINKS,
+        BROKEN_FOOTNOTE,
     ]
 });
 

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -203,6 +203,13 @@ declare_rustdoc_lint! {
     "footnote reference with no associated definition"
 }
 
+declare_rustdoc_lint! {
+    /// This lint checks if all footnote definitions are used.
+    UNUSED_FOOTNOTE_DEFINITION,
+    Warn,
+    "unused footnote definition"
+}
+
 pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
     vec![
         BROKEN_INTRA_DOC_LINKS,
@@ -217,6 +224,7 @@ pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
         UNESCAPED_BACKTICKS,
         REDUNDANT_EXPLICIT_LINKS,
         BROKEN_FOOTNOTE,
+        UNUSED_FOOTNOTE_DEFINITION,
     ]
 });
 

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -200,14 +200,14 @@ declare_rustdoc_lint! {
     /// This lint checks for uses of footnote references without definition.
     BROKEN_FOOTNOTE,
     Warn,
-    "footnote reference with no associated definition"
+    "detects footnote references with no associated definition"
 }
 
 declare_rustdoc_lint! {
     /// This lint checks if all footnote definitions are used.
     UNUSED_FOOTNOTE_DEFINITION,
     Warn,
-    "unused footnote definition"
+    "detects unused footnote definitions"
 }
 
 pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {

--- a/src/librustdoc/passes/lint.rs
+++ b/src/librustdoc/passes/lint.rs
@@ -3,6 +3,7 @@
 
 mod bare_urls;
 mod check_code_block_syntax;
+mod footnotes;
 mod html_tags;
 mod redundant_explicit_links;
 mod unescaped_backticks;
@@ -41,6 +42,7 @@ impl DocVisitor<'_> for Linter<'_, '_> {
             if may_have_link {
                 bare_urls::visit_item(self.cx, item, hir_id, &dox);
                 redundant_explicit_links::visit_item(self.cx, item, hir_id);
+                footnotes::visit_item(self.cx, item, hir_id, &dox);
             }
             if may_have_code {
                 check_code_block_syntax::visit_item(self.cx, item, &dox);

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -23,13 +23,22 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
         match event {
             Event::Text(text)
                 if &*text == "["
-                    && let Some((Event::Text(text), _)) = parser.peek()
-                    && text.trim_start().starts_with('^')
-                    && parser.next().is_some()
-                    && let Some((Event::Text(text), end_span)) = parser.peek()
-                    && &**text == "]" =>
+                    && let Some((Event::Text(_), range)) = parser.next()
+                    && dox[span.end..range.end].starts_with('^') =>
             {
-                missing_footnote_references.insert(Range { start: span.start, end: end_span.end });
+                loop {
+                    let Some((Event::Text(text), new_span)) = parser.peek() else { break };
+                    if &**text != "]" {
+                        parser.next();
+                        continue;
+                    }
+                    let text = &dox[span.end..new_span.end];
+                    if !text.ends_with("\\]") {
+                        missing_footnote_references
+                            .insert(Range { start: span.start, end: new_span.end });
+                    }
+                    break;
+                }
             }
             Event::FootnoteReference(label) => {
                 footnote_references.insert(label);

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -77,26 +77,23 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
 
     #[allow(rustc::potential_query_instability)]
     for span in missing_footnote_references {
-        let (ref_span, precise) =
-            source_span_for_markdown_range(tcx, dox, &span, &item.attrs.doc_strings)
-                .map(|(span, _)| (span, true))
-                .unwrap_or_else(|| (item.attr_span(tcx), false));
+        let ref_span = source_span_for_markdown_range(tcx, dox, &span, &item.attrs.doc_strings)
+            .map(|(span, _)| span)
+            .unwrap_or_else(|| item.attr_span(tcx));
 
-        if precise {
-            tcx.emit_node_span_lint(
-                crate::lint::BROKEN_FOOTNOTE,
-                hir_id,
-                ref_span,
-                DiagDecorator(|lint| {
-                    lint.primary_message("no footnote definition matching this footnote");
-                    lint.span_suggestion(
-                        ref_span.shrink_to_lo(),
-                        "if it should not be a footnote, escape it",
-                        "\\",
-                        Applicability::MaybeIncorrect,
-                    );
-                }),
-            );
-        }
+        tcx.emit_node_span_lint(
+            crate::lint::BROKEN_FOOTNOTE,
+            hir_id,
+            ref_span,
+            DiagDecorator(|lint| {
+                lint.primary_message("no footnote definition matching this footnote");
+                lint.span_suggestion(
+                    ref_span.shrink_to_lo(),
+                    "if it should not be a footnote, escape it",
+                    "\\",
+                    Applicability::MaybeIncorrect,
+                );
+            }),
+        );
     }
 }

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -1,15 +1,3 @@
-//! Detects specific markdown syntax that's different between pulldown-cmark
-//! 0.9 and 0.11.
-//!
-//! This is a mitigation for old parser bugs that affected some
-//! real crates' docs. The old parser claimed to comply with CommonMark,
-//! but it did not. These warnings will eventually be removed,
-//! though some of them may become Clippy lints.
-//!
-//! <https://github.com/rust-lang/rust/pull/121659#issuecomment-1992752820>
-//!
-//! <https://rustc-dev-guide.rust-lang.org/bug-fix-procedure.html#add-the-lint-to-the-list-of-removed-lists>
-
 use std::ops::Range;
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -87,7 +87,7 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
                 lint.span_suggestion(
                     ref_span.shrink_to_lo(),
                     "if it should not be a footnote, escape it",
-                    "\\",
+                    format!("\\{}", &dox[span]),
                     Applicability::MaybeIncorrect,
                 );
             }),

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -12,10 +12,11 @@
 
 use std::ops::Range;
 
-use rustc_data_structures::fx::FxHashSet;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_errors::DiagDecorator;
 use rustc_hir::HirId;
 use rustc_lint_defs::Applicability;
-use rustc_resolve::rustdoc::pulldown_cmark::{Event, Options, Parser};
+use rustc_resolve::rustdoc::pulldown_cmark::{Event, Options, Parser, Tag};
 use rustc_resolve::rustdoc::source_span_for_markdown_range;
 
 use crate::clean::Item;
@@ -25,6 +26,8 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
     let tcx = cx.tcx;
 
     let mut missing_footnote_references = FxHashSet::default();
+    let mut footnote_references = FxHashSet::default();
+    let mut footnote_definitions = FxHashMap::default();
 
     let options = Options::ENABLE_FOOTNOTES;
     let mut parser = Parser::new_ext(dox, options).into_offset_iter().peekable();
@@ -40,7 +43,35 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
             {
                 missing_footnote_references.insert(Range { start: span.start, end: end_span.end });
             }
+            Event::FootnoteReference(label) => {
+                footnote_references.insert(label);
+            }
+            Event::Start(Tag::FootnoteDefinition(label)) => {
+                footnote_definitions.insert(label, span.start + 1);
+            }
             _ => {}
+        }
+    }
+
+    #[allow(rustc::potential_query_instability)]
+    for (footnote, span) in footnote_definitions {
+        if !footnote_references.contains(&footnote) {
+            let (span, _) = source_span_for_markdown_range(
+                tcx,
+                dox,
+                &(span..span + 1),
+                &item.attrs.doc_strings,
+            )
+            .unwrap_or_else(|| (item.attr_span(tcx), false));
+
+            tcx.emit_node_span_lint(
+                crate::lint::UNUSED_FOOTNOTE_DEFINITION,
+                hir_id,
+                span,
+                DiagDecorator(|lint| {
+                    lint.primary_message("unused footnote definition");
+                }),
+            );
         }
     }
 
@@ -56,7 +87,7 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
                 crate::lint::BROKEN_FOOTNOTE,
                 hir_id,
                 ref_span,
-                rustc_errors::DiagDecorator(|lint| {
+                DiagDecorator(|lint| {
                     lint.primary_message("no footnote definition matching this footnote");
                     lint.span_suggestion(
                         ref_span.shrink_to_lo(),

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -1,0 +1,71 @@
+//! Detects specific markdown syntax that's different between pulldown-cmark
+//! 0.9 and 0.11.
+//!
+//! This is a mitigation for old parser bugs that affected some
+//! real crates' docs. The old parser claimed to comply with CommonMark,
+//! but it did not. These warnings will eventually be removed,
+//! though some of them may become Clippy lints.
+//!
+//! <https://github.com/rust-lang/rust/pull/121659#issuecomment-1992752820>
+//!
+//! <https://rustc-dev-guide.rust-lang.org/bug-fix-procedure.html#add-the-lint-to-the-list-of-removed-lists>
+
+use std::ops::Range;
+
+use rustc_data_structures::fx::FxHashSet;
+use rustc_hir::HirId;
+use rustc_lint_defs::Applicability;
+use rustc_resolve::rustdoc::pulldown_cmark::{Event, Options, Parser};
+use rustc_resolve::rustdoc::source_span_for_markdown_range;
+
+use crate::clean::Item;
+use crate::core::DocContext;
+
+pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &str) {
+    let tcx = cx.tcx;
+
+    let mut missing_footnote_references = FxHashSet::default();
+
+    let options = Options::ENABLE_FOOTNOTES;
+    let mut parser = Parser::new_ext(dox, options).into_offset_iter().peekable();
+    while let Some((event, span)) = parser.next() {
+        match event {
+            Event::Text(text)
+                if &*text == "["
+                    && let Some((Event::Text(text), _)) = parser.peek()
+                    && text.trim_start().starts_with('^')
+                    && parser.next().is_some()
+                    && let Some((Event::Text(text), end_span)) = parser.peek()
+                    && &**text == "]" =>
+            {
+                missing_footnote_references.insert(Range { start: span.start, end: end_span.end });
+            }
+            _ => {}
+        }
+    }
+
+    #[allow(rustc::potential_query_instability)]
+    for span in missing_footnote_references {
+        let (ref_span, precise) =
+            source_span_for_markdown_range(tcx, dox, &span, &item.attrs.doc_strings)
+                .map(|(span, _)| (span, true))
+                .unwrap_or_else(|| (item.attr_span(tcx), false));
+
+        if precise {
+            tcx.emit_node_span_lint(
+                crate::lint::BROKEN_FOOTNOTE,
+                hir_id,
+                ref_span,
+                rustc_errors::DiagDecorator(|lint| {
+                    lint.primary_message("no footnote definition matching this footnote");
+                    lint.span_suggestion(
+                        ref_span.shrink_to_lo(),
+                        "if it should not be a footnote, escape it",
+                        "\\",
+                        Applicability::MaybeIncorrect,
+                    );
+                }),
+            );
+        }
+    }
+}

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -4,11 +4,74 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::DiagDecorator;
 use rustc_hir::HirId;
 use rustc_lint_defs::Applicability;
-use rustc_resolve::rustdoc::pulldown_cmark::{Event, Options, Parser, Tag};
+use rustc_resolve::rustdoc::pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
 use rustc_resolve::rustdoc::source_span_for_markdown_range;
 
 use crate::clean::Item;
 use crate::core::DocContext;
+
+// based on
+// https://github.com/pulldown-cmark/pulldown-cmark/blob/fc8fe713f58d7f4495038b48fe76c1f101fb3af1/pulldown-cmark/src/linklabel.rs#L65
+
+fn scan_ch(ch: u8, dox: &[u8], i: &mut usize) -> Option<()> {
+    if dox.get(*i) == Some(&ch) {
+        *i += 1;
+        Some(())
+    } else {
+        None
+    }
+}
+
+fn scan_footnote_ref(dox: &[u8], in_table: bool) -> Option<usize> {
+    let mut i = 0;
+    scan_ch(b'[', dox, &mut i)?;
+    scan_ch(b'^', dox, &mut i)?;
+    if dox.get(i) == Some(&b']') {
+        return None;
+    }
+    while let Some(&ch) = dox.get(i) {
+        if ch == b']'
+            || ch == b'['
+            || ch == b'\r'
+            || ch == b'\n'
+            || (in_table && ch == b'|')
+            // these two cause false negatives in obscure corner cases,
+            // but there's another warning from the unescaped_backticks
+            // and invalid_html_tags lints when they do
+            || ch == b'`'
+            || ch == b'<'
+        {
+            break;
+        } else if in_table
+            && ch == b'\\'
+            && dox.get(i + 1) == Some(&b'\\')
+            && dox.get(i + 2) == Some(&b'|')
+        {
+            i += 3;
+        } else if ch == b'\\' && dox.get(i + 1).copied().map_or(false, is_ascii_punctuation) {
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    scan_ch(b']', dox, &mut i)?;
+    Some(i)
+}
+
+fn is_ascii_punctuation(c: u8) -> bool {
+    c < 128 && (PUNCT_MASKS_ASCII[(c / 16) as usize] & (1 << (c & 15))) != 0
+}
+
+const PUNCT_MASKS_ASCII: [u16; 8] = [
+    0x0000, // U+0000...U+000F
+    0x0000, // U+0010...U+001F
+    0xfffe, // U+0020...U+002F
+    0xfc00, // U+0030...U+003F
+    0x0001, // U+0040...U+004F
+    0xf800, // U+0050...U+005F
+    0x0001, // U+0060...U+006F
+    0x7800, // U+0070...U+007F
+];
 
 pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &str) {
     let tcx = cx.tcx;
@@ -16,29 +79,20 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
     let mut missing_footnote_references = FxHashSet::default();
     let mut footnote_references = FxHashSet::default();
     let mut footnote_definitions = FxHashMap::default();
+    let mut in_table = false;
 
-    let options = Options::ENABLE_FOOTNOTES;
+    let options = Options::ENABLE_FOOTNOTES | Options::ENABLE_TABLES;
     let mut parser = Parser::new_ext(dox, options).into_offset_iter().peekable();
     while let Some((event, span)) = parser.next() {
         match event {
             Event::Text(text)
-                if &*text == "["
-                    && let Some((Event::Text(_), range)) = parser.next()
-                    && dox[span.end..range.end].starts_with('^') =>
+                if text.starts_with("[")
+                    && (span.start == 0 || dox.as_bytes()[span.start - 1] != b'\\')
+                    && let Some(len) =
+                        scan_footnote_ref(&dox.as_bytes()[span.start..], in_table) =>
             {
-                loop {
-                    let Some((Event::Text(text), new_span)) = parser.peek() else { break };
-                    if &**text != "]" {
-                        parser.next();
-                        continue;
-                    }
-                    let text = &dox[span.end..new_span.end];
-                    if !text.ends_with("\\]") {
-                        missing_footnote_references
-                            .insert(Range { start: span.start, end: new_span.end });
-                    }
-                    break;
-                }
+                missing_footnote_references
+                    .insert(Range { start: span.start, end: span.start + len });
             }
             Event::FootnoteReference(label) => {
                 footnote_references.insert(label);
@@ -46,6 +100,8 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
             Event::Start(Tag::FootnoteDefinition(label)) => {
                 footnote_definitions.insert(label, span.start + 1);
             }
+            Event::Start(Tag::Table(_)) => in_table = true,
+            Event::End(TagEnd::Table) => in_table = false,
             _ => {}
         }
     }

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
@@ -5,9 +5,6 @@ mod proc_macros;
 use rustc_codegen_ssa::back::metadata::DefaultMetadataLoader;
 use rustc_interface::util::rustc_version_str;
 use rustc_proc_macro::bridge;
-use rustc_session::config::host_tuple;
-use rustc_target::spec::{Target, TargetTuple};
-use std::path::Path;
 use std::{fs, io, time::SystemTime};
 use temp_dir::TempDir;
 
@@ -78,11 +75,7 @@ struct ProcMacroLibrary {
 impl ProcMacroLibrary {
     fn open(path: &Utf8Path) -> io::Result<Self> {
         let proc_macros = rustc_span::create_default_session_globals_then(|| {
-            let (target, _) =
-                Target::search(&TargetTuple::from_tuple(host_tuple()), Path::new(""), false)
-                    .unwrap();
             rustc_metadata::locator::get_proc_macros(
-                &target,
                 path.as_ref(),
                 &DefaultMetadataLoader,
                 rustc_version_str().unwrap_or("unknown"),

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
@@ -21,9 +21,7 @@ extern crate rustc_interface;
 extern crate rustc_lexer;
 extern crate rustc_metadata;
 extern crate rustc_proc_macro;
-extern crate rustc_session;
 extern crate rustc_span;
-extern crate rustc_target;
 
 mod bridge;
 mod dylib;

--- a/tests/rustdoc-ui/lints/broken-footnote.rs
+++ b/tests/rustdoc-ui/lints/broken-footnote.rs
@@ -1,0 +1,7 @@
+#![deny(rustdoc::broken_footnote)]
+
+//! Footnote referenced [^1]. And [^2]. And [^bla].
+//!
+//! [^1]: footnote defined
+//~^^^ ERROR: no footnote definition matching this footnote
+//~| ERROR: no footnote definition matching this footnote

--- a/tests/rustdoc-ui/lints/broken-footnote.rs
+++ b/tests/rustdoc-ui/lints/broken-footnote.rs
@@ -5,3 +5,23 @@
 //! [^1]: footnote defined
 //~^^^ ERROR: no footnote definition matching this footnote
 //~| ERROR: no footnote definition matching this footnote
+
+//! [^*] special characters can appear within footnote references
+//~^ ERROR: no footnote definition matching this footnote
+//!
+//! [^**]
+//!
+//! [^**]: not an error
+//!
+//! [^\_] so can escaped characters
+//~^ ERROR: no footnote definition matching this footnote
+
+// Backslash escaped footnotes should not be recognized:
+//! [\^4]
+//!
+//! [^5\]
+//!
+//! \[^yup]
+//!
+//! [^foo\
+//! bar]

--- a/tests/rustdoc-ui/lints/broken-footnote.rs
+++ b/tests/rustdoc-ui/lints/broken-footnote.rs
@@ -25,3 +25,45 @@
 //!
 //! [^foo\
 //! bar]
+
+//! [^*] special characters can appear within footnote references
+//~^ ERROR: no footnote definition matching this footnote
+//!
+//! [^**]
+//!
+//! [^**]: not an error
+//!
+//! [^\_] [^\[\]] so can escaped characters
+//~^ ERROR: no footnote definition matching this footnote
+//~| ERROR: no footnote definition matching this footnote
+//!
+//! Mixed with actual emphasis:
+//!
+//! [^a ***b] foobar [^c*** d]
+//~^ ERROR: no footnote definition matching this footnote
+//~| ERROR: no footnote definition matching this footnote
+//! [^e ***f] foobar [^g*** h]
+//!
+//! [^e ***f]: test footnote
+//! [^g*** h]: test footnote`
+//!
+//! [^foo | bar]
+//~^ ERROR: no footnote definition matching this footnote
+//!
+//! |  col  | col  |
+//! |-------|------|
+//! | [^foo | bar] |
+//!
+//! |  col  |  col  |
+//! |-------|-------|
+//! | [^foo \| bar] |
+//~^ ERROR: no footnote definition matching this footnote
+//!
+//! |  col  |  col   |
+//! |-------|--------|
+//! | [^foo \\| bar] |
+//~^ ERROR: no footnote definition matching this footnote
+//!
+//! Code spans and HTML have higher binding power than footnotes:
+//!
+//! [^foo `bar] baz` [^foo <bar title="]"></bar>

--- a/tests/rustdoc-ui/lints/broken-footnote.stderr
+++ b/tests/rustdoc-ui/lints/broken-footnote.stderr
@@ -1,0 +1,24 @@
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:3:45
+   |
+LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
+   |                                             -^^^^^
+   |                                             |
+   |                                             help: if it should not be a footnote, escape it: `\`
+   |
+note: the lint level is defined here
+  --> $DIR/broken-footnote.rs:1:9
+   |
+LL | #![deny(rustdoc::broken_footnote)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:3:35
+   |
+LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
+   |                                   -^^^
+   |                                   |
+   |                                   help: if it should not be a footnote, escape it: `\`
+
+error: aborting due to 2 previous errors
+

--- a/tests/rustdoc-ui/lints/broken-footnote.stderr
+++ b/tests/rustdoc-ui/lints/broken-footnote.stderr
@@ -1,10 +1,10 @@
 error: no footnote definition matching this footnote
-  --> $DIR/broken-footnote.rs:3:45
+  --> $DIR/broken-footnote.rs:9:5
    |
-LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
-   |                                             -^^^^^
-   |                                             |
-   |                                             help: if it should not be a footnote, escape it: `\`
+LL | //! [^*] special characters can appear within footnote references
+   |     -^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\`
    |
 note: the lint level is defined here
   --> $DIR/broken-footnote.rs:1:9
@@ -20,5 +20,21 @@ LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
    |                                   |
    |                                   help: if it should not be a footnote, escape it: `\`
 
-error: aborting due to 2 previous errors
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:3:45
+   |
+LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
+   |                                             -^^^^^
+   |                                             |
+   |                                             help: if it should not be a footnote, escape it: `\`
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:16:5
+   |
+LL | //! [^\_] so can escaped characters
+   |     -^^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\`
+
+error: aborting due to 4 previous errors
 

--- a/tests/rustdoc-ui/lints/broken-footnote.stderr
+++ b/tests/rustdoc-ui/lints/broken-footnote.stderr
@@ -4,7 +4,7 @@ error: no footnote definition matching this footnote
 LL | //! [^*] special characters can appear within footnote references
    |     -^^^
    |     |
-   |     help: if it should not be a footnote, escape it: `\`
+   |     help: if it should not be a footnote, escape it: `\[^*]`
    |
 note: the lint level is defined here
   --> $DIR/broken-footnote.rs:1:9
@@ -18,7 +18,7 @@ error: no footnote definition matching this footnote
 LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
    |                                   -^^^
    |                                   |
-   |                                   help: if it should not be a footnote, escape it: `\`
+   |                                   help: if it should not be a footnote, escape it: `\[^2]`
 
 error: no footnote definition matching this footnote
   --> $DIR/broken-footnote.rs:3:45
@@ -26,7 +26,7 @@ error: no footnote definition matching this footnote
 LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
    |                                             -^^^^^
    |                                             |
-   |                                             help: if it should not be a footnote, escape it: `\`
+   |                                             help: if it should not be a footnote, escape it: `\[^bla]`
 
 error: no footnote definition matching this footnote
   --> $DIR/broken-footnote.rs:16:5
@@ -34,7 +34,7 @@ error: no footnote definition matching this footnote
 LL | //! [^\_] so can escaped characters
    |     -^^^^
    |     |
-   |     help: if it should not be a footnote, escape it: `\`
+   |     help: if it should not be a footnote, escape it: `\[^\_]`
 
 error: aborting due to 4 previous errors
 

--- a/tests/rustdoc-ui/lints/broken-footnote.stderr
+++ b/tests/rustdoc-ui/lints/broken-footnote.stderr
@@ -1,10 +1,10 @@
 error: no footnote definition matching this footnote
-  --> $DIR/broken-footnote.rs:9:5
+  --> $DIR/broken-footnote.rs:36:11
    |
-LL | //! [^*] special characters can appear within footnote references
-   |     -^^^
-   |     |
-   |     help: if it should not be a footnote, escape it: `\[^*]`
+LL | //! [^\_] [^\[\]] so can escaped characters
+   |           -^^^^^^
+   |           |
+   |           help: if it should not be a footnote, escape it: `\[^\[\]]`
    |
 note: the lint level is defined here
   --> $DIR/broken-footnote.rs:1:9
@@ -13,12 +13,20 @@ LL | #![deny(rustdoc::broken_footnote)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: no footnote definition matching this footnote
-  --> $DIR/broken-footnote.rs:3:35
+  --> $DIR/broken-footnote.rs:29:5
    |
-LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
-   |                                   -^^^
-   |                                   |
-   |                                   help: if it should not be a footnote, escape it: `\[^2]`
+LL | //! [^*] special characters can appear within footnote references
+   |     -^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\[^*]`
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:50:5
+   |
+LL | //! [^foo | bar]
+   |     -^^^^^^^^^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\[^foo | bar]`
 
 error: no footnote definition matching this footnote
   --> $DIR/broken-footnote.rs:3:45
@@ -29,6 +37,46 @@ LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
    |                                             help: if it should not be a footnote, escape it: `\[^bla]`
 
 error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:59:7
+   |
+LL | //! | [^foo \| bar] |
+   |       -^^^^^^^^^^^^
+   |       |
+   |       help: if it should not be a footnote, escape it: `\[^foo \| bar]`
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:36:5
+   |
+LL | //! [^\_] [^\[\]] so can escaped characters
+   |     -^^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\[^\_]`
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:9:5
+   |
+LL | //! [^*] special characters can appear within footnote references
+   |     -^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\[^*]`
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:3:35
+   |
+LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
+   |                                   -^^^
+   |                                   |
+   |                                   help: if it should not be a footnote, escape it: `\[^2]`
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:64:7
+   |
+LL | //! | [^foo \| bar] |
+   |       -^^^^^^^^^^^^^
+   |       |
+   |       help: if it should not be a footnote, escape it: `\[^foo \| bar]`
+
+error: no footnote definition matching this footnote
   --> $DIR/broken-footnote.rs:16:5
    |
 LL | //! [^\_] so can escaped characters
@@ -36,5 +84,21 @@ LL | //! [^\_] so can escaped characters
    |     |
    |     help: if it should not be a footnote, escape it: `\[^\_]`
 
-error: aborting due to 4 previous errors
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:42:22
+   |
+LL | //! [^a ***b] foobar [^c*** d]
+   |                      -^^^^^^^^
+   |                      |
+   |                      help: if it should not be a footnote, escape it: `\[^c*** d]`
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:42:5
+   |
+LL | //! [^a ***b] foobar [^c*** d]
+   |     -^^^^^^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\[^a ***b]`
+
+error: aborting due to 12 previous errors
 

--- a/tests/rustdoc-ui/lints/unused-footnote.rs
+++ b/tests/rustdoc-ui/lints/unused-footnote.rs
@@ -1,4 +1,4 @@
-// This test ensures that the rustdoc `unused_footnote` is working as expected.
+// This test ensures that the `rustdoc::unused_footnote` lint is working as expected.
 
 #![deny(rustdoc::unused_footnote_definition)]
 

--- a/tests/rustdoc-ui/lints/unused-footnote.rs
+++ b/tests/rustdoc-ui/lints/unused-footnote.rs
@@ -1,0 +1,9 @@
+// This test ensures that the rustdoc `unused_footnote` is working as expected.
+
+#![deny(rustdoc::unused_footnote_definition)]
+
+//! Footnote referenced. [^2]
+//!
+//! [^1]: footnote defined
+//! [^2]: footnote defined
+//~^^ ERROR: unused_footnote_definition

--- a/tests/rustdoc-ui/lints/unused-footnote.stderr
+++ b/tests/rustdoc-ui/lints/unused-footnote.stderr
@@ -1,0 +1,14 @@
+error: unused footnote definition
+  --> $DIR/unused-footnote.rs:7:6
+   |
+LL | //! [^1]: footnote defined
+   |      ^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-footnote.rs:3:9
+   |
+LL | #![deny(rustdoc::unused_footnote_definition)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/if-semi-before-block.fixed
+++ b/tests/ui/parser/if-semi-before-block.fixed
@@ -1,0 +1,47 @@
+//@ edition:2024
+//@ run-rustfix
+
+#![allow(dead_code)]
+
+fn block() {
+    if let Some(_) = Some(2) {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn and() {
+    if let Some(x) = Some(2) && x != 1 {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn and_paren_cond() {
+    if let Some(x) = Some(2) && (x > 0 && x != 1) {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn and_some() {
+    if let Some(x) = Some(2) && Some(1) == Some(x) {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn or() {
+    if true || false {
+        //~^ ERROR expected `{`, found `;`
+        //~| NOTE expected `{`
+        //~| HELP remove this semicolon
+        //~| NOTE the `if` expression is missing a block after this condition
+    }
+}
+
+fn main() {}

--- a/tests/ui/parser/if-semi-before-block.rs
+++ b/tests/ui/parser/if-semi-before-block.rs
@@ -1,0 +1,47 @@
+//@ edition:2024
+//@ run-rustfix
+
+#![allow(dead_code)]
+
+fn block() {
+    if let Some(_) = Some(2); {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn and() {
+    if let Some(x) = Some(2); && x != 1 {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn and_paren_cond() {
+    if let Some(x) = Some(2); && (x > 0 && x != 1) {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn and_some() {
+    if let Some(x) = Some(2); && Some(1) == Some(x) {}
+    //~^ ERROR expected `{`, found `;`
+    //~| NOTE expected `{`
+    //~| HELP remove this semicolon
+    //~| NOTE the `if` expression is missing a block after this condition
+}
+
+fn or() {
+    if true; || false {
+        //~^ ERROR expected `{`, found `;`
+        //~| NOTE expected `{`
+        //~| HELP remove this semicolon
+        //~| NOTE the `if` expression is missing a block after this condition
+    }
+}
+
+fn main() {}

--- a/tests/ui/parser/if-semi-before-block.stderr
+++ b/tests/ui/parser/if-semi-before-block.stderr
@@ -1,0 +1,87 @@
+error: expected `{`, found `;`
+  --> $DIR/if-semi-before-block.rs:7:29
+   |
+LL |     if let Some(_) = Some(2); {}
+   |                             ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/if-semi-before-block.rs:7:8
+   |
+LL |     if let Some(_) = Some(2); {}
+   |        ^^^^^^^^^^^^^^^^^^^^^
+help: remove this semicolon
+   |
+LL -     if let Some(_) = Some(2); {}
+LL +     if let Some(_) = Some(2) {}
+   |
+
+error: expected `{`, found `;`
+  --> $DIR/if-semi-before-block.rs:15:29
+   |
+LL |     if let Some(x) = Some(2); && x != 1 {}
+   |                             ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/if-semi-before-block.rs:15:8
+   |
+LL |     if let Some(x) = Some(2); && x != 1 {}
+   |        ^^^^^^^^^^^^^^^^^^^^^
+help: remove this semicolon
+   |
+LL -     if let Some(x) = Some(2); && x != 1 {}
+LL +     if let Some(x) = Some(2) && x != 1 {}
+   |
+
+error: expected `{`, found `;`
+  --> $DIR/if-semi-before-block.rs:23:29
+   |
+LL |     if let Some(x) = Some(2); && (x > 0 && x != 1) {}
+   |                             ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/if-semi-before-block.rs:23:8
+   |
+LL |     if let Some(x) = Some(2); && (x > 0 && x != 1) {}
+   |        ^^^^^^^^^^^^^^^^^^^^^
+help: remove this semicolon
+   |
+LL -     if let Some(x) = Some(2); && (x > 0 && x != 1) {}
+LL +     if let Some(x) = Some(2) && (x > 0 && x != 1) {}
+   |
+
+error: expected `{`, found `;`
+  --> $DIR/if-semi-before-block.rs:31:29
+   |
+LL |     if let Some(x) = Some(2); && Some(1) == Some(x) {}
+   |                             ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/if-semi-before-block.rs:31:8
+   |
+LL |     if let Some(x) = Some(2); && Some(1) == Some(x) {}
+   |        ^^^^^^^^^^^^^^^^^^^^^
+help: remove this semicolon
+   |
+LL -     if let Some(x) = Some(2); && Some(1) == Some(x) {}
+LL +     if let Some(x) = Some(2) && Some(1) == Some(x) {}
+   |
+
+error: expected `{`, found `;`
+  --> $DIR/if-semi-before-block.rs:39:12
+   |
+LL |     if true; || false {
+   |            ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/if-semi-before-block.rs:39:8
+   |
+LL |     if true; || false {
+   |        ^^^^
+help: remove this semicolon
+   |
+LL -     if true; || false {
+LL +     if true || false {
+   |
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/parser/semi-in-let-chain.stderr
+++ b/tests/ui/parser/semi-in-let-chain.stderr
@@ -28,6 +28,11 @@ LL |       if let () = ()
    |  ________^
 LL | |         && () == ();
    | |___________________^
+help: remove this semicolon
+   |
+LL -         && () == ();
+LL +         && () == ()
+   |
 
 error: expected `{`, found `;`
   --> $DIR/semi-in-let-chain.rs:22:20


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#137803 (Add new rustdoc `broken_footnote` lint)
 - rust-lang/rust#160975 (Remove target argument from get_proc_macros)
 - rust-lang/rust#160861 (rustc_parse: suggest removing semicolon before `if` block)
 - rust-lang/rust#160990 (Remove old cfg parser which is now dead code)

Failed merges:

 - rust-lang/rust#137858 (Add new `unused_footnote_definition` rustdoc lint)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=137803,160975,137858,160861,160990)
<!-- homu-ignore:end -->

