### PR TITLE
Add `f16` and `f128` inline ASM support for PowerPC

### DIFF
--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -1245,16 +1245,27 @@ fn llvm_fixup_input<'ll, 'tcx>(
         (
             PowerPC(PowerPCInlineAsmRegClass::vreg | PowerPCInlineAsmRegClass::vsreg),
             BackendRepr::Scalar(s),
-        ) if let Primitive::Float(float @ (Float::F32 | Float::F64)) = s.primitive() => {
+        ) if let Primitive::Float(float @ (Float::F16 | Float::F32 | Float::F64)) =
+            s.primitive() =>
+        {
             let num_lanes = 16 / float.size().bytes();
+            // `f16` is located in the rightmost halfword of doubleword 0 per section 7.3.2.5 of
+            // "Power Instruction Set Architecture", version 3.1C.
+            let offset = if float == Float::F16 { 3 } else { 0 };
             bx.insert_element(
                 bx.const_undef(bx.type_vector(bx.type_from_float(float), num_lanes)),
                 value,
                 bx.const_usize(match bx.target_spec().endian {
-                    Endian::Little => num_lanes - 1,
-                    Endian::Big => 0,
+                    Endian::Little => num_lanes - 1 - offset,
+                    Endian::Big => offset,
                 }),
             )
+        }
+        (
+            PowerPC(PowerPCInlineAsmRegClass::vreg | PowerPCInlineAsmRegClass::vsreg),
+            BackendRepr::Scalar(s),
+        ) if s.primitive() == Primitive::Float(Float::F128) => {
+            bx.bitcast(value, bx.type_vector(bx.type_f64(), 2))
         }
         _ => value,
     }
@@ -1409,16 +1420,25 @@ fn llvm_fixup_output<'ll, 'tcx>(
         (
             PowerPC(PowerPCInlineAsmRegClass::vreg | PowerPCInlineAsmRegClass::vsreg),
             BackendRepr::Scalar(s),
-        ) if let Primitive::Float(float @ (Float::F32 | Float::F64)) = s.primitive() => {
+        ) if let Primitive::Float(float @ (Float::F16 | Float::F32 | Float::F64)) =
+            s.primitive() =>
+        {
             let num_lanes = 16 / float.size().bytes();
+            // `f16` is located in the rightmost halfword of doubleword 0 per section 7.3.2.5 of
+            // "Power Instruction Set Architecture", version 3.1C.
+            let offset = if float == Float::F16 { 3 } else { 0 };
             bx.extract_element(
                 value,
                 bx.const_usize(match bx.target_spec().endian {
-                    Endian::Little => num_lanes - 1,
-                    Endian::Big => 0,
+                    Endian::Little => num_lanes - 1 - offset,
+                    Endian::Big => offset,
                 }),
             )
         }
+        (
+            PowerPC(PowerPCInlineAsmRegClass::vreg | PowerPCInlineAsmRegClass::vsreg),
+            BackendRepr::Scalar(s),
+        ) if s.primitive() == Primitive::Float(Float::F128) => bx.bitcast(value, bx.type_f128()),
         _ => value,
     }
 }
@@ -1558,9 +1578,15 @@ fn llvm_fixup_output_type<'ll, 'tcx>(
         (
             PowerPC(PowerPCInlineAsmRegClass::vreg | PowerPCInlineAsmRegClass::vsreg),
             BackendRepr::Scalar(s),
-        ) if let Primitive::Float(float @ (Float::F32 | Float::F64)) = s.primitive() => {
+        ) if let Primitive::Float(float @ (Float::F16 | Float::F32 | Float::F64)) =
+            s.primitive() =>
+        {
             cx.type_vector(cx.type_from_float(float), 16 / float.size().bytes())
         }
+        (
+            PowerPC(PowerPCInlineAsmRegClass::vreg | PowerPCInlineAsmRegClass::vsreg),
+            BackendRepr::Scalar(s),
+        ) if s.primitive() == Primitive::Float(Float::F128) => cx.type_vector(cx.type_f64(), 2),
         _ => layout.llvm_type(cx),
     }
 }

