### PR TITLE
MC/DC Coverage re-introduction (1/3): THIR data gathering

### DIFF
--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -174,6 +174,7 @@ pub struct CoverageInfoHi {
     /// data structures without having to scan the entire body first.
     pub num_block_markers: usize,
     pub branch_spans: Vec<BranchSpan>,
+    pub mcdc_spans: Vec<(mcdc::DecisionSpan, Vec<mcdc::ConditionSpan>)>,
 }
 
 #[derive(Clone, Debug)]
@@ -182,6 +183,83 @@ pub struct BranchSpan {
     pub span: Span,
     pub true_marker: BlockMarkerId,
     pub false_marker: BlockMarkerId,
+}
+
+pub mod mcdc {
+    use rustc_macros::{StableHash, TyDecodable, TyEncodable};
+    use rustc_span::Span;
+
+    use crate::mir::coverage::BlockMarkerId;
+
+    rustc_index::newtype_index! {
+        /// ID of an MC/DC condition. Used by LLVM to check MC/DC coverage.
+        ///
+        /// Note: the maximum number of condition within a decision supported by
+        /// llvm is 32767, thus the max ID is 0x7FFE.
+        #[stable_hash]
+        #[encodable]
+        #[orderable]
+        #[max = 0x7FFE]
+        #[debug_format = "ConditionId({})"]
+        pub struct ConditionId {}
+    }
+
+    impl ConditionId {
+        pub const START: Self = Self::from_usize(0);
+        pub const MAX_AS_USIZE: usize = Self::MAX.as_usize();
+    }
+
+    /// Node in a BDD (Binary Decision Diagram) for MC/DC analysis
+    #[derive(Copy, Clone, Debug)]
+    #[derive(TyEncodable, TyDecodable, Hash, StableHash)]
+    pub struct ConditionInfo {
+        pub condition_id: ConditionId,
+        pub true_next_id: Option<ConditionId>,
+        pub false_next_id: Option<ConditionId>,
+    }
+
+    /// This struct is generated during THIR lowering, it keeps track of a
+    /// condition (simple boolean expression) span. It associates it with a BDD
+    /// node, that helps knowing the shape of the decision graph, and two markers
+    /// inserted in the generated MIR to find the basic blocks corresponding to
+    /// the two possible outcommes of the condition.
+    #[derive(Clone, Debug)]
+    #[derive(TyEncodable, TyDecodable, Hash, StableHash)]
+    pub struct ConditionSpan {
+        pub span: Span,
+        pub condition_info: ConditionInfo,
+        pub true_marker: BlockMarkerId,
+        pub false_marker: BlockMarkerId,
+    }
+
+    /// This struct is generated during THIR lowering for each encountered
+    /// "complex" boolean expression (expressions with at least one logical
+    /// operator). it associates the span of the expression in the source
+    /// code with:
+    /// - the list of markers inserted in the generated MIR to keep
+    ///     track of the output basic blocks of the decision graph.
+    /// - the depth, corresponding to the level of nesting of this decision
+    ///     (e.g. in `true || foo (a && b)`, `true || foo (...)` has depth 0,
+    ///     `a && b` has depth 1).
+    /// - the number of conditions ("simple" boolean expressions) within this
+    ///     decision.
+    ///
+    /// Invariant: for each [`DecisionSpan`] generated, there should be
+    /// `num_conditions` [`ConditionSpan`]'s as well.
+    #[derive(Clone, Debug)]
+    #[derive(TyEncodable, TyDecodable, Hash, StableHash)]
+    pub struct DecisionSpan {
+        pub span: Span,
+
+        /// Marker statements designating outputs of the decision in MIR.
+        pub end_markers: Vec<BlockMarkerId>,
+
+        /// Nesting level of the decision.
+        pub decision_depth: u16,
+
+        /// Number of conditions in the decision.
+        pub num_conditions: usize,
+    }
 }
 
 /// Contains information needed during codegen, obtained by inspecting the

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -637,7 +637,8 @@ fn write_coverage_info_hi(
     coverage_info_hi: &coverage::CoverageInfoHi,
     w: &mut dyn io::Write,
 ) -> io::Result<()> {
-    let coverage::CoverageInfoHi { num_block_markers: _, branch_spans } = coverage_info_hi;
+    let coverage::CoverageInfoHi { num_block_markers: _, branch_spans, mcdc_spans } =
+        coverage_info_hi;
 
     // Only add an extra trailing newline if we printed at least one thing.
     let mut did_print = false;
@@ -647,6 +648,31 @@ fn write_coverage_info_hi(
             w,
             "{INDENT}coverage branch {{ true: {true_marker:?}, false: {false_marker:?} }} => {span:?}",
         )?;
+        did_print = true;
+    }
+
+    for (
+        coverage::mcdc::DecisionSpan { span, end_markers, decision_depth, num_conditions },
+        conditions,
+    ) in mcdc_spans
+    {
+        writeln!(
+            w,
+            "{INDENT}MCDC decision {{ num_conditions: {num_conditions}, depth: {decision_depth}, outputs: {end_markers:?} }} => {span:?}",
+        )?;
+
+        for coverage::mcdc::ConditionSpan {
+            span,
+            condition_info:
+                coverage::mcdc::ConditionInfo { condition_id, true_next_id, false_next_id },
+            ..
+        } in conditions
+        {
+            writeln!(
+                w,
+                "{INDENT}{INDENT}condition {{ id: {condition_id:?}, true_id: {true_next_id:?}, false_id: {false_next_id:?} }} => {span:?}"
+            )?;
+        }
         did_print = true;
     }
 

