### PR TITLE
Overhaul `features-status-dump`

### DIFF
--- a/src/tools/features-status-dump/Cargo.toml
+++ b/src/tools/features-status-dump/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "features-status-dump"
+description = "Dumps info about rustc's features to JSON."
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = { version = "1" }
 clap = { version = "4", features = ["derive"] }
-serde = { version = "1.0.125", features = [ "derive" ] }
+serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.59"
 tidy = { path = "../tidy", features = ["build-metrics"] }

--- a/src/tools/features-status-dump/src/display.rs
+++ b/src/tools/features-status-dump/src/display.rs
@@ -17,6 +17,7 @@ pub(crate) struct SourcedFeature {
     pub(crate) feature: Feature,
 }
 
+// A new struct is defined rather than changing the old one, to keep serialization behaving the same.
 pub struct NewFeaturesStatus {
     features: HashMap<String, SourcedFeature>,
     compare: for<'a, 'b> fn(
@@ -47,12 +48,8 @@ impl Display for NewFeaturesStatus {
                 write!(f, " since {:w_since$}", since, w_since = 7)?;
             }
             if let Some(issue) = &feature.feature.tracking_issue {
-                write!(
-                    f,
-                    " <https://github.com/rust-lang/rust/issues/{:<w_issue$}>",
-                    issue,
-                    w_issue = 6
-                )?;
+                let link = format!("<https://github.com/rust-lang/rust/issues/{}>", issue);
+                write!(f, " {:<w_issue$}", link, w_issue = 49)?;
             }
             if let Some(description) = &feature.feature.description {
                 write!(f, ": {}", description)?;

--- a/src/tools/features-status-dump/src/display.rs
+++ b/src/tools/features-status-dump/src/display.rs
@@ -12,9 +12,9 @@ enum Source {
     Compiler,
 }
 
-pub(crate) struct SourcedFeature {
+pub struct SourcedFeature {
     source: Source,
-    pub(crate) feature: Feature,
+    pub feature: Feature,
 }
 
 // A new struct is defined rather than changing the old one, to keep serialization behaving the same.

--- a/src/tools/features-status-dump/src/display.rs
+++ b/src/tools/features-status-dump/src/display.rs
@@ -59,8 +59,6 @@ impl Display for NewFeaturesStatus {
             }
             writeln!(f)?;
         }
-
-        // TODO
         std::fmt::Result::Ok(())
     }
 }

--- a/src/tools/features-status-dump/src/display.rs
+++ b/src/tools/features-status-dump/src/display.rs
@@ -1,0 +1,88 @@
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use tidy::features::Feature;
+
+use crate::FeaturesStatus;
+
+// Newtype because orphan rule
+
+enum Source {
+    Library,
+    Compiler,
+}
+
+pub(crate) struct SourcedFeature {
+    source: Source,
+    pub(crate) feature: Feature,
+}
+
+pub struct NewFeaturesStatus {
+    features: HashMap<String, SourcedFeature>,
+    compare: for<'a, 'b> fn(
+        &'a (&String, &SourcedFeature),
+        &'b (&String, &SourcedFeature),
+    ) -> std::cmp::Ordering,
+}
+
+impl Display for Source {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let string = match self {
+            Source::Library => "[Library]",
+            Source::Compiler => "[Compiler]",
+        };
+        f.pad(string)
+    }
+}
+
+impl Display for NewFeaturesStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut sorted = self.features.iter().collect::<Vec<_>>();
+        sorted.sort_by(self.compare);
+        for (name, feature) in sorted {
+            write!(f, "{:w_tag$}", feature.source, w_tag = 10)?;
+            write!(f, " {:w_name$}", name, w_name = 40)?;
+            write!(f, " is {:w_status$}", feature.feature.level, w_status = 10)?;
+            if let Some(since) = feature.feature.since {
+                write!(f, " since {:w_since$}", since, w_since = 7)?;
+            }
+            if let Some(issue) = &feature.feature.tracking_issue {
+                write!(
+                    f,
+                    " <https://github.com/rust-lang/rust/issues/{:<w_issue$}>",
+                    issue,
+                    w_issue = 6
+                )?;
+            }
+            if let Some(description) = &feature.feature.description {
+                write!(f, ": {}", description)?;
+            }
+            writeln!(f)?;
+        }
+
+        // TODO
+        std::fmt::Result::Ok(())
+    }
+}
+
+impl NewFeaturesStatus {
+    pub fn new(
+        value: FeaturesStatus,
+        compare: for<'a, 'b> fn(
+            &'a (&String, &SourcedFeature),
+            &'b (&String, &SourcedFeature),
+        ) -> std::cmp::Ordering,
+    ) -> Self {
+        let compiler_features = value
+            .lang_features_status
+            .into_iter()
+            .map(|(name, feature)| (name, SourcedFeature { feature, source: Source::Compiler }));
+        let library_features = value
+            .lib_features_status
+            .into_iter()
+            .map(|(name, feature)| (name, SourcedFeature { feature, source: Source::Library }));
+        let features = compiler_features.chain(library_features).collect();
+
+        Self { features, compare }
+    }
+}

