### PR TITLE
bootstrap: Replace the `exit!` macro with a function `helpers::exit_process`

### DIFF
--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -24,7 +24,8 @@ use crate::core::builder::{
 };
 use crate::core::config::{Subcommand, TargetSelection};
 use crate::utils::build_stamp::{self, BuildStamp};
-use crate::{Compiler, Mode, exit};
+use crate::utils::helpers;
+use crate::{Compiler, Mode};
 
 /// Disable the most spammy clippy lints
 const IGNORED_RULES_FOR_STD_AND_RUSTC: &[&str] = &[
@@ -543,7 +544,7 @@ impl CommandLineStep for CI {
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         if builder.top_stage != 2 {
             eprintln!("ERROR: `x clippy ci` should always be executed with --stage 2");
-            exit!(1);
+            helpers::exit_process(1);
         }
 
         // We want to check in-tree source using in-tree clippy. However, if we naively did

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -34,11 +34,11 @@ use crate::utils::build_stamp;
 use crate::utils::build_stamp::BuildStamp;
 use crate::utils::exec::command;
 use crate::utils::helpers::{
-    exe, get_clang_cl_resource_dir, is_debug_info, is_dylib, symlink_dir, t, up_to_date,
+    self, exe, get_clang_cl_resource_dir, is_debug_info, is_dylib, symlink_dir, t, up_to_date,
 };
 use crate::{
     CLang, CodegenBackendKind, Compiler, DependencyType, FileType, GitRepo, LLVM_TOOLS, Mode,
-    debug, exit, trace,
+    debug, trace,
 };
 
 /// Build a standard library for the given `target` using the given `build_compiler`.
@@ -2044,7 +2044,7 @@ impl Step for Sysroot {
                         sysroot_lib_rustlib_src_rust.display(),
                     );
                 }
-                exit!(1);
+                helpers::exit_process(1);
             }
         }
 
@@ -2062,7 +2062,7 @@ impl Step for Sysroot {
                     builder.src.display(),
                     e,
                 );
-                exit!(1);
+                helpers::exit_process(1);
             }
         }
 
@@ -2741,7 +2741,7 @@ pub fn run_cargo(
     });
 
     if !ok {
-        crate::exit!(1);
+        helpers::exit_process(1);
     }
 
     if builder.config.dry_run() {

--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -152,14 +152,14 @@ pub fn format(
     if build.kind == Kind::Format && build.top_stage != 0 {
         eprintln!("ERROR: `x fmt` only supports stage 0.");
         eprintln!("HELP: Use `x run rustfmt` to run in-tree rustfmt.");
-        crate::exit!(1);
+        helpers::exit_process(1);
     }
 
     if !paths.is_empty() {
         eprintln!(
             "fmt error: path arguments are no longer accepted; use `--all` to format everything"
         );
-        crate::exit!(1);
+        helpers::exit_process(1);
     };
     if build.config.dry_run() {
         return;
@@ -193,7 +193,7 @@ pub fn format(
             // explicit whitelisted entries and traversal of unmentioned files, but for now just
             // forbid such entries.
             eprintln!("fmt error: `!`-prefixed entries are not supported in rustfmt.toml, sorry");
-            crate::exit!(1);
+            helpers::exit_process(1);
         } else {
             override_builder.add(&format!("!{ignore}")).expect(&ignore);
         }
@@ -362,7 +362,7 @@ pub fn format(
     let result = thread.join().unwrap();
 
     if result.is_err() {
-        crate::exit!(1);
+        helpers::exit_process(1);
     }
 
     // Update `build/.rustfmt-stamp`, allowing this code to ignore files which have not been changed

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -26,7 +26,7 @@ use crate::utils::exec::command;
 use crate::utils::helpers::{
     self, exe, get_clang_cl_resource_dir, libdir, t, unhashed_basename, up_to_date,
 };
-use crate::{CLang, GitRepo, exit, trace};
+use crate::{CLang, GitRepo, trace};
 
 /// Result of building or downloading LLVM artifacts.
 #[derive(Clone)]
@@ -1034,7 +1034,7 @@ impl CommandLineStep for RustOffload {
                 "`{lib_rust_offload}` not found in `{}`. Either the build has failed or RustOffload was built with a wrong version of LLVM",
                 build_dir.display()
             );
-            exit!(1);
+            helpers::exit_process(1);
         }
 
         BuiltRustOffload { offload: dylib }
@@ -1266,7 +1266,7 @@ impl CommandLineStep for OmpOffload {
                     "`{p:?}` not found in `{}`. Either the build has failed or Offload was built with a wrong version of LLVM",
                     out_dir.display()
                 );
-                exit!(1);
+                helpers::exit_process(1);
             }
         }
         BuiltOmpOffload { offload: files }
@@ -1414,7 +1414,7 @@ impl CommandLineStep for Enzyme {
                 "`{libenzyme}` not found in `{}`. Either the build has failed or Enzyme was built with a wrong version of LLVM",
                 build_dir.display()
             );
-            exit!(1);
+            helpers::exit_process(1);
         }
 
         t!(stamp.write());

