### PR TITLE
Reduce minimum LLDB to 21.1.0 for `lldb-repr` tests

### DIFF
--- a/tests/debuginfo/basic-types/main.rs
+++ b/tests/debuginfo/basic-types/main.rs
@@ -7,7 +7,7 @@
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc
-//@ min-llvm-lldb-version: 22.1.0
+//@ min-llvm-lldb-version: 21.1.0
 
 // This version corresponds to swift 6.2.3/lldb 19.1.5
 //@ min-apple-lldb-version: 1703.0.236.21

--- a/tests/debuginfo/pretty-std/main.rs
+++ b/tests/debuginfo/pretty-std/main.rs
@@ -13,7 +13,7 @@
 // ignore-tidy-linelength
 //@ ignore-android: FIXME(#10381)
 //@ compile-flags:-g
-//@ min-llvm-lldb-version: 22.1.0
+//@ min-llvm-lldb-version: 21.1.0
 //@ min-apple-lldb-version: 1703.0.236.21
 //@ min-cdb-version: 10.0.18317.1001
 //@ ignore-backends: gcc


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

I wrote `lldb-repr` against LLDB 22, but i don't think i actually use any 22-specific features. PR CI currently uses 21 iirc, so i'm curious if they pass there. 

r? @Kobzol , @jieyouxu 
