### PR TITLE
io: Use `NonNull` for all `Custom` API related to `Box`, update documentation for `Custom`

### DIFF
--- a/library/alloc/src/io/error.rs
+++ b/library/alloc/src/io/error.rs
@@ -250,13 +250,15 @@ fn custom_owner_from_box(
     kind: ErrorKind,
     error: Box<dyn core::error::Error + Send + Sync>,
 ) -> CustomOwner {
+    use core::ptr::NonNull;
+
     /// # Safety
     ///
     /// `ptr` must be valid to pass into `Box::from_raw`.
-    unsafe fn drop_box_raw<T: ?Sized>(ptr: *mut T) {
+    unsafe fn drop_box_raw<T: ?Sized>(ptr: NonNull<T>) {
         // SAFETY
         // Caller ensures `ptr` is valid to pass into `Box::from_raw`.
-        drop(unsafe { Box::from_raw(ptr) })
+        drop(unsafe { Box::from_non_null(ptr) })
     }
 
     let error = Box::into_non_null(error);
@@ -266,7 +268,14 @@ fn custom_owner_from_box(
     // * `drop_box_raw` is safe to call for the pointer `error` exactly once.
     // * `drop_box_raw` is safe to call on a pointer to this instance of `Custom`,
     //   and will be stored in a `CustomOwner`.
-    let custom = unsafe { Custom::from_raw(kind, error, drop_box_raw, drop_box_raw) };
+    let custom = unsafe {
+        Custom::from_raw(
+            kind,
+            error,
+            drop_box_raw::<dyn error::Error + Send + Sync>,
+            drop_box_raw::<Custom>,
+        )
+    };
 
     let custom = Box::into_non_null(Box::new(custom));
 

--- a/library/core/src/io/error.rs
+++ b/library/core/src/io/error.rs
@@ -30,7 +30,7 @@ mod os_functions;
 use self::os_functions::{decode_error_kind, format_os_error, is_interrupted, set_functions};
 use self::repr::Repr;
 use crate::ptr::NonNull;
-use crate::{error, fmt, result};
+use crate::{error, fmt, mem, result};
 
 /// A specialized [`Result`] type for I/O operations.
 ///
@@ -576,6 +576,7 @@ impl OsFunctions {
     };
 }
 
+/// A user-created allocated error.
 // As with `SimpleMessage`: `#[repr(align(4))]` here is just because
 // repr_bitpacked's encoding requires it. In practice it almost certainly be
 // already be this high or higher.
@@ -584,8 +585,13 @@ impl OsFunctions {
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 pub struct Custom {
     kind: ErrorKind,
+    /// `Box<dyn Error + ...>` without `alloc`.
+    // INVARIANT: `error` must be a valid pointer and it must be safe to call `error_drop`
+    // with it once.
     error: NonNull<dyn error::Error + Send + Sync>,
     error_drop: unsafe fn(NonNull<dyn error::Error + Send + Sync>),
+    /// Call to drop a pointer to `Custom`.
+    // INVARIANT: must be safe to call once with a pointer to `Self` in `CustomOwner`.
     outer_drop: unsafe fn(NonNull<Self>),
 }
 
@@ -607,7 +613,7 @@ impl fmt::Debug for Custom {
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 impl Drop for Custom {
     fn drop(&mut self) {
-        // SAFETY: `Custom::from_raw` ensures this call is safe.
+        // SAFETY: by `Custom` invariants, this is a drop call on a valid pointer.
         unsafe {
             (self.error_drop)(self.error);
         }
@@ -620,7 +626,7 @@ impl Custom {
     /// * `error` must be valid for up to a static lifetime, and own its pointee.
     /// * `error_drop` must be safe to call for the pointer `error` exactly once.
     /// * `outer_drop` must be safe to call on a pointer to this instance of `Custom`
-    ///   if it were stored within a [`CustomOwner`].
+    ///   (the pointer is likely stored within a [`CustomOwner`]).
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
     pub unsafe fn from_raw(
         kind: ErrorKind,
@@ -628,13 +634,15 @@ impl Custom {
         error_drop: unsafe fn(NonNull<dyn error::Error + Send + Sync>),
         outer_drop: unsafe fn(NonNull<Self>),
     ) -> Custom {
+        // INVARIANT: function preconditions match type invariants.
         Custom { kind, error, error_drop, outer_drop }
     }
 
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
     pub fn into_raw(self) -> NonNull<dyn error::Error + Send + Sync> {
         let ptr = self.error;
-        core::mem::forget(self);
+        // Avoid `Custom::drop` which would free the error pointer.
+        mem::forget(self);
         ptr
     }
 
@@ -653,6 +661,8 @@ impl Custom {
     }
 }
 
+/// Effectively a `Box<Custom>` without `alloc`. The `Custom` holds the call to free this pointer.
+// INVARIANT: `self.0.outer_drop` must be safe to call once with `self.0`.
 #[derive(Debug)]
 #[repr(transparent)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
@@ -670,7 +680,7 @@ unsafe impl Sync for CustomOwner {}
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 impl Drop for CustomOwner {
     fn drop(&mut self) {
-        // SAFETY: `CustomOwner::from_raw` ensures this call is safe.
+        // SAFETY: by `CustomOwner` invariants, this is a drop call on a valid pointer.
         unsafe {
             (self.0.as_ref().outer_drop)(self.0);
         }
@@ -680,17 +690,20 @@ impl Drop for CustomOwner {
 impl CustomOwner {
     /// # Safety
     ///
-    /// * The `outer_drop` of the provided `custom` must be safe to call exactly once.
+    /// * `custom` must point to valid `Custom`.
+    /// * The `outer_drop` of the provided `custom` must be the drop function for this pointer.
     #[doc(hidden)]
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
     pub unsafe fn from_raw(custom: NonNull<Custom>) -> CustomOwner {
+        // INVARIANT: by the preconditions, `custom.outer_drop` is the drop for `custom`.
         CustomOwner(custom)
     }
 
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
     pub fn into_raw(self) -> NonNull<Custom> {
         let ptr = self.0;
-        core::mem::forget(self);
+        // Avoid `CustomOwner::drop`, which would free the pointer.
+        mem::forget(self);
         ptr
     }
 

--- a/library/core/src/io/error.rs
+++ b/library/core/src/io/error.rs
@@ -29,6 +29,7 @@ mod os_functions;
 
 use self::os_functions::{decode_error_kind, format_os_error, is_interrupted, set_functions};
 use self::repr::Repr;
+use crate::ptr::NonNull;
 use crate::{error, fmt, result};
 
 /// A specialized [`Result`] type for I/O operations.
@@ -583,9 +584,9 @@ impl OsFunctions {
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 pub struct Custom {
     kind: ErrorKind,
-    error: crate::ptr::NonNull<dyn error::Error + Send + Sync>,
-    error_drop: unsafe fn(*mut (dyn error::Error + Send + Sync)),
-    outer_drop: unsafe fn(*mut Self),
+    error: NonNull<dyn error::Error + Send + Sync>,
+    error_drop: unsafe fn(NonNull<dyn error::Error + Send + Sync>),
+    outer_drop: unsafe fn(NonNull<Self>),
 }
 
 // SAFETY: All members of `Custom` are `Send`
@@ -608,7 +609,7 @@ impl Drop for Custom {
     fn drop(&mut self) {
         // SAFETY: `Custom::from_raw` ensures this call is safe.
         unsafe {
-            (self.error_drop)(self.error.as_ptr());
+            (self.error_drop)(self.error);
         }
     }
 }
@@ -623,15 +624,15 @@ impl Custom {
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
     pub unsafe fn from_raw(
         kind: ErrorKind,
-        error: crate::ptr::NonNull<dyn error::Error + Send + Sync>,
-        error_drop: unsafe fn(*mut (dyn error::Error + Send + Sync)),
-        outer_drop: unsafe fn(*mut Self),
+        error: NonNull<dyn error::Error + Send + Sync>,
+        error_drop: unsafe fn(NonNull<dyn error::Error + Send + Sync>),
+        outer_drop: unsafe fn(NonNull<Self>),
     ) -> Custom {
         Custom { kind, error, error_drop, outer_drop }
     }
 
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-    pub fn into_raw(self) -> crate::ptr::NonNull<dyn error::Error + Send + Sync> {
+    pub fn into_raw(self) -> NonNull<dyn error::Error + Send + Sync> {
         let ptr = self.error;
         core::mem::forget(self);
         ptr
@@ -656,7 +657,7 @@ impl Custom {
 #[repr(transparent)]
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
 #[doc(hidden)]
-pub struct CustomOwner(crate::ptr::NonNull<Custom>);
+pub struct CustomOwner(NonNull<Custom>);
 
 // SAFETY: Custom is `Send`
 #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
@@ -671,7 +672,7 @@ impl Drop for CustomOwner {
     fn drop(&mut self) {
         // SAFETY: `CustomOwner::from_raw` ensures this call is safe.
         unsafe {
-            (self.0.as_ref().outer_drop)(self.0.as_ptr());
+            (self.0.as_ref().outer_drop)(self.0);
         }
     }
 }
@@ -682,12 +683,12 @@ impl CustomOwner {
     /// * The `outer_drop` of the provided `custom` must be safe to call exactly once.
     #[doc(hidden)]
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-    pub unsafe fn from_raw(custom: crate::ptr::NonNull<Custom>) -> CustomOwner {
+    pub unsafe fn from_raw(custom: NonNull<Custom>) -> CustomOwner {
         CustomOwner(custom)
     }
 
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-    pub fn into_raw(self) -> crate::ptr::NonNull<Custom> {
+    pub fn into_raw(self) -> NonNull<Custom> {
         let ptr = self.0;
         core::mem::forget(self);
         ptr


### PR DESCRIPTION
Use `NonNull` a few more places to avoid the need to convert to and from `*mut T`. Also document the invariants for `Custom`.

<!-- homu-ignore:start -->
cc @bushrat011899 
<!-- homu-ignore:end -->