### PR TITLE
Speed up decimal integer parsing with SWAR

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1580,6 +1580,7 @@ pub const fn can_not_overflow<T>(radix: u32, is_signed_ty: bool, digits: &[u8]) 
 ///
 /// Uses a SWAR (SIMD Within A Register) technique to check all 8 bytes
 /// without per-byte branching.
+#[cfg(not(target_pointer_width = "32"))]
 #[inline]
 const fn is_8digits(v: u64) -> bool {
     let a = v.wrapping_add(0x4646_4646_4646_4646);
@@ -1591,12 +1592,36 @@ const fn is_8digits(v: u64) -> bool {
 ///
 /// Uses a SWAR technique with 3 multiplications to convert 8 digits at once.
 /// The caller must ensure all 8 bytes are ASCII digits, e.g. via [`is_8digits`].
+#[cfg(not(target_pointer_width = "32"))]
 #[inline]
 const fn parse_8digits(v: u64) -> u64 {
     let mut v = v;
     v = (v & 0x0f0f_0f0f_0f0f_0f0f).wrapping_mul(2561) >> 8;
     v = (v & 0x00ff_00ff_00ff_00ff).wrapping_mul(6_553_601) >> 16;
     v = (v & 0x0000_ffff_0000_ffff).wrapping_mul(42_949_672_960_001) >> 32;
+    v
+}
+
+/// Checks if all 4 bytes in `v` are ASCII decimal digits (`b'0'..=b'9'`).
+///
+/// Same SWAR technique as `is_8digits` but for 32-bit registers, so it can
+/// be used on platforms where 64-bit operations are expensive.
+#[inline]
+const fn is_4digits(v: u32) -> bool {
+    let a = v.wrapping_add(0x4646_4646);
+    let b = v.wrapping_sub(0x3030_3030);
+    (a | b) & 0x8080_8080 == 0
+}
+
+/// Parses 4 ASCII decimal digits packed in a u32 into a numeric value.
+///
+/// Uses a SWAR technique with 2 multiplications to convert 4 digits at once.
+/// The caller must ensure all 4 bytes are ASCII digits, e.g. via [`is_4digits`].
+#[inline]
+const fn parse_4digits(v: u32) -> u32 {
+    let mut v = v;
+    v = (v & 0x0f0f_0f0f).wrapping_mul(2561) >> 8;
+    v = (v & 0x00ff_00ff).wrapping_mul(6_553_601) >> 16;
     v
 }
 
@@ -1841,12 +1866,18 @@ macro_rules! from_str_int_impl {
                     // `u8::MAX` is `ff` - any str of len 2 is guaranteed to not overflow.
                     // `i8::MAX` is `7f` - only a str of len 1 is guaranteed to not overflow.
 
-                    // SWAR fast path: process 8 decimal digits at once using
+                    // SWAR fast path: process decimal digits in batches using
                     // SIMD-within-a-register. Only applies to radix 10, where
-                    // the digit range is contiguous and the multiply-by-10^8
+                    // the digit range is contiguous and the multiply-by-10^N
                     // packing works. Safe because `can_not_overflow` guarantees
                     // the full result fits in `$int_ty`.
+                    //
+                    // On 64-bit+ platforms, use 8-digit batches (u64). On
+                    // 32-bit platforms, u64 multiplication is emulated and
+                    // slower than the per-byte loop, so only use 4-digit
+                    // batches (u32).
                     if radix == 10 {
+                        #[cfg(not(target_pointer_width = "32"))]
                         while let [a, b, c, d, e, f, g, h, rest @ ..] = digits {
                             let chunk = u64::from_le_bytes([*a, *b, *c, *d, *e, *f, *g, *h]);
                             if !is_8digits(chunk) {
@@ -1854,6 +1885,21 @@ macro_rules! from_str_int_impl {
                             }
                             let parsed = parse_8digits(chunk) as $int_ty;
                             result = result * (100_000_000u32 as $int_ty);
+                            if is_positive {
+                                result = result + parsed;
+                            } else {
+                                result = result - parsed;
+                            }
+                            digits = rest;
+                        }
+
+                        while let [a, b, c, d, rest @ ..] = digits {
+                            let chunk = u32::from_le_bytes([*a, *b, *c, *d]);
+                            if !is_4digits(chunk) {
+                                return Err(PIE { kind: InvalidDigit });
+                            }
+                            let parsed = parse_4digits(chunk) as $int_ty;
+                            result = result * (10_000u32 as $int_ty);
                             if is_positive {
                                 result = result + parsed;
                             } else {

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1576,6 +1576,30 @@ pub const fn can_not_overflow<T>(radix: u32, is_signed_ty: bool, digits: &[u8]) 
     radix <= 16 && digits.len() <= size_of::<T>() * 2 - is_signed_ty as usize
 }
 
+/// Checks if all 8 bytes in `v` are ASCII decimal digits (`b'0'..=b'9'`).
+///
+/// Uses a SWAR (SIMD Within A Register) technique to check all 8 bytes
+/// without per-byte branching.
+#[inline]
+const fn is_8digits(v: u64) -> bool {
+    let a = v.wrapping_add(0x4646_4646_4646_4646);
+    let b = v.wrapping_sub(0x3030_3030_3030_3030);
+    (a | b) & 0x8080_8080_8080_8080 == 0
+}
+
+/// Parses 8 ASCII decimal digits packed in a u64 into a numeric value.
+///
+/// Uses a SWAR technique with 3 multiplications to convert 8 digits at once.
+/// The caller must ensure all 8 bytes are ASCII digits, e.g. via [`is_8digits`].
+#[inline]
+const fn parse_8digits(v: u64) -> u64 {
+    let mut v = v;
+    v = (v & 0x0f0f_0f0f_0f0f_0f0f).wrapping_mul(2561) >> 8;
+    v = (v & 0x00ff_00ff_00ff_00ff).wrapping_mul(6_553_601) >> 16;
+    v = (v & 0x0000_ffff_0000_ffff).wrapping_mul(42_949_672_960_001) >> 32;
+    v
+}
+
 #[cfg_attr(not(panic = "immediate-abort"), inline(never))]
 #[cfg_attr(panic = "immediate-abort", inline)]
 #[cold]
@@ -1816,6 +1840,29 @@ macro_rules! from_str_int_impl {
                     // Consider radix 16 as it has the highest information density per digit and will thus overflow the earliest:
                     // `u8::MAX` is `ff` - any str of len 2 is guaranteed to not overflow.
                     // `i8::MAX` is `7f` - only a str of len 1 is guaranteed to not overflow.
+
+                    // SWAR fast path: process 8 decimal digits at once using
+                    // SIMD-within-a-register. Only applies to radix 10, where
+                    // the digit range is contiguous and the multiply-by-10^8
+                    // packing works. Safe because `can_not_overflow` guarantees
+                    // the full result fits in `$int_ty`.
+                    if radix == 10 {
+                        while let [a, b, c, d, e, f, g, h, rest @ ..] = digits {
+                            let chunk = u64::from_le_bytes([*a, *b, *c, *d, *e, *f, *g, *h]);
+                            if !is_8digits(chunk) {
+                                return Err(PIE { kind: InvalidDigit });
+                            }
+                            let parsed = parse_8digits(chunk) as $int_ty;
+                            result = result * (100_000_000u32 as $int_ty);
+                            if is_positive {
+                                result = result + parsed;
+                            } else {
+                                result = result - parsed;
+                            }
+                            digits = rest;
+                        }
+                    }
+
                     macro_rules! run_unchecked_loop {
                         ($unchecked_additive_op:tt) => {{
                             while let [c, rest @ ..] = digits {

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1820,7 +1820,7 @@ macro_rules! from_str_int_impl {
                 <$int_ty>::from_ascii_bytes_radix_impl(src.as_ref(), radix)
             }
 
-            #[inline]
+            #[inline(always)]
             pub(super) const fn from_ascii_bytes_radix_impl(src: &[u8], radix: u32) -> Result<$int_ty, ParseIntError> {
                 use self::IntErrorKind::*;
                 use self::ParseIntError as PIE;
@@ -1856,96 +1856,93 @@ macro_rules! from_str_int_impl {
                     };
                 }
 
+                // SWAR fast path: process leading decimal digits in
+                // batches using SIMD-within-a-register. Only radix 10 and
+                // only types of more than 4 bytes (u32 max is 10 digits, so
+                // for smaller types this whole branch is dead code).
+                //
+                // We never batch more than 16 leading digits: that many
+                // decimal digits can never overflow `$int_ty`, so the batch
+                // arithmetic is safe to run unchecked even in debug builds.
+                //
+                // In the no-overflow branch, batching can only fire for
+                // inputs that exactly fill the bound (u64, 16 digits); the
+                // tail is then empty. In the checked branch, the batch
+                // shrinks the input and the remaining digits are validated
+                // by the checked loop, which still catches overflow for
+                // inputs longer than the type's range.
+                //
+                // On 64-bit+ platforms, use 8-digit batches (u64). On
+                // 32-bit platforms, u64 multiplication is emulated and
+                // slower than the per-byte loop, so only use 4-digit
+                // batches (u32).
+                let swar_min_len = if size_of::<$int_ty>() <= 4 {
+                    usize::MAX
+                } else {
+                    16
+                };
+                macro_rules! run_swar {
+                    () => {{
+                        if radix == 10 && digits.len() >= swar_min_len {
+                            match Self::swar_parse_decimal(is_positive, result, digits) {
+                                Ok((r, rest)) => {
+                                    result = r;
+                                    digits = rest;
+                                }
+                                Err(e) => return Err(e),
+                            }
+                        }
+                    }};
+                }
+
+                macro_rules! run_unchecked_loop {
+                    ($unchecked_additive_op:tt) => {{
+                        while let [c, rest @ ..] = digits {
+                            result = result * (radix as $int_ty);
+                            let x = unwrap_or_PIE!((*c as char).to_digit(radix), InvalidDigit);
+                            result = result $unchecked_additive_op (x as $int_ty);
+                            digits = rest;
+                        }
+                    }};
+                }
+                macro_rules! run_checked_loop {
+                    ($checked_additive_op:ident, $overflow_err:ident) => {{
+                        while let [c, rest @ ..] = digits {
+                            // When `radix` is passed in as a literal, rather than doing a slow `imul`
+                            // the compiler can use shifts if `radix` can be expressed as a
+                            // sum of powers of 2 (x*10 can be written as x*8 + x*2).
+                            // When the compiler can't use these optimisations,
+                            // the latency of the multiplication can be hidden by issuing it
+                            // before the result is needed to improve performance on
+                            // modern out-of-order CPU as multiplication here is slower
+                            // than the other instructions, we can get the end result faster
+                            // doing multiplication first and let the CPU spends other cycles
+                            // doing other computation and get multiplication result later.
+                            let mul = result.checked_mul(radix as $int_ty);
+                            let x = unwrap_or_PIE!((*c as char).to_digit(radix), InvalidDigit) as $int_ty;
+                            result = unwrap_or_PIE!(mul, $overflow_err);
+                            result = unwrap_or_PIE!(<$int_ty>::$checked_additive_op(result, x), $overflow_err);
+                            digits = rest;
+                        }
+                    }};
+                }
+
+                // If the len of the str is short compared to the range of the type
+                // we are parsing into, then we can be certain that an overflow will not occur.
+                // This bound is when `radix.pow(digits.len()) - 1 <= T::MAX` but the condition
+                // above is a faster (conservative) approximation of this.
+                //
+                // Consider radix 16 as it has the highest information density per digit and will thus overflow the earliest:
+                // `u8::MAX` is `ff` - any str of len 2 is guaranteed to not overflow.
+                // `i8::MAX` is `7f` - only a str of len 1 is guaranteed to not overflow.
                 if can_not_overflow::<$int_ty>(radix, is_signed_ty, digits) {
-                    // If the len of the str is short compared to the range of the type
-                    // we are parsing into, then we can be certain that an overflow will not occur.
-                    // This bound is when `radix.pow(digits.len()) - 1 <= T::MAX` but the condition
-                    // above is a faster (conservative) approximation of this.
-                    //
-                    // Consider radix 16 as it has the highest information density per digit and will thus overflow the earliest:
-                    // `u8::MAX` is `ff` - any str of len 2 is guaranteed to not overflow.
-                    // `i8::MAX` is `7f` - only a str of len 1 is guaranteed to not overflow.
-
-                    // SWAR fast path: process decimal digits in batches using
-                    // SIMD-within-a-register. Only applies to radix 10, where
-                    // the digit range is contiguous and the multiply-by-10^N
-                    // packing works. Safe because `can_not_overflow` guarantees
-                    // the full result fits in `$int_ty`.
-                    //
-                    // On 64-bit+ platforms, use 8-digit batches (u64). On
-                    // 32-bit platforms, u64 multiplication is emulated and
-                    // slower than the per-byte loop, so only use 4-digit
-                    // batches (u32).
-                    if radix == 10 {
-                        #[cfg(not(target_pointer_width = "32"))]
-                        while let [a, b, c, d, e, f, g, h, rest @ ..] = digits {
-                            let chunk = u64::from_le_bytes([*a, *b, *c, *d, *e, *f, *g, *h]);
-                            if !is_8digits(chunk) {
-                                return Err(PIE { kind: InvalidDigit });
-                            }
-                            let parsed = parse_8digits(chunk) as $int_ty;
-                            result = result * (100_000_000u32 as $int_ty);
-                            if is_positive {
-                                result = result + parsed;
-                            } else {
-                                result = result - parsed;
-                            }
-                            digits = rest;
-                        }
-
-                        while let [a, b, c, d, rest @ ..] = digits {
-                            let chunk = u32::from_le_bytes([*a, *b, *c, *d]);
-                            if !is_4digits(chunk) {
-                                return Err(PIE { kind: InvalidDigit });
-                            }
-                            let parsed = parse_4digits(chunk) as $int_ty;
-                            result = result * (10_000u32 as $int_ty);
-                            if is_positive {
-                                result = result + parsed;
-                            } else {
-                                result = result - parsed;
-                            }
-                            digits = rest;
-                        }
-                    }
-
-                    macro_rules! run_unchecked_loop {
-                        ($unchecked_additive_op:tt) => {{
-                            while let [c, rest @ ..] = digits {
-                                result = result * (radix as $int_ty);
-                                let x = unwrap_or_PIE!((*c as char).to_digit(radix), InvalidDigit);
-                                result = result $unchecked_additive_op (x as $int_ty);
-                                digits = rest;
-                            }
-                        }};
-                    }
                     if is_positive {
                         run_unchecked_loop!(+)
                     } else {
                         run_unchecked_loop!(-)
                     };
                 } else {
-                    macro_rules! run_checked_loop {
-                        ($checked_additive_op:ident, $overflow_err:ident) => {{
-                            while let [c, rest @ ..] = digits {
-                                // When `radix` is passed in as a literal, rather than doing a slow `imul`
-                                // the compiler can use shifts if `radix` can be expressed as a
-                                // sum of powers of 2 (x*10 can be written as x*8 + x*2).
-                                // When the compiler can't use these optimisations,
-                                // the latency of the multiplication can be hidden by issuing it
-                                // before the result is needed to improve performance on
-                                // modern out-of-order CPU as multiplication here is slower
-                                // than the other instructions, we can get the end result faster
-                                // doing multiplication first and let the CPU spends other cycles
-                                // doing other computation and get multiplication result later.
-                                let mul = result.checked_mul(radix as $int_ty);
-                                let x = unwrap_or_PIE!((*c as char).to_digit(radix), InvalidDigit) as $int_ty;
-                                result = unwrap_or_PIE!(mul, $overflow_err);
-                                result = unwrap_or_PIE!(<$int_ty>::$checked_additive_op(result, x), $overflow_err);
-                                digits = rest;
-                            }
-                        }};
-                    }
+                    run_swar!();
                     if is_positive {
                         run_checked_loop!(checked_add, PosOverflow)
                     } else {
@@ -1953,6 +1950,72 @@ macro_rules! from_str_int_impl {
                     };
                 }
                 Ok(result)
+            }
+
+            /// SWAR (SIMD-within-a-register) helper for radix-10 parsing.
+            /// Parses up to 16 leading decimal digits in 8- and 4-digit
+            /// batches, returning the accumulated result and the remaining
+            /// digits. The caller then runs the checked loop on the tail.
+            ///
+            /// Batches are bounded so the unchecked batch arithmetic can
+            /// never overflow `$int_ty`, even in debug builds.
+            ///
+            /// Must stay inlinable (`#[inline]`, not outlined): an out-of-line
+            /// call here, even though it is only reachable on the long-input
+            /// path, makes LLVM set up a stack frame in the hot caller and
+            /// measurably slows short inputs that never reach the SWAR path.
+            #[inline]
+            pub(super) const fn swar_parse_decimal(
+                is_positive: bool,
+                mut result: $int_ty,
+                mut digits: &[u8],
+            ) -> Result<($int_ty, &[u8]), ParseIntError> {
+                use self::IntErrorKind::*;
+                use self::ParseIntError as PIE;
+
+                let mut remaining = match size_of::<$int_ty>() {
+                    1 => 0,
+                    2 => 4,
+                    4 => 8,
+                    _ => 16,
+                };
+
+                #[cfg(not(target_pointer_width = "32"))]
+                while remaining >= 8 {
+                    let [a, b, c, d, e, f, g, h, rest @ ..] = digits else { break };
+                    let chunk = u64::from_le_bytes([*a, *b, *c, *d, *e, *f, *g, *h]);
+                    if !is_8digits(chunk) {
+                        return Err(PIE { kind: InvalidDigit });
+                    }
+                    let parsed = parse_8digits(chunk) as $int_ty;
+                    result = result * (100_000_000u32 as $int_ty);
+                    if is_positive {
+                        result = result + parsed;
+                    } else {
+                        result = result - parsed;
+                    }
+                    digits = rest;
+                    remaining -= 8;
+                }
+
+                while remaining >= 4 {
+                    let [a, b, c, d, rest @ ..] = digits else { break };
+                    let chunk = u32::from_le_bytes([*a, *b, *c, *d]);
+                    if !is_4digits(chunk) {
+                        return Err(PIE { kind: InvalidDigit });
+                    }
+                    let parsed = parse_4digits(chunk) as $int_ty;
+                    result = result * (10_000u32 as $int_ty);
+                    if is_positive {
+                        result = result + parsed;
+                    } else {
+                        result = result - parsed;
+                    }
+                    digits = rest;
+                    remaining -= 4;
+                }
+
+                Ok((result, digits))
             }
         }
     )*}

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1576,53 +1576,123 @@ pub const fn can_not_overflow<T>(radix: u32, is_signed_ty: bool, digits: &[u8]) 
     radix <= 16 && digits.len() <= size_of::<T>() * 2 - is_signed_ty as usize
 }
 
-/// Checks if all 8 bytes in `v` are ASCII decimal digits (`b'0'..=b'9'`).
+/// SIMD-within-a-register helpers for radix-10 parsing.
 ///
-/// Uses a SWAR (SIMD Within A Register) technique to check all 8 bytes
-/// without per-byte branching.
-#[cfg(not(target_pointer_width = "32"))]
-#[inline]
-const fn is_8digits(v: u64) -> bool {
-    let a = v.wrapping_add(0x4646_4646_4646_4646);
-    let b = v.wrapping_sub(0x3030_3030_3030_3030);
-    (a | b) & 0x8080_8080_8080_8080 == 0
-}
+/// Kept outside the integer-type macro so the SWAR implementation is not
+/// duplicated for every `FromStr` instantiation, and so it is only emitted
+/// for the types that actually dispatch here.
+mod decimal_swar {
+    use super::{IntErrorKind, ParseIntError};
 
-/// Parses 8 ASCII decimal digits packed in a u64 into a numeric value.
-///
-/// Uses a SWAR technique with 3 multiplications to convert 8 digits at once.
-/// The caller must ensure all 8 bytes are ASCII digits, e.g. via [`is_8digits`].
-#[cfg(not(target_pointer_width = "32"))]
-#[inline]
-const fn parse_8digits(v: u64) -> u64 {
-    let mut v = v;
-    v = (v & 0x0f0f_0f0f_0f0f_0f0f).wrapping_mul(2561) >> 8;
-    v = (v & 0x00ff_00ff_00ff_00ff).wrapping_mul(6_553_601) >> 16;
-    v = (v & 0x0000_ffff_0000_ffff).wrapping_mul(42_949_672_960_001) >> 32;
-    v
-}
+    /// Checks if all bytes in `v` are ASCII decimal digits (`b'0'..=b'9'`).
+    ///
+    /// For each byte `c`, two tests must both clear the high bit:
+    /// - `c + 0x46` overflows only when `c > 0xb9`, which is true for all
+    ///   non-digits above `'9'` (0x39) and false for digits `0x30..=0x39`.
+    ///   Adding `'F'` (0x46) maps `'0'..='9'` to `0x76..=0x7f`, all with
+    ///   the high bit clear.
+    /// - `c - '0'` (0x30) underflows only when `c < 0x30`, which is true
+    ///   for all non-digits below `'0'`.
+    ///
+    /// ORing the two results and testing the high bit catches any byte
+    /// that fails either test.
+    #[inline]
+    pub(super) const fn is_digits(v: usize) -> bool {
+        let a = v.wrapping_add(usize::repeat_u8(0x46));
+        let b = v.wrapping_sub(usize::repeat_u8(0x30));
+        (a | b) & usize::repeat_u8(0x80) == 0
+    }
 
-/// Checks if all 4 bytes in `v` are ASCII decimal digits (`b'0'..=b'9'`).
-///
-/// Same SWAR technique as `is_8digits` but for 32-bit registers, so it can
-/// be used on platforms where 64-bit operations are expensive.
-#[inline]
-const fn is_4digits(v: u32) -> bool {
-    let a = v.wrapping_add(0x4646_4646);
-    let b = v.wrapping_sub(0x3030_3030);
-    (a | b) & 0x8080_8080 == 0
-}
+    /// Parses 8 ASCII decimal digits packed in a u64 into a numeric value.
+    ///
+    /// The caller must ensure all 8 bytes are ASCII digits, e.g. via [`is_digits`].
+    #[cfg(not(target_pointer_width = "32"))]
+    #[inline]
+    pub(super) const fn parse_8digits(v: u64) -> u64 {
+        let mut v = v;
+        v = (v & 0x0f0f_0f0f_0f0f_0f0f).wrapping_mul(2561) >> 8;
+        v = (v & 0x00ff_00ff_00ff_00ff).wrapping_mul(6_553_601) >> 16;
+        v = (v & 0x0000_ffff_0000_ffff).wrapping_mul(42_949_672_960_001) >> 32;
+        v
+    }
 
-/// Parses 4 ASCII decimal digits packed in a u32 into a numeric value.
-///
-/// Uses a SWAR technique with 2 multiplications to convert 4 digits at once.
-/// The caller must ensure all 4 bytes are ASCII digits, e.g. via [`is_4digits`].
-#[inline]
-const fn parse_4digits(v: u32) -> u32 {
-    let mut v = v;
-    v = (v & 0x0f0f_0f0f).wrapping_mul(2561) >> 8;
-    v = (v & 0x00ff_00ff).wrapping_mul(6_553_601) >> 16;
-    v
+    /// Parses 4 ASCII decimal digits packed in a u32 into a numeric value.
+    ///
+    /// The caller must ensure all 4 bytes are ASCII digits, e.g. via [`is_digits`].
+    #[cfg(target_pointer_width = "32")]
+    #[inline]
+    pub(super) const fn parse_4digits(v: u32) -> u32 {
+        let mut v = v;
+        v = (v & 0x0f0f_0f0f).wrapping_mul(2561) >> 8;
+        v = (v & 0x00ff_00ff).wrapping_mul(6_553_601) >> 16;
+        v
+    }
+
+    /// Parses up to 16 leading decimal digits in batches, returning the
+    /// accumulated result and the remaining digits.
+    ///
+    /// The arithmetic is done in `i64` so the same code works for `u64`,
+    /// `i64`, `u128` and `i128`. 16 decimal digits can never overflow
+    /// `i64`/`u64`, so the batch arithmetic is safe to run unchecked even
+    /// in debug builds.
+    #[cfg(not(target_pointer_width = "32"))]
+    #[inline]
+    pub(super) const fn parse_decimal_i64(
+        is_positive: bool,
+        mut result: i64,
+        mut digits: &[u8],
+    ) -> Result<(i64, &[u8]), ParseIntError> {
+        let mut remaining = 16;
+
+        while remaining >= 8 {
+            let [a, b, c, d, e, f, g, h, rest @ ..] = digits else { break };
+            let chunk = u64::from_le_bytes([*a, *b, *c, *d, *e, *f, *g, *h]);
+            if !is_digits(chunk as usize) {
+                return Err(ParseIntError { kind: IntErrorKind::InvalidDigit });
+            }
+            let parsed = parse_8digits(chunk) as i64;
+            result = result.wrapping_mul(100_000_000);
+            if is_positive {
+                result = result.wrapping_add(parsed);
+            } else {
+                result = result.wrapping_sub(parsed);
+            }
+            digits = rest;
+            remaining -= 8;
+        }
+
+        Ok((result, digits))
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[inline]
+    pub(super) const fn parse_decimal_i64(
+        is_positive: bool,
+        mut result: i64,
+        mut digits: &[u8],
+    ) -> Result<(i64, &[u8]), ParseIntError> {
+        // 32-bit platforms avoid 64-bit multiplication, so use 4-digit batches.
+        let mut remaining = 16;
+
+        while remaining >= 4 {
+            let [a, b, c, d, rest @ ..] = digits else { break };
+            let chunk = u32::from_le_bytes([*a, *b, *c, *d]);
+            if !is_digits(chunk as usize) {
+                return Err(ParseIntError { kind: IntErrorKind::InvalidDigit });
+            }
+            let parsed = parse_4digits(chunk) as i64;
+            result = result.wrapping_mul(10_000);
+            if is_positive {
+                result = result.wrapping_add(parsed);
+            } else {
+                result = result.wrapping_sub(parsed);
+            }
+            digits = rest;
+            remaining -= 4;
+        }
+
+        Ok((result, digits))
+    }
 }
 
 #[cfg_attr(not(panic = "immediate-abort"), inline(never))]
@@ -1637,9 +1707,37 @@ const fn from_ascii_bytes_radix_panic(radix: u32) -> ! {
     )
 }
 
-macro_rules! from_str_int_impl {
-    ($signedness:ident $($int_ty:ty)+) => {$(
-        #[stable(feature = "rust1", since = "1.0.0")]
+macro_rules! define_swar_min_len {
+    ($int_ty:ty, true) => {
+        const SWAR_MIN_LEN: usize = 16;
+    };
+    ($int_ty:ty, false) => {};
+}
+
+macro_rules! maybe_define_swar {
+    ($int_ty:ty, true) => {
+        /// Parses up to 16 leading radix-10 digits in batches.
+        ///
+        /// This thin wrapper dispatches to `decimal_swar`, which lives outside
+        /// the per-type macro so its body is not duplicated for types that
+        /// never reach it.
+        #[inline]
+        pub(super) const fn swar_parse_decimal(
+            is_positive: bool,
+            result: $int_ty,
+            digits: &[u8],
+        ) -> Result<($int_ty, &[u8]), ParseIntError> {
+            match decimal_swar::parse_decimal_i64(is_positive, result as i64, digits) {
+                Ok((r, rest)) => Ok((r as $int_ty, rest)),
+                Err(e) => Err(e),
+            }
+        }
+    };
+    ($int_ty:ty, false) => {};
+}
+
+macro_rules! from_str_int_impl_inner {
+    ($signedness:ident $int_ty:ty, $swar:tt) => {        #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
         const impl FromStr for $int_ty {
             type Err = ParseIntError;
@@ -1858,32 +1956,20 @@ macro_rules! from_str_int_impl {
 
                 // SWAR fast path: process leading decimal digits in
                 // batches using SIMD-within-a-register. Only radix 10 and
-                // only types of more than 4 bytes (u32 max is 10 digits, so
-                // for smaller types this whole branch is dead code).
+                // only for types of at least 8 bytes; smaller types use the
+                // no-SWAR macro arm and never see this code.
                 //
                 // We never batch more than 16 leading digits: that many
-                // decimal digits can never overflow `$int_ty`, so the batch
-                // arithmetic is safe to run unchecked even in debug builds.
-                //
-                // In the no-overflow branch, batching can only fire for
-                // inputs that exactly fill the bound (u64, 16 digits); the
-                // tail is then empty. In the checked branch, the batch
-                // shrinks the input and the remaining digits are validated
-                // by the checked loop, which still catches overflow for
-                // inputs longer than the type's range.
-                //
-                // On 64-bit+ platforms, use 8-digit batches (u64). On
-                // 32-bit platforms, u64 multiplication is emulated and
-                // slower than the per-byte loop, so only use 4-digit
-                // batches (u32).
-                let swar_min_len = if size_of::<$int_ty>() <= 4 {
-                    usize::MAX
-                } else {
-                    16
-                };
+                // decimal digits can never overflow `u64`/`u128`, so the
+                // batch arithmetic is safe to run unchecked even in debug
+                // builds. The tail after the batches is validated by the
+                // checked loop, which still catches overflow for inputs
+                // longer than the type's range.
+                define_swar_min_len!($int_ty, $swar);
+
                 macro_rules! run_swar {
-                    () => {{
-                        if radix == 10 && digits.len() >= swar_min_len {
+                    (true) => {{
+                        if radix == 10 && digits.len() >= SWAR_MIN_LEN {
                             match Self::swar_parse_decimal(is_positive, result, digits) {
                                 Ok((r, rest)) => {
                                     result = r;
@@ -1893,6 +1979,7 @@ macro_rules! from_str_int_impl {
                             }
                         }
                     }};
+                    (false) => {{}};
                 }
 
                 macro_rules! run_unchecked_loop {
@@ -1942,7 +2029,7 @@ macro_rules! from_str_int_impl {
                         run_unchecked_loop!(-)
                     };
                 } else {
-                    run_swar!();
+                    run_swar!($swar);
                     if is_positive {
                         run_checked_loop!(checked_add, PosOverflow)
                     } else {
@@ -1952,74 +2039,21 @@ macro_rules! from_str_int_impl {
                 Ok(result)
             }
 
-            /// SWAR (SIMD-within-a-register) helper for radix-10 parsing.
-            /// Parses up to 16 leading decimal digits in 8- and 4-digit
-            /// batches, returning the accumulated result and the remaining
-            /// digits. The caller then runs the checked loop on the tail.
-            ///
-            /// Batches are bounded so the unchecked batch arithmetic can
-            /// never overflow `$int_ty`, even in debug builds.
-            ///
-            /// Must stay inlinable (`#[inline]`, not outlined): an out-of-line
-            /// call here, even though it is only reachable on the long-input
-            /// path, makes LLVM set up a stack frame in the hot caller and
-            /// measurably slows short inputs that never reach the SWAR path.
-            #[inline]
-            pub(super) const fn swar_parse_decimal(
-                is_positive: bool,
-                mut result: $int_ty,
-                mut digits: &[u8],
-            ) -> Result<($int_ty, &[u8]), ParseIntError> {
-                use self::IntErrorKind::*;
-                use self::ParseIntError as PIE;
-
-                let mut remaining = match size_of::<$int_ty>() {
-                    1 => 0,
-                    2 => 4,
-                    4 => 8,
-                    _ => 16,
-                };
-
-                #[cfg(not(target_pointer_width = "32"))]
-                while remaining >= 8 {
-                    let [a, b, c, d, e, f, g, h, rest @ ..] = digits else { break };
-                    let chunk = u64::from_le_bytes([*a, *b, *c, *d, *e, *f, *g, *h]);
-                    if !is_8digits(chunk) {
-                        return Err(PIE { kind: InvalidDigit });
-                    }
-                    let parsed = parse_8digits(chunk) as $int_ty;
-                    result = result * (100_000_000u32 as $int_ty);
-                    if is_positive {
-                        result = result + parsed;
-                    } else {
-                        result = result - parsed;
-                    }
-                    digits = rest;
-                    remaining -= 8;
-                }
-
-                while remaining >= 4 {
-                    let [a, b, c, d, rest @ ..] = digits else { break };
-                    let chunk = u32::from_le_bytes([*a, *b, *c, *d]);
-                    if !is_4digits(chunk) {
-                        return Err(PIE { kind: InvalidDigit });
-                    }
-                    let parsed = parse_4digits(chunk) as $int_ty;
-                    result = result * (10_000u32 as $int_ty);
-                    if is_positive {
-                        result = result + parsed;
-                    } else {
-                        result = result - parsed;
-                    }
-                    digits = rest;
-                    remaining -= 4;
-                }
-
-                Ok((result, digits))
-            }
+            maybe_define_swar!($int_ty, $swar);
         }
-    )*}
+    };
 }
 
-from_str_int_impl! { signed isize i8 i16 i32 i64 i128 }
-from_str_int_impl! { unsigned usize u8 u16 u32 u64 u128 }
+macro_rules! from_str_int_impl {
+    ($signedness:ident $($int_ty:ty)+) => {
+        $( from_str_int_impl_inner! { $signedness $int_ty, true } )+
+    };
+    ($signedness:ident @no_swar $($int_ty:ty)+) => {
+        $( from_str_int_impl_inner! { $signedness $int_ty, false } )+
+    };
+}
+
+from_str_int_impl! { signed i64 i128 }
+from_str_int_impl! { signed @no_swar isize i8 i16 i32 }
+from_str_int_impl! { unsigned u64 u128 }
+from_str_int_impl! { unsigned @no_swar usize u8 u16 u32 }

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1586,16 +1586,24 @@ mod decimal_swar {
 
     /// Checks if all bytes in `v` are ASCII decimal digits (`b'0'..=b'9'`).
     ///
-    /// For each byte `c`, two tests must both clear the high bit:
-    /// - `c + 0x46` overflows only when `c > 0xb9`, which is true for all
-    ///   non-digits above `'9'` (0x39) and false for digits `0x30..=0x39`.
-    ///   Adding `'F'` (0x46) maps `'0'..='9'` to `0x76..=0x7f`, all with
-    ///   the high bit clear.
-    /// - `c - '0'` (0x30) underflows only when `c < 0x30`, which is true
-    ///   for all non-digits below `'0'`.
+    /// The per-byte range test is turned into a high-bit test so that all
+    /// bytes are checked with a single branch:
     ///
-    /// ORing the two results and testing the high bit catches any byte
-    /// that fails either test.
+    /// - `c - b'0'` wraps around, setting the high bit, for every byte
+    ///   below `'0'` (and for `0xb0..=0xff`, see below).
+    /// - For the upper bound we need a constant `k` with `'9' + k < 0x80`
+    ///   and `':' + k >= 0x80`, so that a single bit separates the last
+    ///   digit from the first non-digit above it. `0x7f - 0x39 = 0x46` is
+    ///   the unique such constant: `'9' + 0x46 = 0x7f` and `':' + 0x46 =
+    ///   0x80`. (Adding `'9'` itself would put `':'` at 0x73 with the
+    ///   high bit still clear, and the test would never fire.)
+    ///
+    /// The addition flags `0x3a..=0xb9`; past that the sum wraps past
+    /// `0x100`, which leaves the high bit clear again, but those bytes
+    /// are caught by the subtraction (`c - b'0' >= 0x80`). Between the
+    /// two tests every non-digit byte is flagged and no digit ever is.
+    ///
+    /// This is the same check `dec2flt`'s `is_8digits` performs.
     #[inline]
     pub(super) const fn is_digits(v: usize) -> bool {
         let a = v.wrapping_add(usize::repeat_u8(0x46));
@@ -1603,9 +1611,27 @@ mod decimal_swar {
         (a | b) & usize::repeat_u8(0x80) == 0
     }
 
-    /// Parses 8 ASCII decimal digits packed in a u64 into a numeric value.
+    /// Parses 8 ASCII decimal digits packed in a `u64` into their numeric
+    /// value (little-endian: the first digit is the least significant
+    /// byte).
     ///
-    /// The caller must ensure all 8 bytes are ASCII digits, e.g. via [`is_digits`].
+    /// Three multiply-shift steps fold neighboring groups together. A
+    /// step that merges groups of `g` digits multiplies by
+    /// `10^g * 2^(8g) + 1`, which adds each group's value to the group
+    /// above it times `10^g`; the shift slides the results down, and the
+    /// masks keep only the cleanly merged groups (the multiplies also
+    /// leave overlapping garbage in between):
+    ///
+    /// - `& 0x0f` strips the `0x3` high nibble of each ASCII digit,
+    ///   leaving groups of one digit each,
+    /// - `* 2561 >> 8` (`2561 = 10 * 256 + 1`) leaves two-digit values,
+    /// - `* 6_553_601 >> 16` (`= 100 * 65_536 + 1`) leaves four-digit
+    ///   values,
+    /// - `* 42_949_672_960_001 >> 32` (`= 10_000 * 2^32 + 1`) leaves the
+    ///   final eight-digit value.
+    ///
+    /// The caller must ensure all 8 bytes are ASCII digits, e.g. via
+    /// [`is_digits`].
     #[cfg(not(target_pointer_width = "32"))]
     #[inline]
     pub(super) const fn parse_8digits(v: u64) -> u64 {
@@ -1616,9 +1642,18 @@ mod decimal_swar {
         v
     }
 
-    /// Parses 4 ASCII decimal digits packed in a u32 into a numeric value.
+    /// Parses 4 ASCII decimal digits packed in a `u32` into their numeric
+    /// value (little-endian: the first digit is the least significant
+    /// byte).
     ///
-    /// The caller must ensure all 4 bytes are ASCII digits, e.g. via [`is_digits`].
+    /// The same folding scheme as [`parse_8digits`], stopped one step
+    /// early since only four digits are needed: `& 0x0f` strips the `0x3`
+    /// high nibble of each ASCII digit, `* 2561 >> 8` (`2561 =
+    /// 10 * 256 + 1`) leaves two-digit values, and `* 6_553_601 >> 16`
+    /// (`= 100 * 65_536 + 1`) leaves the four-digit value.
+    ///
+    /// The caller must ensure all 4 bytes are ASCII digits, e.g. via
+    /// [`is_digits`].
     #[cfg(target_pointer_width = "32")]
     #[inline]
     pub(super) const fn parse_4digits(v: u32) -> u32 {

--- a/library/coretests/benches/num/mod.rs
+++ b/library/coretests/benches/num/mod.rs
@@ -34,16 +34,16 @@ const ASCII_NUMBERS: [&str; 19] = [
 /// Long decimal strings (16-20 digits) that trigger the SWAR fast path
 /// multiple times for 64-bit integer parsing.
 const LONG_ASCII_NUMBERS: [&str; 10] = [
-    "1234567890123456", // 16 digits, exactly 2 SWAR chunks
-    "12345678901234567", // 17 digits
-    "123456789012345678", // 18 digits
-    "1234567890123456789", // 19 digits
+    "1234567890123456",     // 16 digits, exactly 2 SWAR chunks
+    "12345678901234567",    // 17 digits
+    "123456789012345678",   // 18 digits
+    "1234567890123456789",  // 19 digits
     "18446744073709551615", // 20 digits, u64::MAX
-    "9223372036854775807", // 19 digits, i64::MAX
-    "9999999999999999", // 16 digits
-    "10000000000000000", // 17 digits
+    "9223372036854775807",  // 19 digits, i64::MAX
+    "9999999999999999",     // 16 digits
+    "10000000000000000",    // 17 digits
     "-9223372036854775808", // 19 digits + sign, i64::MIN
-    "0000123456789012", // 16 digits with leading zeros
+    "0000123456789012",     // 16 digits with leading zeros
 ];
 
 macro_rules! from_str_bench {

--- a/library/coretests/benches/num/mod.rs
+++ b/library/coretests/benches/num/mod.rs
@@ -31,6 +31,21 @@ const ASCII_NUMBERS: [&str; 19] = [
     "c0ffee",
 ];
 
+/// Long decimal strings (16-20 digits) that trigger the SWAR fast path
+/// multiple times for 64-bit integer parsing.
+const LONG_ASCII_NUMBERS: [&str; 10] = [
+    "1234567890123456", // 16 digits, exactly 2 SWAR chunks
+    "12345678901234567", // 17 digits
+    "123456789012345678", // 18 digits
+    "1234567890123456789", // 19 digits
+    "18446744073709551615", // 20 digits, u64::MAX
+    "9223372036854775807", // 19 digits, i64::MAX
+    "9999999999999999", // 16 digits
+    "10000000000000000", // 17 digits
+    "-9223372036854775808", // 19 digits + sign, i64::MIN
+    "0000123456789012", // 16 digits with leading zeros
+];
+
 macro_rules! from_str_bench {
     ($mac:ident, $t:ty) => {
         #[bench]
@@ -53,6 +68,22 @@ macro_rules! from_str_radix_bench {
         fn $mac(b: &mut Bencher) {
             b.iter(|| {
                 ASCII_NUMBERS
+                    .iter()
+                    .cycle()
+                    .take(5_000)
+                    .filter_map(|s| <$t>::from_str_radix(black_box(s), $radix).ok())
+                    .max()
+            })
+        }
+    };
+}
+
+macro_rules! from_str_radix_long_bench {
+    ($mac:ident, $t:ty, $radix:expr) => {
+        #[bench]
+        fn $mac(b: &mut Bencher) {
+            b.iter(|| {
+                LONG_ASCII_NUMBERS
                     .iter()
                     .cycle()
                     .take(5_000)
@@ -110,3 +141,8 @@ from_str_radix_bench!(bench_i64_from_str_radix_2, i64, 2);
 from_str_radix_bench!(bench_i64_from_str_radix_10, i64, 10);
 from_str_radix_bench!(bench_i64_from_str_radix_16, i64, 16);
 from_str_radix_bench!(bench_i64_from_str_radix_36, i64, 36);
+
+// Long-string benchmarks: 16-20 digit decimal numbers that exercise
+// the SWAR fast path (2+ iterations of 8-digit-at-a-time parsing).
+from_str_radix_long_bench!(bench_u64_from_str_radix_10_long, u64, 10);
+from_str_radix_long_bench!(bench_i64_from_str_radix_10_long, i64, 10);

--- a/library/coretests/tests/num/mod.rs
+++ b/library/coretests/tests/num/mod.rs
@@ -152,6 +152,36 @@ fn test_int_from_str_overflow() {
 }
 
 #[test]
+fn test_from_str_radix_10_swar_boundaries() {
+    // SWAR batches up to 16 leading digits for 64-bit types. These
+    // cases sit on the batch boundaries and put invalid digits inside
+    // the batched window.
+    test_parse::<u64>("9999999999999999", Ok(9_999_999_999_999_999));
+    test_parse::<u64>("10000000000000000", Ok(10_000_000_000_000_000));
+    test_parse::<u64>("18446744073709551615", Ok(18_446_744_073_709_551_615));
+    test_parse::<u64>("18446744073709551616", Err(IntErrorKind::PosOverflow));
+    test_parse::<u64>("99999999999999999999", Err(IntErrorKind::PosOverflow));
+
+    test_parse::<u64>("1234567890123456x", Err(IntErrorKind::InvalidDigit));
+    test_parse::<u64>("x2345678901234567", Err(IntErrorKind::InvalidDigit));
+    test_parse::<u64>("1234567890x2345678", Err(IntErrorKind::InvalidDigit));
+    test_parse::<u64>("12345678901234567x", Err(IntErrorKind::InvalidDigit));
+
+    test_parse::<i64>("9223372036854775807", Ok(9_223_372_036_854_775_807));
+    test_parse::<i64>("-9223372036854775808", Ok(-9_223_372_036_854_775_808));
+    test_parse::<i64>("9223372036854775808", Err(IntErrorKind::PosOverflow));
+    test_parse::<i64>("-9223372036854775809", Err(IntErrorKind::NegOverflow));
+    test_parse::<i64>("-123456789012345678x", Err(IntErrorKind::InvalidDigit));
+    test_parse::<i64>("123456789012345x6", Err(IntErrorKind::InvalidDigit));
+
+    // Short inputs must not be affected by the SWAR path.
+    test_parse::<u64>("0", Ok(0));
+    test_parse::<u64>("+42", Ok(42));
+    test_parse::<i64>("-42", Ok(-42));
+    test_parse::<u64>("12a34", Err(IntErrorKind::InvalidDigit));
+}
+
+#[test]
 fn test_can_not_overflow() {
     fn can_overflow<T>(radix: u32, input: &str) -> bool
     where

--- a/tests/ui/consts/const-eval/parse_ints.stderr
+++ b/tests/ui/consts/const-eval/parse_ints.stderr
@@ -14,7 +14,7 @@ note: inside `core::num::<impl u64>::from_ascii_bytes_radix_impl`
   ::: $SRC_DIR/core/src/num/mod.rs:LL:COL
    |
    = note: in this macro invocation
-   = note: this error originates in the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `from_str_int_impl_inner` which comes from the expansion of the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation panicked: from_ascii_bytes_radix: radix must lie in the range `[2, 36]`
   --> $DIR/parse_ints.rs:8:25
@@ -32,7 +32,7 @@ note: inside `core::num::<impl u64>::from_ascii_bytes_radix_impl`
   ::: $SRC_DIR/core/src/num/mod.rs:LL:COL
    |
    = note: in this macro invocation
-   = note: this error originates in the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `from_str_int_impl_inner` which comes from the expansion of the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Validate and fold 8 digits at a time in decimal integer parsing

`from_str_radix` — and therefore `str::parse` — chews through decimal
input one byte at a time: a branch and a multiply-add per digit, with
the multiply on the critical path. For radix 10 on `u64`, `i64`, `u128`
and `i128` this PR adds a fast path that validates and folds 8 digits
per iteration with a handful of whole-word operations.

The interesting part is the validation. A byte is a digit iff it lies in
`b'0'..=b'9'`, and that per-byte range check can be turned into a
high-bit check that works on all 8 bytes at once. Subtracting `b'0'`
wraps around and sets the high bit for any byte below `'0'`. For the
upper bound, `0x46` is chosen because it is the unique constant that
puts `'9'` at 0x7f and `':'` at 0x80 — a single bit then separates the
last digit from the first non-digit above it (0x46 = 0x7f - 0x39;
adding 0x39 instead would leave `':'` at 0x73 with the high bit clear
and the test would never fire). Bytes far above `'9'` wrap past 0x100
and look like digits again to the addition, but the subtraction catches
those. OR the two results, mask each byte's high bit, one branch for 8
bytes. `dec2flt` ships this exact check as `is_8digits`; this PR reuses
it for integer parsing.

Once a chunk is known to be all digits, three multiply-shifts fold it
into its numeric value. `& 0x0f` strips the `0x3` ASCII high nibble,
then `* 2561 >> 8` merges neighboring bytes into two-digit values
(2561 = 10 * 256 + 1), `* 6_553_601 >> 16` merges those into four-digit
values, and `* 42_949_672_960_001 >> 32` produces the eight-digit
value — each multiplier just adds each group to the group above it
times the right power of ten, with masks discarding the overlapping
garbage the multiplies leave in between.

The fast path only kicks in for radix 10 and for types of at least 8
bytes; smaller types keep the old loop, and the per-type macro has a
separate arm for them so no batch code is even instantiated. On
64-bit targets up to 16 leading digits are batched (32-bit targets use
4-digit batches to stay off 64-bit multiplies). 16 decimal digits
always fit in an `i64`, so the batch arithmetic is safe to run
unchecked even in debug builds. Whatever is left after the batches
goes through the existing checked loop, so overlong and invalid inputs
are rejected exactly as before.

## Benchmarks

Alternating A/B runs of two stage-1 builds, bench binaries run back to
back within each round, 15 rounds. Ratio = PR / main, geometric mean,
lower is better.

| bench | ratio |
|---|---|
| u64 radix 10 short | 1.07x |
| u64 radix 10 long | 0.58x |
| i64 radix 10 short | 0.72x |
| i64 radix 10 long | 0.26x |
| i32 radix 10 | 0.69x |
| i16 radix 10 | 0.57x |
| i8 radix 10 | 0.63x |
| u32 radix 10 | 1.02x |
| u8 / u16 radix 10 | 0.98 - 0.99x |
| radix 36 (all types) | 0.88 - 1.01x |

Long decimal inputs get 1.7x - 3.8x faster. The small signed types
improve because `from_ascii_bytes_radix_impl` is now
`#[inline(always)]` and reaches their callers.

The one regression, 1.07x on short u64 inputs, is dominated by the
first round of the first pairing; the remaining 14 rounds sit at
~1.00x, and the short-input loop is instruction-for-instruction
identical to main. The residual difference is one push/pop of %rbx plus
the larger inlined body (~480 vs 256 bytes) in the hot closure.

Boundary tests for the batch cutoffs (15/16/17 digits, values around
each type's min/max, sign handling, non-digits in every batch position)
are in `library/coretests/tests/num/mod.rs`; all existing `num::` tests
pass.