### PR TITLE
Treat vars created for opaque subtyping as live everywhere

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -144,7 +144,31 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
                 variance,
                 ty,
             )?;
-            Ok(infcx.resolve_vars_if_possible(Ty::new_infer(infcx.tcx, ty::TyVar(ty_vid))))
+            let new_var =
+                infcx.resolve_vars_if_possible(Ty::new_infer(infcx.tcx, ty::TyVar(ty_vid)));
+
+            // Any regions in this new type must be live everywhere, so we mark them as such.
+            // (It may be that it only needs to be live where the opaque type itself is - which
+            // includes defining use sites, but we'll be conservative and mark all points as live).
+            // This is needed for Polonius, which doesn't propagate constraints
+            // through dead regions. See issue #160669.
+            //
+            // We only do this in the root universe. Inside a binder these regions live in a higher
+            // universe and their values contain placeholders; marking them live at every point
+            // leaks those placeholders, turning the higher-ranked check into an error which then
+            // suppresses the deferred opaque type diagnostics.
+            if infcx.universe() == ty::UniverseIndex::ROOT {
+                let tcx = infcx.tcx;
+                let liveness = &mut self.type_checker.constraints.liveness_constraints;
+                ty::fold_regions(tcx, new_var, |r, _| {
+                    if let ty::ReVar(vid) = r.kind() {
+                        liveness.add_all_points(vid);
+                    }
+                    r
+                });
+            }
+
+            Ok(new_var)
         };
 
         let (a, b) = match (a.kind(), b.kind()) {

--- a/tests/ui/nll/polonius/opaque-multiple-defining-uses-160669.next.stderr
+++ b/tests/ui/nll/polonius/opaque-multiple-defining-uses-160669.next.stderr
@@ -1,0 +1,69 @@
+error[E0597]: `local` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:31:16
+   |
+LL |         let local = String::from("dangling");
+   |             ----- binding `local` declared here
+LL |         return &local;
+   |                ^^^^^^ borrowed value does not live long enough
+LL |     }
+   |     - `local` dropped here while still borrowed
+LL |     s
+LL | }
+   |  - borrow later used here
+
+error[E0597]: `local` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:41:16
+   |
+LL |         let local = String::from("dangling0");
+   |             ----- binding `local` declared here
+LL |         return &local;
+   |                ^^^^^^ borrowed value does not live long enough
+LL |     }
+   |     - `local` dropped here while still borrowed
+...
+LL | }
+   |  - borrow later used here
+
+error[E0597]: `local` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:45:16
+   |
+LL |         let local = String::from("dangling1");
+   |             ----- binding `local` declared here
+LL |         return &local;
+   |                ^^^^^^ borrowed value does not live long enough
+LL |     }
+   |     - `local` dropped here while still borrowed
+LL |     s
+LL | }
+   |  - borrow later used here
+
+error[E0597]: `local` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:57:5
+   |
+LL |     let local = String::from("dangling");
+   |         ----- binding `local` declared here
+LL |     &local
+   |     ^^^^^^ borrowed value does not live long enough
+LL | }
+   | -- borrow later used here
+   | |
+   | `local` dropped here while still borrowed
+
+error[E0597]: `short` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:64:16
+   |
+LL | fn minimal(short: (), out: &'static ()) -> impl Sized {
+   |            ----- binding `short` declared here
+LL |     if true {
+LL |         return &short;
+   |                ^^^^^^ borrowed value does not live long enough
+...
+LL | }
+   |  -
+   |  |
+   |  `short` dropped here while still borrowed
+   |  borrow later used here
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/nll/polonius/opaque-multiple-defining-uses-160669.nll.stderr
+++ b/tests/ui/nll/polonius/opaque-multiple-defining-uses-160669.nll.stderr
@@ -1,0 +1,80 @@
+error[E0597]: `local` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:31:16
+   |
+LL | fn two_uses<'a>(s: &'a String, flag: bool) -> impl Display + use<'a> {
+   |             -- lifetime `'a` defined here
+LL |     if flag {
+LL |         let local = String::from("dangling");
+   |             ----- binding `local` declared here
+LL |         return &local;
+   |                ^^^^^^ borrowed value does not live long enough
+LL |     }
+   |     - `local` dropped here while still borrowed
+LL |     s
+   |     - opaque type requires that `local` is borrowed for `'a`
+
+error[E0597]: `local` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:41:16
+   |
+LL | fn three_uses<'a>(s: &'a String, flag: u8) -> impl Display + use<'a> {
+   |               -- lifetime `'a` defined here
+LL |     if flag == 0 {
+LL |         let local = String::from("dangling0");
+   |             ----- binding `local` declared here
+LL |         return &local;
+   |                ^^^^^^ borrowed value does not live long enough
+LL |     }
+   |     - `local` dropped here while still borrowed
+...
+LL |         return &local;
+   |                ------ opaque type requires that `local` is borrowed for `'a`
+
+error[E0597]: `local` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:45:16
+   |
+LL | fn three_uses<'a>(s: &'a String, flag: u8) -> impl Display + use<'a> {
+   |               -- lifetime `'a` defined here
+...
+LL |         let local = String::from("dangling1");
+   |             ----- binding `local` declared here
+LL |         return &local;
+   |                ^^^^^^
+   |                |
+   |                borrowed value does not live long enough
+   |                opaque type requires that `local` is borrowed for `'a`
+LL |     }
+   |     - `local` dropped here while still borrowed
+
+error[E0597]: `local` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:57:5
+   |
+LL | fn reversed_order<'a>(s: &'a String, flag: bool) -> impl Display + use<'a> {
+   |                   -- lifetime `'a` defined here
+...
+LL |     let local = String::from("dangling");
+   |         ----- binding `local` declared here
+LL |     &local
+   |     ^^^^^^
+   |     |
+   |     borrowed value does not live long enough
+   |     opaque type requires that `local` is borrowed for `'a`
+LL | }
+   | - `local` dropped here while still borrowed
+
+error[E0597]: `short` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:64:16
+   |
+LL | fn minimal(short: (), out: &'static ()) -> impl Sized {
+   |            ----- binding `short` declared here
+LL |     if true {
+LL |         return &short;
+   |                ^^^^^^ borrowed value does not live long enough
+LL |     }
+LL |     out
+   |     --- opaque type requires that `short` is borrowed for `'static`
+LL | }
+   |  - `short` dropped here while still borrowed
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/nll/polonius/opaque-multiple-defining-uses-160669.polonius.stderr
+++ b/tests/ui/nll/polonius/opaque-multiple-defining-uses-160669.polonius.stderr
@@ -1,0 +1,80 @@
+error[E0597]: `local` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:31:16
+   |
+LL | fn two_uses<'a>(s: &'a String, flag: bool) -> impl Display + use<'a> {
+   |             -- lifetime `'a` defined here
+LL |     if flag {
+LL |         let local = String::from("dangling");
+   |             ----- binding `local` declared here
+LL |         return &local;
+   |                ^^^^^^ borrowed value does not live long enough
+LL |     }
+   |     - `local` dropped here while still borrowed
+LL |     s
+   |     - opaque type requires that `local` is borrowed for `'a`
+
+error[E0597]: `local` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:41:16
+   |
+LL | fn three_uses<'a>(s: &'a String, flag: u8) -> impl Display + use<'a> {
+   |               -- lifetime `'a` defined here
+LL |     if flag == 0 {
+LL |         let local = String::from("dangling0");
+   |             ----- binding `local` declared here
+LL |         return &local;
+   |                ^^^^^^ borrowed value does not live long enough
+LL |     }
+   |     - `local` dropped here while still borrowed
+...
+LL |         return &local;
+   |                ------ opaque type requires that `local` is borrowed for `'a`
+
+error[E0597]: `local` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:45:16
+   |
+LL | fn three_uses<'a>(s: &'a String, flag: u8) -> impl Display + use<'a> {
+   |               -- lifetime `'a` defined here
+...
+LL |         let local = String::from("dangling1");
+   |             ----- binding `local` declared here
+LL |         return &local;
+   |                ^^^^^^
+   |                |
+   |                borrowed value does not live long enough
+   |                opaque type requires that `local` is borrowed for `'a`
+LL |     }
+   |     - `local` dropped here while still borrowed
+
+error[E0597]: `local` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:57:5
+   |
+LL | fn reversed_order<'a>(s: &'a String, flag: bool) -> impl Display + use<'a> {
+   |                   -- lifetime `'a` defined here
+...
+LL |     let local = String::from("dangling");
+   |         ----- binding `local` declared here
+LL |     &local
+   |     ^^^^^^
+   |     |
+   |     borrowed value does not live long enough
+   |     opaque type requires that `local` is borrowed for `'a`
+LL | }
+   | - `local` dropped here while still borrowed
+
+error[E0597]: `short` does not live long enough
+  --> $DIR/opaque-multiple-defining-uses-160669.rs:64:16
+   |
+LL | fn minimal(short: (), out: &'static ()) -> impl Sized {
+   |            ----- binding `short` declared here
+LL |     if true {
+LL |         return &short;
+   |                ^^^^^^ borrowed value does not live long enough
+LL |     }
+LL |     out
+   |     --- opaque type requires that `short` is borrowed for `'static`
+LL | }
+   |  - `short` dropped here while still borrowed
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/nll/polonius/opaque-multiple-defining-uses-160669.rs
+++ b/tests/ui/nll/polonius/opaque-multiple-defining-uses-160669.rs
@@ -1,0 +1,69 @@
+// An opaque type has a single hidden type, and the opaque type storage only keeps a
+// single hidden type per key. So, a second defining use replaces the first.
+//
+// In the old solver, MIR is built with unnormalized opaques; and, a defining use
+// is generalized prior to being registered as the hidden type, to allow for
+// subtyping.
+//
+// During this generalization, any regions created were previously not
+// considered live, which means that under Polonius Alpha, outlives constraints
+// were not propogated between a previous hidden type and a new one.
+//
+// We now consider all these lifetimes live at all points.
+//
+// In the new solver, this is all moot, because MIR has *normalized* opaques,
+// and so there is no special subtyping code.
+//
+// Regression test for #160669.
+
+//@ ignore-compare-mode-polonius (explicit revisions)
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ revisions: nll polonius next
+//@ [nll] compile-flags: -Z polonius=off
+//@ [polonius] compile-flags: -Z polonius=next
+//@ [next] compile-flags: -Z next-solver -Z polonius=next
+
+use std::fmt::Display;
+
+fn two_uses<'a>(s: &'a String, flag: bool) -> impl Display + use<'a> {
+    if flag {
+        let local = String::from("dangling");
+        return &local; //~ ERROR `local` does not live long enough
+    }
+    s
+}
+
+// The same, with a borrow of a local in multiple branchs, to check that we
+// don't only report the defining use which happens to be last in MIR order.
+fn three_uses<'a>(s: &'a String, flag: u8) -> impl Display + use<'a> {
+    if flag == 0 {
+        let local = String::from("dangling0");
+        return &local; //~ ERROR `local` does not live long enough
+    }
+    if flag == 1 {
+        let local = String::from("dangling1");
+        return &local; //~ ERROR `local` does not live long enough
+    }
+    s
+}
+
+// Control for the order dependence: here the bad defining use is the last one in MIR order,
+// so it stayed anchored and was caught even before the fix.
+fn reversed_order<'a>(s: &'a String, flag: bool) -> impl Display + use<'a> {
+    if flag {
+        return s;
+    }
+    let local = String::from("dangling");
+    &local //~ ERROR `local` does not live long enough
+}
+
+// This is a much more minimal MIR representation of the same bug. Useful for
+// debugging.
+fn minimal(short: (), out: &'static ()) -> impl Sized {
+    if true {
+        return &short; //~ ERROR `short` does not live long enough
+    }
+    out
+}
+
+fn main() {}

