### PR TITLE
Stop suggesting missing semicolon with multiline indexing

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2387,7 +2387,7 @@ impl<'a> Parser<'a> {
         }
 
         if self.token == token::Comma {
-            if !self.psess.source_map().is_multiline(prev_span.until(self.token.span)) {
+            if !self.psess.source_map().is_multiline(prev_span.until(open_delim_span)) {
                 return Ok(());
             }
             let mut snapshot = self.create_snapshot_for_diagnostic();

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2387,6 +2387,9 @@ impl<'a> Parser<'a> {
         }
 
         if self.token == token::Comma {
+            // Only make this suggestion if the `[` is not on the same line as the last token of
+            // the expression preceding it, which is a sign that it is not intended as an
+            // index expression.
             if !self.psess.source_map().is_multiline(prev_span.until(open_delim_span)) {
                 return Ok(());
             }

--- a/tests/ui/parser/do-not-suggest-semicolon-before-index.rs
+++ b/tests/ui/parser/do-not-suggest-semicolon-before-index.rs
@@ -1,0 +1,8 @@
+fn example() {
+    (foo[
+        bar
+        .baz(), //~ ERROR: expected one of `.`, `?`, `]`, or an operator, found `,`
+    ])
+}
+
+fn main() {}

--- a/tests/ui/parser/do-not-suggest-semicolon-before-index.stderr
+++ b/tests/ui/parser/do-not-suggest-semicolon-before-index.stderr
@@ -1,0 +1,13 @@
+error: expected one of `.`, `?`, `]`, or an operator, found `,`
+  --> $DIR/do-not-suggest-semicolon-before-index.rs:4:15
+   |
+LL |         .baz(),
+   |               ^ expected one of `.`, `?`, `]`, or an operator
+   |
+help: you might have meant to call a macro
+   |
+LL |     (foo![
+   |         +
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Making a change so that when the open bracket is on the same line as the thing being indexed, we don't suggest a semicolon. This does change some existing behaviour though:
```
foo[
  1,
  2]
```
Before, this example would recommend `foo;[` and it will now suggest `foo![` which is probably what was intended.

r? @kpreid 

Closes rust-lang/rust#161147 