--- a/compiler/rustc_target/src/asm/powerpc.rs
+++ b/compiler/rustc_target/src/asm/powerpc.rs
@@ -54,15 +54,17 @@ impl PowerPCInlineAsmRegClass {
                     types! { _: I8, I16, I32, I64; }
                 }
             }
+            // FIXME(f16): Add `f16` if/when it becomes the standard ABI.
+            // (see https://github.com/llvm/llvm-project/pull/196559)
             Self::freg => types! { _: F32, F64; },
             // FIXME: vsx also supports integers?: https://github.com/rust-lang/rust/pull/131551#discussion_r1862535963
             Self::vreg => types! {
                 altivec: VecI8(16), VecI16(8), VecI32(4), VecF32(4);
-                vsx: F32, F64, VecI64(2), VecF64(2);
+                vsx: F16, F32, F64, F128, VecI64(2), VecF16(8), VecF64(2);
             },
             // VSX is a superset of altivec.
             Self::vsreg => types! {
-                vsx: F32, F64, VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF32(4), VecF64(2);
+                vsx: F16, F32, F64, F128, VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF16(8), VecF32(4), VecF64(2);
             },
             Self::cr | Self::ctr | Self::lr | Self::xer | Self::spe_acc => &[],
         }

--- a/tests/assembly-llvm/asm/powerpc-types.rs
+++ b/tests/assembly-llvm/asm/powerpc-types.rs
@@ -35,6 +35,8 @@
 
 //@ compile-flags: -Zmerge-functions=disabled -Copt-level=3
 //@ compile-flags: --check-cfg=cfg(altivec,vsx,power9,power9be)
+// PowerPC `f16` was broken before LLVM 22
+//@ min-llvm-version: 22
 
 #![feature(no_core, f16)]
 #![cfg_attr(vsx, feature(f128))]
@@ -97,6 +99,48 @@ pub extern "C" fn f64_to_f32(x: f64) -> f32 {
     let res;
     unsafe {
         asm!("xscvdpsp {}, {}", out(vsreg) res, in(vsreg) x, options(pure, nostack, nomem));
+    };
+    res
+}
+
+// power9-LABEL: f64_to_f128:
+// power9: .cfi_startproc
+// power9-NEXT: xscpsgndp [[#INPUT:]], 1, 1
+// power9-NEXT: #APP
+// power9-NEXT: xscvdpqp 2, [[#INPUT - 32]]
+// power9-NEXT: #NO_APP
+// power9-NEXT: blr
+#[cfg(power9)]
+#[unsafe(no_mangle)]
+pub extern "C" fn f64_to_f128(x: f64) -> f128 {
+    let res;
+    unsafe {
+        asm!("xscvdpqp {}, {}", out(vreg) res, in(vreg) x, options(pure, nostack, nomem));
+    };
+    res
+}
+
+// FIXME(f16): This test will need to be updated if/when the `f16` ABI gets standardised.
+// (see https://github.com/llvm/llvm-project/pull/196559)
+// power9-LABEL: f64_to_f16:
+// power9: .cfi_startproc
+// powerpc_power9-NEXT: stwu 1, -[[#STACK:]](1)
+// powerpc_power9-NEXT: .cfi_def_cfa_offset [[#STACK]]
+// powerpc64le_power9-NEXT: li [[#INDEX:]], 8
+// power9-NEXT: #APP
+// power9-NEXT: xscvdphp [[#OUTPUT:]], 1
+// power9-NEXT: #NO_APP
+// power9be-NEXT: stxv [[#OUTPUT]], [[#%d,OFFSET:]](1)
+// power9be-NEXT: lhz 3, [[#OFFSET + 6]](1)
+// powerpc_power9-NEXT: addi 1, 1, [[#STACK]]
+// powerpc64le_power9-NEXT: vextuhrx 3, [[#INDEX]], [[#OUTPUT - 32]]
+// power9-NEXT: blr
+#[cfg(power9)]
+#[unsafe(no_mangle)]
+pub extern "C" fn f64_to_f16(x: f64) -> f16 {
+    let res;
+    unsafe {
+        asm!("xscvdphp {}, {}", out(vsreg) res, in(vsreg) x, options(pure, nostack, nomem));
     };
     res
 }