--- a/tests/ui/suggestions/lifetimes/explicit-lifetime-suggestion-in-proper-span-issue-121267.rs
+++ b/tests/ui/suggestions/lifetimes/explicit-lifetime-suggestion-in-proper-span-issue-121267.rs
@@ -8,6 +8,7 @@ fn bar(src: &crate::Foo) -> impl Iterator<Item = i32> {
     [0].into_iter()
  //~^ ERROR hidden type for `impl Iterator<Item = i32>` captures lifetime that does not appear in bounds
         .filter_map(|_| foo(src))
+        //~^ ERROR `src` does not live long enough
 }
 
 struct Foo<'a>(&'a str);

--- a/tests/ui/suggestions/lifetimes/explicit-lifetime-suggestion-in-proper-span-issue-121267.stderr
+++ b/tests/ui/suggestions/lifetimes/explicit-lifetime-suggestion-in-proper-span-issue-121267.stderr
@@ -10,6 +10,21 @@ LL | |         .filter_map(|_| foo(src))
    |
    = note: hidden type `FilterMap<Iter<'_, i32>, {closure@...}>` captures lifetime `'_`
 
-error: aborting due to 1 previous error
+error[E0597]: `src` does not live long enough
+  --> $DIR/explicit-lifetime-suggestion-in-proper-span-issue-121267.rs:10:29
+   |
+LL | fn bar(src: &crate::Foo) -> impl Iterator<Item = i32> {
+   |        --- binding `src` declared here
+...
+LL |         .filter_map(|_| foo(src))
+   |                     ---     ^^^ borrowed value does not live long enough
+   |                     |
+   |                     value captured here
+LL |
+LL | }
+   |  - `src` dropped here while still borrowed
 
