### PR TITLE
Remove references to the obsolete `try-perf` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ on:
       - automation/bors/auto
       - automation/bors/try
       - automation/bors/try-perf
-      - try-perf
   pull_request:
     branches:
       - "**"
@@ -33,9 +32,9 @@ defaults:
 concurrency:
   # For a given workflow, if we push to the same branch, cancel all previous builds on that branch.
   # We add an exception for try builds (automation/bors/try branch) and unrolled rollup builds
-  # (try-perf), which are all triggered on the same branch, but which should be able to run
-  # concurrently.
-  group: ${{ github.workflow }}-${{ ((github.ref == 'refs/heads/try-perf' || github.ref == 'refs/heads/automation/bors/try-perf' || github.ref == 'refs/heads/automation/bors/try') && github.sha) || github.ref }}
+  # (automation/bors/try-perf), which are all triggered on the same branch, but which should be able
+  # to run concurrently.
+  group: ${{ github.workflow }}-${{ ((github.ref == 'refs/heads/automation/bors/try-perf' || github.ref == 'refs/heads/automation/bors/try') && github.sha) || github.ref }}
   cancel-in-progress: true
 env:
   TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
@@ -80,7 +79,7 @@ jobs:
     # access the environment.
     #
     # We only enable the environment for the rust-lang/rust repository, so that CI works on forks.
-    environment: ${{ ((github.repository == 'rust-lang/rust' && (github.ref == 'refs/heads/try-perf' || github.ref == 'refs/heads/automation/bors/try' || github.ref == 'refs/heads/automation/bors/try-perf' || github.ref == 'refs/heads/automation/bors/auto')) && 'bors') || '' }}
+    environment: ${{ ((github.repository == 'rust-lang/rust' && (github.ref == 'refs/heads/automation/bors/try' || github.ref == 'refs/heads/automation/bors/try-perf' || github.ref == 'refs/heads/automation/bors/auto')) && 'bors') || '' }}
     env:
       CI_JOB_NAME: ${{ matrix.name }}
       CI_JOB_DOC_URL: ${{ matrix.doc_url }}

--- a/src/ci/citool/src/main.rs
+++ b/src/ci/citool/src/main.rs
@@ -46,7 +46,7 @@ impl GitHubContext {
     fn get_run_type(&self) -> Option<RunType> {
         match (self.event_name.as_str(), self.branch_ref.as_str()) {
             ("pull_request", _) => Some(RunType::PullRequest),
-            ("push", "refs/heads/automation/bors/try-perf" | "refs/heads/try-perf") => {
+            ("push", "refs/heads/automation/bors/try-perf") => {
                 Some(RunType::TryJob { job_patterns: None, nolimit: false })
             }
             ("push", "refs/heads/automation/bors/try") => {

--- a/src/ci/scripts/verify-channel.sh
+++ b/src/ci/scripts/verify-channel.sh
@@ -8,7 +8,7 @@ IFS=$'\n\t'
 
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
-if isCiBranch try-perf || isCiBranch automation/bors/try-perf || \
+if isCiBranch automation/bors/try-perf || \
    isCiBranch automation/bors/try || isCiBranch automation/bors/auto; then
     echo "channel verification is only executed on PR builds"
     exit


### PR DESCRIPTION
This is no longer needed after https://github.com/rust-lang/rustc-perf/pull/2524.