@@ -213,6 +257,13 @@ check!(vreg_i32x4, i32x4, vreg, "vmr");
 #[cfg(vsx)]
 check!(vreg_i64x2, i64x2, vreg, "vmr");
 
+// vsx-LABEL: vreg_f16x8:
+// vsx: #APP
+// vsx: vmr {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
+#[cfg(vsx)]
+check!(vreg_f16x8, f16x8, vreg, "vmr");
+
 // altivec-LABEL: vreg_f32x4:
 // altivec: #APP
 // altivec: vmr {{[0-9]+}}, {{[0-9]+}}
@@ -227,6 +278,13 @@ check!(vreg_f32x4, f32x4, vreg, "vmr");
 #[cfg(vsx)]
 check!(vreg_f64x2, f64x2, vreg, "vmr");
 
+// vsx-LABEL: vreg_f16:
+// vsx: #APP
+// vsx: vmr {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
+#[cfg(vsx)]
+check!(vreg_f16, f16, vreg, "vmr");
+
 // vsx-LABEL: vreg_f32:
 // vsx: #APP
 // vsx: vmr {{[0-9]+}}, {{[0-9]+}}
@@ -240,6 +298,13 @@ check!(vreg_f32, f32, vreg, "vmr");
 // vsx: #NO_APP
 #[cfg(vsx)]
 check!(vreg_f64, f64, vreg, "vmr");
+
+// vsx-LABEL: vreg_f128:
+// vsx: #APP
+// vsx: vmr {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
+#[cfg(vsx)]
+check!(vreg_f128, f128, vreg, "vmr");
 
 // vsx-LABEL: vsreg_i8x16:
 // vsx: #APP
@@ -269,6 +334,13 @@ check!(vsreg_i32x4, i32x4, vsreg, "xvsqrtdp");
 #[cfg(vsx)]
 check!(vsreg_i64x2, i64x2, vsreg, "xvsqrtdp");
 
+// vsx-LABEL: vsreg_f16x8:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
+#[cfg(vsx)]
+check!(vsreg_f16x8, f16x8, vsreg, "xvsqrtdp");
+
 // vsx-LABEL: vsreg_f32x4:
 // vsx: #APP
 // vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
@@ -283,6 +355,13 @@ check!(vsreg_f32x4, f32x4, vsreg, "xvsqrtdp");
 #[cfg(vsx)]
 check!(vsreg_f64x2, f64x2, vsreg, "xvsqrtdp");
 
+// vsx-LABEL: vsreg_f16:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
+#[cfg(vsx)]
+check!(vsreg_f16, f16, vsreg, "xvsqrtdp");
+
 // vsx-LABEL: vsreg_f32:
 // vsx: #APP
 // vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
@@ -296,6 +375,13 @@ check!(vsreg_f32, f32, vsreg, "xvsqrtdp");
 // vsx: #NO_APP
 #[cfg(vsx)]
 check!(vsreg_f64, f64, vsreg, "xvsqrtdp");
+
+// vsx-LABEL: vsreg_f128:
+// vsx: #APP
+// vsx: xvsqrtdp {{[0-9]+}}, {{[0-9]+}}
+// vsx: #NO_APP
+#[cfg(vsx)]
+check!(vsreg_f128, f128, vsreg, "xvsqrtdp");
 
 // CHECK-LABEL: reg_i8_r0:
 // CHECK: #APP
