### PR TITLE
Also warn if an invalid `doc` attribute is used on a macro invocation

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -2241,7 +2241,11 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                 continue;
             }
 
-            if attr.doc_str_and_fragment_kind().is_some() {
+            if match &attr.kind {
+                AttrKind::Normal(normal) => normal.item.name() == Some(sym::doc),
+                AttrKind::DocComment(..) => true,
+                _ => false,
+            } {
                 self.cx.sess.psess.buffer_lint(
                     UNUSED_DOC_COMMENTS,
                     current_span,

--- a/tests/ui/lint/unused/unused-doc-comments-for-macros.rs
+++ b/tests/ui/lint/unused/unused-doc-comments-for-macros.rs
@@ -14,4 +14,13 @@ fn main() {
     /// line2
     /// line3
     foo!();
+
+    // Even invalid doc attributes should emit the warning.
+    #[doc = { //~ ERROR: unused doc comment
+        let a = 1;
+        let b = 1;
+        let sum = a + b;
+        assert_eq!(sum, 2);
+    }]
+    foo!();
 }

--- a/tests/ui/lint/unused/unused-doc-comments-for-macros.stderr
+++ b/tests/ui/lint/unused/unused-doc-comments-for-macros.stderr
@@ -27,5 +27,18 @@ LL | |     /// line3
    |
    = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
 
-error: aborting due to 2 previous errors
+error: unused doc comment
+  --> $DIR/unused-doc-comments-for-macros.rs:19:5
+   |
+LL | /     #[doc = {
+LL | |         let a = 1;
+LL | |         let b = 1;
+LL | |         let sum = a + b;
+LL | |         assert_eq!(sum, 2);
+LL | |     }]
+   | |______^ rustdoc does not generate documentation for macro invocations
+   |
+   = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Part of rust-lang/rust#160880.

So about this: I think the error message is good enough, but I can specialize it in case it's not a doc comment but a doc attribute.

Also: currently the ignored attributes are not kept in the AST, so when we reach `rustc_attr_parsing`, the attribute is not present and there won't trigger an error. I don't think it's worth changing this logic but in case someone thinks otherwise, it's mentioned. :)

r? @JonathanBrouwer 