### PR TITLE
Wrap Terminator::attributes in Option

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -1644,9 +1644,13 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 MergingSucc::False
             }
 
-            mir::TerminatorKind::Goto { target } => {
-                helper.funclet_br(self, bx, target, mergeable_succ(), &terminator.attributes)
-            }
+            mir::TerminatorKind::Goto { target } => helper.funclet_br(
+                self,
+                bx,
+                target,
+                mergeable_succ(),
+                terminator.attributes.as_ref().map(|v| v.as_slice()).unwrap_or_default(),
+            ),
 
             mir::TerminatorKind::SwitchInt { ref discr, ref targets } => {
                 self.codegen_switchint_terminator(helper, bx, discr, targets);

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -418,7 +418,7 @@ impl<O: fmt::Debug> fmt::Display for AssertKind<O> {
 pub struct Terminator<'tcx> {
     pub source_info: SourceInfo,
     pub kind: TerminatorKind<'tcx>,
-    pub attributes: ThinVec<AttributeKind>,
+    pub attributes: Option<ThinVec<AttributeKind>>,
 }
 
 impl<'tcx> Terminator<'tcx> {

--- a/compiler/rustc_mir_build/src/builder/cfg.rs
+++ b/compiler/rustc_mir_build/src/builder/cfg.rs
@@ -1,6 +1,5 @@
 //! Routines for manipulating the control-flow graph.
 
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 use tracing::debug;
@@ -132,7 +131,7 @@ impl<'tcx> CFG<'tcx> {
             self.block_data(block)
         );
         self.block_data_mut(block).terminator =
-            Some(Terminator { source_info, kind, attributes: ThinVec::new() });
+            Some(Terminator { source_info, kind, attributes: None });
         self.block_data_mut(block).terminator.as_mut().unwrap()
     }
 

--- a/compiler/rustc_mir_build/src/builder/custom/parse.rs
+++ b/compiler/rustc_mir_build/src/builder/custom/parse.rs
@@ -1,4 +1,3 @@
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_index::IndexSlice;
 use rustc_middle::mir::*;
 use rustc_middle::thir::*;
@@ -319,7 +318,7 @@ impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
         data.terminator = Some(Terminator {
             source_info: SourceInfo { span, scope: self.source_scope },
             kind: terminator,
-            attributes: ThinVec::new(),
+            attributes: None,
         });
 
         Ok(data)

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -238,7 +238,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                     let goto = this.cfg.goto(body_block_end, source_info, loop_block);
                     if let Some(attrs) = this.thir.attributes.get(&expr_id) {
-                        goto.attributes = attrs.clone();
+                        goto.attributes = Some(attrs.clone());
                     }
 
                     // Loops are only exited by `break` expressions.

--- a/compiler/rustc_mir_dataflow/src/framework/tests.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/tests.rs
@@ -22,7 +22,7 @@ fn mock_body<'tcx>() -> mir::Body<'tcx> {
 
         blocks.push(mir::BasicBlockData::new_stmts(
             std::iter::repeat(&nop).cloned().take(n).collect(),
-            Some(mir::Terminator { source_info, kind, attributes: ThinVec::new() }),
+            Some(mir::Terminator { source_info, kind, attributes: None }),
             false,
         ))
     };

--- a/compiler/rustc_mir_transform/src/add_call_guards.rs
+++ b/compiler/rustc_mir_transform/src/add_call_guards.rs
@@ -15,7 +15,6 @@
 //!
 //! NOTE: Simplify CFG will happily undo most of the work this pass does.
 
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_index::{Idx, IndexVec};
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
@@ -92,7 +91,7 @@ impl<'tcx> crate::MirPass<'tcx> for AddCallGuards {
                 Some(Terminator {
                     source_info,
                     kind: TerminatorKind::Goto { target },
-                    attributes: ThinVec::new(),
+                    attributes: None,
                 }),
                 is_cleanup,
             );

--- a/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
+++ b/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
@@ -1,4 +1,3 @@
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, TyCtxt};
 use tracing::debug;