--- a/compiler/rustc_mir_build/src/builder/coverageinfo.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo.rs
@@ -168,10 +168,13 @@ impl CoverageInfoBuilder {
         let Self { nots: _, markers: BlockMarkerGen { num_block_markers }, branch_info, mcdc_info } =
             self;
 
-        let branch_spans =
+        let mut branch_spans =
             branch_info.map(|branch_info| branch_info.branch_spans).unwrap_or_default();
 
-        let mcdc_spans = mcdc_info.map(MCDCInfoBuilder::into_done).unwrap_or_default();
+        let (mcdc_spans, standalone_branches) =
+            mcdc_info.map(MCDCInfoBuilder::into_done).unwrap_or_default();
+
+        branch_spans.extend(standalone_branches);
 
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.
@@ -186,14 +189,17 @@ impl CoverageInfoBuilder {
             ref mcdc_info,
         } = self;
 
-        let branch_spans = branch_info
+        let mut branch_spans = branch_info
             .as_ref()
             .map(|branch_info| branch_info.branch_spans.as_slice())
             .unwrap_or_default()
             .to_owned();
 
-        let mcdc_spans =
-            mcdc_info.as_ref().map(|mcdc_info| mcdc_info.as_done().to_vec()).unwrap_or_default();
+        let (mcdc_spans, standalone_branches) =
+            mcdc_info.as_ref().map(|mcdc_info| mcdc_info.as_done()).unwrap_or_default();
+
+        branch_spans.extend(standalone_branches.iter().cloned());
+        let mcdc_spans = mcdc_spans.to_vec();
 
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.

--- a/compiler/rustc_mir_build/src/builder/coverageinfo.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo.rs
@@ -8,7 +8,10 @@ use rustc_middle::thir::{ExprId, ExprKind, Pat, Thir};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::def_id::LocalDefId;
 
+use crate::builder::coverageinfo::mcdc::MCDCInfoBuilder;
 use crate::builder::{Builder, CFG};
+
+mod mcdc;
 
 /// Collects coverage-related information during MIR building, to eventually be
 /// turned into a function's [`CoverageInfoHi`] when MIR building is complete.
@@ -20,6 +23,9 @@ pub(crate) struct CoverageInfoBuilder {
 
     /// Present if branch coverage is enabled.
     branch_info: Option<BranchInfo>,
+
+    /// Present if MC/DC coverage is enabled.
+    mcdc_info: Option<MCDCInfoBuilder>,
 }
 
 #[derive(Default)]
@@ -78,6 +84,7 @@ impl CoverageInfoBuilder {
             nots: FxHashMap::default(),
             markers: BlockMarkerGen::default(),
             branch_info: tcx.sess.instrument_coverage_branch().then(BranchInfo::default),
+            mcdc_info: tcx.sess.instrument_coverage_mcdc().then(MCDCInfoBuilder::default),
         })
     }
 
