### PR TITLE
Speed up tidy again

### DIFF
--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -95,6 +95,7 @@ insta = "1.43"
 # dependencies, only bootstrap itself.
 [profile.dev]
 debug = 0
+debug-assertions = false
 
 [profile.dev.package]
 # Only use debuginfo=1 to further reduce compile times.

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1720,7 +1720,10 @@ HELP: to skip test's attempt to check tidiness, pass `--skip src/tools/tidy` to 
         }
 
         builder.info("tidy check");
-        cmd.delay_failure().run(builder);
+        let ctx = builder.as_ref();
+        let mut cmd = cmd.delay_failure();
+        // spawn child in background so we can do additional work in parallel
+        let tidy = cmd.start(ctx);
 
         builder.info("x.py completions check");
         let completion_paths = get_completion_paths(builder);
@@ -1735,6 +1738,9 @@ HELP: to skip test's attempt to check tidiness, pass `--skip src/tools/tidy` to 
             );
             helpers::exit_process(1);
         }
+
+        // now wait for the child to complete
+        tidy.wait_for_output(ctx);
 
         builder.info("x.py help check");
         if builder.config.cmd.bless() {

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -331,6 +331,11 @@ impl<'a> BootstrapCommand {
         self
     }
 
+    #[track_caller]
+    pub fn start(&mut self, exec_ctx: impl AsRef<ExecutionContext>) -> DeferredCommand<'_> {
+        exec_ctx.as_ref().start(self, OutputMode::Capture, OutputMode::Capture)
+    }
+
     /// Run the command, while printing stdout and stderr.
     /// Returns true if the command has succeeded.
     #[track_caller]