--- a/src/bootstrap/src/core/build_steps/run.rs
+++ b/src/bootstrap/src/core/build_steps/run.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use build_helper::git::get_git_untracked_files;
 use clap_complete::{Generator, shells};
 
+use crate::Mode;
 use crate::core::build_steps::dist::distdir;
 use crate::core::build_steps::test;
 use crate::core::build_steps::tool::{self, RustcPrivateCompilers, SourceType, Tool};
@@ -16,8 +17,7 @@ use crate::core::builder::{Builder, CommandLineStep, Kind, RunConfig, ShouldRun,
 use crate::core::config::TargetSelection;
 use crate::core::config::flags::{get_completion, top_level_help};
 use crate::utils::exec::command;
-use crate::utils::helpers::t;
-use crate::{Mode, exit};
+use crate::utils::helpers::{self, t};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct BuildManifest;
@@ -138,7 +138,7 @@ impl CommandLineStep for Miri {
 
         if stage == 0 {
             eprintln!("ERROR: miri cannot be run at stage 0");
-            exit!(1);
+            helpers::exit_process(1);
         }
 
         // Miri always runs on the host, because it can interpret code for any target

--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -143,7 +143,7 @@ impl CommandLineStep for Profile {
                 }
                 _ => {
                     println!("Exiting.");
-                    crate::exit!(1);
+                    helpers::exit_process(1);
                 }
             }
         }
@@ -415,7 +415,7 @@ pub fn interactive_path() -> io::Result<Profile> {
         io::stdin().read_line(&mut input)?;
         if input.is_empty() {
             eprintln!("EOF on stdin, when expecting answer to question.  Giving up.");
-            crate::exit!(1);
+            helpers::exit_process(1);
         }
         break match parse_with_abbrev(&input) {
             Ok(profile) => profile,

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -45,7 +45,7 @@ use crate::utils::helpers::{
     up_to_date,
 };
 use crate::utils::render_tests::{add_flags_and_try_run_tests, try_run_tests};
-use crate::{CLang, CodegenBackendKind, GitRepo, Mode, TestTarget, envify, exit};
+use crate::{CLang, CodegenBackendKind, GitRepo, Mode, TestTarget, envify};
 
 mod compiletest;
 pub mod failed_tests;
@@ -291,7 +291,7 @@ impl CommandLineStep for Cargotest {
             eprintln!(
                 "ERROR: running cargotest with stage 0 is currently unsupported. Use at least stage 1."
             );
-            exit!(1);
+            helpers::exit_process(1);
         }
         // We want to build cargo stage N (where N == top_stage), and rustc stage N,
         // and test both of these together.
@@ -948,7 +948,7 @@ impl CommandLineStep for CompiletestTest {
 ERROR: `--stage 0` causes compiletest to query information from the stage0 (precompiled) compiler, instead of the in-tree compiler, which can cause some tests to fail inappropriately
 NOTE: if you're sure you want to do this, please open an issue as to why. In the meantime, you can override this with `--set build.compiletest-allow-stage0=true`."
             );
-            crate::exit!(1);
+            helpers::exit_process(1);
         }
 
         let bootstrap_compiler = builder.compiler(0, host);
@@ -1297,7 +1297,7 @@ impl CommandLineStep for Clippy {
         }
 
         if !builder.config.cmd.bless() {
-            crate::exit!(1);
+            helpers::exit_process(1);
         }
     }
 
