### PR TITLE
Library: enforce clippy deref lints in CI

### DIFF
--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -188,7 +188,7 @@ impl<'a, B: ?Sized + ToOwned> Borrow<B> for Cow<'a, B>
 //     B::Owned: [const] Borrow<B>,
 {
     fn borrow(&self) -> &B {
-        &**self
+        self
     }
 }
 

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -2141,7 +2141,7 @@ impl<T: Clone, A: Allocator + Clone> Clone for Box<[T], A> {
     /// ```
     fn clone_from(&mut self, source: &Self) {
         if self.len() == source.len() {
-            self.clone_from_slice(&source);
+            self.clone_from_slice(source);
         } else {
             *self = source.clone();
         }

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -2293,14 +2293,14 @@ impl<T: ?Sized, A: Allocator> Deref for Box<T, A> {
     type Target = T;
 
     fn deref(&self) -> &T {
-        &**self
+        self
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized, A: Allocator> DerefMut for Box<T, A> {
     fn deref_mut(&mut self) -> &mut T {
-        &mut **self
+        self
     }
 }
 
@@ -2396,28 +2396,28 @@ impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Box<U>> for Box<T, Global
 #[stable(feature = "box_borrow", since = "1.1.0")]
 impl<T: ?Sized, A: Allocator> Borrow<T> for Box<T, A> {
     fn borrow(&self) -> &T {
-        &**self
+        self
     }
 }
 
 #[stable(feature = "box_borrow", since = "1.1.0")]
 impl<T: ?Sized, A: Allocator> BorrowMut<T> for Box<T, A> {
     fn borrow_mut(&mut self) -> &mut T {
-        &mut **self
+        self
     }
 }
 
 #[stable(since = "1.5.0", feature = "smart_ptr_as_ref")]
 impl<T: ?Sized, A: Allocator> AsRef<T> for Box<T, A> {
     fn as_ref(&self) -> &T {
-        &**self
+        self
     }
 }
 
 #[stable(since = "1.5.0", feature = "smart_ptr_as_ref")]
 impl<T: ?Sized, A: Allocator> AsMut<T> for Box<T, A> {
     fn as_mut(&mut self) -> &mut T {
-        &mut **self
+        self
     }
 }
 

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -1572,7 +1572,7 @@ impl<K, V, A: Allocator + Clone> BTreeMap<K, V, A> {
 
         let right_root = left_root.split_off(key, (*self.alloc).clone());
 
-        let (new_left_len, right_len) = Root::calc_split_length(total_num, &left_root, &right_root);
+        let (new_left_len, right_len) = Root::calc_split_length(total_num, left_root, &right_root);
         self.length = new_left_len;
 
         BTreeMap {
@@ -2208,8 +2208,8 @@ impl<'a, K, V, R> ExtractIfInner<'a, K, V, R> {
             // On creation, we navigated directly to the left bound, so we need only check the
             // right bound here to decide whether to stop.
             match self.range.end_bound() {
-                Bound::Included(ref end) if (*k).le(end) => (),
-                Bound::Excluded(ref end) if (*k).lt(end) => (),
+                Bound::Included(end) if (*k).le(end) => (),
+                Bound::Excluded(end) if (*k).lt(end) => (),
                 Bound::Unbounded => (),
                 _ => return None,
             }

--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -1430,7 +1430,7 @@ impl<'a, K: 'a, V: 'a> BalancingContext<'a, K, V> {
                 left_node.val_area_mut(old_left_len + 1..new_left_len),
             );
 
-            slice_remove(&mut parent_node.edge_area_mut(..old_parent_len + 1), parent_idx + 1);
+            slice_remove(parent_node.edge_area_mut(..old_parent_len + 1), parent_idx + 1);
             parent_node.correct_childrens_parent_links(parent_idx + 1..old_parent_len);
             *parent_node.len_mut() -= 1;
 

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -1971,7 +1971,7 @@ impl<'a, T: Ord, A: Allocator + Clone> Iterator for Difference<'a, T, A> {
             }
             DifferenceInner::Search { self_iter, other_set } => loop {
                 let self_next = self_iter.next()?;
-                if !other_set.contains(&self_next) {
+                if !other_set.contains(self_next) {
                     return Some(self_next);
                 }
             },
@@ -2068,7 +2068,7 @@ impl<'a, T: Ord, A: Allocator + Clone> Iterator for Intersection<'a, T, A> {
             }
             IntersectionInner::Search { small_iter, large_set } => loop {
                 let small_next = small_iter.next()?;
-                if large_set.contains(&small_next) {
+                if large_set.contains(small_next) {
                     return Some(small_next);
                 }
             },

--- a/library/alloc/src/io/impls.rs
+++ b/library/alloc/src/io/impls.rs
@@ -327,7 +327,7 @@ impl Read for &[u8] {
     fn read_buf_exact(&mut self, mut cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
         if cursor.capacity() > self.len() {
             // Append everything we can to the cursor.
-            cursor.append(*self);
+            cursor.append(self);
             *self = &self[self.len()..];
             return Err(io::Error::READ_EXACT_EOF);
         }
@@ -349,7 +349,7 @@ impl Read for &[u8] {
                 buf.try_extend_from_slice_of_bytes(*self)?;
             }
             _ => {
-                buf.extend_from_slice(*self);
+                buf.extend_from_slice(self);
             }
         }
 

--- a/library/alloc/src/io/impls.rs
+++ b/library/alloc/src/io/impls.rs
@@ -625,7 +625,7 @@ where
 
     #[inline]
     fn is_read_vectored(&self) -> bool {
-        (&**self).is_read_vectored()
+        (**self).is_read_vectored()
     }
 
     #[inline]
@@ -667,7 +667,7 @@ where
 
     #[inline]
     fn is_write_vectored(&self) -> bool {
-        (&**self).is_write_vectored()
+        (**self).is_write_vectored()
     }
 
     #[inline]

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -3858,14 +3858,14 @@ impl<'a> RcInnerPtr for WeakInner<'a> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized, A: Allocator> borrow::Borrow<T> for Rc<T, A> {
     fn borrow(&self) -> &T {
-        &**self
+        self
     }
 }
 
 #[stable(since = "1.5.0", feature = "smart_ptr_as_ref")]
 impl<T: ?Sized, A: Allocator> AsRef<T> for Rc<T, A> {
     fn as_ref(&self) -> &T {
-        &**self
+        self
     }
 }
 
@@ -3990,28 +3990,28 @@ impl<T: ?Sized, A: Allocator> fmt::Pointer for UniqueRc<T, A> {
 #[unstable(feature = "unique_rc_arc", issue = "112566")]
 impl<T: ?Sized, A: Allocator> borrow::Borrow<T> for UniqueRc<T, A> {
     fn borrow(&self) -> &T {
-        &**self
+        self
     }
 }
 
 #[unstable(feature = "unique_rc_arc", issue = "112566")]
 impl<T: ?Sized, A: Allocator> borrow::BorrowMut<T> for UniqueRc<T, A> {
     fn borrow_mut(&mut self) -> &mut T {
-        &mut **self
+        self
     }
 }
 
 #[unstable(feature = "unique_rc_arc", issue = "112566")]
 impl<T: ?Sized, A: Allocator> AsRef<T> for UniqueRc<T, A> {
     fn as_ref(&self) -> &T {
-        &**self
+        self
     }
 }
 
 #[unstable(feature = "unique_rc_arc", issue = "112566")]
 impl<T: ?Sized, A: Allocator> AsMut<T> for UniqueRc<T, A> {
     fn as_mut(&mut self) -> &mut T {
-        &mut **self
+        self
     }
 }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -3836,7 +3836,7 @@ impl Default for Arc<str> {
     #[inline]
     fn default() -> Self {
         let arc: Arc<[u8]> = Default::default();
-        debug_assert!(core::str::from_utf8(&*arc).is_ok());
+        debug_assert!(core::str::from_utf8(&arc).is_ok());
         let (ptr, alloc) = Arc::into_inner_with_allocator(arc);
         unsafe { Arc::from_ptr_in(ptr.as_ptr() as *mut ArcInner<str>, alloc) }
     }
@@ -4246,14 +4246,14 @@ impl<T, I: iter::TrustedLen<Item = T>> ToArcSlice<T> for I {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized, A: Allocator> borrow::Borrow<T> for Arc<T, A> {
     fn borrow(&self) -> &T {
-        &**self
+        self
     }
 }
 
 #[stable(since = "1.5.0", feature = "smart_ptr_as_ref")]
 impl<T: ?Sized, A: Allocator> AsRef<T> for Arc<T, A> {
     fn as_ref(&self) -> &T {
-        &**self
+        self
     }
 }
 
@@ -4463,28 +4463,28 @@ impl<T: ?Sized, A: Allocator> fmt::Pointer for UniqueArc<T, A> {
 #[unstable(feature = "unique_rc_arc", issue = "112566")]
 impl<T: ?Sized, A: Allocator> borrow::Borrow<T> for UniqueArc<T, A> {
     fn borrow(&self) -> &T {
-        &**self
+        self
     }
 }
 
 #[unstable(feature = "unique_rc_arc", issue = "112566")]
 impl<T: ?Sized, A: Allocator> borrow::BorrowMut<T> for UniqueArc<T, A> {
     fn borrow_mut(&mut self) -> &mut T {
-        &mut **self
+        self
     }
 }
 
 #[unstable(feature = "unique_rc_arc", issue = "112566")]
 impl<T: ?Sized, A: Allocator> AsRef<T> for UniqueArc<T, A> {
     fn as_ref(&self) -> &T {
-        &**self
+        self
     }
 }
 
 #[unstable(feature = "unique_rc_arc", issue = "112566")]
 impl<T: ?Sized, A: Allocator> AsMut<T> for UniqueArc<T, A> {
     fn as_mut(&mut self) -> &mut T {
-        &mut **self
+        self
     }
 }
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -3875,7 +3875,7 @@ impl<T: Clone, A: Allocator + Clone> Clone for Vec<T, A> {
     /// capacity of the original.
     fn clone(&self) -> Self {
         let alloc = self.allocator().clone();
-        <[T]>::to_vec_in(&**self, alloc)
+        <[T]>::to_vec_in(self, alloc)
     }
 
     /// Overwrites the contents of `self` with a clone of the contents of `source`.

--- a/library/alloc/src/vec/splice.rs
+++ b/library/alloc/src/vec/splice.rs
@@ -59,7 +59,7 @@ impl<I: Iterator, A: Allocator> Drop for Splice<'_, I, A> {
         // Which means we can replace the slice::Iter with pointers that won't point to deallocated
         // memory, so that Drain::drop is still allowed to call iter.len(), otherwise it would break
         // the ptr.offset_from_unsigned contract.
-        self.drain.iter = (&[]).iter();
+        self.drain.iter = [].iter();
 
         unsafe {
             if self.drain.tail_len == 0 {

--- a/library/alloc/src/wtf8/mod.rs
+++ b/library/alloc/src/wtf8/mod.rs
@@ -284,7 +284,7 @@ impl Wtf8Buf {
     /// like concatenating ill-formed UTF-16 strings effectively would.
     #[inline]
     pub fn push_wtf8(&mut self, other: &Wtf8) {
-        match ((&*self).final_lead_surrogate(), other.initial_trail_surrogate()) {
+        match ((*self).final_lead_surrogate(), other.initial_trail_surrogate()) {
             // Replace newly paired surrogates by a supplementary code point.
             (Some(lead), Some(trail)) => {
                 let len_without_lead_surrogate = self.len() - 3;
@@ -322,7 +322,7 @@ impl Wtf8Buf {
     #[inline]
     pub fn push(&mut self, code_point: CodePoint) {
         if let Some(trail) = code_point.to_trail_surrogate() {
-            if let Some(lead) = (&*self).final_lead_surrogate() {
+            if let Some(lead) = (*self).final_lead_surrogate() {
                 let len_without_lead_surrogate = self.len() - 3;
                 self.bytes.truncate(len_without_lead_surrogate);
                 self.push_char(decode_surrogate_pair(lead, trail));

--- a/library/core/src/bstr/traits.rs
+++ b/library/core/src/bstr/traits.rs
@@ -25,7 +25,7 @@ impl PartialOrd for ByteStr {
 impl PartialEq<ByteStr> for ByteStr {
     #[inline]
     fn eq(&self, other: &ByteStr) -> bool {
-        &self.0 == &other.0
+        self.0 == other.0
     }
 }
 

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -704,7 +704,7 @@ impl<T, const N: usize> AsRef<[Cell<T>; N]> for Cell<[T; N]> {
 impl<T, const N: usize> AsRef<[Cell<T>]> for Cell<[T; N]> {
     #[inline]
     fn as_ref(&self) -> &[Cell<T>] {
-        &*self.as_array_of_cells()
+        self.as_array_of_cells()
     }
 }
 

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -781,7 +781,7 @@ mod impls {
         #[inline(always)]
         #[rustc_diagnostic_item = "noop_method_clone"]
         fn clone(&self) -> Self {
-            *self
+            self
         }
     }
 

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -682,7 +682,7 @@ impl PartialEq<&Self> for CStr {
 impl PartialOrd for CStr {
     #[inline]
     fn partial_cmp(&self, other: &CStr) -> Option<Ordering> {
-        self.to_bytes().partial_cmp(&other.to_bytes())
+        self.to_bytes().partial_cmp(other.to_bytes())
     }
 }
 
@@ -690,7 +690,7 @@ impl PartialOrd for CStr {
 impl Ord for CStr {
     #[inline]
     fn cmp(&self, other: &CStr) -> Ordering {
-        self.to_bytes().cmp(&other.to_bytes())
+        self.to_bytes().cmp(other.to_bytes())
     }
 }
 

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -3189,7 +3189,7 @@ impl<T: ?Sized + Debug> Debug for Ref<'_, T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized + Debug> Debug for RefMut<'_, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        Debug::fmt(&*(self.deref()), f)
+        Debug::fmt(self.deref(), f)
     }
 }
 

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -4082,7 +4082,7 @@ pub const trait Iterator {
             mut compare: impl FnMut(&T, &T) -> bool + 'a,
         ) -> impl FnMut(T) -> bool + 'a {
             move |curr| {
-                if !compare(&last, &curr) {
+                if !compare(last, &curr) {
                     return false;
                 }
                 *last = curr;

--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -116,7 +116,7 @@ where
     type Target = T;
 
     fn deref(&self) -> &T {
-        &*self.inner
+        &self.inner
     }
 }
 
@@ -127,7 +127,7 @@ where
     F: FnOnce(T),
 {
     fn deref_mut(&mut self) -> &mut T {
-        &mut *self.inner
+        &mut self.inner
     }
 }
 

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1639,7 +1639,7 @@ impl<T, const N: usize> AsRef<[MaybeUninit<T>; N]> for MaybeUninit<[T; N]> {
 impl<T, const N: usize> AsRef<[MaybeUninit<T>]> for MaybeUninit<[T; N]> {
     #[inline]
     fn as_ref(&self) -> &[MaybeUninit<T>] {
-        &*AsRef::<[MaybeUninit<T>; N]>::as_ref(self)
+        AsRef::<[MaybeUninit<T>; N]>::as_ref(self)
     }
 }
 

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -1540,7 +1540,7 @@ impl<'a, T: ?Sized> Pin<&'a T> {
         U: ?Sized,
         F: FnOnce(&T) -> &U,
     {
-        let pointer = &*self.pointer;
+        let pointer = self.pointer;
         let new_pointer = func(pointer);
 
         // SAFETY: the safety contract for `new_unchecked` must be

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -91,7 +91,7 @@ impl [u8] {
         let mut b = other;
 
         while let ([first_a, rest_a @ ..], [first_b, rest_b @ ..]) = (a, b) {
-            if first_a.eq_ignore_ascii_case(&first_b) {
+            if first_a.eq_ignore_ascii_case(first_b) {
                 a = rest_a;
                 b = rest_b;
             } else {

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -424,7 +424,7 @@ impl<'a, T: 'a, P: FnMut(&T) -> bool> Split<'a, T, P> {
     /// ```
     #[unstable(feature = "split_as_slice", issue = "96137")]
     pub fn as_slice(&self) -> &'a [T] {
-        if self.finished { &[] } else { &self.v }
+        if self.finished { &[] } else { self.v }
     }
 }
 

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -1410,7 +1410,7 @@ impl<'a> SplitAsciiWhitespace<'a> {
         }
 
         // SAFETY: Slice is created from str.
-        Some(unsafe { crate::str::from_utf8_unchecked(&self.inner.iter.iter.v) })
+        Some(unsafe { crate::str::from_utf8_unchecked(self.inner.iter.iter.v) })
     }
 }
 

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -1051,7 +1051,7 @@ impl<'b> Pattern for &'b str {
 
     #[inline]
     fn as_utf8_pattern(&self) -> Option<Utf8Pattern<'_>> {
-        Some(Utf8Pattern::StringPattern(*self))
+        Some(Utf8Pattern::StringPattern(self))
     }
 }
 

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -245,14 +245,14 @@ impl<'a> Context<'a> {
     #[stable(feature = "futures_api", since = "1.36.0")]
     #[rustc_const_stable(feature = "const_waker", since = "1.82.0")]
     pub const fn waker(&self) -> &'a Waker {
-        &self.waker
+        self.waker
     }
 
     /// Returns a reference to the [`LocalWaker`] for the current task.
     #[inline]
     #[unstable(feature = "local_waker", issue = "118959")]
     pub const fn local_waker(&self) -> &'a LocalWaker {
-        &self.local_waker
+        self.local_waker
     }
 
     /// Returns a reference to the extension data for the current task.

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -719,7 +719,7 @@ impl fmt::Debug for OsString {
 impl PartialEq for OsString {
     #[inline]
     fn eq(&self, other: &OsString) -> bool {
-        &**self == &**other
+        **self == **other
     }
 }
 
@@ -766,19 +766,19 @@ impl PartialOrd for OsString {
     }
     #[inline]
     fn lt(&self, other: &OsString) -> bool {
-        &**self < &**other
+        **self < **other
     }
     #[inline]
     fn le(&self, other: &OsString) -> bool {
-        &**self <= &**other
+        **self <= **other
     }
     #[inline]
     fn gt(&self, other: &OsString) -> bool {
-        &**self > &**other
+        **self > **other
     }
     #[inline]
     fn ge(&self, other: &OsString) -> bool {
-        &**self >= &**other
+        **self >= **other
     }
 }
 

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -762,7 +762,7 @@ impl Eq for OsString {}
 impl PartialOrd for OsString {
     #[inline]
     fn partial_cmp(&self, other: &OsString) -> Option<cmp::Ordering> {
-        (&**self).partial_cmp(&**other)
+        (**self).partial_cmp(&**other)
     }
     #[inline]
     fn lt(&self, other: &OsString) -> bool {
@@ -786,7 +786,7 @@ impl PartialOrd for OsString {
 impl PartialOrd<str> for OsString {
     #[inline]
     fn partial_cmp(&self, other: &str) -> Option<cmp::Ordering> {
-        (&**self).partial_cmp(other)
+        (**self).partial_cmp(other)
     }
 }
 
@@ -794,7 +794,7 @@ impl PartialOrd<str> for OsString {
 impl Ord for OsString {
     #[inline]
     fn cmp(&self, other: &OsString) -> cmp::Ordering {
-        (&**self).cmp(&**other)
+        (**self).cmp(&**other)
     }
 }
 
@@ -802,7 +802,7 @@ impl Ord for OsString {
 impl Hash for OsString {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        (&**self).hash(state)
+        (**self).hash(state)
     }
 }
 
@@ -1777,7 +1777,7 @@ impl AsRef<OsStr> for str {
 impl AsRef<OsStr> for String {
     #[inline]
     fn as_ref(&self) -> &OsStr {
-        (&**self).as_ref()
+        (**self).as_ref()
     }
 }
 

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1497,7 +1497,7 @@ impl Read for File {
     }
     #[inline]
     fn is_read_vectored(&self) -> bool {
-        (&&*self).is_read_vectored()
+        (&self).is_read_vectored()
     }
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
         (&*self).read_to_end(buf)
@@ -1516,7 +1516,7 @@ impl Write for File {
     }
     #[inline]
     fn is_write_vectored(&self) -> bool {
-        (&&*self).is_write_vectored()
+        (&self).is_write_vectored()
     }
     #[inline]
     fn flush(&mut self) -> io::Result<()> {

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -796,7 +796,7 @@ impl Write for Stdout {
     }
     #[inline]
     fn is_write_vectored(&self) -> bool {
-        io::Write::is_write_vectored(&&*self)
+        io::Write::is_write_vectored(&self)
     }
     fn flush(&mut self) -> io::Result<()> {
         (&*self).flush()
@@ -1028,7 +1028,7 @@ impl Write for Stderr {
     }
     #[inline]
     fn is_write_vectored(&self) -> bool {
-        io::Write::is_write_vectored(&&*self)
+        io::Write::is_write_vectored(&self)
     }
     fn flush(&mut self) -> io::Result<()> {
         (&*self).flush()

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -740,7 +740,7 @@ mod panicking;
 
 #[path = "../../backtrace/src/lib.rs"]
 #[allow(dead_code, unused_attributes, implicit_provenance_casts, unsafe_op_in_unsafe_fn)]
-#[allow(clippy::len_zero)] // FIXME
+#[allow(clippy::len_zero, clippy::needless_borrow)] // FIXME
 mod backtrace_rs;
 
 #[stable(feature = "cfg_select", since = "1.95.0")]

--- a/library/std/src/net/socket_addr.rs
+++ b/library/std/src/net/socket_addr.rs
@@ -257,6 +257,6 @@ impl<T: ToSocketAddrs + ?Sized> ToSocketAddrs for &T {
 impl ToSocketAddrs for String {
     type Iter = vec::IntoIter<SocketAddr>;
     fn to_socket_addrs(&self) -> io::Result<vec::IntoIter<SocketAddr>> {
-        (&**self).to_socket_addrs()
+        (**self).to_socket_addrs()
     }
 }

--- a/library/std/src/os/unix/net/ancillary.rs
+++ b/library/std/src/os/unix/net/ancillary.rs
@@ -506,12 +506,12 @@ impl<'a> AncillaryData<'a> {
     fn try_from_cmsghdr(cmsg: &'a libc::cmsghdr) -> Result<Self, AncillaryError> {
         unsafe {
             let cmsg_len_zero = libc::CMSG_LEN(0) as usize;
-            let data_len = (*cmsg).cmsg_len as usize - cmsg_len_zero;
+            let data_len = cmsg.cmsg_len as usize - cmsg_len_zero;
             let data = libc::CMSG_DATA(cmsg).cast();
             let data = from_raw_parts(data, data_len);
 
-            match (*cmsg).cmsg_level {
-                libc::SOL_SOCKET => match (*cmsg).cmsg_type {
+            match cmsg.cmsg_level {
+                libc::SOL_SOCKET => match cmsg.cmsg_type {
                     libc::SCM_RIGHTS => Ok(AncillaryData::as_rights(data)),
                     #[cfg(any(target_os = "android", target_os = "linux", target_os = "cygwin"))]
                     libc::SCM_CREDENTIALS => Ok(AncillaryData::as_credentials(data)),
@@ -524,7 +524,7 @@ impl<'a> AncillaryData<'a> {
                     }
                 },
                 cmsg_level => {
-                    Err(AncillaryError::Unknown { cmsg_level, cmsg_type: (*cmsg).cmsg_type })
+                    Err(AncillaryError::Unknown { cmsg_level, cmsg_type: cmsg.cmsg_type })
                 }
             }
         }

--- a/library/std/src/os/unix/net/ancillary.rs
+++ b/library/std/src/os/unix/net/ancillary.rs
@@ -744,7 +744,7 @@ impl<'a> SocketAncillary<'a> {
     pub fn add_fds(&mut self, fds: &[RawFd]) -> bool {
         self.truncated = false;
         add_to_ancillary_data(
-            &mut self.buffer,
+            self.buffer,
             &mut self.length,
             fds,
             libc::SOL_SOCKET,
@@ -771,7 +771,7 @@ impl<'a> SocketAncillary<'a> {
     pub fn add_creds(&mut self, creds: &[SocketCred]) -> bool {
         self.truncated = false;
         add_to_ancillary_data(
-            &mut self.buffer,
+            self.buffer,
             &mut self.length,
             creds,
             libc::SOL_SOCKET,

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -642,7 +642,7 @@ impl io::Read for UnixStream {
 
     #[inline]
     fn is_read_vectored(&self) -> bool {
-        io::Read::is_read_vectored(&&*self)
+        io::Read::is_read_vectored(&self)
     }
 }
 
@@ -678,7 +678,7 @@ impl io::Write for UnixStream {
 
     #[inline]
     fn is_write_vectored(&self) -> bool {
-        io::Write::is_write_vectored(&&*self)
+        io::Write::is_write_vectored(&self)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2673,7 +2673,7 @@ impl Path {
     #[stable(feature = "path_ancestors", since = "1.28.0")]
     #[inline]
     pub fn ancestors(&self) -> Ancestors<'_> {
-        Ancestors { next: Some(&self) }
+        Ancestors { next: Some(self) }
     }
 
     /// Returns the final component of the `Path`, if there is one.

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -333,7 +333,7 @@ impl Write for ChildStdin {
     }
 
     fn is_write_vectored(&self) -> bool {
-        io::Write::is_write_vectored(&&*self)
+        io::Write::is_write_vectored(&self)
     }
 
     #[inline]

--- a/library/std/src/sync/lazy_lock.rs
+++ b/library/std/src/sync/lazy_lock.rs
@@ -258,7 +258,7 @@ impl<T, F: FnOnce() -> T> LazyLock<T, F> {
         // * the closure was not called, but a previous call initialized `value`.
         // * the closure was not called because the Once is poisoned, which we handled above.
         // So `value` has definitely been initialized and will not be modified again.
-        unsafe { &*(*this.data.get()).value }
+        unsafe { &(*this.data.get()).value }
     }
 }
 

--- a/library/std/src/sync/nonpoison/rwlock.rs
+++ b/library/std/src/sync/nonpoison/rwlock.rs
@@ -636,7 +636,7 @@ impl<'rwlock, T: ?Sized> RwLockReadGuard<'rwlock, T> {
         // reference passed to it. If the closure panics, the guard will be dropped.
         let data = NonNull::from(f(unsafe { orig.data.as_ref() }));
         let orig = ManuallyDrop::new(orig);
-        MappedRwLockReadGuard { data, inner_lock: &orig.inner_lock }
+        MappedRwLockReadGuard { data, inner_lock: orig.inner_lock }
     }
 
     /// Makes a [`MappedRwLockReadGuard`] for a component of the borrowed data. The
@@ -668,7 +668,7 @@ impl<'rwlock, T: ?Sized> RwLockReadGuard<'rwlock, T> {
             Some(data) => {
                 let data = NonNull::from(data);
                 let orig = ManuallyDrop::new(orig);
-                Ok(MappedRwLockReadGuard { data, inner_lock: &orig.inner_lock })
+                Ok(MappedRwLockReadGuard { data, inner_lock: orig.inner_lock })
             }
             None => Err(orig),
         }
@@ -861,7 +861,7 @@ impl<'rwlock, T: ?Sized> MappedRwLockReadGuard<'rwlock, T> {
         // reference passed to it. If the closure panics, the guard will be dropped.
         let data = NonNull::from(f(unsafe { orig.data.as_ref() }));
         let orig = ManuallyDrop::new(orig);
-        MappedRwLockReadGuard { data, inner_lock: &orig.inner_lock }
+        MappedRwLockReadGuard { data, inner_lock: orig.inner_lock }
     }
 
     /// Makes a [`MappedRwLockReadGuard`] for a component of the borrowed data.
@@ -893,7 +893,7 @@ impl<'rwlock, T: ?Sized> MappedRwLockReadGuard<'rwlock, T> {
             Some(data) => {
                 let data = NonNull::from(data);
                 let orig = ManuallyDrop::new(orig);
-                Ok(MappedRwLockReadGuard { data, inner_lock: &orig.inner_lock })
+                Ok(MappedRwLockReadGuard { data, inner_lock: orig.inner_lock })
             }
             None => Err(orig),
         }

--- a/library/std/src/sync/poison/rwlock.rs
+++ b/library/std/src/sync/poison/rwlock.rs
@@ -770,7 +770,7 @@ impl<'rwlock, T: ?Sized> RwLockReadGuard<'rwlock, T> {
         // reference passed to it. If the closure panics, the guard will be dropped.
         let data = NonNull::from(f(unsafe { orig.data.as_ref() }));
         let orig = ManuallyDrop::new(orig);
-        MappedRwLockReadGuard { data, inner_lock: &orig.inner_lock }
+        MappedRwLockReadGuard { data, inner_lock: orig.inner_lock }
     }
 
     /// Makes a [`MappedRwLockReadGuard`] for a component of the borrowed data. The
@@ -802,7 +802,7 @@ impl<'rwlock, T: ?Sized> RwLockReadGuard<'rwlock, T> {
             Some(data) => {
                 let data = NonNull::from(data);
                 let orig = ManuallyDrop::new(orig);
-                Ok(MappedRwLockReadGuard { data, inner_lock: &orig.inner_lock })
+                Ok(MappedRwLockReadGuard { data, inner_lock: orig.inner_lock })
             }
             None => Err(orig),
         }
@@ -996,7 +996,7 @@ impl<'rwlock, T: ?Sized> MappedRwLockReadGuard<'rwlock, T> {
         // reference passed to it. If the closure panics, the guard will be dropped.
         let data = NonNull::from(f(unsafe { orig.data.as_ref() }));
         let orig = ManuallyDrop::new(orig);
-        MappedRwLockReadGuard { data, inner_lock: &orig.inner_lock }
+        MappedRwLockReadGuard { data, inner_lock: orig.inner_lock }
     }
 
     /// Makes a [`MappedRwLockReadGuard`] for a component of the borrowed data.
@@ -1028,7 +1028,7 @@ impl<'rwlock, T: ?Sized> MappedRwLockReadGuard<'rwlock, T> {
             Some(data) => {
                 let data = NonNull::from(data);
                 let orig = ManuallyDrop::new(orig);
-                Ok(MappedRwLockReadGuard { data, inner_lock: &orig.inner_lock })
+                Ok(MappedRwLockReadGuard { data, inner_lock: orig.inner_lock })
             }
             None => Err(orig),
         }

--- a/library/std/src/sys/fs/common.rs
+++ b/library/std/src/sys/fs/common.rs
@@ -72,7 +72,7 @@ impl Dir {
     }
 
     pub fn open_file(&self, path: &Path, opts: &OpenOptions) -> io::Result<File> {
-        File::open(&self.path.join(path), &opts)
+        File::open(&self.path.join(path), opts)
     }
 
     pub fn metadata(&self) -> io::Result<FileAttr> {

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2415,7 +2415,7 @@ mod remove_dir_impl {
 
     fn remove_dir_all_recursive(parent_fd: Option<RawFd>, path: &CStr) -> io::Result<()> {
         // try opening as directory
-        let fd = match openat_nofollow_dironly(parent_fd, &path) {
+        let fd = match openat_nofollow_dironly(parent_fd, path) {
             Err(err) if matches!(err.raw_os_error(), Some(libc::ENOTDIR | libc::ELOOP)) => {
                 // not a directory - don't traverse further
                 // (for symlinks, older Linux kernels may return ELOOP instead of ENOTDIR)
@@ -2485,7 +2485,7 @@ mod remove_dir_impl {
         if attr.file_type().is_symlink() {
             super::unlink(p)
         } else {
-            remove_dir_all_recursive(None, &p)
+            remove_dir_all_recursive(None, p)
         }
     }
 

--- a/library/std/src/sys/fs/unix/dir.rs
+++ b/library/std/src/sys/fs/unix/dir.rs
@@ -38,7 +38,7 @@ impl Dir {
     }
 
     pub fn open_file(&self, path: &Path, opts: &OpenOptions) -> io::Result<File> {
-        run_path_with_cstr(path.as_ref(), &|path| self.open_file_c(path, &opts))
+        run_path_with_cstr(path.as_ref(), &|path| self.open_file_c(path, opts))
     }
 
     pub fn metadata(&self) -> io::Result<FileAttr> {

--- a/library/std/src/sys/fs/windows.rs
+++ b/library/std/src/sys/fs/windows.rs
@@ -339,7 +339,7 @@ impl File {
         let path = maybe_verbatim(path)?;
         // SAFETY: maybe_verbatim returns null-terminated strings
         let path = unsafe { WCStr::from_wchars_with_null_unchecked(&path) };
-        Self::open_native(&path, opts)
+        Self::open_native(path, opts)
     }
 
     fn open_native(path: &WCStr, opts: &OpenOptions) -> io::Result<File> {
@@ -1305,7 +1305,7 @@ pub fn unlink(path: &WCStr) -> io::Result<()> {
             let mut opts = OpenOptions::new();
             opts.access_mode(c::DELETE);
             opts.custom_flags(c::FILE_FLAG_OPEN_REPARSE_POINT);
-            if let Ok(f) = File::open_native(&path, &opts) {
+            if let Ok(f) = File::open_native(path, &opts) {
                 if f.posix_delete().is_ok() {
                     return Ok(());
                 }
@@ -1328,7 +1328,7 @@ pub fn rename(old: &WCStr, new: &WCStr) -> io::Result<()> {
             let mut opts = OpenOptions::new();
             opts.access_mode(c::DELETE);
             opts.custom_flags(c::FILE_FLAG_OPEN_REPARSE_POINT | c::FILE_FLAG_BACKUP_SEMANTICS);
-            let Ok(f) = File::open_native(&old, &opts) else { return Err(err).io_result() };
+            let Ok(f) = File::open_native(old, &opts) else { return Err(err).io_result() };
 
             // Calculate the layout of the `FILE_RENAME_INFO` we pass to `SetFileInformation`
             // This is a dynamically sized struct so we need to get the position of the last field to calculate the actual size.
@@ -1419,7 +1419,7 @@ pub fn readlink(path: &WCStr) -> io::Result<PathBuf> {
     let mut opts = OpenOptions::new();
     opts.access_mode(0);
     opts.custom_flags(c::FILE_FLAG_OPEN_REPARSE_POINT | c::FILE_FLAG_BACKUP_SEMANTICS);
-    let file = File::open_native(&path, &opts)?;
+    let file = File::open_native(path, &opts)?;
     file.readlink()
 }
 
@@ -1506,7 +1506,7 @@ fn metadata(path: &WCStr, reparse: ReparsePoint) -> io::Result<FileAttr> {
     // Attempt to open the file normally.
     // If that fails with `ERROR_SHARING_VIOLATION` then retry using `FindFirstFileExW`.
     // If the fallback fails for any reason we return the original error.
-    match File::open_native(&path, &opts) {
+    match File::open_native(path, &opts) {
         Ok(file) => file.file_attr(),
         Err(e)
             if [Some(c::ERROR_SHARING_VIOLATION as _), Some(c::ERROR_ACCESS_DENIED as _)]

--- a/library/std/src/sys/path/windows.rs
+++ b/library/std/src/sys/path/windows.rs
@@ -251,6 +251,6 @@ pub(crate) fn is_absolute_exact(path: &[u16]) -> bool {
         unsafe {
             new_path.set_len((result as usize) + 1);
         }
-        path == &new_path
+        path == new_path
     }
 }

--- a/library/std/src/sys/process/unix/common.rs
+++ b/library/std/src/sys/process/unix/common.rs
@@ -218,7 +218,7 @@ impl Command {
     pub fn chroot(&mut self, dir: &Path) {
         self.chroot = Some(os2c(dir.as_os_str(), &mut self.saw_nul));
         if self.cwd.is_none() {
-            self.cwd(&OsStr::new("/"));
+            self.cwd(OsStr::new("/"));
         }
     }
     pub fn setsid(&mut self, setsid: bool) {

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -588,6 +588,10 @@ impl CommandLineStep for CI {
                 "clippy::ptr_offset_with_cast".into(),
                 "clippy::let_and_return".into(),
                 "clippy::needless_return".into(),
+                "clippy::needless_borrow".into(),
+                "clippy::op_ref".into(),
+                "clippy::borrow_deref_ref".into(),
+                "clippy::explicit_auto_deref".into(),
             ],
             forbid: vec![],
         };


### PR DESCRIPTION
Best reviewed commit by commit.

The output is from `clippy --fix` but I've reviewed the changes and am feeling confident there are no behaviour changes. Still, a second pair of eyes would be useful.