### PR TITLE
Forward all array `PartialOrd` to slices

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -410,23 +410,41 @@ where
 const impl<T: [const] PartialOrd, const N: usize> PartialOrd for [T; N] {
     #[inline]
     fn partial_cmp(&self, other: &[T; N]) -> Option<Ordering> {
-        PartialOrd::partial_cmp(&&self[..], &&other[..])
+        <[T] as PartialOrd>::partial_cmp(self, other)
     }
+
     #[inline]
     fn lt(&self, other: &[T; N]) -> bool {
-        PartialOrd::lt(&&self[..], &&other[..])
+        <[T] as PartialOrd>::lt(self, other)
     }
     #[inline]
     fn le(&self, other: &[T; N]) -> bool {
-        PartialOrd::le(&&self[..], &&other[..])
+        <[T] as PartialOrd>::le(self, other)
     }
     #[inline]
     fn ge(&self, other: &[T; N]) -> bool {
-        PartialOrd::ge(&&self[..], &&other[..])
+        <[T] as PartialOrd>::ge(self, other)
     }
     #[inline]
     fn gt(&self, other: &[T; N]) -> bool {
-        PartialOrd::gt(&&self[..], &&other[..])
+        <[T] as PartialOrd>::gt(self, other)
+    }
+
+    #[inline]
+    fn __chaining_lt(&self, other: &[T; N]) -> ControlFlow<bool> {
+        <[T] as PartialOrd>::__chaining_lt(self, other)
+    }
+    #[inline]
+    fn __chaining_le(&self, other: &[T; N]) -> ControlFlow<bool> {
+        <[T] as PartialOrd>::__chaining_le(self, other)
+    }
+    #[inline]
+    fn __chaining_ge(&self, other: &[T; N]) -> ControlFlow<bool> {
+        <[T] as PartialOrd>::__chaining_ge(self, other)
+    }
+    #[inline]
+    fn __chaining_gt(&self, other: &[T; N]) -> ControlFlow<bool> {
+        <[T] as PartialOrd>::__chaining_gt(self, other)
     }
 }
 


### PR DESCRIPTION
I happened to notice that these have had too many `&`s since before 1.0 -- it ends up using `&[T]: PartialOrd` and thus wastefully need to forward to `[T]: PartialOrd`.

So re-written to specify the implementation to which we're trying to delegate explicitly (by writing `<[T] as PartialOrd>`) which means we no longer need the `&&self[..]`-style dance at all since the unsizing coercion will do the right thing.

And while I was here delegating stuff, it also delegates the `__chaining_*` methods, since those have custom overrides for slices (rust-lang/rust#138881) and we ought to take advantage of that for arrays too.

<!-- homu-ignore:start -->
---
No LLM used.
<!-- homu-ignore:end -->