@@ -95,11 +94,7 @@ fn add_move_for_packed_drop<'tcx>(
 
     let storage_dead_block = patch.new_block(BasicBlockData::new_stmts(
         vec![Statement::new(source_info, StatementKind::StorageDead(temp))],
-        Some(Terminator {
-            source_info,
-            kind: TerminatorKind::Goto { target },
-            attributes: ThinVec::new(),
-        }),
+        Some(Terminator { source_info, kind: TerminatorKind::Goto { target }, attributes: None }),
         is_cleanup,
     ));
 

--- a/compiler/rustc_mir_transform/src/check_enums.rs
+++ b/compiler/rustc_mir_transform/src/check_enums.rs
@@ -1,5 +1,4 @@
 use rustc_abi::{Scalar, Size, TagEncoding, Variants, WrappingRange};
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_index::IndexVec;
 use rustc_middle::bug;
@@ -65,7 +64,7 @@ impl<'tcx> crate::MirPass<'tcx> for CheckEnums {
                             basic_blocks[block].terminator = Some(Terminator {
                                 source_info,
                                 kind: TerminatorKind::Goto { target: new_block },
-                                attributes: ThinVec::new(),
+                                attributes: None,
                             });
                         }
                         EnumCheckType::Direct { source_op, discr, op_size, valid_discrs } => {
@@ -396,7 +395,7 @@ fn insert_direct_enum_check<'tcx>(
                 invalid_discr_block,
             ),
         },
-        attributes: ThinVec::new(),
+        attributes: None,
     });
 
     // Abort in case of an invalid enum discriminant.
@@ -416,7 +415,7 @@ fn insert_direct_enum_check<'tcx>(
             // make a failing UB check turn into much worse UB when we start unwinding.
             unwind: UnwindAction::Unreachable,
         },
-        attributes: ThinVec::new(),
+        attributes: None,
     });
 }
 
@@ -462,7 +461,7 @@ fn insert_uninhabited_enum_check<'tcx>(
             // make a failing UB check turn into much worse UB when we start unwinding.
             unwind: UnwindAction::Unreachable,
         },
-        attributes: ThinVec::new(),
+        attributes: None,
     });
 }
 
@@ -540,6 +539,6 @@ fn insert_niche_check<'tcx>(
             // make a failing UB check turn into much worse UB when we start unwinding.
             unwind: UnwindAction::Unreachable,
         },
-        attributes: ThinVec::new(),
+        attributes: None,
     });
 }

--- a/compiler/rustc_mir_transform/src/check_pointers.rs
+++ b/compiler/rustc_mir_transform/src/check_pointers.rs
@@ -1,4 +1,3 @@
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_index::IndexVec;
 use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor};
@@ -117,7 +116,7 @@ pub(crate) fn check_pointers<'tcx, F>(
                         // worse UB when we start unwinding.
                         unwind: UnwindAction::Unreachable,
                     },
-                    attributes: ThinVec::new(),
+                    attributes: None,
                 });
             }
         }

--- a/compiler/rustc_mir_transform/src/coroutine/drop.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/drop.rs
@@ -359,7 +359,7 @@ pub(super) fn create_coroutine_drop_shim_proxy_async<'tcx>(
         drop: None,
     };
     body.basic_blocks_mut()[call_bb].terminator =
-        Some(Terminator { source_info, kind, attributes: ThinVec::new() });
+        Some(Terminator { source_info, kind, attributes: None });
 
     // Run derefer to fix Derefs that are not in the first place
     deref_finder(tcx, &mut body, false);

--- a/compiler/rustc_mir_transform/src/coroutine/mod.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/mod.rs
@@ -63,7 +63,6 @@ use drop::{
 pub(super) use layout::mir_coroutine_witnesses;
 use layout::{CoroutineSavedLocals, compute_layout, locals_live_across_suspend_points};
 use rustc_abi::{FieldIdx, VariantIdx};
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::{self as hir, CoroutineDesugaring, CoroutineKind};
 use rustc_index::bit_set::{BitMatrix, DenseBitSet, GrowableBitSet};
@@ -253,11 +252,7 @@ impl<'tcx> TransformVisitor<'tcx> {
 
         body.basic_blocks_mut().push(BasicBlockData::new_stmts(
             statements,
-            Some(Terminator {
-                source_info,
-                kind: TerminatorKind::Return,
-                attributes: ThinVec::new(),
-            }),
+            Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: None }),
             false,
         ));
 
