### PR TITLE
fix crash in async-drop and async-gen

### DIFF
--- a/compiler/rustc_mir_transform/src/coroutine/drop.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/drop.rs
@@ -27,6 +27,23 @@ impl<'tcx> MutVisitor<'tcx> for FixReturnPendingVisitor<'tcx> {
             && let AggregateKind::Adt(_, _, ref mut args, _, _) = **kind
         {
             *args = self.tcx.mk_args(&[self.tcx.types.unit.into()]);
+        } else if let Rvalue::Use(Operand::Constant(constant), _) = rvalue {
+            if let Some(async_gen_pending_def_id) = self.tcx.lang_items().async_gen_pending()
+                && let Const::Unevaluated(unevaluated, _) = constant.const_
+                && unevaluated.def == async_gen_pending_def_id
+            {
+                let poll_def_id = self.tcx.lang_items().poll().unwrap();
+                *rvalue = Rvalue::Aggregate(
+                    Box::new(AggregateKind::Adt(
+                        poll_def_id,
+                        VariantIdx::from_u32(1),
+                        self.tcx.mk_args(&[self.tcx.types.unit.into()]),
+                        None,
+                        None,
+                    )),
+                    IndexVec::new(),
+                );
+            }
         }
     }
 }

--- a/tests/ui/async-await/async-drop/async-drop-async-gen-return-pending.rs
+++ b/tests/ui/async-await/async-drop/async-drop-async-gen-return-pending.rs
@@ -1,0 +1,14 @@
+// issue - https://github.com/rust-lang/rust/issues/161101
+//@ build-pass
+//@ compile-flags: --crate-type=lib
+//@ edition: 2024
+#![feature(async_drop)]
+#![feature(gen_blocks)]
+#![allow(incomplete_features)]
+
+pub async fn html() {
+    async gen {
+        gen { yield };
+        yield
+    };
+}


### PR DESCRIPTION
handle `AsyncGenPending` constants in `FixReturnPendingVisitor` rewrite `AsyncGenPending` constant uses to `Poll::<()>::Pending` in `FutureDropPoll` shims, matching the existing aggregate path

also added a regression test

fixes rust-lang/rust#161101.

issue reproduce - https://godbolt.org/z/d1zb4j974