### PR TITLE
mailmap: fix nia's gazillion emails

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -505,6 +505,11 @@ Nathaniel Hamovitz <18648574+nhamovitz@users.noreply.github.com>
 Nathaniel Herman <nherman@post.harvard.edu> Nathaniel Herman <nherman@college.harvard.edu>
 Neil Pankey <npankey@gmail.com> <neil@wire.im>
 Ngo Iok Ui (Wu Yu Wei) <wusyong9104@gmail.com>
+Nia Deckers <me@nia.gay>
+Nia Deckers <me@nia.gay> <nia-e@haecceity.cc>
+Nia Deckers <me@nia.gay> <nia@zed.dev>
+Nia Deckers <me@nia.gay> <nia@hexcat.nl>
+Nia Deckers <me@nia.gay> <a5b6@riseup.net>
 Nicholas Baron <nicholas.baron.ten@gmail.com>
 Nicholas Bishop <nbishop@nbishop.net> <nicholasbishop@gmail.com>
 Nicholas Bishop <nbishop@nbishop.net> <nicholasbishop@google.com>


### PR DESCRIPTION
Title. The `@hexcat.nl` one isn't used for any existing commits but there's a good chance it will be in the near future.