@@ -743,16 +738,14 @@ fn insert_switch<'tcx>(
     body.basic_blocks_mut()[START_BLOCK].terminator = Some(Terminator {
         source_info: SourceInfo::outermost(body.span),
         kind: switch,
-        attributes: ThinVec::new(),
+        attributes: None,
     });
 }
 
 fn insert_term_block<'tcx>(body: &mut Body<'tcx>, kind: TerminatorKind<'tcx>) -> BasicBlock {
     let source_info = SourceInfo::outermost(body.span);
-    body.basic_blocks_mut().push(BasicBlockData::new(
-        Some(Terminator { source_info, kind, attributes: ThinVec::new() }),
-        false,
-    ))
+    body.basic_blocks_mut()
+        .push(BasicBlockData::new(Some(Terminator { source_info, kind, attributes: None }), false))
 }
 
 fn return_poll_ready_assign<'tcx>(tcx: TyCtxt<'tcx>, source_info: SourceInfo) -> Statement<'tcx> {
@@ -775,7 +768,7 @@ fn insert_poll_ready_block<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) -> Ba
     let source_info = SourceInfo::outermost(body.span);
     body.basic_blocks_mut().push(BasicBlockData::new_stmts(
         [return_poll_ready_assign(tcx, source_info)].to_vec(),
-        Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: ThinVec::new() }),
+        Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: None }),
         false,
     ))
 }
@@ -830,12 +823,7 @@ fn generate_poison_block_and_redirect_unwinds_there<'tcx>(
     let source_info = SourceInfo::outermost(body.span);
     let poison_block = body.basic_blocks_mut().push(BasicBlockData::new_stmts(
         vec![transform.set_discr(VariantIdx::new(CoroutineArgs::POISONED), source_info)],
-        Some(Terminator {
-            source_info,
-            kind: TerminatorKind::UnwindResume,
-
-            attributes: ThinVec::new(),
-        }),
+        Some(Terminator { source_info, kind: TerminatorKind::UnwindResume, attributes: None }),
         true,
     ));
 
@@ -850,7 +838,7 @@ fn generate_poison_block_and_redirect_unwinds_there<'tcx>(
                     source_info,
                     kind: TerminatorKind::Goto { target: poison_block },
 
-                    attributes: ThinVec::new(),
+                    attributes: None,
                 };
             }
         } else if !block.is_cleanup
@@ -1018,7 +1006,7 @@ fn create_cases<'tcx>(
                         source_info,
                         kind: TerminatorKind::Goto { target },
 
-                        attributes: ThinVec::new(),
+                        attributes: None,
                     }),
                     false,
                 ));

--- a/compiler/rustc_mir_transform/src/coverage/tests.rs
+++ b/compiler/rustc_mir_transform/src/coverage/tests.rs
@@ -73,7 +73,7 @@ impl<'tcx> MockBlocks<'tcx> {
             Some(Terminator {
                 source_info: SourceInfo::outermost(Span::with_root_ctxt(next_lo, next_hi)),
                 kind,
-                attributes: ThinVec::new(),
+                attributes: None,
             }),
             false,
         ))

--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -1,6 +1,5 @@
 use std::fmt::Debug;
 
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{Ty, TyCtxt};
 use tracing::trace;
@@ -175,7 +174,7 @@ impl<'tcx> crate::MirPass<'tcx> for EarlyOtherwiseBranch {
                         discr: parent_op,
                         targets: eq_targets,
                     },
-                    attributes: ThinVec::new(),
+                    attributes: None,
                 }),
                 bbs[parent].is_cleanup,
             );

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -2,7 +2,6 @@ use std::{fmt, iter, mem};
 
 use itertools::Itertools;
 use rustc_abi::{FIRST_VARIANT, FieldIdx, VariantIdx};
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::{CoroutineDesugaring, CoroutineKind};
 use rustc_index::Idx;
@@ -1641,7 +1640,7 @@ where
     #[instrument(level = "trace", skip(self), ret)]
     fn new_block(&mut self, unwind: Unwind, k: TerminatorKind<'tcx>) -> BasicBlock {
         self.elaborator.patch().new_block(BasicBlockData::new(
-            Some(Terminator { source_info: self.source_info, kind: k, attributes: ThinVec::new() }),
+            Some(Terminator { source_info: self.source_info, kind: k, attributes: None }),
             unwind.is_cleanup(),
         ))
     }
