### PR TITLE
Keep impl Trait trait-bound lifetimes live under Polonius

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/outlives_for_liveness.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_for_liveness.rs
@@ -22,7 +22,12 @@ use crate::regions::{region_known_to_outlive, ty_known_to_outlive};
 ///    irrelevant, so we return an empty list.
 /// 3. If there are *any* outlives bounds, then we find any args that are known
 ///    to outlive those bounds, since those are the args whose regions the
-///    underlying type could capture.
+///    underlying type could capture. We also include args that appear in the
+///    alias's non-outlives item bounds (e.g. `Produce<'a>` on
+///    `impl Produce<'a> + 'b`): those regions can be observed through the
+///    alias's API even when the parent item does not declare that they outlive
+///    the outlives bound. Nested opaques / impl where-clauses can put them in
+///    the hidden type (see #161038).
 #[tracing::instrument(level = "debug", skip(tcx), ret)]
 pub(crate) fn live_args_for_alias_from_outlives_bounds<'tcx>(
     tcx: TyCtxt<'tcx>,
@@ -112,7 +117,88 @@ pub(crate) fn live_args_for_alias_from_outlives_bounds<'tcx>(
             Some(prev) => *prev = prev.intersection(&new_live_args).copied().collect(),
         };
     }
-    live_args.map(|c| ty::EarlyBinder::bind(tcx, c.into_iter().collect()))
+
+    // Regions named in trait bounds / associated type bindings can still be
+    // extracted from the alias (e.g. `Produce::produce() -> &'a T`), so they
+    // must stay live even if we cannot prove they outlive the alias bound.
+    let interface_args = interface_args_from_item_bounds(self_identity_args, bounds);
+    tracing::debug!(?interface_args);
+    match live_args {
+        Some(mut args) => {
+            args.extend(interface_args);
+            Some(ty::EarlyBinder::bind(tcx, args.into_iter().collect()))
+        }
+        None => None,
+    }
+}
+
+/// Identity args of `alias` that appear in non-outlives item bounds.
+///
+/// `Self` is skipped: it is the alias itself and would otherwise mark every
+/// generic arg live. Lifetime/type args of the trait, GAT args, and associated
+/// type bindings are visited so that e.g. `impl Produce<'a> + 'b` treats `'a`
+/// as live.
+fn interface_args_from_item_bounds<'tcx>(
+    identity_args: ty::GenericArgsRef<'tcx>,
+    bounds: ty::Clauses<'tcx>,
+) -> FxIndexSet<ty::GenericArg<'tcx>> {
+    let mut collected = FxIndexSet::default();
+    let mut collector = IdentityArgCollector { identity_args, collected: &mut collected };
+    for clause in bounds.iter() {
+        if let Some(trait_pred) = clause.as_trait_clause() {
+            // Skip `Self`; it is the alias and mentions every identity arg.
+            for arg in trait_pred.skip_binder().trait_ref.args.iter().skip(1) {
+                arg.visit_with(&mut collector);
+            }
+        } else if let Some(proj) = clause.as_projection_clause() {
+            let pred = proj.skip_binder();
+            for arg in pred.projection_term.args.iter().skip(1) {
+                arg.visit_with(&mut collector);
+            }
+            pred.term.visit_with(&mut collector);
+        }
+    }
+    tracing::debug!(?collected);
+    collected
+}
+
+/// Collects identity generic args of an alias that appear in a visitable value.
+struct IdentityArgCollector<'tcx, 'a> {
+    identity_args: ty::GenericArgsRef<'tcx>,
+    collected: &'a mut FxIndexSet<ty::GenericArg<'tcx>>,
+}
+
+impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for IdentityArgCollector<'tcx, '_> {
+    fn visit_region(&mut self, r: ty::Region<'tcx>) {
+        if let ty::ReBound(..) = r.kind() {
+            return;
+        }
+        for arg in self.identity_args.iter() {
+            if arg.as_region() == Some(r) {
+                self.collected.insert(arg);
+            }
+        }
+    }
+
+    fn visit_ty(&mut self, ty: Ty<'tcx>) {
+        for arg in self.identity_args.iter() {
+            if arg.as_type() == Some(ty) {
+                self.collected.insert(arg);
+                return;
+            }
+        }
+        ty.super_visit_with(self);
+    }
+
+    fn visit_const(&mut self, ct: ty::Const<'tcx>) {
+        for arg in self.identity_args.iter() {
+            if arg.as_const() == Some(ct) {
+                self.collected.insert(arg);
+                return;
+            }
+        }
+        ct.super_visit_with(self);
+    }
 }
 
 /// For each region param of this alias compute the identity args that are known
