### PR TITLE
Add regression test for trait on next solver

### DIFF
--- a/tests/ui/traits/next-solver/assertion-left-right-goal.rs
+++ b/tests/ui/traits/next-solver/assertion-left-right-goal.rs
@@ -1,0 +1,16 @@
+//@ compile-flags: -Znext-solver
+//@ edition: 2018
+//@ check-fail
+
+pub trait Bar: Sized {
+    async fn new() -> impl Fn<()> {
+        //~^ ERROR: the precise format of `Fn`-family traits' type parameters is subject to change
+        //~| ERROR: the precise format of `Fn`-family traits' type parameters is subject to change
+        //~| ERROR: the precise format of `Fn`-family traits' type parameters is subject to change
+        //~| ERROR: the precise format of `Fn`-family traits' type parameters is subject to change
+        //~| ERROR: mismatched types
+        async {}
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/assertion-left-right-goal.stderr
+++ b/tests/ui/traits/next-solver/assertion-left-right-goal.stderr
@@ -1,0 +1,60 @@
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/assertion-left-right-goal.rs:6:28
+   |
+LL |     async fn new() -> impl Fn<()> {
+   |                            ^^^^^^ help: use parenthetical notation instead: `Fn() -> ()`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/assertion-left-right-goal.rs:6:28
+   |
+LL |     async fn new() -> impl Fn<()> {
+   |                            ^^^^^^ help: use parenthetical notation instead: `Fn() -> ()`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/assertion-left-right-goal.rs:6:28
+   |
+LL |     async fn new() -> impl Fn<()> {
+   |                            ^^^^^^ help: use parenthetical notation instead: `Fn() -> ()`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/assertion-left-right-goal.rs:6:28
+   |
+LL |     async fn new() -> impl Fn<()> {
+   |                            ^^^^^^ help: use parenthetical notation instead: `Fn() -> ()`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0308]: mismatched types
+  --> $DIR/assertion-left-right-goal.rs:6:35
+   |
+LL |       async fn new() -> impl Fn<()> {
+   |  ___________________________________^
+...  |
+LL | |         async {}
+LL | |     }
+   | |_____^ expected associated type, found `async` fn body
+   |
+   = note: expected associated type `impl Future<Output = impl Fn<()>>`
+              found `async` fn body `{async fn body of <Self as Bar>::new()}`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0308, E0658.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Closes rust-lang/rust#151306.

The new test crashes on commit 37d85e59 (nightly-2026-04-29).
The new test fails (but not crashes) due to different stderr since c935696dd (nightly-2026-04-30).
Ofc the test passes on current version.

Also, I took the liberty of adding a few bits of code to the minimal reproduction shared in the original issue just to make the stderr less verbose and we can focus on the issue that really matters. So I added main, removed the lifetimes, etc.

It's more code, but I'd argue is easier to reason for a test, although I'd obviously revert back to the minimal example if the reviewer thinks it's best.