### PR TITLE
MC/DC Coverage re-introduction (2/3): MIR instrumentation

### DIFF
--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
@@ -170,6 +170,8 @@ fn fill_region_tables<'tcx>(
                     false_counter: counter_for_bcb(false_bcb),
                 });
             }
+            MappingKind::MCDCCondition { .. } => unimplemented!(),
+            MappingKind::MCDCDecision { .. } => unimplemented!(),
         }
     }
 }

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
@@ -131,6 +131,8 @@ impl<'tcx> CoverageInfoBuilderMethods<'tcx> for Builder<'_, '_, 'tcx> {
             }
             // If a BCB doesn't have an associated physical counter, there's nothing to codegen.
             CoverageKind::VirtualCounter { .. } => {}
+            CoverageKind::MCDCTmpIdxUpdate { .. } => unimplemented!(),
+            CoverageKind::MCDCTestVectorBitmapUpdate { .. } => unimplemented!(),
         }
     }
 }

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -174,6 +174,7 @@ pub struct CoverageInfoHi {
     /// data structures without having to scan the entire body first.
     pub num_block_markers: usize,
     pub branch_spans: Vec<BranchSpan>,
+    pub mcdc_spans: Vec<(mcdc::DecisionSpan, Vec<mcdc::ConditionSpan>)>,
 }
 
 #[derive(Clone, Debug)]
@@ -182,6 +183,83 @@ pub struct BranchSpan {
     pub span: Span,
     pub true_marker: BlockMarkerId,
     pub false_marker: BlockMarkerId,
+}
+
+pub mod mcdc {
+    use rustc_macros::{StableHash, TyDecodable, TyEncodable};
+    use rustc_span::Span;
+
+    use crate::mir::coverage::BlockMarkerId;
+
+    rustc_index::newtype_index! {
+        /// ID of an MC/DC condition. Used by LLVM to check MC/DC coverage.
+        ///
+        /// Note: the maximum number of condition within a decision supported by
+        /// llvm is 32767, thus the max ID is 0x7FFE.
+        #[stable_hash]
+        #[encodable]
+        #[orderable]
+        #[max = 0x7FFE]
+        #[debug_format = "ConditionId({})"]
+        pub struct ConditionId {}
+    }
+
+    impl ConditionId {
+        pub const START: Self = Self::from_usize(0);
+        pub const MAX_AS_USIZE: usize = Self::MAX.as_usize();
+    }
+
+    /// Node in a BDD (Binary Decision Diagram) for MC/DC analysis
+    #[derive(Copy, Clone, Debug)]
+    #[derive(TyEncodable, TyDecodable, Hash, StableHash)]
+    pub struct ConditionInfo {
+        pub condition_id: ConditionId,
+        pub true_next_id: Option<ConditionId>,
+        pub false_next_id: Option<ConditionId>,
+    }
+
+    /// This struct is generated during THIR lowering, it keeps track of a
+    /// condition (simple boolean expression) span. It associates it with a BDD
+    /// node, that helps knowing the shape of the decision graph, and two markers
+    /// inserted in the generated MIR to find the basic blocks corresponding to
+    /// the two possible outcommes of the condition.
+    #[derive(Clone, Debug)]
+    #[derive(TyEncodable, TyDecodable, Hash, StableHash)]
+    pub struct ConditionSpan {
+        pub span: Span,
+        pub condition_info: ConditionInfo,
+        pub true_marker: BlockMarkerId,
+        pub false_marker: BlockMarkerId,
+    }
+
+    /// This struct is generated during THIR lowering for each encountered
+    /// "complex" boolean expression (expressions with at least one logical
+    /// operator). it associates the span of the expression in the source
+    /// code with:
+    /// - the list of markers inserted in the generated MIR to keep
+    ///     track of the output basic blocks of the decision graph.
+    /// - the depth, corresponding to the level of nesting of this decision
+    ///     (e.g. in `true || foo (a && b)`, `true || foo (...)` has depth 0,
+    ///     `a && b` has depth 1).
+    /// - the number of conditions ("simple" boolean expressions) within this
+    ///     decision.
+    ///
+    /// Invariant: for each [`DecisionSpan`] generated, there should be
+    /// `num_conditions` [`ConditionSpan`]'s as well.
+    #[derive(Clone, Debug)]
+    #[derive(TyEncodable, TyDecodable, Hash, StableHash)]
+    pub struct DecisionSpan {
+        pub span: Span,
+
+        /// Marker statements designating outputs of the decision in MIR.
+        pub end_markers: Vec<BlockMarkerId>,
+
+        /// Nesting level of the decision.
+        pub decision_depth: u16,
+
+        /// Number of conditions in the decision.
+        pub num_conditions: usize,
+    }
 }
 
 /// Contains information needed during codegen, obtained by inspecting the

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -191,6 +191,23 @@ pub struct FunctionCoverageInfo {
     pub priority_list: Vec<BasicCoverageBlock>,
 
     pub mappings: Vec<Mapping>,
+    pub mcdc_info: Option<FunctionMCDCExtraInfo>,
+}
+
+/// Additional information carried by [`FunctionCoverageInfo`] when MC/DC is
+/// enabled.
+#[derive(Clone, Debug)]
+#[derive(TyEncodable, TyDecodable, Hash, StableHash)]
+pub struct FunctionMCDCExtraInfo {
+    /// Number of bits to allocate to the MC/DC bitmap for this function.
+    ///
+    /// This is the sum of the number of possible test vectors for each MC/DC
+    /// decision in the function.
+    pub bitmap_bits: usize,
+
+    /// Number of temporary test vector accumulators to allocate in the
+    /// function to accommodate the most deeply nested decisions.
+    pub num_temporaries: usize,
 }
 
 /// Coverage information for a function, recorded during MIR building and

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -90,6 +90,23 @@ pub enum CoverageKind {
     /// During codegen, this might be lowered to `llvm.instrprof.increment` or
     /// to a no-op, depending on the outcome of counter-creation.
     VirtualCounter { bcb: BasicCoverageBlock },
+
+    /// Marks a point in MIR where a condition was evaluated and we increment the
+    /// MC/DC temp variable to build the test vector.
+    MCDCTmpIdxUpdate {
+        /// Number by which to increment the temporary.
+        incr: u32,
+
+        /// Index of the temporary to increment in the stack of temporaries.
+        /// (Needed for nested decisions)
+        decision_depth: u16,
+    },
+
+    /// Marks a point in MIR where we want to register a test vector after evaluating
+    /// a decision.
+    ///
+    /// Eventually lowered to `llvm.instrprof.mcdc.tvbitmap.update` in LLVM IR.
+    MCDCTestVectorBitmapUpdate { bitmap_idx: u32, decision_depth: u16 },
 }
 
 impl Debug for CoverageKind {
@@ -99,6 +116,12 @@ impl Debug for CoverageKind {
             SpanMarker => write!(fmt, "SpanMarker"),
             BlockMarker { id } => write!(fmt, "BlockMarker({:?})", id.index()),
             VirtualCounter { bcb } => write!(fmt, "VirtualCounter({bcb:?})"),
+            MCDCTmpIdxUpdate { incr, decision_depth } => {
+                write!(fmt, "MCDCDecisionIdxUpdate(incr={incr}, depth={decision_depth})")
+            }
+            MCDCTestVectorBitmapUpdate { bitmap_idx, decision_depth } => {
+                write!(fmt, "MCDCTestVectorBitmapUpdate({bitmap_idx}, depth={decision_depth})")
+            }
         }
     }
 }

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -135,6 +135,16 @@ pub enum MappingKind {
     Code { bcb: BasicCoverageBlock },
     /// Associates a branch region with separate counters for true and false.
     Branch { true_bcb: BasicCoverageBlock, false_bcb: BasicCoverageBlock },
+    /// Associates a condition region to a decision graph node and its true
+    /// and false outcomes.
+    MCDCCondition {
+        true_bcb: BasicCoverageBlock,
+        false_bcb: BasicCoverageBlock,
+        mcdc_mappings: mcdc::ConditionInfo,
+    },
+    /// Associate a decision region with its index in the entire MC/DC bitmap,
+    /// and its number of conditions,
+    MCDCDecision { bitmap_idx: u32, num_conditions: u16 },
 }
 
 #[derive(Clone, Debug)]

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -637,7 +637,8 @@ fn write_coverage_info_hi(
     coverage_info_hi: &coverage::CoverageInfoHi,
     w: &mut dyn io::Write,
 ) -> io::Result<()> {
-    let coverage::CoverageInfoHi { num_block_markers: _, branch_spans } = coverage_info_hi;
+    let coverage::CoverageInfoHi { num_block_markers: _, branch_spans, mcdc_spans } =
+        coverage_info_hi;
 
     // Only add an extra trailing newline if we printed at least one thing.
     let mut did_print = false;
@@ -647,6 +648,31 @@ fn write_coverage_info_hi(
             w,
             "{INDENT}coverage branch {{ true: {true_marker:?}, false: {false_marker:?} }} => {span:?}",
         )?;
+        did_print = true;
+    }
+
+    for (
+        coverage::mcdc::DecisionSpan { span, end_markers, decision_depth, num_conditions },
+        conditions,
+    ) in mcdc_spans
+    {
+        writeln!(
+            w,
+            "{INDENT}MCDC decision {{ num_conditions: {num_conditions}, depth: {decision_depth}, outputs: {end_markers:?} }} => {span:?}",
+        )?;
+
+        for coverage::mcdc::ConditionSpan {
+            span,
+            condition_info:
+                coverage::mcdc::ConditionInfo { condition_id, true_next_id, false_next_id },
+            ..
+        } in conditions
+        {
+            writeln!(
+                w,
+                "{INDENT}{INDENT}condition {{ id: {condition_id:?}, true_id: {true_next_id:?}, false_id: {false_next_id:?} }} => {span:?}"
+            )?;
+        }
         did_print = true;
     }
 

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -9,6 +9,7 @@ use tracing::trace;
 use ty::print::PrettyPrinter;
 
 use super::graphviz::write_mir_fn_graphviz;
