### PR TITLE
Silence unecessary errors on `Vec<foo::Bar>` to `Vec<foo:Bar>` typo

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -1563,6 +1563,16 @@ pub fn prohibit_assoc_item_constraint(
         },
     });
 
+    if let hir::AssocItemConstraintKind::Bound {
+        bounds: [hir::GenericBound::Trait(poly_trait_ref)],
+    } = constraint.kind
+        && let Res::Err = poly_trait_ref.trait_ref.path.res
+    {
+        // This was likely a `Vec<foo::Bar>` to `Vec<foo:Bar>` typo. A prior error will have been
+        // emitted during resolve, with better context.
+        err.downgrade_to_delayed_bug();
+    }
+
     // Emit a suggestion to turn the assoc item binding into a generic arg
     // if the relevant item has a generic param whose name matches the binding name;
     // otherwise suggest the removal of the binding.

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
@@ -411,6 +411,22 @@ pub(crate) fn check_generic_arg_count(
     let gen_args = seg.args();
     let default_counts = gen_params.own_defaults();
     let param_counts = gen_params.own_counts();
+    // If we have any `Vec<foo: Bar>` constraint, where `Bar` is unresolved, the user likely meant
+    // to write `Vec<foo::Bar>`, so we silence the incorrect number of generics error.
+    let has_invalid_bound = match seg.args {
+        Some(args) => args.constraints.iter().any(|c| {
+            if let hir::AssocItemConstraintKind::Bound {
+                bounds: [hir::GenericBound::Trait(poly_trait_ref)],
+            } = c.kind
+                && let Res::Err = poly_trait_ref.trait_ref.path.res
+            {
+                true
+            } else {
+                false
+            }
+        }),
+        None => false,
+    };
 
     // Subtracting from param count to ensure type params synthesized from `impl Trait`
     // cannot be explicitly specified.
@@ -586,7 +602,7 @@ pub(crate) fn check_generic_arg_count(
                     gen_args,
                     def_id,
                 ))
-                .emit_unless_delay(all_params_are_binded)
+                .emit_unless_delay(all_params_are_binded || has_invalid_bound)
         });
 
         Err(reported)

--- a/tests/ui/suggestions/struct-field-type-including-single-colon.rs
+++ b/tests/ui/suggestions/struct-field-type-including-single-colon.rs
@@ -19,7 +19,6 @@ struct Bar {
 struct Qux {
     c: Vec<foo:A>,
     //~^ ERROR: struct takes at least 1 generic argument but 0 generic arguments were supplied
-    //~| ERROR: associated item constraints are not allowed here
     //~| ERROR: cannot find trait `A` in this scope
 }
 

--- a/tests/ui/suggestions/struct-field-type-including-single-colon.rs
+++ b/tests/ui/suggestions/struct-field-type-including-single-colon.rs
@@ -18,8 +18,7 @@ struct Bar {
 // Issue #92685.
 struct Qux {
     c: Vec<foo:A>,
-    //~^ ERROR: struct takes at least 1 generic argument but 0 generic arguments were supplied
-    //~| ERROR: cannot find trait `A` in this scope
+    //~^ ERROR: cannot find trait `A` in this scope
 }
 
 fn main() {}

--- a/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
+++ b/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
@@ -35,18 +35,6 @@ help: you might have meant to write a path instead of an associated type bound
 LL |     c: Vec<foo::A>,
    |                +
 
-error[E0107]: struct takes at least 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/struct-field-type-including-single-colon.rs:20:8
-   |
-LL |     c: Vec<foo:A>,
-   |        ^^^ expected at least 1 generic argument
-   |
-help: add missing generic argument
-   |
-LL |     c: Vec<T, foo:A>,
-   |            ++
+error: aborting due to 3 previous errors
 
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0107, E0405.
-For more information about an error, try `rustc --explain E0107`.
+For more information about this error, try `rustc --explain E0405`.

--- a/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
+++ b/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
@@ -46,19 +46,7 @@ help: add missing generic argument
 LL |     c: Vec<T, foo:A>,
    |            ++
 
-error[E0229]: associated item constraints are not allowed here
-  --> $DIR/struct-field-type-including-single-colon.rs:20:12
-   |
-LL |     c: Vec<foo:A>,
-   |            ^^^^^ associated item constraint not allowed here
-   |
-help: consider removing this associated item constraint
-   |
-LL -     c: Vec<foo:A>,
-LL +     c: Vec,
-   |
+error: aborting due to 4 previous errors
 
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0107, E0229, E0405.
+Some errors have detailed explanations: E0107, E0405.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/suggestions/type-ascription-instead-of-path-in-type.rs
+++ b/tests/ui/suggestions/type-ascription-instead-of-path-in-type.rs
@@ -8,5 +8,4 @@ fn main() {
     //~| HELP you might have meant to write a path instead of an associated type bound
     //~| ERROR struct takes at least 1 generic argument but 0 generic arguments were supplied
     //~| HELP add missing generic argument
-    //~| ERROR associated item constraints are not allowed here
 }

--- a/tests/ui/suggestions/type-ascription-instead-of-path-in-type.rs
+++ b/tests/ui/suggestions/type-ascription-instead-of-path-in-type.rs
@@ -6,6 +6,4 @@ fn main() {
     let _: Vec<A:B> = A::B;
     //~^ ERROR cannot find trait `B` in this scope
     //~| HELP you might have meant to write a path instead of an associated type bound
-    //~| ERROR struct takes at least 1 generic argument but 0 generic arguments were supplied
-    //~| HELP add missing generic argument
 }

--- a/tests/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
@@ -9,18 +9,6 @@ help: you might have meant to write a path instead of an associated type bound
 LL |     let _: Vec<A::B> = A::B;
    |                  +
 
-error[E0107]: struct takes at least 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/type-ascription-instead-of-path-in-type.rs:6:12
-   |
-LL |     let _: Vec<A:B> = A::B;
-   |            ^^^ expected at least 1 generic argument
-   |
-help: add missing generic argument
-   |
-LL |     let _: Vec<T, A:B> = A::B;
-   |                ++
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0107, E0405.
-For more information about an error, try `rustc --explain E0107`.
+For more information about this error, try `rustc --explain E0405`.

--- a/tests/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
@@ -20,13 +20,7 @@ help: add missing generic argument
 LL |     let _: Vec<T, A:B> = A::B;
    |                ++
 
-error[E0229]: associated item constraints are not allowed here
-  --> $DIR/type-ascription-instead-of-path-in-type.rs:6:16
-   |
-LL |     let _: Vec<A:B> = A::B;
-   |                ^^^ associated item constraint not allowed here
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0107, E0229, E0405.
+Some errors have detailed explanations: E0107, E0405.
 For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
When encountering a type path with a bound constraint instead of a type path and the bound type isn't resolved, only emit the resolve error, as that has an appropriate suggestion. This cuts down the verbosity of a relatively normal typo.

Fix rust-lang/rust#92685.
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