@@ -129,38 +136,55 @@ impl CoverageInfoBuilder {
 
     fn register_two_way_branch<'tcx>(
         &mut self,
+        tcx: TyCtxt<'tcx>,
         cfg: &mut CFG<'tcx>,
         source_info: SourceInfo,
         true_block: BasicBlock,
         false_block: BasicBlock,
     ) {
-        // Bail out if branch coverage is not enabled.
-        let Some(branch_info) = self.branch_info.as_mut() else { return };
+        let mut inject_block_marker =
+            |bb: BasicBlock| self.markers.inject_block_marker(cfg, source_info, bb);
 
-        let true_marker = self.markers.inject_block_marker(cfg, source_info, true_block);
-        let false_marker = self.markers.inject_block_marker(cfg, source_info, false_block);
+        if let Some(mcdc_info) = self.mcdc_info.as_mut() {
+            // If MC/DC is enabled, register the branch via MCDC
+            let true_marker = inject_block_marker(true_block);
+            let false_marker = inject_block_marker(false_block);
 
-        branch_info.branch_spans.push(BranchSpan {
-            span: source_info.span,
-            true_marker,
-            false_marker,
-        });
+            mcdc_info.record_leaf_condition(tcx, source_info.span, true_marker, false_marker);
+        } else if let Some(branch_info) = self.branch_info.as_mut() {
+            // Else, if branch/condition is enabled, create a new branch span
+            let true_marker = inject_block_marker(true_block);
+            let false_marker = inject_block_marker(false_block);
+
+            branch_info.branch_spans.push(BranchSpan {
+                span: source_info.span,
+                true_marker,
+                false_marker,
+            });
+        }
     }
 
     pub(crate) fn into_done(self) -> Box<CoverageInfoHi> {
-        let Self { nots: _, markers: BlockMarkerGen { num_block_markers }, branch_info } = self;
+        let Self { nots: _, markers: BlockMarkerGen { num_block_markers }, branch_info, mcdc_info } =
+            self;
 
         let branch_spans =
             branch_info.map(|branch_info| branch_info.branch_spans).unwrap_or_default();
 
+        let mcdc_spans = mcdc_info.map(MCDCInfoBuilder::into_done).unwrap_or_default();
+
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.
-        Box::new(CoverageInfoHi { num_block_markers, branch_spans })
+        Box::new(CoverageInfoHi { num_block_markers, branch_spans, mcdc_spans })
     }
 
     pub(crate) fn as_done(&self) -> Box<CoverageInfoHi> {
-        let &Self { nots: _, markers: BlockMarkerGen { num_block_markers }, ref branch_info } =
-            self;
+        let &Self {
+            nots: _,
+            markers: BlockMarkerGen { num_block_markers },
+            ref branch_info,
+            ref mcdc_info,
+        } = self;
 
         let branch_spans = branch_info
             .as_ref()
@@ -168,9 +192,12 @@ impl CoverageInfoBuilder {
             .unwrap_or_default()
             .to_owned();
 
+        let mcdc_spans =
+            mcdc_info.as_ref().map(|mcdc_info| mcdc_info.as_done().to_vec()).unwrap_or_default();
+
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.
-        Box::new(CoverageInfoHi { num_block_markers, branch_spans })
+        Box::new(CoverageInfoHi { num_block_markers, branch_spans, mcdc_spans })
     }
 }
 
@@ -223,7 +250,13 @@ impl<'tcx> Builder<'_, 'tcx> {
             mir::TerminatorKind::if_(mir::Operand::Copy(place), true_block, false_block),
         );
 
-        coverage_info.register_two_way_branch(&mut self.cfg, source_info, true_block, false_block);
+        coverage_info.register_two_way_branch(
+            self.tcx,
+            &mut self.cfg,
+            source_info,
+            true_block,
+            false_block,
+        );
 
         let join_block = self.cfg.start_new_block();
         self.cfg.goto(true_block, source_info, join_block);
@@ -254,7 +287,13 @@ impl<'tcx> Builder<'_, 'tcx> {
 
         let source_info = SourceInfo { span: self.thir[expr_id].span, scope: self.source_scope };
 
-        coverage_info.register_two_way_branch(&mut self.cfg, source_info, then_block, else_block);
+        coverage_info.register_two_way_branch(
+            self.tcx,
+            &mut self.cfg,
+            source_info,
+            then_block,
+            else_block,
+        );
     }
 
     /// If branch coverage is enabled, inject marker statements into `true_block`
@@ -271,6 +310,12 @@ impl<'tcx> Builder<'_, 'tcx> {
         let Some(coverage_info) = self.coverage_info.as_mut() else { return };
 
         let source_info = SourceInfo { span: pattern.span, scope: self.source_scope };
-        coverage_info.register_two_way_branch(&mut self.cfg, source_info, true_block, false_block);
+        coverage_info.register_two_way_branch(
+            self.tcx,
+            &mut self.cfg,
+            source_info,
+            true_block,
+            false_block,
+        );
     }
 }

