### PR TITLE
Improve the ABI between the panic runtime and libstd

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -255,6 +255,7 @@ pub mod fmt;
 pub mod intrinsics;
 #[unstable(feature = "alloc_io", issue = "154046")]
 pub mod io;
+pub mod panicking;
 #[cfg(not(no_rc))]
 pub mod rc;
 pub mod slice;

--- a/library/alloc/src/panicking.rs
+++ b/library/alloc/src/panicking.rs
@@ -1,0 +1,29 @@
+#![doc(hidden)]
+#![unstable(feature = "std_internals", issue = "none")]
+
+use core::any::Any;
+use core::fmt::Display;
+
+use crate::boxed::Box;
+
+/// An internal trait used by std to pass data from std to `panic_unwind` and
+/// other panic runtimes. Not intended to be stabilized any time soon, do not
+/// use.
+pub unsafe trait PanicPayload: Display {
+    /// Take full ownership of the contents.
+    ///
+    /// After this method got called, only some dummy default value is left in `self`.
+    /// Calling this method twice, or calling `get` after calling this method, is an error.
+    ///
+    /// The argument is borrowed because the panic runtime (`__rust_start_panic`) only
+    /// gets a borrowed `dyn PanicPayload`.
+    fn take_box(&mut self) -> Box<dyn Any + Send>;
+
+    /// Just borrow the contents.
+    fn get(&mut self) -> &(dyn Any + Send);
+
+    /// Tries to borrow the contents as `&str`, if possible without doing any allocations.
+    fn as_str(&mut self) -> Option<&str> {
+        None
+    }
+}

--- a/library/alloc/src/panicking.rs
+++ b/library/alloc/src/panicking.rs
@@ -9,7 +9,7 @@ use crate::boxed::Box;
 /// An internal trait used by std to pass data from std to `panic_unwind` and
 /// other panic runtimes. Not intended to be stabilized any time soon, do not
 /// use.
