### PR TITLE
add `Complex<T>` layout tests for straightforward targets

### DIFF
--- a/compiler/rustc_target/src/callconv/s390x.rs
+++ b/compiler/rustc_target/src/callconv/s390x.rs
@@ -42,6 +42,11 @@ where
         return;
     }
 
+    if arg.layout.is_complex_number(cx) {
+        arg.make_indirect();
+        return;
+    }
+
     let size = arg.layout.size;
     if size.bits() <= 128 {
         if let BackendRepr::SimdVector { .. } = arg.layout.backend_repr {

--- a/tests/codegen-llvm/complex-abi.rs
+++ b/tests/codegen-llvm/complex-abi.rs
@@ -35,19 +35,19 @@
 //@ [ARM] compile-flags: --target arm-unknown-linux-gnueabihf
 //@ [ARM] needs-llvm-components: arm
 
+//@ revisions: RISCV64 RISCV32
+//@ [RISCV64] compile-flags: --target riscv64gc-unknown-linux-gnu
+//@ [RISCV64] needs-llvm-components: riscv
+//@ [RISCV32] compile-flags: --target riscv32gc-unknown-linux-gnu
+//@ [RISCV32] needs-llvm-components: riscv
+
+//@ revisions: LOONGARCH64 LOONGARCH32
+//@ [LOONGARCH64] compile-flags: --target loongarch64-unknown-linux-gnu
+//@ [LOONGARCH64] needs-llvm-components: loongarch
+//@ [LOONGARCH32] compile-flags: --target loongarch32-unknown-none
+//@ [LOONGARCH32] needs-llvm-components: loongarch
+
 // FIXME: the below revisions are deliberately disabled for now.
-
-// revisions: RISCV64 RISCV32
-// [RISCV64] compile-flags: --target riscv64gc-unknown-linux-gnu
-// [RISCV64] needs-llvm-components: riscv
-// [RISCV32] compile-flags: --target riscv32gc-unknown-linux-gnu
-// [RISCV32] needs-llvm-components: riscv
-
-// revisions: LOONGARCH64 LOONGARCH32
-// [LOONGARCH64] compile-flags: --target loongarch64-unknown-linux-gnu
-// [LOONGARCH64] needs-llvm-components: loongarch
-// [LOONGARCH32] compile-flags: --target loongarch32-unknown-none
-// [LOONGARCH32] needs-llvm-components: loongarch
 
 // revisions: SPARC64 SPARC
 // [SPARC64] compile-flags: --target sparc64-unknown-linux-gnu
@@ -109,11 +109,11 @@ pub extern "C" fn cplx_f16(x: Complex<f16>) -> Complex<f16> {
     // ARM64EC:        define{{.*}} [2 x half] @cplx_f16([2 x half] {{.*}})
     // ARM:            define{{.*}} [2 x half] @cplx_f16([2 x half] {{.*}})
     // I686:           define{{.*}} <2 x half> @cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
-    // LOONGARCH32:    define{{.*}} { half, half } @cplx_f16(half {{.*}}, half {{.*}})
-    // LOONGARCH64:    define{{.*}} { half, half } @cplx_f16(half {{.*}}, half {{.*}})
+    // LOONGARCH32:    define{{.*}} { half, half } @cplx_f16({ half, half } {{.*}})
+    // LOONGARCH64:    define{{.*}} { half, half } @cplx_f16({ half, half } {{.*}})
     // NVPTX:          define{{.*}} { half, half } @cplx_f16(ptr {{.*}} byval({ half, half }) {{.*}})
-    // RISCV32:        define{{.*}} { half, half } @cplx_f16(half {{.*}}, half {{.*}})
-    // RISCV64:        define{{.*}} { half, half } @cplx_f16(half {{.*}}, half {{.*}})
+    // RISCV32:        define{{.*}} { half, half } @cplx_f16({ half, half } {{.*}})
+    // RISCV64:        define{{.*}} { half, half } @cplx_f16({ half, half } {{.*}})
     // S390X:          define{{.*}} void @cplx_f16(ptr {{.*}} sret({ half, half }) {{.*}}, ptr {{.*}})
     // WIN32_GNU:      define{{.*}} <2 x half> @cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
     // WIN32_MSVC:     define{{.*}} <2 x half> @cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
@@ -134,16 +134,16 @@ pub extern "C" fn cplx_f32(x: Complex<f32>) -> Complex<f32> {
     // BPF:            define{{.*}} void @cplx_f32(ptr {{.*}} sret({ float, float }) {{.*}}, i64 {{.*}})
     // CSKY:           define{{.*}} [2 x i32] @cplx_f32([2 x i32] {{.*}})
     // I686:           define{{.*}} i64 @cplx_f32(ptr {{.*}} byval([8 x i8]) {{.*}})
-    // LOONGARCH32:    define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
-    // LOONGARCH64:    define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
+    // LOONGARCH32:    define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
+    // LOONGARCH64:    define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
     // MIPS64EL:       define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
     // MIPS:           define{{.*}} { float, float } @cplx_f32(i32 {{.*}}, i32 {{.*}})
     // NVPTX:          define{{.*}} { float, float } @cplx_f32(ptr {{.*}} byval({ float, float }) {{.*}})
     // POWERPC64:      define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
     // POWERPC64LE:    define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
     // POWERPC:        define{{.*}} void @cplx_f32(ptr {{.*}} sret({ float, float }) {{.*}}, ptr {{.*}} byval({ float, float }) {{.*}})
-    // RISCV32:        define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
-    // RISCV64:        define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
+    // RISCV32:        define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
+    // RISCV64:        define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
     // S390X:          define{{.*}} void @cplx_f32(ptr {{.*}} sret({ float, float }) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} {{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
     // SPARC:          define{{.*}} { float, float } @cplx_f32(ptr {{.*}} byval({ float, float }) {{.*}})
@@ -168,16 +168,16 @@ pub extern "C" fn cplx_f64(x: Complex<f64>) -> Complex<f64> {
     // BPF:            define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, [2 x i64] {{.*}})
     // CSKY:           define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, [4 x i32] {{.*}})
     // I686:           define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
-    // LOONGARCH32:    define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
-    // LOONGARCH64:    define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
+    // LOONGARCH32:    define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
+    // LOONGARCH64:    define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
     // MIPS64EL:       define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
     // MIPS:           define{{.*}} { double, double } @cplx_f64(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
     // NVPTX:          define{{.*}} { double, double } @cplx_f64(ptr {{.*}} byval({ double, double }) {{.*}})
     // POWERPC64:      define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
     // POWERPC64LE:    define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
     // POWERPC:        define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, ptr {{.*}} byval({ double, double }) {{.*}})
-    // RISCV32:        define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
-    // RISCV64:        define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
+    // RISCV32:        define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
+    // RISCV64:        define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
     // S390X:          define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
     // SPARC:          define{{.*}} { double, double } @cplx_f64(ptr {{.*}} byval({ double, double }) {{.*}})
@@ -200,6 +200,8 @@ pub extern "C" fn cplx_f128(x: Complex<f128>) -> Complex<f128> {
     // WIN32_GNU:      define{{.*}} void @cplx_f128(ptr {{.*}} sret([32 x i8]) {{.*}}, ptr {{.*}} byval([32 x i8]) {{.*}})
     // WINDOWS_GNU:    define{{.*}} void @cplx_f128(ptr {{.*}} sret([32 x i8]) {{.*}}, ptr {{.*}})
     // X86_64:         define{{.*}} void @cplx_f128(ptr {{.*}} sret([32 x i8]) {{.*}}, ptr {{.*}} byval([32 x i8]) {{.*}})
+    // LOONGARCH64:    define{{.*}} void @cplx_f128(ptr {{.*}} sret([32 x i8]) {{.*}}, ptr {{.*}})
+    // RISCV64         define{{.*}} void @cplx_f128(ptr {{.*}} sret([32 x i8]) {{.*}}, ptr {{.*}})
     x
 }
 
@@ -214,16 +216,16 @@ pub extern "C" fn cplx_i8(x: Complex<i8>) -> Complex<i8> {
     // BPF:            define{{.*}} void @cplx_i8(ptr {{.*}} sret({ i8, i8 }) {{.*}}, i16 {{.*}})
     // CSKY:           define{{.*}} {{.*}} i32 @cplx_i8(i32{{.*}})
     // I686:           define{{.*}} i16 @cplx_i8(ptr {{.*}} byval([2 x i8]) {{.*}})
-    // LOONGARCH32:    define{{.*}} {{.*}} i32 @cplx_i8(i32{{.*}})
-    // LOONGARCH64:    define{{.*}} {{.*}} i64 @cplx_i8(i64{{.*}})
+    // LOONGARCH32:    define{{.*}} i32 @cplx_i8(i32{{.*}})
+    // LOONGARCH64:    define{{.*}} i64 @cplx_i8(i64{{.*}})
     // MIPS64EL:       define{{.*}} { i8, i8 } @cplx_i8(i16 {{.*}})
     // MIPS:           define{{.*}} { i8, i8 } @cplx_i8(i16 {{.*}})
     // NVPTX:          define{{.*}} { i8, i8 } @cplx_i8(ptr {{.*}} byval({ i8, i8 }) {{.*}})
     // POWERPC64:      define{{.*}} { i8, i8 } @cplx_i8(i8 {{.*}}, i8 {{.*}})
     // POWERPC64LE:    define{{.*}} { i8, i8 } @cplx_i8(i8 {{.*}}, i8 {{.*}})
     // POWERPC:        define{{.*}} void @cplx_i8(ptr {{.*}} sret({ i8, i8 }) {{.*}}, ptr {{.*}} byval({ i8, i8 }) {{.*}})
-    // RISCV32:        define{{.*}} {{.*}} i32 @cplx_i8(i32{{.*}})
-    // RISCV64:        define{{.*}} {{.*}} i64 @cplx_i8(i64{{.*}})
+    // RISCV32:        define{{.*}} i32 @cplx_i8(i32{{.*}})
+    // RISCV64:        define{{.*}} i64 @cplx_i8(i64{{.*}})
     // S390X:          define{{.*}} void @cplx_i8(ptr {{.*}} sret({ i8, i8 }) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} {{.*}} i64 @cplx_i8(i64{{.*}})
     // SPARC:          define{{.*}} { i8, i8 } @cplx_i8(ptr {{.*}} byval({ i8, i8 }) {{.*}})
@@ -249,7 +251,7 @@ pub extern "C" fn cplx_i16(x: Complex<i16>) -> Complex<i16> {
     // CSKY:           define{{.*}} i32 @cplx_i16(i32 {{.*}})
     // I686:           define{{.*}} i32 @cplx_i16(ptr {{.*}} byval([4 x i8]) {{.*}})
     // LOONGARCH32:    define{{.*}} i32 @cplx_i16(i32 {{.*}})
-    // LOONGARCH64:    define{{.*}} {{.*}} i64 @cplx_i16(i64{{.*}})
+    // LOONGARCH64:    define{{.*}} i64 @cplx_i16(i64{{.*}})
     // MIPS64EL:       define{{.*}} { i16, i16 } @cplx_i16(i32 {{.*}})
     // MIPS:           define{{.*}} { i16, i16 } @cplx_i16(i32 {{.*}})
     // NVPTX:          define{{.*}} { i16, i16 } @cplx_i16(ptr {{.*}} byval({ i16, i16 }) {{.*}})
@@ -257,7 +259,7 @@ pub extern "C" fn cplx_i16(x: Complex<i16>) -> Complex<i16> {
     // POWERPC64LE:    define{{.*}} { i16, i16 } @cplx_i16(i16 {{.*}}, i16 {{.*}})
     // POWERPC:        define{{.*}} void @cplx_i16(ptr {{.*}} sret({ i16, i16 }) {{.*}}, ptr {{.*}} byval({ i16, i16 }) {{.*}})
     // RISCV32:        define{{.*}} i32 @cplx_i16(i32 {{.*}})
-    // RISCV64:        define{{.*}} {{.*}} i64 @cplx_i16(i64{{.*}})
+    // RISCV64:        define{{.*}} i64 @cplx_i16(i64{{.*}})
     // S390X:          define{{.*}} void @cplx_i16(ptr {{.*}} sret({ i16, i16 }) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} {{.*}} i64 @cplx_i16(i64{{.*}})
     // SPARC:          define{{.*}} { i16, i16 } @cplx_i16(ptr {{.*}} byval({ i16, i16 }) {{.*}})
@@ -316,7 +318,7 @@ pub extern "C" fn cplx_i64(x: Complex<i64>) -> Complex<i64> {
     // BPF:            define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
     // CSKY:           define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [4 x i32] {{.*}})
     // I686:           define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
-    // LOONGARCH32:    define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
+    // LOONGARCH32:    define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // LOONGARCH64:    define{{.*}} [2 x i64] @cplx_i64([2 x i64] {{.*}})
     // MIPS64EL:       define{{.*}} { i64, i64 } @cplx_i64(i64 {{.*}}, i64 {{.*}})
     // MIPS:           define{{.*}} { i64, i64 } @cplx_i64(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
@@ -324,7 +326,7 @@ pub extern "C" fn cplx_i64(x: Complex<i64>) -> Complex<i64> {
     // POWERPC64:      define{{.*}} { i64, i64 } @cplx_i64(i64 {{.*}}, i64 {{.*}})
     // POWERPC64LE:    define{{.*}} { i64, i64 } @cplx_i64(i64 {{.*}}, i64 {{.*}})
     // POWERPC:        define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
-    // RISCV32:        define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
+    // RISCV32:        define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // RISCV64:        define{{.*}} [2 x i64] @cplx_i64([2 x i64] {{.*}})
     // S390X:          define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} { i64, i64 } @cplx_i64(i64 {{.*}}, i64 {{.*}})
@@ -355,7 +357,7 @@ pub extern "C" fn wrapper_cplx_i64(
     // BPF:            define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
     // CSKY:           define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [4 x i32] {{.*}})
     // I686:           define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
-    // LOONGARCH32:    define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
+    // LOONGARCH32:    define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // LOONGARCH64:    define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
     // MIPS64EL:       define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
     // MIPS:           define{{.*}} { i64, i64 } @wrapper_cplx_i64(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
@@ -363,7 +365,7 @@ pub extern "C" fn wrapper_cplx_i64(
     // POWERPC64:      define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
     // POWERPC64LE:    define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
     // POWERPC:        define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
-    // RISCV32:        define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
+    // RISCV32:        define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // RISCV64:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
     // S390X:          define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
@@ -388,11 +390,11 @@ pub extern "C" fn wrapper_cplx_f16(
     // ARM64EC:        define{{.*}} [2 x half] @wrapper_cplx_f16([2 x half] {{.*}})
     // ARM:            define{{.*}} [2 x half] @wrapper_cplx_f16([2 x half] {{.*}})
     // I686:           define{{.*}} <2 x half> @wrapper_cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
-    // LOONGARCH32:    define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})
-    // LOONGARCH64:    define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})
+    // LOONGARCH32:    define{{.*}} { half, half } @wrapper_cplx_f16({ half, half } {{.*}})
+    // LOONGARCH64:    define{{.*}} { half, half } @wrapper_cplx_f16({ half, half } {{.*}})
     // NVPTX:          define{{.*}} { half, half } @wrapper_cplx_f16(ptr {{.*}} byval({ half, half }) {{.*}})
-    // RISCV32:        define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})
-    // RISCV64:        define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})
+    // RISCV32:        define{{.*}} { half, half } @wrapper_cplx_f16({ half, half } {{.*}})
+    // RISCV64:        define{{.*}} { half, half } @wrapper_cplx_f16({ half, half } {{.*}})
     // S390X:          define{{.*}} void @wrapper_cplx_f16(ptr {{.*}} sret({ half, half }) {{.*}}, ptr {{.*}})
     // WIN32_GNU:      define{{.*}} <2 x half> @wrapper_cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
     // WIN32_MSVC:     define{{.*}} <2 x half> @wrapper_cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})

--- a/tests/codegen-llvm/complex-abi.rs
+++ b/tests/codegen-llvm/complex-abi.rs
@@ -21,17 +21,17 @@
 //@ [WIN32_GNU] compile-flags: --target i686-pc-windows-gnu
 //@ [WIN32_GNU] needs-llvm-components: x86
 
-// FIXME: the below revisions are deliberately disabled for now.
+//@ revisions: AARCH64 AARCH64_DARWIN AARCH64_MSVC ARM64EC
+//@ [AARCH64] compile-flags: --target aarch64-unknown-linux-gnu
+//@ [AARCH64] needs-llvm-components: aarch64
+//@ [AARCH64_DARWIN] compile-flags: --target aarch64-apple-darwin
+//@ [AARCH64_DARWIN] needs-llvm-components: aarch64
+//@ [AARCH64_MSVC] compile-flags: --target aarch64-pc-windows-msvc
+//@ [AARCH64_MSVC] needs-llvm-components: aarch64
+//@ [ARM64EC] compile-flags: --target arm64ec-pc-windows-msvc
+//@ [ARM64EC] needs-llvm-components: aarch64
 
-// revisions: AARCH64 AARCH64_DARWIN AARCH64_MSVC ARM64EC
-// [AARCH64] compile-flags: --target aarch64-unknown-linux-gnu
-// [AARCH64] needs-llvm-components: aarch64
-// [AARCH64_DARWIN] compile-flags: --target aarch64-apple-darwin
-// [AARCH64_DARWIN] needs-llvm-components: aarch64
-// [AARCH64_MSVC] compile-flags: --target aarch64-pc-windows-msvc
-// [AARCH64_MSVC] needs-llvm-components: aarch64
-// [ARM64EC] compile-flags: --target arm64ec-pc-windows-msvc
-// [ARM64EC] needs-llvm-components: aarch64
+// FIXME: the below revisions are deliberately disabled for now.
 
 // revisions: ARM
 // [ARM] compile-flags: --target arm-unknown-linux-gnueabihf
@@ -103,10 +103,10 @@ use minicore::num::Complex;
 
 #[no_mangle]
 pub extern "C" fn cplx_f16(x: Complex<f16>) -> Complex<f16> {
-    // AARCH64:        define{{.*}} { half, half } @cplx_f16([2 x half] {{.*}})
-    // AARCH64_DARWIN: define{{.*}} { half, half } @cplx_f16([2 x half] {{.*}})
-    // AARCH64_MSVC:   define{{.*}} { half, half } @cplx_f16([2 x half] {{.*}})
-    // ARM64EC:        define{{.*}} { half, half } @cplx_f16([2 x half] {{.*}})
+    // AARCH64:        define{{.*}} [2 x half] @cplx_f16([2 x half] {{.*}})
+    // AARCH64_DARWIN: define{{.*}} [2 x half] @cplx_f16([2 x half] {{.*}})
+    // AARCH64_MSVC:   define{{.*}} [2 x half] @cplx_f16([2 x half] {{.*}})
+    // ARM64EC:        define{{.*}} [2 x half] @cplx_f16([2 x half] {{.*}})
     // ARM:            define{{.*}} i32 @cplx_f16([1 x i32] {{.*}})
     // I686:           define{{.*}} <2 x half> @cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
     // LOONGARCH32:    define{{.*}} { half, half } @cplx_f16(half {{.*}}, half {{.*}})
@@ -125,11 +125,11 @@ pub extern "C" fn cplx_f16(x: Complex<f16>) -> Complex<f16> {
 
 #[no_mangle]
 pub extern "C" fn cplx_f32(x: Complex<f32>) -> Complex<f32> {
-    // AARCH64:        define{{.*}} { float, float } @cplx_f32([2 x float] {{.*}})
-    // AARCH64_DARWIN: define{{.*}} { float, float } @cplx_f32([2 x float] {{.*}})
-    // AARCH64_MSVC:   define{{.*}} { float, float } @cplx_f32([2 x float] {{.*}})
+    // AARCH64:        define{{.*}} [2 x float] @cplx_f32([2 x float] {{.*}})
+    // AARCH64_DARWIN: define{{.*}} [2 x float] @cplx_f32([2 x float] {{.*}})
+    // AARCH64_MSVC:   define{{.*}} [2 x float] @cplx_f32([2 x float] {{.*}})
     // AIX:            define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
-    // ARM64EC:        define{{.*}} { float, float } @cplx_f32([2 x float] {{.*}})
+    // ARM64EC:        define{{.*}} [2 x float] @cplx_f32([2 x float] {{.*}})
     // ARM:            define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
     // BPF:            define{{.*}} void @cplx_f32(ptr {{.*}} sret({ float, float }) {{.*}}, i64 {{.*}})
     // CSKY:           define{{.*}} [2 x i32] @cplx_f32([2 x i32] {{.*}})
@@ -159,11 +159,11 @@ pub extern "C" fn cplx_f32(x: Complex<f32>) -> Complex<f32> {
 
 #[no_mangle]
 pub extern "C" fn cplx_f64(x: Complex<f64>) -> Complex<f64> {
-    // AARCH64:        define{{.*}} { double, double } @cplx_f64([2 x double] {{.*}})
-    // AARCH64_DARWIN: define{{.*}} { double, double } @cplx_f64([2 x double] {{.*}})
-    // AARCH64_MSVC:   define{{.*}} { double, double } @cplx_f64([2 x double] {{.*}})
+    // AARCH64:        define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
+    // AARCH64_DARWIN: define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
+    // AARCH64_MSVC:   define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
     // AIX:            define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
-    // ARM64EC:        define{{.*}} { double, double } @cplx_f64([2 x double] {{.*}})
+    // ARM64EC:        define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
     // ARM:            define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
     // BPF:            define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, [2 x i64] {{.*}})
     // CSKY:           define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, [4 x i32] {{.*}})
@@ -193,6 +193,7 @@ pub extern "C" fn cplx_f64(x: Complex<f64>) -> Complex<f64> {
 
 #[no_mangle]
 pub extern "C" fn cplx_f128(x: Complex<f128>) -> Complex<f128> {
+    // AARCH64:        define{{.*}} [2 x fp128] {{.*}})
     // I686:           define{{.*}} void @cplx_f128(ptr {{.*}} sret([32 x i8]) {{.*}}, ptr {{.*}} byval([32 x i8]) {{.*}})
     // WASM32:         define{{.*}} void @cplx_f128(ptr {{.*}} sret({ fp128, fp128 }) {{.*}}, ptr {{.*}} byval({ fp128, fp128 }) {{.*}})
     // WASM64:         define{{.*}} void @cplx_f128(ptr {{.*}} sret({ fp128, fp128 }) {{.*}}, ptr {{.*}} byval({ fp128, fp128 }) {{.*}})
@@ -204,11 +205,11 @@ pub extern "C" fn cplx_f128(x: Complex<f128>) -> Complex<f128> {
 
 #[no_mangle]
 pub extern "C" fn cplx_i8(x: Complex<i8>) -> Complex<i8> {
-    // AARCH64:        define{{.*}} i16 @cplx_i8(i64{{.*}})
-    // AARCH64_DARWIN: define{{.*}} i16 @cplx_i8(i64{{.*}})
-    // AARCH64_MSVC:   define{{.*}} i16 @cplx_i8(i64{{.*}})
+    // AARCH64:        define{{.*}} i64 @cplx_i8(i64{{.*}})
+    // AARCH64_DARWIN: define{{.*}} i64 @cplx_i8(i64{{.*}})
+    // AARCH64_MSVC:   define{{.*}} i64 @cplx_i8(i64{{.*}})
     // AIX:            define{{.*}} { i8, i8 } @cplx_i8(i8 {{.*}}, i8 {{.*}})
-    // ARM64EC:        define{{.*}} i16 @cplx_i8(i64{{.*}})
+    // ARM64EC:        define{{.*}} i64 @cplx_i8(i64{{.*}})
     // ARM:            define{{.*}} i16 @cplx_i8([1 x i32]{{.*}})
     // BPF:            define{{.*}} void @cplx_i8(ptr {{.*}} sret({ i8, i8 }) {{.*}}, i16 {{.*}})
     // CSKY:           define{{.*}} {{.*}} i32 @cplx_i8(i32{{.*}})
@@ -238,11 +239,11 @@ pub extern "C" fn cplx_i8(x: Complex<i8>) -> Complex<i8> {
 
 #[no_mangle]
 pub extern "C" fn cplx_i16(x: Complex<i16>) -> Complex<i16> {
-    // AARCH64:        define{{.*}} i32 @cplx_i16(i64{{.*}})
-    // AARCH64_DARWIN: define{{.*}} i32 @cplx_i16(i64{{.*}})
-    // AARCH64_MSVC:   define{{.*}} i32 @cplx_i16(i64{{.*}})
+    // AARCH64:        define{{.*}} i64 @cplx_i16(i64{{.*}})
+    // AARCH64_DARWIN: define{{.*}} i64 @cplx_i16(i64{{.*}})
+    // AARCH64_MSVC:   define{{.*}} i64 @cplx_i16(i64{{.*}})
     // AIX:            define{{.*}} { i16, i16 } @cplx_i16(i16 {{.*}}, i16 {{.*}})
-    // ARM64EC:        define{{.*}} i32 @cplx_i16(i64{{.*}})
+    // ARM64EC:        define{{.*}} i64 @cplx_i16(i64{{.*}})
     // ARM:            define{{.*}} i32 @cplx_i16([1 x i32] {{.*}})
     // BPF:            define{{.*}} void @cplx_i16(ptr {{.*}} sret({ i16, i16 }) {{.*}}, i32 {{.*}})
     // CSKY:           define{{.*}} i32 @cplx_i16(i32 {{.*}})
@@ -381,10 +382,10 @@ pub extern "C" fn wrapper_cplx_i64(
 pub extern "C" fn wrapper_cplx_f16(
     x: Wrapper<Complex<Wrapper<f16>>>,
 ) -> Wrapper<Complex<Wrapper<f16>>> {
-    // AARCH64:        define{{.*}} { half, half } @wrapper_cplx_f16([2 x half] {{.*}})
-    // AARCH64_DARWIN: define{{.*}} { half, half } @wrapper_cplx_f16([2 x half] {{.*}})
-    // AARCH64_MSVC:   define{{.*}} { half, half } @wrapper_cplx_f16([2 x half] {{.*}})
-    // ARM64EC:        define{{.*}} { half, half } @wrapper_cplx_f16([2 x half] {{.*}})
+    // AARCH64:        define{{.*}} [2 x half] @wrapper_cplx_f16([2 x half] {{.*}})
+    // AARCH64_DARWIN: define{{.*}} [2 x half] @wrapper_cplx_f16([2 x half] {{.*}})
+    // AARCH64_MSVC:   define{{.*}} [2 x half] @wrapper_cplx_f16([2 x half] {{.*}})
+    // ARM64EC:        define{{.*}} [2 x half] @wrapper_cplx_f16([2 x half] {{.*}})
     // ARM:            define{{.*}} i32 @wrapper_cplx_f16([1 x i32] {{.*}})
     // I686:           define{{.*}} <2 x half> @wrapper_cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
     // LOONGARCH32:    define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})

--- a/tests/codegen-llvm/complex-abi.rs
+++ b/tests/codegen-llvm/complex-abi.rs
@@ -47,17 +47,11 @@
 //@ [LOONGARCH32] compile-flags: --target loongarch32-unknown-none
 //@ [LOONGARCH32] needs-llvm-components: loongarch
 
+//@ revisions: S390X
+//@ [S390X] compile-flags: --target s390x-unknown-linux-gnu
+//@ [S390X] needs-llvm-components: systemz
+
 // FIXME: the below revisions are deliberately disabled for now.
-
-// revisions: SPARC64 SPARC
-// [SPARC64] compile-flags: --target sparc64-unknown-linux-gnu
-// [SPARC64] needs-llvm-components: sparc
-// [SPARC] compile-flags: --target sparc-unknown-linux-gnu
-// [SPARC] needs-llvm-components: sparc
-
-// revisions: S390X
-// [S390X] compile-flags: --target s390x-unknown-linux-gnu
-// [S390X] needs-llvm-components: systemz
 
 // revisions: POWERPC POWERPC64LE POWERPC64 AIX
 // [POWERPC] compile-flags: --target powerpc-unknown-linux-gnu
@@ -114,7 +108,7 @@ pub extern "C" fn cplx_f16(x: Complex<f16>) -> Complex<f16> {
     // NVPTX:          define{{.*}} { half, half } @cplx_f16(ptr {{.*}} byval({ half, half }) {{.*}})
     // RISCV32:        define{{.*}} { half, half } @cplx_f16({ half, half } {{.*}})
     // RISCV64:        define{{.*}} { half, half } @cplx_f16({ half, half } {{.*}})
-    // S390X:          define{{.*}} void @cplx_f16(ptr {{.*}} sret({ half, half }) {{.*}}, ptr {{.*}})
+    // S390X:          define{{.*}} void @cplx_f16(ptr {{.*}} sret([4 x i8]) {{.*}}, ptr {{.*}})
     // WIN32_GNU:      define{{.*}} <2 x half> @cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
     // WIN32_MSVC:     define{{.*}} <2 x half> @cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
     // WINDOWS_GNU:    define{{.*}} i32 @cplx_f16(i32 {{.*}})
@@ -144,7 +138,7 @@ pub extern "C" fn cplx_f32(x: Complex<f32>) -> Complex<f32> {
     // POWERPC:        define{{.*}} void @cplx_f32(ptr {{.*}} sret({ float, float }) {{.*}}, ptr {{.*}} byval({ float, float }) {{.*}})
     // RISCV32:        define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
     // RISCV64:        define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
-    // S390X:          define{{.*}} void @cplx_f32(ptr {{.*}} sret({ float, float }) {{.*}}, ptr {{.*}})
+    // S390X:          define{{.*}} void @cplx_f32(ptr {{.*}} sret([8 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} {{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
     // SPARC:          define{{.*}} { float, float } @cplx_f32(ptr {{.*}} byval({ float, float }) {{.*}})
     // WASM32:         define{{.*}} void @cplx_f32(ptr {{.*}} sret({ float, float }) {{.*}}, ptr {{.*}} byval({ float, float }) {{.*}})
@@ -178,7 +172,7 @@ pub extern "C" fn cplx_f64(x: Complex<f64>) -> Complex<f64> {
     // POWERPC:        define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, ptr {{.*}} byval({ double, double }) {{.*}})
     // RISCV32:        define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
     // RISCV64:        define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
-    // S390X:          define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, ptr {{.*}})
+    // S390X:          define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
     // SPARC:          define{{.*}} { double, double } @cplx_f64(ptr {{.*}} byval({ double, double }) {{.*}})
     // WASM32:         define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, ptr {{.*}} byval({ double, double }) {{.*}})
@@ -226,7 +220,7 @@ pub extern "C" fn cplx_i8(x: Complex<i8>) -> Complex<i8> {
     // POWERPC:        define{{.*}} void @cplx_i8(ptr {{.*}} sret({ i8, i8 }) {{.*}}, ptr {{.*}} byval({ i8, i8 }) {{.*}})
     // RISCV32:        define{{.*}} i32 @cplx_i8(i32{{.*}})
     // RISCV64:        define{{.*}} i64 @cplx_i8(i64{{.*}})
-    // S390X:          define{{.*}} void @cplx_i8(ptr {{.*}} sret({ i8, i8 }) {{.*}}, ptr {{.*}})
+    // S390X:          define{{.*}} void @cplx_i8(ptr {{.*}} sret([2 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} {{.*}} i64 @cplx_i8(i64{{.*}})
     // SPARC:          define{{.*}} { i8, i8 } @cplx_i8(ptr {{.*}} byval({ i8, i8 }) {{.*}})
     // WASM32:         define{{.*}} void @cplx_i8(ptr {{.*}} sret({ i8, i8 }) {{.*}}, ptr {{.*}} byval({ i8, i8 }) {{.*}})
@@ -260,7 +254,7 @@ pub extern "C" fn cplx_i16(x: Complex<i16>) -> Complex<i16> {
     // POWERPC:        define{{.*}} void @cplx_i16(ptr {{.*}} sret({ i16, i16 }) {{.*}}, ptr {{.*}} byval({ i16, i16 }) {{.*}})
     // RISCV32:        define{{.*}} i32 @cplx_i16(i32 {{.*}})
     // RISCV64:        define{{.*}} i64 @cplx_i16(i64{{.*}})
-    // S390X:          define{{.*}} void @cplx_i16(ptr {{.*}} sret({ i16, i16 }) {{.*}}, ptr {{.*}})
+    // S390X:          define{{.*}} void @cplx_i16(ptr {{.*}} sret([4 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} {{.*}} i64 @cplx_i16(i64{{.*}})
     // SPARC:          define{{.*}} { i16, i16 } @cplx_i16(ptr {{.*}} byval({ i16, i16 }) {{.*}})
     // WASM32:         define{{.*}} void @cplx_i16(ptr {{.*}} sret({ i16, i16 }) {{.*}}, ptr {{.*}} byval({ i16, i16 }) {{.*}})
@@ -294,7 +288,7 @@ pub extern "C" fn cplx_i32(x: Complex<i32>) -> Complex<i32> {
     // POWERPC:        define{{.*}} void @cplx_i32(ptr {{.*}} sret({ i32, i32 }) {{.*}}, ptr {{.*}} byval({ i32, i32 }) {{.*}})
     // RISCV32:        define{{.*}} [2 x i32] @cplx_i32([2 x i32] {{.*}})
     // RISCV64:        define{{.*}} i64 @cplx_i32(i64 {{.*}})
-    // S390X:          define{{.*}} void @cplx_i32(ptr {{.*}} sret({ i32, i32 }) {{.*}}, ptr {{.*}})
+    // S390X:          define{{.*}} void @cplx_i32(ptr {{.*}} sret([8 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} i64 @cplx_i32(i64 {{.*}})
     // SPARC:          define{{.*}} { i32, i32 } @cplx_i32(ptr {{.*}} byval({ i32, i32 }) {{.*}})
     // WASM32:         define{{.*}} void @cplx_i32(ptr {{.*}} sret({ i32, i32 }) {{.*}}, ptr {{.*}} byval({ i32, i32 }) {{.*}})
@@ -328,7 +322,7 @@ pub extern "C" fn cplx_i64(x: Complex<i64>) -> Complex<i64> {
     // POWERPC:        define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
     // RISCV32:        define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // RISCV64:        define{{.*}} [2 x i64] @cplx_i64([2 x i64] {{.*}})
-    // S390X:          define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
+    // S390X:          define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} { i64, i64 } @cplx_i64(i64 {{.*}}, i64 {{.*}})
     // SPARC:          define{{.*}} { i64, i64 } @cplx_i64(ptr {{.*}} byval({ i64, i64 }) {{.*}})
     // WASM32:         define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
@@ -367,7 +361,7 @@ pub extern "C" fn wrapper_cplx_i64(
     // POWERPC:        define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
     // RISCV32:        define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // RISCV64:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
-    // S390X:          define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
+    // S390X:          define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
     // SPARC:          define{{.*}} { i64, i64 } @wrapper_cplx_i64(ptr {{.*}} byval({ i64, i64 }) {{.*}})
     // WASM32:         define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
@@ -395,7 +389,7 @@ pub extern "C" fn wrapper_cplx_f16(
     // NVPTX:          define{{.*}} { half, half } @wrapper_cplx_f16(ptr {{.*}} byval({ half, half }) {{.*}})
     // RISCV32:        define{{.*}} { half, half } @wrapper_cplx_f16({ half, half } {{.*}})
     // RISCV64:        define{{.*}} { half, half } @wrapper_cplx_f16({ half, half } {{.*}})
-    // S390X:          define{{.*}} void @wrapper_cplx_f16(ptr {{.*}} sret({ half, half }) {{.*}}, ptr {{.*}})
+    // S390X:          define{{.*}} void @wrapper_cplx_f16(ptr {{.*}} sret([4 x i8]) {{.*}}, ptr {{.*}})
     // WIN32_GNU:      define{{.*}} <2 x half> @wrapper_cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
     // WIN32_MSVC:     define{{.*}} <2 x half> @wrapper_cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
     // WINDOWS_GNU:    define{{.*}} i32 @wrapper_cplx_f16(i32 {{.*}})

--- a/tests/codegen-llvm/complex-abi.rs
+++ b/tests/codegen-llvm/complex-abi.rs
@@ -31,11 +31,11 @@
 //@ [ARM64EC] compile-flags: --target arm64ec-pc-windows-msvc
 //@ [ARM64EC] needs-llvm-components: aarch64
 
-// FIXME: the below revisions are deliberately disabled for now.
+//@ revisions: ARM
+//@ [ARM] compile-flags: --target arm-unknown-linux-gnueabihf
+//@ [ARM] needs-llvm-components: arm
 
-// revisions: ARM
-// [ARM] compile-flags: --target arm-unknown-linux-gnueabihf
-// [ARM] needs-llvm-components: arm
+// FIXME: the below revisions are deliberately disabled for now.
 
 // revisions: RISCV64 RISCV32
 // [RISCV64] compile-flags: --target riscv64gc-unknown-linux-gnu
@@ -107,7 +107,7 @@ pub extern "C" fn cplx_f16(x: Complex<f16>) -> Complex<f16> {
     // AARCH64_DARWIN: define{{.*}} [2 x half] @cplx_f16([2 x half] {{.*}})
     // AARCH64_MSVC:   define{{.*}} [2 x half] @cplx_f16([2 x half] {{.*}})
     // ARM64EC:        define{{.*}} [2 x half] @cplx_f16([2 x half] {{.*}})
-    // ARM:            define{{.*}} i32 @cplx_f16([1 x i32] {{.*}})
+    // ARM:            define{{.*}} [2 x half] @cplx_f16([2 x half] {{.*}})
     // I686:           define{{.*}} <2 x half> @cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
     // LOONGARCH32:    define{{.*}} { half, half } @cplx_f16(half {{.*}}, half {{.*}})
     // LOONGARCH64:    define{{.*}} { half, half } @cplx_f16(half {{.*}}, half {{.*}})
@@ -130,7 +130,7 @@ pub extern "C" fn cplx_f32(x: Complex<f32>) -> Complex<f32> {
     // AARCH64_MSVC:   define{{.*}} [2 x float] @cplx_f32([2 x float] {{.*}})
     // AIX:            define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
     // ARM64EC:        define{{.*}} [2 x float] @cplx_f32([2 x float] {{.*}})
-    // ARM:            define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
+    // ARM:            define{{.*}} [2 x float] @cplx_f32([2 x float] {{.*}})
     // BPF:            define{{.*}} void @cplx_f32(ptr {{.*}} sret({ float, float }) {{.*}}, i64 {{.*}})
     // CSKY:           define{{.*}} [2 x i32] @cplx_f32([2 x i32] {{.*}})
     // I686:           define{{.*}} i64 @cplx_f32(ptr {{.*}} byval([8 x i8]) {{.*}})
@@ -164,7 +164,7 @@ pub extern "C" fn cplx_f64(x: Complex<f64>) -> Complex<f64> {
     // AARCH64_MSVC:   define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
     // AIX:            define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
     // ARM64EC:        define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
-    // ARM:            define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
+    // ARM:            define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
     // BPF:            define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, [2 x i64] {{.*}})
     // CSKY:           define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, [4 x i32] {{.*}})
     // I686:           define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
@@ -210,7 +210,7 @@ pub extern "C" fn cplx_i8(x: Complex<i8>) -> Complex<i8> {
     // AARCH64_MSVC:   define{{.*}} i64 @cplx_i8(i64{{.*}})
     // AIX:            define{{.*}} { i8, i8 } @cplx_i8(i8 {{.*}}, i8 {{.*}})
     // ARM64EC:        define{{.*}} i64 @cplx_i8(i64{{.*}})
-    // ARM:            define{{.*}} i16 @cplx_i8([1 x i32]{{.*}})
+    // ARM:            define{{.*}} i32 @cplx_i8(i32{{.*}})
     // BPF:            define{{.*}} void @cplx_i8(ptr {{.*}} sret({ i8, i8 }) {{.*}}, i16 {{.*}})
     // CSKY:           define{{.*}} {{.*}} i32 @cplx_i8(i32{{.*}})
     // I686:           define{{.*}} i16 @cplx_i8(ptr {{.*}} byval([2 x i8]) {{.*}})
@@ -244,7 +244,7 @@ pub extern "C" fn cplx_i16(x: Complex<i16>) -> Complex<i16> {
     // AARCH64_MSVC:   define{{.*}} i64 @cplx_i16(i64{{.*}})
     // AIX:            define{{.*}} { i16, i16 } @cplx_i16(i16 {{.*}}, i16 {{.*}})
     // ARM64EC:        define{{.*}} i64 @cplx_i16(i64{{.*}})
-    // ARM:            define{{.*}} i32 @cplx_i16([1 x i32] {{.*}})
+    // ARM:            define{{.*}} i32 @cplx_i16(i32{{.*}})
     // BPF:            define{{.*}} void @cplx_i16(ptr {{.*}} sret({ i16, i16 }) {{.*}}, i32 {{.*}})
     // CSKY:           define{{.*}} i32 @cplx_i16(i32 {{.*}})
     // I686:           define{{.*}} i32 @cplx_i16(ptr {{.*}} byval([4 x i8]) {{.*}})
@@ -278,7 +278,7 @@ pub extern "C" fn cplx_i32(x: Complex<i32>) -> Complex<i32> {
     // AARCH64_MSVC:   define{{.*}} i64 @cplx_i32(i64 {{.*}})
     // AIX:            define{{.*}} { i32, i32 } @cplx_i32(i32 {{.*}}, i32 {{.*}})
     // ARM64EC:        define{{.*}} i64 @cplx_i32(i64 {{.*}})
-    // ARM:            define{{.*}} void @cplx_i32(ptr {{.*}} sret({ i32, i32 }) {{.*}}, [2 x i32] {{.*}})
+    // ARM:            define{{.*}} void @cplx_i32(ptr {{.*}} sret([8 x i8]) {{.*}}, [2 x i32] {{.*}})
     // BPF:            define{{.*}} void @cplx_i32(ptr {{.*}} sret({ i32, i32 }) {{.*}}, i64 {{.*}})
     // CSKY:           define{{.*}} [2 x i32] @cplx_i32([2 x i32] {{.*}})
     // I686:           define{{.*}} i64 @cplx_i32(ptr {{.*}} byval([8 x i8]) {{.*}})
@@ -312,7 +312,7 @@ pub extern "C" fn cplx_i64(x: Complex<i64>) -> Complex<i64> {
     // AARCH64_MSVC:   define{{.*}} [2 x i64] @cplx_i64([2 x i64] {{.*}})
     // AIX:            define{{.*}} { i64, i64 } @cplx_i64(i64 {{.*}}, i64 {{.*}})
     // ARM64EC:        define{{.*}} [2 x i64] @cplx_i64([2 x i64] {{.*}})
-    // ARM:            define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
+    // ARM:            define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, [2 x i64] {{.*}})
     // BPF:            define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
     // CSKY:           define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [4 x i32] {{.*}})
     // I686:           define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
@@ -351,7 +351,7 @@ pub extern "C" fn wrapper_cplx_i64(
     // AARCH64_MSVC:   define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
     // AIX:            define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
     // ARM64EC:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
-    // ARM:            define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
+    // ARM:            define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, [2 x i64] {{.*}})
     // BPF:            define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
     // CSKY:           define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [4 x i32] {{.*}})
     // I686:           define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
@@ -386,7 +386,7 @@ pub extern "C" fn wrapper_cplx_f16(
     // AARCH64_DARWIN: define{{.*}} [2 x half] @wrapper_cplx_f16([2 x half] {{.*}})
     // AARCH64_MSVC:   define{{.*}} [2 x half] @wrapper_cplx_f16([2 x half] {{.*}})
     // ARM64EC:        define{{.*}} [2 x half] @wrapper_cplx_f16([2 x half] {{.*}})
-    // ARM:            define{{.*}} i32 @wrapper_cplx_f16([1 x i32] {{.*}})
+    // ARM:            define{{.*}} [2 x half] @wrapper_cplx_f16([2 x half] {{.*}})
     // I686:           define{{.*}} <2 x half> @wrapper_cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
     // LOONGARCH32:    define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})
     // LOONGARCH64:    define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})

--- a/tests/codegen-llvm/complex-abi.rs
+++ b/tests/codegen-llvm/complex-abi.rs
@@ -51,6 +51,12 @@
 //@ [S390X] compile-flags: --target s390x-unknown-linux-gnu
 //@ [S390X] needs-llvm-components: systemz
 
+//@ revisions: WASM32 WASM64
+//@ [WASM32] compile-flags: --target wasm32-unknown-unknown
+//@ [WASM32] needs-llvm-components: webassembly
+//@ [WASM64] compile-flags: --target wasm64-unknown-unknown
+//@ [WASM64] needs-llvm-components: webassembly
+
 // FIXME: the below revisions are deliberately disabled for now.
 
 // revisions: POWERPC POWERPC64LE POWERPC64 AIX
@@ -68,12 +74,6 @@
 // [MIPS64EL] needs-llvm-components: mips
 // [MIPS] compile-flags: --target mips-unknown-linux-gnu
 // [MIPS] needs-llvm-components: mips
-
-// revisions: WASM32 WASM64
-// [WASM32] compile-flags: --target wasm32-unknown-unknown
-// [WASM32] needs-llvm-components: webassembly
-// [WASM64] compile-flags: --target wasm64-unknown-unknown
-// [WASM64] needs-llvm-components: webassembly
 
 // revisions: CSKY
 // [CSKY] compile-flags: --target csky-unknown-linux-gnuabiv2
@@ -141,8 +141,8 @@ pub extern "C" fn cplx_f32(x: Complex<f32>) -> Complex<f32> {
     // S390X:          define{{.*}} void @cplx_f32(ptr {{.*}} sret([8 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} {{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
     // SPARC:          define{{.*}} { float, float } @cplx_f32(ptr {{.*}} byval({ float, float }) {{.*}})
-    // WASM32:         define{{.*}} void @cplx_f32(ptr {{.*}} sret({ float, float }) {{.*}}, ptr {{.*}} byval({ float, float }) {{.*}})
-    // WASM64:         define{{.*}} void @cplx_f32(ptr {{.*}} sret({ float, float }) {{.*}}, ptr {{.*}} byval({ float, float }) {{.*}})
+    // WASM32:         define{{.*}} void @cplx_f32(ptr {{.*}} sret([8 x i8]) {{.*}}, ptr {{.*}})
+    // WASM64:         define{{.*}} void @cplx_f32(ptr {{.*}} sret([8 x i8]) {{.*}}, ptr {{.*}})
     // WIN32_GNU:      define{{.*}} i64 @cplx_f32(ptr {{.*}} byval([8 x i8]) {{.*}})
     // WIN32_MSVC:     define{{.*}} i64 @cplx_f32(ptr {{.*}} byval([8 x i8]) {{.*}})
     // WINDOWS_GNU:    define{{.*}} i64 @cplx_f32(i64 {{.*}})
@@ -175,8 +175,8 @@ pub extern "C" fn cplx_f64(x: Complex<f64>) -> Complex<f64> {
     // S390X:          define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
     // SPARC:          define{{.*}} { double, double } @cplx_f64(ptr {{.*}} byval({ double, double }) {{.*}})
-    // WASM32:         define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, ptr {{.*}} byval({ double, double }) {{.*}})
-    // WASM64:         define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, ptr {{.*}} byval({ double, double }) {{.*}})
+    // WASM32:         define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
+    // WASM64:         define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // WIN32_GNU:      define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
     // WIN32_MSVC:     define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
     // WINDOWS_GNU:    define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
@@ -189,8 +189,8 @@ pub extern "C" fn cplx_f64(x: Complex<f64>) -> Complex<f64> {
 pub extern "C" fn cplx_f128(x: Complex<f128>) -> Complex<f128> {
     // AARCH64:        define{{.*}} [2 x fp128] {{.*}})
     // I686:           define{{.*}} void @cplx_f128(ptr {{.*}} sret([32 x i8]) {{.*}}, ptr {{.*}} byval([32 x i8]) {{.*}})
-    // WASM32:         define{{.*}} void @cplx_f128(ptr {{.*}} sret({ fp128, fp128 }) {{.*}}, ptr {{.*}} byval({ fp128, fp128 }) {{.*}})
-    // WASM64:         define{{.*}} void @cplx_f128(ptr {{.*}} sret({ fp128, fp128 }) {{.*}}, ptr {{.*}} byval({ fp128, fp128 }) {{.*}})
+    // WASM32:         define{{.*}} void @cplx_f128(ptr {{.*}} sret([32 x i8]) {{.*}}, ptr {{.*}})
+    // WASM64:         define{{.*}} void @cplx_f128(ptr {{.*}} sret([32 x i8]) {{.*}}, ptr {{.*}})
     // WIN32_GNU:      define{{.*}} void @cplx_f128(ptr {{.*}} sret([32 x i8]) {{.*}}, ptr {{.*}} byval([32 x i8]) {{.*}})
     // WINDOWS_GNU:    define{{.*}} void @cplx_f128(ptr {{.*}} sret([32 x i8]) {{.*}}, ptr {{.*}})
     // X86_64:         define{{.*}} void @cplx_f128(ptr {{.*}} sret([32 x i8]) {{.*}}, ptr {{.*}} byval([32 x i8]) {{.*}})
@@ -223,8 +223,8 @@ pub extern "C" fn cplx_i8(x: Complex<i8>) -> Complex<i8> {
     // S390X:          define{{.*}} void @cplx_i8(ptr {{.*}} sret([2 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} {{.*}} i64 @cplx_i8(i64{{.*}})
     // SPARC:          define{{.*}} { i8, i8 } @cplx_i8(ptr {{.*}} byval({ i8, i8 }) {{.*}})
-    // WASM32:         define{{.*}} void @cplx_i8(ptr {{.*}} sret({ i8, i8 }) {{.*}}, ptr {{.*}} byval({ i8, i8 }) {{.*}})
-    // WASM64:         define{{.*}} void @cplx_i8(ptr {{.*}} sret({ i8, i8 }) {{.*}}, ptr {{.*}} byval({ i8, i8 }) {{.*}})
+    // WASM32:         define{{.*}} void @cplx_i8(ptr {{.*}} sret([2 x i8]) {{.*}}, ptr {{.*}})
+    // WASM64:         define{{.*}} void @cplx_i8(ptr {{.*}} sret([2 x i8]) {{.*}}, ptr {{.*}})
     // WIN32_GNU:      define{{.*}} i16 @cplx_i8(ptr {{.*}} byval([2 x i8]) {{.*}})
     // WIN32_MSVC:     define{{.*}} i16 @cplx_i8(ptr {{.*}} byval([2 x i8]) {{.*}})
     // WINDOWS_GNU:    define{{.*}} i16 @cplx_i8(i16 {{.*}})
@@ -257,8 +257,8 @@ pub extern "C" fn cplx_i16(x: Complex<i16>) -> Complex<i16> {
     // S390X:          define{{.*}} void @cplx_i16(ptr {{.*}} sret([4 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} {{.*}} i64 @cplx_i16(i64{{.*}})
     // SPARC:          define{{.*}} { i16, i16 } @cplx_i16(ptr {{.*}} byval({ i16, i16 }) {{.*}})
-    // WASM32:         define{{.*}} void @cplx_i16(ptr {{.*}} sret({ i16, i16 }) {{.*}}, ptr {{.*}} byval({ i16, i16 }) {{.*}})
-    // WASM64:         define{{.*}} void @cplx_i16(ptr {{.*}} sret({ i16, i16 }) {{.*}}, ptr {{.*}} byval({ i16, i16 }) {{.*}})
+    // WASM32:         define{{.*}} void @cplx_i16(ptr {{.*}} sret([4 x i8]) {{.*}}, ptr {{.*}})
+    // WASM64:         define{{.*}} void @cplx_i16(ptr {{.*}} sret([4 x i8]) {{.*}}, ptr {{.*}})
     // WIN32_GNU:      define{{.*}} i32 @cplx_i16(ptr {{.*}} byval([4 x i8]) {{.*}})
     // WIN32_MSVC:     define{{.*}} i32 @cplx_i16(ptr {{.*}} byval([4 x i8]) {{.*}})
     // WINDOWS_GNU:    define{{.*}} i32 @cplx_i16(i32 {{.*}})
@@ -291,8 +291,8 @@ pub extern "C" fn cplx_i32(x: Complex<i32>) -> Complex<i32> {
     // S390X:          define{{.*}} void @cplx_i32(ptr {{.*}} sret([8 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} i64 @cplx_i32(i64 {{.*}})
     // SPARC:          define{{.*}} { i32, i32 } @cplx_i32(ptr {{.*}} byval({ i32, i32 }) {{.*}})
-    // WASM32:         define{{.*}} void @cplx_i32(ptr {{.*}} sret({ i32, i32 }) {{.*}}, ptr {{.*}} byval({ i32, i32 }) {{.*}})
-    // WASM64:         define{{.*}} void @cplx_i32(ptr {{.*}} sret({ i32, i32 }) {{.*}}, ptr {{.*}} byval({ i32, i32 }) {{.*}})
+    // WASM32:         define{{.*}} void @cplx_i32(ptr {{.*}} sret([8 x i8]) {{.*}}, ptr {{.*}})
+    // WASM64:         define{{.*}} void @cplx_i32(ptr {{.*}} sret([8 x i8]) {{.*}}, ptr {{.*}})
     // WIN32_GNU:      define{{.*}} i64 @cplx_i32(ptr {{.*}} byval([8 x i8]) {{.*}})
     // WIN32_MSVC:     define{{.*}} i64 @cplx_i32(ptr {{.*}} byval([8 x i8]) {{.*}})
     // WINDOWS_GNU:    define{{.*}} i64 @cplx_i32(i64 {{.*}})
@@ -325,8 +325,8 @@ pub extern "C" fn cplx_i64(x: Complex<i64>) -> Complex<i64> {
     // S390X:          define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} { i64, i64 } @cplx_i64(i64 {{.*}}, i64 {{.*}})
     // SPARC:          define{{.*}} { i64, i64 } @cplx_i64(ptr {{.*}} byval({ i64, i64 }) {{.*}})
-    // WASM32:         define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
-    // WASM64:         define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
+    // WASM32:         define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
+    // WASM64:         define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // WIN32_GNU:      define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
     // WIN32_MSVC:     define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
     // WINDOWS_GNU:    define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
@@ -364,8 +364,8 @@ pub extern "C" fn wrapper_cplx_i64(
     // S390X:          define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // SPARC64:        define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
     // SPARC:          define{{.*}} { i64, i64 } @wrapper_cplx_i64(ptr {{.*}} byval({ i64, i64 }) {{.*}})
-    // WASM32:         define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
-    // WASM64:         define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
+    // WASM32:         define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
+    // WASM64:         define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // WIN32_GNU:      define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
     // WIN32_MSVC:     define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
     // WINDOWS_GNU:    define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})

--- a/tests/codegen-llvm/complex-abi.rs
+++ b/tests/codegen-llvm/complex-abi.rs
@@ -57,6 +57,10 @@
 //@ [WASM64] compile-flags: --target wasm64-unknown-unknown
 //@ [WASM64] needs-llvm-components: webassembly
 
+//@ revisions: CSKY
+//@ [CSKY] compile-flags: --target csky-unknown-linux-gnuabiv2
+//@ [CSKY] needs-llvm-components: csky
+
 // FIXME: the below revisions are deliberately disabled for now.
 
 // revisions: POWERPC POWERPC64LE POWERPC64 AIX
@@ -74,10 +78,6 @@
 // [MIPS64EL] needs-llvm-components: mips
 // [MIPS] compile-flags: --target mips-unknown-linux-gnu
 // [MIPS] needs-llvm-components: mips
-
-// revisions: CSKY
-// [CSKY] compile-flags: --target csky-unknown-linux-gnuabiv2
-// [CSKY] needs-llvm-components: csky
 
 // revisions: NVPTX
 // [NVPTX] compile-flags: --target nvptx64-nvidia-cuda
@@ -131,7 +131,7 @@ pub extern "C" fn cplx_f32(x: Complex<f32>) -> Complex<f32> {
     // LOONGARCH32:    define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
     // LOONGARCH64:    define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
     // MIPS64EL:       define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
-    // MIPS:           define{{.*}} { float, float } @cplx_f32(i32 {{.*}}, i32 {{.*}})
+    // MIPS:           define{{.*}} { float, float } @cplx_f32([2 x i32] {{.*}})
     // NVPTX:          define{{.*}} { float, float } @cplx_f32(ptr {{.*}} byval({ float, float }) {{.*}})
     // POWERPC64:      define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
     // POWERPC64LE:    define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
@@ -160,7 +160,7 @@ pub extern "C" fn cplx_f64(x: Complex<f64>) -> Complex<f64> {
     // ARM64EC:        define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
     // ARM:            define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
     // BPF:            define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, [2 x i64] {{.*}})
-    // CSKY:           define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, [4 x i32] {{.*}})
+    // CSKY:           define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, [4 x i32] {{.*}})
     // I686:           define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
     // LOONGARCH32:    define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
     // LOONGARCH64:    define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
@@ -208,7 +208,7 @@ pub extern "C" fn cplx_i8(x: Complex<i8>) -> Complex<i8> {
     // ARM64EC:        define{{.*}} i64 @cplx_i8(i64{{.*}})
     // ARM:            define{{.*}} i32 @cplx_i8(i32{{.*}})
     // BPF:            define{{.*}} void @cplx_i8(ptr {{.*}} sret({ i8, i8 }) {{.*}}, i16 {{.*}})
-    // CSKY:           define{{.*}} {{.*}} i32 @cplx_i8(i32{{.*}})
+    // CSKY:           define{{.*}} i32 @cplx_i8(i32{{.*}})
     // I686:           define{{.*}} i16 @cplx_i8(ptr {{.*}} byval([2 x i8]) {{.*}})
     // LOONGARCH32:    define{{.*}} i32 @cplx_i8(i32{{.*}})
     // LOONGARCH64:    define{{.*}} i64 @cplx_i8(i64{{.*}})
@@ -310,7 +310,7 @@ pub extern "C" fn cplx_i64(x: Complex<i64>) -> Complex<i64> {
     // ARM64EC:        define{{.*}} [2 x i64] @cplx_i64([2 x i64] {{.*}})
     // ARM:            define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, [2 x i64] {{.*}})
     // BPF:            define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
-    // CSKY:           define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [4 x i32] {{.*}})
+    // CSKY:           define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, [4 x i32] {{.*}})
     // I686:           define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
     // LOONGARCH32:    define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // LOONGARCH64:    define{{.*}} [2 x i64] @cplx_i64([2 x i64] {{.*}})
@@ -349,7 +349,7 @@ pub extern "C" fn wrapper_cplx_i64(
     // ARM64EC:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
     // ARM:            define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, [2 x i64] {{.*}})
     // BPF:            define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
-    // CSKY:           define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [4 x i32] {{.*}})
+    // CSKY:           define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, [4 x i32] {{.*}})
     // I686:           define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
     // LOONGARCH32:    define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // LOONGARCH64:    define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/154023

Best reviewed commit-by-commit.

This PR does two things

- it updates and enables the CHECK lines for targets where rust already matches the ABI of complex numbers. The original check lines are what `clang` emits. Rust often specifies the same signature slightly differently, but those differences are just cosmetic, e.g. `{ half, half }` versus `[2 x half]`.
- adds some custom logic for complex numbers on `s390x`, so that they match `clang` and `gcc` for that target.

I've validated this extensively with `abi-cafe`. But also, this is just locking in the status-quo for an unstable feature. So, I'm not really looking for someone to pore over every line of the diff, just a coarse scan to see if anything odd jumps out. We have automated ways of checking that our logic is actually correct.