### PR TITLE
Add SVE-accelerated Vec::retain_mut for aarch64

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -170,6 +170,9 @@ use self::spec_extend::SpecExtend;
 #[cfg(not(no_global_oom_handling))]
 mod spec_extend;
 
+#[cfg(all(target_arch = "aarch64", target_feature = "sve"))]
+mod sve_retain;
+
 /// A contiguous growable array type, written as `Vec<T>`, short for 'vector'.
 ///
 /// # Examples
@@ -2513,6 +2516,22 @@ impl<T, A: Allocator> Vec<T, A> {
         if original_len == 0 {
             // Empty case: explicit return allows better optimization, vs letting compiler infer it
             return;
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "sve"))]
+        {
+            let long_enough = match mem::size_of::<T>() {
+                1 => original_len >= sve_retain::MIN_SVE_SIZE_1,
+                2 => original_len >= sve_retain::MIN_SVE_SIZE_2,
+                4 => original_len >= sve_retain::MIN_SVE_SIZE_4,
+                8 => original_len >= sve_retain::MIN_SVE_SIZE_8,
+                _ => false,
+            };
+            if long_enough {
+                // SAFETY: size_of::<T>() is 1, 2, 4 or 8, matching
+                // the kernel lane widths.
+                return unsafe { sve_retain::chunked_retain(self, f) };
+            }
         }
 
         // Vec: [Kept, Kept, Hole, Hole, Hole, Hole, Unchecked, Unchecked]

