### PR TITLE
borrowck: Normalize non-rigid aliases in NLL type relating

### DIFF
--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -21,16 +21,19 @@ use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::IndexVec;
-use rustc_infer::infer::NllRegionVariableOrigin;
+use rustc_infer::infer::{NllRegionVariableOrigin, TyCtxtInferExt};
+use rustc_infer::traits::ObligationCause;
 use rustc_macros::extension;
 use rustc_middle::mir::RETURN_PLACE;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{
     self, BoundVariableKind, GenericArgs, GenericArgsRef, InlineConstArgs, InlineConstArgsParts,
-    List, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, fold_regions,
+    List, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, TypingMode,
+    fold_regions,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{ErrorGuaranteed, kw, sym};
+use rustc_trait_selection::traits::ObligationCtxt;
 use tracing::{debug, instrument};
 
 use crate::BorrowckInferCtxt;
@@ -133,12 +136,32 @@ pub(crate) enum DefiningTy<'tcx> {
     GlobalAsm(DefId),
 }
 
+fn normalized_type_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
+    let ty = tcx.type_of(def_id).instantiate_identity();
+    if !tcx.next_trait_solver_globally() {
+        return ty.skip_normalization();
+    }
+
+    let typing_mode = if tcx.use_typing_mode_post_typeck_until_borrowck() {
+        TypingMode::borrowck(tcx, def_id)
+    } else {
+        TypingMode::analysis_in_body(tcx, def_id)
+    };
+    let infcx = tcx.infer_ctxt().build(typing_mode);
+    let ocx = ObligationCtxt::new(&infcx);
+    let span = tcx.def_span(def_id);
+    let cause = ObligationCause::misc(span, def_id);
+    ocx.deeply_normalize(&cause, tcx.param_env(def_id), ty).unwrap()
+}
+
 impl<'tcx> DefiningTy<'tcx> {
     #[instrument(level = "debug", skip(tcx), ret)]
     fn new(tcx: TyCtxt<'tcx>, body_def_id: LocalDefId) -> DefiningTy<'tcx> {
         match tcx.hir_body_owner_kind(body_def_id) {
             BodyOwnerKind::Closure | BodyOwnerKind::Fn => {
-                let defining_ty = tcx.type_of(body_def_id).instantiate_identity().skip_norm_wip();
+                // Normalize after instantiation so coroutine yield/resume
+                // types in the args are rigid under the next solver.
+                let defining_ty = normalized_type_of(tcx, body_def_id);
                 match *defining_ty.kind() {
                     ty::Closure(def_id, args) => DefiningTy::Closure(def_id, args),
                     ty::Coroutine(def_id, args) => DefiningTy::Coroutine(def_id, args),

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -33,6 +33,7 @@ use rustc_hir::{self as hir, BindingMode, ByRef, HirId, ItemLocalId, Node, find_
 use rustc_index::bit_set::GrowableBitSet;
 use rustc_index::{Idx, IndexSlice, IndexVec};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
+use rustc_infer::traits::ObligationCause;
 use rustc_middle::hir::place::PlaceBase as HirPlaceBase;
 use rustc_middle::middle::region;
 use rustc_middle::mir::*;
@@ -40,6 +41,7 @@ use rustc_middle::thir::{self, ExprId, LocalVarId, Param, ParamId, PatKind, Thir
 use rustc_middle::ty::{self, ScalarInt, Ty, TyCtxt, TypeVisitableExt, TypingMode};
 use rustc_middle::{bug, span_bug};
 use rustc_span::{Span, Symbol};
+use rustc_trait_selection::traits::ObligationCtxt;
 
 use crate::builder::expr::as_place::PlaceBuilder;
 use crate::builder::scope::LintLevel;
@@ -477,15 +479,6 @@ fn construct_fn<'tcx>(
     let arguments = &thir.params;
 
     let return_ty = fn_sig.output();
-    let coroutine = match tcx.type_of(fn_def).instantiate_identity().skip_norm_wip().kind() {
-        ty::Coroutine(_, args) => Some(Box::new(CoroutineInfo::initial(
-            tcx.coroutine_kind(fn_def).unwrap(),
-            args.as_coroutine().yield_ty(),
-            args.as_coroutine().resume_ty(),
-        ))),
-        ty::Closure(..) | ty::CoroutineClosure(..) | ty::FnDef(..) => None,
-        ty => span_bug!(span_with_body, "unexpected type of body: {ty:?}"),
-    };
 
     if let Some((dialect, phase)) =
         find_attr!(tcx, fn_id, CustomMir(dialect, phase) => (dialect, phase))
@@ -514,6 +507,17 @@ fn construct_fn<'tcx>(
     };
 
     let infcx = tcx.infer_ctxt().build(typing_mode);
+
+    let coroutine = match normalized_type_of(&infcx, fn_def).kind() {
+        ty::Coroutine(_, args) => Some(Box::new(CoroutineInfo::initial(
+            tcx.coroutine_kind(fn_def).unwrap(),
+            args.as_coroutine().yield_ty(),
+            args.as_coroutine().resume_ty(),
+        ))),
+        ty::Closure(..) | ty::CoroutineClosure(..) | ty::FnDef(..) => None,
+        ty => span_bug!(span_with_body, "unexpected type of body: {ty:?}"),
+    };
+
     let mut builder = Builder::new(
         thir,
         infcx,
@@ -560,6 +564,18 @@ fn construct_fn<'tcx>(
     };
 
     body
+}
+
+fn normalized_type_of<'tcx>(infcx: &InferCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
+    let tcx = infcx.tcx;
+    let ty = tcx.type_of(def_id).instantiate_identity();
+    if !infcx.next_trait_solver() {
+        return ty.skip_normalization();
+    }
+
+    let ocx = ObligationCtxt::new(infcx);
+    let cause = ObligationCause::misc(tcx.def_span(def_id), def_id);
+    ocx.deeply_normalize(&cause, tcx.param_env(def_id), ty).unwrap()
 }
 
 fn construct_const<'a, 'tcx>(

--- a/tests/ui/traits/next-solver/coroutine-yield-unnormalized-alias.rs
+++ b/tests/ui/traits/next-solver/coroutine-yield-unnormalized-alias.rs
@@ -1,0 +1,27 @@
+//@ check-pass
+//@ edition: 2024
+//@ compile-flags: -Znext-solver=globally
+//! Regression test for #160652. Yielding an item from `impl Iterator` without an
+//! explicit `Item` bound used to ICE in NLL type relating: both the MIR `yield_ty`
+//! and the yielded local `i` were `<impl Iterator as Iterator>::Item`.
+
+#![feature(coroutines, coroutine_trait)]
+
+use std::ops::Coroutine;
+
+fn iter() -> impl Iterator {
+    Some(()).into_iter()
+}
+
+fn yield_unnormalized_item() -> impl Coroutine {
+    #[coroutine]
+    move || {
+        for i in iter() {
+            yield i
+        }
+    }
+}
+
+fn main() {
+    let _ = yield_unnormalized_item();
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161012)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#160652

With `-Znext-solver=globally`, yielding from an `impl Iterator` without an explicit `Item` bound ICEs in borrowck. The coroutine defining type returned by `type_of` is unnormalized, so its yield type remains `<impl Iterator as Iterator>::Item`. Skipping normalization propagates that non-rigid alias into both MIR's `CoroutineInfo` and borrowck's `UniversalRegions`; NLL type relating then hits its invariant that non-rigid aliases must already have been normalized.

Deeply normalize the instantiated defining type when MIR construction creates `CoroutineInfo` and when borrowck reconstructs `DefiningTy`. That makes the coroutine yield and resume types rigid before NLL compares them.

This is intentionally gated to the next solver. The old solver keeps the existing skip-normalization path because deeply normalizing defining types there causes regressions.