--- a/src/tools/features-status-dump/src/err.rs
+++ b/src/tools/features-status-dump/src/err.rs
@@ -1,15 +1,7 @@
 #[derive(Debug)]
-pub enum SemverFlag {
-    Before,
-    Since,
-}
-
-#[derive(Debug)]
 pub(crate) enum DumpError {
     NoSources,
     NoVersions,
-    StatusConflict,
-    BadSemver { cause: String, flag: SemverFlag },
 }
 
 impl std::fmt::Display for DumpError {
@@ -18,16 +10,8 @@ impl std::fmt::Display for DumpError {
             DumpError::NoSources => {
                 "No feature sources given. Specify at least one with --library-path or --compiler-path"
             }
-            DumpError::NoVersions => "Empty version range: `after..before`.",
-            DumpError::StatusConflict => {
-                "At most one feature status is allowed to be `required` at once."
-            }
-            DumpError::BadSemver { cause, flag } => {
-                let flag_name = match flag {
-                    SemverFlag::Before => "--before",
-                    SemverFlag::Since => "--after",
-                };
-                &format!("Invalid semver {} in flag {}.", cause, flag_name)
+            DumpError::NoVersions => {
+                "Empty version range. first_version is older than last_version."
             }
         };
         f.pad(msg)

--- a/src/tools/features-status-dump/src/err.rs
+++ b/src/tools/features-status-dump/src/err.rs
@@ -1,0 +1,37 @@
+#[derive(Debug)]
+pub enum SemverFlag {
+    Before,
+    Since,
+}
+
+#[derive(Debug)]
+pub(crate) enum DumpError {
+    NoSources,
+    NoVersions,
+    StatusConflict,
+    BadSemver { cause: String, flag: SemverFlag },
+}
+
+impl std::fmt::Display for DumpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            DumpError::NoSources => {
+                "No feature sources given. Specify at least one with --library-path or --compiler-path"
+            }
+            DumpError::NoVersions => "Empty version range: `after..before`.",
+            DumpError::StatusConflict => {
+                "At most one feature status is allowed to be `required` at once."
+            }
+            DumpError::BadSemver { cause, flag } => {
+                let flag_name = match flag {
+                    SemverFlag::Before => "--before",
+                    SemverFlag::Since => "--after",
+                };
+                &format!("Invalid semver {} in flag {}.", cause, flag_name)
+            }
+        };
+        f.pad(msg)
+    }
+}
+
+impl std::error::Error for DumpError {}

--- a/src/tools/features-status-dump/src/main.rs
+++ b/src/tools/features-status-dump/src/main.rs
@@ -9,7 +9,7 @@ use tidy::diagnostics::RunningCheck;
 use tidy::features::{Feature, Status, collect_lang_features, collect_lib_features};
 
 use crate::display::{NewFeaturesStatus, SourcedFeature};
-use crate::parse::{Args, Tristate};
+use crate::parse::{Cli, Tristate};
 
 mod display;
 mod err;
