### PR TITLE
fix arm homogeneous aggregate ABI

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -2171,8 +2171,8 @@ pub struct LayoutData<FieldIdx: Idx, VariantIdx: Idx> {
     pub max_repr_align: Option<Align>,
 
     /// The alignment the type would have, ignoring any `repr(align)` but including `repr(packed)`.
-    /// Only used on aarch64-linux, where the argument passing ABI ignores the requested alignment
-    /// in some cases.
+    /// Only used on aarch64-linux and arm, where the argument passing ABI ignores the requested
+    /// alignment in some cases.
     pub unadjusted_abi_align: Align,
 
     /// The randomization seed based on this type's own repr and its fields.

--- a/compiler/rustc_target/src/callconv/arm.rs
+++ b/compiler/rustc_target/src/callconv/arm.rs
@@ -1,7 +1,14 @@
 use rustc_abi::{ArmCall, CanonAbi, HasDataLayout, TyAbiInterface};
 
 use crate::callconv::{ArgAbi, FnAbi, Reg, RegKind, Uniform};
-use crate::spec::HasTargetSpec;
+use crate::spec::{CfgAbi, HasTargetSpec, Os};
+
+#[derive(Clone, Copy)]
+enum ArmAbiKind {
+    Aapcs,
+    AapcsVfp,
+    Aapcs16Vfp,
+}
 
 fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>) -> Option<Uniform>
 where
@@ -26,7 +33,7 @@ where
     })
 }
 
-fn classify_ret<'a, Ty, C>(cx: &C, ret: &mut ArgAbi<'a, Ty>, vfp: bool)
+fn classify_ret<'a, Ty, C>(cx: &C, ret: &mut ArgAbi<'a, Ty>, abi_kind: ArmAbiKind, vfp: bool)
 where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout,
@@ -49,14 +56,21 @@ where
 
     let size = ret.layout.size;
     let bits = size.bits();
+
     if bits <= 32 {
+        // Aggregates <= 4 bytes are returned in r0; other aggregates are returned indirectly.
         ret.cast_to(Uniform::new(Reg::i32(), size));
         return;
+    } else if matches!(abi_kind, ArmAbiKind::Aapcs16Vfp) && bits <= 128 {
+        // watchOS returns the remaining aggregates of up to 128 bits in GPRs.
+        ret.cast_to(Uniform::consecutive(Reg::i32(), size));
+        return;
     }
+
     ret.make_indirect();
 }
 
-fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>, vfp: bool)
+fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>, abi_kind: ArmAbiKind, vfp: bool)
 where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout,
@@ -74,14 +88,27 @@ where
         return;
     }
 
-    if vfp {
+    // watchOS also passes homogeneous aggregates in VFP registers, and unlike `AapcsVfp` it does
+    // so even for variadics and for `extern "aapcs"`: the backend will use GPRs if needed.
+    if vfp || matches!(abi_kind, ArmAbiKind::Aapcs16Vfp) {
         if let Some(uniform) = is_homogeneous_aggregate(cx, arg) {
             arg.cast_to(uniform);
             return;
         }
     }
 
-    let align = arg.layout.align.bytes();
+    // For the composites that are left, watchOS adopts the 64-bit AAPCS rule: those larger than
+    // 128 bits are placed in space allocated by the caller, and a pointer is passed.
+    if matches!(abi_kind, ArmAbiKind::Aapcs16Vfp) && arg.layout.size.bits() > 128 {
+        arg.make_indirect();
+        return;
+    }
+
+    let align = match abi_kind {
+        ArmAbiKind::Aapcs | ArmAbiKind::AapcsVfp => arg.layout.unadjusted_abi_align.bytes(),
+        ArmAbiKind::Aapcs16Vfp => arg.layout.align.bytes(),
+    };
+
     let total = arg.layout.size;
     arg.cast_to(Uniform::consecutive(if align <= 4 { Reg::i32() } else { Reg::i64() }, total));
 }