+use crate::mir::coverage::FunctionMCDCExtraInfo;
 use crate::mir::interpret::{
     AllocBytes, AllocId, Allocation, ConstAllocation, GlobalAlloc, Pointer, Provenance,
     alloc_range, read_target_uint,
@@ -687,12 +688,20 @@ fn write_function_coverage_info(
     function_coverage_info: &coverage::FunctionCoverageInfo,
     w: &mut dyn io::Write,
 ) -> io::Result<()> {
-    let coverage::FunctionCoverageInfo { mappings, .. } = function_coverage_info;
+    let coverage::FunctionCoverageInfo { mappings, mcdc_info, .. } = function_coverage_info;
 
     for coverage::Mapping { kind, span } in mappings {
         writeln!(w, "{INDENT}coverage {kind:?} => {span:?};")?;
     }
     writeln!(w)?;
+
+    if let Some(FunctionMCDCExtraInfo { bitmap_bits, num_temporaries }) = mcdc_info.as_ref() {
+        writeln!(
+            w,
+            "{INDENT}coverage (MC/DC: bitmap_bits={bitmap_bits}, num_temporaries={num_temporaries});"
+        )?;
+        writeln!(w)?;
+    }
 
     Ok(())
 }

--- a/compiler/rustc_mir_build/src/builder/coverageinfo.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo.rs
@@ -168,10 +168,13 @@ impl CoverageInfoBuilder {
         let Self { nots: _, markers: BlockMarkerGen { num_block_markers }, branch_info, mcdc_info } =
             self;
 
-        let branch_spans =
+        let mut branch_spans =
             branch_info.map(|branch_info| branch_info.branch_spans).unwrap_or_default();
 
-        let mcdc_spans = mcdc_info.map(MCDCInfoBuilder::into_done).unwrap_or_default();
+        let (mcdc_spans, standalone_branches) =
+            mcdc_info.map(MCDCInfoBuilder::into_done).unwrap_or_default();
+
+        branch_spans.extend(standalone_branches);
 
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.
@@ -186,14 +189,17 @@ impl CoverageInfoBuilder {
             ref mcdc_info,
         } = self;
 
-        let branch_spans = branch_info
+        let mut branch_spans = branch_info
             .as_ref()
             .map(|branch_info| branch_info.branch_spans.as_slice())
             .unwrap_or_default()
             .to_owned();
 
-        let mcdc_spans =
-            mcdc_info.as_ref().map(|mcdc_info| mcdc_info.as_done().to_vec()).unwrap_or_default();
+        let (mcdc_spans, standalone_branches) =
+            mcdc_info.as_ref().map(|mcdc_info| mcdc_info.as_done()).unwrap_or_default();
+
+        branch_spans.extend(standalone_branches.iter().cloned());
+        let mcdc_spans = mcdc_spans.to_vec();
 
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.

--- a/compiler/rustc_mir_build/src/builder/coverageinfo.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo.rs
@@ -8,7 +8,10 @@ use rustc_middle::thir::{ExprId, ExprKind, Pat, Thir};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::def_id::LocalDefId;
 
+use crate::builder::coverageinfo::mcdc::MCDCInfoBuilder;
 use crate::builder::{Builder, CFG};
+
+mod mcdc;
 
 /// Collects coverage-related information during MIR building, to eventually be
 /// turned into a function's [`CoverageInfoHi`] when MIR building is complete.
@@ -20,6 +23,9 @@ pub(crate) struct CoverageInfoBuilder {
 
     /// Present if branch coverage is enabled.
     branch_info: Option<BranchInfo>,
+
+    /// Present if MC/DC coverage is enabled.
+    mcdc_info: Option<MCDCInfoBuilder>,
 }
 
 #[derive(Default)]
@@ -78,6 +84,7 @@ impl CoverageInfoBuilder {
             nots: FxHashMap::default(),
             markers: BlockMarkerGen::default(),
             branch_info: tcx.sess.instrument_coverage_branch().then(BranchInfo::default),
+            mcdc_info: tcx.sess.instrument_coverage_mcdc().then(MCDCInfoBuilder::default),
         })
     }
 
@@ -129,38 +136,55 @@ impl CoverageInfoBuilder {
 
     fn register_two_way_branch<'tcx>(
         &mut self,
+        tcx: TyCtxt<'tcx>,
         cfg: &mut CFG<'tcx>,
         source_info: SourceInfo,
         true_block: BasicBlock,
         false_block: BasicBlock,
     ) {
-        // Bail out if branch coverage is not enabled.
-        let Some(branch_info) = self.branch_info.as_mut() else { return };
+        let mut inject_block_marker =
+            |bb: BasicBlock| self.markers.inject_block_marker(cfg, source_info, bb);
 
-        let true_marker = self.markers.inject_block_marker(cfg, source_info, true_block);
-        let false_marker = self.markers.inject_block_marker(cfg, source_info, false_block);
+        if let Some(mcdc_info) = self.mcdc_info.as_mut() {
+            // If MC/DC is enabled, register the branch via MCDC
+            let true_marker = inject_block_marker(true_block);
+            let false_marker = inject_block_marker(false_block);
 
-        branch_info.branch_spans.push(BranchSpan {
-            span: source_info.span,
-            true_marker,
-            false_marker,
-        });
+            mcdc_info.record_leaf_condition(tcx, source_info.span, true_marker, false_marker);
+        } else if let Some(branch_info) = self.branch_info.as_mut() {
+            // Else, if branch/condition is enabled, create a new branch span
+            let true_marker = inject_block_marker(true_block);
+            let false_marker = inject_block_marker(false_block);
+
+            branch_info.branch_spans.push(BranchSpan {
+                span: source_info.span,
+                true_marker,
+                false_marker,
+            });
+        }
     }
 
     pub(crate) fn into_done(self) -> Box<CoverageInfoHi> {
-        let Self { nots: _, markers: BlockMarkerGen { num_block_markers }, branch_info } = self;
+        let Self { nots: _, markers: BlockMarkerGen { num_block_markers }, branch_info, mcdc_info } =
+            self;
 
         let branch_spans =
             branch_info.map(|branch_info| branch_info.branch_spans).unwrap_or_default();
 
+        let mcdc_spans = mcdc_info.map(MCDCInfoBuilder::into_done).unwrap_or_default();
+
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.
-        Box::new(CoverageInfoHi { num_block_markers, branch_spans })
+        Box::new(CoverageInfoHi { num_block_markers, branch_spans, mcdc_spans })
     }
 
     pub(crate) fn as_done(&self) -> Box<CoverageInfoHi> {
-        let &Self { nots: _, markers: BlockMarkerGen { num_block_markers }, ref branch_info } =
-            self;
+        let &Self {
+            nots: _,
+            markers: BlockMarkerGen { num_block_markers },
+            ref branch_info,
+            ref mcdc_info,
+        } = self;
 
         let branch_spans = branch_info
             .as_ref()
@@ -168,9 +192,12 @@ impl CoverageInfoBuilder {
             .unwrap_or_default()
             .to_owned();
 
+        let mcdc_spans =
+            mcdc_info.as_ref().map(|mcdc_info| mcdc_info.as_done().to_vec()).unwrap_or_default();
+
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.
-        Box::new(CoverageInfoHi { num_block_markers, branch_spans })
+        Box::new(CoverageInfoHi { num_block_markers, branch_spans, mcdc_spans })
     }
 }
 
@@ -223,7 +250,13 @@ impl<'tcx> Builder<'_, 'tcx> {
             mir::TerminatorKind::if_(mir::Operand::Copy(place), true_block, false_block),
         );
 
