### PR TITLE
Import suggestion noise: add a generic parameter filter

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -5607,6 +5607,18 @@ impl<'ast> Visitor<'ast> for ItemInfoCollector<'_, 'ast, '_, '_> {
                     .filter(|param| matches!(param.kind, ast::GenericParamKind::Lifetime { .. }))
                     .count();
                 self.r.item_generics_num_lifetimes.insert(def_id, count);
+                let type_or_const_count = generics
+                    .params
+                    .iter()
+                    .filter(|param| {
+                        matches!(
+                            param.kind,
+                            ast::GenericParamKind::Type { .. }
+                                | ast::GenericParamKind::Const { .. }
+                        )
+                    })
+                    .count();
+                self.r.item_generics_num_type_or_const_params.insert(def_id, type_or_const_count);
             }
 
             ItemKind::ForeignMod(ForeignMod { items, .. }) => {

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1322,7 +1322,17 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         let mut fallback = false;
         let typo_sugg = typo_sugg
             .to_opt_suggestion()
-            .filter(|sugg| !suggested_candidates.contains(sugg.candidate.as_str()));
+            .filter(|sugg| !suggested_candidates.contains(sugg.candidate.as_str()))
+            // this filters out suggestions that require parameters when no parameter is present
+            .filter(|sugg| {
+                if !path.last().is_some_and(|s| s.has_generic_args) {
+                    return true;
+                }
+                let Some(def_id) = sugg.res.opt_def_id() else {
+                    return true;
+                };
+                self.r.item_generics_num_type_or_const_params(def_id) > 0
+            });
         if !self.r.add_typo_suggestion(err, typo_sugg, ident_span) {
             fallback = true;
             match self.diag_metadata.current_let_binding {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1499,6 +1499,8 @@ pub struct Resolver<'ra, 'tcx> {
 
     /// Amount of lifetime parameters for each item in the crate.
     item_generics_num_lifetimes: FxHashMap<LocalDefId, usize> = default::fx_hash_map(),
+    /// Amount of type or const parameters for each item in the crate.
+    item_generics_num_type_or_const_params: FxHashMap<LocalDefId, usize> = default::fx_hash_map(),
     /// Generic args to suggest for required params (e.g. `<'_>`, `<_, _>`), if any.
     item_required_generic_args_suggestions: FxHashMap<LocalDefId, String> = default::fx_hash_map(),
     delegation_fn_sigs: LocalDefIdMap<DelegationFnSig> = Default::default(),
@@ -1707,6 +1709,17 @@ impl<'tcx> Resolver<'_, 'tcx> {
             self.item_generics_num_lifetimes[&def_id]
         } else {
             self.tcx.generics_of(def_id).own_counts().lifetimes
+        }
+    }
+    // Get count of expected parameters
+    fn item_generics_num_type_or_const_params(&self, def_id: DefId) -> usize {
+        if let Some(def_id) = def_id.as_local() {
+            self.item_generics_num_type_or_const_params.get(&def_id).copied().unwrap_or(0)
+        } else {
+            let generics = self.tcx.generics_of(def_id);
+            let counts = generics.own_counts();
+            // saturating_sub may not be strictly necessary, better safe than sorry
+            counts.types.saturating_sub(generics.has_own_self() as usize) + counts.consts
         }
     }
 

--- a/tests/ui/const-generics/mgca/unused_speculative_def_id.stderr
+++ b/tests/ui/const-generics/mgca/unused_speculative_def_id.stderr
@@ -2,16 +2,7 @@ error[E0425]: cannot find value `ERR` in this scope
   --> $DIR/unused_speculative_def_id.rs:20:16
    |
 LL |     field: A<{ ERR::<const { 1 }> }>,
-   |                ^^^
-   |
-  --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named tuple variant `Err` defined here
-help: a tuple variant with a similar name exists
-   |
-LL -     field: A<{ ERR::<const { 1 }> }>,
-LL +     field: A<{ Err::<const { 1 }> }>,
-   |
+   |                ^^^ not found in this scope
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/generic-param-filter.rs
+++ b/tests/ui/imports/generic-param-filter.rs
@@ -1,0 +1,4 @@
+fn test_cloned(_x: cloned<(), ()>){}
+//~^ ERROR: cannot find type `cloned` in this scope
+
+fn main(){}

--- a/tests/ui/imports/generic-param-filter.stderr
+++ b/tests/ui/imports/generic-param-filter.stderr
@@ -1,0 +1,18 @@
+error[E0425]: cannot find type `cloned` in this scope
+  --> $DIR/generic-param-filter.rs:1:20
+   |
+LL | fn test_cloned(_x: cloned<(), ()>){}
+   |                    ^^^^^^
+   |
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+   |
+   = note: similarly named trait `Clone` defined here
+help: a trait with a similar name exists
+   |
+LL - fn test_cloned(_x: cloned<(), ()>){}
+LL + fn test_cloned(_x: Clone<(), ()>){}
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/imports/generic-param-filter.stderr
+++ b/tests/ui/imports/generic-param-filter.stderr
@@ -2,16 +2,7 @@ error[E0425]: cannot find type `cloned` in this scope
   --> $DIR/generic-param-filter.rs:1:20
    |
 LL | fn test_cloned(_x: cloned<(), ()>){}
-   |                    ^^^^^^
-   |
-  --> $SRC_DIR/core/src/clone.rs:LL:COL
-   |
-   = note: similarly named trait `Clone` defined here
-help: a trait with a similar name exists
-   |
-LL - fn test_cloned(_x: cloned<(), ()>){}
-LL + fn test_cloned(_x: Clone<(), ()>){}
-   |
+   |                    ^^^^^^ not found in this scope
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Add a heuristic to reduce suggestion noise: filter out suggestions that do not need generic parameters when some were provided in the code.

This was implemented when I realised that `Cloned<()>` being out of scope was generating a suggestion to use `Clone` which:
  - does not have generic parameters
  - is a trait 


This work was extracted from PR https://github.com/rust-lang/rust/pull/156239.

@rustbot r? mu001999

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
