### PR TITLE
Enable unrolling feature of bors

### DIFF
--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -77,6 +77,7 @@ auto_build_failed = [
     "-S-waiting-on-team",
 ]
 
+# Enable management of EC2 self-hosted runners
 [ec2_runners]
 runner_group_id = 8
 label_prefix = "ec2"
@@ -98,3 +99,6 @@ allowed_instances = [
     "c8a.8xlarge",
     "c8a.12xlarge",
 ]
+
+# Enable unrolling of rollup member PRs after rollup merge
+[unroll]


### PR DESCRIPTION
This was implemented in https://github.com/rust-lang/bors/pull/817.

After merge, we should see each rollup being unrolled twice, because the functionality will be performed both by bors and rustc-perf (on separate branches, so they shouldn't collide). After we check that everything works fine with the unrolled bors builds, I will remove the functionality from rustc-perf by merging https://github.com/rust-lang/rustc-perf/pull/2524. 