@@ -1702,7 +1702,7 @@ HELP: to skip test's attempt to check tidiness, pass `--skip src/tools/tidy` to 
                         PATH = inferred_rustfmt_dir.display(),
                         CHAN = builder.config.channel,
                     );
-                    crate::exit!(1);
+                    helpers::exit_process(1);
                 };
                 let all = false;
                 crate::core::build_steps::format::format(
@@ -1733,7 +1733,7 @@ HELP: to skip test's attempt to check tidiness, pass `--skip src/tools/tidy` to 
             eprintln!(
                 "x.py completions were changed; run `x.py run generate-completions` to update them"
             );
-            crate::exit!(1);
+            helpers::exit_process(1);
         }
 
         builder.info("x.py help check");
@@ -1743,13 +1743,13 @@ HELP: to skip test's attempt to check tidiness, pass `--skip src/tools/tidy` to 
             let help_path = get_help_path(builder);
             let cur_help = std::fs::read_to_string(&help_path).unwrap_or_else(|err| {
                 eprintln!("couldn't read {}: {}", help_path.display(), err);
-                crate::exit!(1);
+                helpers::exit_process(1);
             });
             let new_help = top_level_help();
 
             if new_help != cur_help {
                 eprintln!("x.py help was changed; run `x.py run generate-help` to update it");
-                crate::exit!(1);
+                helpers::exit_process(1);
             }
         }
     }
@@ -2232,7 +2232,7 @@ ERROR: `--stage 0` runs compiletest on the stage0 (precompiled) compiler, not yo
 HELP: to test the compiler or standard library, omit the stage or explicitly use `--stage 1` instead
 NOTE: if you're sure you want to do this, please open an issue as to why. In the meantime, you can override this with `--set build.compiletest-allow-stage0=true`."
             );
-            crate::exit!(1);
+            helpers::exit_process(1);
         }
 
         let mut test_compiler = self.test_compiler;
@@ -2443,7 +2443,7 @@ ERROR: No configured backend named `{name}`
 HELP: You can add it into `bootstrap.toml` in `rust.codegen-backends = [{name:?}]`",
                     name = codegen_backend.name(),
                 );
-                crate::exit!(1);
+                helpers::exit_process(1);
             }
 
             if let CodegenBackendKind::Gcc = codegen_backend
@@ -4806,14 +4806,14 @@ impl CommandLineStep for StdSemverCheck {
                     );
                     if builder.fail_fast {
                         eprintln!("{error}",);
-                        exit!(1);
+                        helpers::exit_process(1);
                     } else {
                         builder.config.exec_ctx().add_to_delay_failure(error);
                     }
                 }
                 _ => {
                     eprintln!("cargo-semver-checks failed.\n{}\n{}", res.stderr(), res.stdout());
-                    exit!(1);
+                    helpers::exit_process(1);
                 }
             }
         }

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -22,7 +22,7 @@ use crate::core::builder::{
 };
 use crate::core::config::{Allocator, DebuginfoLevel, RustcLto, TargetSelection};
 use crate::utils::exec::{BootstrapCommand, command};
