### PR TITLE
Take bors try-perf branch into account in verify-channel.sh

### DIFF
--- a/src/ci/scripts/verify-channel.sh
+++ b/src/ci/scripts/verify-channel.sh
@@ -8,7 +8,8 @@ IFS=$'\n\t'
 
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
-if isCiBranch try-perf || isCiBranch automation/bors/try || isCiBranch automation/bors/auto; then
+if isCiBranch try-perf || isCiBranch automation/bors/try-perf || \
+   isCiBranch automation/bors/try || isCiBranch automation/bors/auto; then
     echo "channel verification is only executed on PR builds"
     exit
 fi


### PR DESCRIPTION
Forgot about this in https://github.com/rust-lang/rust/pull/160693.

r? @Mark-Simulacrum