-        coverage_info.register_two_way_branch(&mut self.cfg, source_info, true_block, false_block);
+        coverage_info.register_two_way_branch(
+            self.tcx,
+            &mut self.cfg,
+            source_info,
+            true_block,
+            false_block,
+        );
 
         let join_block = self.cfg.start_new_block();
         self.cfg.goto(true_block, source_info, join_block);
@@ -254,7 +287,13 @@ impl<'tcx> Builder<'_, 'tcx> {
 
         let source_info = SourceInfo { span: self.thir[expr_id].span, scope: self.source_scope };
 
-        coverage_info.register_two_way_branch(&mut self.cfg, source_info, then_block, else_block);
+        coverage_info.register_two_way_branch(
+            self.tcx,
+            &mut self.cfg,
+            source_info,
+            then_block,
+            else_block,
+        );
     }
 
     /// If branch coverage is enabled, inject marker statements into `true_block`
@@ -271,6 +310,12 @@ impl<'tcx> Builder<'_, 'tcx> {
         let Some(coverage_info) = self.coverage_info.as_mut() else { return };
 
         let source_info = SourceInfo { span: pattern.span, scope: self.source_scope };
-        coverage_info.register_two_way_branch(&mut self.cfg, source_info, true_block, false_block);
+        coverage_info.register_two_way_branch(
+            self.tcx,
+            &mut self.cfg,
+            source_info,
+            true_block,
+            false_block,
+        );
     }
 }

--- a/compiler/rustc_mir_build/src/builder/coverageinfo/mcdc.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo/mcdc.rs
@@ -1,0 +1,318 @@
+use rustc_middle::bug;
+use rustc_middle::mir::coverage::mcdc::{ConditionId, ConditionInfo, ConditionSpan, DecisionSpan};
+use rustc_middle::mir::coverage::BlockMarkerId;
+use rustc_middle::thir::LogicalOp;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+use tracing::instrument;
+
+use crate::builder::Builder;
+use crate::diagnostics::MCDCConditionNumberExceeded;
+
+/// This struct is responsible for tracking a visited decision, assigning
+/// [`ConditionId`]s to its conditions and building its BDD (Binary Decision
+/// Diagram), which are necessary for generating the MC/DC coverage mappings.
+///
+/// The ID assignment algorithm works by assigning an ID to the operands of the
+/// root operator, and then, via consecutive calls on the sub-expressions, if
+/// its a composite expression, re-assign its ID to its LHS, and assign a new
+/// ID to its RHS.
+///
+/// Example: "x = (A && B) || (C && D) || (D && F)"
+///
+///  Visit Depth1:
+///          (A && B) || (C && D) || (D && F)
+///          ^-------LHS--------^    ^-RHS--^
+///                  ID=1              ID=2
+///
+///  Visit LHS-Depth2:
+///          (A && B) || (C && D)
+///          ^-LHS--^    ^-RHS--^
+///            ID=1        ID=3
+///
+///  Visit LHS-Depth3:
+///           (A && B)
+///           LHS   RHS
+///           ID=1  ID=4
+///
+///  Visit RHS-Depth3:
+///                     (C && D)
+///                     LHS   RHS
+///                     ID=3  ID=5
+///
+///  Visit RHS-Depth2:              (D && F)
+///                                 LHS   RHS
+///                                 ID=2  ID=6
+///
+///  Visit Depth1:
+///          (A && B)  || (C && D)  || (D && F)
+///          ID=1  ID=4   ID=3  ID=5   ID=2  ID=6
+///
+#[derive(Debug, Default)]
+struct MCDCDecisionBuilder {
+    /// The stack of [`ConditionInfo`]s representing the BDD of the decision we
+    /// visited so far.
+    bdd_node_stack: Vec<ConditionInfo>,
+
+    /// The spans for leaf condition we already visited.
+    conditions: Vec<ConditionSpan>,
+
+    /// The decision span currently being built when visiting a decision, `None`
+    /// otherwise.
+    decision: Option<DecisionSpan>,
+}
+
+impl MCDCDecisionBuilder {
+    /// Record new condition nodes linked by `logical_op` in the BDD.
+    fn record_operator(&mut self, logical_op: LogicalOp, span: Span, decision_depth: u16) {
+        let decision = match self.decision.as_mut() {
+            Some(decision) => {
+                decision.span = decision.span.to(span);
+                decision
+            }
+            None => self.decision.insert(DecisionSpan {
+                span,
+                end_markers: Vec::new(),
+                decision_depth,
+                num_conditions: 0,
+            }),
+        };
+
+        // Top of the stack is not a leaf condition, pop it and stack both
+        // sides of the `logical_op` instead.
+        let parent_condition = self.bdd_node_stack.pop().unwrap_or_else(|| {
+            assert_eq!(decision.num_conditions, 0, "No condition means num_conditions should be 0");
+            decision.num_conditions += 1;
+            ConditionInfo {
+                condition_id: ConditionId::START,
+                true_next_id: None,
+                false_next_id: None,
+            }
+        });
+
+        let lhs_id = parent_condition.condition_id;
+        let rhs_id = ConditionId::from(decision.num_conditions);
+        decision.num_conditions += 1;
+
+        // If OP is AND, RHS will be checked only if LHS is true.
+        // If OP is OR, RHS will be checked only if LHS is false.
+        let lhs = match logical_op {
+            LogicalOp::And => ConditionInfo {
+                condition_id: lhs_id,
+                true_next_id: Some(rhs_id),
+                false_next_id: parent_condition.false_next_id,
+            },
+            LogicalOp::Or => ConditionInfo {
+                condition_id: lhs_id,
+                true_next_id: parent_condition.true_next_id,
+                false_next_id: Some(rhs_id),
+            },
+        };
+        let rhs = ConditionInfo {
+            condition_id: rhs_id,
+            true_next_id: parent_condition.true_next_id,
+            false_next_id: parent_condition.false_next_id,
+        };
+
+        self.bdd_node_stack.push(rhs);
+        self.bdd_node_stack.push(lhs);
+    }
+
+    /// Called upon encountering a leaf condition of the boolean expression.
+    ///
+    /// Pop the [`ConditionInfo`] at the top of the node stack and make an
+    /// [`ConditionSpan`] from it. If the stack is empty afterwards, it
+    /// means the decision was completely visited, so return the decision and
+    /// condition spans.
+    fn try_finish_decision(
+        &mut self,
+        span: Span,
+        true_marker: BlockMarkerId,
+        false_marker: BlockMarkerId,
+    ) -> Option<(DecisionSpan, Vec<ConditionSpan>)> {
+        let condition_info = self.bdd_node_stack.pop()?;
+        let Some(decision) = self.decision.as_mut() else {
+            bug!("decision should have been created by now");
+        };
+
+        // if true_next_id is None, it means that this condition's evaluation
+        // to true will make the decision true.
+        if condition_info.true_next_id.is_none() {
+            decision.end_markers.push(true_marker);
+        }
+        if condition_info.false_next_id.is_none() {
+            decision.end_markers.push(false_marker);
+        }
+
+        // The condition_info is a leaf condition, make it a branch span.
+        self.conditions.push(ConditionSpan { span, condition_info, true_marker, false_marker });
+
+        if self.bdd_node_stack.is_empty() {
+            // There is no more condition to the decision, return the resulting spans
+            let conditions = std::mem::take(&mut self.conditions);
+            self.decision.take().map(|decision| (decision, conditions))
+        } else {
+            None
+        }
+    }
+
+    /// Returns true if the builder is currently building a decision.
+    #[inline]
+    fn is_empty(&self) -> bool {
+        return self.decision.is_none();
+    }
+}
+
+/// MC/DC decision builder context for a function.
+///
+/// Holds a stack of [`MCDCDecisionBuilder`] to account for nested decisions.
+#[derive(Debug)]
+pub(crate) struct MCDCInfoBuilder {
+    /// Holds a stack of decision builders, to account for nested decisions.
+    ///
+    /// Example:
+    /// ```rust,ignore (illustrative)
+    /// if a && foo(b || c) {}
+    /// ```
+    ///
+    /// Here `b || c` is a different decision nested in `a && ...`.
+    /// To avoid mixing decisions, when we're building a decision and we visit
+    /// a "non-trivial" node (other than parentheses, deref, etc...), we push a
+    /// new builder on the stack.
+    decision_builder_stack: Vec<MCDCDecisionBuilder>,
+
+    /// The list of computed decisions so far.
+    decisions: Vec<(DecisionSpan, Vec<ConditionSpan>)>,
+}
+
+impl Default for MCDCInfoBuilder {
+    fn default() -> Self {
+        Self { decision_builder_stack: vec![MCDCDecisionBuilder::default()], decisions: Vec::new() }
+    }
+}
+
+impl MCDCInfoBuilder {
+    /// Decision depth is given as a u16 to reduce the size of the
+    /// `CoverageKind`, as it is very unlikely that the depth ever reaches
+    /// 2^16.
+    ///
+    /// Note: zero-indexed
+    #[inline]
+    fn decision_depth(&self) -> u16 {
+        match u16::try_from(self.decision_builder_stack.len()).map(|n| n.checked_sub(1)) {
+            Ok(Some(d)) => d,
+            Ok(None) => bug!("Unexpected empty decision builder stack"),
+            Err(e) => bug!(
+                "{e}: decision depth did not fit in u16, this is likely to be an instrumentation error"
+            ),
+        }
+    }
+
+    #[instrument(level = "debug", skip(self), fields(depth = MCDCInfoBuilder::decision_depth(self)))]
+    pub(crate) fn record_operator(&mut self, logical_op: LogicalOp, span: Span) {
+        let depth = self.decision_depth();
+
+        let Some(decision_builder) = self.decision_builder_stack.last_mut() else {
+            bug!("Unexpected empty decision builder stack")
+        };
+
+        decision_builder.record_operator(logical_op, span, depth);
+    }
+
+    #[instrument(level = "debug", skip(self, tcx), fields(depth = MCDCInfoBuilder::decision_depth(self)))]
+    pub(crate) fn record_leaf_condition(
+        &mut self,
+        tcx: TyCtxt<'_>,
+        span: Span,
+        true_marker: BlockMarkerId,
+        false_marker: BlockMarkerId,
+    ) {
+        let Some(decision_builder) = self.decision_builder_stack.last_mut() else {
+            bug!("Unexpected empty decision builder stack")
+        };
+
+        if let Some((decision, conditions)) =
+            decision_builder.try_finish_decision(span, true_marker, false_marker)
+        {
+            let num_conditions = conditions.len();
+            assert_eq!(
+                num_conditions, decision.num_conditions,
+                "decision.num_conditions should equal conditions.len()"
+            );
+
+            match num_conditions {
+                1..=ConditionId::MAX_AS_USIZE => self.decisions.push((decision, conditions)),
+
+                0 => bug!("decision has no condition"),
+
+                // LLVM does not support decisions with more conditions.
+                _ => tcx.dcx().emit_warn(MCDCConditionNumberExceeded {
+                    span: decision.span,
+                    max_conditions: ConditionId::MAX_AS_USIZE,
+                    num_conditions,
+                }),
+            }
+        }
+    }
+
+    /// Called when visiting inside a condition leaf, to correctly record
+    /// nested decisions.
+    #[inline]
+    #[instrument(level = "debug", skip(self), fields(before = MCDCInfoBuilder::decision_depth(self)))]
+    fn increment_depth(&mut self) {
+        self.decision_builder_stack.push(MCDCDecisionBuilder::default());
+    }
+
+    /// Called when stepping out of condition leaf.
+    #[inline]
+    #[instrument(level = "debug", skip(self), fields(before = MCDCInfoBuilder::decision_depth(self)))]
+    fn decrement_depth(&mut self) {
+        let Some(top_builder) = self.decision_builder_stack.pop() else {
+            bug!("Unexpected empty decision builder stack");
+        };
+        if !top_builder.is_empty() {
+            bug!("Popped a decision builder with unfinished decision in it")
+        }
+    }
+
+    #[inline]
+    #[instrument(level = "debug")]
+    pub(crate) fn into_done(self) -> Vec<(DecisionSpan, Vec<ConditionSpan>)> {
+        self.decisions
+    }
+
+    #[inline]
+    #[instrument(level = "debug")]
+    pub(crate) fn as_done(&self) -> &[(DecisionSpan, Vec<ConditionSpan>)] {
+        self.decisions.as_slice()
+    }
+}
+
+impl Builder<'_, '_> {
+    #[inline]
+    fn mcdc_info_as_mut(&mut self) -> Option<&mut MCDCInfoBuilder> {
+        self.coverage_info.as_mut().and_then(|cov_info| cov_info.mcdc_info.as_mut())
+    }
+
+    pub(crate) fn maybe_mcdc_record_operator(&mut self, logical_op: LogicalOp, span: Span) {
+        if let Some(mcdc_builder) = self.mcdc_info_as_mut() {
+            mcdc_builder.record_operator(logical_op, span);
+        }
+    }
+
+    // If MC/DC instrumentation is enabled, push a new MC/DC decision builder
+    // before calling `f(self)`, and pop it afterwards. Otherwise, simply run
+    // `f(self)`.
+    pub(crate) fn in_mcdc_sub_scope<T>(&mut self, mut f: impl FnMut(&mut Self) -> T) -> T {
+        if let Some(mcdc_builder) = self.mcdc_info_as_mut() {
+            mcdc_builder.increment_depth();
+        };
+
+        let result = f(self);
+
+        if let Some(mcdc_builder) = self.mcdc_info_as_mut() {
+            mcdc_builder.decrement_depth();
+        };
+        result
+    }
+}