-use crate::utils::helpers::{add_dylib_path, exe, t};
+use crate::utils::helpers::{self, add_dylib_path, exe, t};
 use crate::{Compiler, FileType, Mode};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -160,7 +160,7 @@ impl Step for ToolBuild {
         );
 
         if !build_success {
-            crate::exit!(1);
+            helpers::exit_process(1);
         } else {
             // HACK(#82501): on Windows, the tools directory gets added to PATH when running tests, and
             // compiletest confuses HTML tidy with the in-tree tidy. Name the in-tree tidy something

--- a/src/bootstrap/src/core/build_steps/toolstate.rs
+++ b/src/bootstrap/src/core/build_steps/toolstate.rs
@@ -92,7 +92,7 @@ fn print_error(tool: &str, submodule: &str) {
     eprintln!("If you do NOT intend to update '{tool}', please ensure you did not accidentally");
     eprintln!("change the submodule at '{submodule}'. You may ask your reviewer for the");
     eprintln!("proper steps.");
-    crate::exit!(3);
+    helpers::exit_process(3);
 }
 
 fn check_changed_files(builder: &Builder<'_>, toolstates: &HashMap<Box<str>, ToolState>) {
@@ -170,7 +170,7 @@ impl CommandLineStep for ToolStateCheck {
         }
 
         if did_error {
-            crate::exit!(1);
+            helpers::exit_process(1);
         }
 
         check_changed_files(builder, &toolstates);
@@ -214,7 +214,7 @@ impl CommandLineStep for ToolStateCheck {
         }
 
         if did_error {
-            crate::exit!(1);
+            helpers::exit_process(1);
         }
 
         if builder.config.channel == "nightly" && env::var_os("TOOLSTATE_PUBLISH").is_some() {

--- a/src/bootstrap/src/core/builder/cli_paths.rs
+++ b/src/bootstrap/src/core/builder/cli_paths.rs
@@ -6,6 +6,7 @@ use std::fmt::{self, Debug};
 use std::path::PathBuf;
 
 use crate::core::builder::{Builder, CommandLineStepDescription, Kind, PathSet, ShouldRun};
+use crate::utils::helpers;
 
 #[cfg(test)]
 mod tests;
@@ -59,7 +60,7 @@ pub(crate) fn match_paths_to_steps_and_run(
             "ERROR: '{}' subcommand is incompatible with `rust.download-rustc`.",
             builder.kind.as_str()
         );
-        crate::exit!(1);
+        helpers::exit_process(1);
     }
 
     // sanity checks on rules
@@ -120,7 +121,7 @@ pub(crate) fn match_paths_to_steps_and_run(
         eprintln!(
             "ERROR: the following paths do not exist on disk or point outside the source directory: {bad_abs_paths:#?}"
         );
-        crate::exit!(1);
+        helpers::exit_process(1);
     }
 
     // Handle all test suite paths.
@@ -190,6 +191,6 @@ pub(crate) fn match_paths_to_steps_and_run(
         eprintln!(
             "NOTE: if you are adding a new Step to bootstrap itself, make sure you register it with `describe!`"
         );
-        crate::exit!(1);
+        helpers::exit_process(1);
     }
 }

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -58,7 +58,7 @@ use crate::core::download::{DownloadContext, download_beta_toolchain, is_downloa
 use crate::utils::channel::{self, GitInfo};
 use crate::utils::exec::{ExecutionContext, command};
 use crate::utils::helpers::{self, exe, fail, get_host_target, t};
-use crate::{CodegenBackendKind, check_ci_llvm, exit};
+use crate::{CodegenBackendKind, check_ci_llvm};
 
 /// Each path in this list is considered "allowed" in the `download-rustc="if-unchanged"` logic.
 /// This means they can be modified and changes to these paths should never trigger a compiler build
@@ -1225,7 +1225,7 @@ impl Config {
                 eprintln!(
                     "ERROR: cannot {kind} anything on stage 0. Use at least stage 1 or set build.local-rebuild=true and use a stage0 compiler built from in-tree sources."
                 );
-                exit!(1);
+                helpers::exit_process(1);
             }
         };
 
@@ -1253,14 +1253,14 @@ impl Config {
                 eprintln!(
                     "ERROR: cannot test anything on stage 0. Use at least stage 1. If you want to run compiletest with an external stage0 toolchain, enable `build.compiletest-allow-stage0`."
                 );
-                exit!(1);
+                helpers::exit_process(1);
             }
             _ => {}
         }
 
         if flags_compile_time_deps && !matches!(flags_cmd, Subcommand::Check { .. }) {
             eprintln!("ERROR: Can't use --compile-time-deps with any subcommand other than check.");
-            exit!(1);
+            helpers::exit_process(1);
         }
 
         if matches!(flags_cmd, Subcommand::Fix) {
@@ -1812,7 +1812,7 @@ NOTE: Please add `--stage 2` to your command line, or if you're sure you want to
                             }
                             Err(e) => {
                                 eprintln!("ERROR: Failed to parse CI rustc bootstrap.toml: {e}");
-                                exit!(2);
+                                helpers::exit_process(2);
                             }
                         };
 
@@ -2261,7 +2261,7 @@ fn postprocess_toml(
                 "ERROR: Failed to parse default config profile at '{}': {e}",
                 include_path.display()
             );