--- a/library/alloc/src/vec/sve_retain.rs
+++ b/library/alloc/src/vec/sve_retain.rs
@@ -1,0 +1,251 @@
+//! SVE-accelerated `Vec::retain_mut` implementation.
+//!
+//! Two-phase algorithm per 64-element chunk:
+//! - Phase A (scalar): evaluates predicate exactly once, in order, into a bool mask.
+//! - Phase B (SVE): uses `COMPACT` instruction to compress retained elements.
+
+use core::{cmp, mem, ptr};
+
+use super::Vec;
+use crate::alloc::Allocator;
+
+const CHUNK_SIZE: usize = 64;
+
+pub(super) const MIN_SVE_SIZE_1: usize = 32;
+pub(super) const MIN_SVE_SIZE_2: usize = 32;
+pub(super) const MIN_SVE_SIZE_4: usize = 64;
+pub(super) const MIN_SVE_SIZE_8: usize = 64;
+
+/// Guard for the SVE retain path. On panic, this guard:
+/// 1. Scalar-compresses the already-decided prefix of the current chunk.
+/// 2. Copies the untouched tail forward.
+/// 3. Sets the Vec length.
+struct PanicGuard<'a, T, A: Allocator> {
+    v: &'a mut Vec<T, A>,
+    /// Start index of the current chunk within the Vec.
+    read: usize,
+    /// Write cursor (accumulated from previous chunks).
+    write: usize,
+    /// How many elements in the current chunk have been decided by the predicate.
+    decided: usize,
+
+    mask: &'a mut [bool; CHUNK_SIZE],
+    /// Original length of the Vec.
+    original_len: usize,
+}
+
+impl<T, A: Allocator> Drop for PanicGuard<'_, T, A> {
+    #[cold]
+    fn drop(&mut self) {
+        // Scalar-compress the decided prefix: move kept elements to write position.
+        let mut dst = self.write;
+        for i in 0..self.decided {
+            if self.mask[i] {
+                // SAFETY: read + i < original_len (in-bounds).
+                let src = unsafe { self.v.as_ptr().add(self.read + i) };
+                let dst_ptr = unsafe { self.v.as_mut_ptr().add(dst) };
+                // SAFETY: src and dst_ptr < original_len
+                unsafe { ptr::copy(src, dst_ptr, 1) };
+                dst += 1;
+            }
+        }
+
+        // Copy the untouched tail.
+        let untouched_start = self.read + self.decided;
+        let untouched_len = self.original_len - untouched_start;
+        if untouched_len > 0 {
+            // SAFETY: untouched_start..original_len are valid; dst + untouched_len <= original_len.
+            unsafe {
+                ptr::copy(
+                    self.v.as_ptr().add(untouched_start),
+                    self.v.as_mut_ptr().add(dst),
+                    untouched_len,
+                );
+            }
+            dst += untouched_len;
+        }
+
+        // SAFETY: After filling holes, all items are in contiguous memory.
+        unsafe { self.v.set_len(dst) };
+    }
+}
+
+/// # Safety
+///
+/// - `size_of::<T>() == 1/2/4/8`
+/// - Called on aarch64 + SVE target.
+pub(crate) unsafe fn chunked_retain<T, F, A: Allocator>(v: &mut Vec<T, A>, mut f: F)
+where
+    F: FnMut(&mut T) -> bool,
+{
+    let original_len = v.len();
+    let mut guard = PanicGuard {
+        v,
+        read: 0,
+        write: 0,
+        decided: 0,
+        mask: &mut [false; CHUNK_SIZE],
+        original_len,
+    };
+
+    while guard.read < guard.original_len {
+        let chunk_len = cmp::min(CHUNK_SIZE, guard.original_len - guard.read);
+
+        guard.decided = 0;
+
+        // Phase A: scalar predicate evaluation (exactly once, in order).
+        for i in 0..chunk_len {
+            // SAFETY: read + i < original_len
+            let cur = unsafe { &mut *guard.v.as_mut_ptr().add(guard.read + i) };
+            guard.mask[i] = f(cur);
+            guard.decided = i + 1;
+            if !guard.mask[i] {
+                // SAFETY: read + i < original_len, and after marking `mask` and `decided`,
+                // the guard can properly handles the case where drop_in_place panics.
+                unsafe { ptr::drop_in_place(cur) };
+            }
+        }
+
+        // Phase B: SVE compress.
+        // SAFETY: write <= read and the dispatch guarantees size_of::<T>() matches the kernel lane width.
+        let kept = match mem::size_of::<T>() {
+            1 => unsafe {
+                compact8_kernel(
+                    guard.v.as_mut_ptr().add(guard.read),
+                    guard.v.as_mut_ptr().add(guard.write),
+                    guard.mask.as_ptr(),
+                    chunk_len,
+                )
+            },
+            2 => unsafe {
+                compact16_kernel(
+                    guard.v.as_mut_ptr().add(guard.read),
+                    guard.v.as_mut_ptr().add(guard.write),
+                    guard.mask.as_ptr(),
+                    chunk_len,
+                )
+            },
+            4 => unsafe {
+                compact32_kernel(
+                    guard.v.as_mut_ptr().add(guard.read),
+                    guard.v.as_mut_ptr().add(guard.write),
+                    guard.mask.as_ptr(),
+                    chunk_len,
+                )
+            },
+            8 => unsafe {
+                compact64_kernel(
+                    guard.v.as_mut_ptr().add(guard.read),
+                    guard.v.as_mut_ptr().add(guard.write),
+                    guard.mask.as_ptr(),
+                    chunk_len,
+                )
+            },
+            _ => unreachable!(),
+        };
+
+        guard.write += kept;
+        guard.read += chunk_len;
+    }
+
+    // SAFETY: write <= original_len, all retained elements are packed at the front.
+    unsafe { guard.v.set_len(guard.write) };
+    mem::forget(guard);
+}
+
+macro_rules! sve_compact_kernel {
+    (
+        $name:ident,
+        size = $size:literal,
+        lane = $lane:literal,
+        mem_lane = $mem_lane:literal,
+        shift = $shift:literal,
+        inc = $inc:literal
+    ) => {
+        /// SVE compress kernel: pack retained elements from `src` to `dst`
+        /// according to `mask`. Returns the number of retained elements.
+        ///
+        /// # Safety
+        ///
+        /// - `src` is valid for `chunk_len` reads of `T`, `dst` for `chunk_len`
+        ///   writes, `mask` for `chunk_len` bool reads.
+        /// - `size_of::<T>()` equals this kernel's lane width in bytes.
+        #[target_feature(enable = "sve")]
+        #[inline]
+        unsafe fn $name<T>(
+            src: *const T,
+            dst: *mut T,
+            mask: *const bool,
+            chunk_len: usize,
+        ) -> usize {
+            debug_assert_eq!(mem::size_of::<T>(), $size);
+
+            let idx_in = 0usize;
+            let mut idx_out = 0usize;
+            // SVE intrinsics require treating the data as integers, which doesn't
+            // correctly handle provenance and uninitialized padding.
+            //
+            // SAFETY: whilelo predicates every load/store to the remaining elements.
+            unsafe {
+                core::arch::asm!(
+                    concat!("whilelo p0.", $lane, ", xzr, {len}"),
+                    "2:",
+                    concat!("ld1b {{ z0.", $lane, " }}, p0/z, [{mask}, {idx_in}]"),
+                    concat!("cmpne p1.", $lane, ", p0/z, z0.", $lane, ", #0"),
+                    concat!("ld1", $mem_lane, " {{ z1.", $lane, " }}, p1/z, [{src}, {idx_in}", $shift, "]"),
+                    concat!("compact z1.", $lane, ", p1, z1.", $lane),
+                    concat!("cntp {kept}, p0, p1.", $lane),
+                    concat!("whilelo p2.", $lane, ", xzr, {kept}"),
+                    concat!("st1", $mem_lane, " {{ z1.", $lane, " }}, p2, [{dst}, {idx_out}", $shift, "]"),
+                    concat!("add {idx_out}, {idx_out}, {kept}"),
+                    concat!("inc", $inc, " {idx_in}"),
+                    concat!("whilelo p0.", $lane, ", {idx_in}, {len}"),
+                    "b.first 2b",
+                    src = in(reg) src,
+                    dst = in(reg) dst,
+                    mask = in(reg) mask,
+                    len = in(reg) chunk_len,
+                    idx_in = inout(reg) idx_in => _,
+                    idx_out = inout(reg) idx_out,
+                    kept = out(reg) _,
+                    out("p0") _,
+                    out("p1") _,
+                    out("p2") _,
+                    out("z0") _,
+                    out("z1") _,
+                    options(nostack),
+                );
+            }
+            idx_out
+        }
+    };
+}
+
+sve_compact_kernel!(compact8_kernel, size = 1, lane = "s", mem_lane = "b", shift = "", inc = "w");
+
+sve_compact_kernel!(
+    compact16_kernel,
+    size = 2,
+    lane = "s",
+    mem_lane = "h",
+    shift = ", lsl #1",
+    inc = "w"
+);
+
+sve_compact_kernel!(
+    compact32_kernel,
+    size = 4,
+    lane = "s",
+    mem_lane = "w",
+    shift = ", lsl #2",
+    inc = "w"
+);
+
+sve_compact_kernel!(
+    compact64_kernel,
+    size = 8,
+    lane = "d",
+    mem_lane = "d",
+    shift = ", lsl #3",
+    inc = "d"
+);

