### PR TITLE
Revert "Rollup merge of #161006 - GuillaumeGomez:gcc-binutils, r=Kobzol"

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
@@ -19,16 +19,4 @@ if [ "${DIST_TRY_BUILD:-0}" == "0" ]; then
     CC=/rustroot/bin/cc CXX=/rustroot/bin/c++ python3 ../x.py dist \
       gcc-dev \
       gcc
-    # We confirm that the built GCC has support for the `retain` attribute.
-    # FIXME: Maybe get the path from `.x.py` instead?
-    gcc_path="./build/$HOSTS/gcc/$HOSTS/install/bin/gcc"
-    c_code='int x __attribute__((used, retain));'
-    if echo "$c_code" | "$gcc_path" -S -x c -o - - | grep -i '"a.*R"'; then
-        echo "retain attribute is supported"
-    else
-        echo "retain attribute is not supported"
-        # We display the generated asm just in case...
-        echo "$c_code" | "$gcc_path" -S -x c -o - -
-        exit 1
-    fi
 fi

--- a/src/ci/docker/scripts/build-gcc.sh
+++ b/src/ci/docker/scripts/build-gcc.sh
@@ -4,27 +4,6 @@ set -eux
 
 source shared.sh
 
-# We have to build our own binutils for the GCC build, because the default CentOS 7 binutils are
-# too old, and they do not support `SHF_GNU_RETAIN`.
-BINUTILS="2.47"
-curl https://ci-mirrors.rust-lang.org/rustc/gcc/binutils-$BINUTILS.tar.xz | xzcat | tar xf -
-mkdir binutils-build
-cd binutils-build
-hide_output ../binutils-$BINUTILS/configure --prefix=/rustroot
-hide_output make -j$(nproc)
-hide_output make install
-
-cd ..
-rm -rf binutils-build binutils-$BINUTILS
-
-if echo '.section .test,"awR",@progbits' | as - -o /dev/null 2>/dev/null; then
-    echo "binutils assembler supports SHF_GNU_RETAIN"
-else
-    echo "binutils assembler DOES NOT support SHF_GNU_RETAIN"
-    exit 1
-fi
-
-
 # Note: in the future when bumping to version 10.1.0, also take care of the sed block below.
 # This version is specified in the Dockerfile
 GCC=$GCC_VERSION
@@ -57,7 +36,6 @@ sed -i'' 's|ftp://gcc\.gnu\.org/pub/gcc/infrastructure|https://ci-mirrors.rust-l
 mkdir ../gcc-build
 cd ../gcc-build
 
-export PATH=/rustroot/bin:$PATH
 # '-fno-reorder-blocks-and-partition' is required to
 # enable BOLT optimization of the C++ standard library,
 # which is included in librustc_driver.so


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161218)*
<!-- homu-ignore:end -->

This reverts PR https://github.com/rust-lang/rust/pull/161006.

