### PR TITLE
bootstrap: leverage cargo trim-paths

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -290,15 +290,6 @@ fn main() {
         cfg.flag(&*flag);
     }
 
-    // Remap ci-llvm include paths in debug info for reproducible builds.
-    if let Some(maps) = tracked_env_var_os("RUSTC_DEBUGINFO_MAP")
-        && let Some(maps_str) = maps.to_str()
-    {
-        for map in maps_str.split('\t') {
-            cfg.flag_if_supported(&format!("-ffile-prefix-map={map}"));
-        }
-    }
-
     for component in &components {
         let mut flag = String::from("LLVM_COMPONENT_");
         flag.push_str(&component.to_uppercase());

--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/161603
+Last change is for: https://github.com/rust-lang/rust/pull/161049

--- a/src/bootstrap/src/bin/rustc.rs
+++ b/src/bootstrap/src/bin/rustc.rs
@@ -163,20 +163,6 @@ fn main() {
         }
     }
 
-    // The remap flags for the compiler and standard library sources.
-    if let Ok(maps) = env::var("RUSTC_DEBUGINFO_MAP") {
-        for map in maps.split('\t') {
-            cmd.arg("--remap-path-prefix").arg(map);
-        }
-    }
-    // The remap flags for Cargo registry sources need to be passed after the remapping for the
-    // Rust source code directory, to handle cases when $CARGO_HOME is inside the source directory.
-    if let Ok(maps) = env::var("RUSTC_CARGO_REGISTRY_SRC_TO_REMAP") {
-        for map in maps.split('\t') {
-            cmd.arg("--remap-path-prefix").arg(map);
-        }
-    }
-
     // Here we pass additional paths that essentially act as a sysroot.
     // These are used to load rustc crates (e.g. `extern crate rustc_ast;`)
     // for rustc_private tools, so that we do not have to copy them into the

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -33,7 +33,7 @@ use crate::core::config::toml::target::DefaultLinuxLinkerOverride;
 use crate::core::config::{
     Allocator, CompilerBuiltins, DebuginfoLevel, LlvmLibunwind, RustcLto, TargetSelection,
 };
-use crate::core::session::{CLang, DependencyType, FileType, GitRepo, Mode};
+use crate::core::session::{CLang, DependencyType, FileType, Mode};
 use crate::utils::build_stamp;
 use crate::utils::build_stamp::BuildStamp;
 use crate::utils::exec::command;
@@ -1912,7 +1912,7 @@ pub fn compiler_file(
     }
     let mut cmd = command(compiler);
     cmd.args(builder.cc_handled_cflags(target, c));
-    cmd.args(builder.cc_unhandled_cflags(target, GitRepo::Rustc, c));
+    cmd.args(builder.cc_unhandled_cflags(target, c));
     cmd.arg(format!("-print-file-name={file}"));
     let out = cmd.run_capture_stdout(builder).stdout();
     PathBuf::from(out.trim())

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -21,14 +21,13 @@ use crate::core::builder::{
     Builder, CommandLineStep, Kind, RunConfig, ShouldRun, Step, StepMetadata,
 };
 use crate::core::config::{Config, LlvmCiMode, LlvmPgoGenerationMode, TargetSelection};
-use crate::core::session::{CLang, GitRepo};
+use crate::core::session::CLang;
 use crate::trace;
 use crate::utils::build_stamp::{BuildStamp, generate_smart_stamp_hash};
 use crate::utils::exec::command;
 use crate::utils::helpers::{
     self, exe, get_clang_cl_resource_dir, libdir, t, unhashed_basename, up_to_date,
 };
-
 /// Path where a file containing the link type (dynamic or static) is stored in the LLVM CI tarball.
 pub const LLVM_CI_LINK_TYPE_PATH: &str = "link-type.txt";
 
@@ -804,6 +803,27 @@ fn check_llvm_version(builder: &Builder<'_>, llvm_config: &Path) {
     panic!("\n\nbad LLVM version: {version}, need >=21\n\n")
 }
 