--- a/compiler/rustc_mir_build/src/builder/coverageinfo/mcdc.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo/mcdc.rs
@@ -1,0 +1,318 @@
+use rustc_middle::bug;
+use rustc_middle::mir::coverage::mcdc::{ConditionId, ConditionInfo, ConditionSpan, DecisionSpan};
+use rustc_middle::mir::coverage::BlockMarkerId;
+use rustc_middle::thir::LogicalOp;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+use tracing::instrument;
+
+use crate::builder::Builder;
+use crate::diagnostics::MCDCConditionNumberExceeded;
+
+/// This struct is responsible for tracking a visited decision, assigning
+/// [`ConditionId`]s to its conditions and building its BDD (Binary Decision
+/// Diagram), which are necessary for generating the MC/DC coverage mappings.
+///
+/// The ID assignment algorithm works by assigning an ID to the operands of the
+/// root operator, and then, via consecutive calls on the sub-expressions, if
+/// its a composite expression, re-assign its ID to its LHS, and assign a new
+/// ID to its RHS.
+///
+/// Example: "x = (A && B) || (C && D) || (D && F)"
+///
+///  Visit Depth1:
+///          (A && B) || (C && D) || (D && F)
+///          ^-------LHS--------^    ^-RHS--^
+///                  ID=1              ID=2
+///
+///  Visit LHS-Depth2:
+///          (A && B) || (C && D)
+///          ^-LHS--^    ^-RHS--^
+///            ID=1        ID=3
+///
+///  Visit LHS-Depth3:
+///           (A && B)
+///           LHS   RHS
+///           ID=1  ID=4
+///
+///  Visit RHS-Depth3:
+///                     (C && D)
+///                     LHS   RHS
+///                     ID=3  ID=5
+///
+///  Visit RHS-Depth2:              (D && F)
+///                                 LHS   RHS
+///                                 ID=2  ID=6
+///
+///  Visit Depth1:
+///          (A && B)  || (C && D)  || (D && F)
+///          ID=1  ID=4   ID=3  ID=5   ID=2  ID=6
+///
+#[derive(Debug, Default)]
+struct MCDCDecisionBuilder {
+    /// The stack of [`ConditionInfo`]s representing the BDD of the decision we
+    /// visited so far.
+    bdd_node_stack: Vec<ConditionInfo>,
+
+    /// The spans for leaf condition we already visited.
+    conditions: Vec<ConditionSpan>,
+
+    /// The decision span currently being built when visiting a decision, `None`
+    /// otherwise.
+    decision: Option<DecisionSpan>,
+}
+
+impl MCDCDecisionBuilder {
+    /// Record new condition nodes linked by `logical_op` in the BDD.
+    fn record_operator(&mut self, logical_op: LogicalOp, span: Span, decision_depth: u16) {
+        let decision = match self.decision.as_mut() {
+            Some(decision) => {
+                decision.span = decision.span.to(span);
+                decision
+            }
+            None => self.decision.insert(DecisionSpan {
+                span,
+                end_markers: Vec::new(),
+                decision_depth,
+                num_conditions: 0,
+            }),
+        };
+
+        // Top of the stack is not a leaf condition, pop it and stack both
+        // sides of the `logical_op` instead.
+        let parent_condition = self.bdd_node_stack.pop().unwrap_or_else(|| {
+            assert_eq!(decision.num_conditions, 0, "No condition means num_conditions should be 0");
+            decision.num_conditions += 1;
+            ConditionInfo {
+                condition_id: ConditionId::START,
+                true_next_id: None,
+                false_next_id: None,
+            }
+        });
+
+        let lhs_id = parent_condition.condition_id;
+        let rhs_id = ConditionId::from(decision.num_conditions);
+        decision.num_conditions += 1;
+
+        // If OP is AND, RHS will be checked only if LHS is true.
+        // If OP is OR, RHS will be checked only if LHS is false.
+        let lhs = match logical_op {
+            LogicalOp::And => ConditionInfo {
+                condition_id: lhs_id,
+                true_next_id: Some(rhs_id),
+                false_next_id: parent_condition.false_next_id,
+            },
+            LogicalOp::Or => ConditionInfo {
+                condition_id: lhs_id,
+                true_next_id: parent_condition.true_next_id,
+                false_next_id: Some(rhs_id),
+            },
+        };
+        let rhs = ConditionInfo {
+            condition_id: rhs_id,
+            true_next_id: parent_condition.true_next_id,
+            false_next_id: parent_condition.false_next_id,
+        };
+
+        self.bdd_node_stack.push(rhs);
+        self.bdd_node_stack.push(lhs);
+    }
+
+    /// Called upon encountering a leaf condition of the boolean expression.
+    ///
+    /// Pop the [`ConditionInfo`] at the top of the node stack and make an
+    /// [`ConditionSpan`] from it. If the stack is empty afterwards, it
+    /// means the decision was completely visited, so return the decision and
+    /// condition spans.
+    fn try_finish_decision(
+        &mut self,
+        span: Span,
+        true_marker: BlockMarkerId,
+        false_marker: BlockMarkerId,
+    ) -> Option<(DecisionSpan, Vec<ConditionSpan>)> {
+        let condition_info = self.bdd_node_stack.pop()?;
+        let Some(decision) = self.decision.as_mut() else {
+            bug!("decision should have been created by now");
+        };
+
+        // if true_next_id is None, it means that this condition's evaluation
+        // to true will make the decision true.
+        if condition_info.true_next_id.is_none() {
+            decision.end_markers.push(true_marker);
+        }
+        if condition_info.false_next_id.is_none() {
+            decision.end_markers.push(false_marker);
+        }
+
+        // The condition_info is a leaf condition, make it a branch span.
+        self.conditions.push(ConditionSpan { span, condition_info, true_marker, false_marker });
+
+        if self.bdd_node_stack.is_empty() {
+            // There is no more condition to the decision, return the resulting spans
+            let conditions = std::mem::take(&mut self.conditions);
+            self.decision.take().map(|decision| (decision, conditions))
+        } else {
+            None
+        }
+    }
+
+    /// Returns true if the builder is currently building a decision.
+    #[inline]
+    fn is_empty(&self) -> bool {
+        return self.decision.is_none();
+    }
+}
+
+/// MC/DC decision builder context for a function.
+///
+/// Holds a stack of [`MCDCDecisionBuilder`] to account for nested decisions.
+#[derive(Debug)]
+pub(crate) struct MCDCInfoBuilder {
+    /// Holds a stack of decision builders, to account for nested decisions.
+    ///
+    /// Example:
+    /// ```rust,ignore (illustrative)
+    /// if a && foo(b || c) {}
+    /// ```
+    ///
+    /// Here `b || c` is a different decision nested in `a && ...`.
+    /// To avoid mixing decisions, when we're building a decision and we visit
+    /// a "non-trivial" node (other than parentheses, deref, etc...), we push a
+    /// new builder on the stack.
+    decision_builder_stack: Vec<MCDCDecisionBuilder>,
+
+    /// The list of computed decisions so far.
+    decisions: Vec<(DecisionSpan, Vec<ConditionSpan>)>,
+}
+
+impl Default for MCDCInfoBuilder {
+    fn default() -> Self {
+        Self { decision_builder_stack: vec![MCDCDecisionBuilder::default()], decisions: Vec::new() }
+    }
+}
+
+impl MCDCInfoBuilder {
+    /// Decision depth is given as a u16 to reduce the size of the
+    /// `CoverageKind`, as it is very unlikely that the depth ever reaches
+    /// 2^16.
+    ///
+    /// Note: zero-indexed
+    #[inline]
+    fn decision_depth(&self) -> u16 {
+        match u16::try_from(self.decision_builder_stack.len()).map(|n| n.checked_sub(1)) {
+            Ok(Some(d)) => d,
+            Ok(None) => bug!("Unexpected empty decision builder stack"),
+            Err(e) => bug!(
+                "{e}: decision depth did not fit in u16, this is likely to be an instrumentation error"
+            ),
+        }
+    }
+
+    #[instrument(level = "debug", skip(self), fields(depth = MCDCInfoBuilder::decision_depth(self)))]
+    pub(crate) fn record_operator(&mut self, logical_op: LogicalOp, span: Span) {
+        let depth = self.decision_depth();
+
+        let Some(decision_builder) = self.decision_builder_stack.last_mut() else {
+            bug!("Unexpected empty decision builder stack")
+        };
+
+        decision_builder.record_operator(logical_op, span, depth);
+    }
+
+    #[instrument(level = "debug", skip(self, tcx), fields(depth = MCDCInfoBuilder::decision_depth(self)))]
+    pub(crate) fn record_leaf_condition(
+        &mut self,
+        tcx: TyCtxt<'_>,
+        span: Span,
+        true_marker: BlockMarkerId,
+        false_marker: BlockMarkerId,
+    ) {
+        let Some(decision_builder) = self.decision_builder_stack.last_mut() else {
+            bug!("Unexpected empty decision builder stack")
+        };
+
+        if let Some((decision, conditions)) =
+            decision_builder.try_finish_decision(span, true_marker, false_marker)
+        {
+            let num_conditions = conditions.len();
+            assert_eq!(
+                num_conditions, decision.num_conditions,
+                "decision.num_conditions should equal conditions.len()"
+            );
+
+            match num_conditions {
+                1..=ConditionId::MAX_AS_USIZE => self.decisions.push((decision, conditions)),
+
+                0 => bug!("decision has no condition"),
+
+                // LLVM does not support decisions with more conditions.
+                _ => tcx.dcx().emit_warn(MCDCConditionNumberExceeded {
+                    span: decision.span,
+                    max_conditions: ConditionId::MAX_AS_USIZE,
+                    num_conditions,
+                }),
+            }
+        }
+    }
+
+    /// Called when visiting inside a condition leaf, to correctly record
+    /// nested decisions.
+    #[inline]
+    #[instrument(level = "debug", skip(self), fields(before = MCDCInfoBuilder::decision_depth(self)))]
+    fn increment_depth(&mut self) {
+        self.decision_builder_stack.push(MCDCDecisionBuilder::default());
+    }
+
+    /// Called when stepping out of condition leaf.
+    #[inline]
+    #[instrument(level = "debug", skip(self), fields(before = MCDCInfoBuilder::decision_depth(self)))]
+    fn decrement_depth(&mut self) {
+        let Some(top_builder) = self.decision_builder_stack.pop() else {
+            bug!("Unexpected empty decision builder stack");
+        };
+        if !top_builder.is_empty() {
+            bug!("Popped a decision builder with unfinished decision in it")
+        }
+    }
+
+    #[inline]
+    #[instrument(level = "debug")]
+    pub(crate) fn into_done(self) -> Vec<(DecisionSpan, Vec<ConditionSpan>)> {
+        self.decisions
+    }
+
+    #[inline]
+    #[instrument(level = "debug")]
+    pub(crate) fn as_done(&self) -> &[(DecisionSpan, Vec<ConditionSpan>)] {
+        self.decisions.as_slice()
+    }
+}
+
+impl Builder<'_, '_> {
+    #[inline]
+    fn mcdc_info_as_mut(&mut self) -> Option<&mut MCDCInfoBuilder> {
+        self.coverage_info.as_mut().and_then(|cov_info| cov_info.mcdc_info.as_mut())
+    }
+
+    pub(crate) fn maybe_mcdc_record_operator(&mut self, logical_op: LogicalOp, span: Span) {
+        if let Some(mcdc_builder) = self.mcdc_info_as_mut() {
+            mcdc_builder.record_operator(logical_op, span);
+        }
+    }
+
+    // If MC/DC instrumentation is enabled, push a new MC/DC decision builder
+    // before calling `f(self)`, and pop it afterwards. Otherwise, simply run
+    // `f(self)`.
+    pub(crate) fn in_mcdc_sub_scope<T>(&mut self, mut f: impl FnMut(&mut Self) -> T) -> T {
+        if let Some(mcdc_builder) = self.mcdc_info_as_mut() {
+            mcdc_builder.increment_depth();
+        };
+
+        let result = f(self);
+
+        if let Some(mcdc_builder) = self.mcdc_info_as_mut() {
+            mcdc_builder.decrement_depth();
+        };
+        result
+    }
+}

