### PR TITLE
avoid pointless spans in target modifier errors

### DIFF
--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -344,12 +344,10 @@ impl CStore {
 
     fn report_target_modifiers_extended(
         tcx: TyCtxt<'_>,
-        krate: &Crate,
         mods: &TargetModifiers,
         dep_mods: &TargetModifiers,
         data: &CrateMetadata,
     ) {
-        let span = krate.spans.inner_span.shrink_to_lo();
         let allowed_flag_mismatches = &tcx.sess.opts.cg.unsafe_allow_abi_mismatch;
         let local_crate = tcx.crate_name(LOCAL_CRATE);
         let tmod_extender = |tmod: &TargetModifier| (tmod.extend(), tmod.clone());
@@ -367,7 +365,6 @@ impl CStore {
             match (flag_local_value, flag_extern_value) {
                 (Some(local_value), Some(extern_value)) => {
                     tcx.dcx().emit_err(diagnostics::IncompatibleTargetModifiers {
-                        span,
                         extern_crate,
                         local_crate,
                         flag_name,
@@ -378,7 +375,6 @@ impl CStore {
                 }
                 (None, Some(extern_value)) => {
                     tcx.dcx().emit_err(diagnostics::IncompatibleTargetModifiersLMissed {
-                        span,
                         extern_crate,
                         local_crate,
                         flag_name,
@@ -389,7 +385,6 @@ impl CStore {
                 }
                 (Some(local_value), None) => {
                     tcx.dcx().emit_err(diagnostics::IncompatibleTargetModifiersRMissed {
-                        span,
                         extern_crate,
                         local_crate,
                         flag_name,
@@ -453,16 +448,15 @@ impl CStore {
     }
 
     pub fn report_session_incompatibilities(&self, tcx: TyCtxt<'_>, krate: &Crate) {
-        self.report_incompatible_target_modifiers(tcx, krate);
+        self.report_incompatible_target_modifiers(tcx);
         self.report_incompatible_partial_mitigations(tcx, krate);
         self.report_incompatible_async_drop_feature(tcx, krate);
     }
 
-    pub fn report_incompatible_target_modifiers(&self, tcx: TyCtxt<'_>, krate: &Crate) {
+    pub fn report_incompatible_target_modifiers(&self, tcx: TyCtxt<'_>) {
         for flag_name in &tcx.sess.opts.cg.unsafe_allow_abi_mismatch {
             if !OptionsTargetModifiers::is_target_modifier(flag_name) {
                 tcx.dcx().emit_err(diagnostics::UnknownTargetModifierUnsafeAllowed {
-                    span: krate.spans.inner_span.shrink_to_lo(),
                     flag_name: flag_name.clone(),
                 });
             }
@@ -474,7 +468,7 @@ impl CStore {
             }
             let dep_mods = data.target_modifiers();
             if mods != dep_mods {
-                Self::report_target_modifiers_extended(tcx, krate, &mods, &dep_mods, data);
+                Self::report_target_modifiers_extended(tcx, &mods, &dep_mods, data);
             }
         }
     }

--- a/compiler/rustc_metadata/src/diagnostics.rs
+++ b/compiler/rustc_metadata/src/diagnostics.rs
@@ -550,8 +550,6 @@ pub(crate) struct WasmCAbi {
     "if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch={$flag_name}` to silence this error"
 )]
 pub(crate) struct IncompatibleTargetModifiers {
-    #[primary_span]
-    pub span: Span,
     pub extern_crate: Symbol,
     pub local_crate: Symbol,
     pub flag_name: String,
@@ -581,8 +579,6 @@ pub(crate) struct IncompatibleTargetModifiers {
     "if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch={$flag_name}` to silence this error"
 )]
 pub(crate) struct IncompatibleTargetModifiersLMissed {
-    #[primary_span]
-    pub span: Span,
     pub extern_crate: Symbol,
     pub local_crate: Symbol,
     pub flag_name: String,
@@ -612,8 +608,6 @@ pub(crate) struct IncompatibleTargetModifiersLMissed {
     "if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch={$flag_name}` to silence this error"
 )]
 pub(crate) struct IncompatibleTargetModifiersRMissed {
-    #[primary_span]
-    pub span: Span,
     pub extern_crate: Symbol,
     pub local_crate: Symbol,
     pub flag_name: String,
@@ -627,8 +621,6 @@ pub(crate) struct IncompatibleTargetModifiersRMissed {
     "unknown target modifier `{$flag_name}`, requested by `-Cunsafe-allow-abi-mismatch={$flag_name}`"
 )]
 pub(crate) struct UnknownTargetModifierUnsafeAllowed {
-    #[primary_span]
-    pub span: Span,
     pub flag_name: String,
 }
 

--- a/tests/ui/target_modifiers/defaults_check.error.stderr
+++ b/tests/ui/target_modifiers/defaults_check.error.stderr
@@ -1,8 +1,4 @@
 error: mixing `-Zreg-struct-return` will cause an ABI mismatch in crate `defaults_check`
-  --> $DIR/defaults_check.rs:16:1
-   |
-LL | #![feature(no_core)]
-   | ^
    |
    = help: the `-Zreg-struct-return` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
    = note: `-Zreg-struct-return=true` in this crate is incompatible with `-Zreg-struct-return` being unset in dependency `default_reg_struct_return`

--- a/tests/ui/target_modifiers/defaults_check.rs
+++ b/tests/ui/target_modifiers/defaults_check.rs
@@ -14,8 +14,9 @@
 //@ ignore-backends: gcc
 
 #![feature(no_core)]
-//[error]~^ ERROR mixing `-Zreg-struct-return` will cause an ABI mismatch in crate `defaults_check`
 #![crate_type = "rlib"]
 #![no_core]
 
 extern crate default_reg_struct_return;
+
+//[error]~? ERROR mixing `-Zreg-struct-return` will cause an ABI mismatch in crate `defaults_check`

--- a/tests/ui/target_modifiers/incompatible_fixedx18.error_generated.stderr
+++ b/tests/ui/target_modifiers/incompatible_fixedx18.error_generated.stderr
@@ -1,8 +1,4 @@
 error: mixing `-Zfixed-x18` will cause an ABI mismatch in crate `incompatible_fixedx18`
-  --> $DIR/incompatible_fixedx18.rs:13:1
-   |
-LL | #![feature(no_core)]
-   | ^
    |
    = help: the `-Zfixed-x18` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
    = note: `-Zfixed-x18` is unset in this crate which is incompatible with `-Zfixed-x18` being set in dependency `fixed_x18`

--- a/tests/ui/target_modifiers/incompatible_fixedx18.rs
+++ b/tests/ui/target_modifiers/incompatible_fixedx18.rs
@@ -11,8 +11,9 @@
 //@ ignore-backends: gcc
 
 #![feature(no_core)]
-//[error_generated]~^ ERROR mixing `-Zfixed-x18` will cause an ABI mismatch in crate `incompatible_fixedx18`
 #![crate_type = "rlib"]
 #![no_core]
 
 extern crate fixed_x18;
+
+//[error_generated]~? ERROR mixing `-Zfixed-x18` will cause an ABI mismatch in crate `incompatible_fixedx18`

--- a/tests/ui/target_modifiers/incompatible_regparm.error_generated.stderr
+++ b/tests/ui/target_modifiers/incompatible_regparm.error_generated.stderr
@@ -1,8 +1,4 @@
 error: mixing `-Zregparm` will cause an ABI mismatch in crate `incompatible_regparm`
-  --> $DIR/incompatible_regparm.rs:12:1
-   |
-LL | #![feature(no_core)]
-   | ^
    |
    = help: the `-Zregparm` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
    = note: `-Zregparm=1` in this crate is incompatible with `-Zregparm=2` in dependency `wrong_regparm`

--- a/tests/ui/target_modifiers/incompatible_regparm.rs
+++ b/tests/ui/target_modifiers/incompatible_regparm.rs
@@ -10,10 +10,10 @@
 //@ ignore-backends: gcc
 
 #![feature(no_core)]
-//[error_generated]~^ ERROR mixing `-Zregparm` will cause an ABI mismatch in crate `incompatible_regparm`
 #![crate_type = "rlib"]
 #![no_core]
 
 extern crate wrong_regparm;
 
 //[allow_no_value]~? ERROR codegen option `unsafe-allow-abi-mismatch` requires a comma-separated list of strings
+//[error_generated]~? ERROR mixing `-Zregparm` will cause an ABI mismatch in crate `incompatible_regparm`

--- a/tests/ui/target_modifiers/no_value_bool.error.stderr
+++ b/tests/ui/target_modifiers/no_value_bool.error.stderr
@@ -1,8 +1,4 @@
 error: mixing `-Zreg-struct-return` will cause an ABI mismatch in crate `no_value_bool`
-  --> $DIR/no_value_bool.rs:17:1
-   |
-LL | #![feature(no_core)]
-   | ^
    |
    = help: the `-Zreg-struct-return` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
    = note: `-Zreg-struct-return` is unset in this crate which is incompatible with `-Zreg-struct-return=true` in dependency `enabled_reg_struct_return`

--- a/tests/ui/target_modifiers/no_value_bool.error_explicit.stderr
+++ b/tests/ui/target_modifiers/no_value_bool.error_explicit.stderr
@@ -1,8 +1,4 @@
 error: mixing `-Zreg-struct-return` will cause an ABI mismatch in crate `no_value_bool`
-  --> $DIR/no_value_bool.rs:17:1
-   |
-LL | #![feature(no_core)]
-   | ^
    |
    = help: the `-Zreg-struct-return` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
    = note: `-Zreg-struct-return` is unset in this crate which is incompatible with `-Zreg-struct-return=true` in dependency `enabled_reg_struct_return`

--- a/tests/ui/target_modifiers/no_value_bool.rs
+++ b/tests/ui/target_modifiers/no_value_bool.rs
@@ -15,9 +15,10 @@
 //@ ignore-backends: gcc
 
 #![feature(no_core)]
-//[error]~^ ERROR mixing `-Zreg-struct-return` will cause an ABI mismatch in crate `no_value_bool`
-//[error_explicit]~^^ ERROR mixing `-Zreg-struct-return` will cause an ABI mismatch in crate `no_value_bool`
 #![crate_type = "rlib"]
 #![no_core]
 
 extern crate enabled_reg_struct_return;
+
+//[error]~? ERROR mixing `-Zreg-struct-return` will cause an ABI mismatch in crate `no_value_bool`
+//[error_explicit]~? ERROR mixing `-Zreg-struct-return` will cause an ABI mismatch in crate `no_value_bool`

--- a/tests/ui/target_modifiers/sanitizer-kcfi-normalize-ints.rs
+++ b/tests/ui/target_modifiers/sanitizer-kcfi-normalize-ints.rs
@@ -10,9 +10,10 @@
 //@[ok] check-pass
 
 #![feature(no_core)]
-//[wrong_flag]~^ ERROR mixing `-Zsanitizer-cfi-normalize-integers` will cause an ABI mismatch in crate `sanitizer_kcfi_normalize_ints`
-//[wrong_sanitizer]~^^ ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizer_kcfi_normalize_ints`
 #![crate_type = "rlib"]
 #![no_core]
 
 extern crate kcfi_normalize_ints;
+
+//[wrong_flag]~? ERROR mixing `-Zsanitizer-cfi-normalize-integers` will cause an ABI mismatch in crate `sanitizer_kcfi_normalize_ints`
+//[wrong_sanitizer]~? ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizer_kcfi_normalize_ints`

--- a/tests/ui/target_modifiers/sanitizer-kcfi-normalize-ints.wrong_flag.stderr
+++ b/tests/ui/target_modifiers/sanitizer-kcfi-normalize-ints.wrong_flag.stderr
@@ -1,8 +1,4 @@
 error: mixing `-Zsanitizer-cfi-normalize-integers` will cause an ABI mismatch in crate `sanitizer_kcfi_normalize_ints`
-  --> $DIR/sanitizer-kcfi-normalize-ints.rs:12:1
-   |
-LL | #![feature(no_core)]
-   | ^
    |
    = help: the `-Zsanitizer-cfi-normalize-integers` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
    = note: `-Zsanitizer-cfi-normalize-integers` is unset in this crate which is incompatible with `-Zsanitizer-cfi-normalize-integers` being set in dependency `kcfi_normalize_ints`

--- a/tests/ui/target_modifiers/sanitizer-kcfi-normalize-ints.wrong_sanitizer.stderr
+++ b/tests/ui/target_modifiers/sanitizer-kcfi-normalize-ints.wrong_sanitizer.stderr
@@ -1,8 +1,4 @@
 error: mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizer_kcfi_normalize_ints`
-  --> $DIR/sanitizer-kcfi-normalize-ints.rs:12:1
-   |
-LL | #![feature(no_core)]
-   | ^
    |
    = help: the `-Zsanitizer` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
    = note: `-Zsanitizer` is unset in this crate which is incompatible with `-Zsanitizer=kcfi` in dependency `kcfi_normalize_ints`

--- a/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.missed_both.stderr
+++ b/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.missed_both.stderr
@@ -1,8 +1,4 @@
 error: mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
-  --> $DIR/sanitizers-safestack-and-kcfi.rs:18:1
-   |
-LL | #![feature(no_core)]
-   | ^
    |
    = help: the `-Zsanitizer` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
    = note: `-Zsanitizer` is unset in this crate which is incompatible with `-Zsanitizer=safestack,kcfi` in dependency `safestack_and_kcfi`

--- a/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.missed_kcfi.stderr
+++ b/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.missed_kcfi.stderr
@@ -1,8 +1,4 @@
 error: mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
-  --> $DIR/sanitizers-safestack-and-kcfi.rs:18:1
-   |
-LL | #![feature(no_core)]
-   | ^
    |
    = help: the `-Zsanitizer` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
    = note: `-Zsanitizer=safestack` in this crate is incompatible with `-Zsanitizer=safestack,kcfi` in dependency `safestack_and_kcfi`

--- a/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.missed_safestack.stderr
+++ b/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.missed_safestack.stderr
@@ -1,8 +1,4 @@
 error: mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
-  --> $DIR/sanitizers-safestack-and-kcfi.rs:18:1
-   |
-LL | #![feature(no_core)]
-   | ^
    |
    = help: the `-Zsanitizer` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
    = note: `-Zsanitizer=kcfi` in this crate is incompatible with `-Zsanitizer=safestack,kcfi` in dependency `safestack_and_kcfi`

--- a/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.rs
+++ b/tests/ui/target_modifiers/sanitizers-safestack-and-kcfi.rs
@@ -16,10 +16,11 @@
 //@[good_multiple] check-pass
 
 #![feature(no_core)]
-//[missed_safestack]~^ ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
-//[missed_kcfi]~^^ ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
-//[missed_both]~^^^ ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
 #![crate_type = "rlib"]
 #![no_core]
 
 extern crate safestack_and_kcfi;
+
+//[missed_safestack]~? ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
+//[missed_kcfi]~? ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`
+//[missed_both]~? ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizers_safestack_and_kcfi`

--- a/tests/ui/target_modifiers/target_cpu_default.explicit_mismatch.stderr
+++ b/tests/ui/target_modifiers/target_cpu_default.explicit_mismatch.stderr
@@ -1,8 +1,4 @@
 error: mixing `-Ctarget-cpu` will cause an ABI mismatch in crate `target_cpu_default`
-  --> $DIR/target_cpu_default.rs:25:1
-   |
-LL | #![feature(no_core)]
-   | ^
    |
    = help: the `-Ctarget-cpu` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
    = note: `-Ctarget-cpu=sm_70` in this crate is incompatible with `-Ctarget-cpu=sm_80` in dependency `target_cpu_non_default`

--- a/tests/ui/target_modifiers/target_cpu_default.implicit_mismatch.stderr
+++ b/tests/ui/target_modifiers/target_cpu_default.implicit_mismatch.stderr
@@ -1,8 +1,4 @@
 error: mixing `-Ctarget-cpu` will cause an ABI mismatch in crate `target_cpu_default`
-  --> $DIR/target_cpu_default.rs:25:1
-   |
-LL | #![feature(no_core)]
-   | ^
    |
    = help: the `-Ctarget-cpu` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
    = note: `-Ctarget-cpu` is unset in this crate which is incompatible with `-Ctarget-cpu=sm_80` in dependency `target_cpu_non_default`

--- a/tests/ui/target_modifiers/target_cpu_default.rs
+++ b/tests/ui/target_modifiers/target_cpu_default.rs
@@ -23,8 +23,8 @@
 //@[explicit_mismatch] compile-flags: -Ctarget-cpu=sm_70
 
 #![feature(no_core)]
-//[implicit_mismatch]~^ ERROR mixing `-Ctarget-cpu` will cause an ABI mismatch
-//[explicit_mismatch]~^^ ERROR mixing `-Ctarget-cpu` will cause an ABI mismatch
+//[implicit_mismatch]~? ERROR mixing `-Ctarget-cpu` will cause an ABI mismatch
+//[explicit_mismatch]~? ERROR mixing `-Ctarget-cpu` will cause an ABI mismatch
 #![crate_type = "rlib"]
 #![no_core]
 

--- a/tests/ui/target_modifiers/two_flags.rs
+++ b/tests/ui/target_modifiers/two_flags.rs
@@ -9,8 +9,9 @@
 //@ ignore-backends: gcc
 
 #![feature(no_core)]
-//[unknown_allowed]~^ ERROR unknown target modifier `unknown_flag`, requested by `-Cunsafe-allow-abi-mismatch=unknown_flag`
 #![crate_type = "rlib"]
 #![no_core]
 
 extern crate wrong_regparm_and_ret;
+
+//[unknown_allowed]~? ERROR unknown target modifier `unknown_flag`, requested by `-Cunsafe-allow-abi-mismatch=unknown_flag`

--- a/tests/ui/target_modifiers/two_flags.unknown_allowed.stderr
+++ b/tests/ui/target_modifiers/two_flags.unknown_allowed.stderr
@@ -1,8 +1,4 @@
 error: unknown target modifier `unknown_flag`, requested by `-Cunsafe-allow-abi-mismatch=unknown_flag`
-  --> $DIR/two_flags.rs:11:1
-   |
-LL | #![feature(no_core)]
-   | ^
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/161174.

Currently the diagnostics for target modifier issues always point at the beginning of the first non-empty line in the file. That makes no sense at all IMO since the error has nothing to do with that line: the error is in the CLI flags. So let's just remove this pointless span.

While doing this I realized there are other errors also doing this, e.g. `report_incompatible_partial_mitigations` and `report_incompatible_async_drop_feature`.  Cc @arielb1 @azhogin why was this done?
@rust-lang/wg-diagnostics do you see any reason to have these diagnostics point at `krate.spans.inner_span.shrink_to_lo()`? IMO that is just never a useful thing to do.