### PR TITLE
Perf: Fix the check in the provisional cache's on_failure

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -3130,7 +3130,7 @@ impl<'tcx> ProvisionalEvaluationCache<'tcx> {
     fn on_failure(&self, dfn: usize) {
         debug!(?dfn, "on_failure");
         self.map.borrow_mut().retain(|key, eval| {
-            if !eval.from_dfn >= dfn {
+            if eval.from_dfn >= dfn {
                 debug!("on_failure: removing {:?}", key);
                 false
             } else {


### PR DESCRIPTION
`on_failure` should drop the provisional cache entries added since `dfn`, but it
asks `!eval.from_dfn >= dfn`. `!` on a `usize` is a bitwise NOT, so the left side
is a huge number and the check is true for every dfn we ever see .

On top of rust-lang/rust#161130, which makes that scan stop
early, proving `Send` for a graph of N mutually recursive types gives:

| types | rust-lang/rust#161130 | + this |
|---:|---:|---:|
| 60 | 60.94ms | 57.85ms |
| 120 | 117.91ms | 109.76ms |
| 240 | 242.62ms | 224.01ms |
| 480 | 549.83ms | 444.17ms |

The two go together, probably good to wait until rust-lang/rust#161130 lands.

# AI Disclosure

I used LLM (Claude) to run some experiments and change the code
