### PR TITLE
rust-installer/install-template.sh: catch cp(1) error when installing…

### DIFF
--- a/src/tools/rust-installer/install-template.sh
+++ b/src/tools/rust-installer/install-template.sh
@@ -611,6 +611,8 @@ install_components() {
             maybe_backup_path "$_file_install_path"
 
             run cp "$_src_dir/$_component/$_file" "$_file_install_path"
+            critical_need_ok "failed to copy file"
+
             if $_is_bin || test -x "$_src_dir/$_component/$_file"; then
                 run chmod 755 "$_file_install_path"
             else


### PR DESCRIPTION
… files

In Gentoo, we had a report [0] of `install.sh` ignoring an error from `cp`:
```
install: installing component 'rustc'
cp: failed to clone '.../rust-bin-1.96.1/lib/librustc_driver-07ef66cfcebfb535.so'
   from '.../rustc/lib/librustc_driver-07ef66cfcebfb535.so': Input/output error
install: installing component 'cargo'
install: installing component 'rust-std-x86_64-unknown-linux-gnu'
install: installing component 'rust-docs'
```

Use `critical_need_ok` after calling cp, as is done elsewhere in the script.

[0] https://bugs.gentoo.org/980971