@@ -91,20 +118,37 @@ where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout + HasTargetSpec,
 {
-    // If this is a target with a hard-float ABI, and the function is not explicitly
-    // `extern "aapcs"`, then we must use the VFP registers for homogeneous aggregates.
-    let vfp = cx.target_spec().llvm_target.ends_with("hf")
-        && fn_abi.conv != CanonAbi::Arm(ArmCall::Aapcs)
-        && !fn_abi.c_variadic;
+    let abi_kind = if cx.target_spec().os == Os::WatchOs {
+        ArmAbiKind::Aapcs16Vfp
+    } else if cx.target_spec().cfg_abi == CfgAbi::EabiHf {
+        ArmAbiKind::AapcsVfp
+    } else {
+        ArmAbiKind::Aapcs
+    };
+
+    // Whether we must use the VFP registers for homogeneous aggregates.
+    let is_effectively_vfp = |accept_aapcs16| {
+        // When the user requested aapcs explicitly, honor that.
+        if matches!(fn_abi.conv, CanonAbi::Arm(ArmCall::Aapcs)) {
+            return false;
+        }
+
+        match abi_kind {
+            ArmAbiKind::AapcsVfp => true,
+            ArmAbiKind::Aapcs16Vfp => accept_aapcs16,
+            ArmAbiKind::Aapcs => false,
+        }
+    };
 
     if !fn_abi.ret.is_ignore() {
-        classify_ret(cx, &mut fn_abi.ret, vfp);
+        classify_ret(cx, &mut fn_abi.ret, abi_kind, !fn_abi.c_variadic && is_effectively_vfp(true));
     }
 
+    let is_arg_vfp = !fn_abi.c_variadic && is_effectively_vfp(false);
     for arg in fn_abi.args.iter_mut() {
         if arg.is_ignore() {
             continue;
         }
-        classify_arg(cx, arg, vfp);
+        classify_arg(cx, arg, abi_kind, is_arg_vfp);
     }
 }