That fixes the mysterious Miri build issue on aarch64-linux:
```
error: linking with `cc` failed: exit status: 1
|
= note: "cc" "-Wl,--fix-cortex-a53-843419" "/home/runner/work/miri/miri/target/release/build/miri/cd7c7136867df99d/out/rustcCgh8cr/symbols.o" "<9 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/aarch64-unknown-linux-gnu/lib/libtikv_jemalloc_sys-*.rlib" "/home/runner/work/miri/miri/target/release/build/miri/066391e6b2ce8aa3/out/libmiri-066391e6b2ce8aa3.rlib" "/home/runner/work/miri/miri/target/release/build/directories/839d79c0abf643b9/out/libdirectories-839d79c0abf643b9.rlib" "/home/runner/work/miri/miri/target/release/build/dirs-sys/85035a9d09d384eb/out/libdirs_sys-85035a9d09d384eb.rlib" "/home/runner/work/miri/miri/target/release/build/option-ext/f18695aec5c506ba/out/liboption_ext-f18695aec5c506ba.rlib" "/home/runner/work/miri/miri/target/release/build/libloading/839165948c6a5ee8/out/liblibloading-839165948c6a5ee8.rlib" "/home/runner/work/miri/miri/target/release/build/measureme/903cc8fb53ad83e3/out/libmeasureme-903cc8fb53ad83e3.rlib" "/home/runner/work/miri/miri/target/release/build/rustc-hash/e49345dfb31aa501/out/librustc_hash-e49345dfb31aa501.rlib" "/home/runner/work/miri/miri/target/release/build/parking_lot/885d4f925d9d80e5/out/libparking_lot-885d4f925d9d80e5.rlib" "/home/runner/work/miri/miri/target/release/build/parking_lot_core/3801e2f2e2a1da6f/out/libparking_lot_core-3801e2f2e2a1da6f.rlib" "/home/runner/work/miri/miri/target/release/build/lock_api/0e2d895d91ddbe1a/out/liblock_api-0e2d895d91ddbe1a.rlib" "/home/runner/work/miri/miri/target/release/build/scopeguard/bf5eec70b487ef5b/out/libscopeguard-bf5eec70b487ef5b.rlib" "/home/runner/work/miri/miri/target/release/build/aes/80fb98a96a210235/out/libaes-80fb98a96a210235.rlib" "/home/runner/work/miri/miri/target/release/build/cpubits/3e8c46ad778f86f7/out/libcpubits-3e8c46ad778f86f7.rlib" "/home/runner/work/miri/miri/target/release/build/cpufeatures/18fe67ba3eaef6bd/out/libcpufeatures-18fe67ba3eaef6bd.rlib" "/home/runner/work/miri/miri/target/release/build/cipher/d15b62a10cc2ec99/out/libcipher-d15b62a10cc2ec99.rlib" "/home/runner/work/miri/miri/target/release/build/inout/525f5e448b9de16b/out/libinout-525f5e448b9de16b.rlib" "/home/runner/work/miri/miri/target/release/build/crypto-common/04c6bcb29cdd3fa4/out/libcrypto_common-04c6bcb29cdd3fa4.rlib" "/home/runner/work/miri/miri/target/release/build/hybrid-array/aa6ffe623e7bfea9/out/libhybrid_array-aa6ffe623e7bfea9.rlib" "/home/runner/work/miri/miri/target/release/build/typenum/2e73db423490f594/out/libtypenum-2e73db423490f594.rlib" "/home/runner/work/miri/miri/target/release/build/chrono-tz/0adc3b970614e15c/out/libchrono_tz-0adc3b970614e15c.rlib" "/home/runner/work/miri/miri/target/release/build/phf/e5204e816703d512/out/libphf-e5204e816703d512.rlib" "/home/runner/work/miri/miri/target/release/build/phf_shared/36f0f8f974163d11/out/libphf_shared-36f0f8f974163d11.rlib" "/home/runner/work/miri/miri/target/release/build/siphasher/56a29901c40cbc8c/out/libsiphasher-56a29901c40cbc8c.rlib" "/home/runner/work/miri/miri/target/release/build/chrono/6e4e2a3c91cb6e07/out/libchrono-6e4e2a3c91cb6e07.rlib" "/home/runner/work/miri/miri/target/release/build/num-traits/b17e54b36344b4a2/out/libnum_traits-b17e54b36344b4a2.rlib" "/home/runner/work/miri/miri/target/release/build/bitflags/8d0761067f7c2f2f/out/libbitflags-8d0761067f7c2f2f.rlib" "/home/runner/work/miri/miri/target/release/build/serde/d2436d35c16be608/out/libserde-d2436d35c16be608.rlib" "/home/runner/work/miri/miri/target/release/build/serde_core/603537d6fd6fed8c/out/libserde_core-603537d6fd6fed8c.rlib" "/home/runner/work/miri/miri/target/release/build/libffi/a2e24ae477df3b54/out/liblibffi-a2e24ae477df3b54.rlib" "/home/runner/work/miri/miri/target/release/build/libffi-sys/d461abdd542dfb39/out/liblibffi_sys-d461abdd542dfb39.rlib" "/home/runner/work/miri/miri/target/release/build/mio/58c9866d47f565e1/out/libmio-58c9866d47f565e1.rlib" "/home/runner/work/miri/miri/target/release/build/log/6311f34877871a03/out/liblog-6311f34877871a03.rlib" "/home/runner/work/miri/miri/target/release/build/smallvec/40211a3a9b111236/out/libsmallvec-40211a3a9b111236.rlib" "/home/runner/work/miri/miri/target/release/build/rand/75fdd173eed4421c/out/librand-75fdd173eed4421c.rlib" "/home/runner/work/miri/miri/target/release/build/getrandom/c4f2a791e3f9743c/out/libgetrandom-c4f2a791e3f9743c.rlib" "/home/runner/work/miri/miri/target/release/build/libc/d9926cdbd3f01bba/out/liblibc-d9926cdbd3f01bba.rlib" "/home/runner/work/miri/miri/target/release/build/chacha20/9ea74cbee8151503/out/libchacha20-9ea74cbee8151503.rlib" "/home/runner/work/miri/miri/target/release/build/cfg-if/ddb446835519044b/out/libcfg_if-ddb446835519044b.rlib" "/home/runner/work/miri/miri/target/release/build/rand_core/ad55995e6c234549/out/librand_core-ad55995e6c234549.rlib" "-Wl,-Bdynamic" "<sysroot>/lib/rustlib/aarch64-unknown-linux-gnu/lib/librustc_driver-e5626671c701e88f.so" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/aarch64-unknown-linux-gnu/lib/libcompiler_builtins-*.rlib" "-Wl,-Bdynamic" "-ldl" "-lLLVM-23-rust-1.100.0-nightly" "-ldl" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/home/runner/work/miri/miri/target/release/build/miri/cd7c7136867df99d/out/rustcCgh8cr/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/home/runner/work/miri/miri/target/release/build/capstone-sys/c9d4335146bfa0df/out" "-L" "/home/runner/work/miri/miri/target/release/build/libffi-sys/a3eb5cb25babb541/out/libffi-root/lib" "-L" "/home/runner/work/miri/miri/target/release/build/libffi-sys/a3eb5cb25babb541/out/libffi-root/lib32" "-L" "/home/runner/work/miri/miri/target/release/build/libffi-sys/a3eb5cb25babb541/out/libffi-root/lib64" "-L" "<sysroot>/lib/rustlib/aarch64-unknown-linux-gnu/lib" "-o" "/home/runner/work/miri/miri/target/release/build/miri/cd7c7136867df99d/out/miri" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-Wl,--strip-debug" "-nodefaultlibs" "-Wl,-rpath,<sysroot>/lib/rustlib/aarch64-unknown-linux-gnu/lib"
= note: some arguments are omitted. use `--verbose` to show all linker arguments
= note: /usr/bin/ld: /home/runner/.rustup/toolchains/miri/lib/rustlib/aarch64-unknown-linux-gnu/lib/libtikv_jemalloc_sys-94b57e83a66832ed.rlib: error adding symbols: file format not recognized
collect2: error: ld returned 1 exit status
```

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