--- a/compiler/rustc_mir_build/src/builder/coverageinfo/mcdc.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo/mcdc.rs
@@ -1,6 +1,6 @@
 use rustc_middle::bug;
 use rustc_middle::mir::coverage::mcdc::{ConditionId, ConditionInfo, ConditionSpan, DecisionSpan};
-use rustc_middle::mir::coverage::BlockMarkerId;
+use rustc_middle::mir::coverage::{BlockMarkerId, BranchSpan};
 use rustc_middle::thir::LogicalOp;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
@@ -8,6 +8,11 @@ use tracing::instrument;
 
 use crate::builder::Builder;
 use crate::diagnostics::MCDCConditionNumberExceeded;
+
+enum FinishedDecision {
+    MCDCDecision(DecisionSpan, Vec<ConditionSpan>),
+    StandaloneBranch(BranchSpan),
+}
 
 /// This struct is responsible for tracking a visited decision, assigning
 /// [`ConditionId`]s to its conditions and building its BDD (Binary Decision
@@ -129,8 +134,18 @@ impl MCDCDecisionBuilder {
         span: Span,
         true_marker: BlockMarkerId,
         false_marker: BlockMarkerId,
-    ) -> Option<(DecisionSpan, Vec<ConditionSpan>)> {
-        let condition_info = self.bdd_node_stack.pop()?;
+    ) -> Option<FinishedDecision> {
+        let Some(condition_info) = self.bdd_node_stack.pop() else {
+            // If there's no existing node, it means we didn't encounter a
+            // boolean operator above this condition, so it must be a
+            // single condition decision.
+            return Some(FinishedDecision::StandaloneBranch(BranchSpan {
+                span,
+                true_marker,
+                false_marker,
+            }));
+        };
+
         let Some(decision) = self.decision.as_mut() else {
             bug!("decision should have been created by now");
         };
@@ -150,7 +165,9 @@ impl MCDCDecisionBuilder {
         if self.bdd_node_stack.is_empty() {
             // There is no more condition to the decision, return the resulting spans
             let conditions = std::mem::take(&mut self.conditions);
-            self.decision.take().map(|decision| (decision, conditions))
+            self.decision
+                .take()
+                .map(|decision| FinishedDecision::MCDCDecision(decision, conditions))
         } else {
             None
         }
@@ -183,11 +200,19 @@ pub(crate) struct MCDCInfoBuilder {
 
     /// The list of computed decisions so far.
     decisions: Vec<(DecisionSpan, Vec<ConditionSpan>)>,
+
+    /// The list of extra branch span, i.e. 1-condition decisions we'd rather
+    /// instrument via branch instrumentation since it is equivalent.
+    standalone_branches: Vec<BranchSpan>,
 }
 
 impl Default for MCDCInfoBuilder {
     fn default() -> Self {
-        Self { decision_builder_stack: vec![MCDCDecisionBuilder::default()], decisions: Vec::new() }
+        Self {
+            decision_builder_stack: vec![MCDCDecisionBuilder::default()],
+            decisions: Vec::new(),
+            standalone_branches: Vec::new(),
+        }
     }
 }
 
@@ -231,27 +256,41 @@ impl MCDCInfoBuilder {
             bug!("Unexpected empty decision builder stack")
         };
 
-        if let Some((decision, conditions)) =
-            decision_builder.try_finish_decision(span, true_marker, false_marker)
-        {
-            let num_conditions = conditions.len();
-            assert_eq!(
-                num_conditions, decision.num_conditions,
-                "decision.num_conditions should equal conditions.len()"
-            );
+        match decision_builder.try_finish_decision(span, true_marker, false_marker) {
+            // Decision was completed, save it.
+            Some(FinishedDecision::MCDCDecision(decision, conditions)) => {
+                let num_conditions = conditions.len();
+                assert_eq!(
+                    num_conditions, decision.num_conditions,
+                    "decision.num_conditions should equal conditions.len()"
+                );
 
-            match num_conditions {
-                1..=ConditionId::MAX_AS_USIZE => self.decisions.push((decision, conditions)),
+                match num_conditions {
+                    1..=ConditionId::MAX_AS_USIZE => self.decisions.push((decision, conditions)),
 
-                0 => bug!("decision has no condition"),
+                    0 => bug!("decision has no condition"),
 
-                // LLVM does not support decisions with more conditions.
-                _ => tcx.dcx().emit_warn(MCDCConditionNumberExceeded {
-                    span: decision.span,
-                    max_conditions: ConditionId::MAX_AS_USIZE,
-                    num_conditions,
-                }),
+                    // LLVM does not support decisions with more conditions.
+                    _ => {
+                        tcx.dcx().emit_warn(MCDCConditionNumberExceeded {
+                            span: decision.span,
+                            max_conditions: ConditionId::MAX_AS_USIZE,
+                            num_conditions,
+                        });
+
+                        // Upon error, decision_builder should be in a
+                        // sound state for the next decision.
+                        debug_assert!(decision_builder.is_empty())
+                    }
+                }
             }
+            // Decision is a simple condition without an operator,
+            // save it to instrument it with branch coverage.
+            Some(FinishedDecision::StandaloneBranch(branch_span)) => {
+                self.standalone_branches.push(branch_span)
+            }
+            // Decision isn't complete yet
+            None => {}
         }
     }
 
@@ -277,14 +316,14 @@ impl MCDCInfoBuilder {
 
     #[inline]
     #[instrument(level = "debug")]
-    pub(crate) fn into_done(self) -> Vec<(DecisionSpan, Vec<ConditionSpan>)> {
-        self.decisions
+    pub(crate) fn into_done(self) -> (Vec<(DecisionSpan, Vec<ConditionSpan>)>, Vec<BranchSpan>) {
+        (self.decisions, self.standalone_branches)
     }
 
     #[inline]
     #[instrument(level = "debug")]
-    pub(crate) fn as_done(&self) -> &[(DecisionSpan, Vec<ConditionSpan>)] {
-        self.decisions.as_slice()
+    pub(crate) fn as_done(&self) -> (&[(DecisionSpan, Vec<ConditionSpan>)], &[BranchSpan]) {
+        (self.decisions.as_slice(), self.standalone_branches.as_slice())
     }
 }
 

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -160,6 +160,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let condition_scope = this.local_scope();
                 let source_info = this.source_info(expr.span);
 
+                // Build the binary decision diagram from for MC/DC purposes if
+                // enabled.
+                this.maybe_mcdc_record_operator(op, expr.span);
+
                 // We first evaluate the left-hand side of the predicate ...
                 let (then_block, else_block) =
                     this.in_if_then_scope(condition_scope, expr.span, |this| {

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -115,13 +115,17 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let expr_span = expr.span;
 
         match expr.kind {
-            ExprKind::LogicalOp { op: LogicalOp::And, lhs, rhs } => {
+            ExprKind::LogicalOp { op: op @ LogicalOp::And, lhs, rhs } => {
+                this.maybe_mcdc_record_operator(op, expr_span);
+
                 let lhs_then_block = this.then_else_break_inner(block, lhs, args).into_block();
                 let rhs_then_block =
                     this.then_else_break_inner(lhs_then_block, rhs, args).into_block();
                 rhs_then_block.unit()
             }
-            ExprKind::LogicalOp { op: LogicalOp::Or, lhs, rhs } => {
+            ExprKind::LogicalOp { op: op @ LogicalOp::Or, lhs, rhs } => {
+                this.maybe_mcdc_record_operator(op, expr_span);
+
                 let local_scope = this.local_scope();
                 let (lhs_success_block, failure_block) =
                     this.in_if_then_scope(local_scope, expr_span, |this| {
@@ -201,17 +205,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let temp_scope = args.temp_scope_override.unwrap_or_else(|| this.local_scope());
                 let mutability = Mutability::Mut;
 
-                let place = unpack!(
-                    block = this.as_temp(
-                        block,
-                        TempLifetime {
-                            temp_lifetime: Some(temp_scope),
-                            backwards_incompatible: None
-                        },
-                        expr_id,
-                        mutability
+                let place = this.in_mcdc_sub_scope(|this| {
+                    unpack!(
+                        block = this.as_temp(
+                            block,
+                            TempLifetime {
+                                temp_lifetime: Some(temp_scope),
+                                backwards_incompatible: None
+                            },
+                            expr_id,
+                            mutability
+                        )
                     )
-                );
+                });
 
                 let operand = Operand::Move(Place::from(place));
 

--- a/compiler/rustc_mir_build/src/diagnostics.rs
+++ b/compiler/rustc_mir_build/src/diagnostics.rs
@@ -1438,3 +1438,13 @@ pub(crate) struct ConstContinueUnknownJumpTarget {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag("number of conditions in decision ({$num_conditions}) exceeds limit ({$max_conditions}), so MC/DC analysis will not count this expression
+")]
+pub(crate) struct MCDCConditionNumberExceeded {
+    #[primary_span]
+    pub span: Span,
+    pub max_conditions: usize,
+    pub num_conditions: usize,
+}

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -190,6 +190,8 @@ pub enum CoverageLevel {
     /// instrumentation, so it might be removed in the future when MC/DC is
     /// sufficiently complete, or if it is making MC/DC changes difficult.
     Condition,
+    /// Instrument decisions for MC/DC coverage.
+    Mcdc,
 }
 
 // The different settings that the `-Z offload` flag can have.

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -849,7 +849,7 @@ mod desc {
     pub(crate) const parse_linker_flavor: &str = ::rustc_target::spec::LinkerFlavorCli::one_of();
     pub(crate) const parse_dump_mono_stats: &str = "`markdown` (default) or `json`";
     pub(crate) const parse_instrument_coverage: &str = parse_bool;
-    pub(crate) const parse_coverage_options: &str = "`block` | `branch` | `condition`";
+    pub(crate) const parse_coverage_options: &str = "`block` | `branch` | `condition` | `mcdc`";
     pub(crate) const parse_codegen_retag_options: &str =
         "either no value or a comma-separated list of settings: `no-precise-im`, `no-precise-pin`";
     pub(crate) const parse_instrument_mcount: &str =
@@ -1661,6 +1661,7 @@ pub mod parse {
                 "block" => slot.level = CoverageLevel::Block,
                 "branch" => slot.level = CoverageLevel::Branch,
                 "condition" => slot.level = CoverageLevel::Condition,
+                "mcdc" => slot.level = CoverageLevel::Mcdc,
                 "discard-all-spans-in-codegen" => slot.discard_all_spans_in_codegen = true,
                 _ => return false,
             }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -582,6 +582,11 @@ impl Session {
             && self.opts.unstable_opts.coverage_options.level >= CoverageLevel::Condition
     }
 
+    pub fn instrument_coverage_mcdc(&self) -> bool {
+        self.instrument_coverage()
+            && self.opts.unstable_opts.coverage_options.level >= CoverageLevel::Mcdc
+    }
+
     /// Provides direct access to the `CoverageOptions` struct, so that
     /// individual flags for debugging/testing coverage instrumetation don't
     /// need separate accessors.

--- a/src/doc/unstable-book/src/compiler-flags/coverage-options.md
+++ b/src/doc/unstable-book/src/compiler-flags/coverage-options.md
@@ -5,7 +5,7 @@ This option controls details of the coverage instrumentation performed by
 
 Multiple options can be passed, separated by commas. Valid options are:
 
-- `block`, `branch`, `condition`:
+- `block`, `branch`, `condition`, `mcdc`:
   Sets the level of coverage instrumentation.
   Setting the level will override any previously-specified level.
   - `block` (default):
@@ -15,3 +15,6 @@ Multiple options can be passed, separated by commas. Valid options are:
   - `condition`:
     In addition to branch coverage, also instruments some boolean expressions
     as branches, even if they are not directly used as branch conditions.
+  - `mcdc`:
+    In addition to condition coverage, also enables MC/DC instrumentation.
+    (Branch coverage instrumentation may differ in some cases.)

--- a/tests/ui/instrument-coverage/coverage-options.bad.stderr
+++ b/tests/ui/instrument-coverage/coverage-options.bad.stderr
@@ -1,2 +1,2 @@
-error: incorrect value `bad` for unstable option `coverage-options` - `block` | `branch` | `condition` was expected
+error: incorrect value `bad` for unstable option `coverage-options` - `block` | `branch` | `condition` | `mcdc` was expected
 


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/goals/issues/638

Identify MC/DC decision in the AST form, to allow for incoming instrumentation and mappings creation.

1. Introduce a `-Z coverage-options=mcdc` flag
2. Detect boolean expressions in THIR to: 
    1. Gather sufficient data to construct MC/DC decisions;
    2. Emit *block markers* in MIR to track the expressions and instrument them

<!-- homu-ignore:start -->
r? @davidtwco
<!-- homu-ignore:end -->