### PR TITLE
windows: stabilise inherit_handles

### DIFF
--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -372,7 +372,10 @@ pub impl(self) trait CommandExt {
     /// see the [Remarks][1] section of the `CreateProcessW` documentation.
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw#remarks
-    #[unstable(feature = "windows_process_extensions_inherit_handles", issue = "146407")]
+    #[stable(
+        feature = "windows_process_extensions_inherit_handles",
+        since = "CURRENT_RUSTC_VERSION"
+    )]
     fn inherit_handles(&mut self, inherit_handles: bool) -> &mut process::Command;
 }
 

--- a/tests/ui/process/win-inherit-handles.rs
+++ b/tests/ui/process/win-inherit-handles.rs
@@ -6,8 +6,6 @@
 //@ needs-subprocess
 //@ edition: 2024
 
-#![feature(windows_process_extensions_inherit_handles)]
-
 use std::os::windows::io::AsRawHandle;
 use std::os::windows::process::CommandExt;
 use std::process::{Command, Stdio};


### PR DESCRIPTION
Relevant to rust-lang/rust#161158; closes rust-lang/rust#146407 (by stabilising it). See my comment on the tracking issue.

r? libs