-            exit!(2);
+            helpers::exit_process(2);
         });
         toml.merge(
             Some(include_path),
@@ -2303,7 +2303,7 @@ fn postprocess_toml(
             }
         }
         eprintln!("failed to parse override `{option}`: `{err}");
-        exit!(2);
+        helpers::exit_process(2);
     }
     toml.merge(None, &mut Default::default(), override_toml, ReplaceOpt::Override);
 }
@@ -2411,7 +2411,7 @@ pub fn download_ci_rustc_commit<'a>(
                 println!(
                     "ERROR: `download-rustc=if-unchanged` is only compatible with Git managed sources."
                 );
-                crate::exit!(1);
+                helpers::exit_process(1);
             }
 
             true
@@ -2504,7 +2504,7 @@ pub fn parse_download_ci_llvm<'a>(
         if rust_info.is_from_tarball() {
             // Git is needed for running "if-unchanged" logic.
             println!("ERROR: 'if-unchanged' is only compatible with Git managed sources.");
-            crate::exit!(1);
+            helpers::exit_process(1);
         }
 
         // Fetching the LLVM submodule is unnecessary for self-tests.
@@ -2774,7 +2774,7 @@ fn bad_config(toml_path: &Path, e: toml::de::Error) -> ! {
         }
     }
 
-    exit!(2);
+    helpers::exit_process(2);
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -15,6 +15,7 @@ use crate::core::build_steps::setup::Profile;
 use crate::core::builder::{Builder, Kind};
 use crate::core::config::Config;
 use crate::core::config::target_selection::{TargetSelectionList, target_selection_list};
+use crate::utils::helpers;
 use crate::{Build, CodegenBackendKind, TestTarget};
 
 #[derive(Copy, Clone, Default, Debug, ValueEnum)]
@@ -740,7 +741,7 @@ pub fn get_completion(shell: &dyn Generator, path: &Path) -> Option<String> {
     } else {
         std::fs::read_to_string(path).unwrap_or_else(|_| {
             eprintln!("couldn't read {}", path.display());
-            crate::exit!(1);
+            helpers::exit_process(1);
         })
     };
     let mut buf = Vec::new();

--- a/src/bootstrap/src/core/config/mod.rs
+++ b/src/bootstrap/src/core/config/mod.rs
@@ -42,7 +42,7 @@ pub use toml::change_id::ChangeId;
 pub use toml::rust::BootstrapOverrideLld;
 pub use toml::target::Target;
 
-use crate::exit;
+use crate::utils::helpers;
 
 // We are using a decl macro instead of a derive proc macro here to reduce the compile time of bootstrap.
 #[macro_export]
