### PR TITLE
Add regression test for path printing with infinitely many visible names

### DIFF
--- a/tests/ui/imports/auxiliary/pathloop.rs
+++ b/tests/ui/imports/auxiliary/pathloop.rs
@@ -1,0 +1,6 @@
+pub struct AStruct;
+
+pub mod prelude {
+    pub use crate as pathloop;
+    pub use crate::AStruct;
+}

--- a/tests/ui/imports/path-with-infinite-visible-names-57500.rs
+++ b/tests/ui/imports/path-with-infinite-visible-names-57500.rs
@@ -1,0 +1,12 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/57500>.
+// An item reachable under infinitely many paths used to hang path printing
+// while rendering this error.
+//@ aux-build: pathloop.rs
+
+extern crate pathloop;
+
+use pathloop::prelude::*;
+
+fn main() {
+    let _x: AStruct = 42; //~ ERROR mismatched types
+}

--- a/tests/ui/imports/path-with-infinite-visible-names-57500.stderr
+++ b/tests/ui/imports/path-with-infinite-visible-names-57500.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/path-with-infinite-visible-names-57500.rs:11:23
+   |
+LL |     let _x: AStruct = 42;
+   |             -------   ^^ expected `AStruct`, found integer
+   |             |
+   |             expected due to this
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Closes rust-lang/rust#57500