### PR TITLE
Only look for attribute/keyword/primitive docs when the features are enabled

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -238,33 +238,10 @@ impl ExternalCrate {
 
     fn mapped_root_anon_consts<T>(
         &self,
-        tcx: TyCtxt<'_>,
-        f: impl Fn(DefId, TyCtxt<'_>) -> Option<(DefId, T)>,
+        _tcx: TyCtxt<'_>,
+        _f: impl Fn(DefId, TyCtxt<'_>) -> Option<(DefId, T)>,
     ) -> impl Iterator<Item = (DefId, T)> {
-        let root = self.def_id();
-
-        if root.is_local() {
-            Either::Left(
-                tcx.hir_root_module()
-                    .item_ids
-                    .iter()
-                    .filter(move |&&id| matches!(tcx.hir_item(id).kind, hir::ItemKind::Const(..)))
-                    .filter_map(move |&id| f(id.owner_id.into(), tcx)),
-            )
-        } else {
-            Either::Right(
-                tcx.module_children(root)
-                    .iter()
-                    .filter_map(|item| {
-                        if let Res::Def(DefKind::Const { is_type_const: false }, did) = item.res {
-                            Some(did)
-                        } else {
-                            None
-                        }
-                    })
-                    .filter_map(move |did| f(did, tcx)),
-            )
-        }
+        [].into_iter()
     }
 
     pub(crate) fn keywords(&self, tcx: TyCtxt<'_>) -> impl Iterator<Item = (DefId, Symbol)> {
@@ -306,7 +283,7 @@ impl ExternalCrate {
         // `#[rustc_doc_primitive]` feature is explicitly designed to only allow the
         // primitive tags to show up as the top level items in a crate.
         //
-        // Also note that this does not attempt to deal with modules tagged
+        // Also note that this does not attempt to deal with consts tagged
         // duplicately for the same primitive. This is handled later on when
         // rendering by delegating everything to a hash map.
         fn as_primitive(def_id: DefId, tcx: TyCtxt<'_>) -> Option<(DefId, PrimitiveType)> {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161142)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
