### PR TITLE
std: guard against unwinds in queue-based `Once`

### DIFF
--- a/library/std/src/sys/sync/once/queue.rs
+++ b/library/std/src/sys/sync/once/queue.rs
@@ -60,7 +60,7 @@ use crate::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use crate::sync::atomic::{Atomic, AtomicBool, AtomicPtr};
 use crate::sync::once::OnceExclusiveState;
 use crate::thread::{self, Thread};
-use crate::{fmt, ptr, sync as public};
+use crate::{fmt, mem, ptr, sync as public};
 
 type StateAndQueue = *mut ();
 
@@ -237,6 +237,15 @@ impl Once {
     }
 }
 
+/// A type to guard against the unwinds of stacks that nodes are located on due to panics.
+struct PanicGuard;
+
+impl Drop for PanicGuard {
+    fn drop(&mut self) {
+        rtabort!("tried to drop node in intrusive list.");
+    }
+}
+
 fn wait(
     state_and_queue: &Atomic<*mut ()>,
     mut current: StateAndQueue,
@@ -272,6 +281,9 @@ fn wait(
             continue;
         }
 
+        // Guard against unwinds using a `PanicGuard` that aborts when dropped.
+        let guard = PanicGuard;
+
         // We have enqueued ourselves, now lets wait.
         // It is important not to return before being signaled, otherwise we
         // would drop our `Waiter` node and leave a hole in the linked list
@@ -287,6 +299,9 @@ fn wait(
             // SAFETY: we retrieved this handle on the current thread above.
             unsafe { node.thread.park() }
         }
+
+        // The node was removed from the queue, disarm the guard.
+        mem::forget(guard);
 
         return state_and_queue.load(Acquire);
     }


### PR DESCRIPTION
While the public `thread::park` guards against unwinds, the inner `Thread::park` method does not. In the unlikely but plausible scenario that it did, this would lead to undefined behaviour in the queue-based `Once`; a thread's waiter node must be removed from the list before it can be freed. To fix this, promote unwinds to aborts, just like the queue-based `RwLock` [does](https://github.com/rust-lang/rust/blob/874e6f2a533b28b77892709ba774614a96686840/library/std/src/sys/sync/rwlock/queue.rs#L428-L429).