### PR TITLE
Rustify the `compare_bytes` return type

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -1533,7 +1533,12 @@ fn codegen_regular_intrinsic_call<'tcx>(
             let returns = vec![AbiParam::new(types::I32)];
             let args = &[lhs_ptr, rhs_ptr, bytes_val];
             // Here we assume that the `memcmp` provided by the target is a NOP for size 0.
-            let cmp = fx.lib_call("memcmp", params, returns, args)[0];
+            let raw = fx.lib_call("memcmp", params, returns, args)[0];
+            // `memcmp` can return things other than -1/0/+1, so similar to `BinOp::Cmp`
+            // we emit `(raw > 0) - (raw < 0)` to get the sign only.
+            let gt = fx.bcx.ins().icmp_imm_s(IntCC::SignedGreaterThan, raw, 0);
+            let lt = fx.bcx.ins().icmp_imm_s(IntCC::SignedLessThan, raw, 0);
+            let cmp = fx.bcx.ins().isub(gt, lt);
             ret.write_cvalue(fx, CValue::by_val(cmp, ret.layout()));
         }
 

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -525,8 +525,11 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
 
                 // Here we assume that the `memcmp` provided by the target is a NOP for size 0.
                 let builtin = self.context.get_builtin_function("memcmp");
-                let cmp = self.context.new_call(None, builtin, &[a_ptr, b_ptr, n]);
-                self.sext(cmp, self.type_ix(32))
+                let raw = self.context.new_call(None, builtin, &[a_ptr, b_ptr, n]);
+                // Return just the sign (-1/0/+1) of the `i16` or `i32` from `memcmp`.
+                let rty = self.val_ty(raw);
+                let zero = self.const_int(rty, 0);
+                self.three_way_compare(raw, zero, /*is_signed*/ true)
             }
 
             sym::black_box => {

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -1138,14 +1138,14 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
 
     fn three_way_compare(
         &mut self,
-        ty: Ty<'tcx>,
         lhs: Self::Value,
         rhs: Self::Value,
+        is_signed: bool,
     ) -> Self::Value {
-        let size = ty.primitive_size(self.tcx);
-        let name = if ty.is_signed() { "llvm.scmp" } else { "llvm.ucmp" };
+        let llty = self.val_ty(lhs);
+        let name = if is_signed { "llvm.scmp" } else { "llvm.ucmp" };
 
-        self.call_intrinsic(name, &[self.type_i8(), self.type_ix(size.bits())], &[lhs, rhs])
+        self.call_intrinsic(name, &[self.type_i8(), llty], &[lhs, rhs])
     }
 
     /* Miscellaneous instructions */

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -596,13 +596,15 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
 
             sym::compare_bytes => {
                 // Here we assume that the `memcmp` provided by the target is a NOP for size 0.
-                let cmp = self.call_intrinsic(
+                let raw = self.call_intrinsic(
                     "memcmp",
                     &[],
                     &[args[0].immediate(), args[1].immediate(), args[2].immediate()],
                 );
-                // Some targets have `memcmp` returning `i16`, but the intrinsic is always `i32`.
-                self.sext(cmp, self.type_ix(32))
+                // Note that `memcmp` returns different types on different platforms, not always `i32`.
+                let rty = self.val_ty(raw);
+                let zero = self.const_int(rty, 0);
+                self.three_way_compare(raw, zero, /*is_signed*/ true)
             }
 
             sym::black_box => {

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -998,7 +998,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
             mir::BinOp::Cmp => {
                 assert!(!is_float);
-                bx.three_way_compare(lhs_ty, lhs, rhs)
+                bx.three_way_compare(lhs, rhs, is_signed)
             }
             mir::BinOp::AddWithOverflow
             | mir::BinOp::SubWithOverflow

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -415,16 +415,16 @@ pub trait BuilderMethods<'a, 'tcx>:
     /// Returns `-1` if `lhs < rhs`, `0` if `lhs == rhs`, and `1` if `lhs > rhs`.
     fn three_way_compare(
         &mut self,
-        ty: Ty<'tcx>,
         lhs: Self::Value,
         rhs: Self::Value,
+        is_signed: bool,
     ) -> Self::Value {
         // FIXME: This implementation was designed around LLVM's ability to optimize, but `cg_llvm`
         // overrides this to just use `@llvm.scmp`/`ucmp` since LLVM 20. This default impl should be
         // reevaluated with respect to the remaining backends like cg_gcc, whether they might use
         // specialized implementations as well, or continue to use a generic implementation here.
         use std::cmp::Ordering;
-        let pred = |op| crate::base::bin_op_to_icmp_predicate(op, ty.is_signed());
+        let pred = |op| crate::base::bin_op_to_icmp_predicate(op, is_signed);
         if self.cx().sess().opts.optimize == OptLevel::No {
             // This actually generates tighter assembly, and is a classic trick:
             // <https://graphics.stanford.edu/~seander/bithacks.html#CopyIntegerSign>.

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -1170,9 +1170,9 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let left_bytes = self.read_bytes_ptr_strip_provenance(left, n)?;
         let right_bytes = self.read_bytes_ptr_strip_provenance(right, n)?;
 
-        // `Ordering`'s discriminants are -1/0/+1, so casting does the right thing.
-        let result = Ord::cmp(left_bytes, right_bytes) as i32;
-        interp_ok(Scalar::from_i32(result))
+        // The intrinsic also returns `Ordering`, so return it directly.
+        let result = Ord::cmp(left_bytes, right_bytes) as i8;
+        interp_ok(Scalar::from_i8(result))
     }
 
     pub(crate) fn raw_eq_intrinsic(

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -413,7 +413,7 @@ pub(crate) fn check_intrinsic_type(
         ),
         sym::compare_bytes => {
             let byte_ptr = Ty::new_imm_ptr(tcx, tcx.types.u8);
-            (0, 0, vec![byte_ptr, byte_ptr, tcx.types.usize], tcx.types.i32)
+            (0, 0, vec![byte_ptr, byte_ptr, tcx.types.usize], tcx.ty_ordering_enum(span))
         }
         sym::write_bytes | sym::volatile_set_memory => (
             1,

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2520,7 +2520,11 @@ pub const unsafe fn raw_eq<T>(a: &T, b: &T) -> bool;
 #[rustc_nounwind]
 #[rustc_intrinsic]
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-pub const unsafe fn compare_bytes(left: *const u8, right: *const u8, bytes: usize) -> i32;
+pub const unsafe fn compare_bytes(
+    left: *const u8,
+    right: *const u8,
+    bytes: usize,
+) -> crate::cmp::Ordering;
 
 /// See documentation of [`std::hint::black_box`] for details.
 ///

--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -154,7 +154,7 @@ where
         // not to overflow because it exists in memory;
         unsafe {
             let size = crate::intrinsics::unchecked_mul(len, Self::SIZE);
-            compare_bytes(lhs as _, rhs as _, size) == 0
+            compare_bytes(lhs as _, rhs as _, size).is_eq()
         }
     }
 }
@@ -323,12 +323,10 @@ const unsafe impl UnsignedBytewiseOrd for ascii::Char {}
 const impl<A: [const] Ord + [const] UnsignedBytewiseOrd> SliceOrd for A {
     #[inline]
     fn compare(left: &[Self], right: &[Self]) -> Ordering {
-        // Since the length of a slice is always less than or equal to
-        // isize::MAX, this never underflows.
-        let diff = left.len() as isize - right.len() as isize;
-        // This comparison gets optimized away (on x86_64 and ARM) because the
-        // subtraction updates flags.
-        let len = if left.len() < right.len() { left.len() } else { right.len() };
+        // `cmp` and `min` can share the same comparison (on x86_64 and ARM)
+        // as they both work using flags from the same test.
+        let len_cmp = usize::cmp(&left.len(), &right.len());
+        let len = usize::min(left.len(), right.len());
         let left = left.as_ptr().cast();
         let right = right.as_ptr().cast();
         // SAFETY: `left` and `right` are references and are thus guaranteed to
@@ -336,11 +334,8 @@ const impl<A: [const] Ord + [const] UnsignedBytewiseOrd> SliceOrd for A {
         // are valid u8s and can be compared the same way. We use the minimum
         // of both lengths which guarantees that both regions are valid for
         // reads in that interval.
-        let mut order = unsafe { compare_bytes(left, right, len) as isize };
-        if order == 0 {
-            order = diff;
-        }
-        order.cmp(&0)
+        let order = unsafe { compare_bytes(left, right, len) };
+        order.then(len_cmp)
     }
 }
 

--- a/src/tools/miri/tests/fail/uninit/uninit_alloc_diagnostic.stderr
+++ b/src/tools/miri/tests/fail/uninit/uninit_alloc_diagnostic.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: reading memory at ALLOC[0x0..0x10], but memory is uninitialized at [0x4..0x10], and this operation requires initialized memory
   --> RUSTLIB/core/src/slice/cmp.rs:LL:CC
    |
-LL |         let mut order = unsafe { compare_bytes(left, right, len) as isize };
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |         let order = unsafe { compare_bytes(left, right, len) };
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/uninit/uninit_alloc_diagnostic_with_provenance.stderr
+++ b/src/tools/miri/tests/fail/uninit/uninit_alloc_diagnostic_with_provenance.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: reading memory at ALLOC[0x0..0x8], but memory is uninitialized at [0x4..0x8], and this operation requires initialized memory
   --> RUSTLIB/core/src/slice/cmp.rs:LL:CC
    |
-LL |         let mut order = unsafe { compare_bytes(left, right, len) as isize };
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |         let order = unsafe { compare_bytes(left, right, len) };
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/codegen-llvm/intrinsics/compare_bytes.rs
+++ b/tests/codegen-llvm/intrinsics/compare_bytes.rs
@@ -10,25 +10,25 @@ use std::intrinsics::compare_bytes;
 
 #[no_mangle]
 // CHECK-LABEL: @bytes_cmp(
-pub unsafe fn bytes_cmp(a: *const u8, b: *const u8, n: usize) -> i32 {
-    // INT32: %[[TEMP:.+]] = tail call i32 @memcmp(ptr %a, ptr %b, {{i32|i64}} %n)
-    // INT32-NOT: sext
-    // INT32: ret i32 %[[TEMP]]
+pub unsafe fn bytes_cmp(a: *const u8, b: *const u8, n: usize) -> std::cmp::Ordering {
+    // INT32: %[[RAW:.+]] = tail call i32 @memcmp(ptr %a, ptr %b, {{i32|i64}} %n)
+    // INT16: %[[RAW:.+]] = tail call i16 @memcmp(ptr %a, ptr %b, i16 %n)
 
-    // INT16: %[[TEMP1:.+]] = tail call i16 @memcmp(ptr %a, ptr %b, i16 %n)
-    // INT16: %[[TEMP2:.+]] = sext i16 %[[TEMP1]] to i32
-    // INT16: ret i32 %[[TEMP2]]
+    // INT32: %[[ORD:.+]] = tail call i8 @llvm.scmp.i8.i32(i32 %[[RAW]], i32 0)
+    // INT16: %[[ORD:.+]] = tail call i8 @llvm.scmp.i8.i16(i16 %[[RAW]], i16 0)
+
+    // CHECK: ret i8 %[[ORD]]
     compare_bytes(a, b, n)
 }
 
-// Ensure that, even though there's an `sext` emitted by the intrinsic,
+// Ensure that, even though there's an `scmp` emitted by the intrinsic,
 // that doesn't end up pessiming checks against zero.
 #[no_mangle]
 // CHECK-LABEL: @bytes_eq(
 pub unsafe fn bytes_eq(a: *const u8, b: *const u8, n: usize) -> bool {
-    // CHECK: call {{.+}} @{{bcmp|memcmp}}(ptr %a, ptr %b, {{i16|i32|i64}} %n)
-    // CHECK-NOT: sext
-    // INT32: icmp eq i32
-    // INT16: icmp eq i16
-    compare_bytes(a, b, n) == 0_i32
+    // CHECK: %[[RAW:.+]] = tail call {{.+}} @{{bcmp|memcmp}}(ptr %a, ptr %b, {{i16|i32|i64}} %n)
+    // INT32: %[[B:.+]] = icmp eq i32 %[[RAW]], 0
+    // INT16: %[[B:.+]] = icmp eq i16 %[[RAW]], 0
+    // CHECK: ret i1 %[[B]]
+    compare_bytes(a, b, n).is_eq()
 }

--- a/tests/ui/consts/const-compare-bytes-ub.rs
+++ b/tests/ui/consts/const-compare-bytes-ub.rs
@@ -1,39 +1,40 @@
 //@ check-fail
 
 #![feature(core_intrinsics, const_cmp)]
+use std::cmp::Ordering;
 use std::intrinsics::compare_bytes;
 use std::mem::MaybeUninit;
 
 fn main() {
-    const LHS_NULL: i32 = unsafe {
+    const LHS_NULL: Ordering = unsafe {
         compare_bytes(0 as *const u8, 2 as *const u8, 1)
         //~^ ERROR memory access failed
     };
-    const RHS_NULL: i32 = unsafe {
+    const RHS_NULL: Ordering = unsafe {
         compare_bytes(1 as *const u8, 0 as *const u8, 1)
         //~^ ERROR memory access failed
     };
-    const DANGLING_PTR_NON_ZERO_LENGTH: i32 = unsafe {
+    const DANGLING_PTR_NON_ZERO_LENGTH: Ordering = unsafe {
         compare_bytes(1 as *const u8, 2 as *const u8, 1)
         //~^ ERROR memory access failed
     };
-    const LHS_OUT_OF_BOUNDS: i32 = unsafe {
+    const LHS_OUT_OF_BOUNDS: Ordering = unsafe {
         compare_bytes([1, 2, 3].as_ptr(), [1, 2, 3, 4].as_ptr(), 4)
         //~^ ERROR memory access failed
     };
-    const RHS_OUT_OF_BOUNDS: i32 = unsafe {
+    const RHS_OUT_OF_BOUNDS: Ordering = unsafe {
         compare_bytes([1, 2, 3, 4].as_ptr(), [1, 2, 3].as_ptr(), 4)
         //~^ ERROR memory access failed
     };
-    const LHS_UNINIT: i32 = unsafe {
+    const LHS_UNINIT: Ordering = unsafe {
         compare_bytes(MaybeUninit::uninit().as_ptr(), [1].as_ptr(), 1)
         //~^ ERROR memory is uninitialized
     };
-    const RHS_UNINIT: i32 = unsafe {
+    const RHS_UNINIT: Ordering = unsafe {
         compare_bytes([1].as_ptr(), MaybeUninit::uninit().as_ptr(), 1)
         //~^ ERROR memory is uninitialized
     };
-    const WITH_PROVENANCE: i32 = unsafe {
+    const WITH_PROVENANCE: Ordering = unsafe {
         compare_bytes([&1].as_ptr().cast(), [&2].as_ptr().cast(), std::mem::size_of::<usize>())
         //~^ ERROR unable to turn pointer into integer
     };

--- a/tests/ui/consts/const-compare-bytes-ub.stderr
+++ b/tests/ui/consts/const-compare-bytes-ub.stderr
@@ -1,35 +1,35 @@
 error[E0080]: memory access failed: attempting to access 1 byte, but got null pointer
-  --> $DIR/const-compare-bytes-ub.rs:9:9
+  --> $DIR/const-compare-bytes-ub.rs:10:9
    |
 LL |         compare_bytes(0 as *const u8, 2 as *const u8, 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::LHS_NULL` failed here
 
 error[E0080]: memory access failed: attempting to access 1 byte, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
-  --> $DIR/const-compare-bytes-ub.rs:13:9
+  --> $DIR/const-compare-bytes-ub.rs:14:9
    |
 LL |         compare_bytes(1 as *const u8, 0 as *const u8, 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::RHS_NULL` failed here
 
 error[E0080]: memory access failed: attempting to access 1 byte, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
-  --> $DIR/const-compare-bytes-ub.rs:17:9
+  --> $DIR/const-compare-bytes-ub.rs:18:9
    |
 LL |         compare_bytes(1 as *const u8, 2 as *const u8, 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::DANGLING_PTR_NON_ZERO_LENGTH` failed here
 
 error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC$ID which is only 3 bytes from the end of the allocation
-  --> $DIR/const-compare-bytes-ub.rs:21:9
+  --> $DIR/const-compare-bytes-ub.rs:22:9
    |
 LL |         compare_bytes([1, 2, 3].as_ptr(), [1, 2, 3, 4].as_ptr(), 4)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::LHS_OUT_OF_BOUNDS` failed here
 
 error[E0080]: memory access failed: attempting to access 4 bytes, but got ALLOC$ID which is only 3 bytes from the end of the allocation
-  --> $DIR/const-compare-bytes-ub.rs:25:9
+  --> $DIR/const-compare-bytes-ub.rs:26:9
    |
 LL |         compare_bytes([1, 2, 3, 4].as_ptr(), [1, 2, 3].as_ptr(), 4)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::RHS_OUT_OF_BOUNDS` failed here
 
 error[E0080]: reading memory at ALLOC$ID[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
-  --> $DIR/const-compare-bytes-ub.rs:29:9
+  --> $DIR/const-compare-bytes-ub.rs:30:9
    |
 LL |         compare_bytes(MaybeUninit::uninit().as_ptr(), [1].as_ptr(), 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::LHS_UNINIT` failed here
@@ -39,7 +39,7 @@ LL |         compare_bytes(MaybeUninit::uninit().as_ptr(), [1].as_ptr(), 1)
            }
 
 error[E0080]: reading memory at ALLOC$ID[0x0..0x1], but memory is uninitialized at [0x0..0x1], and this operation requires initialized memory
-  --> $DIR/const-compare-bytes-ub.rs:33:9
+  --> $DIR/const-compare-bytes-ub.rs:34:9
    |
 LL |         compare_bytes([1].as_ptr(), MaybeUninit::uninit().as_ptr(), 1)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::RHS_UNINIT` failed here
@@ -49,7 +49,7 @@ LL |         compare_bytes([1].as_ptr(), MaybeUninit::uninit().as_ptr(), 1)
            }
 
 error[E0080]: unable to turn pointer into integer
-  --> $DIR/const-compare-bytes-ub.rs:37:9
+  --> $DIR/const-compare-bytes-ub.rs:38:9
    |
 LL |         compare_bytes([&1].as_ptr().cast(), [&2].as_ptr().cast(), std::mem::size_of::<usize>())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::WITH_PROVENANCE` failed here

--- a/tests/ui/consts/const-compare-bytes.rs
+++ b/tests/ui/consts/const-compare-bytes.rs
@@ -1,26 +1,19 @@
 //@ run-pass
 
 #![feature(core_intrinsics, const_cmp)]
+use std::cmp::Ordering;
 use std::intrinsics::compare_bytes;
 
 fn main() {
-    const A: i32 = unsafe {
-        compare_bytes(1 as *const u8, 2 as *const u8, 0)
-    };
-    assert_eq!(A, 0);
+    const A: Ordering = unsafe { compare_bytes(1 as *const u8, 2 as *const u8, 0) };
+    assert_eq!(A, Ordering::Equal);
 
-    const B: i32 = unsafe {
-        compare_bytes([1, 2].as_ptr(), [1, 3].as_ptr(), 1)
-    };
-    assert_eq!(B, 0);
+    const B: Ordering = unsafe { compare_bytes([1, 2].as_ptr(), [1, 3].as_ptr(), 1) };
+    assert_eq!(B, Ordering::Equal);
 
-    const C: i32 = unsafe {
-        compare_bytes([1, 2, 9].as_ptr(), [1, 3, 8].as_ptr(), 2)
-    };
-    assert!(C < 0);
+    const C: Ordering = unsafe { compare_bytes([1, 2, 9].as_ptr(), [1, 3, 8].as_ptr(), 2) };
+    assert_eq!(C, Ordering::Less);
 
-    const D: i32 = unsafe {
-        compare_bytes([1, 3, 8].as_ptr(), [1, 2, 9].as_ptr(), 2)
-    };
-    assert!(D > 0);
+    const D: Ordering = unsafe { compare_bytes([1, 3, 8].as_ptr(), [1, 2, 9].as_ptr(), 2) };
+    assert_eq!(D, Ordering::Greater);
 }


### PR DESCRIPTION
We had it as `i32`, which caused a bunch of `sext` questions because of platform differences, but I think we actually just want `Ordering`, now that we've paid the cost of having that type available as a tcx method anyway.

<!-- homu-ignore:start -->
*No LLM used*
<!-- homu-ignore:end -->