@@ -399,6 +485,13 @@ check_reg!(vreg_i32x4_v0, i32x4, "0", "v0", "vmr");
 #[cfg(vsx)]
 check_reg!(vreg_i64x2_v0, i64x2, "0", "v0", "vmr");
 
+// vsx-LABEL: vreg_f16x8_v0:
+// vsx: #APP
+// vsx: vmr 0, 0
+// vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vreg_f16x8_v0, f16x8, "0", "v0", "vmr");
+
 // altivec-LABEL: vreg_f32x4_v0:
 // altivec: #APP
 // altivec: vmr 0, 0
@@ -413,6 +506,13 @@ check_reg!(vreg_f32x4_v0, f32x4, "0", "v0", "vmr");
 #[cfg(vsx)]
 check_reg!(vreg_f64x2_v0, f64x2, "0", "v0", "vmr");
 
+// vsx-LABEL: vreg_f16_v0:
+// vsx: #APP
+// vsx: vmr 0, 0
+// vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vreg_f16_v0, f16, "0", "v0", "vmr");
+
 // vsx-LABEL: vreg_f32_v0:
 // vsx: #APP
 // vsx: vmr 0, 0
@@ -426,6 +526,13 @@ check_reg!(vreg_f32_v0, f32, "0", "v0", "vmr");
 // vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f64_v0, f64, "0", "v0", "vmr");
+
+// vsx-LABEL: vreg_f128_v0:
+// vsx: #APP
+// vsx: vmr 0, 0
+// vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vreg_f128_v0, f128, "0", "v0", "vmr");
 
 // altivec-LABEL: vreg_i8x16_v18:
 // altivec: #APP
@@ -455,6 +562,13 @@ check_reg!(vreg_i32x4_v18, i32x4, "18", "v18", "vmr");
 #[cfg(vsx)]
 check_reg!(vreg_i64x2_v18, i64x2, "18", "v18", "vmr");
 
+// vsx-LABEL: vreg_f16x8_v18:
+// vsx: #APP
+// vsx: vmr 18, 18
+// vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vreg_f16x8_v18, f16x8, "18", "v18", "vmr");
+
 // altivec-LABEL: vreg_f32x4_v18:
 // altivec: #APP
 // altivec: vmr 18, 18
@@ -469,6 +583,13 @@ check_reg!(vreg_f32x4_v18, f32x4, "18", "v18", "vmr");
 #[cfg(vsx)]
 check_reg!(vreg_f64x2_v18, f64x2, "18", "v18", "vmr");
 
+// vsx-LABEL: vreg_f16_v18:
+// vsx: #APP
+// vsx: vmr 18, 18
+// vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vreg_f16_v18, f16, "18", "v18", "vmr");
+
 // vsx-LABEL: vreg_f32_v18:
 // vsx: #APP
 // vsx: vmr 18, 18
@@ -482,6 +603,13 @@ check_reg!(vreg_f32_v18, f32, "18", "v18", "vmr");
 // vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vreg_f64_v18, f64, "18", "v18", "vmr");
+
+// vsx-LABEL: vreg_f128_v18:
+// vsx: #APP
+// vsx: vmr 18, 18
+// vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vreg_f128_v18, f128, "18", "v18", "vmr");
 
 // vsx-LABEL: vsreg_i8x16_vs0:
 // vsx: #APP
@@ -511,6 +639,13 @@ check_reg!(vsreg_i32x4_vs0, i32x4, "0", "vs0", "xvsqrtdp");
 #[cfg(vsx)]
 check_reg!(vsreg_i64x2_vs0, i64x2, "0", "vs0", "xvsqrtdp");
 
+// vsx-LABEL: vsreg_f16x8_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f16x8_vs0, f16x8, "0", "vs0", "xvsqrtdp");
+
 // vsx-LABEL: vsreg_f32x4_vs0:
 // vsx: #APP
 // vsx: xvsqrtdp 0, 0
