### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -21,7 +21,8 @@ use rustc_data_structures::fx::FxHashSet;
 use rustc_hir as hir;
 use rustc_middle::bug;
 use rustc_middle::mir::interpret::{
-    InterpErrorKind, InvalidMetaKind, Misalignment, Provenance, alloc_range, interp_ok,
+    InterpErrorKind, InvalidMetaKind, Misalignment, PointerArithmetic, Provenance, alloc_range,
+    interp_ok,
 };
 use rustc_middle::ty::layout::{LayoutCx, TyAndLayout};
 use rustc_middle::ty::{self, Ty};
@@ -653,9 +654,13 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
             let scalar = Scalar::from_maybe_pointer(place.ptr(), self.ecx);
             // Skip this if we don't know the absolute address (during CTFE).
             if let Ok(addr) = scalar.try_to_scalar_int() {
-                // Try to compute the end address.
-                let addr = Size::from_bytes(addr.to_target_usize(*self.ecx.tcx));
-                if addr.checked_add(size, self.ecx).is_none() {
+                // Try to compute the end address. Cannot use `Size` addition as that also applies
+                // the "max obj size" bound.
+                let addr = Size::from_bytes(addr.to_target_usize(*self.ecx.tcx)).bytes();
+                if addr
+                    .checked_add(size.bytes())
+                    .is_none_or(|result| result >= self.ecx.target_usize_max())
+                {
                     throw_validation_failure!(
                         self.path,
                         format!(

--- a/src/tools/miri/tests/pass/both_borrows/maybe_dangling.rs
+++ b/src/tools/miri/tests/pass/both_borrows/maybe_dangling.rs
@@ -13,6 +13,7 @@ fn main() {
     boxy();
     reference();
     write_through_shared_ref();
+    large();
 }
 
 fn boxy() {
@@ -57,4 +58,9 @@ fn write_through_shared_ref() {
             y.write(1);
         }
     }
+}
+
+fn large() {
+    // Used to be rejected due to faulty logic for the "does this fit the address space" check.
+    let _x: MaybeDangling<&i8> = unsafe { mem::transmute(usize::MAX - 127) };
 }

--- a/tests/ui/assumptions_on_binders/missing-placeholder-assumptions-issue-159890.rs
+++ b/tests/ui/assumptions_on_binders/missing-placeholder-assumptions-issue-159890.rs
@@ -1,0 +1,34 @@
+//@ edition: 2024
+//@ compile-flags: -Znext-solver=globally -Zassumptions-on-binders
+//@ check-fail
+
+trait FutureIterator: 'static {
+    type Future<'s, 'cx>: Future + Send + 'cx;
+}
+
+trait IterCaller: 'static {
+    type Future2<'cx>: Future + 'cx;
+
+    fn call_2() {}
+}
+
+struct UseIter<FI1, FI2> {
+    fi_1: FI1,
+    fi_2: FI2,
+}
+
+impl<FI1, FI2: 'static> IterCaller for UseIter<FI1, FI2>
+//~^ ERROR not all trait items implemented
+where
+    FI1: FutureIterator + 'static + Send,
+    for<'s, 'cx> FI1::Future<'s, 'cx>: Send,
+{
+    fn call_2<'s, 'cx>() -> Self::Future2<'cx>
+    //~^ ERROR lifetime parameters or bounds on associated function `call_2` do not match
+    where
+        's: 'cx,
+    {
+    }
+}
+
+fn main() {}

--- a/tests/ui/assumptions_on_binders/missing-placeholder-assumptions-issue-159890.stderr
+++ b/tests/ui/assumptions_on_binders/missing-placeholder-assumptions-issue-159890.stderr
@@ -1,0 +1,30 @@
+error[E0195]: lifetime parameters or bounds on associated function `call_2` do not match the trait declaration
+  --> $DIR/missing-placeholder-assumptions-issue-159890.rs:26:14
+   |
+LL |       fn call_2() {}
+   |                - lifetimes in impl do not match this associated function in trait
+...
+LL |       fn call_2<'s, 'cx>() -> Self::Future2<'cx>
+   |                ^^^^^^^^^ lifetimes do not match associated function in trait
+LL |
+LL | /     where
+LL | |         's: 'cx,
+   | |________________- this `where` clause might not match the one in the trait
+
+error[E0046]: not all trait items implemented, missing: `Future2`
+  --> $DIR/missing-placeholder-assumptions-issue-159890.rs:20:1
+   |
+LL |       type Future2<'cx>: Future + 'cx;
+   |       ------------------------------- `Future2` from trait
+...
+LL | / impl<FI1, FI2: 'static> IterCaller for UseIter<FI1, FI2>
+LL | |
+LL | | where
+LL | |     FI1: FutureIterator + 'static + Send,
+LL | |     for<'s, 'cx> FI1::Future<'s, 'cx>: Send,
+   | |____________________________________________^ missing `Future2` in implementation
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0046, E0195.
+For more information about an error, try `rustc --explain E0046`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#161125 (fix buggy MaybeDangling<&T> validation logic)
 - rust-lang/rust#159971 (Add regression test for rust-lang/rust#159890)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=161125,159971)
<!-- homu-ignore:end -->

