### PR TITLE
disallow `#[cold]` on `extern "custom"` functions

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -38,7 +38,7 @@ use rustc_session::lint::builtin::{
 use rustc_span::{Ident, Span, Symbol, kw, sym};
 use rustc_target::spec::{AbiMap, AbiMapping};
 
-use crate::diagnostics::{self, TildeConstReason};
+use crate::diagnostics::{self, AbiCustomCannotBeCold, AbiCustomMustBeNaked, TildeConstReason};
 
 /// Is `self` allowed semantically as the first parameter in an `FnDecl`?
 enum SelfSemantic {
@@ -895,6 +895,44 @@ impl<'a> AstValidator<'a> {
             self.dcx().emit_err(diagnostics::ExternItemAscii {
                 span: ident.span,
                 block: self.current_extern_span(),
+            });
+        }
+    }
+
+    /// Check the attributes on an `extern "custom"` function:
+    ///
+    /// - require `#[naked]`
+    /// - reject `#[cold]` (these functions cannot be called so `#[cold]` is meaningless)
+    fn check_extern_custom(&self, fk: FnKind<'_>, attrs: &AttrVec) {
+        let FnKind::Fn(fn_ctxt, _, Fn { sig, body: Some(_), .. }) = fk else {
+            return;
+        };
+
+        match fn_ctxt {
+            FnCtxt::Foreign => return,
+            FnCtxt::Free | FnCtxt::Assoc(_) => { /* fall through */ }
+        }
+
+        let Extern::Explicit(StrLit { symbol_unescaped, .. }, ext_span) = sig.header.ext else {
+            return;
+        };
+
+        let Ok(ExternAbi::Custom) = ExternAbi::from_str(symbol_unescaped.as_str()) else {
+            return;
+        };
+
+        if !attr::contains_name(attrs, sym::naked) {
+            self.dcx().emit_err(AbiCustomMustBeNaked {
+                span: sig.span,
+                naked_span: sig.span.shrink_to_lo(),
+            });
+        }
+
+        if let Some(cold) = attr::find_by_name(attrs, sym::cold) {
+            self.dcx().emit_err(AbiCustomCannotBeCold {
+                span: sig.span,
+                abi_span: ext_span,
+                cold_span: cold.span,
             });
         }
     }
@@ -1937,6 +1975,7 @@ impl Visitor<'_> for AstValidator<'_> {
             }
         }
 
+        self.check_extern_custom(fk, attrs);
         self.check_c_variadic_type(fk, attrs);
 
         // Functions cannot both be `const async` or `const gen`

--- a/compiler/rustc_ast_passes/src/diagnostics.rs
+++ b/compiler/rustc_ast_passes/src/diagnostics.rs
@@ -1264,3 +1264,37 @@ pub(crate) struct VarargsWithoutPattern {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(
+    "an `extern \"custom\"` function can only be declared externally or defined via naked functions"
+)]
+pub(crate) struct AbiCustomMustBeNaked {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion(
+        "convert this to an `#[unsafe(naked)]` function",
+        applicability = "maybe-incorrect",
+        code = "#[unsafe(naked)]\n",
+        style = "short"
+    )]
+    pub naked_span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag("an `extern \"custom\"` function cannot be marked `#[cold]`")]
+pub(crate) struct AbiCustomCannotBeCold {
+    #[primary_span]
+    pub span: Span,
+
+    #[suggestion(
+        "remove the `#[cold]` attribute",
+        applicability = "maybe-incorrect",
+        code = "",
+        style = "short"
+    )]
+    pub cold_span: Span,
+
+    #[label("`extern \"custom\"` because of this")]
+    pub abi_span: Span,
+}

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -21,7 +21,7 @@ use rustc_middle::ty::error::TypeErrorToStringExt;
 use rustc_middle::ty::layout::LayoutError;
 use rustc_middle::ty::util::Discr;
 use rustc_middle::ty::{
-    AdtDef, BottomUpFolder, FnSig, GenericArgKind, RegionKind, TypeFoldable, TypeSuperVisitable,
+    AdtDef, BottomUpFolder, GenericArgKind, RegionKind, TypeFoldable, TypeSuperVisitable,
     TypeVisitable, TypeVisitableExt, Unnormalized, fold_regions,
 };
 use rustc_session::lint::builtin::UNINHABITED_STATIC;
@@ -89,18 +89,6 @@ pub fn check_abi(tcx: TyCtxt<'_>, hir_id: hir::HirId, span: Span, abi: ExternAbi
                 span,
                 UnsupportedCallingConventions { abi },
             );
