### PR TITLE
rustdoc: Small `doc_cfg` messages improvements

### DIFF
--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -227,14 +227,25 @@ impl Cfg {
     }
 
     fn should_append_only_to_description(&self) -> bool {
-        match self.0 {
-            CfgEntry::Any(..)
-            | CfgEntry::All(..)
-            | CfgEntry::NameValue { .. }
-            | CfgEntry::Version(..)
-            | CfgEntry::Not(CfgEntry::NameValue { .. }, _) => true,
-            CfgEntry::Not(..) | CfgEntry::Bool(..) => false,
+        fn should_append_only_to_description(cfg: &CfgEntry) -> bool {
+            match cfg {
+                CfgEntry::NameValue { .. }
+                | CfgEntry::Version(..)
+                | CfgEntry::Not(CfgEntry::NameValue { .. }, _) => true,
+                CfgEntry::Any(a, _) | CfgEntry::All(a, _) => {
+                    if a.is_empty() {
+                        false
+                    } else if let [a] = a.as_slice() {
+                        should_append_only_to_description(&a)
+                    } else {
+                        true
+                    }
+                }
+                CfgEntry::Not(a, _) => !should_append_only_to_description(a),
+                CfgEntry::Bool(..) => false,
+            }
         }
+        should_append_only_to_description(&self.0)
     }
 
     fn should_use_with_in_description(&self) -> bool {
@@ -309,7 +320,19 @@ impl Cfg {
     }
 
     fn omit_preposition(&self) -> bool {
-        matches!(self.0, CfgEntry::Bool(..))
+        fn omit_preposition(cfg: &CfgEntry) -> bool {
+            match cfg {
+                CfgEntry::NameValue { .. }
+                | CfgEntry::Version(..)
+                | CfgEntry::Not(CfgEntry::NameValue { .. }, _) => false,
+                CfgEntry::Any(a, _) | CfgEntry::All(a, _) => {
+                    a.is_empty() || matches!(a.as_slice(), [a] if omit_preposition(&a))
+                }
+                CfgEntry::Not(a, _) => omit_preposition(a),
+                CfgEntry::Bool(..) => true,
+            }
+        }
+        omit_preposition(&self.0)
     }
 
     pub(crate) fn inner(&self) -> &CfgEntry {
@@ -459,15 +482,20 @@ impl Display<'_> {
         use fmt::Display as _;
 
         let short_longhand = self.1.is_long() && {
-            let all_crate_features = sub_cfgs.iter().all(|sub_cfg| {
-                matches!(sub_cfg, CfgEntry::NameValue { name: sym::feature, value: Some(_), .. })
-            });
-            let all_target_features = sub_cfgs.iter().all(|sub_cfg| {
-                matches!(
-                    sub_cfg,
-                    CfgEntry::NameValue { name: sym::target_feature, value: Some(_), .. }
-                )
-            });
+            let all_crate_features = !sub_cfgs.is_empty()
+                && sub_cfgs.iter().all(|sub_cfg| {
+                    matches!(
+                        sub_cfg,
+                        CfgEntry::NameValue { name: sym::feature, value: Some(_), .. }
+                    )
+                });
+            let all_target_features = !sub_cfgs.is_empty()
+                && sub_cfgs.iter().all(|sub_cfg| {
+                    matches!(
+                        sub_cfg,
+                        CfgEntry::NameValue { name: sym::target_feature, value: Some(_), .. }
+                    )
+                });
 
             if all_crate_features {
                 fmt.write_str("crate features ")?;

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -235,14 +235,11 @@ impl Cfg {
                 CfgEntry::Any(a, _) | CfgEntry::All(a, _) => {
                     if a.is_empty() {
                         false
-                    } else if let [a] = a.as_slice() {
-                        should_append_only_to_description(&a)
                     } else {
-                        true
+                        a.iter().any(|sub| should_append_only_to_description(sub))
                     }
                 }
-                CfgEntry::Not(a, _) => !should_append_only_to_description(a),
-                CfgEntry::Bool(..) => false,
+                CfgEntry::Not(..) | CfgEntry::Bool(..) => false,
             }
         }
         should_append_only_to_description(&self.0)
@@ -534,20 +531,45 @@ impl Display<'_> {
 
 impl fmt::Display for Display<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.0 {
-            CfgEntry::Not(CfgEntry::Any(sub_cfgs, _), _) => {
-                let separator = if sub_cfgs.iter().all(is_simple_cfg) { " nor " } else { ", nor " };
-                fmt.write_str("neither ")?;
+        fn display_bool(fmt: &mut fmt::Formatter<'_>, value: bool) -> fmt::Result {
+            if value { fmt.write_str("everywhere") } else { fmt.write_str("nowhere") }
+        }
 
-                sub_cfgs
-                    .iter()
-                    .map(|sub_cfg| {
-                        Wrapped::with_parens()
-                            .when(is_any_cfg(sub_cfg))
-                            .wrap(Display(sub_cfg, self.1))
-                    })
-                    .joined(separator, fmt)
-            }
+        match &self.0 {
+            CfgEntry::Not(CfgEntry::Not(sub_cfg, _), _) => Display(sub_cfg, self.1).fmt(fmt),
+            CfgEntry::Not(CfgEntry::Any(sub_cfgs, _), _) => match sub_cfgs.as_slice() {
+                // `not(any())` is `true` because `any()` is `false`.
+                [] => display_bool(fmt, true),
+                [CfgEntry::Bool(value, _)] => display_bool(fmt, !*value),
+                sub_cfgs => {
+                    let separator =
+                        if sub_cfgs.iter().all(is_simple_cfg) { " nor " } else { ", nor " };
+                    if sub_cfgs.len() > 1 {
+                        fmt.write_str("neither ")?;
+                    } else {
+                        fmt.write_str("not(")?;
+                    }
+
+                    sub_cfgs
+                        .iter()
+                        .map(|sub_cfg| {
+                            Wrapped::with_parens()
+                                .when(is_any_cfg(sub_cfg))
+                                .wrap(Display(sub_cfg, self.1))
+                        })
+                        .joined(separator, fmt)?;
+                    if sub_cfgs.len() == 1 {
+                        fmt.write_str(")")?;
+                    }
+                    Ok(())
+                }
+            },
+            CfgEntry::Not(s @ CfgEntry::All(sub_cfgs, _), _) => match sub_cfgs.as_slice() {
+                // `not(all())` is `false` because `all()` is `true`.
+                [] => display_bool(fmt, false),
+                [CfgEntry::Bool(value, _)] => display_bool(fmt, !*value),
+                _ => write!(fmt, "not ({})", Display(s, self.1)),
+            },
             CfgEntry::Not(simple @ CfgEntry::NameValue { .. }, _) => {
                 write!(fmt, "non-{}", Display(simple, self.1))
             }
@@ -559,13 +581,7 @@ impl fmt::Display for Display<'_> {
             }
             CfgEntry::All(sub_cfgs, _) => self.display_sub_cfgs(fmt, sub_cfgs.as_slice(), " and "),
 
-            CfgEntry::Bool(v, _) => {
-                if *v {
-                    fmt.write_str("everywhere")
-                } else {
-                    fmt.write_str("nowhere")
-                }
-            }
+            CfgEntry::Bool(v, _) => display_bool(fmt, *v),
 
             &CfgEntry::NameValue { name, value, .. } => {
                 let human_readable = match (*name, value) {

--- a/src/librustdoc/clean/cfg/tests.rs
+++ b/src/librustdoc/clean/cfg/tests.rs
@@ -46,7 +46,11 @@ fn cfg_not(v: CfgEntry) -> Cfg {
 }
 
 fn cfg_true() -> Cfg {
-    Cfg(CfgEntry::Bool(true, DUMMY_SP))
+    Cfg(cfg_true_e())
+}
+
+fn cfg_true_e() -> CfgEntry {
+    CfgEntry::Bool(true, DUMMY_SP)
 }
 
 fn cfg_false() -> Cfg {
@@ -376,6 +380,14 @@ fn test_render_long_html() {
             (name_value_cfg("target_arch", "x86_64") & name_value_cfg("target_feature", "sse2"))
                 .render_long_html(),
             "Available on <strong>x86-64 and target feature <code>sse2</code></strong> only."
+        );
+        assert_eq!(
+            cfg_any(thin_vec![cfg_true_e()]).render_long_html(),
+            "Available <strong>everywhere</strong>.",
+        );
+        assert_eq!(
+            cfg_any(thin_vec![cfg_all_e(thin_vec![cfg_true_e()])]).render_long_html(),
+            "Available <strong>everywhere</strong>."
         );
     })
 }

--- a/src/librustdoc/clean/cfg/tests.rs
+++ b/src/librustdoc/clean/cfg/tests.rs
@@ -42,7 +42,11 @@ fn cfg_any_e(v: ThinVec<CfgEntry>) -> CfgEntry {
 }
 
 fn cfg_not(v: CfgEntry) -> Cfg {
-    Cfg(CfgEntry::Not(Box::new(v), DUMMY_SP))
+    Cfg(cfg_not_e(v))
+}
+
+fn cfg_not_e(v: CfgEntry) -> CfgEntry {
+    CfgEntry::Not(Box::new(v), DUMMY_SP)
 }
 
 fn cfg_true() -> Cfg {
@@ -381,13 +385,31 @@ fn test_render_long_html() {
                 .render_long_html(),
             "Available on <strong>x86-64 and target feature <code>sse2</code></strong> only."
         );
+        // `any(true)`
         assert_eq!(
             cfg_any(thin_vec![cfg_true_e()]).render_long_html(),
             "Available <strong>everywhere</strong>.",
         );
+        // `not(any(true))`
+        assert_eq!(
+            cfg_not(cfg_any_e(thin_vec![cfg_true_e()])).render_long_html(),
+            "Available <strong>nowhere</strong>.",
+        );
+        // `any(all(true))`
         assert_eq!(
             cfg_any(thin_vec![cfg_all_e(thin_vec![cfg_true_e()])]).render_long_html(),
             "Available <strong>everywhere</strong>."
+        );
+        // `not(any(all(true)))`
+        assert_eq!(
+            cfg_not(cfg_any_e(thin_vec![cfg_all_e(thin_vec![cfg_true_e()])])).render_long_html(),
+            "Available <strong>not(everywhere)</strong>.",
+        );
+        // `not(not(any(all(true))))`
+        assert_eq!(
+            cfg_not(cfg_not_e(cfg_any_e(thin_vec![cfg_all_e(thin_vec![cfg_true_e()])])))
+                .render_long_html(),
+            "Available <strong>everywhere</strong>.",
         );
     })
 }

--- a/tests/rustdoc-html/doc-cfg/always-true.rs
+++ b/tests/rustdoc-html/doc-cfg/always-true.rs
@@ -1,0 +1,20 @@
+// Some generated "cfg text" check.
+// Regression test for <https://github.com/rust-lang/rust/issues/145075>.
+
+#![feature(doc_cfg)]
+#![crate_name = "foo"]
+
+// This one doesn't display any cfg label.
+//@ has 'foo/fn.f.html'
+//@ count - '//*[@class="stab portability"]' 0
+#[cfg(any(all()))]
+pub fn f() {}
+
+//@ has 'foo/fn.f2.html'
+// If you change the selector in this one, don't forget to update the one of the `f`
+// function as well!
+//@ count - '//*[@class="stab portability"]' 1
+//@ has - '//*[@class="stab portability"]' 'Available everywhere.'
+// This one display a cfg label.
+#[cfg(any(true))]
+pub fn f2() {}


### PR DESCRIPTION
Fixes rust-lang/rust#145075.

I was writing a regression test for rust-lang/rust#145075 which was already fixed, saw it was looking like this:

<img width="242" height="247" alt="image" src="https://github.com/user-attachments/assets/421e6b4b-698f-4a01-93d9-022eb346d73c" />

So I made some small changes to improve the wording. Now it looks like this:

<img width="242" height="247" alt="image" src="https://github.com/user-attachments/assets/c950dd68-a760-4f18-b974-555e05fcfd78" />

r? @Urgau 