### PR TITLE
[DO NOT MERGE] Check that binutils add is working

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
@@ -18,4 +18,15 @@ if [ "${DIST_TRY_BUILD:-0}" == "0" ]; then
     CC=/rustroot/bin/cc CXX=/rustroot/bin/c++ python3 ../x.py dist \
       gcc-dev \
       gcc
+    # We confirm that the built GCC has support for the `retain` attribute.
+    # FIXME: Maybe get the path from `.x.py` instead?
+    gcc_path="./build/$HOSTS/gcc/$HOSTS/install/bin/gcc"
+    if echo 'int x __attribute__((used, retain));' | "$gcc_path" -S -x c -o - - | grep -i '"a.*R"'; then
+        echo "retain attribute is supported"
+    else
+        echo "retain attribute is not supported"
+        # We display the generated asm just in case...
+        echo 'int x __attribute__((used, retain));' | "$gcc_path" -S -x c -o - -
+        exit 1
+    fi
 fi

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
@@ -21,12 +21,13 @@ if [ "${DIST_TRY_BUILD:-0}" == "0" ]; then
     # We confirm that the built GCC has support for the `retain` attribute.
     # FIXME: Maybe get the path from `.x.py` instead?
     gcc_path="./build/$HOSTS/gcc/$HOSTS/install/bin/gcc"
-    if echo 'int x __attribute__((used, retain));' | "$gcc_path" -S -x c -o - - | grep -i '"a.*R"'; then
+    c_code='int x __attribute__((used, retain));'
+    if echo "$c_code" | "$gcc_path" -S -x c -o - - | grep -i '"a.*R"'; then
         echo "retain attribute is supported"
     else
         echo "retain attribute is not supported"
         # We display the generated asm just in case...
-        echo 'int x __attribute__((used, retain));' | "$gcc_path" -S -x c -o - -
+        echo "$c_code" | "$gcc_path" -S -x c -o - -
         exit 1
     fi
 fi

--- a/src/ci/docker/scripts/build-gcc.sh
+++ b/src/ci/docker/scripts/build-gcc.sh
@@ -4,25 +4,6 @@ set -eux
 
 source shared.sh
 
-BINUTILS="2.47"
-curl https://ci-mirrors.rust-lang.org/rustc/gcc/binutils-$BINUTILS.tar.xz | xzcat | tar xf -
-mkdir binutils-build
-cd binutils-build
-hide_output ../binutils-$BINUTILS/configure --prefix=/rustroot
-hide_output make -j$(nproc)
-hide_output make install
-
-cd ..
-rm -rf binutils-build binutils-$BINUTILS
-
-if echo '.section .test,"awR",@progbits' | as - -o /dev/null 2>/dev/null; then
-    echo "binutils assembler supports SHF_GNU_RETAIN"
-else
-    echo "binutils assembler DOES NOT support SHF_GNU_RETAIN"
-    exit 1
-fi
-
-
 # Note: in the future when bumping to version 10.1.0, also take care of the sed block below.
 # This version is specified in the Dockerfile
 GCC=$GCC_VERSION

--- a/src/ci/docker/scripts/build-gcc.sh
+++ b/src/ci/docker/scripts/build-gcc.sh
@@ -55,11 +55,13 @@ sed -i'' 's|ftp://gcc\.gnu\.org/pub/gcc/infrastructure|https://ci-mirrors.rust-l
 mkdir ../gcc-build
 cd ../gcc-build
 
+export PATH=/rustroot/bin:$PATH
 # '-fno-reorder-blocks-and-partition' is required to
 # enable BOLT optimization of the C++ standard library,
 # which is included in librustc_driver.so
 hide_output ../gcc-$GCC/configure \
     --prefix=/rustroot \
+    --with-bintuils=/rustroot/bin \
     --with-as=$AS_PATH \
     --with-ld=$LD_PATH \
     --enable-languages=c,c++ \
