### PR TITLE
Perf: Only scan the affected suffix of the provisional cache

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -3110,10 +3110,13 @@ impl<'tcx> ProvisionalEvaluationCache<'tcx> {
         //          A // depth 0
         //   D (reached depth 1)
         //      C (cache -- reached depth = 2)
-        for (_k, v) in &mut *map {
-            if v.from_dfn >= from_dfn {
-                v.reached_depth = reached_depth.min(v.reached_depth);
+        // Anything this can affect was inserted while `from_dfn` was on the
+        // stack, so it is a suffix of this insertion-ordered map.
+        for (_k, v) in map.iter_mut().rev() {
+            if v.from_dfn < from_dfn {
+                break;
             }
+            v.reached_depth = reached_depth.min(v.reached_depth);
         }
 
         map.insert(fresh_trait_pred, ProvisionalEvaluation { from_dfn, reached_depth, result });


### PR DESCRIPTION
`insert_provisional` walks the whole provisional cache on every insert, to lower
`reached_depth` on entries at or above `from_dfn`. Everything it can affect was
inserted while `from_dfn` was on the stack, so those entries are a suffix of this
insertion-ordered map, and the walk can stop at the first older entry.

The full walk is quadratic in the size of the cache. That cache only fills up for
mutually recursive types, so this shows up when proving `Send` or `Sync` for a
graph of such types: for a graph of N of them the loop ran about N² times.

`evaluate_obligation` self time on that graph:

| types | before | after |
|---:|---:|---:|
| 60 | 104ms | 61ms |
| 120 | 315ms | 118ms |
| 240 | 886ms | 243ms |
| 480 | 3.06s | 0.55s |

Growth goes from superlinear to linear, which is what the same graph already does
when it has no cycles.

I ran into this looking at DataFusion, whose `Expr` and `LogicalPlan` types are
mutually recursive across a few hundred types.

# AI Disclosure

I used LLM (Claude) to run some experiments and change the code

