### PR TITLE
Stabilize `funnel_shifts` (including `const`)

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2211,7 +2211,7 @@ pub const unsafe fn unchecked_mul<T: Copy>(x: T, y: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-#[rustc_allow_const_fn_unstable(const_trait_impl, funnel_shifts)]
+#[rustc_allow_const_fn_unstable(const_trait_impl)]
 #[miri::intrinsic_fallback_is_spec]
 pub const fn rotate_left<T: [const] fallback::FunnelShift>(x: T, shift: u32) -> T {
     // Make sure to call the intrinsic for `funnel_shl`, not the fallback impl.
@@ -2233,7 +2233,7 @@ pub const fn rotate_left<T: [const] fallback::FunnelShift>(x: T, shift: u32) -> 
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-#[rustc_allow_const_fn_unstable(const_trait_impl, funnel_shifts)]
+#[rustc_allow_const_fn_unstable(const_trait_impl)]
 #[miri::intrinsic_fallback_is_spec]
 pub const fn rotate_right<T: [const] fallback::FunnelShift>(x: T, shift: u32) -> T {
     // Make sure to call the intrinsic for `funnel_shr`, not the fallback impl.
@@ -2329,11 +2329,11 @@ pub const fn saturating_sub<T: Copy>(a: T, b: T) -> T;
 ///
 /// Safe versions of this intrinsic are available on the integer primitives
 /// via the `funnel_shl` method. For example, [`u32::funnel_shl`].
+#[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-#[rustc_const_unstable(feature = "funnel_shifts", issue = "145686")]
-#[unstable(feature = "funnel_shifts", issue = "145686")]
 #[track_caller]
+#[rustc_allow_const_fn_unstable(const_trait_impl, core_intrinsics_fallbacks)]
 #[miri::intrinsic_fallback_is_spec]
 pub const unsafe fn unchecked_funnel_shl<T: [const] fallback::FunnelShift>(
     a: T,
@@ -2357,11 +2357,11 @@ pub const unsafe fn unchecked_funnel_shl<T: [const] fallback::FunnelShift>(
 ///
 /// Safer versions of this intrinsic are available on the integer primitives
 /// via the `funnel_shr` method. For example, [`u32::funnel_shr`]
+#[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[rustc_nounwind]
-#[rustc_const_unstable(feature = "funnel_shifts", issue = "145686")]
-#[unstable(feature = "funnel_shifts", issue = "145686")]
 #[track_caller]
+#[rustc_allow_const_fn_unstable(const_trait_impl, core_intrinsics_fallbacks)]
 #[miri::intrinsic_fallback_is_spec]
 pub const unsafe fn unchecked_funnel_shr<T: [const] fallback::FunnelShift>(
     a: T,

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -131,7 +131,6 @@
 #![feature(final_associated_functions)]
 #![feature(freeze_impls)]
 #![feature(fundamental)]
-#![feature(funnel_shifts)]
 #![feature(impl_restriction)]
 #![feature(intra_doc_pointers)]
 #![feature(intrinsics)]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -526,8 +526,6 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(funnel_shifts)]
-        ///
         #[doc = concat!("let a = ", $rot_op, "_", stringify!($SelfT), ";")]
         #[doc = concat!("let b = ", $fsh_op, "_", stringify!($SelfT), ";")]
         ///
@@ -547,10 +545,8 @@ macro_rules! uint_impl {
         /// rotating by an unbounded amount like [`rotate_left`](Self::rotate_left) does:
         ///
         /// ```should_panic
-        /// #![feature(funnel_shifts)]
         /// # #![feature(cfg_overflow_checks)]
         /// # #[cfg(overflow_checks)] {
-        ///
         #[doc = concat!("let a = ", stringify!($SelfT), "::MAX;")]
         /// // Okay
         #[doc = concat!("let _ = a.rotate_left(", stringify!($SelfT), "::BITS);")]
@@ -559,8 +555,8 @@ macro_rules! uint_impl {
         /// # }
         /// # #[cfg(not(overflow_checks))] panic!("fulfill should_panic");
         /// ```
-        #[rustc_const_unstable(feature = "funnel_shifts", issue = "145686")]
-        #[unstable(feature = "funnel_shifts", issue = "145686")]
+        #[rustc_const_stable(feature = "funnel_shifts", since = "CURRENT_RUSTC_VERSION")]
+        #[stable(feature = "funnel_shifts", since = "CURRENT_RUSTC_VERSION")]
         #[must_use = "this returns the result of the operation, without modifying the original"]
         #[inline(always)]
         #[rustc_inherit_overflow_checks]
@@ -597,8 +593,6 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(funnel_shifts)]
-        ///
         #[doc = concat!("let a = ", $rot_op, "_", stringify!($SelfT), ";")]
         #[doc = concat!("let b = ", $fsh_op, "_", stringify!($SelfT), ";")]
         ///
@@ -618,10 +612,8 @@ macro_rules! uint_impl {
         /// rotating by an unbounded amount like [`rotate_right`](Self::rotate_right) does:
         ///
         /// ```should_panic
-        /// #![feature(funnel_shifts)]
         /// # #![feature(cfg_overflow_checks)]
         /// # #[cfg(overflow_checks)] {
-        ///
         #[doc = concat!("let a = ", stringify!($SelfT), "::MAX;")]
         /// // Okay
         #[doc = concat!("let _ = a.rotate_right(", stringify!($SelfT), "::BITS);")]
@@ -630,8 +622,8 @@ macro_rules! uint_impl {
         /// # }
         /// # #[cfg(not(overflow_checks))] panic!("fulfill should_panic");
         /// ```
-        #[rustc_const_unstable(feature = "funnel_shifts", issue = "145686")]
-        #[unstable(feature = "funnel_shifts", issue = "145686")]
+        #[rustc_const_stable(feature = "funnel_shifts", since = "CURRENT_RUSTC_VERSION")]
+        #[stable(feature = "funnel_shifts", since = "CURRENT_RUSTC_VERSION")]
         #[must_use = "this returns the result of the operation, without modifying the original"]
         #[inline(always)]
         #[rustc_inherit_overflow_checks]
@@ -654,8 +646,9 @@ macro_rules! uint_impl {
         #[doc = concat!("`", stringify!($SelfT) , "::BITS`,")]
         /// i.e. when [`funnel_shl`](Self::funnel_shl) would panic.
         ///
-        #[rustc_const_unstable(feature = "funnel_shifts", issue = "145686")]
-        #[unstable(feature = "funnel_shifts", issue = "145686")]
+        #[rustc_const_stable(feature = "funnel_shifts", since = "CURRENT_RUSTC_VERSION")]
+        #[stable(feature = "funnel_shifts", since = "CURRENT_RUSTC_VERSION")]
+        #[rustc_allow_const_fn_unstable(const_trait_impl)]
         #[must_use = "this returns the result of the operation, without modifying the original"]
         #[inline(always)]
         #[track_caller]
@@ -680,8 +673,9 @@ macro_rules! uint_impl {
         #[doc = concat!("`", stringify!($SelfT) , "::BITS`,")]
         /// i.e. when [`funnel_shr`](Self::funnel_shr) would panic.
         ///
-        #[rustc_const_unstable(feature = "funnel_shifts", issue = "145686")]
-        #[unstable(feature = "funnel_shifts", issue = "145686")]
+        #[rustc_const_stable(feature = "funnel_shifts", since = "CURRENT_RUSTC_VERSION")]
+        #[stable(feature = "funnel_shifts", since = "CURRENT_RUSTC_VERSION")]
+        #[rustc_allow_const_fn_unstable(const_trait_impl)]
         #[must_use = "this returns the result of the operation, without modifying the original"]
         #[inline(always)]
         #[track_caller]

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -63,7 +63,6 @@
 #![feature(fmt_internals)]
 #![feature(formatting_options)]
 #![feature(freeze)]
-#![feature(funnel_shifts)]
 #![feature(future_join)]
 #![feature(generic_assert_internals)]
 #![feature(hasher_prefixfree_extras)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -349,7 +349,6 @@
 #![feature(fmt_internals)]
 #![feature(fn_static)]
 #![feature(formatting_options)]
-#![feature(funnel_shifts)]
 #![feature(generic_atomic)]
 #![feature(hash_map_internals)]
 #![feature(hash_map_macro)]

--- a/library/stdarch/crates/core_arch/src/lib.rs
+++ b/library/stdarch/crates/core_arch/src/lib.rs
@@ -33,7 +33,6 @@
     x86_amx_intrinsics,
     f16,
     aarch64_unstable_target_feature,
-    funnel_shifts,
     avx10_target_feature,
     const_trait_impl,
     const_cmp,

--- a/src/tools/miri/tests/fail/intrinsics/funnel_shl.rs
+++ b/src/tools/miri/tests/fail/intrinsics/funnel_shl.rs
@@ -1,4 +1,4 @@
-#![feature(core_intrinsics, funnel_shifts)]
+#![feature(core_intrinsics)]
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/funnel_shr.rs
+++ b/src/tools/miri/tests/fail/intrinsics/funnel_shr.rs
@@ -1,4 +1,4 @@
-#![feature(core_intrinsics, funnel_shifts)]
+#![feature(core_intrinsics)]
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/pass/intrinsics/integer.rs
+++ b/src/tools/miri/tests/pass/intrinsics/integer.rs
@@ -1,5 +1,5 @@
 //@run-native
-#![feature(core_intrinsics, funnel_shifts)]
+#![feature(core_intrinsics)]
 use std::intrinsics::*;
 
 fn main() {

--- a/tests/codegen-llvm/force-intrinsic-fallback.rs
+++ b/tests/codegen-llvm/force-intrinsic-fallback.rs
@@ -2,7 +2,7 @@
 //
 //@ revisions: NORMAL FALLBACK
 //@ [FALLBACK] compile-flags: -Zforce-intrinsic-fallback
-#![feature(core_intrinsics, funnel_shifts)]
+#![feature(core_intrinsics)]
 
 // Check the effect of `-Zforce-intrinsic-fallback`.
 //

--- a/tests/ui/std/overflow-check-ops.rs
+++ b/tests/ui/std/overflow-check-ops.rs
@@ -7,7 +7,6 @@
 //@[WRAP] compile-flags: -C overflow-checks=false
 
 #![feature(cfg_overflow_checks)]
-#![feature(funnel_shifts)]
 
 use std::hint::black_box as bb;
 use std::{assert_matches, fmt, panic};


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161015)*
<!-- homu-ignore:end -->

`funnel_shl` and `funnel_shr` have been around for close to a year, the unchecked versions for a number of months. These are reasonably small and uncontroversial, and it can be tricky to get similar performance with a fallback; stabilize them here.

Newly stable API:

```rust
impl {u8, u16, u32, u64, u128, usize} {
    pub const fn funnel_shl(self, right: Self, shift: u32) -> Self;
    pub const fn funnel_shr(self, right: Self, shift: u32) -> Self;

    pub const unsafe fn unchecked_funnel_shl(self, right: Self, shift: u32) -> Self;
    pub const unsafe fn unchecked_funnel_shr(self, right: Self, shift: u32) -> Self;
}
```

The tracking issue also mentions a `wrapping_` version but it has not been implemented.

Closes: https://github.com/rust-lang/rust/issues/145686 (tracking issue, wrapping versions will need a new issue)

<!-- homu-ignore:start -->
This involves an intrinsic stabilization so needs FCP from both @rust-lang/lang and @rust-lang/libs-api.

@rustbot label +I-lang-nominated +I-libs-api-nominated 

Cc others who have been involved: @RalfJung, @folkertdev, @sayantn

r? libs
<!-- homu-ignore:end -->