### PR TITLE
Switch to c8a EC2 runner for auto merges

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -312,7 +312,7 @@ auto:
   - name: dist-x86_64-illumos
     <<: *job-linux-4c
 
-  - <<: [*job-dist-x86_64-linux, *job-linux-36c-codebuild]
+  - <<: [*job-dist-x86_64-linux, *job-linux-32c-ec2]
 
   - name: dist-x86_64-linux-alt
     env:


### PR DESCRIPTION
I *think* this is the only line that needs changing to switch? I expect we'll want to clean up the codebuild stuff, but I think it makes sense to leave it in place until this has merged successfully and run for a few weeks.

r? Kobzol