### PR TITLE
Simplify Encodable derives

### DIFF
--- a/compiler/rustc_macros/src/serialize.rs
+++ b/compiler/rustc_macros/src/serialize.rs
@@ -192,6 +192,11 @@ fn encodable_body(
         [] => {
             quote! {}
         }
+        // Unit-like types don't need to encode anything.
+        // This covers fieldless structs and enums with zero or one fieldless variant.
+        [vi] if vi.bindings().is_empty() => {
+            quote! {}
+        }
         [vi] => {
             let pat = vi.pat();
             let body = vi

--- a/compiler/rustc_macros/src/serialize.rs
+++ b/compiler/rustc_macros/src/serialize.rs
@@ -194,24 +194,26 @@ fn encodable_body(
                 match *self {}
             }
         }
-        [_] => {
-            let encode_inner = s.each_variant(|vi| {
-                vi.bindings()
-                    .iter()
-                    .map(|binding| {
-                        let bind_ident = &binding.binding;
-                        let result = quote! {
-                            ::rustc_serialize::Encodable::<#encoder_ty>::encode(
-                                #bind_ident,
-                                __encoder,
-                            );
-                        };
-                        result
-                    })
-                    .collect::<TokenStream>()
-            });
+        [vi] => {
+            let pat = vi.pat();
+            let body = vi
+                .bindings()
+                .iter()
+                .map(|binding| {
+                    let bind_ident = &binding.binding;
+                    let result = quote! {
+                        ::rustc_serialize::Encodable::<#encoder_ty>::encode(
+                            #bind_ident,
+                            __encoder,
+                        );
+                    };
+                    result
+                })
+                .collect::<TokenStream>();
+
             quote! {
-                match *self { #encode_inner }
+                let #pat = *self;
+                #body
             }
         }
         _ => {

--- a/compiler/rustc_macros/src/serialize.rs
+++ b/compiler/rustc_macros/src/serialize.rs
@@ -244,27 +244,32 @@ fn encodable_body(
                 }
             };
 
-            let encode_inner = s.each_variant(|vi| {
-                let encode_fields: TokenStream = vi
-                    .bindings()
-                    .iter()
-                    .map(|binding| {
-                        let bind_ident = &binding.binding;
-                        let result = quote! {
-                            ::rustc_serialize::Encodable::<#encoder_ty>::encode(
-                                #bind_ident,
-                                __encoder,
-                            );
-                        };
-                        result
-                    })
-                    .collect();
-                encode_fields
-            });
-            quote! {
-                #disc
-                match *self {
-                    #encode_inner
+            if s.variants().iter().all(|v| v.bindings().is_empty()) {
+                // Avoid generating second match statement if all variants are fieldless
+                disc
+            } else {
+                let encode_inner = s.each_variant(|vi| {
+                    let encode_fields: TokenStream = vi
+                        .bindings()
+                        .iter()
+                        .map(|binding| {
+                            let bind_ident = &binding.binding;
+                            let result = quote! {
+                                ::rustc_serialize::Encodable::<#encoder_ty>::encode(
+                                    #bind_ident,
+                                    __encoder,
+                                );
+                            };
+                            result
+                        })
+                        .collect();
+                    encode_fields
+                });
+                quote! {
+                    #disc
+                    match *self {
+                        #encode_inner
+                    }
                 }
             }
         }

--- a/compiler/rustc_macros/src/serialize.rs
+++ b/compiler/rustc_macros/src/serialize.rs
@@ -241,7 +241,6 @@ fn encodable_body(
                 }
             };
 