--- a/src/tools/tidy/src/bins.rs
+++ b/src/tools/tidy/src/bins.rs
@@ -111,7 +111,7 @@ mod os_impl {
 
     #[cfg(unix)]
     pub fn check(path: &Path, tidy_ctx: TidyCtx) {
-        let mut check = tidy_ctx.start_check("bins");
+        let check = tidy_ctx.start_check("bins");
 
         use std::ffi::OsStr;
 

--- a/src/tools/tidy/src/codegen.rs
+++ b/src/tools/tidy/src/codegen.rs
@@ -20,7 +20,7 @@ fn has_supported_extension(path: &Path) -> bool {
 }
 
 pub fn check(path: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check(CheckId::new("codegen").path(path));
+    let check = tidy_ctx.start_check(CheckId::new("codegen").path(path));
 
     fn skip(path: &Path, is_dir: bool) -> bool {
         if path.file_name().is_some_and(|name| name.to_string_lossy().starts_with(".#")) {

--- a/src/tools/tidy/src/debug_artifacts.rs
+++ b/src/tools/tidy/src/debug_artifacts.rs
@@ -8,7 +8,7 @@ use crate::walk::{filter_dirs, filter_not_rust, walk};
 const GRAPHVIZ_POSTFLOW_MSG: &str = "`borrowck_graphviz_postflow` attribute in test";
 
 pub fn check(test_dir: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check(CheckId::new("debug_artifacts").path(test_dir));
+    let check = tidy_ctx.start_check(CheckId::new("debug_artifacts").path(test_dir));
 
     walk(
         test_dir,

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -3,8 +3,10 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::fs::{self, read_dir};
-use std::io;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::Scope;
+use std::{io, thread};
 
 use cargo_metadata::semver::Version;
 use cargo_metadata::{Metadata, Package, PackageId};
@@ -630,62 +632,80 @@ const PERMITTED_CRANELIFT_DEPENDENCIES: &[&str] = &[
 ///
 /// `root` is path to the directory with the root `Cargo.toml` (for the workspace). `cargo` is path
 /// to the cargo executable.
-pub fn check(root: &Path, cargo: &Path, tidy_ctx: TidyCtx) {
+pub fn check(
+    root: &Path,
+    cargo: &Path,
+    _scope: &'_ Scope<'_, '_>,
+    sem: &'_ crate::Semaphore,
+    tidy_ctx: TidyCtx,
+) {
     let mut check = tidy_ctx.start_check("deps");
     let bless = tidy_ctx.is_bless_enabled();
+    let is_ci = tidy_ctx.is_running_on_ci();
 
-    let mut checked_runtime_licenses = false;
+    let checked_runtime_licenses = AtomicBool::new(false);
 
     check_proc_macro_dep_list(root, cargo, bless, &mut check);
 
-    for &WorkspaceInfo { path, exceptions, crates_and_deps, submodules } in WORKSPACES {
-        if has_missing_submodule(root, submodules, tidy_ctx.is_running_on_ci()) {
-            continue;
-        }
+    thread::scope(|s| {
+        for (i, WorkspaceInfo { path, exceptions, crates_and_deps, submodules }) in
+            WORKSPACES.iter().enumerate()
+        {
+            let check = &check;
+            let checked_runtime_licenses = &checked_runtime_licenses;
+            let guard = if i > 0 { Some(sem.acquire()) } else { None };
+            s.spawn(move || {
+                if has_missing_submodule(root, submodules, is_ci) {
+                    return;
+                }
 
-        if !root.join(path).join("Cargo.lock").exists() {
-            check.error(format!("the `{path}` workspace doesn't have a Cargo.lock"));
-            continue;
-        }
+                if !root.join(path).join("Cargo.lock").exists() {
+                    check.error(format!("the `{path}` workspace doesn't have a Cargo.lock"));
+                    return;
+                }
 
-        let mut cmd = cargo_metadata::MetadataCommand::new();
-        cmd.cargo_path(cargo)
-            .manifest_path(root.join(path).join("Cargo.toml"))
-            .features(cargo_metadata::CargoOpt::AllFeatures)
-            .other_options(vec!["--locked".to_owned()]);
-        let metadata = t!(cmd.exec());
+                let mut cmd = cargo_metadata::MetadataCommand::new();
+                cmd.cargo_path(cargo)
+                    .manifest_path(root.join(path).join("Cargo.toml"))
+                    .features(cargo_metadata::CargoOpt::AllFeatures)
+                    .other_options(vec!["--locked".to_owned()]);
+                let metadata = t!(cmd.exec());
 
-        // Check for packages which have been moved into a different workspace and not updated
-        let absolute_root =
-            if path == "." { root.to_path_buf() } else { t!(std::path::absolute(root.join(path))) };
-        let absolute_root_real = t!(std::path::absolute(&metadata.workspace_root));
-        if absolute_root_real != absolute_root {
-            check.error(format!("{path} is part of another workspace ({} != {}), remove from `WORKSPACES` ({WORKSPACE_LOCATION})", absolute_root.display(), absolute_root_real.display()));
-        }
-        check_license_exceptions(&metadata, path, exceptions, &mut check);
-        if let Some((crates, permitted_deps, location)) = crates_and_deps {
-            let descr = crates.get(0).unwrap_or(&path);
-            check_permitted_dependencies(
-                &metadata,
-                descr,
-                permitted_deps,
-                crates,
-                location,
-                &mut check,
-            );
-        }
+                // Check for packages which have been moved into a different workspace and not updated
+                let absolute_root =
+                    if *path == "." { root.to_path_buf() } else { t!(std::path::absolute(root.join(path))) };
+                let absolute_root_real = t!(std::path::absolute(&metadata.workspace_root));
+                if absolute_root_real != absolute_root {
+                    check.error(format!("{path} is part of another workspace ({} != {}), remove from `WORKSPACES` ({WORKSPACE_LOCATION})", absolute_root.display(), absolute_root_real.display()));
+                }
+                check_license_exceptions(&metadata, path, exceptions, &check);
+                if let Some((crates, permitted_deps, location)) = &crates_and_deps {
+                    let descr = crates.get(0).unwrap_or(&path);
+                    check_permitted_dependencies(
+                        &metadata,
+                        descr,
+                        permitted_deps,
+                        crates,
+                        location,
+                        &check,
+                    );
+                }
 
-        if path == "library" {
-            check_runtime_license_exceptions(&metadata, &mut check);
-            check_runtime_no_duplicate_dependencies(&metadata, &mut check);
-            check_runtime_no_proc_macros(&metadata, &mut check);
-            checked_runtime_licenses = true;
+                if *path == "library" {
+                    check_runtime_license_exceptions(&metadata, &check);
+                    check_runtime_no_duplicate_dependencies(&metadata, &check);
+                    check_runtime_no_proc_macros(&metadata, &check);
+                    checked_runtime_licenses.store(true, Ordering::Relaxed);
+                }
+
+                let _guard = guard;
+            });
         }
-    }
+    });
 
     // Sanity check to ensure we don't accidentally remove the workspace containing the runtime
     // crates.
-    assert!(checked_runtime_licenses);
+    assert!(checked_runtime_licenses.load(Ordering::Relaxed));
 }
 
 /// Ensure the list of proc-macro crate transitive dependencies is up to date
@@ -788,7 +808,7 @@ pub fn has_missing_submodule(root: &Path, submodules: &[&str], is_ci: bool) -> b
 ///
 /// Unlike for tools we don't allow exceptions to the `LICENSES` list for the runtime with the sole
 /// exception of `fortanix-sgx-abi` which is only used on x86_64-fortanix-unknown-sgx.
-fn check_runtime_license_exceptions(metadata: &Metadata, check: &mut RunningCheck) {
+fn check_runtime_license_exceptions(metadata: &Metadata, check: &RunningCheck) {
     for pkg in &metadata.packages {
         if pkg.source.is_none() {
             // No need to check local packages.
@@ -823,7 +843,7 @@ fn check_license_exceptions(
     metadata: &Metadata,
     workspace: &str,
     exceptions: &[(&str, &str)],
-    check: &mut RunningCheck,
+    check: &RunningCheck,
 ) {
     // Validate the EXCEPTIONS list hasn't changed.
     for (name, license) in exceptions {
@@ -890,7 +910,7 @@ fn check_license_exceptions(
     }
 }
 
-fn check_runtime_no_duplicate_dependencies(metadata: &Metadata, check: &mut RunningCheck) {
+fn check_runtime_no_duplicate_dependencies(metadata: &Metadata, check: &RunningCheck) {
     let mut seen_pkgs = HashSet::new();
     for pkg in &metadata.packages {
         if pkg.source.is_none() {
@@ -906,7 +926,7 @@ fn check_runtime_no_duplicate_dependencies(metadata: &Metadata, check: &mut Runn
     }
 }
 
-fn check_runtime_no_proc_macros(metadata: &Metadata, check: &mut RunningCheck) {
+fn check_runtime_no_proc_macros(metadata: &Metadata, check: &RunningCheck) {
     for pkg in &metadata.packages {
         if pkg.targets.iter().any(|target| target.is_proc_macro()) {
             check.error(format!(
@@ -928,8 +948,8 @@ fn check_permitted_dependencies(
     descr: &str,
     permitted_dependencies: &[&'static str],
     restricted_dependency_crates: &[&'static str],
-    permitted_location: ListLocation,
-    check: &mut RunningCheck,
+    permitted_location: &ListLocation,
+    check: &RunningCheck,
 ) {
     let mut has_permitted_dep_error = false;
     let mut deps = HashSet::new();

--- a/src/tools/tidy/src/diagnostics.rs
+++ b/src/tools/tidy/src/diagnostics.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use build_helper::ci::CiEnv;
@@ -86,10 +87,10 @@ impl TidyCtx {
         ctx.start_check(id.clone());
         RunningCheck {
             id,
-            bad: false,
+            bad: AtomicBool::new(false),
             ctx: self.diag_ctx.clone(),
             #[cfg(test)]
-            errors: vec![],
+            errors: Mutex::new(vec![]),
         }
     }
 
@@ -228,10 +229,10 @@ impl FinishedCheck {
 /// Represents a single tidy check, identified by its `name`, running.
 pub struct RunningCheck {
     id: CheckId,
-    bad: bool,
+    bad: AtomicBool,
     ctx: Arc<Mutex<DiagCtxInner>>,
     #[cfg(test)]
-    errors: Vec<String>,
+    errors: Mutex<Vec<String>>,
 }
 
 impl RunningCheck {
@@ -245,26 +246,26 @@ impl RunningCheck {
     }
 
     /// Immediately output an error and mark the check as failed.
-    pub fn error<T: Display>(&mut self, msg: T) {
+    pub fn error<T: Display>(&self, msg: T) {
         self.mark_as_bad();
         let msg = msg.to_string();
         output_message(&msg, Some(&self.id), Some(COLOR_ERROR));
         #[cfg(test)]
-        self.errors.push(msg);
+        self.errors.lock().unwrap().push(msg);
     }
 
     /// Immediately output a warning.
-    pub fn warning<T: Display>(&mut self, msg: T) {
+    pub fn warning<T: Display>(&self, msg: T) {
         output_message(&msg.to_string(), Some(&self.id), Some(COLOR_WARNING));
     }
 
     /// Output an informational message
-    pub fn message<T: Display>(&mut self, msg: T) {
+    pub fn message<T: Display>(&self, msg: T) {
         output_message(&msg.to_string(), Some(&self.id), None);
     }
 
     /// Output a message only if verbose output is enabled.
-    pub fn verbose_msg<T: Display>(&mut self, msg: T) {
+    pub fn verbose_msg<T: Display>(&self, msg: T) {
         if self.is_verbose_enabled() {
             self.message(msg);
         }
@@ -272,7 +273,7 @@ impl RunningCheck {
 
     /// Has an error already occurred for this check?
     pub fn is_bad(&self) -> bool {
-        self.bad
+        self.bad.load(Ordering::Relaxed)
     }
 
     /// Is verbose output enabled?
@@ -282,17 +283,20 @@ impl RunningCheck {
 
     #[cfg(test)]
     pub fn get_errors(&self) -> Vec<String> {
-        self.errors.clone()
+        self.errors.lock().unwrap().clone()
     }
 
-    fn mark_as_bad(&mut self) {
-        self.bad = true;
+    fn mark_as_bad(&self) {
+        self.bad.store(true, Ordering::Relaxed);
     }
 }
 
 impl Drop for RunningCheck {
     fn drop(&mut self) {
-        self.ctx.lock().unwrap().finish_check(FinishedCheck { id: self.id.clone(), bad: self.bad })
+        self.ctx.lock().unwrap().finish_check(FinishedCheck {
+            id: self.id.clone(),
+            bad: self.bad.load(Ordering::Relaxed),
+        })
     }
 }
 

--- a/src/tools/tidy/src/edition.rs
+++ b/src/tools/tidy/src/edition.rs
@@ -6,7 +6,7 @@ use crate::diagnostics::{CheckId, TidyCtx};
 use crate::walk::{filter_dirs, walk};
 
 pub fn check(path: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check(CheckId::new("edition").path(path));
+    let check = tidy_ctx.start_check(CheckId::new("edition").path(path));
     walk(path, |path, _is_dir| filter_dirs(path), &mut |entry, contents| {
         let file = entry.path();
         let filename = file.file_name().unwrap();

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -16,7 +16,7 @@ const ALLOWED_SOURCES: &[&str] = &[
 /// Checks for external package sources. `root` is the path to the directory that contains the
 /// workspace `Cargo.toml`.
 pub fn check(root: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check("extdeps");
+    let check = tidy_ctx.start_check("extdeps");
 
     for &WorkspaceInfo { path, submodules, .. } in crate::deps::WORKSPACES {
         if crate::deps::has_missing_submodule(root, submodules, tidy_ctx.is_running_on_ci()) {

--- a/src/tools/tidy/src/extra_checks/mod.rs
+++ b/src/tools/tidy/src/extra_checks/mod.rs
@@ -171,7 +171,7 @@ pub fn check(
 }
 
 fn py_prepare(root_path: &Path, outdir: &Path, tidy_ctx: &TidyCtx) -> Option<PathBuf> {
-    let mut check = tidy_ctx.start_check("extra_checks:py_prepare");
+    let check = tidy_ctx.start_check("extra_checks:py_prepare");
 
     let venv_path = outdir.join("venv");
     let mut reqs_path = root_path.to_owned();
@@ -187,7 +187,7 @@ fn py_prepare(root_path: &Path, outdir: &Path, tidy_ctx: &TidyCtx) -> Option<Pat
 }
 
 fn js_prepare(root_path: &Path, outdir: &Path, npm: &Path, tidy_ctx: &TidyCtx) -> Option<()> {
-    let mut check = tidy_ctx.start_check("extra_checks:js_prepare");
+    let check = tidy_ctx.start_check("extra_checks:js_prepare");
 
     if let Err(e) = rustdoc_js::npm_install(root_path, outdir, npm) {
         check.error(e.to_string());
@@ -206,7 +206,7 @@ fn show_bless_help(mode: &str, action: &str, bless: bool) {
 }
 
 fn check_spellcheck(root_path: &Path, outdir: &Path, cargo: &Path, tidy_ctx: &TidyCtx) {
-    let mut check = tidy_ctx.start_check("extra_checks:spellcheck");
+    let check = tidy_ctx.start_check("extra_checks:spellcheck");
 
     let bless = tidy_ctx.is_bless_enabled();
 
@@ -230,7 +230,7 @@ fn check_spellcheck(root_path: &Path, outdir: &Path, cargo: &Path, tidy_ctx: &Ti
 }
 
 fn check_js_lint(outdir: &Path, librustdoc_path: &Path, tools_path: &Path, tidy_ctx: &TidyCtx) {
-    let mut check = tidy_ctx.start_check("extra_checks:js_lint");
+    let check = tidy_ctx.start_check("extra_checks:js_lint");
 
     let bless = tidy_ctx.is_bless_enabled();
 
@@ -252,7 +252,7 @@ fn check_js_lint(outdir: &Path, librustdoc_path: &Path, tools_path: &Path, tidy_
 }
 
 fn check_js_typecheck(outdir: &Path, librustdoc_path: &Path, tidy_ctx: &TidyCtx) {
-    let mut check = tidy_ctx.start_check("extra_checks:js_typecheck");
+    let check = tidy_ctx.start_check("extra_checks:js_typecheck");
 
     eprintln!("typechecking javascript files");
     if let Err(e) = rustdoc_js::typecheck(outdir, librustdoc_path) {
@@ -266,7 +266,7 @@ fn check_shell_lint(
     file_args: &Vec<&OsStr>,
     tidy_ctx: &TidyCtx,
 ) {
-    let mut check = tidy_ctx.start_check("extra_checks:shell_lint");
+    let check = tidy_ctx.start_check("extra_checks:shell_lint");
 
     eprintln!("linting shell files");
 
@@ -297,7 +297,7 @@ fn check_python_lint(
     py_path: &Path,
     tidy_ctx: &TidyCtx,
 ) {
-    let mut check = tidy_ctx.start_check("extra_checks:python_lint");
+    let check = tidy_ctx.start_check("extra_checks:python_lint");
 
     let bless = tidy_ctx.is_bless_enabled();
 
@@ -340,7 +340,7 @@ fn check_python_fmt(
     py_path: &Path,
     tidy_ctx: &TidyCtx,
 ) {
-    let mut check = tidy_ctx.start_check("extra_checks:python_fmt");
+    let check = tidy_ctx.start_check("extra_checks:python_fmt");
 
     let bless = tidy_ctx.is_bless_enabled();
 
@@ -380,7 +380,7 @@ fn check_cpp_fmt(
     py_path: &Path,
     tidy_ctx: &TidyCtx,
 ) {
-    let mut check = tidy_ctx.start_check("extra_checks:cpp_fmt");
+    let check = tidy_ctx.start_check("extra_checks:cpp_fmt");
 
     let bless = tidy_ctx.is_bless_enabled();
 

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -125,7 +125,7 @@ pub fn check(
             let filename_gate = test_filen_gate(&filen_underscore, &mut features);
 
             for (i, line) in contents.lines().enumerate() {
-                let mut err = |msg: &str| {
+                let err = |msg: &str| {
                     check.error(format!("{}:{}: {}", file.display(), i + 1, msg));
                 };
 
@@ -449,7 +449,7 @@ fn get_and_check_lib_features(
     let mut lib_features = Features::new();
     map_lib_features(base_src_path, &mut |res, file, line| match res {
         Ok((name, f)) => {
-            let mut check_features = |f: &Feature, list: &Features, display: &str| {
+            let check_features = |f: &Feature, list: &Features, display: &str| {
                 if let Some(s) = list.get(name)
                     && f.tracking_issue != s.tracking_issue
                     && f.level != Status::Accepted

--- a/src/tools/tidy/src/filenames.rs
+++ b/src/tools/tidy/src/filenames.rs
@@ -13,7 +13,7 @@ use std::process::Command;
 use crate::diagnostics::TidyCtx;
 
 pub fn check(root_path: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check("filenames");
+    let check = tidy_ctx.start_check("filenames");
     let stat_output = Command::new("git")
         .arg("-C")
         .arg(root_path)

--- a/src/tools/tidy/src/gcc_submodule.rs
+++ b/src/tools/tidy/src/gcc_submodule.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 use crate::diagnostics::TidyCtx;
 
 pub fn check(root_path: &Path, compiler_path: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check("gcc_submodule");
+    let check = tidy_ctx.start_check("gcc_submodule");
 
     let cg_gcc_version_path = compiler_path.join("rustc_codegen_gcc/libgccjit.version");
     let cg_gcc_version = std::fs::read_to_string(&cg_gcc_version_path)

--- a/src/tools/tidy/src/known_bug.rs
+++ b/src/tools/tidy/src/known_bug.rs
@@ -6,7 +6,7 @@ use crate::diagnostics::{CheckId, TidyCtx};
 use crate::walk::*;
 
 pub fn check(filepath: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check(CheckId::new("known_bug").path(filepath));
+    let check = tidy_ctx.start_check(CheckId::new("known_bug").path(filepath));
     walk(filepath, |path, _is_dir| filter_not_rust(path), &mut |entry, contents| {
         let file: &Path = entry.path();
 

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -4,6 +4,7 @@
 //! to be used by tools.
 
 use std::ffi::OsStr;
+use std::num::NonZeroUsize;
 use std::process::Command;
 
 macro_rules! static_regex {
@@ -135,3 +136,39 @@ pub mod unknown_revision;
 pub mod unstable_book;
 pub mod walk;
 pub mod x_version;
+
+pub struct Semaphore {
+    sem: std::sync::Mutex<usize>,
+    cond: std::sync::Condvar,
+}
+
+impl Semaphore {
+    pub fn new(count: NonZeroUsize) -> Self {
+        Self { sem: std::sync::Mutex::new(count.get()), cond: std::sync::Condvar::new() }
+    }
+
+    pub fn acquire(&self) -> Guard<'_> {
+        let mut count = self.sem.lock().unwrap();
+        while *count == 0 {
+            count = self.cond.wait(count).unwrap();
+        }
+        *count -= 1;
+        Guard { sem: self }
+    }
+
+    fn release(&self) {
+        let mut count = self.sem.lock().unwrap();
+        *count += 1;
+        self.cond.notify_one();
+    }
+}
+
+pub struct Guard<'a> {
+    sem: &'a Semaphore,
+}
+
+impl Drop for Guard<'_> {
+    fn drop(&mut self) {
+        self.sem.release();
+    }
+}

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -4,8 +4,8 @@
 //! etc. This is run by default on `./x.py test` and as part of the auto
 //! builders. The tidy checks can be executed with `./x.py test tidy`.
 
-use std::collections::VecDeque;
-use std::thread::{self, ScopedJoinHandle, scope};
+use std::num::NonZeroUsize;
+use std::thread::{self, scope};
 use std::{env, process};
 
 use tidy::arg_parser::TidyArgParser;
@@ -46,22 +46,9 @@ fn main() {
 
     let tidy_ctx = TidyCtx::new(&root_path, verbose, ci, TidyFlags::new(bless));
 
-    let drain_handles = |handles: &mut VecDeque<ScopedJoinHandle<'_, ()>>| {
-        // poll all threads for completion before awaiting the oldest one
-        for i in (0..handles.len()).rev() {
-            if handles[i].is_finished() {
-                handles.swap_remove_back(i).unwrap().join().unwrap();
-            }
-        }
-
-        while handles.len() >= concurrency {
-            handles.pop_front().unwrap().join().unwrap();
-        }
-    };
+    let sem = Semaphore::new(NonZeroUsize::new(concurrency).unwrap());
 
     scope(|s| {
-        let mut handles: VecDeque<ScopedJoinHandle<'_, ()>> = VecDeque::with_capacity(concurrency);
-
         macro_rules! check {
             ($p:ident) => {
                 check!(@ $p, name=format!("{}", stringify!($p)));
@@ -76,20 +63,19 @@ fn main() {
                 check!(@ $p, name=name, $path $(,$args)*);
             };
             (@ $p:ident, name=$name:expr $(, $args:expr)* ) => {
-                drain_handles(&mut handles);
-
+                let guard = sem.acquire();
                 let tidy_ctx = tidy_ctx.clone();
-                let handle = thread::Builder::new().name($name).spawn_scoped(s, || {
+                thread::Builder::new().name($name).spawn_scoped(s, || {
                     $p::check($($args, )* tidy_ctx);
+                    let _guard = guard;
                 }).unwrap();
-                handles.push_back(handle);
             }
         }
 
         check!(target_specific_tests, &tests_path);
 
         // Checks that are done on the cargo workspace.
-        check!(deps, &root_path, &cargo);
+        check!(deps, &root_path, &cargo, s, &sem);
         check!(extdeps, &root_path);
 
         // Checks over tests.
@@ -123,8 +109,8 @@ fn main() {
             check!(bins, &root_path);
         }
 
-        check!(style, &src_path);
         check!(style, &tests_path);
+        check!(style, &src_path);
         check!(style, &compiler_path);
         check!(style, &library_path);
 
@@ -145,8 +131,6 @@ fn main() {
         check!(filenames, &root_path);
 
         let collected = {
-            drain_handles(&mut handles);
-
             features::check(&src_path, &tests_path, &compiler_path, &library_path, tidy_ctx.clone())
         };
         check!(unstable_book, &src_path, collected);

--- a/src/tools/tidy/src/rustdoc_gui_tests.rs
+++ b/src/tools/tidy/src/rustdoc_gui_tests.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use crate::diagnostics::{CheckId, TidyCtx};
 
 pub fn check(path: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check(CheckId::new("rustdoc_gui_tests").path(path));
+    let check = tidy_ctx.start_check(CheckId::new("rustdoc_gui_tests").path(path));
 
     crate::walk::walk(
         &path.join("rustdoc-gui"),

--- a/src/tools/tidy/src/rustdoc_json.rs
+++ b/src/tools/tidy/src/rustdoc_json.rs
@@ -9,7 +9,7 @@ use crate::diagnostics::{CheckId, TidyCtx};
 const RUSTDOC_JSON_TYPES: &str = "src/rustdoc-json-types";
 
 pub fn check(src_path: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check(CheckId::new("rustdoc_json").path(src_path));
+    let check = tidy_ctx.start_check(CheckId::new("rustdoc_json").path(src_path));
 
     let Some(base_commit) = &tidy_ctx.base_commit else {
         check.verbose_msg("No base commit, skipping rustdoc_json check");

--- a/src/tools/tidy/src/rustdoc_templates.rs
+++ b/src/tools/tidy/src/rustdoc_templates.rs
@@ -13,7 +13,7 @@ use crate::walk::walk;
 const TAGS: &[(&str, &str)] = &[("{#", "#}"), ("{%", "%}"), ("{{", "}}")];
 
 pub fn check(librustdoc_path: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check(CheckId::new("rustdoc_templates").path(librustdoc_path));
+    let check = tidy_ctx.start_check(CheckId::new("rustdoc_templates").path(librustdoc_path));
 
     walk(
         &librustdoc_path.join("html/templates"),

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -426,7 +426,7 @@ fn check_file_style(check: &mut RunningCheck, file: &Path, contents: &str) {
             lines += 1;
         }
 
-        let mut err = |msg: &str| {
+        let err = |msg: &str| {
             check.error(format!("{}:{}: {msg}", file.display(), line_number));
         };
 
@@ -614,7 +614,7 @@ fn check_file_style(check: &mut RunningCheck, file: &Path, contents: &str) {
             } else if let Some((start_line, backtick_count, directive)) = comment_block.take()
                 && backtick_count % 2 == 1
             {
-                let mut err = |msg: &str| {
+                let err = |msg: &str| {
                     check.error(format!("{}:{start_line}: {msg}", file.display()));
                 };
                 let block_len = line_number - start_line;
@@ -641,12 +641,12 @@ fn check_file_style(check: &mut RunningCheck, file: &Path, contents: &str) {
         ignore.check_usage(check, file);
     }
     if leading_new_lines {
-        let mut err = |_| {
+        let err = |_| {
             check.error(format!("{}: leading newline", file.display()));
         };
         suppressible_tidy_err!(err, file_ignore.leading_newlines, "missing leading newline");
     }
-    let mut err = |msg: &str| {
+    let err = |msg: &str| {
         check.error(format!("{}: {}", file.display(), msg));
     };
     match trailing_new_lines {
@@ -659,7 +659,7 @@ fn check_file_style(check: &mut RunningCheck, file: &Path, contents: &str) {
         ),
     };
     if lines > LINES {
-        let mut err = |_| {
+        let err = |_| {
             check.error(format!(
                 "{}: too many lines ({lines}) (add `// \
                      ignore-tidy-file-filelength` to the file to suppress this error)",

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -431,8 +431,8 @@ fn check_file_style(check: &mut RunningCheck, file: &Path, contents: &str) {
         };
 
         if !is_this_file
-            && trimmed.contains("dbg!")
             && !trimmed.starts_with("//")
+            && trimmed.contains("dbg!")
             && !file.ancestors().any(|a| {
                 (a.ends_with("tests") && a.join("COMPILER_TESTS.md").exists())
                     || a.ends_with("library/alloctests")
@@ -447,8 +447,8 @@ fn check_file_style(check: &mut RunningCheck, file: &Path, contents: &str) {
         }
 
         if !is_this_file
-            && trimmed.contains("todo!")
             && !trimmed.starts_with("//")
+            && trimmed.contains("todo!")
             && !file.ancestors().any(|a| {
                 (a.ends_with("tests") && a.join("COMPILER_TESTS.md").exists())
                     || a.ends_with("library/alloctests")
@@ -498,10 +498,11 @@ fn check_file_style(check: &mut RunningCheck, file: &Path, contents: &str) {
                     || Directives::parse(LineNumber::WholeFile, line)
                         .iter()
                         .any(|directive| directive.is_ignore_and_defuse()));
-            let has_alphabetical_directive =
-                line.contains("tidy-alphabetical-start") || line.contains("tidy-alphabetical-end");
+            let has_alphabetical_directive = contains_potential_directive
+                && (line.contains("tidy-alphabetical-start")
+                    || line.contains("tidy-alphabetical-end"));
             let has_other_tidy_ignore_directive =
-                line.contains("ignore-tidy-target-specific-tests");
+                contains_potential_directive && line.contains("ignore-tidy-target-specific-tests");
             let has_recognized_directive = has_recognized_ignore_directive
                 || has_alphabetical_directive
                 || has_other_tidy_ignore_directive;

--- a/src/tools/tidy/src/style/directive.rs
+++ b/src/tools/tidy/src/style/directive.rs
@@ -323,8 +323,13 @@ pub enum LineNumber {
 }
 
 pub fn match_ignore(contents: &str, whole_file: bool, check: Option<&str>) -> bool {
-    let comments = [("// ", ""), ("# ", ""), ("/* ", " */"), ("<!-- ", " -->")];
     let base = "ignore-tidy";
+    // fast-path
+    if !contents.contains(base) {
+        return false;
+    }
+
+    let comments = [("// ", ""), ("# ", ""), ("/* ", " */"), ("<!-- ", " -->")];
     let file = if whole_file { "file-" } else { "" };
 
     for (start, end) in comments {

--- a/src/tools/tidy/src/target_policy.rs
+++ b/src/tools/tidy/src/target_policy.rs
@@ -25,7 +25,7 @@ const EXCEPTIONS: &[&str] = &[
 ];
 
 pub fn check(root_path: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check("target_policy");
+    let check = tidy_ctx.start_check("target_policy");
 
     let mut targets_to_find = HashSet::new();
 

--- a/src/tools/tidy/src/target_specific_tests.rs
+++ b/src/tools/tidy/src/target_specific_tests.rs
@@ -20,7 +20,7 @@ struct RevisionInfo<'a> {
 }
 
 pub fn check(tests_path: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check(CheckId::new("target-specific-tests").path(tests_path));
+    let check = tidy_ctx.start_check(CheckId::new("target-specific-tests").path(tests_path));
 
     crate::walk::walk(tests_path, |path, _is_dir| filter_not_rust(path), &mut |entry, content| {
         if content.contains("// ignore-tidy-target-specific-tests") {

--- a/src/tools/tidy/src/tests_placement.rs
+++ b/src/tools/tidy/src/tests_placement.rs
@@ -6,7 +6,7 @@ const FORBIDDEN_PATH: &str = "src/test";
 const ALLOWED_PATH: &str = "tests";
 
 pub fn check(root_path: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check("tests_placement");
+    let check = tidy_ctx.start_check("tests_placement");
 
     if root_path.join(FORBIDDEN_PATH).exists() {
         check.error(format!(

--- a/src/tools/tidy/src/tests_revision_unpaired_stdout_stderr.rs
+++ b/src/tools/tidy/src/tests_revision_unpaired_stdout_stderr.rs
@@ -23,7 +23,7 @@ const EXTENSIONS: &[&str] = &["stdout", "stderr"];
 const SPECIAL_TEST: &str = "tests/ui/command/need-crate-arg-ignore-tidy.x.rs";
 
 pub fn check(tests_path: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx
+    let check = tidy_ctx
         .start_check(CheckId::new("tests_revision_unpaired_stdout_stderr").path(tests_path));
 
     // Recurse over subdirectories under `tests/`

--- a/src/tools/tidy/src/triagebot.rs
+++ b/src/tools/tidy/src/triagebot.rs
@@ -19,7 +19,7 @@ static SUBMODULES: LazyLock<Vec<&'static Path>> = LazyLock::new(|| {
 });
 
 pub fn check(path: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check("triagebot");
+    let check = tidy_ctx.start_check("triagebot");
     let triagebot_path = path.join("triagebot.toml");
 
     // This check is mostly to catch broken path filters *within* `triagebot.toml`, and not enforce

--- a/src/tools/tidy/src/unit_tests.rs
+++ b/src/tools/tidy/src/unit_tests.rs
@@ -15,7 +15,7 @@ use crate::diagnostics::{CheckId, TidyCtx};
 use crate::walk::{filter_dirs, walk};
 
 pub fn check(root_path: &Path, stdlib: bool, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check(CheckId::new("unit_tests").path(root_path));
+    let check = tidy_ctx.start_check(CheckId::new("unit_tests").path(root_path));
 
     let skip = move |path: &Path, is_dir| {
         let file_name = path.file_name().unwrap_or_default();

--- a/src/tools/tidy/src/x_version.rs
+++ b/src/tools/tidy/src/x_version.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use crate::diagnostics::{CheckId, TidyCtx};
 
 pub fn check(root: &Path, cargo: &Path, tidy_ctx: TidyCtx) {
-    let mut check = tidy_ctx.start_check(CheckId::new("x_version").path(root));
+    let check = tidy_ctx.start_check(CheckId::new("x_version").path(root));
     let cargo_list = Command::new(cargo).args(["install", "--list"]).stdout(Stdio::piped()).spawn();
 
     let child = match cargo_list {


### PR DESCRIPTION
Tidy has slowed down quite a bit over the years (https://github.com/rust-lang/rust/pull/81833, https://github.com/rust-lang/rust/pull/105829), so let's recover some perf

```
OLD

$ hyperfine -w 1 "./x test tidy"
Benchmark #1: ./x test tidy
  Time (mean ± σ):      5.076 s ±  0.057 s    [User: 12.724 s, System: 6.707 s]
  Range (min … max):    4.972 s …  5.148 s    10 runs

$ taskset -c 0-5 hyperfine -w 1 "./x test tidy"
Benchmark #1: ./x test tidy
  Time (mean ± σ):      7.973 s ±  0.099 s    [User: 12.072 s, System: 5.550 s]
  Range (min … max):    7.838 s …  8.184 s    10 runs

NEW

$ hyperfine -w 1 "./x test tidy"
Benchmark #1: ./x test tidy
  Time (mean ± σ):      3.134 s ±  0.055 s    [User: 7.993 s, System: 6.842 s]
  Range (min … max):    3.047 s …  3.204 s    10 runs

$ taskset -c 0-5 hyperfine -w 1 "./x test tidy"
Benchmark #1: ./x test tidy
  Time (mean ± σ):      3.921 s ±  0.129 s    [User: 7.204 s, System: 5.563 s]
  Range (min … max):    3.740 s …  4.069 s    10 runs
```

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

After this about half of the remaining time is burned by bootstrap doing git and cargo stuff.

<img width="2546" height="1061" alt="image" src="https://github.com/user-attachments/assets/0049a525-9c2e-433a-a88c-94e8063dce5b" />

Fixes: https://github.com/rust-lang/rust/issues/141074

----

LLM disclosure: I used copilot's autocomplete. Most suggestions were trivial (or discarded for being incorrect), with the exception of the Semaphore type which it produced almost wholesale. I compared it to implementations in the wild and they look almost identical, so I hope this too falls under "trivial".