@@ -1655,7 +1654,7 @@ where
     ) -> BasicBlock {
         self.elaborator.patch().new_block(BasicBlockData::new_stmts(
             statements,
-            Some(Terminator { source_info: self.source_info, kind: k, attributes: ThinVec::new() }),
+            Some(Terminator { source_info: self.source_info, kind: k, attributes: None }),
             unwind.is_cleanup(),
         ))
     }

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -4,7 +4,6 @@ use std::ops::{Range, RangeFrom};
 use std::{debug_assert_matches, iter};
 
 use rustc_abi::{ExternAbi, FieldIdx};
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::attrs::{InlineAttr, OptimizeAttr};
 use rustc_hir::def::DefKind;
@@ -872,7 +871,7 @@ fn inline_call<'tcx, I: Inliner<'tcx>>(
             Some(Terminator {
                 source_info: terminator.source_info,
                 kind: TerminatorKind::Goto { target: block },
-                attributes: ThinVec::new(),
+                attributes: None,
             }),
             caller_body[block].is_cleanup,
         );
@@ -1011,7 +1010,7 @@ fn inline_call<'tcx, I: Inliner<'tcx>>(
     caller_body[callsite.block].terminator = Some(Terminator {
         source_info: callsite.source_info,
         kind: TerminatorKind::Goto { target: integrator.map_block(START_BLOCK) },
-        attributes: ThinVec::new(),
+        attributes: None,
     });
 
     // Copy required constants from the callee_body into the caller_body. Although we are only

--- a/compiler/rustc_mir_transform/src/patch.rs
+++ b/compiler/rustc_mir_transform/src/patch.rs
@@ -1,5 +1,4 @@
 use rustc_data_structures::fx::FxHashMap;
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_index::Idx;
 use rustc_middle::mir::*;
 use rustc_middle::ty::Ty;
@@ -93,7 +92,7 @@ impl<'tcx> MirPatch<'tcx> {
             Some(Terminator {
                 source_info: SourceInfo::outermost(self.body_span),
                 kind: TerminatorKind::UnwindResume,
-                attributes: ThinVec::new(),
+                attributes: None,
             }),
             true,
         ));
@@ -110,7 +109,7 @@ impl<'tcx> MirPatch<'tcx> {
             Some(Terminator {
                 source_info: SourceInfo::outermost(self.body_span),
                 kind: TerminatorKind::Unreachable,
-                attributes: ThinVec::new(),
+                attributes: None,
             }),
             true,
         ));
@@ -127,7 +126,7 @@ impl<'tcx> MirPatch<'tcx> {
             Some(Terminator {
                 source_info: SourceInfo::outermost(self.body_span),
                 kind: TerminatorKind::Unreachable,
-                attributes: ThinVec::new(),
+                attributes: None,
             }),
             false,
         ));
@@ -146,7 +145,7 @@ impl<'tcx> MirPatch<'tcx> {
             Some(Terminator {
                 source_info: SourceInfo::outermost(self.body_span),
                 kind: TerminatorKind::UnwindTerminate(reason),
-                attributes: ThinVec::new(),
+                attributes: None,
             }),
             true,
         ));

--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -16,7 +16,6 @@ use std::{assert_matches, cmp, iter, mem};
 use either::{Left, Right};
 use rustc_const_eval::check_consts::{ConstCx, qualifs};
 use rustc_data_structures::fx::FxHashSet;
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_index::{IndexSlice, IndexVec};
@@ -754,7 +753,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
             Some(Terminator {
                 source_info: SourceInfo::outermost(span),
                 kind: TerminatorKind::Return,
-                attributes: ThinVec::new(),
+                attributes: None,
             }),
             false,
         ))
@@ -843,7 +842,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
                 Terminator {
                     source_info: terminator.source_info,
                     kind: mem::replace(&mut terminator.kind, TerminatorKind::Goto { target }),
-                    attributes: ThinVec::new(),
+                    attributes: None,
                 }
             };
 

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -1,7 +1,6 @@
 use std::{assert_matches, fmt, iter};
 
 use rustc_abi::{ExternAbi, FIRST_VARIANT, FieldIdx, VariantIdx};
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_hir as hir;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::def_id::DefId;
@@ -281,7 +280,7 @@ pub fn build_drop_shim<'tcx>(
     let mut blocks = IndexVec::with_capacity(2);
     let block = |blocks: &mut IndexVec<_, _>, kind| {
         blocks.push(BasicBlockData::new(
-            Some(Terminator { source_info, kind, attributes: ThinVec::new() }),
+            Some(Terminator { source_info, kind, attributes: None }),
             false,
         ))
     };