-For more information about this error, try `rustc --explain E0700`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0597, E0700.
+For more information about an error, try `rustc --explain E0597`.


### PR DESCRIPTION
Fixes rust-lang/rust#160669

r? lqd

Let's look at a minimal variant of rust-lang/rust#160669

```rust
fn minimal(short: (), out: &'static ()) -> impl Sized {
    if true {
        return &short; //~ ERROR `short` does not live long enough
    }
    out
}
```

That has the following (simplified) MIR:

```rust
fn foo(_1: (), _2: &'?4 ()) -> Opaque(DefId(foo::{opaque#0}), []) {
    bb0: { switchInt(move _4) -> [0: bb2, otherwise: bb1]; }

    bb1: {
        _0 = &'?2 _1; // bb1[0]
        goto -> bb3;
    }

    bb2: {
        _0 = &'?3 (*_2); // bb2[3]
        goto -> bb3;
    }

    bb3: {
        return;
    }
}
```

And the following region constraints:

<img width="236" height="583" alt="image" src="https://github.com/user-attachments/assets/4c450ccd-1c5c-4a9c-a4f1-0875cf0e5553" />

Note `'?5` and `'?6`: these don't show up in the MIR graph because they arise from the `enable_subtyping` closure in [`relate_opaques`](https://github.com/rust-lang/rust/blob/c9b7f178899788fac53d942b82cf97665ee59aaa/compiler/rustc_borrowck/src/type_check/relate_tys.rs#L116). Importantly (today), these regions are related to each other (and to other regions in hidden types) *at a single point*, but **are not live at any point**.

