### PR TITLE
Add regression test for non lifetime binders

### DIFF
--- a/tests/ui/traits/non_lifetime_binders/expected-region-found-kind.rs
+++ b/tests/ui/traits/non_lifetime_binders/expected-region-found-kind.rs
@@ -1,0 +1,21 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/155802>.
+//@ check-fail
+
+#![feature(non_lifetime_binders)]
+trait E<'e> {
+    type As;
+}
+
+trait F<'a>: for<F> E<'a> + for<'e> E<'e> {}
+//~^ ERROR type annotations needed: cannot satisfy `Self: E<'a>` [E0283]
+
+struct G<'a, T>
+where
+    T: F<'a, As: E<'a>>,
+    //~^ ERROR type annotations needed: cannot satisfy `T: E<'a>` [E0283]
+    //~| ERROR ambiguous associated type `As` in bounds of `F` [E0221]
+{
+    x: &'a T,
+}
+
+fn main() {}

--- a/tests/ui/traits/non_lifetime_binders/expected-region-found-kind.stderr
+++ b/tests/ui/traits/non_lifetime_binders/expected-region-found-kind.stderr
@@ -1,0 +1,45 @@
+error[E0283]: type annotations needed: cannot satisfy `Self: E<'a>`
+  --> $DIR/expected-region-found-kind.rs:9:14
+   |
+LL | trait F<'a>: for<F> E<'a> + for<'e> E<'e> {}
+   |              ^^^^^^^^^^^^
+   |
+note: multiple `impl`s or `where` clauses satisfying `Self: E<'a>` found
+  --> $DIR/expected-region-found-kind.rs:9:14
+   |
+LL | trait F<'a>: for<F> E<'a> + for<'e> E<'e> {}
+   |              ^^^^^^^^^^^^   ^^^^^^^^^^^^^
+
+error[E0221]: ambiguous associated type `As` in bounds of `F`
+  --> $DIR/expected-region-found-kind.rs:14:14
+   |
+LL |     type As;
+   |     -------
+   |     |
+   |     ambiguous `As` from `for<'e> E<'e>`
+   |     ambiguous `As` from `E<'a>`
+...
+LL |     T: F<'a, As: E<'a>>,
+   |              ^^^^^^^^^ ambiguous associated type `As`
+
+error[E0283]: type annotations needed: cannot satisfy `T: E<'a>`
+  --> $DIR/expected-region-found-kind.rs:14:8
+   |
+LL |     T: F<'a, As: E<'a>>,
+   |        ^^^^^^^^^^^^^^^^
+   |
+note: multiple `impl`s or `where` clauses satisfying `T: E<'a>` found
+  --> $DIR/expected-region-found-kind.rs:14:8
+   |
+LL |     T: F<'a, As: E<'a>>,
+   |        ^^^^^^^^^^^^^^^^
+note: required by a bound in `F`
+  --> $DIR/expected-region-found-kind.rs:9:14
+   |
+LL | trait F<'a>: for<F> E<'a> + for<'e> E<'e> {}
+   |              ^^^^^^^^^^^^ required by this bound in `F`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0221, E0283.
+For more information about an error, try `rustc --explain E0221`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Closes rust-lang/rust#155802.

I was able to reduce the code to generate the ICE even without the `#![feature(non_lifetime_binders)]` (using treereduce).
I left it there as is on the issue because I thought it might change the example too much from it's origin.

Question for reviewer, is it better to have a really really minimal example in this case? I could update the PR if it's needed.