### PR TITLE
PassWrapper: handle LLVM 24 change in function types

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -523,6 +523,17 @@ extern "C" typedef void (*LLVMRustSelfProfileBeforePassCallback)(
 extern "C" typedef void (*LLVMRustSelfProfileAfterPassCallback)(
     void *); // LlvmSelfProfiler
 
+#if LLVM_VERSION_GE(24, 0)
+std::string LLVMRustwrappedIrGetName(const llvm::IRUnitRef &WrappedIr) {
+  if (const auto *Cast = dyn_cast<Module>(WrappedIr))
+    return Cast->getName().str();
+  if (const auto *Cast = dyn_cast<Function>(WrappedIr))
+    return Cast->getName().str();
+  if (const auto *Cast = dyn_cast<Loop>(WrappedIr))
+    return Cast->getName().str();
+  if (const auto *Cast = dyn_cast<LazyCallGraph::SCC>(WrappedIr))
+    return Cast->getName();
+#else
 std::string LLVMRustwrappedIrGetName(const llvm::Any &WrappedIr) {
   if (const auto *Cast = any_cast<const Module *>(&WrappedIr))
     return (*Cast)->getName().str();
@@ -532,6 +543,7 @@ std::string LLVMRustwrappedIrGetName(const llvm::Any &WrappedIr) {
     return (*Cast)->getName().str();
   if (const auto *Cast = any_cast<const LazyCallGraph::SCC *>(&WrappedIr))
     return (*Cast)->getName();
+#endif
   return "<UNKNOWN>";
 }
 
@@ -540,15 +552,24 @@ void LLVMSelfProfileInitializeCallbacks(
     LLVMRustSelfProfileBeforePassCallback BeforePassCallback,
     LLVMRustSelfProfileAfterPassCallback AfterPassCallback) {
   PIC.registerBeforeNonSkippedPassCallback(
+#if LLVM_VERSION_GE(24, 0)
+      [LlvmSelfProfiler, BeforePassCallback](StringRef Pass, llvm::IRUnitRef Ir) {
+#else
       [LlvmSelfProfiler, BeforePassCallback](StringRef Pass, llvm::Any Ir) {
+#endif
         std::string PassName = Pass.str();
         std::string IrName = LLVMRustwrappedIrGetName(Ir);
         BeforePassCallback(LlvmSelfProfiler, PassName.c_str(), IrName.c_str());
       });
 
   PIC.registerAfterPassCallback(
+#if LLVM_VERSION_GE(24, 0)
+      [LlvmSelfProfiler, AfterPassCallback](
+          StringRef Pass, llvm::IRUnitRef IR, const PreservedAnalyses &Preserved) {
+#else
       [LlvmSelfProfiler, AfterPassCallback](
           StringRef Pass, llvm::Any IR, const PreservedAnalyses &Preserved) {
+#endif
         AfterPassCallback(LlvmSelfProfiler);
       });
 
@@ -557,16 +578,25 @@ void LLVMSelfProfileInitializeCallbacks(
        AfterPassCallback](StringRef Pass, const PreservedAnalyses &Preserved) {
         AfterPassCallback(LlvmSelfProfiler);
       });
-
+#if LLVM_VERSION_GE(24, 0)
+  PIC.registerBeforeAnalysisCallback(
+      [LlvmSelfProfiler, BeforePassCallback](StringRef Pass, llvm::IRUnitRef Ir) {
+#else
   PIC.registerBeforeAnalysisCallback(
       [LlvmSelfProfiler, BeforePassCallback](StringRef Pass, llvm::Any Ir) {
+#endif
         std::string PassName = Pass.str();
         std::string IrName = LLVMRustwrappedIrGetName(Ir);
         BeforePassCallback(LlvmSelfProfiler, PassName.c_str(), IrName.c_str());
       });
 
+#if LLVM_VERSION_GE(24, 0)
+  PIC.registerAfterAnalysisCallback(
+      [LlvmSelfProfiler, AfterPassCallback](StringRef Pass, llvm::IRUnitRef Ir) {
+#else
   PIC.registerAfterAnalysisCallback(
       [LlvmSelfProfiler, AfterPassCallback](StringRef Pass, llvm::Any Ir) {
+#endif
         AfterPassCallback(LlvmSelfProfiler);
       });
 }

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -580,6 +580,7 @@ void LLVMSelfProfileInitializeCallbacks(
        AfterPassCallback](StringRef Pass, const PreservedAnalyses &Preserved) {
         AfterPassCallback(LlvmSelfProfiler);
       });
+
 #if LLVM_VERSION_GE(24, 0)
   PIC.registerBeforeAnalysisCallback([LlvmSelfProfiler, BeforePassCallback](
                                          StringRef Pass, llvm::IRUnitRef Ir) {

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -553,7 +553,8 @@ void LLVMSelfProfileInitializeCallbacks(
     LLVMRustSelfProfileAfterPassCallback AfterPassCallback) {
   PIC.registerBeforeNonSkippedPassCallback(
 #if LLVM_VERSION_GE(24, 0)
-      [LlvmSelfProfiler, BeforePassCallback](StringRef Pass, llvm::IRUnitRef Ir) {
+      [LlvmSelfProfiler, BeforePassCallback](StringRef Pass,
+                                             llvm::IRUnitRef Ir) {
 #else
       [LlvmSelfProfiler, BeforePassCallback](StringRef Pass, llvm::Any Ir) {
 #endif
@@ -564,8 +565,9 @@ void LLVMSelfProfileInitializeCallbacks(
 
   PIC.registerAfterPassCallback(
 #if LLVM_VERSION_GE(24, 0)
-      [LlvmSelfProfiler, AfterPassCallback](
-          StringRef Pass, llvm::IRUnitRef IR, const PreservedAnalyses &Preserved) {
+      [LlvmSelfProfiler,
+       AfterPassCallback](StringRef Pass, llvm::IRUnitRef IR,
+                          const PreservedAnalyses &Preserved) {
 #else
       [LlvmSelfProfiler, AfterPassCallback](
           StringRef Pass, llvm::Any IR, const PreservedAnalyses &Preserved) {
@@ -579,26 +581,26 @@ void LLVMSelfProfileInitializeCallbacks(
         AfterPassCallback(LlvmSelfProfiler);
       });
 #if LLVM_VERSION_GE(24, 0)
-  PIC.registerBeforeAnalysisCallback(
-      [LlvmSelfProfiler, BeforePassCallback](StringRef Pass, llvm::IRUnitRef Ir) {
+  PIC.registerBeforeAnalysisCallback([LlvmSelfProfiler, BeforePassCallback](
+                                         StringRef Pass, llvm::IRUnitRef Ir) {
 #else
   PIC.registerBeforeAnalysisCallback(
       [LlvmSelfProfiler, BeforePassCallback](StringRef Pass, llvm::Any Ir) {
 #endif
-        std::string PassName = Pass.str();
-        std::string IrName = LLVMRustwrappedIrGetName(Ir);
-        BeforePassCallback(LlvmSelfProfiler, PassName.c_str(), IrName.c_str());
-      });
+    std::string PassName = Pass.str();
+    std::string IrName = LLVMRustwrappedIrGetName(Ir);
+    BeforePassCallback(LlvmSelfProfiler, PassName.c_str(), IrName.c_str());
+  });
 
 #if LLVM_VERSION_GE(24, 0)
-  PIC.registerAfterAnalysisCallback(
-      [LlvmSelfProfiler, AfterPassCallback](StringRef Pass, llvm::IRUnitRef Ir) {
+  PIC.registerAfterAnalysisCallback([LlvmSelfProfiler, AfterPassCallback](
+                                        StringRef Pass, llvm::IRUnitRef Ir) {
 #else
   PIC.registerAfterAnalysisCallback(
       [LlvmSelfProfiler, AfterPassCallback](StringRef Pass, llvm::Any Ir) {
 #endif
-        AfterPassCallback(LlvmSelfProfiler);
-      });
+    AfterPassCallback(LlvmSelfProfiler);
+  });
 }
 
 enum class LLVMRustOptStage {


### PR DESCRIPTION
LLVM 24 stopped using llvm::Any here [to avoid heap allocations](https://github.com/llvm/llvm-project/commit/fa23198d685b8d6daaf09b02cf89cfe36a707d10) in PassInstrumentation.

@rustbot label: +llvm-main