### PR TITLE
bootstrap: Make various things non-pub

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -409,8 +409,9 @@ macro_rules! bootstrap_tool {
         ;
     )+) => {
         #[derive(PartialEq, Eq, Clone)]
-        pub enum Tool {
+        pub(crate) enum Tool {
             $(
+                #[allow(dead_code, reason = "not all bootstrap-tools need a variant")]
                 $name,
             )+
         }
@@ -419,14 +420,14 @@ macro_rules! bootstrap_tool {
             /// Ensure a tool is built, then get the path to its executable.
             ///
             /// The actual building, if any, will be handled via [`ToolBuild`].
-            pub fn tool_exe(&self, tool: Tool) -> PathBuf {
+            pub(crate) fn tool_exe(&self, tool: Tool) -> PathBuf {
                 self.tool(tool).tool_path
             }
 
             /// Ensure a tool is built, then return its build output.
             ///
             /// The actual building, if any, will be handled via [`ToolBuild`].
-            pub fn tool(&self, tool: Tool) -> ToolBuildResult {
+            pub(crate) fn tool(&self, tool: Tool) -> ToolBuildResult {
                 match tool {
                     $(Tool::$name =>
                         self.ensure($name {
@@ -1621,7 +1622,7 @@ impl Builder<'_> {
     /// `host`.
     ///
     /// This also ensures that the given tool is built (using [`ToolBuild`]).
-    pub fn tool_cmd(&self, tool: Tool) -> BootstrapCommand {
+    pub(crate) fn tool_cmd(&self, tool: Tool) -> BootstrapCommand {
         let mut cmd = command(self.tool_exe(tool));
         let compiler = self.compiler(0, self.config.host_target);
         let host = &compiler.host;

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -139,7 +139,7 @@ impl HostFlags {
 }
 
 #[derive(Debug)]
-pub struct Cargo {
+pub(crate) struct Cargo {
     command: BootstrapCommand,
     args: Vec<OsString>,
     compiler: Compiler,
@@ -158,7 +158,7 @@ impl Cargo {
     /// Calls [`Builder::cargo`] and [`Cargo::configure_linker`] to prepare an invocation of `cargo`
     /// to be run.
     #[track_caller]
-    pub fn new(
+    pub(crate) fn new(
         builder: &Builder<'_>,
         compiler: Compiler,
         mode: Mode,
@@ -182,30 +182,31 @@ impl Cargo {
         cargo
     }
 
-    pub fn release_build(&mut self, release_build: bool) {
+    pub(crate) fn release_build(&mut self, release_build: bool) {
         self.profile = if release_build { Some("release") } else { None };
     }
 
-    pub fn profile(&mut self, profile: &'static str) {
+    #[expect(dead_code, reason = "general-purpose, currently unused")]
+    pub(crate) fn profile(&mut self, profile: &'static str) {
         self.profile = Some(profile);
     }
 
-    pub fn compiler(&self) -> Compiler {
+    pub(crate) fn compiler(&self) -> Compiler {
         self.compiler
     }
 
-    pub fn mode(&self) -> Mode {
+    pub(crate) fn mode(&self) -> Mode {
         self.mode
     }
 
-    pub fn into_cmd(self) -> BootstrapCommand {
+    pub(crate) fn into_cmd(self) -> BootstrapCommand {
         self.into()
     }
 
     /// Same as [`Cargo::new`] except this one doesn't configure the linker with
     /// [`Cargo::configure_linker`].
     #[track_caller]
-    pub fn new_for_mir_opt_tests(
+    pub(crate) fn new_for_mir_opt_tests(
         builder: &Builder<'_>,
         compiler: Compiler,
         mode: Mode,
@@ -220,22 +221,22 @@ impl Cargo {
         cargo
     }
 
-    pub fn rustdocflag(&mut self, arg: &str) -> &mut Cargo {
+    pub(crate) fn rustdocflag(&mut self, arg: &str) -> &mut Cargo {
         self.rustdocflags.arg(arg);
         self
     }
 
-    pub fn rustflag(&mut self, arg: &str) -> &mut Cargo {
+    pub(crate) fn rustflag(&mut self, arg: &str) -> &mut Cargo {
         self.rustflags.arg(arg);
         self
     }
 
-    pub fn arg(&mut self, arg: impl AsRef<OsStr>) -> &mut Cargo {
+    pub(crate) fn arg(&mut self, arg: impl AsRef<OsStr>) -> &mut Cargo {
         self.args.push(arg.as_ref().into());
         self
     }
 
-    pub fn args<I, S>(&mut self, args: I) -> &mut Cargo
+    pub(crate) fn args<I, S>(&mut self, args: I) -> &mut Cargo
     where
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
@@ -249,7 +250,7 @@ impl Cargo {
     /// Add an env var to the cargo command instance. Note that `RUSTFLAGS`/`RUSTDOCFLAGS` must go
     /// through [`Cargo::rustdocflags`] and [`Cargo::rustflags`] because inconsistent `RUSTFLAGS`
     /// and `RUSTDOCFLAGS` usages will trigger spurious rebuilds.
-    pub fn env(&mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) -> &mut Cargo {
+    pub(crate) fn env(&mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) -> &mut Cargo {
         assert_ne!(key.as_ref(), "RUSTFLAGS");
         assert_ne!(key.as_ref(), "RUSTDOCFLAGS");
         self.command.env(key.as_ref(), value.as_ref());
@@ -262,7 +263,7 @@ impl Cargo {
     ///
     /// Note that this only considers the existence of the env. var. configured on this `Cargo`
     /// instance. It does not look at the environment of this process.
-    pub fn append_to_env(
+    pub(crate) fn append_to_env(
         &mut self,
         key: impl AsRef<OsStr>,
         value: impl AsRef<OsStr>,
@@ -282,11 +283,11 @@ impl Cargo {
         }
     }
 
-    pub fn add_rustc_lib_path(&mut self, builder: &Builder<'_>) {
+    pub(crate) fn add_rustc_lib_path(&mut self, builder: &Builder<'_>) {
         builder.add_rustc_lib_path(self.compiler, &mut self.command);
     }
 
-    pub fn current_dir(&mut self, dir: &Path) -> &mut Cargo {
+    pub(crate) fn current_dir(&mut self, dir: &Path) -> &mut Cargo {
         self.command.current_dir(dir);
         self
     }
@@ -295,7 +296,7 @@ impl Cargo {
     ///
     /// By default, all nightly features are allowed. Once this is called, it will be restricted to
     /// the given set.
-    pub fn allow_features(&mut self, features: &str) -> &mut Cargo {
+    pub(crate) fn allow_features(&mut self, features: &str) -> &mut Cargo {
         if !self.allow_features.is_empty() {
             self.allow_features.push(',');
         }
@@ -554,7 +555,7 @@ impl From<Cargo> for BootstrapCommand {
 impl Builder<'_> {
     /// Like [`Builder::cargo`], but only passes flags that are valid for all commands.
     #[track_caller]
-    pub fn bare_cargo(
+    pub(crate) fn bare_cargo(
         &self,
         compiler: Compiler,
         mode: Mode,
@@ -1538,7 +1539,7 @@ impl Builder<'_> {
     }
 }
 
-pub fn cargo_profile_var(name: &str, config: &Config, mode: Mode) -> String {
+pub(crate) fn cargo_profile_var(name: &str, config: &Config, mode: Mode) -> String {
     let profile = match (mode, config.rust_optimize.is_release()) {
         // Some std configuration exists in its own profile
         (Mode::Std, _) => "DIST",
@@ -1550,7 +1551,7 @@ pub fn cargo_profile_var(name: &str, config: &Config, mode: Mode) -> String {
 
 /// Applies PGO compile flags to the given Cargo invocation based on the given PGO config.
 /// PGO flags are only applied when compiling a stage2 component.
-pub fn apply_pgo(
+pub(crate) fn apply_pgo(
     builder: &Builder<'_>,
     cargo: &mut Cargo,
     build_compiler: Compiler,

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -108,7 +108,7 @@ impl dyn AnyDebug {
 /// Historically, steps also participated in command-line processing.
 /// That responsibility has been split off into the larger [`CommandLineStep`] trait,
 /// which helper steps don't need to implement.
-pub trait Step: 'static + Clone + Debug + PartialEq + Eq + Hash {
+pub(crate) trait Step: 'static + Clone + Debug + PartialEq + Eq + Hash {
     /// Result type of [`Step::run`]. Stored in the step cache for later lookup.
     type Output: Clone;
 
@@ -118,6 +118,7 @@ pub trait Step: 'static + Clone + Debug + PartialEq + Eq + Hash {
     fn run(self, builder: &Builder<'_>) -> Self::Output;
 
     /// Returns metadata of the step, for tests.
+    #[cfg_attr(not(any(test, feature = "tracing")), expect(dead_code))]
     fn metadata(&self) -> Option<StepMetadata> {
         None
     }
@@ -141,7 +142,7 @@ impl<S: CommandLineStep> Step for S {
 /// A blanket impl allows every [`CommandLineStep`] to be used as a [`Step`].
 /// This is arguably nicer than having it be a subtrait, because it avoids the
 /// need for two separate `impl` blocks per command-line-step type.
-pub trait CommandLineStep: 'static + Clone + Debug + PartialEq + Eq + Hash {
+pub(crate) trait CommandLineStep: 'static + Clone + Debug + PartialEq + Eq + Hash {
     /// Result type of [`Step::run`].
     type Output: Clone;
 
@@ -190,7 +191,7 @@ pub trait CommandLineStep: 'static + Clone + Debug + PartialEq + Eq + Hash {
 
 /// Metadata that describes an executed step, mostly for testing and tracing.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct StepMetadata {
+pub(crate) struct StepMetadata {
     name: String,
     kind: Kind,
     target: TargetSelection,
@@ -248,7 +249,8 @@ impl StepMetadata {
         self
     }
 
-    pub fn get_stage(&self) -> Option<u32> {
+    #[cfg_attr(not(any(test, feature = "tracing")), expect(dead_code))]
+    pub(crate) fn get_stage(&self) -> Option<u32> {
         self.stage.or(self
             .built_by
             // For std, its stage corresponds to the stage of the compiler that builds it.
@@ -256,11 +258,13 @@ impl StepMetadata {
             .map(|compiler| if self.name == "std" { compiler.stage } else { compiler.stage + 1 }))
     }
 
-    pub fn get_name(&self) -> &str {
+    #[cfg_attr(not(feature = "tracing"), expect(dead_code))]
+    pub(crate) fn get_name(&self) -> &str {
         &self.name
     }
 
-    pub fn get_target(&self) -> TargetSelection {
+    #[cfg_attr(not(feature = "tracing"), expect(dead_code))]
+    pub(crate) fn get_target(&self) -> TargetSelection {
         self.target
     }
 }
@@ -1565,7 +1569,7 @@ Alternatively, you can set `build.local-rebuild=true` and use a stage0 compiler 
     /// cache the step, so it is safe (and good!) to call this as often as
     /// needed to ensure that all dependencies are built.
     #[track_caller]
-    pub fn ensure<S: Step>(&'a self, step: S) -> S::Output {
+    pub(crate) fn ensure<S: Step>(&'a self, step: S) -> S::Output {
         {
             let mut stack = self.stack.borrow_mut();
             for stack_step in stack.iter() {

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -13,7 +13,7 @@ use clap::ValueEnum;
 #[cfg(feature = "tracing")]
 use tracing::instrument;
 
-pub use self::cargo::{Cargo, apply_pgo, cargo_profile_var};
+pub(crate) use self::cargo::{Cargo, apply_pgo, cargo_profile_var};
 use crate::core::build_steps::compile::{Std, StdLink, looks_like_codegen_backend};
 use crate::core::build_steps::tool::RustcPrivateCompilers;
 use crate::core::build_steps::{

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -288,7 +288,6 @@ pub struct Config {
     pub windows_rc: Option<PathBuf>,
     pub reuse: Option<PathBuf>,
     pub cargo_native_static: bool,
-    pub configure_args: Vec<String>,
     pub out: PathBuf,
     pub rust_info: channel::GitInfo,
 
@@ -517,7 +516,10 @@ impl Config {
             profiler: build_profiler,
             cargo_native_static: build_cargo_native_static,
             low_priority: build_low_priority,
-            configure_args: build_configure_args,
+            // Our `./configure` script saves a copy of its command-line arguments as
+            // `build.configure-args` when generating `bootstrap.toml`.
+            // This is for debugging only, and bootstrap itself doesn't use these values.
+            configure_args: _,
             local_rebuild: build_local_rebuild,
             print_step_timings: build_print_step_timings,
             print_step_rusage: build_print_step_rusage,
@@ -1430,7 +1432,6 @@ NOTE: Please add `--stage 2` to your command line, or if you're sure you want to
             compiletest_allow_stage0: build_compiletest_allow_stage0.unwrap_or(false),
             compiletest_diff_tool: build_compiletest_diff_tool,
             config: toml_path,
-            configure_args: build_configure_args.unwrap_or_default(),
             control_flow_guard: rust_control_flow_guard.unwrap_or(false),
             datadir: install_datadir.map(PathBuf::from),
             deny_warnings,

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -89,7 +89,7 @@ pub const RUSTC_IF_UNCHANGED_ALLOWED_PATHS: &[&str] = &[
 /// on each field, see the corresponding fields in
 /// `bootstrap.example.toml`.
 #[derive(Clone)]
-pub struct Config {
+pub(crate) struct Config {
     pub change_id: Option<ChangeId>,
     pub bypass_bootstrap_lock: bool,
     pub ccache: Option<String>,

--- a/src/bootstrap/src/core/config/mod.rs
+++ b/src/bootstrap/src/core/config/mod.rs
@@ -22,7 +22,6 @@ use std::fmt::Display;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-pub use config::*;
 use serde::de::Unexpected;
 use serde::{Deserialize, Deserializer};
 use serde_derive::Deserialize;
@@ -32,6 +31,7 @@ pub use toml::change_id::ChangeId;
 pub use toml::rust::BootstrapOverrideLld;
 pub use toml::target::Target;
 
+pub(crate) use self::config::*;
 use crate::utils::helpers;
 
 pub(crate) trait Merge {

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1851,10 +1851,6 @@ to download LLVM rather than building it.
         result
     }
 
-    pub fn exec_ctx(&self) -> &ExecutionContext {
-        &self.config.exec_ctx
-    }
-
     pub fn report_summary(&self, path: &Path, start_time: Instant) {
         self.config.exec_ctx.profiler().report_summary(path, start_time);
     }

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -293,7 +293,7 @@ impl Build {
     /// line and the filesystem `config`.
     ///
     /// By default all build output will be placed in the current directory.
-    pub fn new(mut config: Config) -> Build {
+    pub(crate) fn new(mut config: Config) -> Build {
         let src = config.src.clone();
         let out = config.out.clone();
 
@@ -576,7 +576,7 @@ impl Build {
     }
 
     /// Updates the given submodule only if it's initialized already; nothing happens otherwise.
-    pub fn update_existing_submodule(config: &Config, submodule: &str) {
+    pub(crate) fn update_existing_submodule(config: &Config, submodule: &str) {
         // Avoid running git when there isn't a git checkout.
         if !config.submodules() {
             return;

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -509,11 +509,6 @@ impl CommandOutput {
     }
 
     #[must_use]
-    pub fn stdout_if_present(&self) -> Option<String> {
-        self.stdout.as_ref().and_then(|s| String::from_utf8(s.clone()).ok())
-    }
-
-    #[must_use]
     pub fn stdout_if_ok(&self) -> Option<String> {
         if self.is_success() { Some(self.stdout()) } else { None }
     }
@@ -524,11 +519,6 @@ impl CommandOutput {
             self.stderr.clone().expect("Accessing stderr of a command that did not capture stderr"),
         )
         .expect("Cannot parse process stderr as UTF-8")
-    }
-
-    #[must_use]
-    pub fn stderr_if_present(&self) -> Option<String> {
-        self.stderr.as_ref().and_then(|s| String::from_utf8(s.clone()).ok())
     }
 }
 
@@ -546,7 +536,7 @@ impl Default for CommandOutput {
 pub struct ExecutionContext {
     dry_run: DryRun,
     pub verbosity: u8,
-    pub fail_fast: bool,
+    fail_fast: bool,
     delayed_failures: Arc<Mutex<Vec<String>>>,
     command_cache: Arc<CommandCache>,
     profiler: Arc<CommandProfiler>,
@@ -627,20 +617,12 @@ impl ExecutionContext {
         self.verbosity > 0
     }
 
-    pub fn fail_fast(&self) -> bool {
-        self.fail_fast
-    }
-
     pub fn set_dry_run(&mut self, value: DryRun) {
         self.dry_run = value;
     }
 
     pub fn set_verbosity(&mut self, value: u8) {
         self.verbosity = value;
-    }
-
-    pub fn set_fail_fast(&mut self, value: bool) {
-        self.fail_fast = value;
     }
 
     pub fn add_to_delay_failure(&self, message: String) {

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -29,7 +29,7 @@ use crate::utils::helpers::{self, t};
 
 /// What should be done when the command fails.
 #[derive(Debug, Copy, Clone)]
-pub enum BehaviorOnFailure {
+pub(crate) enum BehaviorOnFailure {
     /// Immediately stop bootstrap.
     Exit,
     /// Delay failure until the end of bootstrap invocation.
@@ -41,7 +41,7 @@ pub enum BehaviorOnFailure {
 /// How should the output of a specific stream of the command (stdout/stderr) be handled
 /// (whether it should be captured or printed).
 #[derive(Debug, Copy, Clone)]
-pub enum OutputMode {
+pub(crate) enum OutputMode {
     /// Prints the stream by inheriting it from the bootstrap process.
     Print,
     /// Captures the stream into memory.
@@ -49,14 +49,14 @@ pub enum OutputMode {
 }
 
 impl OutputMode {
-    pub fn captures(&self) -> bool {
+    pub(crate) fn captures(&self) -> bool {
         match self {
             OutputMode::Print => false,
             OutputMode::Capture => true,
         }
     }
 
-    pub fn stdio(&self) -> Stdio {
+    pub(crate) fn stdio(&self) -> Stdio {
         match self {
             OutputMode::Print => Stdio::inherit(),
             OutputMode::Capture => Stdio::piped(),
@@ -65,7 +65,7 @@ impl OutputMode {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
-pub struct CommandFingerprint {
+pub(crate) struct CommandFingerprint {
     program: OsString,
     args: Vec<OsString>,
     envs: Vec<(OsString, Option<OsString>)>,
@@ -103,30 +103,30 @@ impl CommandFingerprint {
 }
 
 #[derive(Default, Clone)]
-pub struct CommandProfile {
-    pub traces: Vec<ExecutionTrace>,
+pub(crate) struct CommandProfile {
+    pub(crate) traces: Vec<ExecutionTrace>,
 }
 
 #[derive(Default)]
-pub struct CommandProfiler {
+pub(crate) struct CommandProfiler {
     stats: Mutex<HashMap<CommandFingerprint, CommandProfile>>,
 }
 
 impl CommandProfiler {
-    pub fn record_execution(&self, key: CommandFingerprint, start_time: Instant) {
+    pub(crate) fn record_execution(&self, key: CommandFingerprint, start_time: Instant) {
         let mut stats = self.stats.lock().unwrap();
         let entry = stats.entry(key).or_default();
         entry.traces.push(ExecutionTrace::Executed { duration: start_time.elapsed() });
     }
 
-    pub fn record_cache_hit(&self, key: CommandFingerprint) {
+    pub(crate) fn record_cache_hit(&self, key: CommandFingerprint) {
         let mut stats = self.stats.lock().unwrap();
         let entry = stats.entry(key).or_default();
         entry.traces.push(ExecutionTrace::CacheHit);
     }
 
     /// Report summary of executed commands file at the specified `path`.
-    pub fn report_summary(&self, path: &Path, start_time: Instant) {
+    pub(crate) fn report_summary(&self, path: &Path, start_time: Instant) {
         let file = t!(File::create(path));
 
         let mut writer = BufWriter::new(file);
@@ -221,7 +221,7 @@ impl CommandProfiler {
 }
 
 #[derive(Clone)]
-pub enum ExecutionTrace {
+pub(crate) enum ExecutionTrace {
     CacheHit,
     Executed { duration: Duration },
 }
@@ -242,11 +242,11 @@ pub enum ExecutionTrace {
 ///
 /// [allow_failure]: BootstrapCommand::allow_failure
 /// [delay_failure]: BootstrapCommand::delay_failure
-pub struct BootstrapCommand {
+pub(crate) struct BootstrapCommand {
     command: Command,
-    pub failure_behavior: BehaviorOnFailure,
+    pub(crate) failure_behavior: BehaviorOnFailure,
     // Run the command even during dry run
-    pub run_in_dry_run: bool,
+    pub(crate) run_in_dry_run: bool,
     // This field makes sure that each command is executed (or disarmed) before it is dropped,
     // to avoid forgetting to execute a command.
     drop_bomb: DropBomb,
@@ -255,10 +255,10 @@ pub struct BootstrapCommand {
 
 impl<'a> BootstrapCommand {
     #[track_caller]
-    pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
+    pub(crate) fn new<S: AsRef<OsStr>>(program: S) -> Self {
         Command::new(program).into()
     }
-    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+    pub(crate) fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
         self.command.arg(arg.as_ref());
         self
     }
@@ -266,12 +266,12 @@ impl<'a> BootstrapCommand {
     /// Cache the command. If it will be executed multiple times with the exact same arguments
     /// and environment variables in the same bootstrap invocation, the previous result will be
     /// loaded from memory.
-    pub fn cached(&mut self) -> &mut Self {
+    pub(crate) fn cached(&mut self) -> &mut Self {
         self.should_cache = true;
         self
     }
 
-    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    pub(crate) fn args<I, S>(&mut self, args: I) -> &mut Self
     where
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
@@ -280,7 +280,7 @@ impl<'a> BootstrapCommand {
         self
     }
 
-    pub fn env<K, V>(&mut self, key: K, val: V) -> &mut Self
+    pub(crate) fn env<K, V>(&mut self, key: K, val: V) -> &mut Self
     where
         K: AsRef<OsStr>,
         V: AsRef<OsStr>,
@@ -289,44 +289,44 @@ impl<'a> BootstrapCommand {
         self
     }
 
-    pub fn get_envs(&self) -> CommandEnvs<'_> {
+    pub(crate) fn get_envs(&self) -> CommandEnvs<'_> {
         self.command.get_envs()
     }
 
-    pub fn get_args(&self) -> CommandArgs<'_> {
+    pub(crate) fn get_args(&self) -> CommandArgs<'_> {
         self.command.get_args()
     }
 
-    pub fn env_remove<K: AsRef<OsStr>>(&mut self, key: K) -> &mut Self {
+    pub(crate) fn env_remove<K: AsRef<OsStr>>(&mut self, key: K) -> &mut Self {
         self.command.env_remove(key);
         self
     }
 
-    pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
+    pub(crate) fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
         self.command.current_dir(dir);
         self
     }
 
-    pub fn stdin(&mut self, stdin: std::process::Stdio) -> &mut Self {
+    pub(crate) fn stdin(&mut self, stdin: std::process::Stdio) -> &mut Self {
         self.command.stdin(stdin);
         self
     }
 
     #[must_use]
-    pub fn delay_failure(self) -> Self {
+    pub(crate) fn delay_failure(self) -> Self {
         Self { failure_behavior: BehaviorOnFailure::DelayFail, ..self }
     }
 
-    pub fn fail_fast(self) -> Self {
+    pub(crate) fn fail_fast(self) -> Self {
         Self { failure_behavior: BehaviorOnFailure::Exit, ..self }
     }
 
     #[must_use]
-    pub fn allow_failure(self) -> Self {
+    pub(crate) fn allow_failure(self) -> Self {
         Self { failure_behavior: BehaviorOnFailure::Ignore, ..self }
     }
 
-    pub fn run_in_dry_run(&mut self) -> &mut Self {
+    pub(crate) fn run_in_dry_run(&mut self) -> &mut Self {
         self.run_in_dry_run = true;
         self
     }
@@ -334,25 +334,29 @@ impl<'a> BootstrapCommand {
     /// Run the command, while printing stdout and stderr.
     /// Returns true if the command has succeeded.
     #[track_caller]
-    pub fn run(&mut self, exec_ctx: impl AsRef<ExecutionContext>) -> bool {
+    pub(crate) fn run(&mut self, exec_ctx: impl AsRef<ExecutionContext>) -> bool {
         exec_ctx.as_ref().run(self, OutputMode::Print, OutputMode::Print).is_success()
     }
 
     /// Run the command, while capturing and returning all its output.
     #[track_caller]
-    pub fn run_capture(&mut self, exec_ctx: impl AsRef<ExecutionContext>) -> CommandOutput {
+    pub(crate) fn run_capture(&mut self, exec_ctx: impl AsRef<ExecutionContext>) -> CommandOutput {
         exec_ctx.as_ref().run(self, OutputMode::Capture, OutputMode::Capture)
     }
 
     /// Run the command, while capturing and returning stdout, and printing stderr.
     #[track_caller]
-    pub fn run_capture_stdout(&mut self, exec_ctx: impl AsRef<ExecutionContext>) -> CommandOutput {
+    pub(crate) fn run_capture_stdout(
+        &mut self,
+        exec_ctx: impl AsRef<ExecutionContext>,
+    ) -> CommandOutput {
         exec_ctx.as_ref().run(self, OutputMode::Capture, OutputMode::Print)
     }
 
     /// Spawn the command in background, while capturing and returning all its output.
     #[track_caller]
-    pub fn start_capture(
+    #[expect(dead_code, reason = "general-purpose, currently unused")]
+    pub(crate) fn start_capture(
         &'a mut self,
         exec_ctx: impl AsRef<ExecutionContext>,
     ) -> DeferredCommand<'a> {
@@ -361,7 +365,7 @@ impl<'a> BootstrapCommand {
 
     /// Spawn the command in background, while capturing and returning stdout, and printing stderr.
     #[track_caller]
-    pub fn start_capture_stdout(
+    pub(crate) fn start_capture_stdout(
         &'a mut self,
         exec_ctx: impl AsRef<ExecutionContext>,
     ) -> DeferredCommand<'a> {
@@ -371,7 +375,7 @@ impl<'a> BootstrapCommand {
     /// Spawn the command in background, while capturing and returning stdout, and printing stderr.
     /// Returns None in dry-mode
     #[track_caller]
-    pub fn stream_capture_stdout(
+    pub(crate) fn stream_capture_stdout(
         &'a mut self,
         exec_ctx: impl AsRef<ExecutionContext>,
     ) -> Option<StreamingCommand> {
@@ -380,16 +384,16 @@ impl<'a> BootstrapCommand {
 
     /// Mark the command as being executed, disarming the drop bomb.
     /// If this method is not called before the command is dropped, its drop will panic.
-    pub fn mark_as_executed(&mut self) {
+    pub(crate) fn mark_as_executed(&mut self) {
         self.drop_bomb.defuse();
     }
 
     /// Returns the source code location where this command was created.
-    pub fn get_created_location(&self) -> std::panic::Location<'static> {
+    pub(crate) fn get_created_location(&self) -> std::panic::Location<'static> {
         self.drop_bomb.get_created_location()
     }
 
-    pub fn fingerprint(&self) -> CommandFingerprint {
+    pub(crate) fn fingerprint(&self) -> CommandFingerprint {
         let command = &self.command;
         CommandFingerprint {
             program: command.get_program().into(),
@@ -437,13 +441,13 @@ enum CommandStatus {
 /// shorter than `BootstrapCommand::new`.
 #[track_caller]
 #[must_use]
-pub fn command<S: AsRef<OsStr>>(program: S) -> BootstrapCommand {
+pub(crate) fn command<S: AsRef<OsStr>>(program: S) -> BootstrapCommand {
     BootstrapCommand::new(program)
 }
 
 /// Represents the output of an executed process.
 #[derive(Clone, PartialEq)]
-pub struct CommandOutput {
+pub(crate) struct CommandOutput {
     status: CommandStatus,
     stdout: Option<Vec<u8>>,
     stderr: Option<Vec<u8>>,
@@ -451,7 +455,7 @@ pub struct CommandOutput {
 
 impl CommandOutput {
     #[must_use]
-    pub fn not_finished(stdout: OutputMode, stderr: OutputMode) -> Self {
+    pub(crate) fn not_finished(stdout: OutputMode, stderr: OutputMode) -> Self {
         Self {
             status: CommandStatus::DidNotStartOrFinish,
             stdout: match stdout {
@@ -466,7 +470,7 @@ impl CommandOutput {
     }
 
     #[must_use]
-    pub fn from_output(output: Output, stdout: OutputMode, stderr: OutputMode) -> Self {
+    pub(crate) fn from_output(output: Output, stdout: OutputMode, stderr: OutputMode) -> Self {
         Self {
             status: CommandStatus::Finished(output.status),
             stdout: match stdout {
@@ -481,7 +485,7 @@ impl CommandOutput {
     }
 
     #[must_use]
-    pub fn is_success(&self) -> bool {
+    pub(crate) fn is_success(&self) -> bool {
         match self.status {
             CommandStatus::Finished(status) => status.success(),
             CommandStatus::DidNotStartOrFinish => false,
@@ -489,11 +493,11 @@ impl CommandOutput {
     }
 
     #[must_use]
-    pub fn is_failure(&self) -> bool {
+    pub(crate) fn is_failure(&self) -> bool {
         !self.is_success()
     }
 
-    pub fn status(&self) -> Option<ExitStatus> {
+    pub(crate) fn status(&self) -> Option<ExitStatus> {
         match self.status {
             CommandStatus::Finished(status) => Some(status),
             CommandStatus::DidNotStartOrFinish => None,
@@ -501,7 +505,7 @@ impl CommandOutput {
     }
 
     #[must_use]
-    pub fn stdout(&self) -> String {
+    pub(crate) fn stdout(&self) -> String {
         String::from_utf8(
             self.stdout.clone().expect("Accessing stdout of a command that did not capture stdout"),
         )
@@ -509,12 +513,12 @@ impl CommandOutput {
     }
 
     #[must_use]
-    pub fn stdout_if_ok(&self) -> Option<String> {
+    pub(crate) fn stdout_if_ok(&self) -> Option<String> {
         if self.is_success() { Some(self.stdout()) } else { None }
     }
 
     #[must_use]
-    pub fn stderr(&self) -> String {
+    pub(crate) fn stderr(&self) -> String {
         String::from_utf8(
             self.stderr.clone().expect("Accessing stderr of a command that did not capture stderr"),
         )
@@ -533,9 +537,9 @@ impl Default for CommandOutput {
 }
 
 #[derive(Clone, Default)]
-pub struct ExecutionContext {
+pub(crate) struct ExecutionContext {
     dry_run: DryRun,
-    pub verbosity: u8,
+    pub(crate) verbosity: u8,
     fail_fast: bool,
     delayed_failures: Arc<Mutex<Vec<String>>>,
     command_cache: Arc<CommandCache>,
@@ -543,7 +547,7 @@ pub struct ExecutionContext {
 }
 
 #[derive(Default)]
-pub struct CommandCache {
+pub(crate) struct CommandCache {
     cache: Mutex<HashMap<CommandFingerprint, CommandOutput>>,
 }
 
@@ -562,10 +566,11 @@ enum CommandState<'a> {
     },
 }
 
-pub struct StreamingCommand {
+pub(crate) struct StreamingCommand {
     child: Child,
-    pub stdout: Option<ChildStdout>,
-    pub stderr: Option<ChildStderr>,
+    pub(crate) stdout: Option<ChildStdout>,
+    #[expect(dead_code, reason = "symmetric with `stdout`")]
+    pub(crate) stderr: Option<ChildStderr>,
     fingerprint: CommandFingerprint,
     start_time: Instant,
     #[cfg(feature = "tracing")]
@@ -573,63 +578,63 @@ pub struct StreamingCommand {
 }
 
 #[must_use]
-pub struct DeferredCommand<'a> {
+pub(crate) struct DeferredCommand<'a> {
     state: CommandState<'a>,
 }
 
 impl CommandCache {
-    pub fn get(&self, key: &CommandFingerprint) -> Option<CommandOutput> {
+    pub(crate) fn get(&self, key: &CommandFingerprint) -> Option<CommandOutput> {
         self.cache.lock().unwrap().get(key).cloned()
     }
 
-    pub fn insert(&self, key: CommandFingerprint, output: CommandOutput) {
+    pub(crate) fn insert(&self, key: CommandFingerprint, output: CommandOutput) {
         self.cache.lock().unwrap().insert(key, output);
     }
 }
 
 impl ExecutionContext {
-    pub fn new(verbosity: u8, fail_fast: bool) -> Self {
+    pub(crate) fn new(verbosity: u8, fail_fast: bool) -> Self {
         Self { verbosity, fail_fast, ..Default::default() }
     }
 
-    pub fn dry_run(&self) -> bool {
+    pub(crate) fn dry_run(&self) -> bool {
         match self.dry_run {
             DryRun::Disabled => false,
             DryRun::SelfCheck | DryRun::UserSelected => true,
         }
     }
 
-    pub fn profiler(&self) -> &CommandProfiler {
+    pub(crate) fn profiler(&self) -> &CommandProfiler {
         &self.profiler
     }
 
-    pub fn get_dry_run(&self) -> &DryRun {
+    pub(crate) fn get_dry_run(&self) -> &DryRun {
         &self.dry_run
     }
 
-    pub fn do_if_verbose(&self, f: impl Fn()) {
+    pub(crate) fn do_if_verbose(&self, f: impl Fn()) {
         if self.is_verbose() {
             f()
         }
     }
 
-    pub fn is_verbose(&self) -> bool {
+    pub(crate) fn is_verbose(&self) -> bool {
         self.verbosity > 0
     }
 
-    pub fn set_dry_run(&mut self, value: DryRun) {
+    pub(crate) fn set_dry_run(&mut self, value: DryRun) {
         self.dry_run = value;
     }
 
-    pub fn set_verbosity(&mut self, value: u8) {
+    pub(crate) fn set_verbosity(&mut self, value: u8) {
         self.verbosity = value;
     }
 
-    pub fn add_to_delay_failure(&self, message: String) {
+    pub(crate) fn add_to_delay_failure(&self, message: String) {
         self.delayed_failures.lock().unwrap().push(message);
     }
 
-    pub fn report_failures_and_exit(&self) {
+    pub(crate) fn report_failures_and_exit(&self) {
         let failures = self.delayed_failures.lock().unwrap();
         if failures.is_empty() {
             return;
@@ -645,7 +650,7 @@ impl ExecutionContext {
     /// Note: Ideally, you should use one of the BootstrapCommand::run* functions to
     /// execute commands. They internally call this method.
     #[track_caller]
-    pub fn start<'a>(
+    pub(crate) fn start<'a>(
         &self,
         command: &'a mut BootstrapCommand,
         stdout: OutputMode,
@@ -713,7 +718,7 @@ impl ExecutionContext {
     /// Note: Ideally, you should use one of the BootstrapCommand::run* functions to
     /// execute commands. They internally call this method.
     #[track_caller]
-    pub fn run(
+    pub(crate) fn run(
         &self,
         command: &mut BootstrapCommand,
         stdout: OutputMode,
@@ -734,7 +739,7 @@ impl ExecutionContext {
     /// Spawns the command with configured stdout and stderr handling.
     ///
     /// Returns None if in dry-run mode or Panics if the command fails to spawn.
-    pub fn stream(
+    pub(crate) fn stream(
         &self,
         command: &mut BootstrapCommand,
         stdout: OutputMode,
@@ -780,7 +785,7 @@ impl AsRef<ExecutionContext> for ExecutionContext {
 }
 
 impl StreamingCommand {
-    pub fn wait(
+    pub(crate) fn wait(
         mut self,
         exec_ctx: impl AsRef<ExecutionContext>,
     ) -> Result<ExitStatus, std::io::Error> {
@@ -792,7 +797,7 @@ impl StreamingCommand {
 }
 
 impl<'a> DeferredCommand<'a> {
-    pub fn wait_for_output(self, exec_ctx: impl AsRef<ExecutionContext>) -> CommandOutput {
+    pub(crate) fn wait_for_output(self, exec_ctx: impl AsRef<ExecutionContext>) -> CommandOutput {
         match self.state {
             CommandState::Cached(output) => output,
             CommandState::Deferred {
@@ -827,7 +832,7 @@ impl<'a> DeferredCommand<'a> {
         }
     }
 
-    pub fn finish_process(
+    pub(crate) fn finish_process(
         mut process: Option<Result<Child, std::io::Error>>,
         command: &mut BootstrapCommand,
         stdout: OutputMode,


### PR DESCRIPTION
- Previously: https://github.com/rust-lang/rust/pull/161157
---

During my quest to move things out of bootstrap's `lib.rs`, I have found several clusters of code that start to emit dead-code warnings when `lib.rs` is cleared out.

This PR aims to pre-emptively resolve some of those clusters, by making various things non-pub and dealing with the resulting warnings.

There should be no change to bootstrap behaviour.