-        }
-    }
-}
-
-pub fn check_custom_abi(tcx: TyCtxt<'_>, def_id: LocalDefId, fn_sig: FnSig<'_>, fn_sig_span: Span) {
-    if fn_sig.abi() == ExternAbi::Custom {
-        // Function definitions that use `extern "custom"` must be naked functions.
-        if !find_attr!(tcx, def_id, Naked(_)) {
-            tcx.dcx().emit_err(crate::diagnostics::AbiCustomClothedFunction {
-                span: fn_sig_span,
-                naked_span: tcx.def_span(def_id).shrink_to_lo(),
-            });
         }
     }
 }

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -74,7 +74,7 @@ pub mod wfcheck;
 use std::borrow::Cow;
 use std::num::NonZero;
 
-pub use check::{check_abi, check_custom_abi};
+pub use check::check_abi;
 use rustc_abi::VariantIdx;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_errors::{ErrorGuaranteed, pluralize, struct_span_code_err};

--- a/compiler/rustc_hir_analysis/src/diagnostics.rs
+++ b/compiler/rustc_hir_analysis/src/diagnostics.rs
@@ -1948,22 +1948,6 @@ pub(crate) struct DynTraitAssocItemBindingMentionsSelf {
 }
 
 #[derive(Diagnostic)]
-#[diag(
-    "items with the \"custom\" ABI can only be declared externally or defined via naked functions"
-)]
-pub(crate) struct AbiCustomClothedFunction {
-    #[primary_span]
-    pub span: Span,
-    #[suggestion(
-        "convert this to an `#[unsafe(naked)]` function",
-        applicability = "maybe-incorrect",
-        code = "#[unsafe(naked)]\n",
-        style = "short"
-    )]
-    pub naked_span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag("`AsyncDrop` impl without `Drop` impl")]
 #[help(
     "type implementing `AsyncDrop` trait must also implement `Drop` trait to be used in sync context and unwinds"

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -47,7 +47,7 @@ use rustc_errors::{Applicability, Diag, ErrorGuaranteed, struct_span_code_err};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{HirId, HirIdMap, Node};
-use rustc_hir_analysis::check::{check_abi, check_custom_abi};
+use rustc_hir_analysis::check::check_abi;
 use rustc_hir_analysis::hir_ty_lowering::HirTyLowerer;
 use rustc_infer::traits::{ObligationCauseCode, ObligationInspector, TraitEngine, WellFormedLoc};
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
@@ -138,7 +138,7 @@ fn typeck_with_inspect<'tcx>(
         // for visit the asm expr of the body.
         let ty = fcx.check_expr(body.value);
         fcx.write_ty(id, ty);