@@ -68,12 +70,13 @@ hide_output ../gcc-$GCC/configure \
 hide_output make -j$(nproc)
 hide_output make install
 ln -s gcc /rustroot/bin/cc
-if echo 'int x __attribute__((used, retain));' | gcc -S -x c -o - - | grep -i '"a.*R"'; then
+
+if echo 'int x __attribute__((used, retain));' | /rustroot/bin/gcc -S -x c -o - - | grep -i '"a.*R"'; then
     echo "retain attribute is supported"
 else
     echo "retain attribute is not supported"
     # We display the generated asm just in case...
-    echo 'int x __attribute__((used, retain));' | gcc -S -x c -o - -
+    echo 'int x __attribute__((used, retain));' | /rustroot/bin/gcc -S -x c -o - -
     exit 1
 fi
 

--- a/src/ci/docker/scripts/build-gcc.sh
+++ b/src/ci/docker/scripts/build-gcc.sh
@@ -6,22 +6,22 @@ source shared.sh
 
 BINUTILS="2.47"
 curl https://ci-mirrors.rust-lang.org/rustc/gcc/binutils-$BINUTILS.tar.xz | xzcat | tar xf -
-cd binutils-$BINUTILS
-hide_output ./configure --prefix=/rustroot
+mkdir binutils-build
+cd binutils-build
+hide_output ../binutils-$BINUTILS/configure --prefix=/rustroot
 hide_output make -j$(nproc)
 hide_output make install
 
-if echo '.section .test,"awR",@progbits' | /rustroot/bin/as - -o /dev/null 2>/dev/null; then
+cd ..
+rm -rf binutils-build binutils-$BINUTILS
+
+if echo '.section .test,"awR",@progbits' | as - -o /dev/null 2>/dev/null; then
     echo "binutils assembler supports SHF_GNU_RETAIN"
 else
     echo "binutils assembler DOES NOT support SHF_GNU_RETAIN"
     exit 1
 fi
 
-AS_PATH="/rustroot/bin/as"
-LD_PATH="/rustroot/bin/ld"
-
-cd ..
 
 # Note: in the future when bumping to version 10.1.0, also take care of the sed block below.
 # This version is specified in the Dockerfile
@@ -61,24 +61,12 @@ export PATH=/rustroot/bin:$PATH
 # which is included in librustc_driver.so
 hide_output ../gcc-$GCC/configure \
     --prefix=/rustroot \
-    --with-bintuils=/rustroot/bin \
-    --with-as=$AS_PATH \
-    --with-ld=$LD_PATH \
     --enable-languages=c,c++ \
     --disable-gnu-unique-object \
     --enable-cxx-flags='-fno-reorder-blocks-and-partition'
 hide_output make -j$(nproc)
 hide_output make install
 ln -s gcc /rustroot/bin/cc
-
-if echo 'int x __attribute__((used, retain));' | /rustroot/bin/gcc -S -x c -o - - | grep -i '"a.*R"'; then
-    echo "retain attribute is supported"
-else
-    echo "retain attribute is not supported"
-    # We display the generated asm just in case...
-    echo 'int x __attribute__((used, retain));' | /rustroot/bin/gcc -S -x c -o - -
-    exit 1
-fi
 
 cd ..
 rm -rf gcc-build

--- a/src/ci/docker/scripts/build-gcc.sh
+++ b/src/ci/docker/scripts/build-gcc.sh
@@ -4,6 +4,13 @@ set -eux
 
 source shared.sh
 
+BINUTILS="2.47"
+curl https://ci-mirrors.rust-lang.org/rustc/gcc/binutils-$BINUTILS.tar.xz | xzcat | tar xf -
+cd binutils-$BINUTILS
+hide_output ./configure
+hide_output make
+hide_output make install
+
 # Note: in the future when bumping to version 10.1.0, also take care of the sed block below.
 # This version is specified in the Dockerfile
 GCC=$GCC_VERSION

