### PR TITLE
bootstrap: Clean up imports related to `define_config!` and `check_ci_llvm!`

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -28,11 +28,13 @@ use serde::Deserialize;
 #[cfg(feature = "tracing")]
 use tracing::{instrument, span};
 
+use crate::CodegenBackendKind;
 use crate::core::build_steps::llvm;
 use crate::core::build_steps::llvm::LLVM_INVALIDATION_PATHS;
 use crate::core::build_steps::test::failed_tests::collect_previously_failed_tests;
 pub use crate::core::config::flags::Subcommand;
 use crate::core::config::flags::{Color, Flags, Warnings};
+use crate::core::config::macros::check_ci_llvm;
 use crate::core::config::target_selection::TargetSelectionList;
 use crate::core::config::toml::TomlConfig;
 use crate::core::config::toml::build::{Build, Tool};
@@ -58,7 +60,6 @@ use crate::core::download::{DownloadContext, download_beta_toolchain, is_downloa
 use crate::utils::channel::{self, GitInfo};
 use crate::utils::exec::{ExecutionContext, command};
 use crate::utils::helpers::{self, exe, fail, get_host_target, t};
-use crate::{CodegenBackendKind, check_ci_llvm};
 
 /// Each path in this list is considered "allowed" in the `download-rustc="if-unchanged"` logic.
 /// This means they can be modified and changes to these paths should never trigger a compiler build

--- a/src/bootstrap/src/core/config/macros.rs
+++ b/src/bootstrap/src/core/config/macros.rs
@@ -11,14 +11,16 @@
 //!
 
 // We are using a decl macro instead of a derive proc macro here to reduce the compile time of bootstrap.
-#[macro_export]
 macro_rules! define_config {
-    ($(#[$attr:meta])* struct $name:ident {
-        $(
-            $(#[$field_attr:meta])*
-            $field:ident: Option<$field_ty:ty> = $field_key:literal,
-        )*
-    }) => {
+    (
+        $(#[$attr:meta])*
+            struct $name:ident {
+            $(
+                $(#[$field_attr:meta])*
+                $field:ident: Option<$field_ty:ty> = $field_key:literal,
+            )*
+        }
+    ) => {
         $(#[$attr])*
         pub struct $name {
             $(
@@ -27,14 +29,15 @@ macro_rules! define_config {
             )*
         }
 
-        impl Merge for $name {
+        impl crate::core::config::Merge for $name {
             fn merge(
                 &mut self,
                 _parent_config_path: Option<std::path::PathBuf>,
                 _included_extensions: &mut std::collections::HashSet<std::path::PathBuf>,
                 other: Self,
-                replace: ReplaceOpt
+                replace: crate::core::config::ReplaceOpt
             ) {
+                use crate::core::config::ReplaceOpt;
                 $(
                     match replace {
                         ReplaceOpt::IgnoreDuplicate => {
@@ -69,10 +72,10 @@ macro_rules! define_config {
         // The following is a trimmed version of what serde_derive generates. All parts not relevant
         // for toml deserialization have been removed. This reduces the binary size and improves
         // compile time of bootstrap.
-        impl<'de> Deserialize<'de> for $name {
+        impl<'de> serde::Deserialize<'de> for $name {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
-                D: Deserializer<'de>,
+                D: serde::Deserializer<'de>,
             {
                 struct Field;
                 impl<'de> serde::de::Visitor<'de> for Field {
@@ -122,7 +125,7 @@ macro_rules! define_config {
                 const FIELDS: &'static [&'static str] = &[
                     $($field_key,)*
                 ];
-                Deserializer::deserialize_struct(
+                serde::Deserializer::deserialize_struct(
                     deserializer,
                     stringify!($name),
                     FIELDS,
@@ -133,7 +136,6 @@ macro_rules! define_config {
     }
 }
 
-#[macro_export]
 macro_rules! check_ci_llvm {
     ($name:expr) => {
         assert!(
@@ -143,3 +145,6 @@ macro_rules! check_ci_llvm {
         );
     };
 }
+
+pub(crate) use check_ci_llvm;
+pub(crate) use define_config;

--- a/src/bootstrap/src/core/config/macros.rs
+++ b/src/bootstrap/src/core/config/macros.rs
@@ -1,0 +1,145 @@
+//! This module defines two macros:
+//!
+//! - `define_config!`: A declarative macro used instead of `#[derive(Deserialize)]` to reduce
+//!   compile time and binary size, especially for the bootstrap binary.
+//!
+//! - `check_ci_llvm!`: A compile-time assertion macro that ensures certain settings are
+//!   not enabled when `download-ci-llvm` is active.
+//!
+//! A declarative macro is used here in place of a procedural derive macro to minimize
+//! the compile time of the bootstrap process.
+//!
+
+// We are using a decl macro instead of a derive proc macro here to reduce the compile time of bootstrap.
+#[macro_export]
+macro_rules! define_config {
+    ($(#[$attr:meta])* struct $name:ident {
+        $(
+            $(#[$field_attr:meta])*
+            $field:ident: Option<$field_ty:ty> = $field_key:literal,
+        )*
+    }) => {
+        $(#[$attr])*
+        pub struct $name {
+            $(
+                $(#[$field_attr])*
+                pub $field: Option<$field_ty>,
+            )*
+        }
+
+        impl Merge for $name {
+            fn merge(
+                &mut self,
+                _parent_config_path: Option<std::path::PathBuf>,
+                _included_extensions: &mut std::collections::HashSet<std::path::PathBuf>,
+                other: Self,
+                replace: ReplaceOpt
+            ) {
+                $(
+                    match replace {
+                        ReplaceOpt::IgnoreDuplicate => {
+                            if self.$field.is_none() {
+                                self.$field = other.$field;
+                            }
+                        },
+                        ReplaceOpt::Override => {
+                            if other.$field.is_some() {
+                                self.$field = other.$field;
+                            }
+                        }
+                        ReplaceOpt::ErrorOnDuplicate => {
+                            if other.$field.is_some() {
+                                if self.$field.is_some() {
+                                    if cfg!(test) {
+                                        panic!("overriding existing option")
+                                    } else {
+                                        eprintln!("overriding existing option: `{}`", stringify!($field));
+                                        $crate::utils::helpers::exit_process(2);
+                                    }
+                                } else {
+                                    self.$field = other.$field;
+                                }
+                            }
+                        }
+                    }
+                )*
+            }
+        }
+
+        // The following is a trimmed version of what serde_derive generates. All parts not relevant
+        // for toml deserialization have been removed. This reduces the binary size and improves
+        // compile time of bootstrap.
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct Field;
+                impl<'de> serde::de::Visitor<'de> for Field {
+                    type Value = $name;
+                    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        f.write_str(concat!("struct ", stringify!($name)))
+                    }
+
+                    #[inline]
+                    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+                    where
+                        A: serde::de::MapAccess<'de>,
+                    {
+                        $(let mut $field: Option<$field_ty> = None;)*
+                        while let Some(key) =
+                            match serde::de::MapAccess::next_key::<String>(&mut map) {
+                                Ok(val) => val,
+                                Err(err) => {
+                                    return Err(err);
+                                }
+                            }
+                        {
+                            match &*key {
+                                $($field_key => {
+                                    if $field.is_some() {
+                                        return Err(<A::Error as serde::de::Error>::duplicate_field(
+                                            $field_key,
+                                        ));
+                                    }
+                                    $field = match serde::de::MapAccess::next_value::<$field_ty>(
+                                        &mut map,
+                                    ) {
+                                        Ok(val) => Some(val),
+                                        Err(err) => {
+                                            return Err(err);
+                                        }
+                                    };
+                                })*
+                                key => {
+                                    return Err(serde::de::Error::unknown_field(key, FIELDS));
+                                }
+                            }
+                        }
+                        Ok($name { $($field),* })
+                    }
+                }
+                const FIELDS: &'static [&'static str] = &[
+                    $($field_key,)*
+                ];
+                Deserializer::deserialize_struct(
+                    deserializer,
+                    stringify!($name),
+                    FIELDS,
+                    Field,
+                )
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! check_ci_llvm {
+    ($name:expr) => {
+        assert!(
+            $name.is_none(),
+            "setting {} is incompatible with download-ci-llvm.",
+            stringify!($name).replace("_", "-")
+        );
+    };
+}

--- a/src/bootstrap/src/core/config/mod.rs
+++ b/src/bootstrap/src/core/config/mod.rs
@@ -1,16 +1,5 @@
 //! Entry point for the `config` module.
 //!
-//! This module defines two macros:
-//!
-//! - `define_config!`: A declarative macro used instead of `#[derive(Deserialize)]` to reduce
-//!   compile time and binary size, especially for the bootstrap binary.
-//!
-//! - `check_ci_llvm!`: A compile-time assertion macro that ensures certain settings are
-//!   not enabled when `download-ci-llvm` is active.
-//!
-//! A declarative macro is used here in place of a procedural derive macro to minimize
-//! the compile time of the bootstrap process.
-//!
 //! Additionally, this module defines common types, enums, and helper functions used across
 //! various TOML configuration sections in `bootstrap.toml`.
 //!
@@ -22,6 +11,7 @@
 #[expect(clippy::module_inception)]
 mod config;
 pub mod flags;
+pub(crate) mod macros;
 pub mod target_selection;
 #[cfg(test)]
 mod tests;
@@ -43,140 +33,6 @@ pub use toml::rust::BootstrapOverrideLld;
 pub use toml::target::Target;
 
 use crate::utils::helpers;
-
-// We are using a decl macro instead of a derive proc macro here to reduce the compile time of bootstrap.
-#[macro_export]
-macro_rules! define_config {
-    ($(#[$attr:meta])* struct $name:ident {
-        $(
-            $(#[$field_attr:meta])*
-            $field:ident: Option<$field_ty:ty> = $field_key:literal,
-        )*
-    }) => {
-        $(#[$attr])*
-        pub struct $name {
-            $(
-                $(#[$field_attr])*
-                pub $field: Option<$field_ty>,
-            )*
-        }
-
-        impl Merge for $name {
-            fn merge(
-                &mut self,
-                _parent_config_path: Option<std::path::PathBuf>,
-                _included_extensions: &mut std::collections::HashSet<std::path::PathBuf>,
-                other: Self,
-                replace: ReplaceOpt
-            ) {
-                $(
-                    match replace {
-                        ReplaceOpt::IgnoreDuplicate => {
-                            if self.$field.is_none() {
-                                self.$field = other.$field;
-                            }
-                        },
-                        ReplaceOpt::Override => {
-                            if other.$field.is_some() {
-                                self.$field = other.$field;
-                            }
-                        }
-                        ReplaceOpt::ErrorOnDuplicate => {
-                            if other.$field.is_some() {
-                                if self.$field.is_some() {
-                                    if cfg!(test) {
-                                        panic!("overriding existing option")
-                                    } else {
-                                        eprintln!("overriding existing option: `{}`", stringify!($field));
-                                        $crate::utils::helpers::exit_process(2);
-                                    }
-                                } else {
-                                    self.$field = other.$field;
-                                }
-                            }
-                        }
-                    }
-                )*
-            }
-        }
-
-        // The following is a trimmed version of what serde_derive generates. All parts not relevant
-        // for toml deserialization have been removed. This reduces the binary size and improves
-        // compile time of bootstrap.
-        impl<'de> Deserialize<'de> for $name {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                struct Field;
-                impl<'de> serde::de::Visitor<'de> for Field {
-                    type Value = $name;
-                    fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                        f.write_str(concat!("struct ", stringify!($name)))
-                    }
-
-                    #[inline]
-                    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-                    where
-                        A: serde::de::MapAccess<'de>,
-                    {
-                        $(let mut $field: Option<$field_ty> = None;)*
-                        while let Some(key) =
-                            match serde::de::MapAccess::next_key::<String>(&mut map) {
-                                Ok(val) => val,
-                                Err(err) => {
-                                    return Err(err);
-                                }
-                            }
-                        {
-                            match &*key {
-                                $($field_key => {
-                                    if $field.is_some() {
-                                        return Err(<A::Error as serde::de::Error>::duplicate_field(
-                                            $field_key,
-                                        ));
-                                    }
-                                    $field = match serde::de::MapAccess::next_value::<$field_ty>(
-                                        &mut map,
-                                    ) {
-                                        Ok(val) => Some(val),
-                                        Err(err) => {
-                                            return Err(err);
-                                        }
-                                    };
-                                })*
-                                key => {
-                                    return Err(serde::de::Error::unknown_field(key, FIELDS));
-                                }
-                            }
-                        }
-                        Ok($name { $($field),* })
-                    }
-                }
-                const FIELDS: &'static [&'static str] = &[
-                    $($field_key,)*
-                ];
-                Deserializer::deserialize_struct(
-                    deserializer,
-                    stringify!($name),
-                    FIELDS,
-                    Field,
-                )
-            }
-        }
-    }
-}
-
-#[macro_export]
-macro_rules! check_ci_llvm {
-    ($name:expr) => {
-        assert!(
-            $name.is_none(),
-            "setting {} is incompatible with download-ci-llvm.",
-            stringify!($name).replace("_", "-")
-        );
-    };
-}
 
 pub(crate) trait Merge {
     fn merge(

--- a/src/bootstrap/src/core/config/toml/build.rs
+++ b/src/bootstrap/src/core/config/toml/build.rs
@@ -9,11 +9,8 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
-use serde::{Deserialize, Deserializer};
-
-use crate::core::config::toml::ReplaceOpt;
-use crate::core::config::{Allocator, CompilerBuiltins, DebuggerPath, Merge, StringOrBool};
-use crate::define_config;
+use crate::core::config::macros::define_config;
+use crate::core::config::{Allocator, CompilerBuiltins, DebuggerPath, StringOrBool};
 
 define_config! {
     /// TOML representation of various global build decisions.

--- a/src/bootstrap/src/core/config/toml/dist.rs
+++ b/src/bootstrap/src/core/config/toml/dist.rs
@@ -5,11 +5,7 @@
 //! including signing, uploading artifacts, source tarballs, compression settings,
 //! and inclusion of specific tools.
 
-use serde::{Deserialize, Deserializer};
-
-use crate::core::config::Merge;
-use crate::core::config::toml::ReplaceOpt;
-use crate::define_config;
+use crate::core::config::macros::define_config;
 
 define_config! {
     #[derive(Default)]

--- a/src/bootstrap/src/core/config/toml/gcc.rs
+++ b/src/bootstrap/src/core/config/toml/gcc.rs
@@ -6,11 +6,7 @@
 
 use std::path::PathBuf;
 
-use serde::{Deserialize, Deserializer};
-
-use crate::core::config::Merge;
-use crate::core::config::toml::ReplaceOpt;
-use crate::define_config;
+use crate::core::config::macros::define_config;
 
 define_config! {
     /// TOML representation of how the GCC build is configured.

--- a/src/bootstrap/src/core/config/toml/install.rs
+++ b/src/bootstrap/src/core/config/toml/install.rs
@@ -6,11 +6,7 @@
 //! executables, libraries, documentation, and other files will be placed
 //! during the `install` stage of the build.
 
-use serde::{Deserialize, Deserializer};
-
-use crate::core::config::Merge;
-use crate::core::config::toml::ReplaceOpt;
-use crate::define_config;
+use crate::core::config::macros::define_config;
 
 define_config! {
     /// TOML representation of various global install decisions.

--- a/src/bootstrap/src/core/config/toml/llvm.rs
+++ b/src/bootstrap/src/core/config/toml/llvm.rs
@@ -3,11 +3,9 @@
 
 use std::collections::HashMap;
 
-use serde::{Deserialize, Deserializer};
-
 use crate::core::config::StringOrBool;
-use crate::core::config::toml::{Merge, ReplaceOpt, TomlConfig};
-use crate::define_config;
+use crate::core::config::macros::define_config;
+use crate::core::config::toml::TomlConfig;
 
 define_config! {
     /// TOML representation of how the LLVM build is configured.

--- a/src/bootstrap/src/core/config/toml/pgo.rs
+++ b/src/bootstrap/src/core/config/toml/pgo.rs
@@ -6,11 +6,7 @@
 
 use std::path::PathBuf;
 
-use serde::{Deserialize, Deserializer};
-
-use crate::core::config::Merge;
-use crate::core::config::toml::ReplaceOpt;
-use crate::define_config;
+use crate::core::config::macros::define_config;
 
 #[derive(Clone, Default, Debug, serde_derive::Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/bootstrap/src/core/config/toml/rust.rs
+++ b/src/bootstrap/src/core/config/toml/rust.rs
@@ -7,12 +7,11 @@ use std::path::PathBuf;
 use build_helper::ci::CiEnv;
 use serde::{Deserialize, Deserializer};
 
+use crate::CodegenBackendKind;
+use crate::core::config::macros::define_config;
 use crate::core::config::toml::TomlConfig;
-use crate::core::config::{
-    CompressDebuginfo, DebuginfoLevel, Merge, ReplaceOpt, StringOrBool, TargetSelection,
-};
+use crate::core::config::{CompressDebuginfo, DebuginfoLevel, StringOrBool, TargetSelection};
 use crate::utils::helpers;
-use crate::{CodegenBackendKind, define_config};
 
 define_config! {
     /// TOML representation of how the Rust build is configured.

--- a/src/bootstrap/src/core/config/toml/target.rs
+++ b/src/bootstrap/src/core/config/toml/target.rs
@@ -15,11 +15,11 @@ use std::path::PathBuf;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 
+use crate::CodegenBackendKind;
+use crate::core::config::macros::define_config;
 use crate::core::config::{
-    Allocator, CompilerBuiltins, CompressDebuginfo, LlvmLibunwind, Merge, ReplaceOpt,
-    SplitDebuginfo, StringOrBool,
+    Allocator, CompilerBuiltins, CompressDebuginfo, LlvmLibunwind, SplitDebuginfo, StringOrBool,
 };
-use crate::{CodegenBackendKind, define_config};
 
 define_config! {
     /// TOML representation of how each build target is configured.


### PR DESCRIPTION
This PR takes the two macros defined in `core/config/mod.rs`, moves them to their own module, and adjusts all callers to import the macros from that module instead of from the crate root. This lets us remove `#[macro_export]` from the macro declarations.

Along the way, we also adjust `define_config!` to use more fully-qualified paths, so that callers don't have to add several mysterious imports in order to compile.

---

(Because macro-rules have weird namespacing by default, it's usually a good idea to isolate them in their own module, and then write `pub(use)` below to pull them into the normal name-resolution system.)

There should be no change to bootstrap's behaviour.