-    } else if let Some(hir::FnSig { header, decl, span: fn_sig_span }) = node.fn_sig() {
+    } else if let Some(hir::FnSig { header, decl, span: _ }) = node.fn_sig() {
         let fn_sig = if decl.output.is_suggestable_infer_ty().is_some() {
             // In the case that we're recovering `fn() -> W<_>` or some other return
             // type that has an infer in it, lower the type directly so that it'll
@@ -150,7 +150,6 @@ fn typeck_with_inspect<'tcx>(
         };
 
         check_abi(tcx, id, span, fn_sig.abi());
-        check_custom_abi(tcx, def_id, fn_sig.skip_binder(), *fn_sig_span);
 
         loops::check(tcx, def_id, body);
 

--- a/tests/ui/abi/bad-custom.rs
+++ b/tests/ui/abi/bad-custom.rs
@@ -8,7 +8,7 @@ unsafe extern "custom" fn return_explicit_unit() -> () {
     std::arch::naked_asm!("")
 }
 
-// Rejecting an alias is the status quo, this may change in the future.
+// The unit must be syntactic, an alias is rejected.
 type UnitAlias = ();
 #[unsafe(naked)]
 unsafe extern "custom" fn return_alias_unit() -> UnitAlias {
@@ -55,7 +55,7 @@ type NoNeverReturnType = unsafe extern "custom" fn() -> !;
 //~^ ERROR invalid signature for `extern "custom"` function
 
 unsafe extern "custom" fn not_both(a: i64) -> i64 {
-    //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
+    //~^ ERROR an `extern "custom"` function can only be declared externally or defined via naked functions
     //~| ERROR invalid signature for `extern "custom"` function
     unimplemented!()
 }
@@ -67,7 +67,7 @@ struct Thing(i64);
 
 impl Thing {
     extern "custom" fn is_even(self) -> bool {
-        //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
+        //~^ ERROR an `extern "custom"` function can only be declared externally or defined via naked functions
         //~| ERROR invalid signature for `extern "custom"` function
         //~| ERROR functions with the "custom" ABI must be unsafe
         unimplemented!()
@@ -76,7 +76,7 @@ impl Thing {
 
 trait BitwiseNot {
     extern "custom" fn bitwise_not(a: i64) -> i64 {
-        //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
+        //~^ ERROR an `extern "custom"` function can only be declared externally or defined via naked functions
         //~| ERROR invalid signature for `extern "custom"` function
         //~| ERROR functions with the "custom" ABI must be unsafe
         unimplemented!()
@@ -93,7 +93,7 @@ trait Negate {
 
 impl Negate for Thing {
     extern "custom" fn negate(a: i64) -> i64 {
-        //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
+        //~^ ERROR an `extern "custom"` function can only be declared externally or defined via naked functions
         //~| ERROR functions with the "custom" ABI must be unsafe
         //~| ERROR invalid signature for `extern "custom"` function
         -a
@@ -138,13 +138,20 @@ const unsafe extern "custom" fn no_const_fn() {
 }
 
 async unsafe extern "custom" fn no_async_fn() {
-    //~^ ERROR items with the "custom" ABI can only be declared externally or defined via naked functions
+    //~^ ERROR an `extern "custom"` function can only be declared externally or defined via naked functions
     //~| ERROR functions with the "custom" ABI cannot be `async`
 }
 
 fn no_promotion_to_fn_trait(f: unsafe extern "custom" fn()) -> impl Fn() {
     //~^ ERROR expected an `Fn()` closure, found `unsafe extern "custom" fn()`
     f
+}
+
+#[cold]
+#[unsafe(naked)]
+unsafe extern "custom" fn no_cold_attribute() {
+    //~^ ERROR an `extern "custom"` function cannot be marked `#[cold]`
+    std::arch::naked_asm!("")
 }
 
 pub fn main() {

--- a/tests/ui/abi/bad-custom.stderr
+++ b/tests/ui/abi/bad-custom.stderr
@@ -150,6 +150,18 @@ LL - unsafe extern "custom" fn not_both(a: i64) -> i64 {
 LL + unsafe extern "custom" fn not_both() {
    |
 
+error: an `extern "custom"` function can only be declared externally or defined via naked functions
+  --> $DIR/bad-custom.rs:57:1
+   |
+LL | unsafe extern "custom" fn not_both(a: i64) -> i64 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: convert this to an `#[unsafe(naked)]` function
+   |
+LL + #[unsafe(naked)]
+LL | unsafe extern "custom" fn not_both(a: i64) -> i64 {
+   |
+
 error: invalid signature for `extern "custom"` function
   --> $DIR/bad-custom.rs:63:42
    |
@@ -187,6 +199,18 @@ LL -     extern "custom" fn is_even(self) -> bool {
 LL +     extern "custom" fn is_even() {
    |
 
+error: an `extern "custom"` function can only be declared externally or defined via naked functions
+  --> $DIR/bad-custom.rs:69:5
+   |
+LL |     extern "custom" fn is_even(self) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: convert this to an `#[unsafe(naked)]` function
+   |
+LL +     #[unsafe(naked)]
+LL |     extern "custom" fn is_even(self) -> bool {
+   |
+
 error: functions with the "custom" ABI must be unsafe
   --> $DIR/bad-custom.rs:78:5
    |
@@ -209,6 +233,18 @@ help: remove the parameters and return type
    |
 LL -     extern "custom" fn bitwise_not(a: i64) -> i64 {
 LL +     extern "custom" fn bitwise_not() {
+   |
+
+error: an `extern "custom"` function can only be declared externally or defined via naked functions
+  --> $DIR/bad-custom.rs:78:5
+   |
+LL |     extern "custom" fn bitwise_not(a: i64) -> i64 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: convert this to an `#[unsafe(naked)]` function
+   |
+LL +     #[unsafe(naked)]
+LL |     extern "custom" fn bitwise_not(a: i64) -> i64 {
    |
 
 error: functions with the "custom" ABI must be unsafe
@@ -257,6 +293,18 @@ help: remove the parameters and return type
    |
 LL -     extern "custom" fn negate(a: i64) -> i64 {
 LL +     extern "custom" fn negate() {
+   |
+
+error: an `extern "custom"` function can only be declared externally or defined via naked functions
+  --> $DIR/bad-custom.rs:95:5
+   |
+LL |     extern "custom" fn negate(a: i64) -> i64 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: convert this to an `#[unsafe(naked)]` function
+   |
+LL +     #[unsafe(naked)]
+LL |     extern "custom" fn negate(a: i64) -> i64 {
    |
 
 error: invalid signature for `extern "custom"` function
@@ -347,7 +395,7 @@ LL - async unsafe extern "custom" fn no_async_fn() {
 LL + unsafe extern "custom" fn no_async_fn() {
    |
 
-error: items with the "custom" ABI can only be declared externally or defined via naked functions
+error: an `extern "custom"` function can only be declared externally or defined via naked functions
   --> $DIR/bad-custom.rs:140:1
    |
 LL | async unsafe extern "custom" fn no_async_fn() {
@@ -358,6 +406,17 @@ help: convert this to an `#[unsafe(naked)]` function
 LL + #[unsafe(naked)]
 LL | async unsafe extern "custom" fn no_async_fn() {
    |
+
+error: an `extern "custom"` function cannot be marked `#[cold]`
+  --> $DIR/bad-custom.rs:152:1
+   |
+LL | #[cold]
+   | ------- help: remove the `#[cold]` attribute
+LL | #[unsafe(naked)]
+LL | unsafe extern "custom" fn no_cold_attribute() {
+   | ^^^^^^^---------------^^^^^^^^^^^^^^^^^^^^^^^
+   |        |
+   |        `extern "custom"` because of this
 
 error[E0277]: expected an `Fn()` closure, found `unsafe extern "custom" fn()`
   --> $DIR/bad-custom.rs:145:64
@@ -372,54 +431,6 @@ LL |     f
    = note: wrap the `unsafe extern "custom" fn()` in a closure with no arguments: `|| { /* code */ }`
    = note: unsafe function cannot be called generically without an unsafe block
 
-error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:57:1
-   |
-LL | unsafe extern "custom" fn not_both(a: i64) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: convert this to an `#[unsafe(naked)]` function
-   |
-LL + #[unsafe(naked)]
-LL | unsafe extern "custom" fn not_both(a: i64) -> i64 {
-   |
-
-error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:69:5
-   |
-LL |     extern "custom" fn is_even(self) -> bool {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: convert this to an `#[unsafe(naked)]` function
-   |
-LL +     #[unsafe(naked)]
-LL |     extern "custom" fn is_even(self) -> bool {
-   |
-
-error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:78:5
-   |
-LL |     extern "custom" fn bitwise_not(a: i64) -> i64 {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: convert this to an `#[unsafe(naked)]` function
-   |
-LL +     #[unsafe(naked)]
-LL |     extern "custom" fn bitwise_not(a: i64) -> i64 {
-   |
-
-error: items with the "custom" ABI can only be declared externally or defined via naked functions
-  --> $DIR/bad-custom.rs:95:5
-   |
-LL |     extern "custom" fn negate(a: i64) -> i64 {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: convert this to an `#[unsafe(naked)]` function
-   |
-LL +     #[unsafe(naked)]
-LL |     extern "custom" fn negate(a: i64) -> i64 {
-   |
-
 error: functions with the "custom" ABI cannot be called
   --> $DIR/bad-custom.rs:116:14
    |
@@ -457,49 +468,49 @@ LL |     unsafe { f(x) }
    |              ^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:152:20
+  --> $DIR/bad-custom.rs:159:20
    |
 LL |         assert_eq!(not_both(21), 42);
    |                    ^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:152:20
+  --> $DIR/bad-custom.rs:159:20
    |
 LL |         assert_eq!(not_both(21), 42);
    |                    ^^^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:155:29
+  --> $DIR/bad-custom.rs:162:29
    |
 LL |         assert_eq!(unsafe { increment(41) }, 42);
    |                             ^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:155:29
+  --> $DIR/bad-custom.rs:162:29
    |
 LL |         assert_eq!(unsafe { increment(41) }, 42);
    |                             ^^^^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:158:17
+  --> $DIR/bad-custom.rs:165:17
    |
 LL |         assert!(Thing(41).is_even());
    |                 ^^^^^^^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:158:17
+  --> $DIR/bad-custom.rs:165:17
    |
 LL |         assert!(Thing(41).is_even());
    |                 ^^^^^^^^^^^^^^^^^^^
 
 error: functions with the "custom" ABI cannot be called
-  --> $DIR/bad-custom.rs:161:20
+  --> $DIR/bad-custom.rs:168:20
    |
 LL |         assert_eq!(Thing::bitwise_not(42), !42);
    |                    ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: an `extern "custom"` function can only be called using inline assembly
-  --> $DIR/bad-custom.rs:161:20
+  --> $DIR/bad-custom.rs:168:20
    |
 LL |         assert_eq!(Thing::bitwise_not(42), !42);
    |                    ^^^^^^^^^^^^^^^^^^^^^^
@@ -510,7 +521,7 @@ error[E0015]: inline assembly is not allowed in constant functions
 LL |     std::arch::naked_asm!("")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 42 previous errors
+error: aborting due to 43 previous errors
 
 Some errors have detailed explanations: E0015, E0277.
 For more information about an error, try `rustc --explain E0015`.


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/140829

We decided in the T-lang meeting ([notes](https://hackmd.io/nPO0wh-4QhSwVU-1f_QfJg#Stabilize-extern-custom-rust158504)) to:

- reject `#[cold]`
- reject aliases for unit, only no return type or `-> ()` is accepted

I also move the check for `naked` into `ast_validation`

r? @tgross35