### PR TITLE
proc_macro: add support for 16-bit targets

### DIFF
--- a/library/proc_macro/src/bridge/arena.rs
+++ b/library/proc_macro/src/bridge/arena.rs
@@ -9,14 +9,6 @@ use std::mem::MaybeUninit;
 use std::ops::Range;
 use std::{cmp, ptr, slice};
 
-// The arenas start with PAGE-sized chunks, and then each new chunk is twice as
-// big as its predecessor, up until we reach HUGE_PAGE-sized chunks, whereupon
-// we stop growing. This scales well, from arenas that are barely used up to
-// arenas that are used for 100s of MiBs. Note also that the chosen sizes match
-// the usual sizes of pages and huge pages on Linux.
-const PAGE: usize = 4096;
-const HUGE_PAGE: usize = 2 * 1024 * 1024;
-
 /// A minimal arena allocator inspired by `rustc_arena::DroplessArena`.
 ///
 /// This is unfortunately a complete re-implementation rather than a dependency
@@ -44,6 +36,18 @@ impl Arena {
     #[inline(never)]
     #[cold]
     fn grow(&self, additional: usize) {
+        // The arenas start with PAGE-sized chunks, and then each new chunk is twice as
+        // big as its predecessor, up until we reach HUGE_PAGE-sized chunks, whereupon
+        // we stop growing. This scales well, from arenas that are barely used up to
+        // arenas that are used for 100s of MiBs. Note also that the chosen sizes match
+        // the usual sizes of pages and huge pages on Linux.
+        const PAGE: usize = 4096;
+        const HUGE_PAGE: usize =
+            cfg_select! {
+                any(target_pointer_width = "64", target_pointer_width = "32") => 2 * 1024 * 1024,
+                _ => 8192, // just make it compile for -Zbuild-std
+            };
+
         let mut chunks = self.chunks.borrow_mut();
         let mut new_cap;
         if let Some(last_chunk) = chunks.last_mut() {

--- a/library/proc_macro/src/bridge/fxhash.rs
+++ b/library/proc_macro/src/bridge/fxhash.rs
@@ -27,14 +27,14 @@ pub(super) struct FxHasher {
     hash: usize,
 }
 
-#[cfg(target_pointer_width = "32")]
-const K: usize = 0x9e3779b9;
-#[cfg(target_pointer_width = "64")]
-const K: usize = 0x517cc1b727220a95;
-
 impl FxHasher {
     #[inline]
     fn add_to_hash(&mut self, i: usize) {
+        const K: usize = cfg_select! {
+            target_pointer_width = "64" => 0x517cc1b727220a95,
+            target_pointer_width = "32" => 0x9e3779b9,
+            _ => 0, // just make it compile for -Zbuild-std
+        };
         self.hash = self.hash.rotate_left(5).bitxor(i).wrapping_mul(K);
     }
 }
@@ -42,15 +42,10 @@ impl FxHasher {
 impl Hasher for FxHasher {
     #[inline]
     fn write(&mut self, mut bytes: &[u8]) {
-        #[cfg(target_pointer_width = "32")]
-        let read_usize = |bytes: &[u8]| u32::from_ne_bytes(bytes[..4].try_into().unwrap());
-        #[cfg(target_pointer_width = "64")]
-        let read_usize = |bytes: &[u8]| u64::from_ne_bytes(bytes[..8].try_into().unwrap());
-
         let mut hash = FxHasher { hash: self.hash };
         assert!(size_of::<usize>() <= 8);
         while bytes.len() >= size_of::<usize>() {
-            hash.add_to_hash(read_usize(bytes) as usize);
+            hash.add_to_hash(usize::from_ne_bytes(bytes[..size_of::<usize>()].try_into().unwrap()));
             bytes = &bytes[size_of::<usize>()..];
         }
         if (size_of::<usize>() > 4) && (bytes.len() >= 4) {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161161)*
<!-- homu-ignore:end -->

When building Rust for 16-bit targets, the `proc_macro` crate cannot currently be used. There are two places that have guards in place for 32- and 64-bit targets, but no support for 16-bit targets.

Add gates to the `proc_macro` crate to support 16-bit targets. This was tested on a MOS6502 target running on a Commodore 64.

Disclosure: This issue was found with the assistance of an LLM as part of porting a project to a Commodore 64.