### PR TITLE
rustdoc: Fix link title attribute value when field of enum variants

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -674,11 +674,15 @@ pub(crate) fn link_tooltip(
             fqp
         };
         if let &Some(UrlFragment::Item(id)) = fragment {
-            write!(f, "{} ", cx.tcx().def_descr(id))?;
+            let tcx = cx.tcx();
+            write!(f, "{} ", tcx.def_descr(id))?;
             for component in fqp {
                 write!(f, "{component}::")?;
             }
-            write!(f, "{}", cx.tcx().item_name(id))?;
+            if *shortty == ItemType::Enum && tcx.def_kind(id) == DefKind::Field {
+                write!(f, "{}::", tcx.item_name(tcx.parent(id)))?;
+            }
+            write!(f, "{}", tcx.item_name(id))?;
         } else if !fqp.is_empty() {
             write!(f, "{shortty} ")?;
             write!(f, "{}", join_path_syms(fqp))?;

--- a/tests/rustdoc-html/intra-doc/enum-variant-field-title.rs
+++ b/tests/rustdoc-html/intra-doc/enum-variant-field-title.rs
@@ -1,0 +1,13 @@
+// This test ensures that the generated "title" attribute for field of enum variant
+// is correctly generated and includes the variant's name.
+// Regression test for <https://github.com/rust-lang/rust/issues/161028>.
+
+#![crate_name = "foo"]
+
+//@ has 'foo/enum.Enum.html'
+//@ has - '//*[@class="docblock"]//a[@title="field foo::Enum::Variant::field"]' 'Enum::Variant::field'
+
+/// [Enum::Variant::field]
+pub enum Enum {
+    Variant { field: i32 }
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/161028.

The issue was that we link to parent page, we generate a "fragment" to the parent item (so here the enum), because we forgot to take into account that there might be two levels: enum variants can have fields. So in case it's an enum and the `DefId` is a field, we add the field's parent name (so the enum variant) to the title.

r? @Urgau 