### PR TITLE
Tweak error for stmt macro expansion in expression context

### DIFF
--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -412,15 +412,14 @@ pub(super) fn emit_frag_parse_err(
                     "the macro call doesn't expand to an expression, but it can expand to a statement",
                 );
 
-                if parser.token == token::Semi {
-                    if let Ok(snippet) = parser.psess.source_map().span_to_snippet(site_span) {
-                        e.span_suggestion_verbose(
-                            site_span,
-                            "surround the macro invocation with `{}` to interpret the expansion as a statement",
-                            format!("{{ {snippet}; }}"),
-                            Applicability::MaybeIncorrect,
-                        );
-                    }
+                if parser.token == token::Semi
+                    || matches!(parser.token.kind, token::TokenKind::OpenInvisible(_))
+                {
+                    e.multipart_suggestion(
+                        "surround the macro invocation with `{}` to interpret the expansion as a statement",
+                        vec![(site_span.shrink_to_lo(), "{ ".to_string()), (site_span.shrink_to_hi(), "; }".to_string())],
+                        Applicability::MaybeIncorrect,
+                    );
                 } else {
                     e.span_suggestion_verbose(
                         site_span.shrink_to_hi(),

--- a/tests/ui/macros/issue-109237.stderr
+++ b/tests/ui/macros/issue-109237.stderr
@@ -11,9 +11,8 @@ LL |     let _ = statement!();
    = note: this error originates in the macro `statement` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: surround the macro invocation with `{}` to interpret the expansion as a statement
    |
-LL -     let _ = statement!();
-LL +     let _ = { statement!(); };
-   |
+LL |     let _ = { statement!(); };
+   |             +             +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/stmt-where-expr-expected-in-macro.rs
+++ b/tests/ui/macros/stmt-where-expr-expected-in-macro.rs
@@ -1,0 +1,11 @@
+// Macro that expans to statement called in expression context of another macro argument must not
+// suggest using a `;`. Issue #30597.
+
+macro_rules! foo {
+    ($s:stmt) => { $s } //~ ERROR expected expression, found `stmt` metavariable
+}
+
+fn main() {
+    println!("{}", foo!(42));
+    //~^ HELP surround the macro invocation with `{}` to interpret the expansion as a statement
+}

--- a/tests/ui/macros/stmt-where-expr-expected-in-macro.stderr
+++ b/tests/ui/macros/stmt-where-expr-expected-in-macro.stderr
@@ -1,0 +1,18 @@
+error: expected expression, found `stmt` metavariable
+  --> $DIR/stmt-where-expr-expected-in-macro.rs:5:20
+   |
+LL |     ($s:stmt) => { $s }
+   |                    ^^ expected expression
+...
+LL |     println!("{}", foo!(42));
+   |                    -------- in this macro invocation
+   |
+   = note: the macro call doesn't expand to an expression, but it can expand to a statement
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: surround the macro invocation with `{}` to interpret the expansion as a statement
+   |
+LL |     println!("{}", { foo!(42); });
+   |                    +         +++
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
- Use a multipart suggestion
- When encountering a `stmt` metavariable where an expression is expected in another macro expansion, do not suggest a stray `;`

Fix rust-lang/rust#30597.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