+/// C/C++ debug info remap flags for LLVM build.
+///
+/// The remap is observable when LLVM is compiled with debug info,
+/// for example, with `llvm.release-debuginfo = true`.
+fn debuginfo_map_cflags(builder: &Builder<'_>, target: TargetSelection) -> Vec<String> {
+    if !builder.config.rust_remap_debuginfo {
+        return Vec::new();
+    }
+
+    let mut flags = Vec::new();
+    let map = format!("{}=/rustc/llvm", builder.src.display());
+    let cc = builder.cc_tool(target);
+    if cc.is_like_clang() || cc.is_like_gnu() {
+        flags.push(format!("-fdebug-prefix-map={map}"));
+    } else if cc.is_like_clang_cl() {
+        flags.push("-Xclang".into());
+        flags.push(format!("-fdebug-prefix-map={map}"));
+    }
+    flags
+}
+
 fn configure_cmake(
     builder: &Builder<'_>,
     target: TargetSelection,
@@ -968,7 +988,8 @@ fn configure_cmake(
     for flag in builder
         .cc_handled_cflags(target, CLang::C)
         .into_iter()
-        .chain(builder.cc_unhandled_cflags(target, GitRepo::Llvm, CLang::C))
+        .chain(builder.cc_unhandled_cflags(target, CLang::C))
+        .chain(debuginfo_map_cflags(builder, target))
         .filter(|flag| !suppressed_compiler_flag_prefixes.iter().any(|p| flag.starts_with(p)))
     {
         cflags.push(" ");
@@ -989,7 +1010,8 @@ fn configure_cmake(
     for flag in builder
         .cc_handled_cflags(target, CLang::Cxx)
         .into_iter()
-        .chain(builder.cc_unhandled_cflags(target, GitRepo::Llvm, CLang::Cxx))
+        .chain(builder.cc_unhandled_cflags(target, CLang::Cxx))
+        .chain(debuginfo_map_cflags(builder, target))
         .filter(|flag| {
             !suppressed_compiler_flag_prefixes
                 .iter()

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -38,7 +38,7 @@ use crate::core::builder::{
 use crate::core::compiler::Compiler;
 use crate::core::config::TargetSelection;
 use crate::core::config::flags::{Subcommand, get_completion, top_level_help};
-use crate::core::session::{CLang, GitRepo, Mode};
+use crate::core::session::{CLang, Mode};
 use crate::core::{android, debuggers};
 use crate::utils::build_stamp::{self, BuildStamp};
 use crate::utils::exec::{BootstrapCommand, command};
@@ -48,7 +48,6 @@ use crate::utils::helpers::{
     target_supports_cranelift_backend, up_to_date,
 };
 use crate::utils::render_tests::{add_flags_and_try_run_tests, try_run_tests};
-
 mod compiletest;
 pub mod failed_tests;
 
@@ -2836,9 +2835,9 @@ Please disable assertions with `rust.debug-assertions = false`.
         // requires that a C++ compiler was configured which isn't always the case.
         if !builder.config.dry_run() && mode == CompiletestMode::RunMake {
             let mut cflags = builder.cc_handled_cflags(target, CLang::C);
-            cflags.extend(builder.cc_unhandled_cflags(target, GitRepo::Rustc, CLang::C));
+            cflags.extend(builder.cc_unhandled_cflags(target, CLang::C));
             let mut cxxflags = builder.cc_handled_cflags(target, CLang::Cxx);
-            cxxflags.extend(builder.cc_unhandled_cflags(target, GitRepo::Rustc, CLang::Cxx));
+            cxxflags.extend(builder.cc_unhandled_cflags(target, CLang::Cxx));
             cmd.arg("--cc")
                 .arg(builder.cc(target))
                 .arg("--cxx")

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1158,9 +1158,16 @@ impl Builder<'_> {
         //
         // Keep this scheme in sync with `rustc_metadata::rmeta::decoder`'s
         // `try_to_translate_virtual_to_real`.
-        //
-        // `RUSTC_DEBUGINFO_MAP` is used to pass through to the underlying rustc
-        // `--remap-path-prefix`.
+        let trim_paths = |cargo: &mut BootstrapCommand, ws_remap: &str| {
+            cargo.arg("-Ztrim-paths");
+            cargo.arg("--config").arg("profile.release.trim-paths='all'");
+            cargo.arg("--config").arg("profile.dev.trim-paths='all'");
+            // This is an internal contract with cargo.
+            // bootstrap needs workspace sources remapped to `/rust{c,-dev}/<sha>` instead of `.`
+            // See <https://github.com/rust-lang/cargo/issues/17309>.
+            cargo.env("__CARGO_RUSTC_BOOTSTRAP_WS_REMAP", ws_remap);
+        };
+
         match mode {
             Mode::Rustc | Mode::Codegen => {
                 if let Some(ref map_to) =
@@ -1176,24 +1183,7 @@ impl Builder<'_> {
                     // Tell the compiler which prefix was used for remapping the compiler it-self
                     cargo.env("CFG_VIRTUAL_RUSTC_DEV_SOURCE_BASE_DIR", map_to);
 
-                    // When building compiler sources, we want to apply the compiler remap scheme.
-                    let map = [
-                        // Cargo use relative paths for workspace members, so let's remap those.
-                        format!("compiler/={map_to}/compiler"),
-                        // rustc creates absolute paths (in part bc of the `rust-src` unremap
-                        // and for working directory) so let's remap the build directory as well.
-                        format!("{}={map_to}", self.sess.src.display()),
-                        // remap OUT_DIR so they don't leak into artifacts.
-                        format!("{}={map_to}/out", self.sess.out.display()),
-                        // on windows, rustc may use forward slashes internally
-                        #[cfg(windows)]
-                        format!(
-                            "{}={map_to}\\out",
-                            self.sess.out.display().to_string().replace('/', "\\")
-                        ),
-                    ]
-                    .join("\t");
-                    cargo.env("RUSTC_DEBUGINFO_MAP", map);
+                    trim_paths(&mut cargo, map_to);
                 }
             }
             Mode::Std
@@ -1204,44 +1194,9 @@ impl Builder<'_> {
                 if let Some(ref map_to) =
                     self.sess.debuginfo_map_to(GitRepo::Rustc, RemapScheme::NonCompiler)
                 {
-                    // When building the standard library sources, we want to apply the std remap scheme.
-                    let map = [
-                        // Cargo use relative paths for workspace members, so let's remap those.
-                        format!("library/={map_to}/library"),
-                        // rustc creates absolute paths (in part bc of the `rust-src` unremap
-                        // and for working directory) so let's remap the build directory as well.
-                        format!("{}={map_to}", self.sess.src.display()),
-                        // remap OUT_DIR so they don't leak into artifacts.
-                        format!("{}={map_to}/out", self.sess.out.display()),
-                        // on windows, rustc may use forward slashes internally
-                        #[cfg(windows)]
-                        format!(
-                            "{}={map_to}\\out",
-                            self.sess.out.display().to_string().replace('/', "\\")
-                        ),
-                    ]
-                    .join("\t");
-                    cargo.env("RUSTC_DEBUGINFO_MAP", map);
+                    trim_paths(&mut cargo, map_to);
                 }
             }
-        }
-
-        if self.config.rust_remap_debuginfo {
-            let mut env_var = OsString::new();
-            if let Some(vendor) = self.sess.vendored_crates_path() {
-                env_var.push(vendor);
-                env_var.push("=/rust/deps");
-            } else {
-                let registry_src = t!(home::cargo_home()).join("registry").join("src");
-                for entry in t!(std::fs::read_dir(registry_src)) {
-                    if !env_var.is_empty() {
-                        env_var.push("\t");
-                    }
-                    env_var.push(t!(entry).path());
-                    env_var.push("=/rust/deps");
-                }
-            }
-            cargo.env("RUSTC_CARGO_REGISTRY_SRC_TO_REMAP", env_var);
         }
 
         // Enable usage of unstable features

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -13,7 +13,7 @@ use crate::core::config::toml::pgo::PgoConfig;
 use crate::core::config::{
     CompressDebuginfo, Config, DryRun, RustcLto, SplitDebuginfo, TargetSelection,
 };
-use crate::core::session::{CLang, GitRepo, Mode, RemapScheme};
+use crate::core::session::{CLang, Mode, RemapScheme};
 use crate::utils::build_stamp;
 use crate::utils::exec::{BootstrapCommand, command};
 use crate::utils::helpers::{self, LldThreads, check_cfg_arg, envify, linker_flags, t};
@@ -484,8 +484,7 @@ impl Cargo {
 
             // Extend `CFLAGS_$TARGET` with our extra flags.
             let env = format!("CFLAGS_{triple_underscored}");
-            let mut cflags =
-                builder.cc_unhandled_cflags(target, GitRepo::Rustc, CLang::C).join(" ");
+            let mut cflags = builder.cc_unhandled_cflags(target, CLang::C).join(" ");
             if let Some(lto_cflag) = lto_cflag {
                 cflags.push(' ');
                 cflags.push_str(lto_cflag);
@@ -509,8 +508,7 @@ impl Cargo {
 
                 // Extend `CXXFLAGS_$TARGET` with our extra flags.
                 let env = format!("CXXFLAGS_{triple_underscored}");
-                let mut cxxflags =
-                    builder.cc_unhandled_cflags(target, GitRepo::Rustc, CLang::Cxx).join(" ");
+                let mut cxxflags = builder.cc_unhandled_cflags(target, CLang::Cxx).join(" ");
                 if let Some(lto_cflag) = lto_cflag {
                     cxxflags.push(' ');
                     cxxflags.push_str(lto_cflag);
@@ -1170,16 +1168,12 @@ impl Builder<'_> {
 
         match mode {
             Mode::Rustc | Mode::Codegen => {
-                if let Some(ref map_to) =
-                    self.sess.debuginfo_map_to(GitRepo::Rustc, RemapScheme::NonCompiler)
-                {
+                if let Some(ref map_to) = self.sess.debuginfo_map_to(RemapScheme::NonCompiler) {
                     // Tell the compiler which prefix was used for remapping the standard library
                     cargo.env("CFG_VIRTUAL_RUST_SOURCE_BASE_DIR", map_to);
                 }
 
-                if let Some(ref map_to) =
-                    self.sess.debuginfo_map_to(GitRepo::Rustc, RemapScheme::Compiler)
-                {
+                if let Some(ref map_to) = self.sess.debuginfo_map_to(RemapScheme::Compiler) {
                     // Tell the compiler which prefix was used for remapping the compiler it-self
                     cargo.env("CFG_VIRTUAL_RUSTC_DEV_SOURCE_BASE_DIR", map_to);
 
@@ -1191,9 +1185,7 @@ impl Builder<'_> {
             | Mode::ToolRustcPrivate
             | Mode::ToolStd
             | Mode::ToolTarget => {
-                if let Some(ref map_to) =
-                    self.sess.debuginfo_map_to(GitRepo::Rustc, RemapScheme::NonCompiler)
-                {
+                if let Some(ref map_to) = self.sess.debuginfo_map_to(RemapScheme::NonCompiler) {
                     trim_paths(&mut cargo, map_to);
                 }
             }

--- a/src/bootstrap/src/core/session.rs
+++ b/src/bootstrap/src/core/session.rs
@@ -31,11 +31,6 @@ use crate::utils::helpers::{
 };
 use crate::{debug, trace};
 
-pub(crate) enum GitRepo {
-    Rustc,
-    Llvm,
-}
-
 /// Global configuration for the build system.
 ///
 /// This structure transitively contains all configuration for the build system.
@@ -965,38 +960,29 @@ impl Session {
         })
     }
 
-    pub(crate) fn debuginfo_map_to(
-        &self,
-        which: GitRepo,
-        remap_scheme: RemapScheme,
-    ) -> Option<String> {
+    pub(crate) fn debuginfo_map_to(&self, remap_scheme: RemapScheme) -> Option<String> {
         if !self.config.rust_remap_debuginfo {
             return None;
         }
 
-        match which {
-            GitRepo::Rustc => {
-                let sha = self.rust_sha().unwrap_or(&self.version);
+        let sha = self.rust_sha().unwrap_or(&self.version);
 
-                match remap_scheme {
-                    RemapScheme::Compiler => {
-                        // For compiler sources, remap via `/rustc-dev/{sha}` to allow
-                        // distinguishing between compiler sources vs library sources, since
-                        // `rustc-dev` dist component places them under
-                        // `$sysroot/lib/rustlib/rustc-src/rust` as opposed to `rust-src`'s
-                        // `$sysroot/lib/rustlib/src/rust`.
-                        //
-                        // Keep this scheme in sync with `rustc_metadata::rmeta::decoder`'s
-                        // `try_to_translate_virtual_to_real`.
-                        Some(format!("/rustc-dev/{sha}"))
-                    }
-                    RemapScheme::NonCompiler => {
-                        // For non-compiler sources, use `/rustc/{sha}` remapping scheme.
-                        Some(format!("/rustc/{sha}"))
-                    }
-                }
+        match remap_scheme {
+            RemapScheme::Compiler => {
+                // For compiler sources, remap via `/rustc-dev/{sha}` to allow
+                // distinguishing between compiler sources vs library sources, since
+                // `rustc-dev` dist component places them under
+                // `$sysroot/lib/rustlib/rustc-src/rust` as opposed to `rust-src`'s
+                // `$sysroot/lib/rustlib/src/rust`.
+                //
+                // Keep this scheme in sync with `rustc_metadata::rmeta::decoder`'s
+                // `try_to_translate_virtual_to_real`.
+                Some(format!("/rustc-dev/{sha}"))
             }
-            GitRepo::Llvm => Some(String::from("/rustc/llvm")),
+            RemapScheme::NonCompiler => {
+                // For non-compiler sources, use `/rustc/{sha}` remapping scheme.
+                Some(format!("/rustc/{sha}"))
+            }
         }
     }
 
@@ -1039,12 +1025,7 @@ impl Session {
     }
 
     /// Returns extra C flags that `cc-rs` doesn't handle.
-    pub(crate) fn cc_unhandled_cflags(
-        &self,
-        target: TargetSelection,
-        which: GitRepo,
-        c: CLang,
-    ) -> Vec<String> {
+    pub(crate) fn cc_unhandled_cflags(&self, target: TargetSelection, c: CLang) -> Vec<String> {
         let mut base = Vec::new();
 
         // If we're compiling C++ on macOS then we add a flag indicating that
@@ -1061,16 +1042,6 @@ impl Session {
             base.push("-fno-omit-frame-pointer".into());
         }
 
-        if let Some(map_to) = self.debuginfo_map_to(which, RemapScheme::NonCompiler) {
-            let map = format!("{}={}", self.src.display(), map_to);
-            let cc = self.cc_tool(target);
-            if cc.is_like_clang() || cc.is_like_gnu() {
-                base.push(format!("-fdebug-prefix-map={map}"));
-            } else if cc.is_like_clang_cl() {
-                base.push("-Xclang".into());
-                base.push(format!("-fdebug-prefix-map={map}"));
-            }
-        }
         base
     }
 

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -27,9 +27,8 @@ use std::path::{Path, PathBuf};
 
 use crate::core::config::flags::Subcommand;
 use crate::core::config::{CompressDebuginfo, TargetSelection};
-use crate::core::session::{CLang, GitRepo, Session};
+use crate::core::session::{CLang, Session};
 use crate::utils::exec::{BootstrapCommand, command};
-
 /// Creates and configures a new [`cc::Build`] instance for the given target.
 fn new_cc_build(sess: &Session, target: TargetSelection) -> cc::Build {
     let mut cfg = cc::Build::new();
@@ -124,7 +123,7 @@ fn fill_target_compiler(sess: &mut Session, target: TargetSelection) {
 
     sess.cc.insert(target, compiler.clone());
     let mut cflags = sess.cc_handled_cflags(target, CLang::C);
-    cflags.extend(sess.cc_unhandled_cflags(target, GitRepo::Rustc, CLang::C));
+    cflags.extend(sess.cc_unhandled_cflags(target, CLang::C));
 
     // If we use llvm-libunwind, we will need a C++ compiler as well for all targets
     // We'll need one anyways if the target triple is also a host triple
@@ -151,7 +150,7 @@ fn fill_target_compiler(sess: &mut Session, target: TargetSelection) {
     sess.do_if_verbose(|| println!("CFLAGS_{} = {cflags:?}", target.triple));
     if let Ok(cxx) = sess.cxx(target) {
         let mut cxxflags = sess.cc_handled_cflags(target, CLang::Cxx);
-        cxxflags.extend(sess.cc_unhandled_cflags(target, GitRepo::Rustc, CLang::Cxx));
+        cxxflags.extend(sess.cc_unhandled_cflags(target, CLang::Cxx));
         sess.do_if_verbose(|| println!("CXX_{} = {cxx:?}", target.triple));
         sess.do_if_verbose(|| println!("CXXFLAGS_{} = {cxxflags:?}", target.triple));
     }

--- a/tests/run-make/remap-path-prefix-std/rmake.rs
+++ b/tests/run-make/remap-path-prefix-std/rmake.rs
@@ -93,7 +93,7 @@ fn main() {
         // Check that remapped paths are present if the rlib has debug info.
         if stdout.contains("DW_TAG_compile_unit") {
             assert!(
-                stdout.contains("/rustc/") || stdout.contains("/rust/deps"),
+                stdout.contains("/rustc/") || stdout.contains("/cargo/registry/"),
                 "Expected remapped paths in dwarfdump output for {link_name}",
             );
         }

--- a/tests/run-make/remap-path-prefix-std/rmake.rs
+++ b/tests/run-make/remap-path-prefix-std/rmake.rs
@@ -43,6 +43,13 @@ fn main() {
     // There must be at least one rlib (libstd itself, plus many others)
     assert!(!all_rlibs.is_empty(), "no rlibs found in target libdir {target_libdir:?}");
 
+    let source_root = source_root();
+    let cargo_home = std::env::var("CARGO_HOME").map(PathBuf::from);
+    let mut local_roots = vec![("source-root", source_root.to_string_lossy())];
+    if let Ok(cargo_home) = &cargo_home {
+        local_roots.push(("cargo-home", cargo_home.to_string_lossy()));
+    }
+
     for rlib in &all_rlibs {
         // Use a stable symlink name based on the crate part (before the '-<hash>' suffix).
         // e.g. "libstd-92abaa9b58c011c1.rlib" → "libstd.rlib"
@@ -63,13 +70,6 @@ fn main() {
         }
 
         let stdout = completed.stdout_utf8();
-        let source_root = source_root();
-
-        let cargo_home = std::env::var("CARGO_HOME").map(PathBuf::from);
-        let mut local_roots = vec![("source-root", source_root.to_string_lossy())];
-        if let Ok(cargo_home) = &cargo_home {
-            local_roots.push(("cargo-home", cargo_home.to_string_lossy()));
-        }
 
         for (kind, root) in &local_roots {
             if let Some((i, _)) =
@@ -96,6 +96,23 @@ fn main() {
                 stdout.contains("/rustc/") || stdout.contains("/rust/deps"),
                 "Expected remapped paths in dwarfdump output for {link_name}",
             );
+        }
+    }
+
+    // `-Zembed-metadata=no` creates separate rmeta that may leak absolute paths
+    let all_rmetas =
+        shallow_find_files(&target_libdir, |p| p.extension().is_some_and(|ext| ext == "rmeta"));
+    assert!(!all_rmetas.is_empty(), "no rmeta files found in target libdir {target_libdir:?}");
+
+    for rmeta in &all_rmetas {
+        let filename = rmeta.file_name().unwrap().to_string_lossy();
+        let bytes = rfs::read(rmeta);
+
+        for (kind, root_str) in &local_roots {
+            let root = root_str.as_bytes();
+            if bytes.windows(root.len()).any(|window| window == root) {
+                panic!("found leaked {kind} path in {filename} at {root_str}");
+            }
         }
     }
 }

--- a/tests/run-make/remap-path-prefix-std/rmake.rs
+++ b/tests/run-make/remap-path-prefix-std/rmake.rs
@@ -64,23 +64,30 @@ fn main() {
 
         let stdout = completed.stdout_utf8();
         let source_root = source_root();
-        let root = source_root.to_string_lossy();
 
-        if let Some((i, _)) =
-            stdout.lines().enumerate().find(|(_, line)| line.contains(root.as_ref()))
-        {
-            let lines: Vec<_> = stdout.lines().collect();
+        let cargo_home = std::env::var("CARGO_HOME").map(PathBuf::from);
+        let mut local_roots = vec![("source-root", source_root.to_string_lossy())];
+        if let Ok(cargo_home) = &cargo_home {
+            local_roots.push(("cargo-home", cargo_home.to_string_lossy()));
+        }
 
-            let start = i.saturating_sub(2);
-            let end = (i + 3).min(lines.len());
+        for (kind, root) in &local_roots {
+            if let Some((i, _)) =
+                stdout.lines().enumerate().find(|(_, line)| line.contains(root.as_ref()))
+            {
+                let lines: Vec<_> = stdout.lines().collect();
 
-            eprintln!("leaked source-root path found in {link_name}:");
+                let start = i.saturating_sub(2);
+                let end = (i + 3).min(lines.len());
 
-            for line in &lines[start..end] {
-                eprintln!("{line}");
+                eprintln!("leaked {kind} path found in {link_name}:");
+
+                for line in &lines[start..end] {
+                    eprintln!("{line}");
+                }
+
+                panic!("found leaked {kind} path in {link_name} at {root}");
             }
-
-            panic!("found leaked source-root path in {link_name}");
         }
 
         // Check that remapped paths are present if the rlib has debug info.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161049)*
<!-- homu-ignore:end -->

## What 

Leverage Cargo's `-Ztrim-paths` to remap compiler and library. See <https://github.com/rust-lang/cargo/issues/17309>. Bootstrap no longer needs custom remap.

Changes in toolchain distributions:

* `/rustc/<sha>` remap does not change for toolchain binaries
* `/rustc-dev/<sha>` remap does not change for toolchain private binaries
* `/rustc/llvm` remap does not change for LLVM we distributed 
* crates.io dependency remaps becomes `/cargo/registry/<hash>` from `/rust/deps`
* vendored dependency remaps becomes `/cargo/deps` from `/rust/deps`

This has some implicit dependencies:

* cc-rs must be `1.3.0+` in rustc_llvm and other packages that depend on cc-rs.
* Bootstrap stage0 must be cbae9b4cae2b108f6a3d18cfe6075714bb739463 to get `__CARGO_RUSTC_BOOTSTRAP_WS_REMAP` support
* Remaps only apply to the `release` and `dev` Cargo profiles.
* It follows cargo's remap rules: <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#profile-trim-paths-option>


try-jobs: dist-x86_64-msvc
try-jobs: dist-x86_64-linux
try-jobs: dist-aarch64-apple


🤖 **LLM disclosure:** I used LLM to do the first pass of bootstrap integration and temporary stage0 bump. The usage was signed off here on Zulip: [#llm-reviews > Experiment with Cargo's trim-path in bootstrap](https://rust-lang.zulipchat.com/#narrow/channel/606558-llm-reviews/topic/Experiment.20with.20Cargo.27s.20trim-path.20in.20bootstrap/with/615203079). See <https://github.com/rust-lang/rust/pull/161049#issuecomment-5498045095> for a more recent disclosure.