### PR TITLE
Improve `powerpc-types.rs` test

### DIFF
--- a/tests/assembly-llvm/asm/powerpc-types.rs
+++ b/tests/assembly-llvm/asm/powerpc-types.rs
@@ -1,8 +1,9 @@
 // ignore-tidy-file-linelength (some revision //@ lines are over 100 chars long)
 
 //@ add-minicore
-//@ revisions: powerpc powerpc_altivec powerpc_vsx powerpc_power8 powerpc64 powerpc64_vsx powerpc64_power8 powerpc64le
+//@ revisions: powerpc powerpc_altivec powerpc_vsx powerpc_power9 powerpc64 powerpc64_vsx powerpc64_power9 powerpc64le powerpc64le_power9
 //@ assembly-output: emit-asm
+
 //@[powerpc] compile-flags: --target powerpc-unknown-linux-gnu
 //@[powerpc] needs-llvm-components: powerpc
 //@[powerpc_altivec] compile-flags: --target powerpc-unknown-linux-gnu -C target-feature=+altivec --cfg altivec
@@ -11,25 +12,32 @@
 //@[powerpc_vsx] compile-flags: --target powerpc-unknown-linux-gnu -C target-feature=+altivec,+vsx --cfg altivec --cfg vsx
 //@[powerpc_vsx] needs-llvm-components: powerpc
 //@[powerpc_vsx] filecheck-flags: --check-prefix altivec --check-prefix vsx
-//@[powerpc_power8] compile-flags: --target powerpc-unknown-linux-gnu -C target-feature=+altivec,+vsx,+power8-vector --cfg altivec --cfg vsx --cfg power8
-//@[powerpc_power8] needs-llvm-components: powerpc
-//@[powerpc_power8] filecheck-flags: --check-prefix altivec --check-prefix vsx --check-prefix power8
+//@[powerpc_power9] compile-flags: --target powerpc-unknown-linux-gnu -C target-feature=+altivec,+vsx,+power9-vector --cfg altivec --cfg vsx --cfg power9 --cfg power9be
+//@[powerpc_power9] needs-llvm-components: powerpc
+//@[powerpc_power9] filecheck-flags: --check-prefix altivec --check-prefix vsx --check-prefix power9 --check-prefix power9be
+
 //@[powerpc64] compile-flags: --target powerpc64-unknown-linux-gnu --cfg altivec
 //@[powerpc64] needs-llvm-components: powerpc
 //@[powerpc64] filecheck-flags: --check-prefix altivec
 //@[powerpc64_vsx] compile-flags: --target powerpc64-unknown-linux-gnu -C target-feature=+vsx --cfg powerpc64 --cfg altivec --cfg vsx
 //@[powerpc64_vsx] needs-llvm-components: powerpc
 //@[powerpc64_vsx] filecheck-flags: --check-prefix powerpc64 --check-prefix altivec --check-prefix vsx
-//@[powerpc64_power8] compile-flags: --target powerpc64-unknown-linux-gnu -C target-feature=+vsx,+power8-vector --cfg powerpc64 --cfg altivec --cfg vsx --cfg power8
-//@[powerpc64_power8] needs-llvm-components: powerpc
-//@[powerpc64_power8] filecheck-flags: --check-prefix powerpc64 --check-prefix altivec --check-prefix vsx --check-prefix power8
-//@[powerpc64le] compile-flags: --target powerpc64le-unknown-linux-gnu --cfg powerpc64 --cfg altivec --cfg vsx --cfg power8
-//@[powerpc64le] needs-llvm-components: powerpc
-//@[powerpc64le] filecheck-flags: --check-prefix powerpc64 --check-prefix altivec --check-prefix vsx --check-prefix power8
-//@ compile-flags: -Zmerge-functions=disabled -O
-//@ compile-flags: --check-cfg=cfg(altivec,vsx,power8)
+//@[powerpc64_power9] compile-flags: --target powerpc64-unknown-linux-gnu -C target-feature=+vsx,+power9-vector --cfg powerpc64 --cfg altivec --cfg vsx --cfg power9 --cfg power9be
+//@[powerpc64_power9] needs-llvm-components: powerpc
+//@[powerpc64_power9] filecheck-flags: --check-prefix powerpc64 --check-prefix altivec --check-prefix vsx --check-prefix power9 --check-prefix=power9be
 
-#![feature(no_core)]
+//@[powerpc64le] compile-flags: --target powerpc64le-unknown-linux-gnu --cfg powerpc64 --cfg altivec --cfg vsx
+//@[powerpc64le] needs-llvm-components: powerpc
+//@[powerpc64le] filecheck-flags: --check-prefix powerpc64 --check-prefix altivec --check-prefix vsx
+//@[powerpc64le_power9] compile-flags: --target powerpc64le-unknown-linux-gnu -C target-feature=+power9-vector --cfg powerpc64 --cfg altivec --cfg vsx --cfg power9
+//@[powerpc64le_power9] needs-llvm-components: powerpc
+//@[powerpc64le_power9] filecheck-flags: --check-prefix powerpc64 --check-prefix altivec --check-prefix vsx --check-prefix power9
+
+//@ compile-flags: -Zmerge-functions=disabled -Copt-level=3
+//@ compile-flags: --check-cfg=cfg(altivec,vsx,power9,power9be)
+
+#![feature(no_core, f16)]
+#![cfg_attr(vsx, feature(f128))]
 #![crate_type = "rlib"]
 #![no_core]
 #![allow(asm_sub_register, non_camel_case_types, unused_imports)]