--- a/compiler/rustc_mir_build/src/builder/coverageinfo/mcdc.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo/mcdc.rs
@@ -1,6 +1,6 @@
 use rustc_middle::bug;
 use rustc_middle::mir::coverage::mcdc::{ConditionId, ConditionInfo, ConditionSpan, DecisionSpan};
-use rustc_middle::mir::coverage::BlockMarkerId;
+use rustc_middle::mir::coverage::{BlockMarkerId, BranchSpan};
 use rustc_middle::thir::LogicalOp;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
@@ -8,6 +8,11 @@ use tracing::instrument;
 
 use crate::builder::Builder;
 use crate::diagnostics::MCDCConditionNumberExceeded;
+
+enum FinishedDecision {
+    MCDCDecision(DecisionSpan, Vec<ConditionSpan>),
+    StandaloneBranch(BranchSpan),
+}
 
 /// This struct is responsible for tracking a visited decision, assigning
 /// [`ConditionId`]s to its conditions and building its BDD (Binary Decision
@@ -129,8 +134,18 @@ impl MCDCDecisionBuilder {
         span: Span,
         true_marker: BlockMarkerId,
         false_marker: BlockMarkerId,
-    ) -> Option<(DecisionSpan, Vec<ConditionSpan>)> {
-        let condition_info = self.bdd_node_stack.pop()?;
+    ) -> Option<FinishedDecision> {
+        let Some(condition_info) = self.bdd_node_stack.pop() else {
+            // If there's no existing node, it means we didn't encounter a
+            // boolean operator above this condition, so it must be a
+            // single condition decision.
+            return Some(FinishedDecision::StandaloneBranch(BranchSpan {
+                span,
+                true_marker,
+                false_marker,
+            }));
+        };
+
         let Some(decision) = self.decision.as_mut() else {
             bug!("decision should have been created by now");
         };
@@ -150,7 +165,9 @@ impl MCDCDecisionBuilder {
         if self.bdd_node_stack.is_empty() {
             // There is no more condition to the decision, return the resulting spans
             let conditions = std::mem::take(&mut self.conditions);
-            self.decision.take().map(|decision| (decision, conditions))
+            self.decision
+                .take()
+                .map(|decision| FinishedDecision::MCDCDecision(decision, conditions))
         } else {
             None
         }
@@ -183,11 +200,19 @@ pub(crate) struct MCDCInfoBuilder {
 
     /// The list of computed decisions so far.
     decisions: Vec<(DecisionSpan, Vec<ConditionSpan>)>,
+
+    /// The list of extra branch span, i.e. 1-condition decisions we'd rather
+    /// instrument via branch instrumentation since it is equivalent.
+    standalone_branches: Vec<BranchSpan>,
 }
 
 impl Default for MCDCInfoBuilder {
     fn default() -> Self {
-        Self { decision_builder_stack: vec![MCDCDecisionBuilder::default()], decisions: Vec::new() }
+        Self {
+            decision_builder_stack: vec![MCDCDecisionBuilder::default()],
+            decisions: Vec::new(),
+            standalone_branches: Vec::new(),
+        }
     }
 }
 
@@ -231,27 +256,41 @@ impl MCDCInfoBuilder {
             bug!("Unexpected empty decision builder stack")
         };
 
-        if let Some((decision, conditions)) =
-            decision_builder.try_finish_decision(span, true_marker, false_marker)
-        {
-            let num_conditions = conditions.len();
-            assert_eq!(
-                num_conditions, decision.num_conditions,
-                "decision.num_conditions should equal conditions.len()"
-            );
+        match decision_builder.try_finish_decision(span, true_marker, false_marker) {
+            // Decision was completed, save it.
+            Some(FinishedDecision::MCDCDecision(decision, conditions)) => {
+                let num_conditions = conditions.len();
+                assert_eq!(
+                    num_conditions, decision.num_conditions,
+                    "decision.num_conditions should equal conditions.len()"
+                );
 
-            match num_conditions {
-                1..=ConditionId::MAX_AS_USIZE => self.decisions.push((decision, conditions)),
+                match num_conditions {
+                    1..=ConditionId::MAX_AS_USIZE => self.decisions.push((decision, conditions)),
 
-                0 => bug!("decision has no condition"),
+                    0 => bug!("decision has no condition"),
 
-                // LLVM does not support decisions with more conditions.
-                _ => tcx.dcx().emit_warn(MCDCConditionNumberExceeded {
-                    span: decision.span,
-                    max_conditions: ConditionId::MAX_AS_USIZE,
-                    num_conditions,
-                }),
+                    // LLVM does not support decisions with more conditions.
+                    _ => {
+                        tcx.dcx().emit_warn(MCDCConditionNumberExceeded {
+                            span: decision.span,
+                            max_conditions: ConditionId::MAX_AS_USIZE,
+                            num_conditions,
+                        });
+
+                        // Upon error, decision_builder should be in a
+                        // sound state for the next decision.
+                        debug_assert!(decision_builder.is_empty())
+                    }
+                }
             }
+            // Decision is a simple condition without an operator,
+            // save it to instrument it with branch coverage.
+            Some(FinishedDecision::StandaloneBranch(branch_span)) => {
+                self.standalone_branches.push(branch_span)
+            }
+            // Decision isn't complete yet
+            None => {}
         }
     }
 
@@ -277,14 +316,14 @@ impl MCDCInfoBuilder {
 
     #[inline]
     #[instrument(level = "debug")]
-    pub(crate) fn into_done(self) -> Vec<(DecisionSpan, Vec<ConditionSpan>)> {
-        self.decisions
+    pub(crate) fn into_done(self) -> (Vec<(DecisionSpan, Vec<ConditionSpan>)>, Vec<BranchSpan>) {
+        (self.decisions, self.standalone_branches)
     }
 
     #[inline]
     #[instrument(level = "debug")]
-    pub(crate) fn as_done(&self) -> &[(DecisionSpan, Vec<ConditionSpan>)] {
-        self.decisions.as_slice()
+    pub(crate) fn as_done(&self) -> (&[(DecisionSpan, Vec<ConditionSpan>)], &[BranchSpan]) {
+        (self.decisions.as_slice(), self.standalone_branches.as_slice())
     }
 }
 

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -160,6 +160,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let condition_scope = this.local_scope();
                 let source_info = this.source_info(expr.span);
 
+                // Build the binary decision diagram from for MC/DC purposes if
+                // enabled.
+                this.maybe_mcdc_record_operator(op, expr.span);
+
                 // We first evaluate the left-hand side of the predicate ...
                 let (then_block, else_block) =
                     this.in_if_then_scope(condition_scope, expr.span, |this| {

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -115,13 +115,17 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let expr_span = expr.span;
 
         match expr.kind {
-            ExprKind::LogicalOp { op: LogicalOp::And, lhs, rhs } => {
+            ExprKind::LogicalOp { op: op @ LogicalOp::And, lhs, rhs } => {
+                this.maybe_mcdc_record_operator(op, expr_span);
+
                 let lhs_then_block = this.then_else_break_inner(block, lhs, args).into_block();
                 let rhs_then_block =
                     this.then_else_break_inner(lhs_then_block, rhs, args).into_block();
                 rhs_then_block.unit()
             }
-            ExprKind::LogicalOp { op: LogicalOp::Or, lhs, rhs } => {
+            ExprKind::LogicalOp { op: op @ LogicalOp::Or, lhs, rhs } => {
+                this.maybe_mcdc_record_operator(op, expr_span);
+
                 let local_scope = this.local_scope();
                 let (lhs_success_block, failure_block) =
                     this.in_if_then_scope(local_scope, expr_span, |this| {
@@ -201,17 +205,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let temp_scope = args.temp_scope_override.unwrap_or_else(|| this.local_scope());
                 let mutability = Mutability::Mut;
 
-                let place = unpack!(
-                    block = this.as_temp(
-                        block,
-                        TempLifetime {
-                            temp_lifetime: Some(temp_scope),
-                            backwards_incompatible: None
-                        },
-                        expr_id,
-                        mutability
+                let place = this.in_mcdc_sub_scope(|this| {
+                    unpack!(
+                        block = this.as_temp(
+                            block,
+                            TempLifetime {
+                                temp_lifetime: Some(temp_scope),
+                                backwards_incompatible: None
+                            },
+                            expr_id,
+                            mutability
+                        )
                     )
-                );
+                });
 
                 let operand = Operand::Move(Place::from(place));
 

--- a/compiler/rustc_mir_build/src/diagnostics.rs
+++ b/compiler/rustc_mir_build/src/diagnostics.rs
@@ -1438,3 +1438,13 @@ pub(crate) struct ConstContinueUnknownJumpTarget {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag("number of conditions in decision ({$num_conditions}) exceeds limit ({$max_conditions}), so MC/DC analysis will not count this expression
+")]
+pub(crate) struct MCDCConditionNumberExceeded {
+    #[primary_span]
+    pub span: Span,
+    pub max_conditions: usize,
+    pub num_conditions: usize,
+}

--- a/compiler/rustc_mir_transform/src/check_inline.rs
+++ b/compiler/rustc_mir_transform/src/check_inline.rs
@@ -46,6 +46,16 @@ pub(super) fn is_inline_valid_on_fn<'tcx>(
         return Err("#[rustc_no_mir_inline]");
     }
 
+    // MC/DC coverage does not work properly with inlining, because the
+    // instrumenter adds temporary variables to the functions which aren't
+    // (yet?) taken in account when inlining.
+    //
+    // FIXME(peron): Consider a refinement of the condition to only prevent
+    // functions with MC/DC instrumentation from inlining.
+    if tcx.sess.instrument_coverage_mcdc() {
+        return Err("No inlining when MC/DC coverage is enabled");
+    }
+
     let ty = tcx.type_of(def_id);
     if match ty.instantiate_identity().skip_norm_wip().kind() {
         ty::FnDef(..) => tcx.fn_sig(def_id).instantiate_identity().skip_norm_wip().c_variadic(),

--- a/compiler/rustc_mir_transform/src/coverage/expansion.rs
+++ b/compiler/rustc_mir_transform/src/coverage/expansion.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet, IndexEntry};
 use rustc_middle::mir;
-use rustc_middle::mir::coverage::{BasicCoverageBlock, BranchSpan};
+use rustc_middle::mir::coverage::{BasicCoverageBlock, BranchSpan, mcdc};
 use rustc_span::{ExpnKind, Span, SyntaxContext};
 
 use crate::coverage::from_mir;
@@ -62,6 +62,9 @@ pub(crate) struct ExpnNode {
     /// Branch spans (recorded during MIR building) belonging to this expansion.
     pub(crate) branch_spans: Vec<BranchSpan>,
 
+    /// MC/DC spans (recorded during MIR building) belonging to this expansion.
+    pub(crate) mcdc_spans: Vec<(mcdc::DecisionSpan, Vec<mcdc::ConditionSpan>)>,
+
     /// Hole spans belonging to this expansion, to be carved out from the
     /// code spans during span refinement.
     pub(crate) hole_spans: Vec<Span>,
@@ -90,6 +93,7 @@ impl ExpnNode {
             minmax_bcbs: None,
 
             branch_spans: vec![],
+            mcdc_spans: vec![],
 
             hole_spans: vec![],
         }
@@ -171,12 +175,20 @@ pub(crate) fn build_expn_tree(
         node.hole_spans.push(hole_span);
     }
 
-    // Associate each branch span (recorded during MIR building) with its
-    // corresponding expansion tree node.
     if let Some(coverage_info_hi) = mir_body.coverage_info_hi.as_deref() {
+        // Associate each branch span (recorded during MIR building) with its
+        // corresponding expansion tree node.
         for branch_span in &coverage_info_hi.branch_spans {
             if let Some(node) = nodes.get_mut(&branch_span.span.ctxt()) {
                 node.branch_spans.push(BranchSpan::clone(branch_span));
+            }
+        }
+
+        // Associate spans of MCDC decisions to the expansion node of the
+        // decision span.
+        for (decision_span, condition_spans) in &coverage_info_hi.mcdc_spans {
+            if let Some(node) = nodes.get_mut(&decision_span.span.ctxt()) {
+                node.mcdc_spans.push((decision_span.clone(), condition_spans.clone()))
             }
         }
     }

--- a/compiler/rustc_mir_transform/src/coverage/from_mir.rs
+++ b/compiler/rustc_mir_transform/src/coverage/from_mir.rs
@@ -98,7 +98,11 @@ fn filtered_statement_span(statement: &Statement<'_>) -> Option<Span> {
         StatementKind::Coverage(CoverageKind::BlockMarker { .. }) => None,
 
         // These coverage statements should not exist prior to coverage instrumentation.
-        StatementKind::Coverage(CoverageKind::VirtualCounter { .. }) => bug!(
+        StatementKind::Coverage(
+            CoverageKind::VirtualCounter { .. }
+            | CoverageKind::MCDCTmpIdxUpdate { .. }
+            | CoverageKind::MCDCTestVectorBitmapUpdate { .. },
+        ) => bug!(
             "Unexpected coverage statement found during coverage instrumentation: {statement:?}"
         ),
     }

--- a/compiler/rustc_mir_transform/src/coverage/mappings.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mappings.rs
@@ -1,6 +1,7 @@
 use rustc_index::IndexVec;
 use rustc_middle::mir::coverage::{
-    BlockMarkerId, BranchSpan, CoverageInfoHi, CoverageKind, Mapping, MappingKind,
+    BlockMarkerId, BranchSpan, CoverageInfoHi, CoverageKind, FunctionMCDCExtraInfo, Mapping,
+    MappingKind,
 };
 use rustc_middle::mir::{self, BasicBlock, StatementKind};
 use rustc_middle::ty::TyCtxt;
@@ -9,6 +10,7 @@ use rustc_span::ExpnKind;
 use crate::coverage::expansion::{self, ExpnTree};
 use crate::coverage::graph::CoverageGraph;
 use crate::coverage::hir_info::ExtractedHirInfo;
+use crate::coverage::mcdc;
 use crate::coverage::spans::extract_refined_covspans;
 
 /// Indicates why mapping extraction failed, for debug-logging purposes.
@@ -21,6 +23,7 @@ pub(crate) enum MappingsError {
 #[derive(Default)]
 pub(crate) struct ExtractedMappings {
     pub(crate) mappings: Vec<Mapping>,
+    pub(crate) mcdc_data: Option<(Vec<mcdc::MCDCMetaMapping>, FunctionMCDCExtraInfo)>,
 }
 
 /// Extracts coverage-relevant spans from MIR, and uses them to create
@@ -40,14 +43,16 @@ pub(crate) fn extract_mappings_from_mir<'tcx>(
 
     extract_branch_mappings(mir_body, hir_info, graph, &expn_tree, &mut mappings);
 
-    if mappings.is_empty() {
+    let mcdc_data = mcdc::extract_mcdc_mappings(mir_body, hir_info, graph, &expn_tree);
+
+    if mappings.is_empty() && mcdc_data.is_none() {
         tracing::debug!("no mappings were extracted");
         return Err(MappingsError::NoMappings);
     }
-    Ok(ExtractedMappings { mappings })
+    Ok(ExtractedMappings { mappings, mcdc_data })
 }
 
-fn resolve_block_markers(
+pub(crate) fn resolve_block_markers(
     coverage_info_hi: &CoverageInfoHi,
     mir_body: &mir::Body<'_>,
 ) -> IndexVec<BlockMarkerId, Option<BasicBlock>> {

--- a/compiler/rustc_mir_transform/src/coverage/mcdc.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mcdc.rs
@@ -1,0 +1,372 @@
+//! MC/DC instrumentation enables MC/DC coverage to be performed on the
+//! program. That is, for each "decision" (a boolean expression with at least
+//! one logical operator), ensure that each "condition" (single operands of
+//! the expression) is independently proven to have an effect on the outcome of
+//! the decision. To do that, we need to :
+//! 1. Detect decisions and their conditions in the AST (THIR).
+//!
+//! 2. Instrument the BDD (Binary Decision Diagram) (subset of MIR
+//!     corresponding to the decision). The goal of this step is to make sure
+//!     that upon finishing the evaluation of a decision, the program saves a
+//!     trace of the test vector (i.e. the set of input values) that was just
+//!     given. There are 3 requirements to do this:
+//!     - Allocate a temporary variable during the evaluation of the
+//!         decision, which should represent the current test vector being
+//!         evaluated.
+//!     - Upon ending a decision, save the aforementioned temporary variable
+//!         somehow, so we know this input was exercised.
+//!     - When evaluating a condition within the decision, update the
+//!         aforementioned temporary variable to keep track of this specific
+//!         condition evaluation.
+//!     *Note* that it is necessary that all possible test vectors produce a
+//!     unique value.
+//!
+//! 3. Adapt the codegen. Once all the processing is done pass all the data
+//!     the backend needs to generate MC/DC entries.
+//!     For LLVM, that includes providing it with "mappings", that are needed
+//!     by the instrumentation backend, so the post-execution script can map
+//!     back the coverage data to actual places in the source code, and calls
+//!     to the `llvm.instrprof.mcdc.tvbitmapupdate` intrinsic were decisions
+//!     end.
+//!
+//! The implementation is detailed below :
+//!
+//! 1. Detection of boolean decisions and conditions. This phase happens in
+//!     `rustc_mir_build::builder::coverageinfo::mcdc` and it does 2 things.
+//!     First, it detects boolean expressions, keeps a representation of all of
+//!     them ([`rustc_middle::mir::coverage::mcdc::DecisionSpan`] and
+//!     [`rustc_middle::mir::coverage::mcdc::ConditionSpan`]) along with the
+//!     corresponding spans in the source code, and stores it in
+//!     [`rustc_middle::mir::coverage::CoverageInfoHi`].
+//!     Additionally, it alters the MIR building and inserts [`BlockMarkerId`]s
+//!     to keep track of which basic blocks are generated from this decisions.
+//!
+//! 2. Instrumentation of MIR. This phase happens mostly in this module.
+//!     First, [`extract_mcdc_mappings`] processes
+//!     [`rustc_middle::mir::coverage::mcdc::DecisionSpan`]s and
+//!     [`rustc_middle::mir::coverage::mcdc::ConditionSpan`]s to create
+//!     "meta-mappings", which are essentially the structures we will give to
+//!     LLVM but with some extra data we cannot get rid of just yet.
+//!     [`extract_mcdc_mappings`] is also responsible for computing the index
+//!     increment values of each condition outcome via
+//!     [`calc_test_vectors_index`].
+//!     > **Warning**: [`calc_test_vectors_index`] reimplements an algorithm
+//!         from LLVM and should be kept synced with it, otherwise, test
+//!         vectors may be wrongly indexed between compilation and LLVM
+//!         reporting.
+//!
+//!     Once index increments are computed, we inject
+//!     [`CoverageKind`]`::TmpIdxUpdate` and
+//!     [`CoverageKind`]`::TvBitmapUpdate` instructions in MIR, and generate
+//!     the [`Mapping`]s we'll be passing to LLVM.
+//!
+
+use std::collections::BTreeSet;
+
+use rustc_data_structures::fx::FxIndexMap;
+use rustc_index::IndexVec;
+use rustc_middle::mir;
+use rustc_middle::mir::coverage::mcdc::{ConditionId, ConditionInfo, ConditionSpan};
+use rustc_middle::mir::coverage::{
+    BasicCoverageBlock, BlockMarkerId, CoverageKind, FunctionMCDCExtraInfo, Mapping, MappingKind,
+};
+use rustc_span::{ExpnKind, Span};
+
+use crate::coverage::expansion::ExpnTree;
+use crate::coverage::graph::CoverageGraph;
+use crate::coverage::hir_info::ExtractedHirInfo;
+use crate::coverage::inject_statement;
+use crate::coverage::mappings::resolve_block_markers;
+
+pub(crate) type MCDCMetaMapping = (MCDCMetaDecisionMapping, Vec<MCDCMetaConditionMapping>);
+
+/// MC/DC Condition Mapping with extra data to compute `num_test_vectors`.
+#[derive(Debug)]
+pub(crate) struct MCDCMetaConditionMapping {
+    span: Span,
+    condition_info: ConditionInfo,
+    true_bcb: BasicCoverageBlock,
+    false_bcb: BasicCoverageBlock,
+    // Offset added to test vector idx if this branch is evaluated to true.
+    true_incr: usize,
+    // Offset added to test vector idx if this branch is evaluated to false.
+    false_incr: usize,
+}
+
+impl MCDCMetaConditionMapping {
+    fn new(
+        span: Span,
+        condition_info: ConditionInfo,
+        true_bcb: BasicCoverageBlock,
+        false_bcb: BasicCoverageBlock,
+    ) -> Self {
+        Self {
+            span,
+            condition_info,
+            true_bcb,
+            false_bcb,
+            true_incr: usize::MAX,
+            false_incr: usize::MAX,
+        }
+    }
+}
+
+impl From<MCDCMetaConditionMapping> for Mapping {
+    fn from(
+        MCDCMetaConditionMapping {
+            span,
+            condition_info,
+            true_bcb,
+            false_bcb,
+            ..
+        }: MCDCMetaConditionMapping,
+    ) -> Self {
+        Self {
+            kind: MappingKind::MCDCCondition { true_bcb, false_bcb, mcdc_mappings: condition_info },
+            span,
+        }
+    }
+}
+
+/// Holds all the information about an MC/DC decision mapping.
+/// Later transformed into a regular LLVM-equivalent mapping.
+#[derive(Debug)]
+pub(crate) struct MCDCMetaDecisionMapping {
+    span: Span,
+    /// Output basic blocks where the executed test vector should be saved.
+    end_bcbs: BTreeSet<BasicCoverageBlock>,
+    /// STARTING index of the decision in the function's MCDC bitmap.
+    bitmap_idx: u32,
+    num_conditions: u16,
+    num_test_vectors: usize,
+    decision_depth: u16,
+}
+
+impl From<MCDCMetaDecisionMapping> for Mapping {
+    fn from(
+        MCDCMetaDecisionMapping { span, bitmap_idx, num_conditions, num_test_vectors, .. }: MCDCMetaDecisionMapping,
+    ) -> Self {
+        // LLVM expects the ENDING bitmap index.
+        let bitmap_idx = bitmap_idx + num_test_vectors as u32;
+        Self { kind: MappingKind::MCDCDecision { bitmap_idx, num_conditions }, span }
+    }
+}
+
+#[derive(Default)]
+struct BitmapIndexGen {
+    idx: usize,
+}
+
+impl BitmapIndexGen {
+    #[inline(always)]
+    fn next(&mut self, num_tv: usize) -> Option<usize> {
+        let ret = self.idx;
+        let next_idx = ret + num_tv;
+
+        if next_idx < MCDC_MAX_BITMAP_SIZE {
+            self.idx = next_idx;
+            Some(ret)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the total number of bytes needed to accommodate for all the test
+    /// vectors of the function.
+    #[inline(always)]
+    fn total(self) -> usize {
+        self.idx
+    }
+}
+
+// LLVM uses `i32` to index the bitmap. Thus `i32::MAX` is the hard limit for
+// number of all test vectors in a function.
+const MCDC_MAX_BITMAP_SIZE: usize = i32::MAX as _;
+
+pub(crate) fn extract_mcdc_mappings(
+    mir_body: &mir::Body<'_>,
+    hir_info: &ExtractedHirInfo,
+    graph: &CoverageGraph,
+    expn_tree: &ExpnTree,
+) -> Option<(Vec<MCDCMetaMapping>, FunctionMCDCExtraInfo)> {
+    let Some(coverage_info_hi) = mir_body.coverage_info_hi.as_deref() else { return None };
+    let block_markers = resolve_block_markers(coverage_info_hi, mir_body);
+
+    // For now, ignore any MCDC decision span that was introduced by
+    // expansion. This makes things like assert macros less noisy.
+    // FIXME(peron): Investigate better expansion support.
+    let Some(node) = expn_tree.get(hir_info.body_span.ctxt()) else { return None };
+    if node.expn_kind != ExpnKind::Root {
+        return None;
+    }
+
+    // No decision to instrument, either because the function has no decision,
+    // or we didn't ask for MC/DC instrumentation.
+    if node.mcdc_spans.is_empty() {
+        return None;
+    }
+
+    let bcb_from_marker = |marker: BlockMarkerId| graph.bcb_from_bb(block_markers[marker]?);
+
+    let mut mcdc_mappings = vec![];
+    let mut bitmap_idx_gen = BitmapIndexGen::default();
+    let mut max_depth = 0;
+
+    for (decision, conditions) in node.mcdc_spans.iter() {
+        let end_bcbs = decision
+            .end_markers
+            .iter()
+            .map(|&marker| bcb_from_marker(marker))
+            .collect::<Option<BTreeSet<_>>>()?; // FIXME(renjisann): deal with bcb_from_marker errors.
+
+        let mut condition_meta_mappings = vec![];
+
+        for ConditionSpan { span, condition_info, true_marker, false_marker } in conditions {
+            let true_bcb = bcb_from_marker(*true_marker)?;
+            let false_bcb = bcb_from_marker(*false_marker)?;
+
+            condition_meta_mappings.push(MCDCMetaConditionMapping::new(
+                *span,
+                *condition_info,
+                true_bcb,
+                false_bcb,
+            ));
+        }
+
+        let num_test_vectors = calc_test_vectors_index(&mut condition_meta_mappings);
+        let Some(bitmap_idx) = bitmap_idx_gen.next(num_test_vectors) else {
+            tracing::debug!("Exceeded test vector limit");
+            return None;
+        };
+
+        let decision_meta_mapping = MCDCMetaDecisionMapping {
+            span: decision.span,
+            end_bcbs,
+            bitmap_idx: bitmap_idx as _,
+            num_conditions: decision.num_conditions as _,
+            num_test_vectors,
+            decision_depth: decision.decision_depth,
+        };
+
+        max_depth = max_depth.max(decision.decision_depth);
+
+        mcdc_mappings.push((decision_meta_mapping, condition_meta_mappings));
+    }
+
+    Some((
+        mcdc_mappings,
+        FunctionMCDCExtraInfo {
+            bitmap_bits: bitmap_idx_gen.total(),
+            num_temporaries: (max_depth as usize).saturating_add(1),
+        },
+    ))
+}
+
+pub(crate) fn inject_statements_for_decisions(
+    mir_body: &mut mir::Body<'_>,
+    graph: &CoverageGraph,
+    mappings: &Vec<(MCDCMetaDecisionMapping, Vec<MCDCMetaConditionMapping>)>,
+) {
+    for (decision, conditions) in mappings {
+        let &MCDCMetaDecisionMapping { ref end_bcbs, bitmap_idx, decision_depth, .. } = decision;
+
+        // Insert llvm.instrprof.mcdc.tvbitmap.update values.
+        for bcb in end_bcbs {
+            let leader_bb = graph[*bcb].leader_bb();
+            inject_statement(
+                mir_body,
+                CoverageKind::MCDCTestVectorBitmapUpdate { bitmap_idx, decision_depth },
+                leader_bb,
+            );
+        }
+
+        // Insert temporary variable updates for each visited condition.
+        let tmp_indexes_increments = conditions.iter().flat_map(
+            |MCDCMetaConditionMapping { true_bcb, false_bcb, true_incr, false_incr, .. }| {
+                [(true_bcb, true_incr), (false_bcb, false_incr)]
+            },
+        );
+
+        for (&bcb, &incr) in tmp_indexes_increments {
+            let leader_bb = graph[bcb].leader_bb();
+            inject_statement(
+                mir_body,
+                CoverageKind::MCDCTmpIdxUpdate { incr: incr as u32, decision_depth },
+                leader_bb,
+            );
+        }
+    }
+}
+
+// LLVM checks the executed test vector by accumulating indices of tested branches.
+// We calculate number of all possible test vectors of the decision and assign indices
+// to branches here.
+// See [the rfc](https://discourse.llvm.org/t/rfc-coverage-new-algorithm-and-file-format-for-mc-dc/76798/)
+// for more details about the algorithm.
+// This function is mostly like [`TVIdxBuilder::TvIdxBuilder`](https://github.com/llvm/llvm-project/blob/d594d9f7f4dc6eb748b3261917db689fdc348b96/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp#L226)
+fn calc_test_vectors_index(conditions: &mut Vec<MCDCMetaConditionMapping>) -> usize {
+    let mut indegree_stats = IndexVec::<ConditionId, usize>::from_elem_n(0, conditions.len());
+
+    // `num_paths` is `width` described at the llvm rfc, which indicates how many paths reaching the condition node.
+    let mut num_paths_stats = IndexVec::<ConditionId, usize>::from_elem_n(0, conditions.len());
+    num_paths_stats[ConditionId::START] = 1;
+
+    let mut next_conditions = conditions
+        .iter_mut()
+        .map(|branch| {
+            let ConditionInfo { condition_id, true_next_id, false_next_id } = branch.condition_info;
+            [true_next_id, false_next_id]
+                .into_iter()
+                .flatten()
+                .for_each(|next_id| indegree_stats[next_id] += 1);
+            (condition_id, branch)
+        })
+        .collect::<FxIndexMap<_, _>>();
+    let mut queue =
+        std::collections::VecDeque::from_iter(next_conditions.swap_remove(&ConditionId::START));
+
+    let mut decision_end_nodes = Vec::new();
+
+    while let Some(branch) = queue.pop_front() {
+        let ConditionInfo { condition_id, true_next_id, false_next_id }: ConditionInfo =
+            branch.condition_info;
+
+        let (false_incr, true_incr) = (&mut branch.false_incr, &mut branch.true_incr);
+
+        // `width` of this branch
+        let this_paths_count = num_paths_stats[condition_id];
+
+        // Note. First check the false next to ensure conditions are touched in same order with llvm-cov.
+        for (next, incr) in [(false_next_id, false_incr), (true_next_id, true_incr)] {
+            if let Some(next_id) = next {
+                let next_paths_count = &mut num_paths_stats[next_id];
+                *incr = *next_paths_count;
+                *next_paths_count = next_paths_count.saturating_add(this_paths_count);
+                let next_indegree = &mut indegree_stats[next_id];
+                *next_indegree -= 1;
+                if *next_indegree == 0 {
+                    queue.push_back(next_conditions.swap_remove(&next_id).expect(
+                        "conditions with non-zero indegree before must be in next_conditions",
+                    ));
+                }
+            } else {
+                decision_end_nodes.push((this_paths_count, condition_id, incr));
+            }
+        }
+    }
+    assert!(next_conditions.is_empty(), "the decision tree has untouched nodes");
+    let mut cur_idx = 0;
+    // LLVM hopes the end nodes are sorted in descending order by `num_paths` so that it can
+    // optimize bitmap size for decisions in tree form such as `a && b && c && d && ...`.
+    decision_end_nodes.sort_by_key(|(num_paths, _, _)| usize::MAX - *num_paths);
+    for (num_paths, condition_id, index) in decision_end_nodes {
+        assert_eq!(
+            num_paths, num_paths_stats[condition_id],
+            "end nodes should not be updated since they were visited"
+        );
+        assert_eq!(*index, usize::MAX, "end nodes should not be assigned index before");
+        *index = cur_idx;
+        cur_idx += num_paths;
+    }
+    cur_idx
+}

--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -1,4 +1,4 @@
-use rustc_middle::mir::coverage::{CoverageKind, FunctionCoverageInfo};
+use rustc_middle::mir::coverage::{CoverageKind, FunctionCoverageInfo, Mapping};
 use rustc_middle::mir::{self, BasicBlock, Statement, StatementKind, TerminatorKind};
 use rustc_middle::ty::TyCtxt;
 use tracing::{debug, debug_span, trace};
@@ -13,6 +13,7 @@ mod from_mir;
 mod graph;
 mod hir_info;
 mod mappings;
+mod mcdc;
 pub(super) mod query;
 mod spans;
 #[cfg(test)]
@@ -72,7 +73,7 @@ fn instrument_function_for_coverage<'tcx>(tcx: TyCtxt<'tcx>, mir_body: &mut mir:
 
     ////////////////////////////////////////////////////
     // Extract coverage spans and other mapping info from MIR.
-    let ExtractedMappings { mappings } =
+    let ExtractedMappings { mut mappings, mcdc_data } =
         match mappings::extract_mappings_from_mir(tcx, mir_body, &hir_info, &graph) {
             Ok(m) => m,
             Err(error) => {
@@ -90,6 +91,18 @@ fn instrument_function_for_coverage<'tcx>(tcx: TyCtxt<'tcx>, mir_body: &mut mir:
     // Inject coverage statements into MIR.
     inject_coverage_statements(mir_body, &graph);
 
+    let mcdc_info = mcdc_data.map(|(mcdc_mappings, mcdc_info)| {
+        // Insert statements according to mappings meta data.
+        mcdc::inject_statements_for_decisions(mir_body, &graph, &mcdc_mappings);
+
+        // Make regular mappings from meta mappings and push them in the mapping list.
+        mappings.extend(mcdc_mappings.into_iter().flat_map(|(decision, conditions)| {
+            [decision.into()].into_iter().chain(conditions.into_iter().map(Mapping::from))
+        }));
+
+        mcdc_info
+    });
+
     mir_body.function_coverage_info = Some(Box::new(FunctionCoverageInfo {
         function_source_hash: hir_info.function_source_hash,
 
@@ -97,6 +110,7 @@ fn instrument_function_for_coverage<'tcx>(tcx: TyCtxt<'tcx>, mir_body: &mut mir:
         priority_list,
 
         mappings,
+        mcdc_info,
     }));
 }
 
@@ -108,7 +122,11 @@ fn inject_coverage_statements<'tcx>(mir_body: &mut mir::Body<'tcx>, graph: &Cove
     }
 }
 
-fn inject_statement(mir_body: &mut mir::Body<'_>, counter_kind: CoverageKind, bb: BasicBlock) {
+pub(crate) fn inject_statement(
+    mir_body: &mut mir::Body<'_>,
+    counter_kind: CoverageKind,
+    bb: BasicBlock,
+) {
     debug!("  injecting statement {counter_kind:?} for {bb:?}");
     let data = &mut mir_body[bb];
     let source_info = data.terminator().source_info;

--- a/compiler/rustc_mir_transform/src/coverage/query.rs
+++ b/compiler/rustc_mir_transform/src/coverage/query.rs
@@ -109,6 +109,13 @@ fn coverage_ids_info<'tcx>(
                 bcb_needs_counter.insert(true_bcb);
                 bcb_needs_counter.insert(false_bcb);
             }
+            MappingKind::MCDCCondition { true_bcb, false_bcb, .. } => {
+                // Not actually necessary for MC/DC, but needed to have branch
+                // coverage when instrumenting for MC/DC.
+                bcb_needs_counter.insert(true_bcb);
+                bcb_needs_counter.insert(false_bcb);
+            }
+            MappingKind::MCDCDecision { .. } => {}
         }
     }
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -190,6 +190,8 @@ pub enum CoverageLevel {
     /// instrumentation, so it might be removed in the future when MC/DC is
     /// sufficiently complete, or if it is making MC/DC changes difficult.
     Condition,
+    /// Instrument decisions for MC/DC coverage.
+    Mcdc,
 }
 
 // The different settings that the `-Z offload` flag can have.

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -849,7 +849,7 @@ mod desc {
     pub(crate) const parse_linker_flavor: &str = ::rustc_target::spec::LinkerFlavorCli::one_of();
     pub(crate) const parse_dump_mono_stats: &str = "`markdown` (default) or `json`";
     pub(crate) const parse_instrument_coverage: &str = parse_bool;
-    pub(crate) const parse_coverage_options: &str = "`block` | `branch` | `condition`";
+    pub(crate) const parse_coverage_options: &str = "`block` | `branch` | `condition` | `mcdc`";
     pub(crate) const parse_codegen_retag_options: &str =
         "either no value or a comma-separated list of settings: `no-precise-im`, `no-precise-pin`";
     pub(crate) const parse_instrument_mcount: &str =
@@ -1661,6 +1661,7 @@ pub mod parse {
                 "block" => slot.level = CoverageLevel::Block,
                 "branch" => slot.level = CoverageLevel::Branch,
                 "condition" => slot.level = CoverageLevel::Condition,
+                "mcdc" => slot.level = CoverageLevel::Mcdc,
                 "discard-all-spans-in-codegen" => slot.discard_all_spans_in_codegen = true,
                 _ => return false,
             }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -582,6 +582,11 @@ impl Session {
             && self.opts.unstable_opts.coverage_options.level >= CoverageLevel::Condition
     }
 
+    pub fn instrument_coverage_mcdc(&self) -> bool {
+        self.instrument_coverage()
+            && self.opts.unstable_opts.coverage_options.level >= CoverageLevel::Mcdc
+    }
+
     /// Provides direct access to the `CoverageOptions` struct, so that
     /// individual flags for debugging/testing coverage instrumetation don't
     /// need separate accessors.

--- a/src/doc/unstable-book/src/compiler-flags/coverage-options.md
+++ b/src/doc/unstable-book/src/compiler-flags/coverage-options.md
@@ -5,7 +5,7 @@ This option controls details of the coverage instrumentation performed by
 
 Multiple options can be passed, separated by commas. Valid options are:
 
-- `block`, `branch`, `condition`:
+- `block`, `branch`, `condition`, `mcdc`:
   Sets the level of coverage instrumentation.
   Setting the level will override any previously-specified level.
   - `block` (default):
@@ -15,3 +15,6 @@ Multiple options can be passed, separated by commas. Valid options are:
   - `condition`:
     In addition to branch coverage, also instruments some boolean expressions
     as branches, even if they are not directly used as branch conditions.
+  - `mcdc`:
+    In addition to condition coverage, also enables MC/DC instrumentation.
+    (Branch coverage instrumentation may differ in some cases.)

--- a/tests/ui/instrument-coverage/coverage-options.bad.stderr
+++ b/tests/ui/instrument-coverage/coverage-options.bad.stderr
@@ -1,2 +1,2 @@
-error: incorrect value `bad` for unstable option `coverage-options` - `block` | `branch` | `condition` was expected
+error: incorrect value `bad` for unstable option `coverage-options` - `block` | `branch` | `condition` | `mcdc` was expected
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
Follow-up of rust-lang/rust#161222
<!-- homu-ignore:end -->

Tracking issue: https://github.com/rust-lang/goals/issues/638

1. Create MC/DC coverage mappings to provide them to LLVM
2. Determine the number of possible test vectors within each decision, and deduce the required size of the MC/DC bitmap.
3. Instrument MIR to track the status of ongoing decision evaluation in temporary variables, and save test vectors to the bitmap

> A documentation comment lives in `compiler/rustc_mir_transform/src/coverage/mcdc.rs` to give implementation details.

<!-- homu-ignore:start -->
r? @davidtwco
<!-- homu-ignore:end -->