### PR TITLE
rustc.1: `-O` is `-C opt-level=3`

### DIFF
--- a/src/doc/man/rustc.1
+++ b/src/doc/man/rustc.1
@@ -62,7 +62,7 @@ Comma separated list of compiler information to print on stdout.
 Equivalent to \fI\-C\ debuginfo=2\fR.
 .TP
 \fB\-O\fR
-Equivalent to \fI\-C\ opt\-level=2\fR.
+Equivalent to \fI\-C\ opt\-level=3\fR.
 .TP
 \fB\-o\fR \fIFILENAME\fR
 Write output to \fIFILENAME\fR. Ignored if multiple \fI\-\-emit\fR outputs are specified which


### PR DESCRIPTION
This was changed back in 1.86, rust-lang/rust#135439.