--- a/library/alloctests/benches/lib.rs
+++ b/library/alloctests/benches/lib.rs
@@ -2,6 +2,7 @@
 #![cfg(not(miri))]
 #![allow(internal_features)]
 #![feature(iter_next_chunk)]
+#![feature(macro_metavar_expr_concat)]
 #![feature(repr_simd)]
 #![feature(slice_partition_dedup)]
 #![feature(strict_provenance_lints)]

--- a/library/alloctests/benches/vec.rs
+++ b/library/alloctests/benches/vec.rs
@@ -857,6 +857,69 @@ fn bench_retain_whole_100000(b: &mut Bencher) {
     b.iter(|| v.retain(|x| *x == 826u32));
 }
 
+macro_rules! retain_type_benches {
+    (
+        len = $len:literal,
+        suffix = $suffix:literal,
+        types = [$($ty:ident),*]
+    ) => {
+        $(
+            #[bench]
+            fn ${concat(bench_retain_, $ty, _, $suffix)}(b: &mut Bencher) {
+                let mut v: Vec<$ty> = Vec::with_capacity($len);
+                b.iter(|| {
+                    v.clear();
+                    v.extend(black_box((0..$len).map(|x| { x as $ty })));
+                    v.retain(|x| *x & 1 == 0)
+                });
+            }
+
+            #[bench]
+            fn ${concat(bench_retain_whole_, $ty, _, $suffix)}(b: &mut Bencher) {
+                let mut v = black_box(vec![82 as $ty; $len]);
+                b.iter(|| v.retain(|x| *x == 82 ));
+            }
+        )*
+    };
+}
+
+macro_rules! retain_matrix_benches {
+    ($($len:literal => $suffix:literal;)*) => {
+        $(
+            retain_type_benches! {
+                len = $len,
+                suffix = $suffix,
+                types = [u8, u16, u32, u64]
+            }
+
+            #[bench]
+            fn ${concat(bench_retain_iter_u32_, $suffix)}(b: &mut Bencher) {
+                let mut v: Vec<u32> = Vec::with_capacity($len);
+                b.iter(|| {
+                    let mut tmp = std::mem::take(&mut v);
+                    tmp.clear();
+                    tmp.extend(black_box(1..=$len as u32));
+                    v = tmp.into_iter().filter(|x| x & 1 == 0).collect();
+                });
+            }
+        )*
+    };
+}
+
+retain_matrix_benches! {
+    4 => "000004";
+    8 => "000008";
+    16 => "000016";
+    32 => "000032";
+    64 => "000064";
+    128 => "000128";
+    256 => "000256";
+    512 => "000512";
+    1000 => "001000";
+    10000 => "010000";
+    100000 => "100000";
+}
+
 #[bench]
 fn bench_next_chunk(b: &mut Bencher) {
     let v = vec![13u8; 2048];


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161034)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

