### PR TITLE
mir: accept ambiguous unsize coercion validation results

### DIFF
--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -598,7 +598,11 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         crate::util::relate_types(self.tcx, self.typing_env, variance, src, dest)
     }
 
-    /// Check that the given predicate definitely holds in the param-env of this MIR body.
+    /// Check that the given predicate is not provably false in the param-env of this MIR body.
+    ///
+    /// We deliberately accept ambiguous and cycle results, such as post-monomorphization cycles,
+    /// mirroring the behavior of `impossible_clauses` which also only rejects definite failures.
+    /// See <https://github.com/rust-lang/rust/issues/155538>.
     fn predicate_must_hold_modulo_regions(
         &self,
         pred: impl Upcast<TyCtxt<'tcx>, ty::Predicate<'tcx>>,
@@ -622,7 +626,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             param_env,
             pred,
         ));
-        ocx.evaluate_obligations_error_on_ambiguity().no_errors()
+        let errors = ocx.try_evaluate_obligations();
+        errors.as_slice().iter().all(|error| !error.is_true_error())
     }
 }
 

--- a/tests/ui/mir/validate/validate-unsize-cast-cycle.rs
+++ b/tests/ui/mir/validate/validate-unsize-cast-cycle.rs
@@ -1,0 +1,27 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/155538>.
+//
+// This must be a full build test: `check-pass` only emits metadata and
+// therefore does not run the post-mono MIR validator that this ICEs in.
+//@ build-pass
+
+trait Apply {
+    type Output<T: Trait>: Trait;
+}
+struct Identity;
+impl Apply for Identity {
+    type Output<T: Trait> = T;
+}
+
+struct Thing<A: Apply>(A);
+
+trait Trait {}
+
+impl<A: Apply> Trait for Thing<A> where <A as Apply>::Output<Self>: Trait {}
+
+fn weird<A: Apply>(x: A) -> impl Trait {
+    Thing(x)
+}
+
+fn main() {
+    let _ = Box::new(weird(Identity)) as Box<dyn Trait>;
+}


### PR DESCRIPTION
Fixes rust-lang/rust#155538
MIR validator might ICE on unsize coercion after monomorphization because the obligation may fall into a cycle, but that doesn't make coercion invalid. 
Modified the test report only definitive errors and accept cycle results also added a test for the ICE bug.
