### PR TITLE
rustfmt: restrict `cfg_select!` formatting to the `nightly` release channel

### DIFF
--- a/src/tools/rustfmt/src/macros.rs
+++ b/src/tools/rustfmt/src/macros.rs
@@ -27,6 +27,7 @@ use crate::config::StyleEdition;
 use crate::config::lists::*;
 use crate::expr::{RhsAssignKind, rewrite_array, rewrite_assign_rhs};
 use crate::header::{HeaderPart, format_header};
+use crate::is_nightly_channel;
 use crate::lists::{ListFormatting, itemize_list, write_list};
 use crate::overflow;
 use crate::parse::macros::cfg_select::{CfgSelectFormatPredicate, parse_cfg_select_arms};
@@ -247,7 +248,7 @@ fn rewrite_macro_inner(
         }
     }
 
-    if macro_name.ends_with("cfg_select!") {
+    if is_nightly_channel!() && macro_name.ends_with("cfg_select!") {
         match format_cfg_select(context, shape, mac.span(), &macro_name, style, ts.clone()) {
             Ok(rw) => return Ok(rw),
             Err(err) => match err {

--- a/src/tools/rustfmt/src/test/mod.rs
+++ b/src/tools/rustfmt/src/test/mod.rs
@@ -754,6 +754,15 @@ fn check_files(files: Vec<PathBuf>, opt_config: &Option<PathBuf>) -> (Vec<Format
             continue;
         }
 
+        if sig_comments.contains_key("stable") && is_nightly_channel!() {
+            debug!(
+                "Skipping '{}' because nightly introduces formatting changes. \
+                 Formatting should be stable on the `stable` channel.",
+                file_name.display()
+            );
+            continue;
+        }
+
         debug!("Testing '{}'...", file_name.display());
 
         match idempotent_check(&file_name, opt_config) {
@@ -824,7 +833,7 @@ fn read_config(filename: &Path) -> Config {
     };
 
     for (key, val) in &sig_comments {
-        if key != "target" && key != "config" && key != "unstable" {
+        if key != "target" && key != "config" && key != "unstable" && key != "stable" {
             config.override_value(key, val);
             if config.is_default(key) {
                 warn!("Default value {} used explicitly for {}", val, key);

--- a/src/tools/rustfmt/tests/source/cfg_select.rs
+++ b/src/tools/rustfmt/tests/source/cfg_select.rs
@@ -1,3 +1,4 @@
+// rustfmt-unstable: true
 // rustfmt-style_edition: 2024
 // rustfmt-skip_children: true
 

--- a/src/tools/rustfmt/tests/source/cfg_select_stable.rs
+++ b/src/tools/rustfmt/tests/source/cfg_select_stable.rs
@@ -1,0 +1,10 @@
+// rustfmt-stable: true
+
+// While we gate the `cfg_select!` formatting behind the `is_nightly_channel!()` check
+// this test helps ensure that we don't start formatting `cfg_select!` on the `stable`
+// or `beta` release channels. It is intentionally formatted incorrectly. As soon as the
+// `is_nightly_channel!()` gate is removed this will start formatting and we can remove this test.
+cfg_select! (
+       unix     => 1,
+       windows     => 1,
+);

--- a/src/tools/rustfmt/tests/target/cfg_select.rs
+++ b/src/tools/rustfmt/tests/target/cfg_select.rs
@@ -1,3 +1,4 @@
+// rustfmt-unstable: true
 // rustfmt-style_edition: 2024
 // rustfmt-skip_children: true
 

--- a/src/tools/rustfmt/tests/target/cfg_select_stable.rs
+++ b/src/tools/rustfmt/tests/target/cfg_select_stable.rs
@@ -1,0 +1,10 @@
+// rustfmt-stable: true
+
+// While we gate the `cfg_select!` formatting behind the `is_nightly_channel!()` check
+// this test helps ensure that we don't start formatting `cfg_select!` on the `stable`
+// or `beta` release channels. It is intentionally formatted incorrectly. As soon as the
+// `is_nightly_channel!()` gate is removed this will start formatting and we can remove this test.
+cfg_select! (
+       unix     => 1,
+       windows     => 1,
+);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->


Closes: https://github.com/rust-lang/rust/issues/160944

`cfg_select!` formatting was implemented in https://github.com/rust-lang/rust/pull/154202. The formatting diverged from what was outlined in the original Style FCP (https://github.com/rust-lang/style-team/issues/201#issuecomment-2843199321 and https://github.com/rust-lang/rust/pull/144323#issuecomment-3208197563).

Since the 1.99 beta is scheduled to branch from main on August 14 I want to get this nightly formatting gate out so that we can correct the formatting issues before we promote the formatting to the beta / stable release channels.

Style Guide PR: https://github.com/rust-lang/rust/pull/160967

r? @jieyouxu

cc: @traviscross 