@@ -525,6 +660,13 @@ check_reg!(vsreg_f32x4_vs0, f32x4, "0", "vs0", "xvsqrtdp");
 #[cfg(vsx)]
 check_reg!(vsreg_f64x2_vs0, f64x2, "0", "vs0", "xvsqrtdp");
 
+// vsx-LABEL: vsreg_f16_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f16_vs0, f16, "0", "vs0", "xvsqrtdp");
+
 // vsx-LABEL: vsreg_f32_vs0:
 // vsx: #APP
 // vsx: xvsqrtdp 0, 0
@@ -538,6 +680,13 @@ check_reg!(vsreg_f32_vs0, f32, "0", "vs0", "xvsqrtdp");
 // vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f64_vs0, f64, "0", "vs0", "xvsqrtdp");
+
+// vsx-LABEL: vsreg_f128_vs0:
+// vsx: #APP
+// vsx: xvsqrtdp 0, 0
+// vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f128_vs0, f128, "0", "vs0", "xvsqrtdp");
 
 // vsx-LABEL: vsreg_i8x16_v40:
 // vsx: #APP
@@ -567,6 +716,13 @@ check_reg!(vsreg_i32x4_v40, i32x4, "40", "vs40", "xvsqrtdp");
 #[cfg(vsx)]
 check_reg!(vsreg_i64x2_v40, i64x2, "40", "vs40", "xvsqrtdp");
 
+// vsx-LABEL: vsreg_f16x8_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f16x8_v40, f16x8, "40", "vs40", "xvsqrtdp");
+
 // vsx-LABEL: vsreg_f32x4_v40:
 // vsx: #APP
 // vsx: xvsqrtdp 40, 40
@@ -581,6 +737,13 @@ check_reg!(vsreg_f32x4_v40, f32x4, "40", "vs40", "xvsqrtdp");
 #[cfg(vsx)]
 check_reg!(vsreg_f64x2_v40, f64x2, "40", "vs40", "xvsqrtdp");
 
+// vsx-LABEL: vsreg_f16_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f16_v40, f16, "40", "vs40", "xvsqrtdp");
+
 // vsx-LABEL: vsreg_f32_v40:
 // vsx: #APP
 // vsx: xvsqrtdp 40, 40
@@ -594,3 +757,10 @@ check_reg!(vsreg_f32_v40, f32, "40", "vs40", "xvsqrtdp");
 // vsx: #NO_APP
 #[cfg(vsx)]
 check_reg!(vsreg_f64_v40, f64, "40", "vs40", "xvsqrtdp");
+
+// vsx-LABEL: vsreg_f128_v40:
+// vsx: #APP
+// vsx: xvsqrtdp 40, 40
+// vsx: #NO_APP
+#[cfg(vsx)]
+check_reg!(vsreg_f128_v40, f128, "40", "vs40", "xvsqrtdp");

--- a/tests/ui/asm/powerpc/bad-reg.aix64.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.aix64.stderr
@@ -718,7 +718,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                           ^
    |
-   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
+   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f16, f32, f64, f128, i64x2, f16x8, f64x2
 
 error: type `i32` cannot be used with this register class
   --> $DIR/bad-reg.rs:61:28
@@ -726,7 +726,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                            ^
    |
-   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
+   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f16, f32, f64, f128, i64x2, f16x8, f64x2
 
 error: type `i32` cannot be used with this register class
   --> $DIR/bad-reg.rs:69:35
@@ -734,7 +734,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                                   ^
    |
-   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
+   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f16, f32, f64, f128, i64x2, f16x8, f64x2
 
 error: type `i32` cannot be used with this register class
   --> $DIR/bad-reg.rs:98:28
@@ -742,7 +742,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    |                            ^
    |
-   = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
+   = note: register class `vsreg` supports these types: f16, f32, f64, f128, i8x16, i16x8, i32x4, i64x2, f16x8, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
   --> $DIR/bad-reg.rs:101:29