--- a/tests/codegen-llvm/arm-abi/homogeneous-aggregate.rs
+++ b/tests/codegen-llvm/arm-abi/homogeneous-aggregate.rs
@@ -1,0 +1,180 @@
+//@ add-minicore
+//@ compile-flags: -Cno-prepopulate-passes -Copt-level=0
+//
+//@ revisions: linux eabi watchos
+//@[linux] compile-flags: --target armv7-unknown-linux-gnueabihf
+//@[eabi] compile-flags: --target armv7r-none-eabi
+//@[watchos] compile-flags: --target armv7k-apple-watchos
+//
+//@ needs-llvm-components: arm
+
+// Test that homogeneous aggregates are passed and returned with the correct ABI on 32-bit arm.
+
+#![feature(no_core, lang_items)]
+#![crate_type = "lib"]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+// A homogeneous float aggregate, which a hard-float ABI passes in VFP registers.
+#[repr(C)]
+pub struct Hfa {
+    pub a: f32,
+    pub b: f32,
+}
+impl Copy for Hfa {}
+
+// linux:   define void @test_hfa([2 x float] %0)
+// eabi:    define dso_local void @test_hfa([2 x i32] %0)
+// watchos: define void @test_hfa([2 x float] %0)
+#[unsafe(no_mangle)]
+pub extern "C" fn test_hfa(a: Hfa) {
+    hint::black_box(a);
+}
+
+// linux:   define [2 x float] @ret_hfa([2 x float] %0)
+// eabi:    define dso_local void @ret_hfa(ptr sret([8 x i8]) align 4 %_0, [2 x i32] %0)
+// watchos: define [2 x float] @ret_hfa([2 x float] %0)
+#[unsafe(no_mangle)]
+pub extern "C" fn ret_hfa(a: Hfa) -> Hfa {
+    a
+}
+
+// When we ask for `extern "aapcs"` specifically, GPRs are used, except on watchOS.
+//
+// linux:   define arm_aapcscc void @test_hfa_aapcs([2 x i32] %0)
+// eabi:    define dso_local arm_aapcscc void @test_hfa_aapcs([2 x i32] %0)
+// watchos: define arm_aapcscc void @test_hfa_aapcs([2 x float] %0)
+#[unsafe(no_mangle)]
+pub extern "aapcs" fn test_hfa_aapcs(a: Hfa) {
+    hint::black_box(a);
+}
+
+// A homogeneous aggregate can have at most 4 fields.
+#[repr(C)]
+pub struct Hfa4F64 {
+    pub a: f64,
+    pub b: f64,
+    pub c: f64,
+    pub d: f64,
+}
+
+// linux:   define void @test_hfa_4_f64([4 x double] %0)
+// eabi:    define dso_local void @test_hfa_4_f64([4 x i64] %0)
+// watchos: define void @test_hfa_4_f64([4 x double] %0)
+#[unsafe(no_mangle)]
+pub extern "C" fn test_hfa_4_f64(a: Hfa4F64) {
+    hint::black_box(a);
+}
+
+// A homogeneous aggregate can have at most 4 fields, so this does not qualify.
+#[repr(C)]
+pub struct Floats5 {
+    pub a: f32,
+    pub b: f32,
+    pub c: f32,
+    pub d: f32,
+    pub e: f32,
+}
+
+// linux:   define void @test_floats_5([5 x i32] %0)
+// eabi:    define dso_local void @test_floats_5([5 x i32] %0)
+// watchos: define void @test_floats_5(ptr align 4 %a)
+#[unsafe(no_mangle)]
+pub extern "C" fn test_floats_5(a: Floats5) {
+    hint::black_box(a);
+}
+
+// Just a big struct, note how watchOS passes it indirectly.
+#[repr(C)]
+pub struct Ints6 {
+    pub a: u32,
+    pub b: u32,
+    pub c: u32,
+    pub d: u32,
+    pub e: u32,
+    pub f: u32,
+}
+impl Copy for Ints6 {}
+
+// linux:   define void @test_ints_6([6 x i32] %0)
+// eabi:    define dso_local void @test_ints_6([6 x i32] %0)
+// watchos: define void @test_ints_6(ptr align 4 %a)
+#[unsafe(no_mangle)]
+pub extern "C" fn test_ints_6(a: Ints6) {
+    hint::black_box(a);
+}
+
+#[repr(C)]
+pub struct Natural {
+    pub a: u32,
+    pub b: u32,
+}
+
+// Returns are indirect once they exceed 32 bits, except on watchOS.
+//
+// linux:   define void @ret_natural(ptr sret([8 x i8]) align 4 %_0, [2 x i32] %0)
+// eabi:    define dso_local void @ret_natural(ptr sret([8 x i8]) align 4 %_0, [2 x i32] %0)
+// watchos: define [2 x i32] @ret_natural([2 x i32] %0)
+#[unsafe(no_mangle)]
+pub extern "C" fn ret_natural(a: Natural) -> Natural {
+    a
+}
+
+#[repr(C)]
+#[repr(align(16))]
+pub struct Align16 {
+    pub a: u32,
+    pub b: u32,
+}
+
+// linux:   define void @ret_align16(ptr sret([16 x i8]) align 16 %_0, [4 x i32] %0)
+// eabi:    define dso_local void @ret_align16(ptr sret([16 x i8]) align 16 %_0, [4 x i32] %0)
+// watchos: define [4 x i32] @ret_align16([2 x i64] %0)
+#[unsafe(no_mangle)]
+pub extern "C" fn ret_align16(a: Align16) -> Align16 {
+    a
+}
+
+// Larger than 128 bits, so the return is indirect everywhere.
+//
+// linux:   define void @ret_ints_6(ptr sret([24 x i8]) align 4 %_0, [6 x i32] %0)
+// eabi:    define dso_local void @ret_ints_6(ptr sret([24 x i8]) align 4 %_0, [6 x i32] %0)
+// watchos: define void @ret_ints_6(ptr sret([24 x i8]) align 4 %_0, ptr align 4 %a)
+#[unsafe(no_mangle)]
+pub extern "C" fn ret_ints_6(a: Ints6) -> Ints6 {
+    a
+}
+
+extern "C" {
+    // linux:   declare void @test_hfa_variadic_c([2 x i32], ...)
+    // eabi:    declare dso_local void @test_hfa_variadic_c([2 x i32], ...)
+    // watchos: declare void @test_hfa_variadic_c([2 x float], ...)
+    fn test_hfa_variadic_c(_: Hfa, ...);
+
+    // linux:   declare void @test_ints_6_variadic_c([6 x i32], ...)
+    // eabi:    declare dso_local void @test_ints_6_variadic_c([6 x i32], ...)
+    // watchos: declare void @test_ints_6_variadic_c(ptr align 4, ...)
+    fn test_ints_6_variadic_c(_: Ints6, ...);
+}
+
+extern "aapcs" {
+    // linux:   declare arm_aapcscc void @test_hfa_variadic_aapcs([2 x i32], ...)
+    // eabi:    declare dso_local arm_aapcscc void @test_hfa_variadic_aapcs([2 x i32], ...)
+    // watchos: declare arm_aapcscc void @test_hfa_variadic_aapcs([2 x float], ...)
+    fn test_hfa_variadic_aapcs(_: Hfa, ...);
+
+    // linux:   declare arm_aapcscc void @test_ints_6_variadic_aapcs([6 x i32], ...)
+    // eabi:    declare dso_local arm_aapcscc void @test_ints_6_variadic_aapcs([6 x i32], ...)
+    // watchos: declare arm_aapcscc void @test_ints_6_variadic_aapcs(ptr align 4, ...)
+    fn test_ints_6_variadic_aapcs(_: Ints6, ...);
+}
+
+pub unsafe fn call_variadics(a: Hfa, b: Ints6) {
+    test_hfa_variadic_c(a);
+    test_ints_6_variadic_c(b);
+
+    test_hfa_variadic_aapcs(a);
+    test_ints_6_variadic_aapcs(b);
+}

