### PR TITLE
Skip empty projections in UnDerefer

### DIFF
--- a/compiler/rustc_mir_dataflow/src/un_derefer.rs
+++ b/compiler/rustc_mir_dataflow/src/un_derefer.rs
@@ -46,7 +46,8 @@ impl<'a, 'tcx> ProjectionIter<'a, 'tcx> {
         let last = if place.as_local().is_none() {
             Some(place)
         } else {
-            debug_assert!(deref_chain.is_empty());
+            // CopyForDeref of a local after OpaqueCast is stripped (#160800).
+            debug_assert!(deref_chain.iter().all(|p| p.projection.is_empty()));
             None
         };
 
@@ -59,21 +60,28 @@ impl<'tcx> Iterator for ProjectionIter<'_, 'tcx> {
 
     #[inline]
     fn next(&mut self) -> Option<(PlaceRef<'tcx>, PlaceElem<'tcx>)> {
-        let place = self.places.read()?;
+        loop {
+            let place = self.places.read()?;
 
-        // the projection should never be empty except for a bare local which is handled in new
-        let partial_place =
-            PlaceRef { local: place.local, projection: &place.projection[..self.proj_idx] };
-        let elem = place.projection[self.proj_idx];
+            // CopyForDeref of a local (empty projection) after OpaqueCast stripping (#160800).
+            if place.projection.is_empty() {
+                self.places.advance();
+                continue;
+            }
 
-        if self.proj_idx == place.projection.len() - 1 {
-            self.proj_idx = 0;
-            self.places.advance();
-        } else {
-            self.proj_idx += 1;
+            let partial_place =
+                PlaceRef { local: place.local, projection: &place.projection[..self.proj_idx] };
+            let elem = place.projection[self.proj_idx];
+
+            if self.proj_idx == place.projection.len() - 1 {
+                self.proj_idx = 0;
+                self.places.advance();
+            } else {
+                self.proj_idx += 1;
+            }
+
+            return Some((partial_place, elem));
         }
-
-        Some((partial_place, elem))
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/ice-un-derefer-160800.rs
+++ b/tests/ui/type-alias-impl-trait/ice-un-derefer-160800.rs
@@ -1,0 +1,19 @@
+//! Regression test for #160800.
+
+#![feature(type_alias_impl_trait)]
+
+type Foo = impl Send;
+
+#[define_opaque(Foo)]
+const VALUE: Foo = todo!();
+//~^ ERROR item does not constrain `Foo::{opaque#0}`
+
+#[define_opaque(Foo)]
+fn test(_foo: Foo) {
+    match VALUE {
+        &mut Some(ref mut x) => *x,
+        &mut None => panic!(),
+    }
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/ice-un-derefer-160800.stderr
+++ b/tests/ui/type-alias-impl-trait/ice-un-derefer-160800.stderr
@@ -1,0 +1,15 @@
+error: item does not constrain `Foo::{opaque#0}`
+  --> $DIR/ice-un-derefer-160800.rs:8:7
+   |
+LL | const VALUE: Foo = todo!();
+   |       ^^^^^
+   |
+   = note: consider removing `#[define_opaque]` or adding an empty `#[define_opaque()]`
+note: this opaque type is supposed to be constrained
+  --> $DIR/ice-un-derefer-160800.rs:5:12
+   |
+LL | type Foo = impl Send;
+   |            ^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Skip empty projections when replaying `CopyForDeref` chains.

`PostAnalysisNormalize` can strip an `OpaqueCast` that was the only
projection, leaving `CopyForDeref` of a local. Drop elaboration then
panicked in `UnDerefer` by indexing that empty projection.

Fixes rust-lang/rust#160800

r? @ghost

<!-- homu-ignore:start -->
LLM disclosure: I used Cursor to investigate rust-lang/rust#160800 and implement the
UnDerefer change plus a UI regression test. I reviewed the MIR before and
after PostAnalysisNormalize, confirmed the empty-projection panic, and ran
the new test plus related TAIT drop-elaboration tests locally.

This is not pre-arranged with a reviewer. rust-lang LLM policy asks new
contributors to find a reviewer (e.g. #t-compiler/llm-mentoring on Zulip)
before LLM-assisted PRs are assigned. Using `r? @ghost` until then.
<!-- homu-ignore:end -->

Made with [Cursor](https://cursor.com)