@@ -750,7 +750,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    |                             ^
    |
-   = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
+   = note: register class `vsreg` supports these types: f16, f32, f64, f128, i8x16, i16x8, i32x4, i64x2, f16x8, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
   --> $DIR/bad-reg.rs:108:36
@@ -758,7 +758,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
    |                                    ^
    |
-   = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
+   = note: register class `vsreg` supports these types: f16, f32, f64, f128, i8x16, i16x8, i32x4, i64x2, f16x8, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
   --> $DIR/bad-reg.rs:131:27

--- a/tests/ui/asm/powerpc/bad-reg.powerpc64.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc64.stderr
@@ -734,7 +734,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                           ^
    |
-   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
+   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f16, f32, f64, f128, i64x2, f16x8, f64x2
 
 error: type `i32` cannot be used with this register class
   --> $DIR/bad-reg.rs:61:28
@@ -742,7 +742,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                            ^
    |
-   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
+   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f16, f32, f64, f128, i64x2, f16x8, f64x2
 
 error: `vsx` target feature is not enabled
   --> $DIR/bad-reg.rs:66:35
@@ -758,7 +758,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                                   ^
    |
-   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
+   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f16, f32, f64, f128, i64x2, f16x8, f64x2
 
 error: register class `vsreg` requires the `vsx` target feature
   --> $DIR/bad-reg.rs:90:18

--- a/tests/ui/asm/powerpc/bad-reg.powerpc64le.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc64le.stderr
@@ -718,7 +718,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                           ^
    |
-   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
+   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f16, f32, f64, f128, i64x2, f16x8, f64x2
 
 error: type `i32` cannot be used with this register class
   --> $DIR/bad-reg.rs:61:28
@@ -726,7 +726,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                            ^
    |
-   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
+   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f16, f32, f64, f128, i64x2, f16x8, f64x2
 
 error: type `i32` cannot be used with this register class
   --> $DIR/bad-reg.rs:69:35
@@ -734,7 +734,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                                   ^
    |
-   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
+   = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f16, f32, f64, f128, i64x2, f16x8, f64x2
 
 error: type `i32` cannot be used with this register class
   --> $DIR/bad-reg.rs:98:28
@@ -742,7 +742,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("", in("vs0") x); // FIXME: should be ok if vsx is available
    |                            ^
    |
-   = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
+   = note: register class `vsreg` supports these types: f16, f32, f64, f128, i8x16, i16x8, i32x4, i64x2, f16x8, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
   --> $DIR/bad-reg.rs:101:29
@@ -750,7 +750,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("", out("vs0") x); // FIXME: should be ok if vsx is available
    |                             ^
    |
-   = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
+   = note: register class `vsreg` supports these types: f16, f32, f64, f128, i8x16, i16x8, i32x4, i64x2, f16x8, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
   --> $DIR/bad-reg.rs:108:36
@@ -758,7 +758,7 @@ error: type `i32` cannot be used with this register class
 LL |         asm!("/* {} */", in(vsreg) x); // FIXME: should be ok if vsx is available
    |                                    ^
    |
-   = note: register class `vsreg` supports these types: f32, f64, i8x16, i16x8, i32x4, i64x2, f32x4, f64x2
+   = note: register class `vsreg` supports these types: f16, f32, f64, f128, i8x16, i16x8, i32x4, i64x2, f16x8, f32x4, f64x2
 
 error: type `i32` cannot be used with this register class
   --> $DIR/bad-reg.rs:131:27


### PR DESCRIPTION
This PR adds support for `f16`, `f128` and `f16x8` in PowerPC inline ASM vector registers ([PowerPC ISA](https://files.openpowerfoundation.org/s/AKX2KtLkwCXxEaC)).

Ping target maintainers: @daltenty @gilamn5tr @amy-kwan @Gelbpunkt @famfo @neuschaefer

Tracking issue: rust-lang/rust#125398 (part of rust-lang/rust#116909)