For NLL this is not a problem (since liveness does not matter for outlives constraint propagation. For Polonius, this is an issue.

The fix here is fairly simple: consider these lifetimes live at all points. This may be an *overestimate* of liveness, but this is all code that doesn't get called with the next solver.

This is also the same reason that this is not an issue with the next solver. Opaque types are normalized in HIR typeck, so these hacky regions are never created.

There are a couple alternative fixes that I think are ultimately not as good:

1) Equate the previous hidden type with the new hidden type using `Locations::All` - when [registering the goals](https://github.com/rust-lang/rust/blob/c9b7f178899788fac53d942b82cf97665ee59aaa/compiler/rustc_borrowck/src/type_check/relate_tys.rs#L161) from equating these two, force `Locations::All` instead of `Locations::Single`.
2) [**Equate all uses, not just the final defining use, in borrowck**](https://github.com/rust-lang/rust/commit/59a4c62a0e483f7197b090980dea92e8d575d57d) - this has us store any duplicates in `insert_hidden_type`, which then get equated with the "expected" hidden type in `apply_definition_site_hidden_types` with `Locations::All`. I think this is fine, but a lot less "local" logic.

I'll note that for the next solver, we equate the hidden types with the return type in the signature with`Locations::Single`:

<img width="289" height="586" alt="image" src="https://github.com/user-attachments/assets/34d15820-06e3-4205-9278-e82465dca139" />

(note, this MIR is slightly different: `'5` is `short`'s lifetime; `'6` is the lifetime from the normalized opaque (`&'?6 ()`); `'4` is the renumbered lifetime for the MIR body)

Given that, perhaps (1) is the most faithful to the spirit of the next solver (that there is one hidden type that things get related to), but this seems like a *slightly* smaller-in-scope fix.

In any case, I think any solution here is mostly just a waiting game for the next solver.