@@ -88,7 +88,7 @@ macro_rules! define_config {
                                         panic!("overriding existing option")
                                     } else {
                                         eprintln!("overriding existing option: `{}`", stringify!($field));
-                                        $crate::exit!(2);
+                                        $crate::utils::helpers::exit_process(2);
                                     }
                                 } else {
                                     self.$field = other.$field;
@@ -214,7 +214,7 @@ impl<T> Merge for Option<T> {
                             panic!("overriding existing option")
                         } else {
                             eprintln!("overriding existing option");
-                            exit!(2);
+                            helpers::exit_process(2);
                         }
                     } else {
                         *self = other;

--- a/src/bootstrap/src/core/config/toml/mod.rs
+++ b/src/bootstrap/src/core/config/toml/mod.rs
@@ -34,9 +34,8 @@ use target::TomlTarget;
 
 use crate::core::config::toml::pgo::Pgo;
 use crate::core::config::{Config, Merge, ReplaceOpt};
-use crate::exit;
 use crate::utils::change_tracker::{find_recent_config_change_ids, human_readable_changes};
-use crate::utils::helpers::t;
+use crate::utils::helpers::{self, t};
 
 /// Structure of the `bootstrap.toml` file that configuration is read from.
 ///
@@ -126,12 +125,12 @@ impl Merge for TomlConfig {
             let include_path = parent_dir.join(include_path);
             let include_path = include_path.canonicalize().unwrap_or_else(|e| {
                 eprintln!("ERROR: Failed to canonicalize '{}' path: {e}", include_path.display());
-                exit!(2);
+                helpers::exit_process(2);
             });
 
             let included_toml = Config::get_toml_inner(&include_path).unwrap_or_else(|e| {
                 eprintln!("ERROR: Failed to parse '{}': {e}", include_path.display());
-                exit!(2);
+                helpers::exit_process(2);
             });
 
             assert!(

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -11,7 +11,8 @@ use crate::core::config::toml::TomlConfig;
 use crate::core::config::{
     CompressDebuginfo, DebuginfoLevel, Merge, ReplaceOpt, StringOrBool, TargetSelection,
 };
-use crate::{CodegenBackendKind, define_config, exit};
+use crate::utils::helpers;
+use crate::{CodegenBackendKind, define_config};
 
 define_config! {
     /// TOML representation of how the Rust build is configured.
@@ -463,7 +464,7 @@ pub(crate) fn parse_codegen_backends(
         if !BUILTIN_CODEGEN_BACKENDS.contains(&backend.name()) {
             if CiEnv::is_rust_lang_managed_ci_job() {
                 eprintln!("Unknown codegen backend {}", backend.name());
-                exit!(1);
+                helpers::exit_process(1);
             }
 
             println!(
@@ -476,7 +477,7 @@ pub(crate) fn parse_codegen_backends(
     }
     if found_backends.is_empty() {
         eprintln!("ERROR: `{section}.codegen-backends` should not be set to `[]`");
-        exit!(1);
+        helpers::exit_process(1);
     }
     found_backends
 }

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -14,10 +14,9 @@ use xz2::bufread::XzDecoder;
 use crate::core::build_steps::llvm::detect_llvm_freshness;
 use crate::core::config::toml::llvm::check_incompatible_options_for_ci_llvm;
 use crate::core::config::{BUILDER_CONFIG_FILENAME, Config, TargetSelection};
-use crate::exit;
 use crate::utils::build_stamp::BuildStamp;
 use crate::utils::exec::{ExecutionContext, command};
-use crate::utils::helpers::{exe, hex_encode, move_file, t};
+use crate::utils::helpers::{self, exe, hex_encode, move_file, t};
 
 static SHOULD_FIX_BINS_AND_DYLIBS: OnceLock<bool> = OnceLock::new();
 
@@ -294,7 +293,7 @@ impl Config {
                 eprintln!("HELP: maybe your repository history is too shallow?");
                 eprintln!("HELP: consider disabling `download-ci-llvm`");
                 eprintln!("HELP: or fetch enough history to include one upstream commit");
-                crate::exit!(1);
+                helpers::exit_process(1);
             }
         };
         let stamp_key = format!("{}{}", llvm_sha, self.llvm_assertions);
@@ -350,7 +349,7 @@ impl Config {
                 }
                 Err(e) => {
                     eprintln!("ERROR: Failed to parse CI LLVM bootstrap.toml: {e}");
-                    exit!(2);
+                    helpers::exit_process(2);
                 }
             };
         };
@@ -1121,7 +1120,7 @@ fn download_http_with_retries(
         if !help_on_error.is_empty() {
             eprintln!("{help_on_error}");
         }
-        crate::exit!(1);
+        helpers::exit_process(1);
     }
 }
 

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -19,7 +19,7 @@ use crate::core::build_steps::tool;
 use crate::core::builder::Builder;
 use crate::core::config::{CompilerBuiltins, DebuggerPath, Subcommand, Target};
 use crate::utils::exec::command;
-use crate::utils::helpers::t;
+use crate::utils::helpers::{self, t};
 
 pub struct Finder {
     cache: HashMap<OsString, Option<PathBuf>>,
@@ -161,7 +161,7 @@ You should install cmake, or set `download-ci-llvm = true` in the
 than building it.
 "
         );
-        crate::exit!(1);
+        helpers::exit_process(1);
     }
 
     build.config.python = build

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -688,7 +688,7 @@ impl Build {
                 "submodule {submodule} does not appear to be checked out, \
                  but it is required for this step{maybe_enable}{err_hint}"
             );
-            exit!(1);
+            helpers::exit_process(1);
         }
     }
 