@@ -569,6 +655,23 @@ where
                         for arg in capturable_args {
                             let arg = arg.instantiate(tcx, args).skip_norm_wip();
                             arg.visit_with(self);
+                        }
+                        // Param-env outlives clauses intersect `capturable` and can
+                        // drop regions that are still observable through the alias
+                        // API (`Produce<'a>`). Re-visit those unless the alias itself
+                        // is `'static` (in which case the query returns an empty set).
+                        if let Some(live_args) = tcx.live_args_for_alias_from_outlives_bounds(kind)
+                            && !live_args.as_ref().skip_binder().is_empty()
+                        {
+                            let identity = ty::GenericArgs::identity_for_item(tcx, def_id);
+                            let bounds =
+                                tcx.item_bounds(def_id).instantiate_identity().skip_norm_wip();
+                            for arg in interface_args_from_item_bounds(identity, bounds) {
+                                ty::EarlyBinder::bind(tcx, arg)
+                                    .instantiate(tcx, args)
+                                    .skip_norm_wip()
+                                    .visit_with(self);
+                            }
                         }
                     }
                     None => {

--- a/tests/ui/borrowck/alias-liveness/rpit-outlives-shorten-unsound.nll.stderr
+++ b/tests/ui/borrowck/alias-liveness/rpit-outlives-shorten-unsound.nll.stderr
@@ -1,0 +1,16 @@
+error[E0597]: `*x` does not live long enough
+  --> $DIR/rpit-outlives-shorten-unsound.rs:45:27
+   |
+LL |         let x: Box<Payload> = Box::new(Box::new(1));
+   |             - binding `x` declared here
+LL |         let r: &Payload = &*x;
+   |                           ^^^ borrowed value does not live long enough
+...
+LL |     }
+   |     - `*x` dropped here while still borrowed
+LL |     let _ = wrong;
+   |             ----- borrow later used here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/borrowck/alias-liveness/rpit-outlives-shorten-unsound.polonius.stderr
+++ b/tests/ui/borrowck/alias-liveness/rpit-outlives-shorten-unsound.polonius.stderr
@@ -1,0 +1,16 @@
+error[E0597]: `*x` does not live long enough
+  --> $DIR/rpit-outlives-shorten-unsound.rs:45:27
+   |
+LL |         let x: Box<Payload> = Box::new(Box::new(1));
+   |             - binding `x` declared here
+LL |         let r: &Payload = &*x;
+   |                           ^^^ borrowed value does not live long enough
+...
+LL |     }
+   |     - `*x` dropped here while still borrowed
+LL |     let _ = wrong;
+   |             ----- borrow later used here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/borrowck/alias-liveness/rpit-outlives-shorten-unsound.rs
+++ b/tests/ui/borrowck/alias-liveness/rpit-outlives-shorten-unsound.rs
@@ -1,0 +1,50 @@
+//@ revisions: nll polonius
+//@ ignore-compare-mode-polonius (explicit revisions)
+//@ [nll] compile-flags: -Zpolonius=off
+//@ [polonius] compile-flags: -Zpolonius=next
+//@ edition: 2024
+
+// Regression test for #161038: Polonius accepted an illegal lifetime
+// shortening through `impl Trait`. `Outlives::shorten` turns
+// `impl Produce<'a> + 'a` into `impl Produce<'a> + 'b` (`'a: 'b` on the
+// impl). The `'b` outlives bound made liveness treat `'a` as dead even
+// though `.produce()` still yields `&'a Payload`, so a reference to
+// dropped data was returned. NLL already rejected this; Polonius must too.
+
+type Payload = Box<i32>;
+
+trait Produce<'a> {
+    fn produce(self) -> &'a Payload;
+}
+impl<'a> Produce<'a> for &'a Payload {
+    fn produce(self) -> &'a Payload {
+        self
+    }
+}
+
+trait Outlives<'a, 'b> {
+    fn shorten(x: impl Produce<'a> + 'a) -> impl Produce<'a> + 'b;
+}
+impl<'a: 'b, 'b> Outlives<'a, 'b> for () {
+    fn shorten(x: impl Produce<'a> + 'a) -> impl Produce<'a> + 'b {
+        x
+    }
+}
+
+fn make_producer<'a, 'b>(payload: &'a Payload) -> impl Produce<'a> + 'b + use<'a, 'b>
+where
+    (): Outlives<'a, 'b>,
+{
+    <()>::shorten(payload)
+}
+
+fn main() {
+    let wrong: &Payload;
+    {
+        let x: Box<Payload> = Box::new(Box::new(1));
+        let r: &Payload = &*x;
+        //~^ ERROR `*x` does not live long enough
+        wrong = make_producer(r).produce();
+    }
+    let _ = wrong;
+}


### PR DESCRIPTION
Fixes rust-lang/rust#161038

Polonius currently accepts a program that NLL rejects and that can
segfault: an `impl Produce<'a> + 'b` opaque (produced by shortening
`impl Produce<'a> + 'a` through a trait impl with `'a: 'b`) is treated
as only keeping `'b` live. `.produce()` still yields `&'a Payload`, so
the input borrow is not required to last as long as the output.

The hole is in opaque/alias liveness. With a unique non-`'static`
outlives bound we only marked args *known* to outlive that bound, using
the parent function's where-clauses and implied bounds. That misses
lifetimes that appear in the alias's trait bounds (`Produce<'a>`) and
that nested opaques / impl where-clauses can still put in the hidden
type.

This change also visits those interface args (trait generic args other
than `Self`, GAT args, and associated type bindings). A `'static`
outlives bound on the alias itself still skips all args, so
`Captures<'a> + 'static` keeps compiling.

T-types should review (Polonius / opaque liveness).

r? lqd

## Test plan

- [x] `./x test tests/ui/borrowck/alias-liveness/rpit-outlives-shorten-unsound.rs --stage 1` (NLL and Polonius both error)
- [x] `./x test tests/ui/borrowck/alias-liveness --stage 1` (41 passed, including `rpit-static`)

changelog: rustc: reject unsound impl Trait lifetime shortening under Polonius