-            let mut variant_idx = 0usize;
             let encode_inner = s.each_variant(|vi| {
                 let encode_fields: TokenStream = vi
                     .bindings()
@@ -257,7 +256,6 @@ fn encodable_body(
                         result
                     })
                     .collect();
-                variant_idx += 1;
                 encode_fields
             });
             quote! {

--- a/compiler/rustc_macros/src/serialize.rs
+++ b/compiler/rustc_macros/src/serialize.rs
@@ -248,9 +248,8 @@ fn encodable_body(
                 // Avoid generating second match statement if all variants are fieldless
                 disc
             } else {
-                let encode_inner = s.each_variant(|vi| {
-                    let encode_fields: TokenStream = vi
-                        .bindings()
+                let encode_inner = s.each_variant(|vi| -> TokenStream {
+                    vi.bindings()
                         .iter()
                         .map(|binding| {
                             let bind_ident = &binding.binding;
@@ -262,8 +261,7 @@ fn encodable_body(
                             };
                             result
                         })
-                        .collect();
-                    encode_fields
+                        .collect()
                 });
                 quote! {
                     #disc

--- a/compiler/rustc_macros/src/serialize.rs
+++ b/compiler/rustc_macros/src/serialize.rs
@@ -215,6 +215,9 @@ fn encodable_body(
             }
         }
         _ => {
+            // This code generates two separate match statements on purpose, because
+            //  LLVM can optimize the first one into direct discriminant read.
+            //  See: https://github.com/rust-lang/rust/pull/108440
             let disc = {
                 let mut variant_idx = 0usize;
                 let encode_inner = s.each_variant(|_| {

--- a/compiler/rustc_macros/src/serialize.rs
+++ b/compiler/rustc_macros/src/serialize.rs
@@ -190,9 +190,7 @@ fn encodable_body(
 
     let encode_body = match s.variants() {
         [] => {
-            quote! {
-                match *self {}
-            }
+            quote! {}
         }
         [vi] => {
             let pat = vi.pat();

--- a/tests/ui-fulldeps/derive-encodable.rs
+++ b/tests/ui-fulldeps/derive-encodable.rs
@@ -1,0 +1,43 @@
+//@ edition: 2024
+//@ check-pass
+//@ compile-flags: -Zunpretty=expanded
+
+#![crate_type = "rlib"]
+#![feature(rustc_private)]
+
+extern crate rustc_macros;
+extern crate rustc_serialize;
+extern crate rustc_span;
+
+use rustc_macros::Encodable;
+
+#[derive(Encodable)]
+struct UnitStruct;
+
+#[derive(Encodable)]
+struct EmptyStruct {}
+
+#[derive(Encodable)]
+enum EmptyEnum {}
+
+#[derive(Encodable)]
+enum SingleFieldlessEnum {
+    A,
+}
+
+#[derive(Encodable)]
+enum SingleEnum {
+    A(u32),
+}
+
+#[derive(Encodable)]
+enum FieldlessEnum {
+    A,
+    B,
+}
+
+#[derive(Encodable)]
+enum PartlyFieldlessEnum {
+    A,
+    B(u32),
+}

--- a/tests/ui-fulldeps/derive-encodable.stdout
+++ b/tests/ui-fulldeps/derive-encodable.stdout
@@ -40,7 +40,7 @@ const _: () =
     {
         impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
             for EmptyEnum {
-            fn encode(&self, __encoder: &mut __E) { match *self {} }
+            fn encode(&self, __encoder: &mut __E) {}
         }
     };
 

--- a/tests/ui-fulldeps/derive-encodable.stdout
+++ b/tests/ui-fulldeps/derive-encodable.stdout
@@ -20,7 +20,7 @@ const _: () =
     {
         impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
             for UnitStruct {
-            fn encode(&self, __encoder: &mut __E) { let UnitStruct = *self; }
+            fn encode(&self, __encoder: &mut __E) {}
         }
     };
 
@@ -29,9 +29,7 @@ const _: () =
     {
         impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
             for EmptyStruct {
-            fn encode(&self, __encoder: &mut __E) {
-                let EmptyStruct {} = *self;
-            }
+            fn encode(&self, __encoder: &mut __E) {}
         }
     };
 
@@ -49,9 +47,7 @@ const _: () =
     {
         impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
             for SingleFieldlessEnum {
-            fn encode(&self, __encoder: &mut __E) {
-                let SingleFieldlessEnum::A = *self;
-            }
+            fn encode(&self, __encoder: &mut __E) {}
         }
     };
 

--- a/tests/ui-fulldeps/derive-encodable.stdout
+++ b/tests/ui-fulldeps/derive-encodable.stdout
@@ -1,0 +1,114 @@
+#![feature(prelude_import)]
+//@ edition: 2024
+//@ check-pass
+//@ compile-flags: -Zunpretty=expanded
+
+#![crate_type = "rlib"]
+#![feature(rustc_private)]
+extern crate std;
+#[prelude_import]
+use std::prelude::rust_2024::*;
+
+extern crate rustc_macros;
+extern crate rustc_serialize;
+extern crate rustc_span;
+
+use rustc_macros::Encodable;
+
+struct UnitStruct;
+const _: () =
+    {
+        impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
+            for UnitStruct {
+            fn encode(&self, __encoder: &mut __E) {
+                match *self { UnitStruct => {} }
+            }
+        }
+    };
+
+struct EmptyStruct {}
+const _: () =
+    {
+        impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
+            for EmptyStruct {
+            fn encode(&self, __encoder: &mut __E) {
+                match *self { EmptyStruct {} => {} }
+            }
+        }
+    };
+
+enum EmptyEnum {}
+const _: () =
+    {
+        impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
+            for EmptyEnum {
+            fn encode(&self, __encoder: &mut __E) { match *self {} }
+        }
+    };
+
+enum SingleFieldlessEnum { A, }
+const _: () =
+    {
+        impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
+            for SingleFieldlessEnum {
+            fn encode(&self, __encoder: &mut __E) {
+                match *self { SingleFieldlessEnum::A => {} }
+            }
+        }
+    };
+
+enum SingleEnum { A(u32), }
+const _: () =
+    {
+        impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
+            for SingleEnum {
+            fn encode(&self, __encoder: &mut __E) {
+                match *self {
+                    SingleEnum::A(ref __binding_0) => {
+                        ::rustc_serialize::Encodable::<__E>::encode(__binding_0,
+                            __encoder);
+                    }
+                }
+            }
+        }
+    };
+
+enum FieldlessEnum { A, B, }
+const _: () =
+    {
+        impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
+            for FieldlessEnum {
+            fn encode(&self, __encoder: &mut __E) {
+                let disc =
+                    match *self {
+                        FieldlessEnum::A => { 0usize }
+                        FieldlessEnum::B => { 1usize }
+                    };
+                ::rustc_serialize::Encoder::emit_u8(__encoder, disc as u8);
+                match *self { FieldlessEnum::A => {} FieldlessEnum::B => {} }
+            }
+        }
+    };
+
+enum PartlyFieldlessEnum { A, B(u32), }
+const _: () =
+    {
+        impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
+            for PartlyFieldlessEnum {
+            fn encode(&self, __encoder: &mut __E) {
+                let disc =
+                    match *self {
+                        PartlyFieldlessEnum::A => { 0usize }
+                        PartlyFieldlessEnum::B(ref __binding_0) => { 1usize }
+                    };
+                ::rustc_serialize::Encoder::emit_u8(__encoder, disc as u8);
+                match *self {
+                    PartlyFieldlessEnum::A => {}
+                    PartlyFieldlessEnum::B(ref __binding_0) => {
+                        ::rustc_serialize::Encodable::<__E>::encode(__binding_0,
+                            __encoder);
+                    }
+                }
+            }
+        }
+    };

--- a/tests/ui-fulldeps/derive-encodable.stdout
+++ b/tests/ui-fulldeps/derive-encodable.stdout
@@ -20,9 +20,7 @@ const _: () =
     {
         impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
             for UnitStruct {
-            fn encode(&self, __encoder: &mut __E) {
-                match *self { UnitStruct => {} }
-            }
+            fn encode(&self, __encoder: &mut __E) { let UnitStruct = *self; }
         }
     };
 
@@ -32,7 +30,7 @@ const _: () =
         impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
             for EmptyStruct {
             fn encode(&self, __encoder: &mut __E) {
-                match *self { EmptyStruct {} => {} }
+                let EmptyStruct {} = *self;
             }
         }
     };
@@ -52,7 +50,7 @@ const _: () =
         impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
             for SingleFieldlessEnum {
             fn encode(&self, __encoder: &mut __E) {
-                match *self { SingleFieldlessEnum::A => {} }
+                let SingleFieldlessEnum::A = *self;
             }
         }
     };
@@ -63,12 +61,9 @@ const _: () =
         impl<__E: ::rustc_span::SpanEncoder> ::rustc_serialize::Encodable<__E>
             for SingleEnum {
             fn encode(&self, __encoder: &mut __E) {
-                match *self {
-                    SingleEnum::A(ref __binding_0) => {
-                        ::rustc_serialize::Encodable::<__E>::encode(__binding_0,
-                            __encoder);
-                    }
-                }
+                let SingleEnum::A(ref __binding_0) = *self;
+                ::rustc_serialize::Encodable::<__E>::encode(__binding_0,
+                    __encoder);
             }
         }
     };

--- a/tests/ui-fulldeps/derive-encodable.stdout
+++ b/tests/ui-fulldeps/derive-encodable.stdout
@@ -85,7 +85,6 @@ const _: () =
                         FieldlessEnum::B => { 1usize }
                     };
                 ::rustc_serialize::Encoder::emit_u8(__encoder, disc as u8);
-                match *self { FieldlessEnum::A => {} FieldlessEnum::B => {} }
             }
         }
     };


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161137)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Few cleanups I found when investigating encoding code.

 - avoid generating match for structs
 - remove second match for enums if it is empty
 - clarify why is the enum matched twice
 - cleanup dead code and style
 
This is not super impactful but it makes the expanded code simpler, which is nice when you look at it for debugging purposes.
 Best reviewed commit by commit
 
 r? nnethercote
 (I believe you've looked into this code quite a bit before)