The PR adds SVE support for specified width types(8, 16, 32 and 64 bits) in `Vec::retain_mut`. Due to [pointer provenance being stripped by intrinsics](https://rust-lang.zulipchat.com/#narrow/channel/208962-t-libs.2Fstdarch/topic/MaybeUninit.20lane.20variants.20for.20vector.20data-movement.20intrinsic/with/615526760)) here it has to use inline asm instead of sve intrinsics.

## 1. retain half (ns/iter)

| Elements | u32 SVE | u32 scalar | Change | u64 SVE | u64 scalar | Change |
|---|---|---|---|---|---|---|
| 4 | 10.32 | 12.36 | / | 10.25 | 11.83 | / |
| 8 | 12.93 | 15.08 | / | 13.40 | 14.74 | / |
| 16 | 18.66 | 19.46 | / | 19.08 | 18.89 | / |
| 32 | 31.84 | 31.12 |/ | 31.78 | 31.26 | / |
| 64 | 32.99 | 59.17 | **-44.2%** | 59.86 | 59.44 | / |
| 1,000 | 471.51 | 811.71 | **-41.9%** | 820.98 | 827.16 | / |
| 10,000 | 4,660 | 7,990 | **-41.7%** | 5,836 | 8,242 | **-29.2%** |
| 100,000 | 46,414 | 79,608 | **-41.7%** | 57,561 | 82,861 | **-30.5%** |

## 2. retain whole

| Elements | u32 SVE | u32 scalar | Change | u64 SVE | u64 scalar | Change |
|---|---|---|---|---|---|---|
| 4 | 3.46 | 3.11 | / | 3.45 | 3.45 | / |
| 8 | 4.90 | 4.49 | / | 4.83 | 6.22 | / |
| 16 | 8.44 | 8.14 | / | 8.44 | 11.74 | / |
| 32 | 15.83 | 15.51 | / | 15.83 | 22.79 | / |
| 64 | 21.57 | 30.66 | **-29.6%** | 30.72 | 44.89 | / |
| 1,000 | 358.53 | 483.33 | **-25.8%** | 469.18 | 696.43 | / |
| 10,000 | 3,127 | 4,745 | **-34.1%** | 5,082 | 6,912 | **-26.5%** |
| 100,000 | 32,509 | 49,501 | **-34.3%** | 49,484 | 79,749 | **-38.0%** |

r? @Amanieu 