@@ -23,7 +23,7 @@ struct FeaturesStatus {
 }
 
 fn main() -> Result<()> {
-    let args = Args::parse()?;
+    let args = crate::parse::parse()?;
 
     let lang_features_status: HashMap<_, _> = args
         .compiler_path
@@ -68,7 +68,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn write_output<W>(mut writer: W, features_status: FeaturesStatus, args: &Args) -> Result<()>
+fn write_output<W>(mut writer: W, features_status: FeaturesStatus, args: &Cli) -> Result<()>
 where
     W: io::Write,
 {
@@ -101,7 +101,7 @@ fn compare_ascending<'a, 'b>(
     a.1.feature.tracking_issue.cmp(&b.1.feature.tracking_issue)
 }
 
-fn include(feature: &Feature, args: &Args) -> bool {
+fn include(feature: &Feature, args: &Cli) -> bool {
     let accept = match args.accepted {
         Tristate::Require => feature.level == Status::Accepted,
         Tristate::Allow => true,
@@ -117,24 +117,24 @@ fn include(feature: &Feature, args: &Args) -> bool {
         Tristate::Allow => true,
         Tristate::Deny => feature.level != Status::Unstable,
     };
-    let tracking = match args.tracking_issue {
+    let tracking_issue = match args.tracking_issue {
         Tristate::Require => feature.tracking_issue.is_some(),
         Tristate::Allow => true,
         Tristate::Deny => feature.tracking_issue.is_none(),
     };
-    let before = match args.before {
-        Some(before) => match feature.since {
-            Some(version) => version < before,
-            None => false, // reject features without version
-        },
-        None => true,
-    };
     let since = match args.since {
-        Some(since) => match feature.since {
-            Some(version) => version >= since,
-            None => false, // reject features without version
-        },
-        None => true,
+        Tristate::Require => feature.since.is_some(),
+        Tristate::Allow => true,
+        Tristate::Deny => feature.since.is_none(),
     };
-    accept && remove && unstable && tracking && before && since
+
+    let last_version = args
+        .last_version
+        .is_none_or(|last_version| feature.since.is_some_and(|version| version <= last_version));
+
+    let first_version = args
+        .first_version
+        .is_none_or(|last_version| feature.since.is_some_and(|version| version >= last_version));
+
+    accept && remove && unstable && tracking_issue && since && last_version && first_version
 }

--- a/src/tools/features-status-dump/src/main.rs
+++ b/src/tools/features-status-dump/src/main.rs
@@ -85,10 +85,7 @@ where
             };
             let new_features = NewFeaturesStatus::new(features_status, compare);
 
-            match write!(writer, "{}", new_features) {
-                Ok(()) => Ok(()),
-                Err(e) => Err(e.into()),
-            }
+            write!(writer, "{}", new_features).map_err(Into::into)
         }
     }
 }

--- a/src/tools/features-status-dump/src/main.rs
+++ b/src/tools/features-status-dump/src/main.rs
@@ -1,54 +1,143 @@
+use std::cmp::Ordering;
+// For behaviour, see parse.rs
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::BufWriter;
-use std::path::PathBuf;
+use std::io::{self, BufWriter};
 
 use anyhow::{Context, Result};
-use clap::Parser;
 use tidy::diagnostics::RunningCheck;
-use tidy::features::{Feature, collect_lang_features, collect_lib_features};
+use tidy::features::{Feature, Status, collect_lang_features, collect_lib_features};
 
-#[derive(Debug, Parser)]
-struct Cli {
-    /// Path to `library/` directory.
-    #[arg(long)]
-    library_path: PathBuf,
-    /// Path to `compiler/` directory.
-    #[arg(long)]
-    compiler_path: PathBuf,
-    /// Path to `output/` directory.
-    #[arg(long)]
-    output_path: PathBuf,
-}
+use crate::display::{NewFeaturesStatus, SourcedFeature};
+use crate::parse::{Args, Tristate};
 
+mod display;
+mod err;
+mod parse;
+
+// Placing this into a structure makes it easier to serialize
 #[derive(Debug, serde::Serialize)]
 struct FeaturesStatus {
-    lang_features_status: HashMap<String, Feature>,
-    lib_features_status: HashMap<String, Feature>,
+    pub(crate) lang_features_status: HashMap<String, Feature>,
+    pub(crate) lib_features_status: HashMap<String, Feature>,
 }
 
 fn main() -> Result<()> {
-    let Cli { compiler_path, library_path, output_path } = Cli::parse();
+    let args = Args::parse()?;
 
-    let lang_features_status = collect_lang_features(&compiler_path, &mut RunningCheck::new_noop());
-    let lib_features_status = collect_lib_features(&library_path)
-        .into_iter()
-        .filter(|&(ref name, _)| !lang_features_status.contains_key(name))
+    let lang_features_status: HashMap<_, _> = args
+        .compiler_path
+        .iter()
+        .flat_map(|compiler_path| {
+            collect_lang_features(&compiler_path, &mut RunningCheck::new_noop())
+        })
+        .filter(|(_, feature)| include(feature, &args))
         .collect();
+
+    let lib_features_status = args
+        .library_path
+        .iter()
+        .flat_map(|library_path| collect_lib_features(&library_path).into_iter())
+        // The library contains less info on their features. Prefer the ones found in the compiler.
+        .filter(|&(ref name, _)| !lang_features_status.contains_key(name))
+        .filter(|(_, feature)| include(feature, &args))
+        .collect();
+
     let features_status = FeaturesStatus { lang_features_status, lib_features_status };
 
-    let output_dir = output_path.parent().with_context(|| {
-        format!("failed to get parent dir of output path `{}`", output_path.display())
-    })?;
-    std::fs::create_dir_all(output_dir).with_context(|| {
-        format!("failed to create output directory at `{}`", output_dir.display())
-    })?;
+    match &args.output_path {
+        Some(output_path) => {
+            let output_dir = output_path.parent().with_context(|| {
+                format!("failed to get parent dir of output path `{}`", output_path.display())
+            })?;
+            std::fs::create_dir_all(output_dir).with_context(|| {
+                format!("failed to create output directory at `{}`", output_dir.display())
+            })?;
 
-    let output_file = File::create(&output_path).with_context(|| {
-        format!("failed to create file at given output path `{}`", output_path.display())
-    })?;
-    let writer = BufWriter::new(output_file);
-    serde_json::to_writer_pretty(writer, &features_status)
-        .context("failed to write json output")?;
+            let output_file = File::create(&output_path).with_context(|| {
+                format!("failed to create file at given output path `{}`", output_path.display())
+            })?;
+            let writer = BufWriter::new(output_file);
+            write_output(writer, features_status, &args)?;
+        }
+        None => {
+            let writer = BufWriter::new(std::io::stdout());
+            write_output(writer, features_status, &args)?;
+        }
+    };
     Ok(())
+}
+
+fn write_output<W>(mut writer: W, features_status: FeaturesStatus, args: &Args) -> Result<()>
+where
+    W: io::Write,
+{
+    match args.format {
+        parse::Format::JSON => serde_json::to_writer_pretty(writer, &features_status)
+            .context("failed to write json output"),
+        parse::Format::Text => {
+            let compare: for<'a, 'b> fn(
+                &'a (&String, &SourcedFeature),
+                &'b (&String, &SourcedFeature),
+            ) -> Ordering = match args.sort_by {
+                parse::SortBy::Newest => |a, b| compare_ascending(a, b).reverse(),
+                parse::SortBy::Oldest => compare_ascending,
+            };
+            let new_features = NewFeaturesStatus::new(features_status, compare);
+
+            match write!(writer, "{}", new_features) {
+                Ok(()) => Ok(()),
+                Err(e) => Err(e.into()),
+            }
+        }
+    }
+}
+
+fn compare_ascending<'a, 'b>(
+    a: &'a (&String, &SourcedFeature),
+    b: &'b (&String, &SourcedFeature),
+) -> Ordering {
+    match a.1.feature.since.cmp(&b.1.feature.since) {
+        Ordering::Equal => (),
+        other => return other,
+    };
+    a.1.feature.tracking_issue.cmp(&b.1.feature.tracking_issue)
+}
+
+fn include(feature: &Feature, args: &Args) -> bool {
+    let accept = match args.accepted {
+        Tristate::Require => feature.level == Status::Accepted,
+        Tristate::Allow => true,
+        Tristate::Deny => feature.level != Status::Accepted,
+    };
+    let remove = match args.removed {
+        Tristate::Require => feature.level == Status::Removed,
+        Tristate::Allow => true,
+        Tristate::Deny => feature.level != Status::Removed,
+    };
+    let unstable = match args.unstable {
+        Tristate::Require => feature.level == Status::Unstable,
+        Tristate::Allow => true,
+        Tristate::Deny => feature.level != Status::Unstable,
+    };
+    let tracking = match args.tracking_issue {
+        Tristate::Require => feature.tracking_issue.is_some(),
+        Tristate::Allow => true,
+        Tristate::Deny => feature.tracking_issue.is_none(),
+    };
+    let before = match args.before {
+        Some(before) => match feature.since {
+            Some(version) => version < before,
+            None => false, // reject features without version
+        },
+        None => true,
+    };
+    let since = match args.since {
+        Some(since) => match feature.since {
+            Some(version) => version >= since,
+            None => false, // reject features without version
+        },
+        None => true,
+    };
+    accept && remove && unstable && tracking && before && since
 }

--- a/src/tools/features-status-dump/src/parse.rs
+++ b/src/tools/features-status-dump/src/parse.rs
@@ -5,76 +5,92 @@ use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use tidy::features::Version;
 
-use crate::err::{DumpError, SemverFlag};
+use crate::err::DumpError;
 
 #[derive(Debug, Parser)]
 #[command(version, about)]
-struct Cli {
+pub struct Cli {
     /// Path to `library/` directory. Use this flag to read features from the standard library.
     #[arg(long)]
-    library_path: Option<PathBuf>,
+    pub library_path: Option<PathBuf>,
     /// Path to `compiler/` directory. Use this flag to read language features.
     #[arg(long)]
-    compiler_path: Option<PathBuf>,
+    pub compiler_path: Option<PathBuf>,
     /// Which file to write to. If none, writes to stdout.
     #[arg(long)]
-    output_path: Option<PathBuf>,
+    pub output_path: Option<PathBuf>,
 
     /// What file format to write to. Text is the human-readable option.
     #[arg(long)]
     #[arg(default_value = "json")]
-    format: Format,
+    pub format: Format,
 
     /// Which features to show first. Only has effect when `format = text`.
     /// Features two features with equal versions are ordered by issue number.
     /// Features with no version are considered old.
     #[arg(long)]
     #[arg(default_value = "newest")]
-    sort_by: SortBy,
+    pub sort_by: SortBy,
 
     /// How to filter unstable features.
     #[arg(long)]
     #[arg(default_value = "allow")]
-    unstable: Tristate,
+    #[arg(conflicts_with_all = ["accepted", "removed"])]
+    pub unstable: Tristate,
 
     /// How to filter accepted (stable) features.
     #[arg(long)]
     #[arg(default_value = "allow")]
-    accepted: Tristate,
+    #[arg(conflicts_with_all = ["removed", "unstable"])]
+    pub accepted: Tristate,
 
     /// How to filter removed features.
     #[arg(long)]
     #[arg(default_value = "allow")]
-    removed: Tristate,
+    #[arg(conflicts_with_all = ["accepted", "unstable"])]
+    pub removed: Tristate,
 
     /// How to filter issues with(out) a tracking issue.
     #[arg(long)]
     #[arg(default_value = "allow")]
-    tracking_issue: Tristate,
+    pub tracking_issue: Tristate,
 
-    /// Only show features introduced before this version (semver triple).
-    /// Features without known version are considered oldest.
-    /// Features notated with `Current Version` are considered newer than any concrete semver.
+    /// How to filter issues with(out) `since` version.
     #[arg(long)]
-    before: Option<String>,
+    #[arg(default_value = "allow")]
+    #[arg(conflicts_with_all(["first_version", "last_version"]))]
+    pub since: Tristate,
 
     /// Only show features introduced after or in this version (semver triple)
+    /// Features without known version are filtered out using this flag.
+    /// Features notated with `Current Version` are considered newer than any concrete semver.
     #[arg(long)]
-    since: Option<String>,
+    #[arg(value_parser = Version::from_str)]
+    pub first_version: Option<Version>,
+
+    /// Only show features introduced before or in this version (semver triple).
+    /// Features without known version are filtered out using this flag.
+    /// Features notated with `Current Version` are considered newer than any concrete semver.
+    #[arg(long)]
+    #[arg(value_parser = Version::from_str)]
+    pub last_version: Option<Version>,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 pub enum Tristate {
-    /// Only show these features
+    /// Only show these features.
     Require,
-    /// Has no effect
+    /// Has no effect.
     Allow,
-    /// Do not show these features
+    /// Do not show these features.
     Deny,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 pub enum Format {
+    /// Formats into JSON.
+    /// Contains two objects "lang_features_status" and "lib_features_status",
+    /// each containing strings (feature names) mapping to tidy::features::Feature objects.
     JSON,
     /// formats each feature into a line like
     ///
@@ -90,86 +106,19 @@ pub enum SortBy {
     Newest,
 }
 
-// Not everything can be parsed by clap, so there's a second struct for properly parsed arguments.
-pub struct Args {
-    pub library_path: Option<PathBuf>,
-    pub compiler_path: Option<PathBuf>,
-    pub output_path: Option<PathBuf>,
+pub fn parse() -> Result<Cli> {
+    let cli = Cli::parse();
 
-    pub format: Format,
-    pub sort_by: SortBy,
-
-    pub unstable: Tristate,
-    pub accepted: Tristate,
-    pub removed: Tristate,
-    pub tracking_issue: Tristate,
-
-    pub before: Option<Version>,
-    pub since: Option<Version>,
-}
-
-impl Args {
-    pub fn parse() -> Result<Self> {
-        let cli = Cli::parse();
-
-        if cli.compiler_path == None && cli.library_path == None {
-            return Err(DumpError::NoSources.into());
-        }
-
-        let before = match &cli.before {
-            Some(string) => {
-                let result = Version::from_str(string.as_str());
-                // tidy's error is opaque and does not implement Display, so we cannot propagate it into anyhow.
-                let version = result.map_err(|_| DumpError::BadSemver {
-                    cause: string.clone(),
-                    flag: SemverFlag::Before,
-                })?;
-                Some(version)
-            }
-            None => None,
-        };
-
-        let since = match &cli.since {
-            Some(string) => {
-                let result = Version::from_str(string.as_str());
-                // tidy's error is opaque and does not implement Display, so we cannot propagate it into anyhow.
-                let version = result.map_err(|_| DumpError::BadSemver {
-                    cause: string.clone(),
-                    flag: SemverFlag::Since,
-                })?;
-                Some(version)
-            }
-            None => None,
-        };
-
-        if let Some(since) = since
-            && let Some(before) = before
-            && since >= before
-        {
-            return Err(DumpError::NoVersions.into());
-        }
-
-        let require_count = [cli.unstable, cli.accepted, cli.removed]
-            .iter()
-            .filter(|&&x| Tristate::Require == x)
-            .count();
-        if require_count > 1 {
-            return Err(DumpError::StatusConflict.into());
-        }
-
-        let args = Args {
-            library_path: cli.library_path,
-            compiler_path: cli.compiler_path,
-            output_path: cli.output_path,
-            format: cli.format,
-            sort_by: cli.sort_by,
-            unstable: cli.unstable,
-            accepted: cli.accepted,
-            removed: cli.removed,
-            tracking_issue: cli.tracking_issue,
-            before,
-            since,
-        };
-        Ok(args)
+    if cli.compiler_path == None && cli.library_path == None {
+        return Err(DumpError::NoSources.into());
     }
+
+    if let Some(first_version) = cli.first_version
+        && let Some(last_version) = cli.last_version
+        && first_version > last_version
+    {
+        return Err(DumpError::NoVersions.into());
+    }
+
+    Ok(cli)
 }

--- a/src/tools/features-status-dump/src/parse.rs
+++ b/src/tools/features-status-dump/src/parse.rs
@@ -65,8 +65,11 @@ struct Cli {
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
 pub enum Tristate {
+    /// Only show these features
     Require,
+    /// Has no effect
     Allow,
+    /// Do not show these features
     Deny,
 }
 
@@ -113,39 +116,28 @@ impl Args {
             return Err(DumpError::NoSources.into());
         }
 
-        // map is avoided because it would not be possible to use in the fixed variant.
         let before = match &cli.before {
             Some(string) => {
-                let version = Version::from_str(string.as_str());
-                match version {
-                    // tidy's error is opaque and does not implement Display, so we cannot propagate it.
-                    Err(_e) => {
-                        return Err(DumpError::BadSemver {
-                            cause: string.clone(),
-                            flag: SemverFlag::Before,
-                        }
-                        .into());
-                    }
-                    Ok(x) => Some(x),
-                }
+                let result = Version::from_str(string.as_str());
+                // tidy's error is opaque and does not implement Display, so we cannot propagate it into anyhow.
+                let version = result.map_err(|_| DumpError::BadSemver {
+                    cause: string.clone(),
+                    flag: SemverFlag::Before,
+                })?;
+                Some(version)
             }
             None => None,
         };
 
         let since = match &cli.since {
             Some(string) => {
-                let version = Version::from_str(string.as_str());
-                match version {
-                    // tidy's error is opaque and does not implement Display, so we cannot propagate it.
-                    Err(_e) => {
-                        return Err(DumpError::BadSemver {
-                            cause: string.clone(),
-                            flag: SemverFlag::Since,
-                        }
-                        .into());
-                    }
-                    Ok(x) => Some(x),
-                }
+                let result = Version::from_str(string.as_str());
+                // tidy's error is opaque and does not implement Display, so we cannot propagate it into anyhow.
+                let version = result.map_err(|_| DumpError::BadSemver {
+                    cause: string.clone(),
+                    flag: SemverFlag::Since,
+                })?;
+                Some(version)
             }
             None => None,
         };

--- a/src/tools/features-status-dump/src/parse.rs
+++ b/src/tools/features-status-dump/src/parse.rs
@@ -1,0 +1,183 @@
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use anyhow::Result;
+use clap::{Parser, ValueEnum};
+use tidy::features::Version;
+
+use crate::err::{DumpError, SemverFlag};
+
+#[derive(Debug, Parser)]
+#[command(version, about)]
+struct Cli {
+    /// Path to `library/` directory. Use this flag to read features from the standard library.
+    #[arg(long)]
+    library_path: Option<PathBuf>,
+    /// Path to `compiler/` directory. Use this flag to read language features.
+    #[arg(long)]
+    compiler_path: Option<PathBuf>,
+    /// Which file to write to. If none, writes to stdout.
+    #[arg(long)]
+    output_path: Option<PathBuf>,
+
+    /// What file format to write to. Text is the human-readable option.
+    #[arg(long)]
+    #[arg(default_value = "json")]
+    format: Format,
+
+    /// Which features to show first. Only has effect when `format = text`.
+    /// Features two features with equal versions are ordered by issue number.
+    /// Features with no version are considered old.
+    #[arg(long)]
+    #[arg(default_value = "newest")]
+    sort_by: SortBy,
+
+    /// How to filter unstable features.
+    #[arg(long)]
+    #[arg(default_value = "allow")]
+    unstable: Tristate,
+
+    /// How to filter accepted (stable) features.
+    #[arg(long)]
+    #[arg(default_value = "allow")]
+    accepted: Tristate,
+
+    /// How to filter removed features.
+    #[arg(long)]
+    #[arg(default_value = "allow")]
+    removed: Tristate,
+
+    /// How to filter issues with(out) a tracking issue.
+    #[arg(long)]
+    #[arg(default_value = "allow")]
+    tracking_issue: Tristate,
+
+    /// Only show features introduced before this version (semver triple).
+    /// Features without known version are considered oldest.
+    /// Features notated with `Current Version` are considered newer than any concrete semver.
+    #[arg(long)]
+    before: Option<String>,
+
+    /// Only show features introduced after or in this version (semver triple)
+    #[arg(long)]
+    since: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum Tristate {
+    Require,
+    Allow,
+    Deny,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum Format {
+    JSON,
+    /// formats each feature into a line like
+    ///
+    /// > [SOURCE] NAME is STATUS since VERSION <LINK TO ISSUE>: DESCRIPTION
+    ///
+    /// Leaving out the unknown parts.
+    Text,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum SortBy {
+    Oldest,
+    Newest,
+}
+
+// Not everything can be parsed by clap, so there's a second struct for properly parsed arguments.
+pub struct Args {
+    pub library_path: Option<PathBuf>,
+    pub compiler_path: Option<PathBuf>,
+    pub output_path: Option<PathBuf>,
+
+    pub format: Format,
+    pub sort_by: SortBy,
+
+    pub unstable: Tristate,
+    pub accepted: Tristate,
+    pub removed: Tristate,
+    pub tracking_issue: Tristate,
+
+    pub before: Option<Version>,
+    pub since: Option<Version>,
+}
+
+impl Args {
+    pub fn parse() -> Result<Self> {
+        let cli = Cli::parse();
+
+        if cli.compiler_path == None && cli.library_path == None {
+            return Err(DumpError::NoSources.into());
+        }
+
+        // map is avoided because it would not be possible to use in the fixed variant.
+        let before = match &cli.before {
+            Some(string) => {
+                let version = Version::from_str(string.as_str());
+                match version {
+                    // tidy's error is opaque and does not implement Display, so we cannot propagate it.
+                    Err(_e) => {
+                        return Err(DumpError::BadSemver {
+                            cause: string.clone(),
+                            flag: SemverFlag::Before,
+                        }
+                        .into());
+                    }
+                    Ok(x) => Some(x),
+                }
+            }
+            None => None,
+        };
+
+        let since = match &cli.since {
+            Some(string) => {
+                let version = Version::from_str(string.as_str());
+                match version {
+                    // tidy's error is opaque and does not implement Display, so we cannot propagate it.
+                    Err(_e) => {
+                        return Err(DumpError::BadSemver {
+                            cause: string.clone(),
+                            flag: SemverFlag::Since,
+                        }
+                        .into());
+                    }
+                    Ok(x) => Some(x),
+                }
+            }
+            None => None,
+        };
+
+        if let Some(since) = since
+            && let Some(before) = before
+            && since >= before
+        {
+            return Err(DumpError::NoVersions.into());
+        }
+
+        let require_count = [cli.unstable, cli.accepted, cli.removed]
+            .iter()
+            .filter(|&&x| Tristate::Require == x)
+            .count();
+        if require_count > 1 {
+            return Err(DumpError::StatusConflict.into());
+        }
+
+        let args = Args {
+            library_path: cli.library_path,
+            compiler_path: cli.compiler_path,
+            output_path: cli.output_path,
+            format: cli.format,
+            sort_by: cli.sort_by,
+            unstable: cli.unstable,
+            accepted: cli.accepted,
+            removed: cli.removed,
+            tracking_issue: cli.tracking_issue,
+            before,
+            since,
+        };
+        Ok(args)
+    }
+}

--- a/src/tools/tidy/src/features/version.rs
+++ b/src/tools/tidy/src/features/version.rs
@@ -37,6 +37,22 @@ impl From<ParseIntError> for ParseVersionError {
     }
 }
 
+impl std::fmt::Display for ParseVersionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match self {
+            ParseVersionError::ParseIntError(parse_int_error) => {
+                &format!("Invalid semver. Part is not an integer: {}", parse_int_error)
+            }
+            ParseVersionError::WrongNumberOfParts => {
+                "Invalid semver. Must contain exactly three parts."
+            }
+        };
+        f.pad(msg)
+    }
+}
+
+impl std::error::Error for ParseVersionError {}
+
 impl FromStr for Version {
     type Err = ParseVersionError;
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

`features-status-dump` was made to dump the state of all features in the compiler and standard library to a JSON file. This allows out-of-tree programs to inspect the data, without needing to have access to the in-tree crates used to obtain the data.

After a certain RustNL talk inspired me to look through the list of features in search of interesting ones to work on, I decided to make a tool to make looking through them easier. Since this tool requires access to the Rust source to work, and will likely only be used by rust-lang devs, I decided to develop it in-tree. This crate seems to be the perfect basis to turn into this tool, as the following changes to it allow it to work for feature-finding, while retaining exact backwards compatibility (if I did it right):

- Only force at least one of `--library-path` and `--compiler-path` to be specified, so users can look through just the project they're interested in. Notably library lookup is *much* slower than listing language features. Being able to only look at language features is a massive performance advantage to users who only need to know those.
- Make `--output-path` optional and default to stdout, so users can get quick feedback.
- Add `--first-version` and `--last-version` flags for specifying a version range for the feature's `since` attribute.
- Add `--unstable`, `--accepted`, and `--rejected` flags for filtering by feature level.
- Add `--tracking-issue` and `--since` flag for filtering on presence of this metadata. (A version range implies --since=required).
- Add a `--format` flag to choose whether to print human-readable plaintext or the standard JSON.
- Add a `--sort-by` flag to see relevant features first. (Sorts by newest/oldest version, with issue number as tie breaker.)

I hope that the tool is welcome in this project, and will turn out to be useful. If there's any feedback, I'd be happy to hear it, as I'm quite new here.