@@ -751,7 +751,7 @@ impl Build {
                     let builder = builder::Builder::new(self);
                     let rustfmt_path = builder.ensure(InternalRustfmt).unwrap_or_else(|| {
                         eprintln!("fmt error: `x fmt` is not supported on this channel");
-                        crate::exit!(1);
+                        helpers::exit_process(1);
                     });
                     return core::build_steps::format::format(
                         &builder,
@@ -1686,7 +1686,7 @@ impl Build {
                 "ERROR: Unable to find the stamp file {}, did you try to keep a nonexistent build stage?",
                 stamp.path().display()
             );
-            crate::exit!(1);
+            helpers::exit_process(1);
         }
 
         let mut paths = Vec::new();
@@ -1961,7 +1961,7 @@ Alternatively, set `download-ci-llvm = true` in that `[llvm]` section
 to download LLVM rather than building it.
 "
                 );
-                exit!(1);
+                helpers::exit_process(1);
             }
         }
 
@@ -2084,11 +2084,4 @@ pub fn prepare_behaviour_dump_dir(build: &Build) {
 
         t!(INITIALIZED.set(true));
     }
-}
-
-#[macro_export]
-macro_rules! exit {
-    ($code:expr) => {
-        $crate::utils::helpers::detail_exit($code, cfg!(test));
-    };
 }

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -25,8 +25,7 @@ use std::time::{Duration, Instant};
 use build_helper::drop_bomb::DropBomb;
 
 use crate::core::config::DryRun;
-use crate::exit;
-use crate::utils::helpers::t;
+use crate::utils::helpers::{self, t};
 
 /// What should be done when the command fails.
 #[derive(Debug, Copy, Clone)]
@@ -657,7 +656,7 @@ impl ExecutionContext {
         for failure in &*failures {
             eprintln!("  - {failure}");
         }
-        exit!(1);
+        helpers::exit_process(1);
     }
 
     /// Execute a command and return its output.
@@ -747,7 +746,7 @@ impl ExecutionContext {
         if !self.is_verbose() {
             println!("Command has failed. Rerun with -v to see more details.");
         }
-        exit!(1);
+        helpers::exit_process(1);
     }
 
     /// Spawns the command with configured stdout and stderr handling.

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -571,11 +571,16 @@ pub fn set_file_times<P: AsRef<Path>>(path: P, times: fs::FileTimes) -> io::Resu
     f.set_times(times)
 }
 
-/// If code is not 0 (successful exit status), exit status is 101 (rust's default error code.)
-/// If `is_test` true and code is an error code, it will cause a panic.
-pub fn detail_exit(code: i32, is_test: bool) -> ! {
-    // if in test and code is an error code, panic with status code provided
-    if is_test {
+/// Exits the process by calling [`std::process::exit`].
+///
+/// In CI, extra information will be printed to make failures easier to investigate.
+///
+/// If `cfg!(test)` is true, this will panic instead of exiting the process.
+/// Doing so avoids disturbing other tests in the process, and allows `#[should_panic]`
+/// to detect expected failures.
+pub(crate) fn exit_process(code: i32) -> ! {
+    // In bootstrap unit tests, panic instead of killing the whole test process.
+    if cfg!(test) {
         panic!("status code: {code}");
     } else {
         // If we're in CI, print the current bootstrap invocation command, to make it easier to
@@ -600,5 +605,5 @@ pub fn detail_exit(code: i32, is_test: bool) -> ! {
 
 pub fn fail(s: &str) -> ! {
     eprintln!("\n\n{s}\n\n");
-    detail_exit(1, cfg!(test));
+    exit_process(1);
 }

--- a/src/bootstrap/src/utils/render_tests.rs
+++ b/src/bootstrap/src/utils/render_tests.rs
@@ -16,6 +16,7 @@ use termcolor::{Color, ColorSpec, WriteColor};
 use crate::core::build_steps::test::failed_tests::RecordFailedTests;
 use crate::core::builder::Builder;
 use crate::utils::exec::BootstrapCommand;
+use crate::utils::helpers;
 
 const TERSE_TESTS_PER_LINE: usize = 88;
 
@@ -43,7 +44,7 @@ pub(crate) fn try_run_tests(
     }
 
     if builder.fail_fast {
-        crate::exit!(1);
+        helpers::exit_process(1);
     }
 
     builder.config.exec_ctx().add_to_delay_failure(format!("{cmd:?}"));


### PR DESCRIPTION
The function can check `cfg!(test)` internally, without needing any macro magic. This lets us remove a crate-root definition and a `#[macro_export]`.