-pub unsafe trait PanicPayload: Display {
+pub trait PanicPayload: Display {
     /// Take full ownership of the contents.
     ///
     /// After this method got called, only some dummy default value is left in `self`.

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -14,7 +14,6 @@ pub use self::panic_info::PanicInfo;
 pub use self::panic_info::PanicMessage;
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 pub use self::unwind_safe::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
-use crate::any::Any;
 
 #[doc(hidden)]
 #[unstable(feature = "edition_panic", issue = "none", reason = "use panic!() instead")]
@@ -118,31 +117,6 @@ pub macro unreachable_2021 {
 #[rustc_nounwind]
 pub fn abort_on_unwind<F: FnOnce() -> R, R>(f: F) -> R {
     f()
-}
-
-/// An internal trait used by std to pass data from std to `panic_unwind` and
-/// other panic runtimes. Not intended to be stabilized any time soon, do not
-/// use.
-#[unstable(feature = "std_internals", issue = "none")]
-#[doc(hidden)]
-pub unsafe trait PanicPayload: crate::fmt::Display {
-    /// Take full ownership of the contents.
-    /// The return type is actually `Box<dyn Any + Send>`, but we cannot use `Box` in core.
-    ///
-    /// After this method got called, only some dummy default value is left in `self`.
-    /// Calling this method twice, or calling `get` after calling this method, is an error.
-    ///
-    /// The argument is borrowed because the panic runtime (`__rust_start_panic`) only
-    /// gets a borrowed `dyn PanicPayload`.
-    fn take_box(&mut self) -> *mut (dyn Any + Send);
-
-    /// Just borrow the contents.
-    fn get(&mut self) -> &(dyn Any + Send);
-
-    /// Tries to borrow the contents as `&str`, if possible without doing any allocations.
-    fn as_str(&mut self) -> Option<&str> {
-        None
-    }
 }
 
 /// Helper macro for panicking in a `const fn`.

--- a/library/panic_abort/Cargo.toml
+++ b/library/panic_abort/Cargo.toml
@@ -12,10 +12,8 @@ bench = false
 doc = false
 
 [dependencies]
+alloc = { path = "../alloc" }
 core = { path = "../rustc-std-workspace-core", package = "rustc-std-workspace-core" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 libc = { version = "0.2", default-features = false }
-
-[target.'cfg(any(target_os = "android", target_os = "zkvm"))'.dependencies]
-alloc = { path = "../alloc" }

--- a/library/panic_abort/src/android.rs
+++ b/library/panic_abort/src/android.rs
@@ -1,6 +1,6 @@
+use alloc::panicking::PanicPayload;
 use alloc::string::String;
 use core::mem::transmute;
-use core::panic::PanicPayload;
 use core::ptr::copy_nonoverlapping;
 
 const ANDROID_SET_ABORT_MESSAGE: &[u8] = b"android_set_abort_message\0";

--- a/library/panic_abort/src/android.rs
+++ b/library/panic_abort/src/android.rs
@@ -15,7 +15,7 @@ type SetAbortMessageType = unsafe extern "C" fn(*const libc::c_char) -> ();
 //
 // Weakly resolve the symbol for android_set_abort_message. This function is only available
 // for API >= 21.
-pub(crate) unsafe fn android_set_abort_message(payload: &mut dyn PanicPayload) {
+pub(crate) fn android_set_abort_message(payload: &mut dyn PanicPayload) {
     let func_addr = unsafe {
         libc::dlsym(libc::RTLD_DEFAULT, ANDROID_SET_ABORT_MESSAGE.as_ptr() as *const libc::c_char)
             as usize

--- a/library/panic_abort/src/lib.rs
+++ b/library/panic_abort/src/lib.rs
@@ -30,16 +30,12 @@ pub unsafe fn __rust_panic_cleanup(_: *mut u8) -> Box<dyn Any + Send + 'static> 
 
 // "Leak" the payload and shim to the relevant abort on the platform in question.
 #[rustc_std_internal_symbol]
-pub unsafe fn __rust_start_panic(_payload: &mut dyn PanicPayload) -> u32 {
+pub fn __rust_start_panic(_payload: &mut dyn PanicPayload) -> u32 {
     // Android has the ability to attach a message as part of the abort.
     #[cfg(target_os = "android")]
-    unsafe {
-        android::android_set_abort_message(_payload);
-    }
+    android::android_set_abort_message(_payload);
     #[cfg(target_os = "zkvm")]
-    unsafe {
-        zkvm::zkvm_set_abort_message(_payload);
-    }
+    zkvm::zkvm_set_abort_message(_payload);
 
     unsafe extern "Rust" {
         // This is defined in std::rt.

--- a/library/panic_abort/src/lib.rs
+++ b/library/panic_abort/src/lib.rs
@@ -19,11 +19,12 @@ mod android;
 #[cfg(target_os = "zkvm")]
 mod zkvm;
 
+use alloc::boxed::Box;
+use alloc::panicking::PanicPayload;
 use core::any::Any;
-use core::panic::PanicPayload;
 
 #[rustc_std_internal_symbol]
-pub unsafe fn __rust_panic_cleanup(_: *mut u8) -> *mut (dyn Any + Send + 'static) {
+pub unsafe fn __rust_panic_cleanup(_: *mut u8) -> Box<dyn Any + Send + 'static> {
     unreachable!()
 }
 

--- a/library/panic_abort/src/lib.rs
+++ b/library/panic_abort/src/lib.rs
@@ -23,8 +23,7 @@ use core::any::Any;
 use core::panic::PanicPayload;
 
 #[rustc_std_internal_symbol]
-#[allow(improper_ctypes_definitions)]
-pub unsafe extern "C" fn __rust_panic_cleanup(_: *mut u8) -> *mut (dyn Any + Send + 'static) {
+pub unsafe fn __rust_panic_cleanup(_: *mut u8) -> *mut (dyn Any + Send + 'static) {
     unreachable!()
 }
 

--- a/library/panic_abort/src/zkvm.rs
+++ b/library/panic_abort/src/zkvm.rs
@@ -3,7 +3,7 @@ use alloc::string::String;
 
 // Forward the abort message to zkVM's sys_panic. This is implemented by RISC Zero's
 // platform crate which exposes system calls specifically for the zkVM.
-pub(crate) unsafe fn zkvm_set_abort_message(payload: &mut dyn PanicPayload) {
+pub(crate) fn zkvm_set_abort_message(payload: &mut dyn PanicPayload) {
     let payload = payload.get();
     let msg = match payload.downcast_ref::<&'static str>() {
         Some(msg) => msg.as_bytes(),

--- a/library/panic_abort/src/zkvm.rs
+++ b/library/panic_abort/src/zkvm.rs
@@ -1,5 +1,5 @@
+use alloc::panicking::PanicPayload;
 use alloc::string::String;
-use core::panic::PanicPayload;
 
 // Forward the abort message to zkVM's sys_panic. This is implemented by RISC Zero's
 // platform crate which exposes system calls specifically for the zkVM.

--- a/library/panic_unwind/src/dummy.rs
+++ b/library/panic_unwind/src/dummy.rs
@@ -3,6 +3,7 @@
 //! Stubs that simply abort for targets that don't support unwinding otherwise.
 
 use alloc::boxed::Box;
+use alloc::panicking::PanicPayload;
 use core::any::Any;
 
 unsafe extern "Rust" {
@@ -15,6 +16,6 @@ pub(crate) unsafe fn cleanup(_ptr: *mut u8) -> Box<dyn Any + Send> {
     __rust_abort()
 }
 
-pub(crate) unsafe fn panic(_data: Box<dyn Any + Send>) -> u32 {
+pub(crate) fn panic(_data: &mut dyn PanicPayload) -> u32 {
     __rust_abort()
 }

--- a/library/panic_unwind/src/gcc.rs
+++ b/library/panic_unwind/src/gcc.rs
@@ -76,10 +76,8 @@ pub(crate) fn panic(data: &mut dyn PanicPayload) -> u32 {
         _unwind_code: uw::_Unwind_Reason_Code,
         exception: *mut uw::_Unwind_Exception,
     ) {
-        unsafe {
-            let _: Box<Exception> = Box::from_raw(exception as *mut Exception);
-            super::__rust_drop_panic();
-        }
+        let _: Box<Exception> = unsafe { Box::from_raw(exception as *mut Exception) };
+        super::__rust_drop_panic();
     }
 }
 

--- a/library/panic_unwind/src/gcc.rs
+++ b/library/panic_unwind/src/gcc.rs
@@ -37,6 +37,7 @@
 //! and the last personality routine transfers control to the catch block.
 
 use alloc::boxed::Box;
+use alloc::panicking::PanicPayload;
 use core::any::Any;
 use core::ptr;
 
@@ -58,7 +59,7 @@ struct Exception {
     cause: Box<dyn Any + Send>,
 }
 
-pub(crate) unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
+pub(crate) fn panic(data: &mut dyn PanicPayload) -> u32 {
     let exception = Box::new(Exception {
         _uwe: uw::_Unwind_Exception {
             exception_class: RUST_EXCEPTION_CLASS,
@@ -66,7 +67,7 @@ pub(crate) unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
             private: [core::ptr::null(); _],
         },
         canary: &CANARY,
-        cause: data,
+        cause: data.take_box(),
     });
     let exception_param = Box::into_raw(exception) as *mut uw::_Unwind_Exception;
     return unsafe { uw::_Unwind_RaiseException(exception_param) as u32 };

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -80,8 +80,7 @@ unsafe extern "C" {
 }
 
 #[rustc_std_internal_symbol]
-#[allow(improper_ctypes_definitions)]
-pub unsafe extern "C" fn __rust_panic_cleanup(payload: *mut u8) -> *mut (dyn Any + Send + 'static) {
+pub unsafe fn __rust_panic_cleanup(payload: *mut u8) -> *mut (dyn Any + Send + 'static) {
     unsafe { Box::into_raw(imp::cleanup(payload)) }
 }
 

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -88,6 +88,5 @@ pub unsafe fn __rust_panic_cleanup(payload: *mut u8) -> Box<dyn Any + Send + 'st
 // implementation.
 #[rustc_std_internal_symbol]
 pub fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32 {
-    let payload = payload.take_box();
-    unsafe { imp::panic(payload) }
+    imp::panic(payload)
 }

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -28,8 +28,8 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 use alloc::boxed::Box;
+use alloc::panicking::PanicPayload;
 use core::any::Any;
-use core::panic::PanicPayload;
 
 cfg_select! {
     any(
@@ -80,17 +80,14 @@ unsafe extern "C" {
 }
 
 #[rustc_std_internal_symbol]
-pub unsafe fn __rust_panic_cleanup(payload: *mut u8) -> *mut (dyn Any + Send + 'static) {
-    unsafe { Box::into_raw(imp::cleanup(payload)) }
+pub unsafe fn __rust_panic_cleanup(payload: *mut u8) -> Box<dyn Any + Send + 'static> {
+    unsafe { imp::cleanup(payload) }
 }
 
 // Entry point for raising an exception, just delegates to the platform-specific
 // implementation.
 #[rustc_std_internal_symbol]
 pub unsafe fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32 {
-    unsafe {
-        let payload = Box::from_raw(payload.take_box());
-
-        imp::panic(payload)
-    }
+    let payload = payload.take_box();
+    unsafe { imp::panic(payload) }
 }

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -87,7 +87,7 @@ pub unsafe fn __rust_panic_cleanup(payload: *mut u8) -> Box<dyn Any + Send + 'st
 // Entry point for raising an exception, just delegates to the platform-specific
 // implementation.
 #[rustc_std_internal_symbol]
-pub unsafe fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32 {
+pub fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32 {
     let payload = payload.take_box();
     unsafe { imp::panic(payload) }
 }

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -68,15 +68,15 @@ cfg_select! {
     }
 }
 
-unsafe extern "C" {
+unsafe extern "Rust" {
     /// Handler in std called when a panic object is dropped outside of
     /// `catch_unwind`.
     #[rustc_std_internal_symbol]
-    fn __rust_drop_panic() -> !;
+    safe fn __rust_drop_panic() -> !;
 
     /// Handler in std called when a foreign exception is caught.
     #[rustc_std_internal_symbol]
-    fn __rust_foreign_exception() -> !;
+    safe fn __rust_foreign_exception() -> !;
 }
 
 #[rustc_std_internal_symbol]

--- a/library/panic_unwind/src/miri.rs
+++ b/library/panic_unwind/src/miri.rs
@@ -1,6 +1,7 @@
 //! Unwinding panics for Miri.
 
 use alloc::boxed::Box;
+use alloc::panicking::PanicPayload;
 use core::any::Any;
 
 // The type of the payload that the Miri engine propagates through unwinding for us.
@@ -12,10 +13,10 @@ unsafe extern "Rust" {
     fn miri_start_unwind(payload: *mut u8) -> !;
 }
 
-pub(crate) unsafe fn panic(payload: Box<dyn Any + Send>) -> u32 {
+pub(crate) fn panic(payload: &mut dyn PanicPayload) -> u32 {
     // The payload we pass to `miri_start_unwind` will be exactly the argument we get
     // in `cleanup` below. So we just box it up once, to get something pointer-sized.
-    let payload_box: Payload = Box::new(payload);
+    let payload_box: Payload = Box::new(payload.take_box());
     unsafe { miri_start_unwind(Box::into_raw(payload_box) as *mut u8) }
 }
 

--- a/library/panic_unwind/src/seh.rs
+++ b/library/panic_unwind/src/seh.rs
@@ -371,13 +371,13 @@ unsafe fn throw_exception(data: Option<Box<dyn Any + Send>>) -> ! {
 }
 
 pub(crate) unsafe fn cleanup(payload: *mut u8) -> Box<dyn Any + Send> {
+    // A null payload here means that we got here from the catch (...) of
+    // __rust_try. This happens when a non-Rust foreign exception is caught.
+    if payload.is_null() {
+        super::__rust_foreign_exception();
+    }
+    let exception = payload as *mut Exception;
     unsafe {
-        // A null payload here means that we got here from the catch (...) of
-        // __rust_try. This happens when a non-Rust foreign exception is caught.
-        if payload.is_null() {
-            super::__rust_foreign_exception();
-        }
-        let exception = payload as *mut Exception;
         let canary = (&raw const (*exception).canary).read();
         if !core::ptr::eq(canary, &raw const TYPE_DESCRIPTOR) {
             // A foreign Rust exception.

--- a/library/panic_unwind/src/seh.rs
+++ b/library/panic_unwind/src/seh.rs
@@ -47,6 +47,7 @@
 #![allow(nonstandard_style)]
 
 use alloc::boxed::Box;
+use alloc::panicking::PanicPayload;
 use core::any::Any;
 use core::ffi::{c_int, c_uint, c_void};
 use core::mem::ManuallyDrop;
@@ -298,8 +299,8 @@ cfg_select! {
    }
 }
 
-pub(crate) unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
-    unsafe { throw_exception(Some(data)) }
+pub(crate) fn panic(data: &mut dyn PanicPayload) -> u32 {
+    unsafe { throw_exception(Some(data.take_box())) }
 }
 
 unsafe fn throw_exception(data: Option<Box<dyn Any + Send>>) -> ! {

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -69,7 +69,7 @@ unsafe extern "Rust" {
 /// with our panic count.
 #[cfg(not(test))]
 #[rustc_std_internal_symbol]
-extern "C" fn __rust_drop_panic() -> ! {
+fn __rust_drop_panic() -> ! {
     rtabort!("Rust panics must be rethrown");
 }
 
@@ -77,7 +77,7 @@ extern "C" fn __rust_drop_panic() -> ! {
 /// object which does not correspond to a Rust panic.
 #[cfg(not(test))]
 #[rustc_std_internal_symbol]
-extern "C" fn __rust_foreign_exception() -> ! {
+fn __rust_foreign_exception() -> ! {
     rtabort!("Rust cannot catch foreign exceptions");
 }
 

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -53,13 +53,10 @@ pub static EMPTY_PANIC: fn(&'static str) -> ! =
 //
 // One day this may look a little less ad-hoc with the compiler helping out to
 // hook up these functions, but it is not this day!
-#[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "Rust" {
     #[rustc_std_internal_symbol]
     fn __rust_panic_cleanup(payload: *mut u8) -> *mut (dyn Any + Send + 'static);
-}
 
-unsafe extern "Rust" {
     /// `PanicPayload` lazily performs allocation only when needed (this avoids
     /// allocations when using the "abort" panic runtime).
     #[rustc_std_internal_symbol]

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -9,7 +9,8 @@
 
 #![deny(unsafe_op_in_unsafe_fn)]
 
-use core::panic::{Location, PanicPayload};
+use alloc::panicking::PanicPayload;
+use core::panic::Location;
 
 // make sure to use the stderr output configured
 // by libtest in the real copy of std
@@ -55,7 +56,7 @@ pub static EMPTY_PANIC: fn(&'static str) -> ! =
 // hook up these functions, but it is not this day!
 unsafe extern "Rust" {
     #[rustc_std_internal_symbol]
-    fn __rust_panic_cleanup(payload: *mut u8) -> *mut (dyn Any + Send + 'static);
+    fn __rust_panic_cleanup(payload: *mut u8) -> Box<dyn Any + Send + 'static>;
 
     /// `PanicPayload` lazily performs allocation only when needed (this avoids
     /// allocations when using the "abort" panic runtime).
@@ -556,7 +557,7 @@ pub unsafe fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any +
         // the panic handler `__rust_panic_cleanup`. As such we can only
         // assume it returns the correct thing for `Box::from_raw` to work
         // without undefined behavior.
-        let obj = unsafe { Box::from_raw(__rust_panic_cleanup(payload)) };
+        let obj = unsafe { __rust_panic_cleanup(payload) };
         panic_count::decrease();
         obj
     }
@@ -626,12 +627,12 @@ pub fn panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
     }
 
     unsafe impl PanicPayload for FormatStringPayload<'_> {
-        fn take_box(&mut self) -> *mut (dyn Any + Send) {
+        fn take_box(&mut self) -> Box<dyn Any + Send> {
             // We do two allocations here, unfortunately. But (a) they're required with the current
             // scheme, and (b) we don't handle panic + OOM properly anyway (see comment in
             // begin_panic below).
             let contents = mem::take(self.fill());
-            Box::into_raw(Box::new(contents))
+            Box::new(contents)
         }
 
         fn get(&mut self) -> &(dyn Any + Send) {
@@ -652,8 +653,8 @@ pub fn panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
     struct StaticStrPayload(&'static str);
 
     unsafe impl PanicPayload for StaticStrPayload {
-        fn take_box(&mut self) -> *mut (dyn Any + Send) {
-            Box::into_raw(Box::new(self.0))
+        fn take_box(&mut self) -> Box<dyn Any + Send> {
+            Box::new(self.0)
         }
 
         fn get(&mut self) -> &(dyn Any + Send) {
@@ -714,17 +715,16 @@ pub const fn begin_panic<M: Any + Send>(msg: M) -> ! {
     }
 
     unsafe impl<A: Send + 'static> PanicPayload for Payload<A> {
-        fn take_box(&mut self) -> *mut (dyn Any + Send) {
+        fn take_box(&mut self) -> Box<dyn Any + Send> {
             // Note that this should be the only allocation performed in this code path. Currently
             // this means that panic!() on OOM will invoke this code path, but then again we're not
             // really ready for panic on OOM anyway. If we do start doing this, then we should
             // propagate this allocation to be performed in the parent of this thread instead of the
             // thread that's panicking.
-            let data = match self.inner.take() {
+            match self.inner.take() {
                 Some(a) => Box::new(a) as Box<dyn Any + Send>,
                 None => process::abort(),
-            };
-            Box::into_raw(data)
+            }
         }
 
         fn get(&mut self) -> &(dyn Any + Send) {
@@ -857,8 +857,8 @@ pub fn resume_unwind(payload: Box<dyn Any + Send>) -> ! {
     struct RewrapBox(Box<dyn Any + Send>);
 
     unsafe impl PanicPayload for RewrapBox {
-        fn take_box(&mut self) -> *mut (dyn Any + Send) {
-            Box::into_raw(mem::replace(&mut self.0, Box::new(())))
+        fn take_box(&mut self) -> Box<dyn Any + Send> {
+            mem::replace(&mut self.0, Box::new(()))
         }
 
         fn get(&mut self) -> &(dyn Any + Send) {

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -61,7 +61,7 @@ unsafe extern "Rust" {
     /// `PanicPayload` lazily performs allocation only when needed (this avoids
     /// allocations when using the "abort" panic runtime).
     #[rustc_std_internal_symbol]
-    fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32;
+    safe fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32;
 }
 
 /// This function is called by the panic runtime if FFI code catches a Rust
@@ -626,7 +626,7 @@ pub fn panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
         }
     }
 
-    unsafe impl PanicPayload for FormatStringPayload<'_> {
+    impl PanicPayload for FormatStringPayload<'_> {
         fn take_box(&mut self) -> Box<dyn Any + Send> {
             // We do two allocations here, unfortunately. But (a) they're required with the current
             // scheme, and (b) we don't handle panic + OOM properly anyway (see comment in
@@ -652,7 +652,7 @@ pub fn panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
 
     struct StaticStrPayload(&'static str);
 
-    unsafe impl PanicPayload for StaticStrPayload {
+    impl PanicPayload for StaticStrPayload {
         fn take_box(&mut self) -> Box<dyn Any + Send> {
             Box::new(self.0)
         }
@@ -714,7 +714,7 @@ pub const fn begin_panic<M: Any + Send>(msg: M) -> ! {
         inner: Option<A>,
     }
 
-    unsafe impl<A: Send + 'static> PanicPayload for Payload<A> {
+    impl<A: Send + 'static> PanicPayload for Payload<A> {
         fn take_box(&mut self) -> Box<dyn Any + Send> {
             // Note that this should be the only allocation performed in this code path. Currently
             // this means that panic!() on OOM will invoke this code path, but then again we're not
@@ -856,7 +856,7 @@ pub fn resume_unwind(payload: Box<dyn Any + Send>) -> ! {
 
     struct RewrapBox(Box<dyn Any + Send>);
 
-    unsafe impl PanicPayload for RewrapBox {
+    impl PanicPayload for RewrapBox {
         fn take_box(&mut self) -> Box<dyn Any + Send> {
             mem::replace(&mut self.0, Box::new(()))
         }
@@ -881,7 +881,7 @@ pub fn resume_unwind(payload: Box<dyn Any + Send>) -> ! {
 #[cfg_attr(not(test), rustc_std_internal_symbol)]
 #[cfg(not(panic = "immediate-abort"))]
 fn rust_panic(msg: &mut dyn PanicPayload) -> ! {
-    let code = unsafe { __rust_start_panic(msg) };
+    let code = __rust_start_panic(msg);
     rtabort!("failed to initiate panic, error {code}")
 }
 


### PR DESCRIPTION
* Use the Rust ABI rather than C ABI
* Mark some extern functions as safe
* Move `PanicPayload` from libcore to liballoc and directly reference `Box<dyn Any>` instead of `*mut dyn Any`
* Avoid an unnecessary allocation with panic=abort

Follow up to https://github.com/rust-lang/rust/pull/160440