### PR TITLE
m68k-unknown-none-elf: Remove code model and change CPU to base MC68000

### DIFF
--- a/compiler/rustc_target/src/spec/targets/m68k_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/m68k_unknown_none_elf.rs
@@ -6,13 +6,13 @@ use crate::spec::{
 
 pub(crate) fn target() -> Target {
     let options = TargetOptions {
-        cpu: "M68010".into(),
+        cpu: "M68000".into(),
         max_atomic_width: None,
         endian: Endian::Big,
         // LLD currently does not have support for M68k
         linker: Some("m68k-linux-gnu-ld".into()),
         panic_strategy: PanicStrategy::Abort,
-        code_model: Some(CodeModel::Medium),
+        code_model: None,
         has_rpath: false,
         // should be soft-float
         llvm_floatabi: None,

--- a/compiler/rustc_target/src/spec/targets/m68k_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/m68k_unknown_none_elf.rs
@@ -1,8 +1,6 @@
 use rustc_abi::Endian;
 
-use crate::spec::{
-    Arch, CodeModel, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions,
-};
+use crate::spec::{Arch, PanicStrategy, RelocModel, Target, TargetMetadata, TargetOptions};
 
 pub(crate) fn target() -> Target {
     let options = TargetOptions {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

This PR removes the code model because [it causes issues when compiling with `rustc_codegen_gcc`](https://github.com/rust-lang/rustc_codegen_gcc/pull/958) (the code model option doesn't exist in GCC for m68k), and changes the CPU from `M68010` to `M68000`, since it seems like an arbitrary CPU choice over the first CPU in the Motorola 68000 series that the compiler can compile for

r? @knickish 