### PR TITLE
Perf: Clear the param env for more global trait goals

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1009,8 +1009,14 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         mut obligation: PolyTraitObligation<'tcx>,
     ) -> Result<EvaluationResult, OverflowError> {
         if !self.typing_mode().is_coherence()
-            && obligation.is_global()
-            && obligation.param_env.caller_bounds().iter().all(|bound| bound.has_param())
+            && obligation.predicate.is_global()
+            && obligation.param_env.caller_bounds().iter().all(|bound| {
+                bound.has_param()
+                    || matches!(
+                        bound.kind().skip_binder(),
+                        ty::ClauseKind::RegionOutlives(_) | ty::ClauseKind::TypeOutlives(_)
+                    )
+            })
         {
             // If a param env has no global bounds, global obligations do not
             // depend on its particular value in order to work, so we can clear


### PR DESCRIPTION
`evaluate_trait_predicate_recursively` clears the param env when its bounds cannot
affect a global goal, so the result can go in the global cache. It almost never
fires today, for two reasons:

- It asks `obligation.is_global()`. An `Obligation` visits its own `param_env`, so
  this is false whenever the env holds anything local, including the region
  inference variables the branch is about to discard. In practice it could only
  fire when the env was already empty.

- It requires every bound to mention a generic parameter. An outlives bound is
  never a selection candidate, so it cannot change the answer either.

Code using `#[async_trait]` runs into this. Every method there carries
`where 'life0: 'async_trait, ..`, and those bounds hold region inference
variables, so each method re-proves the same `Send`/`Sync` goals from scratch.

On a generated test file with an `async_trait`-shaped trait over a large concrete
type graph, `evaluate_obligation` self time drops:

| methods | before | after |
|---:|---:|---:|
| 1 | 150ms | 103ms |
| 10 | 594ms | 449ms |
| 30 | 1.56s | 1.08s |

I found this while looking at compile times in DataFusion, where a few crates
spend most of their time proving `Send` for futures returned by `#[async_trait]`
methods.

# AI Disclosure

I used LLM (Claude) to run some experiments and change the code