@@ -48,24 +56,27 @@ compile_error!("altivec cfg and target feature mismatch");
 #[cfg_attr(vsx, cfg(not(target_feature = "vsx")))]
 #[cfg_attr(not(vsx), cfg(target_feature = "vsx"))]
 compile_error!("vsx cfg and target feature mismatch");
-#[cfg_attr(power8, cfg(not(target_feature = "power8-vector")))]
-#[cfg_attr(not(power8), cfg(target_feature = "power8-vector"))]
-compile_error!("power8-vector cfg and target feature mismatch");
+#[cfg_attr(power9, cfg(not(target_feature = "power9-vector")))]
+#[cfg_attr(not(power9), cfg(target_feature = "power9-vector"))]
+compile_error!("power9-vector cfg and target feature mismatch");
+#[cfg_attr(power9be, cfg(not(all(target_feature = "power9-vector", target_endian = "big"))))]
+#[cfg_attr(not(power9be), cfg(all(target_feature = "power9-vector", target_endian = "big")))]
+compile_error!("power9be cfg and target feature mismatch");
 
-// Check floating point scalars are put in the right vector lane. This uses power8 for consistent
+// Check floating point scalars are put in the right vector lane. This uses power9 for consistent
 // assembly between powerpc64le and big-endian powerpc/powerpc64.
 
-// power8-LABEL: f32_to_f64:
-// power8: .cfi_startproc
-// power8-NEXT: xscvdpspn [[#INPUT:]], 1
-// powerpc64le-NEXT: vmrgow [[#INPUT - 32]], [[#INPUT - 32]], [[#INPUT - 32]]
-// power8-NEXT: #APP
-// power8-NEXT: xscvspdp 1, [[#INPUT]]
-// power8-NEXT: #NO_APP
-// power8-NEXT: blr
-#[cfg(power8)]
+// power9-LABEL: f32_to_f64:
+// power9: .cfi_startproc
+// power9-NEXT: xscvdpspn [[#INPUT:]], 1
+// powerpc64le_power9-NEXT: vmrgow [[#INPUT - 32]], [[#INPUT - 32]], [[#INPUT - 32]]
+// power9-NEXT: #APP
+// power9-NEXT: xscvspdp 1, [[#INPUT]]
+// power9-NEXT: #NO_APP
+// power9-NEXT: blr
+#[cfg(power9)]
 #[unsafe(no_mangle)]
-pub fn f32_to_f64(x: f32) -> f64 {
+pub extern "C" fn f32_to_f64(x: f32) -> f64 {
     let res;
     unsafe {
         asm!("xscvspdp {}, {}", out(vsreg) res, in(vsreg) x, options(pure, nostack, nomem));
@@ -73,16 +84,16 @@ pub fn f32_to_f64(x: f32) -> f64 {
     res
 }
 
-// power8-LABEL: f64_to_f32:
-// power8: .cfi_startproc
-// power8-NEXT: #APP
-// power8-NEXT: xscvdpsp [[#OUTPUT:]], 1
-// power8-NEXT: #NO_APP
-// power8-NEXT: xscvspdpn 1, [[#OUTPUT]]
-// power8-NEXT: blr
-#[cfg(power8)]
+// power9-LABEL: f64_to_f32:
+// power9: .cfi_startproc
+// power9-NEXT: #APP
+// power9-NEXT: xscvdpsp [[#OUTPUT:]], 1
+// power9-NEXT: #NO_APP
+// power9-NEXT: xscvspdpn 1, [[#OUTPUT]]
+// power9-NEXT: blr
+#[cfg(power9)]
 #[unsafe(no_mangle)]
-pub fn f64_to_f32(x: f64) -> f32 {
+pub extern "C" fn f64_to_f32(x: f64) -> f32 {
     let res;
     unsafe {
         asm!("xscvdpsp {}, {}", out(vsreg) res, in(vsreg) x, options(pure, nostack, nomem));
@@ -92,18 +103,22 @@ pub fn f64_to_f32(x: f64) -> f32 {
 
 macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
     #[unsafe(no_mangle)]
-    pub unsafe fn $func(x: $ty) -> $ty {
+    // FIXME(f128): Replace `&$ty` with `$ty` once
+    // https://github.com/llvm/llvm-project/issues/213355 is fixed.
+    pub unsafe fn $func(x: &$ty) -> $ty {
         let y;
-        asm!(concat!($mov," {}, {}"), out($class) y, in($class) x);
+        asm!(concat!($mov," {}, {}"), out($class) y, in($class) *x);
         y
     }
 };}
 
 macro_rules! check_reg { ($func:ident, $ty:ty, $rego:tt, $regc:tt, $mov:literal) => {
     #[unsafe(no_mangle)]
-    pub unsafe fn $func(x: $ty) -> $ty {
+    // FIXME(f128): Replace `&$ty` with `$ty` once
+    // https://github.com/llvm/llvm-project/issues/213355 is fixed.
+    pub unsafe fn $func(x: &$ty) -> $ty {
         let y;
-        asm!(concat!($mov, " ", $rego, ", ", $rego), lateout($regc) y, in($regc) x);
+        asm!(concat!($mov, " ", $rego, ", ", $rego), lateout($regc) y, in($regc) *x);
         y
     }
 };}


### PR DESCRIPTION
This makes the changes from rust-lang/rust#161135 (except the `min-llvm-version`) that don't require actually adding `f16`/`f128` support.

r? @folkertdev