@@ -338,7 +337,7 @@ pub fn build_drop_shim<'tcx>(
                 call_source: CallSource::Misc,
                 fn_span: span,
             },
-            attributes: ThinVec::new(),
+            attributes: None,
         });
     } else {
         let patch = {
@@ -491,7 +490,7 @@ fn build_thread_local_shim<'tcx>(tcx: TyCtxt<'tcx>, shim: ty::ShimKind<'tcx>) ->
                 Rvalue::ThreadLocalRef(def_id),
             ))),
         )],
-        Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: ThinVec::new() }),
+        Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: None }),
         false,
     )]);
 
@@ -577,7 +576,7 @@ impl<'tcx> CloneShimBuilder<'tcx> {
         let source_info = self.source_info();
         self.blocks.push(BasicBlockData::new_stmts(
             statements,
-            Some(Terminator { source_info, kind, attributes: ThinVec::new() }),
+            Some(Terminator { source_info, kind, attributes: None }),
             is_cleanup,
         ))
     }
@@ -923,7 +922,7 @@ fn build_call_shim<'tcx>(
     let block = |blocks: &mut IndexVec<_, _>, statements, kind, is_cleanup| {
         blocks.push(BasicBlockData::new_stmts(
             statements,
-            Some(Terminator { source_info, kind, attributes: ThinVec::new() }),
+            Some(Terminator { source_info, kind, attributes: None }),
             is_cleanup,
         ))
     };
@@ -1050,7 +1049,7 @@ pub(super) fn build_adt_ctor(tcx: TyCtxt<'_>, ctor_id: DefId) -> Body<'_> {
 
     let start_block = BasicBlockData::new_stmts(
         vec![statement],
-        Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: ThinVec::new() }),
+        Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: None }),
         false,
     );
 
@@ -1110,7 +1109,7 @@ fn build_fn_ptr_addr_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, self_ty: Ty<'t
     let statements = vec![stmt];
     let start_block = BasicBlockData::new_stmts(
         statements,
-        Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: ThinVec::new() }),
+        Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: None }),
         false,
     );
     let source = MirSource::from_shim(ty::ShimKind::FnPtrAddr(def_id, self_ty));
@@ -1208,7 +1207,7 @@ fn build_construct_coroutine_by_move_shim<'tcx>(
     let statements = vec![stmt];
     let start_block = BasicBlockData::new_stmts(
         statements,
-        Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: ThinVec::new() }),
+        Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: None }),
         false,
     );
 

--- a/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
+++ b/compiler/rustc_mir_transform/src/shim/async_destructor_ctor.rs
@@ -86,7 +86,7 @@ pub(super) fn build_async_drop_shim<'tcx>(
     let mut blocks = IndexVec::with_capacity(2);
     let block = |blocks: &mut IndexVec<_, _>, kind| {
         blocks.push(BasicBlockData::new(
-            Some(Terminator { source_info, kind, attributes: ThinVec::new() }),
+            Some(Terminator { source_info, kind, attributes: None }),
             false,
         ))
     };
@@ -394,7 +394,7 @@ fn build_adrop_for_adrop_shim<'tcx>(
                 fn_span: span,
             },
 
-            attributes: ThinVec::new(),
+            attributes: None,
         }),
         false,
     ));
@@ -419,12 +419,12 @@ fn build_adrop_for_adrop_shim<'tcx>(
                 fn_span: span,
             },
 
-            attributes: ThinVec::new(),
+            attributes: None,
         }),
         false,
     ));
     blocks.push(BasicBlockData::new(
-        Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: ThinVec::new() }),
+        Some(Terminator { source_info, kind: TerminatorKind::Return, attributes: None }),
         false,
     ));
 


### PR DESCRIPTION
Empty ThinVec is slightly more expensive than None, because it's a pointer to a static singleton, while None is just a constant on a stack. We've seen this before in other places. This is a small win in local Cachegrind runs.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
