### PR TITLE
Fix asimd/neon detection on aarch64-darwin

### DIFF
--- a/library/std_detect/src/detect/os/darwin/aarch64.rs
+++ b/library/std_detect/src/detect/os/darwin/aarch64.rs
@@ -36,7 +36,7 @@ pub(crate) fn detect_features() -> cache::Initializer {
 
     // Armv8.0 features not using the standard identifiers
     let fp = _sysctlbyname(c"hw.optional.floatingpoint");
-    let asimd = _sysctlbyname(c"hw.optional.AdvSIMD");
+    let asimd = _sysctlbyname(c"hw.optional.AdvSIMD") || _sysctlbyname(c"hw.optional.arm.AdvSIMD");
     let crc_old = _sysctlbyname(c"hw.optional.armv8_crc32");
 
     // Armv8 and Armv9 features using the standard identifiers


### PR DESCRIPTION
Fixes rust-lang/rust#160467

Previously `asimd` (alias for `neon`) for aarch64-darwin target was checked using 'hw.optional.AdvSIMD' key.
As observed on macOS Tahoe 26.5.1 and 26.6:

```console
$ sysctl -n hw.optional.AdvSIMD
sysctl: unknown oid 'hw.optional.AdvSIMD'
```
Key has been replaced with:
```console
$ sysctl -n hw.optional.arm.AdvSIMD
1
```
On latest macOS versions, `asimd` check relying on older key without arm in its path is broken and breaks `sha2`/`sha3` downstream as they depend on `asimd` in [`library/std_detect/src/detect/os/darwin/aarch64.rs`](https://github.com/rust-lang/rust/blob/c98d0cb27cc63afdd62602a52eb4feb8a1c682dd/library/std_detect/src/detect/os/darwin/aarch64.rs#L154-L155):
```rust
enable_feature(Feature::sha2, sha1 && sha256 && asimd);
enable_feature(Feature::sha3, sha512 && sha3 && asimd);
```

Changed [from](https://github.com/rust-lang/rust/blob/c98d0cb27cc63afdd62602a52eb4feb8a1c682dd/library/std_detect/src/detect/os/darwin/aarch64.rs#L39):
```rust
let asimd = _sysctlbyname(c"hw.optional.AdvSIMD");
```

[To](https://github.com/patrikas-sestokas/rust/blob/eb3bf33322c2b8e94e865b2efb33c0e252e70a6b/library/std_detect/src/detect/os/darwin/aarch64.rs#L39):
```rust
let asimd = _sysctlbyname(c"hw.optional.AdvSIMD") || _sysctlbyname(c"hw.optional.arm.AdvSIMD");
```

To support both old and new environments.

## Verification

`main.rs` using fixed version of std_detect:
```rust
#![allow(internal_features)]
#![feature(stdarch_internal)]
use std_detect::is_aarch64_feature_detected;

macro_rules! feature_bug_check {
    ($($f: tt),*) => {
        $(
            print!("{}:", $f);
            is_aarch64_feature_detected!($f).then(|| print!("r"));
            #[cfg(target_feature = $f)]
            print!("c");
            println!();
        )*
    };
}

fn main() {
    feature_bug_check!(
        "neon", "sha2", "sha3", "crc", "fp16", "fcma", "dotprod", "rdm", "lse", "rcpc", "dit",
        "dpb", "dpb2", "jsconv", "paca", "pacg", "frintts", "flagm", "sb", "ssbs"
    );
}
```

`.cargo/config.toml` statically disabling `neon` to force runtime check:
```toml
[target.'cfg(target_arch = "aarch64")']
rustflags = ["-C", "target-feature=-neon"]
```

`cargo run`:
```console
neon:r
sha2:r
sha3:r
crc:rc
fp16:r
fcma:r
dotprod:r
rdm:r
lse:rc
rcpc:rc
dit:rc
dpb:rc
dpb2:rc
jsconv:r
paca:rc
pacg:rc
frintts:rc
flagm:rc
sb:rc
ssbs:rc
```

Changing `std_detect::is_aarch64_feature_detected` to `std::arch::is_aarch64_feature_detected` reproduces rust-lang/rust#160467:
```console
neon:
sha2:
sha3:
crc:rc
fp16:r
fcma:r
dotprod:r
rdm:r
lse:rc
rcpc:rc
dit:rc
dpb:rc
dpb2:rc
jsconv:r
paca:rc
pacg:rc
frintts:rc
flagm:rc
sb:rc
ssbs:rc
```

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
