### PR TITLE
fix: unfulfilled nested dead code lint

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -1099,6 +1099,57 @@ impl<'tcx> DeadVisitor<'tcx> {
         (level_spec.level(), level_spec.lint_id())
     }
 
+    fn fulfill_dead_code_expectations(&self, def_id: LocalDefId, include: bool) {
+        let fulfill_if_expected = |node: DefId| {
+            // Only consider local, dead symbols where lint level carries an expectation
+            if let Some(node) = node.as_local()
+                && !self.live_symbols.contains(&node)
+                && let (_, Some(expectation)) = self.def_lint_level_plus(node)
+            {
+                // Same mechanism as LintContext::fulfill_expectation.
+                self.tcx
+                    .dcx()
+                    .struct_expect(
+                        "this is a dummy diagnostic, to submit and store an expectation",
+                        expectation.into(),
+                    )
+                    .emit();
+            }
+        };
+
+        if include {
+            fulfill_if_expected(def_id.to_def_id());
+        }
+
+        match self.tcx.def_kind(def_id) {
+            DefKind::Struct | DefKind::Union | DefKind::Enum => {
+                let adt = self.tcx.adt_def(def_id);
+                for variant in adt.variants() {
+                    if variant.def_id != def_id.to_def_id() {
+                        fulfill_if_expected(variant.def_id);
+                    }
+                    for field in &variant.fields {
+                        fulfill_if_expected(field.did);
+                    }
+                }
+            }
+            DefKind::Variant => {
+                let parent_enum = self.tcx.local_parent(def_id);
+                let variant = self.tcx.adt_def(parent_enum).variant_with_id(def_id.to_def_id());
+                //Check to see if fields carry expectation
+                for field in &variant.fields {
+                    fulfill_if_expected(field.did);
+                }
+            }
+            DefKind::Trait => {
+                for &assoc_def_id in self.tcx.associated_item_def_ids(def_id) {
+                    fulfill_if_expected(assoc_def_id);
+                }
+            }
+            _ => {}
+        }
+    }
+
     fn dead_code_pub_in_binary_note(&self) -> Option<DeadCodePubInBinaryNote> {
         self.target_lint.name.eq(DEAD_CODE_PUB_IN_BINARY.name).then_some(DeadCodePubInBinaryNote)
     }
@@ -1405,10 +1456,12 @@ fn lint_dead_codes<'tcx>(
         if !live_symbols.contains(&item.owner_id.def_id) {
             let parent = tcx.local_parent(item.owner_id.def_id);
             if parent != module.to_local_def_id() && !live_symbols.contains(&parent) {
-                // We already have diagnosed something.
+                // We already have diagnosed something, but check parent's field for #[expect]
+                visitor.fulfill_dead_code_expectations(item.owner_id.def_id, true);
                 continue;
             }
             visitor.check_definition(item.owner_id.def_id);
+            visitor.fulfill_dead_code_expectations(item.owner_id.def_id, false);
             continue;
         }
 
@@ -1422,6 +1475,7 @@ fn lint_dead_codes<'tcx>(
                     // Record to group diagnostics.
                     let level_plus = visitor.def_lint_level_plus(def_id);
                     dead_variants.push(DeadItem { def_id, name: variant.name, level_plus });
+                    visitor.fulfill_dead_code_expectations(def_id, false);
                     continue;
                 }
 

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_inside_dead_code.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_inside_dead_code.rs
@@ -1,0 +1,56 @@
+//@ check-pass
+// Expectations on dead code covered by a dead parent's diagnostic must still be fulfilled.
+
+#[cfg_attr(all(), expect(unused))]
+struct Foo {
+    #[expect(unused)]
+    x: u32,
+}
+
+#[expect(dead_code)]
+struct Direct {
+    #[expect(dead_code)]
+    x: u32,
+}
+
+#[expect(unused)]
+enum DeadEnum {
+    Variant {
+        #[expect(unused)]
+        x: u32,
+    },
+}
+
+enum PartiallyDead {
+    Used,
+    #[expect(unused)]
+    Dead {
+        #[expect(unused)]
+        x: u32,
+    },
+}
+
+#[expect(unused)]
+fn dead_outer() {
+    #[expect(unused)]
+    fn dead_inner() {}
+}
+
+#[expect(unused)]
+trait DeadTrait {
+    #[expect(unused)]
+    fn dead_method(&self);
+}
+
+// `y` is read, so this expectation must stay unfulfilled.
+struct Live {
+    #[expect(unused)]
+    //~^ WARNING this lint expectation is unfulfilled
+    //~| NOTE `#[warn(unfulfilled_lint_expectations)]` on by default
+    y: u32,
+}
+
+fn main() {
+    let _ = PartiallyDead::Used;
+    let _ = Live { y: 1 }.y;
+}

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_inside_dead_code.stderr
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_inside_dead_code.stderr
@@ -1,0 +1,10 @@
+warning: this lint expectation is unfulfilled
+  --> $DIR/expect_inside_dead_code.rs:47:14
+   |
+LL |     #[expect(unused)]
+   |              ^^^^^^
+   |
+   = note: `#[warn(unfulfilled_lint_expectations)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161005)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#160942

Dead code diagnostic being covered by parent's dead diagnostic resulting in false positives on expectations not being fulfilled. fixed by checking each child of a dead item for its own expectation now and fulfilling their expectation (if valid). Follows suite for manually fulfilling expect level diagnostics (copies mechanism from `LintContext::fulfill_expectation`.

UI tests fail as expected on main (without fix)

**Input**

```rust
// This struct is only used on windows.
#[cfg_attr(not(target_os = "windows"), expect(unused))]
struct Foo {
    // This field is never used regardless of whether on windows or other.
    #[expect(unused)]
    x: u32,
}
```

**Output**
Before
```
warning: this lint expectation is unfulfilled
 --> src/lib.rs:5:14
  |
5 |     #[expect(unused)]
  |              ^^^^^^
```

After: no output

<!-- homu-ignore:start -->
I used llm originally to get an understanding of the existing flows and context of the flow around the problem, through prompting helped locate how could reuse the dummy diagnostic lint strategy created cases and I worked backwards from these cases to generate implementation and corresponding logic. I then had it wrote UI tests for those cases for me. The UI tests felt redundant to recreate since I already had it generate the original cases the linter was meant to handle and after review they seem robust couldn't seem to come up with another case.
<!-- homu-ignore:end -->
