### PR TITLE
Avoid ICE when recovering parenthesized type parameters

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1321,11 +1321,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
                             span: data.span,
                         }
                     } else {
-                        self.emit_bad_parenthesized_trait_in_assoc_ty(data);
+                        let guar = self.emit_bad_parenthesized_trait_in_assoc_ty(data);
                         self.lower_angle_bracketed_parameter_data(
                             &data.as_angle_bracketed_args(),
                             ParamMode::Explicit,
-                            itctx,
+                            ImplTraitContext::AlreadyErrored(guar),
                         )
                         .0
                     }
@@ -1394,7 +1394,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
         }
     }
 
-    fn emit_bad_parenthesized_trait_in_assoc_ty(&self, data: &ParenthesizedArgs) {
+    fn emit_bad_parenthesized_trait_in_assoc_ty(
+        &self,
+        data: &ParenthesizedArgs,
+    ) -> ErrorGuaranteed {
         // Suggest removing empty parentheses: "Trait()" -> "Trait"
         let sub = if data.inputs.is_empty() {
             let parentheses_span =
@@ -1415,7 +1418,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 data.inputs.last().unwrap().span.shrink_to_hi().to(data.inputs_span.shrink_to_hi());
             AssocTyParenthesesSub::NotEmpty { open_param, close_param }
         };
-        self.dcx().emit_err(AssocTyParentheses { span: data.span, sub });
+        self.dcx().emit_err(AssocTyParentheses { span: data.span, sub })
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -1738,7 +1741,15 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         });
                         hir::TyKind::Err(guar)
                     }
-                    ImplTraitContext::AlreadyErrored(guar) => hir::TyKind::Err(guar),
+                    ImplTraitContext::AlreadyErrored(guar) => {
+                        // `GenericArgs::Parenthesized` stores its inputs as `Param`s, so the def
+                        // collector visits `impl Trait` in a universal context and creates a
+                        // `DefKind::TyParam`. During recovery we reinterpret these arguments as
+                        // angle-bracketed, where lowering may otherwise expect an opaque type.
+                        // The parenthesized syntax has already been rejected, so avoid lowering
+                        // this `impl Trait` with the inconsistent `DefKind`.
+                        hir::TyKind::Err(guar)
+                    }
                 }
             }
             TyKind::Pat(ty, pat) => {

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -411,6 +411,9 @@ enum ImplTraitContext {
     FeatureGated(ImplTraitPosition, Symbol),
     /// `impl Trait` is not accepted in this position.
     Disallowed(ImplTraitPosition),
+
+    /// An error has already been emitted for this type.
+    AlreadyErrored(ErrorGuaranteed),
 }
 
 /// Position in which `impl Trait` is disallowed.
@@ -1735,6 +1738,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         });
                         hir::TyKind::Err(guar)
                     }
+                    ImplTraitContext::AlreadyErrored(guar) => hir::TyKind::Err(guar),
                 }
             }
             TyKind::Pat(ty, pat) => {

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -338,12 +338,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         } else {
                             None
                         };
-                        self.dcx().emit_err(GenericTypeWithParentheses { span: data.span, sub });
+                        let guar = self
+                            .dcx()
+                            .emit_err(GenericTypeWithParentheses { span: data.span, sub });
                         (
                             self.lower_angle_bracketed_parameter_data(
                                 &data.as_angle_bracketed_args(),
                                 param_mode,
-                                itctx,
+                                ImplTraitContext::AlreadyErrored(guar),
                             )
                             .0,
                             false,

--- a/tests/ui/typeck/parenthesized-type-params-in-paths.rs
+++ b/tests/ui/typeck/parenthesized-type-params-in-paths.rs
@@ -39,3 +39,8 @@ fn foo<X:Default>() {
     let d : X() = Default::default();
     //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
 }
+
+struct A<T>(T);
+
+fn issue_161062() -> A(impl Sized) {}
+//~^ ERROR parenthesized type parameters may only be used with a `Fn` trait

--- a/tests/ui/typeck/parenthesized-type-params-in-paths.rs
+++ b/tests/ui/typeck/parenthesized-type-params-in-paths.rs
@@ -44,3 +44,12 @@ struct A<T>(T);
 
 fn issue_161062() -> A(impl Sized) {}
 //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
+
+trait Trait {
+    type Assoc<T>;
+}
+
+fn issue_161062_assoc_constraint() -> &'static dyn Trait<Assoc(impl Sized) = usize> {
+    //~^ ERROR parenthesized generic arguments cannot be used in associated type constraints
+    loop {}
+}

--- a/tests/ui/typeck/parenthesized-type-params-in-paths.stderr
+++ b/tests/ui/typeck/parenthesized-type-params-in-paths.stderr
@@ -58,6 +58,18 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
 LL |     let d : X() = Default::default();
    |             ^^^ only `Fn` traits may use parentheses
 
-error: aborting due to 10 previous errors
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
+  --> $DIR/parenthesized-type-params-in-paths.rs:45:22
+   |
+LL | fn issue_161062() -> A(impl Sized) {}
+   |                      ^^^^^^^^^^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL - fn issue_161062() -> A(impl Sized) {}
+LL + fn issue_161062() -> A<impl Sized> {}
+   |
+
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0214`.

--- a/tests/ui/typeck/parenthesized-type-params-in-paths.stderr
+++ b/tests/ui/typeck/parenthesized-type-params-in-paths.stderr
@@ -70,6 +70,18 @@ LL - fn issue_161062() -> A(impl Sized) {}
 LL + fn issue_161062() -> A<impl Sized> {}
    |
 
-error: aborting due to 11 previous errors
+error: parenthesized generic arguments cannot be used in associated type constraints
+  --> $DIR/parenthesized-type-params-in-paths.rs:52:58
+   |
+LL | fn issue_161062_assoc_constraint() -> &'static dyn Trait<Assoc(impl Sized) = usize> {
+   |                                                          ^^^^^^^^^^^^^^^^^
+   |
+help: use angle brackets instead
+   |
+LL - fn issue_161062_assoc_constraint() -> &'static dyn Trait<Assoc(impl Sized) = usize> {
+LL + fn issue_161062_assoc_constraint() -> &'static dyn Trait<Assoc<impl Sized> = usize> {
+   |
+
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0214`.


### PR DESCRIPTION
fix an ICE when impl Trait appears inside invalid parenthesized generic arguments by preserving the existing E0214 error path instead of lowering it as an opaque type
Fixes rust-lang/rust#161062