--- a/src/ci/docker/scripts/build-gcc.sh
+++ b/src/ci/docker/scripts/build-gcc.sh
@@ -7,8 +7,8 @@ source shared.sh
 BINUTILS="2.47"
 curl https://ci-mirrors.rust-lang.org/rustc/gcc/binutils-$BINUTILS.tar.xz | xzcat | tar xf -
 cd binutils-$BINUTILS
-hide_output ./configure
-hide_output make
+hide_output ./configure --prefix=/rustroot
+hide_output make -j$(nproc)
 hide_output make install
 
 if echo '.section .test,"awR",@progbits' | as - -o /dev/null 2>/dev/null; then

--- a/src/ci/docker/scripts/build-gcc.sh
+++ b/src/ci/docker/scripts/build-gcc.sh
@@ -11,12 +11,15 @@ hide_output ./configure --prefix=/rustroot
 hide_output make -j$(nproc)
 hide_output make install
 
-if echo '.section .test,"awR",@progbits' | as - -o /dev/null 2>/dev/null; then
+if echo '.section .test,"awR",@progbits' | /rustroot/bin/as - -o /dev/null 2>/dev/null; then
     echo "binutils assembler supports SHF_GNU_RETAIN"
 else
     echo "binutils assembler DOES NOT support SHF_GNU_RETAIN"
     exit 1
 fi
+
+AS_PATH="/rustroot/bin/as"
+LD_PATH="/rustroot/bin/ld"
 
 cd ..
 
@@ -57,6 +60,8 @@ cd ../gcc-build
 # which is included in librustc_driver.so
 hide_output ../gcc-$GCC/configure \
     --prefix=/rustroot \
+    --with-as=$AS_PATH \
+    --with-ld=$LD_PATH \
     --enable-languages=c,c++ \
     --disable-gnu-unique-object \
     --enable-cxx-flags='-fno-reorder-blocks-and-partition'

--- a/src/ci/docker/scripts/build-gcc.sh
+++ b/src/ci/docker/scripts/build-gcc.sh
@@ -67,6 +67,8 @@ if echo 'int x __attribute__((used, retain));' | gcc -S -x c -o - - | grep -i '"
     echo "retain attribute is supported"
 else
     echo "retain attribute is not supported"
+    # We display the generated asm just in case...
+    echo 'int x __attribute__((used, retain));' | gcc -S -x c -o - -
     exit 1
 fi
 

--- a/src/ci/docker/scripts/build-gcc.sh
+++ b/src/ci/docker/scripts/build-gcc.sh
@@ -11,6 +11,15 @@ hide_output ./configure
 hide_output make
 hide_output make install
 
+if echo '.section .test,"awR",@progbits' | as - -o /dev/null 2>/dev/null; then
+    echo "binutils assembler supports SHF_GNU_RETAIN"
+else
+    echo "binutils assembler DOES NOT support SHF_GNU_RETAIN"
+    exit 1
+fi
+
+cd ..
+
 # Note: in the future when bumping to version 10.1.0, also take care of the sed block below.
 # This version is specified in the Dockerfile
 GCC=$GCC_VERSION
@@ -54,6 +63,12 @@ hide_output ../gcc-$GCC/configure \
 hide_output make -j$(nproc)
 hide_output make install
 ln -s gcc /rustroot/bin/cc
+if echo 'int x __attribute__((used, retain));' | gcc -S -x c -o - - | grep -i '"a.*R"'; then
+    echo "retain attribute is supported"
+else
+    echo "retain attribute is not supported"
+    exit 1
+fi
 
 cd ..
 rm -rf gcc-build


### PR DESCRIPTION
Just to confirm https://github.com/rust-lang/rust/pull/161006 works as expected, this PR adds an extra commit which removes the installation of newer binutils. It should fail the ASM gcc CI check.

r? ghost