--- a/tests/codegen-llvm/arm-abi/struct-alignment.rs
+++ b/tests/codegen-llvm/arm-abi/struct-alignment.rs
@@ -1,0 +1,115 @@
+//@ add-minicore
+//@ compile-flags: -Cno-prepopulate-passes -Copt-level=0
+//
+//@ revisions: linux eabi watchos
+//@[linux] compile-flags: --target armv7-unknown-linux-gnueabihf
+//@[eabi] compile-flags: --target armv7r-none-eabi
+//@[watchos] compile-flags: --target armv7k-apple-watchos
+//
+//@ needs-llvm-components: arm
+
+// Test that structs are passed with the correct register alignment.
+
+#![feature(no_core, lang_items)]
+#![crate_type = "lib"]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+#[repr(C)]
+pub struct Natural {
+    pub a: u32,
+    pub b: u32,
+}
+
+// linux:   define void @test_natural([2 x i32] %0)
+// eabi:    define dso_local void @test_natural([2 x i32] %0)
+// watchos: define void @test_natural([2 x i32] %0)
+#[unsafe(no_mangle)]
+pub extern "C" fn test_natural(a: Natural) {
+    hint::black_box(a);
+}
+
+#[repr(C)]
+pub struct HasU64 {
+    pub a: u64,
+}
+
+// linux:   define void @test_has_u64(i64 %0)
+// eabi:    define dso_local void @test_has_u64(i64 %0)
+// watchos: define void @test_has_u64(i64 %0)
+#[unsafe(no_mangle)]
+pub extern "C" fn test_has_u64(a: HasU64) {
+    hint::black_box(a);
+}
+
+#[repr(C)]
+#[repr(align(8))]
+pub struct Align8 {
+    pub a: u32,
+    pub b: u32,
+}
+
+#[repr(transparent)]
+pub struct Transparent8 {
+    a: Align8,
+}
+
+// Here watchOS deviates from the others. On linux and eabi, the natural alignment of the struct
+// contents is used, and the alignment modifier of the struct is not considered for ABI purposes.
+// watchOS does respect the alignment annotation for register allocation.
+//
+// linux:   define void @test_8([2 x i32] %0, [2 x i32] %1)
+// eabi:    define dso_local void @test_8([2 x i32] %0, [2 x i32] %1)
+// watchos: define void @test_8(i64 %0, i64 %1)
+#[unsafe(no_mangle)]
+pub extern "C" fn test_8(a: Align8, b: Transparent8) {
+    hint::black_box(a);
+    hint::black_box(b);
+}
+
+#[repr(C)]
+#[repr(align(16))]
+pub struct Align16 {
+    pub a: u32,
+    pub b: u32,
+}
+
+#[repr(transparent)]
+pub struct Transparent16 {
+    a: Align16,
+}
+
+#[repr(C)]
+pub struct Wrapped16 {
+    pub a: Align16,
+}
+
+// Wrapping resets the unadjusted alignment.
+//
+// linux:   define void @test_16([4 x i32] %0, [4 x i32] %1, [2 x i64] %2)
+// eabi:    define dso_local void @test_16([4 x i32] %0, [4 x i32] %1, [2 x i64] %2)
+// watchos: define void @test_16([2 x i64] %0, [2 x i64] %1, [2 x i64] %2)
+#[unsafe(no_mangle)]
+pub extern "C" fn test_16(a: Align16, b: Transparent16, c: Wrapped16) {
+    hint::black_box(a);
+    hint::black_box(b);
+    hint::black_box(c);
+}
+
+// Packing is different, the alignment is 1 across targets.
+#[repr(C)]
+#[repr(packed)]
+pub struct Packed {
+    pub a: u8,
+    pub b: u64,
+}
+
+// linux:   define void @test_packed([3 x i32] %0)
+// eabi:    define dso_local void @test_packed([3 x i32] %0)
+// watchos: define void @test_packed([3 x i32] %0)
+#[unsafe(no_mangle)]
+pub extern "C" fn test_packed(a: Packed) {
+    hint::black_box(a);
+}


### PR DESCRIPTION
This started with abi-cafe finding a mismatch between rustc and clang/gcc, but turned into quite the rabbit hole of bits of ABI that were never implemented. The code is effectively ported from LLVM, and abi-cafe is happy now.

The bug I hit was that aligned structs were passed incorrectly:

https://godbolt.org/z/jErPoPrv5

The assertions for watchOS are best-effort, I can't actually run that. But, it's tier 3, it was already broken, so at worst it's just less broken now. 

The relevant code is in https://github.com/llvm/llvm-project/blob/551766823bb7b5a6af84e4ec1c1aff6dff431229/clang/lib/CodeGen/Targets/ARM.cpp, I'll link some specific parts.

r? davidtwco 