### PR TITLE
MC/DC Coverage re-introduction (3/3): Codegen

### DIFF
--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -2078,4 +2078,58 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
     ) {
         self.call_intrinsic("llvm.instrprof.increment", &[], &[fn_name, hash, num_counters, index]);
     }
+
+    /// Emits a call to `llvm.instrprof.mcdc.parameters`.
+    ///
+    /// This doesn't produce any code directly, but is used as input by
+    /// the LLVM pass that handles coverage instrumentation.
+    ///
+    /// (See clang's [`CodeGenPGO::emitMCDCParameters`] for comparison.)
+    ///
+    /// [`CodeGenPGO::emitMCDCParameters`]:
+    ///     https://github.com/rust-lang/llvm-project/blob/5399a24/clang/lib/CodeGen/CodeGenPGO.cpp#L1124
+    #[instrument(level = "debug", skip(self))]
+    pub(crate) fn mcdc_parameters(
+        &mut self,
+        fn_name: &'ll Value,
+        hash: &'ll Value,
+        bitmap_bits: &'ll Value,
+    ) {
+        self.call_intrinsic("llvm.instrprof.mcdc.parameters", &[], &[fn_name, hash, bitmap_bits]);
+    }
+
+    /// Call an LLVM intrinsic that uses the value in `mcdc_temp` as an index
+    /// in the function's MC/DC bitmap.
+    ///
+    /// Think of it like `func_mcdc_bitmap[bitmap_idx + mcdc_temp as u32] += 1`
+    #[instrument(level = "debug", skip(self))]
+    pub(crate) fn mcdc_tvbitmap_update(
+        &mut self,
+        fn_name: &'ll Value,
+        hash: &'ll Value,
+        bitmap_idx: &'ll Value,
+        mcdc_temp: &'ll Value,
+    ) {
+        let args = &[fn_name, hash, bitmap_idx, mcdc_temp];
+        self.call_intrinsic("llvm.instrprof.mcdc.tvbitmap.update", &[], args);
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    pub(crate) fn mcdc_condition_temp_reset(&mut self, mcdc_temp: &'ll Value) {
+        self.store(self.const_i32(0), mcdc_temp, self.tcx.data_layout.i32_align);
+    }
+
+    /// Increment `mcdc_temp` by `cond_incr` to keep track of the execution
+    /// path in an MC/DC instrumented decision.
+    #[instrument(level = "debug", skip(self))]
+    pub(crate) fn mcdc_condition_temp_update(
+        &mut self,
+        cond_incr: &'ll Value,
+        mcdc_temp: &'ll Value,
+    ) {
+        let align = self.tcx.data_layout.i32_align;
+        let current_tv_index = self.load(self.cx.type_i32(), mcdc_temp, align);
+        let new_tv_index = self.add(current_tv_index, cond_incr);
+        self.store(new_tv_index, mcdc_temp, align);
+    }
 }

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/ffi.rs
@@ -98,3 +98,59 @@ pub(crate) struct BranchRegion {
     pub(crate) true_counter: Counter,
     pub(crate) false_counter: Counter,
 }
+
+pub(crate) mod mcdc {
+    use rustc_middle::mir::coverage::mcdc;
+
+    use crate::coverageinfo::ffi::{Counter, CoverageSpan};
+
+    /// Must match the layout of `LLVMRustCoverageMCDCDecisionRegion`.
+    #[repr(C)]
+    #[derive(Debug, Clone)]
+    pub(crate) struct DecisionRegion {
+        pub(crate) cov_span: CoverageSpan,
+        pub(crate) params: DecisionParameters,
+    }
+
+    /// Must match the layout of `LLVMRustCoverageMCDCConditionRegion`.
+    #[repr(C)]
+    #[derive(Debug, Clone)]
+    pub(crate) struct ConditionRegion {
+        pub(crate) cov_span: CoverageSpan,
+        pub(crate) true_counter: Counter,
+        pub(crate) false_counter: Counter,
+        pub(crate) params: ConditionParameters,
+    }
+
+    /// Must match the layout of `LLVMRustCoverageMCDCDecisionParameters`.
+    #[repr(C)]
+    #[derive(Debug, Default, Clone, Copy)]
+    pub(crate) struct DecisionParameters {
+        pub(crate) bitmap_idx: u32,
+        pub(crate) num_conditions: u16,
+    }
+
+    type LLVMConditionID = i16;
+
+    /// Must match the layout of `LLVMRustCoverageMCDCConditionParameters`.
+    #[repr(C)]
+    #[derive(Debug, Default, Clone, Copy)]
+    pub(crate) struct ConditionParameters {
+        condition_id: LLVMConditionID,
+        condition_ids: [LLVMConditionID; 2],
+    }
+
+    impl From<mcdc::ConditionInfo> for ConditionParameters {
+        fn from(value: mcdc::ConditionInfo) -> Self {
+            let to_llvm_id = |id: Option<mcdc::ConditionId>| {
+                id.map(mcdc::ConditionId::as_usize)
+                    .and_then(|id| LLVMConditionID::try_from(id).ok())
+                    .unwrap_or(-1)
+            };
+            Self {
+                condition_id: to_llvm_id(Some(value.condition_id)),
+                condition_ids: [to_llvm_id(value.false_next_id), to_llvm_id(value.true_next_id)],
+            }
+        }
+    }
+}

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/llvm_cov.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/llvm_cov.rs
@@ -69,14 +69,26 @@ pub(crate) struct Regions {
     pub(crate) code_regions: Vec<ffi::CodeRegion>,
     pub(crate) expansion_regions: Vec<ffi::ExpansionRegion>,
     pub(crate) branch_regions: Vec<ffi::BranchRegion>,
+    pub(crate) mcdc_condition_regions: Vec<ffi::mcdc::ConditionRegion>,
+    pub(crate) mcdc_decision_regions: Vec<ffi::mcdc::DecisionRegion>,
 }
 
 impl Regions {
     /// Returns true if none of this structure's tables contain any regions.
     pub(crate) fn has_no_regions(&self) -> bool {
-        let Self { code_regions, expansion_regions, branch_regions } = self;
+        let Self {
+            code_regions,
+            expansion_regions,
+            branch_regions,
+            mcdc_condition_regions,
+            mcdc_decision_regions,
+        } = self;
 
-        code_regions.is_empty() && expansion_regions.is_empty() && branch_regions.is_empty()
+        code_regions.is_empty()
+            && expansion_regions.is_empty()
+            && branch_regions.is_empty()
+            && mcdc_condition_regions.is_empty()
+            && mcdc_decision_regions.is_empty()
     }
 }
 
@@ -85,7 +97,13 @@ pub(crate) fn write_function_mappings_to_buffer(
     expressions: &[ffi::CounterExpression],
     regions: &Regions,
 ) -> Vec<u8> {
-    let Regions { code_regions, expansion_regions, branch_regions } = regions;
+    let Regions {
+        code_regions,
+        expansion_regions,
+        branch_regions,
+        mcdc_condition_regions,
+        mcdc_decision_regions,
+    } = regions;
 
     // SAFETY:
     // - All types are FFI-compatible and have matching representations in Rust/C++.
@@ -103,6 +121,10 @@ pub(crate) fn write_function_mappings_to_buffer(
             expansion_regions.len(),
             branch_regions.as_ptr(),
             branch_regions.len(),
+            mcdc_condition_regions.as_ptr(),
+            mcdc_condition_regions.len(),
+            mcdc_decision_regions.as_ptr(),
+            mcdc_decision_regions.len(),
             buffer,
         )
     })

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
@@ -151,8 +151,8 @@ fn fill_region_tables<'tcx>(
         code_regions,
         expansion_regions: _, // FIXME(Zalathar): Fill out support for expansion regions
         branch_regions,
-        mcdc_condition_regions: _, // FIXME(RenjiSann): Fill MCDC region
-        mcdc_decision_regions: _,
+        mcdc_condition_regions,
+        mcdc_decision_regions,
     } = &mut covfun.regions;
 
     // For each counter/region pair in this function+file, convert it to a
@@ -172,8 +172,20 @@ fn fill_region_tables<'tcx>(
                     false_counter: counter_for_bcb(false_bcb),
                 });
             }
-            MappingKind::MCDCCondition { .. } => unimplemented!(),
-            MappingKind::MCDCDecision { .. } => unimplemented!(),
+            MappingKind::MCDCCondition { true_bcb, false_bcb, mcdc_mappings } => {
+                mcdc_condition_regions.push(ffi::mcdc::ConditionRegion {
+                    cov_span,
+                    true_counter: counter_for_bcb(true_bcb),
+                    false_counter: counter_for_bcb(false_bcb),
+                    params: mcdc_mappings.into(),
+                });
+            }
+            MappingKind::MCDCDecision { bitmap_idx, num_conditions } => {
+                mcdc_decision_regions.push(ffi::mcdc::DecisionRegion {
+                    cov_span,
+                    params: ffi::mcdc::DecisionParameters { bitmap_idx, num_conditions },
+                });
+            }
         }
     }
 }

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
@@ -170,6 +170,8 @@ fn fill_region_tables<'tcx>(
                     false_counter: counter_for_bcb(false_bcb),
                 });
             }
+            MappingKind::MCDCCondition { .. } => unimplemented!(),
+            MappingKind::MCDCDecision { .. } => unimplemented!(),
         }
     }
 }

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
@@ -151,6 +151,8 @@ fn fill_region_tables<'tcx>(
         code_regions,
         expansion_regions: _, // FIXME(Zalathar): Fill out support for expansion regions
         branch_regions,
+        mcdc_condition_regions: _, // FIXME(RenjiSann): Fill MCDC region
+        mcdc_decision_regions: _,
     } = &mut covfun.regions;
 
     // For each counter/region pair in this function+file, convert it to a

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
@@ -131,6 +131,8 @@ impl<'tcx> CoverageInfoBuilderMethods<'tcx> for Builder<'_, '_, 'tcx> {
             }
             // If a BCB doesn't have an associated physical counter, there's nothing to codegen.
             CoverageKind::VirtualCounter { .. } => {}
+            CoverageKind::MCDCTmpIdxUpdate { .. } => unimplemented!(),
+            CoverageKind::MCDCTestVectorBitmapUpdate { .. } => unimplemented!(),
         }
     }
 }

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
@@ -1,10 +1,12 @@
 use std::cell::{OnceCell, RefCell};
 use std::ffi::{CStr, CString};
 
+use rustc_abi::Size;
 use rustc_codegen_ssa::traits::{
-    ConstCodegenMethods, CoverageInfoBuilderMethods, MiscCodegenMethods,
+    BuilderMethods, ConstCodegenMethods, CoverageInfoBuilderMethods, MiscCodegenMethods,
 };
 use rustc_data_structures::fx::FxIndexMap;
+use rustc_middle::bug;
 use rustc_middle::mir::coverage::CoverageKind;
 use rustc_middle::ty::Instance;
 use tracing::{debug, instrument};
@@ -28,12 +30,34 @@ pub(crate) struct CguCoverageContext<'ll, 'tcx> {
     /// hash back to an entry in the binary's `__llvm_prf_names` linker section.
     pub(crate) pgo_func_name_var_map: RefCell<FxIndexMap<Instance<'tcx>, &'ll llvm::Value>>,
 
+    /// Holds temporary variables needed for MCDC test vector computations.
+    /// Allocates as many temps as the maximum decision depth of the function,
+    /// This is done to save the status of the test vector of a "parent"
+    /// decision while evaluating the nested one in another temp.
+    pub(crate) mcdc_temporaries_map: RefCell<FxIndexMap<Instance<'tcx>, Vec<&'ll llvm::Value>>>,
+
     covfun_section_name: OnceCell<CString>,
 }
 
 impl<'ll, 'tcx> CguCoverageContext<'ll, 'tcx> {
     pub(crate) fn new() -> Self {
-        Self { pgo_func_name_var_map: Default::default(), covfun_section_name: Default::default() }
+        Self {
+            pgo_func_name_var_map: Default::default(),
+            mcdc_temporaries_map: Default::default(),
+            covfun_section_name: Default::default(),
+        }
+    }
+
+    fn try_get_mcdc_condition_temporary(
+        &self,
+        instance: &Instance<'tcx>,
+        decision_depth: u16,
+    ) -> Option<&'ll llvm::Value> {
+        self.mcdc_temporaries_map
+            .borrow()
+            .get(instance)
+            .and_then(|map| map.get(decision_depth as usize))
+            .copied()
     }
 
     /// Returns the list of instances considered "used" in this CGU, as
@@ -84,6 +108,43 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
 
 impl<'tcx> CoverageInfoBuilderMethods<'tcx> for Builder<'_, '_, 'tcx> {
     #[instrument(level = "debug", skip(self))]
+    fn init_coverage(&mut self, instance: Instance<'tcx>) {
+        let Some(function_coverage_info) =
+            self.tcx.instance_mir(instance.def).function_coverage_info.as_deref()
+        else {
+            // Early return if there is no coverage info.
+            return;
+        };
+
+        let Some(mcdc_info) = function_coverage_info.mcdc_info.as_ref() else {
+            return;
+        };
+
+        let fn_name = self.ensure_pgo_func_name_var(instance);
+        let hash = self.const_u64(function_coverage_info.function_source_hash);
+        let bitmap_bits = self.const_u32(mcdc_info.bitmap_bits as u32);
+
+        self.mcdc_parameters(fn_name, hash, bitmap_bits);
+
+        let num_temporaries = mcdc_info.num_temporaries;
+
+        let mut temporaries = vec![];
+
+        for i in 0..num_temporaries {
+            // MC/DC intrinsics will perform loads/stores that use the ABI default
+            // alignment for i32, so our variable declaration should match.
+            let align = self.tcx.data_layout.i32_align;
+            let temp = self.alloca(Size::from_bytes(4), align);
+            llvm::set_value_name(temp, format!("mcdc.temp.{i}").as_bytes());
+            self.store(self.const_i32(0), temp, align);
+            temporaries.push(temp);
+        }
+
+        // After building the list of temps, save it to the coverage context
+        self.coverage_cx().mcdc_temporaries_map.borrow_mut().insert(instance, temporaries);
+    }
+
+    #[instrument(level = "debug", skip(self))]
     fn add_coverage(&mut self, instance: Instance<'tcx>, kind: &CoverageKind) {
         // Our caller should have already taken care of inlining subtleties,
         // so we can assume that counter/expression IDs in this coverage
@@ -99,7 +160,7 @@ impl<'tcx> CoverageInfoBuilderMethods<'tcx> for Builder<'_, '_, 'tcx> {
         // When that happens, we currently just discard those statements, so
         // the corresponding code will be undercounted.
         // FIXME(Zalathar): Find a better solution for mixed-coverage builds.
-        let Some(_coverage_cx) = &bx.cx.coverage_cx else { return };
+        let Some(coverage_cx) = &bx.cx.coverage_cx else { return };
 
         let Some(function_coverage_info) =
             bx.tcx.instance_mir(instance.def).function_coverage_info.as_deref()
@@ -131,8 +192,39 @@ impl<'tcx> CoverageInfoBuilderMethods<'tcx> for Builder<'_, '_, 'tcx> {
             }
             // If a BCB doesn't have an associated physical counter, there's nothing to codegen.
             CoverageKind::VirtualCounter { .. } => {}
-            CoverageKind::MCDCTmpIdxUpdate { .. } => unimplemented!(),
-            CoverageKind::MCDCTestVectorBitmapUpdate { .. } => unimplemented!(),
+
+            // Handle MC/DC
+            CoverageKind::MCDCTmpIdxUpdate { incr, decision_depth } => {
+                let Some(temp_var) =
+                    coverage_cx.try_get_mcdc_condition_temporary(&instance, decision_depth)
+                else {
+                    bug!("temporary bitmap should have been allocated for depth {decision_depth:?}")
+                };
+                let incr = bx.const_i32(incr as i32);
+                bx.mcdc_condition_temp_update(incr, temp_var);
+            }
+            CoverageKind::MCDCTestVectorBitmapUpdate { bitmap_idx, decision_depth } => {
+                let Some(temp_var) =
+                    coverage_cx.try_get_mcdc_condition_temporary(&instance, decision_depth)
+                else {
+                    bug!("temporary bitmap should have been allocated for depth {decision_depth:?}")
+                };
+
+                assert!(
+                    function_coverage_info
+                        .mcdc_info
+                        .as_ref()
+                        .is_some_and(|mcdc_info| bitmap_idx as usize <= mcdc_info.bitmap_bits),
+                    "bitmap_idx ({bitmap_idx:?} out of range"
+                );
+
+                let fn_name = bx.ensure_pgo_func_name_var(instance);
+                let hash = bx.const_u64(function_coverage_info.function_source_hash);
+                let bitmap_idx = bx.const_u32(bitmap_idx as u32);
+
+                bx.mcdc_tvbitmap_update(fn_name, hash, bitmap_idx, temp_var);
+                bx.mcdc_condition_temp_reset(temp_var);
+            }
         }
     }
 }

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2198,6 +2198,10 @@ unsafe extern "C" {
         NumExpansionRegions: size_t,
         BranchRegions: *const crate::coverageinfo::ffi::BranchRegion,
         NumBranchRegions: size_t,
+        MCDCConditionRegions: *const crate::coverageinfo::ffi::mcdc::ConditionRegion,
+        NumMCDCConditionRegions: size_t,
+        MCDCDecisionRegions: *const crate::coverageinfo::ffi::mcdc::DecisionRegion,
+        NumMCDCDecisionRegions: size_t,
         BufferOut: &RustString,
     );
 

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -369,6 +369,10 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     // Apply debuginfo to the newly allocated locals.
     fx.debug_introduce_locals(&mut start_bx, consts_debug_info.unwrap_or_default());
 
+    // If the backend supports coverage, and coverage is enabled for this function,
+    // do any necessary start-of-function codegen (e.g. locals for MC/DC bitmaps).
+    start_bx.init_coverage(instance);
+
     // The builders will be created separately for each basic block at `codegen_block`.
     // So drop the builder of `start_llbb` to avoid having two at the same time.
     drop(start_bx);

--- a/compiler/rustc_codegen_ssa/src/traits/coverageinfo.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/coverageinfo.rs
@@ -2,6 +2,15 @@ use rustc_middle::mir::coverage::CoverageKind;
 use rustc_middle::ty::Instance;
 
 pub trait CoverageInfoBuilderMethods<'tcx> {
+    /// Take care of any preparatory codegen work needed for coverage
+    /// instrumentation.
+    ///
+    /// This can potentially be a no-op in backends that don't support coverage
+    /// instrumentation.
+    fn init_coverage(&mut self, _instance: Instance<'tcx>) {
+        // no-op by default
+    }
+
     /// Handle the MIR coverage info in a backend-specific way.
     ///
     /// This can potentially be a no-op in backends that don't support

--- a/compiler/rustc_llvm/llvm-wrapper/CoverageMappingWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/CoverageMappingWrapper.cpp
@@ -38,6 +38,32 @@ static coverage::Counter fromRust(LLVMRustCounter Counter) {
 }
 
 // Must match the layout of
+// `rustc_codegen_llvm::coverageinfo::ffi::mcdc::DecisionParameters`.
+struct LLVMRustMCDCDecisionParameters {
+  uint32_t BitmapIdx;
+  uint16_t NumConditions;
+};
+
+// Must match the layout of
+// `rustc_codegen_llvm::coverageinfo::ffi::mcdc::ConditionRegion`.
+struct LLVMRustMCDCConditionParameters {
+  int16_t ConditionID;
+  int16_t ConditionIDs[2];
+};
+
+static coverage::mcdc::BranchParameters
+fromRust(LLVMRustMCDCConditionParameters Params) {
+  return coverage::mcdc::BranchParameters(
+      Params.ConditionID, {Params.ConditionIDs[0], Params.ConditionIDs[1]});
+}
+
+static coverage::mcdc::DecisionParameters
+fromRust(LLVMRustMCDCDecisionParameters Params) {
+  return coverage::mcdc::DecisionParameters(Params.BitmapIdx,
+                                            Params.NumConditions);
+}
+
+// Must match the layout of
 // `rustc_codegen_llvm::coverageinfo::ffi::CoverageSpan`.
 struct LLVMRustCoverageSpan {
   uint32_t FileID;
@@ -66,6 +92,22 @@ struct LLVMRustCoverageBranchRegion {
   LLVMRustCoverageSpan Span;
   LLVMRustCounter TrueCount;
   LLVMRustCounter FalseCount;
+};
+
+// Must match the layout of
+// `rustc_codegen_llvm::coverageinfo::ffi::mcdc::DecisionRegion`.
+struct LLVMRustCoverageMCDCDecisionRegion {
+  LLVMRustCoverageSpan Span;
+  LLVMRustMCDCDecisionParameters MCDCDecisionParams;
+};
+
+// Must match the layout of
+// `rustc_codegen_llvm::coverageinfo::ffi::mcdc::ConditionRegion`.
+struct LLVMRustCoverageMCDCConditionRegion {
+  LLVMRustCoverageSpan Span;
+  LLVMRustCounter TrueCount;
+  LLVMRustCounter FalseCount;
+  LLVMRustMCDCConditionParameters MCDCConditionParams;
 };
 
 // FFI equivalent of enum `llvm::coverage::CounterExpression::ExprKind`
@@ -121,7 +163,10 @@ extern "C" void LLVMRustCoverageWriteFunctionMappingsToBuffer(
     const LLVMRustCoverageExpansionRegion *ExpansionRegions,
     size_t NumExpansionRegions,
     const LLVMRustCoverageBranchRegion *BranchRegions, size_t NumBranchRegions,
-    RustStringRef BufferOut) {
+    const LLVMRustCoverageMCDCConditionRegion *MCDCConditionRegions,
+    size_t NumMCDCConditionRegions,
+    const LLVMRustCoverageMCDCDecisionRegion *MCDCDecisionRegions,
+    size_t NumMCDCDecisionRegions, RustStringRef BufferOut) {
   // Convert from FFI representation to LLVM representation.
 
   // Expressions:
@@ -136,7 +181,8 @@ extern "C" void LLVMRustCoverageWriteFunctionMappingsToBuffer(
 
   std::vector<coverage::CounterMappingRegion> MappingRegions;
   MappingRegions.reserve(NumCodeRegions + NumExpansionRegions +
-                         NumBranchRegions);
+                         NumBranchRegions + NumMCDCConditionRegions +
+                         NumMCDCDecisionRegions);
 
   // Code regions:
   for (const auto &Region : ArrayRef(CodeRegions, NumCodeRegions)) {
@@ -158,6 +204,25 @@ extern "C" void LLVMRustCoverageWriteFunctionMappingsToBuffer(
         fromRust(Region.TrueCount), fromRust(Region.FalseCount),
         Region.Span.FileID, Region.Span.LineStart, Region.Span.ColumnStart,
         Region.Span.LineEnd, Region.Span.ColumnEnd));
+  }
+
+  // MC/DC condition regions
+  for (const auto &Region :
+       ArrayRef(MCDCConditionRegions, NumMCDCConditionRegions)) {
+    MappingRegions.push_back(coverage::CounterMappingRegion::makeBranchRegion(
+        fromRust(Region.TrueCount), fromRust(Region.FalseCount),
+        Region.Span.FileID, Region.Span.LineStart, Region.Span.ColumnStart,
+        Region.Span.LineEnd, Region.Span.ColumnEnd,
+        fromRust(Region.MCDCConditionParams)));
+  }
+
+  // MC/DC decision regions
+  for (const auto &Region :
+       ArrayRef(MCDCDecisionRegions, NumMCDCDecisionRegions)) {
+    MappingRegions.push_back(coverage::CounterMappingRegion::makeDecisionRegion(
+        fromRust(Region.MCDCDecisionParams), Region.Span.FileID,
+        Region.Span.LineStart, Region.Span.ColumnStart, Region.Span.LineEnd,
+        Region.Span.ColumnEnd));
   }
 
   // Write the converted expressions and mappings to a byte buffer.

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -174,6 +174,7 @@ pub struct CoverageInfoHi {
     /// data structures without having to scan the entire body first.
     pub num_block_markers: usize,
     pub branch_spans: Vec<BranchSpan>,
+    pub mcdc_spans: Vec<(mcdc::DecisionSpan, Vec<mcdc::ConditionSpan>)>,
 }
 
 #[derive(Clone, Debug)]
@@ -182,6 +183,83 @@ pub struct BranchSpan {
     pub span: Span,
     pub true_marker: BlockMarkerId,
     pub false_marker: BlockMarkerId,
+}
+
+pub mod mcdc {
+    use rustc_macros::{StableHash, TyDecodable, TyEncodable};
+    use rustc_span::Span;
+
+    use crate::mir::coverage::BlockMarkerId;
+
+    rustc_index::newtype_index! {
+        /// ID of an MC/DC condition. Used by LLVM to check MC/DC coverage.
+        ///
+        /// Note: the maximum number of condition within a decision supported by
+        /// llvm is 32767, thus the max ID is 0x7FFE.
+        #[stable_hash]
+        #[encodable]
+        #[orderable]
+        #[max = 0x7FFE]
+        #[debug_format = "ConditionId({})"]
+        pub struct ConditionId {}
+    }
+
+    impl ConditionId {
+        pub const START: Self = Self::from_usize(0);
+        pub const MAX_AS_USIZE: usize = Self::MAX.as_usize();
+    }
+
+    /// Node in a BDD (Binary Decision Diagram) for MC/DC analysis
+    #[derive(Copy, Clone, Debug)]
+    #[derive(TyEncodable, TyDecodable, Hash, StableHash)]
+    pub struct ConditionInfo {
+        pub condition_id: ConditionId,
+        pub true_next_id: Option<ConditionId>,
+        pub false_next_id: Option<ConditionId>,
+    }
+
+    /// This struct is generated during THIR lowering, it keeps track of a
+    /// condition (simple boolean expression) span. It associates it with a BDD
+    /// node, that helps knowing the shape of the decision graph, and two markers
+    /// inserted in the generated MIR to find the basic blocks corresponding to
+    /// the two possible outcommes of the condition.
+    #[derive(Clone, Debug)]
+    #[derive(TyEncodable, TyDecodable, Hash, StableHash)]
+    pub struct ConditionSpan {
+        pub span: Span,
+        pub condition_info: ConditionInfo,
+        pub true_marker: BlockMarkerId,
+        pub false_marker: BlockMarkerId,
+    }
+
+    /// This struct is generated during THIR lowering for each encountered
+    /// "complex" boolean expression (expressions with at least one logical
+    /// operator). it associates the span of the expression in the source
+    /// code with:
+    /// - the list of markers inserted in the generated MIR to keep
+    ///     track of the output basic blocks of the decision graph.
+    /// - the depth, corresponding to the level of nesting of this decision
+    ///     (e.g. in `true || foo (a && b)`, `true || foo (...)` has depth 0,
+    ///     `a && b` has depth 1).
+    /// - the number of conditions ("simple" boolean expressions) within this
+    ///     decision.
+    ///
+    /// Invariant: for each [`DecisionSpan`] generated, there should be
+    /// `num_conditions` [`ConditionSpan`]'s as well.
+    #[derive(Clone, Debug)]
+    #[derive(TyEncodable, TyDecodable, Hash, StableHash)]
+    pub struct DecisionSpan {
+        pub span: Span,
+
+        /// Marker statements designating outputs of the decision in MIR.
+        pub end_markers: Vec<BlockMarkerId>,
+
+        /// Nesting level of the decision.
+        pub decision_depth: u16,
+
+        /// Number of conditions in the decision.
+        pub num_conditions: usize,
+    }
 }
 
 /// Contains information needed during codegen, obtained by inspecting the

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -191,6 +191,23 @@ pub struct FunctionCoverageInfo {
     pub priority_list: Vec<BasicCoverageBlock>,
 
     pub mappings: Vec<Mapping>,
+    pub mcdc_info: Option<FunctionMCDCExtraInfo>,
+}
+
+/// Additional information carried by [`FunctionCoverageInfo`] when MC/DC is
+/// enabled.
+#[derive(Clone, Debug)]
+#[derive(TyEncodable, TyDecodable, Hash, StableHash)]
+pub struct FunctionMCDCExtraInfo {
+    /// Number of bits to allocate to the MC/DC bitmap for this function.
+    ///
+    /// This is the sum of the number of possible test vectors for each MC/DC
+    /// decision in the function.
+    pub bitmap_bits: usize,
+
+    /// Number of temporary test vector accumulators to allocate in the
+    /// function to accommodate the most deeply nested decisions.
+    pub num_temporaries: usize,
 }
 
 /// Coverage information for a function, recorded during MIR building and

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -90,6 +90,23 @@ pub enum CoverageKind {
     /// During codegen, this might be lowered to `llvm.instrprof.increment` or
     /// to a no-op, depending on the outcome of counter-creation.
     VirtualCounter { bcb: BasicCoverageBlock },
+
+    /// Marks a point in MIR where a condition was evaluated and we increment the
+    /// MC/DC temp variable to build the test vector.
+    MCDCTmpIdxUpdate {
+        /// Number by which to increment the temporary.
+        incr: u32,
+
+        /// Index of the temporary to increment in the stack of temporaries.
+        /// (Needed for nested decisions)
+        decision_depth: u16,
+    },
+
+    /// Marks a point in MIR where we want to register a test vector after evaluating
+    /// a decision.
+    ///
+    /// Eventually lowered to `llvm.instrprof.mcdc.tvbitmap.update` in LLVM IR.
+    MCDCTestVectorBitmapUpdate { bitmap_idx: u32, decision_depth: u16 },
 }
 
 impl Debug for CoverageKind {
@@ -99,6 +116,12 @@ impl Debug for CoverageKind {
             SpanMarker => write!(fmt, "SpanMarker"),
             BlockMarker { id } => write!(fmt, "BlockMarker({:?})", id.index()),
             VirtualCounter { bcb } => write!(fmt, "VirtualCounter({bcb:?})"),
+            MCDCTmpIdxUpdate { incr, decision_depth } => {
+                write!(fmt, "MCDCDecisionIdxUpdate(incr={incr}, depth={decision_depth})")
+            }
+            MCDCTestVectorBitmapUpdate { bitmap_idx, decision_depth } => {
+                write!(fmt, "MCDCTestVectorBitmapUpdate({bitmap_idx}, depth={decision_depth})")
+            }
         }
     }
 }

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -135,6 +135,16 @@ pub enum MappingKind {
     Code { bcb: BasicCoverageBlock },
     /// Associates a branch region with separate counters for true and false.
     Branch { true_bcb: BasicCoverageBlock, false_bcb: BasicCoverageBlock },
+    /// Associates a condition region to a decision graph node and its true
+    /// and false outcomes.
+    MCDCCondition {
+        true_bcb: BasicCoverageBlock,
+        false_bcb: BasicCoverageBlock,
+        mcdc_mappings: mcdc::ConditionInfo,
+    },
+    /// Associate a decision region with its index in the entire MC/DC bitmap,
+    /// and its number of conditions,
+    MCDCDecision { bitmap_idx: u32, num_conditions: u16 },
 }
 
 #[derive(Clone, Debug)]

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -637,7 +637,8 @@ fn write_coverage_info_hi(
     coverage_info_hi: &coverage::CoverageInfoHi,
     w: &mut dyn io::Write,
 ) -> io::Result<()> {
-    let coverage::CoverageInfoHi { num_block_markers: _, branch_spans } = coverage_info_hi;
+    let coverage::CoverageInfoHi { num_block_markers: _, branch_spans, mcdc_spans } =
+        coverage_info_hi;
 
     // Only add an extra trailing newline if we printed at least one thing.
     let mut did_print = false;
@@ -647,6 +648,31 @@ fn write_coverage_info_hi(
             w,
             "{INDENT}coverage branch {{ true: {true_marker:?}, false: {false_marker:?} }} => {span:?}",
         )?;
+        did_print = true;
+    }
+
+    for (
+        coverage::mcdc::DecisionSpan { span, end_markers, decision_depth, num_conditions },
+        conditions,
+    ) in mcdc_spans
+    {
+        writeln!(
+            w,
+            "{INDENT}MCDC decision {{ num_conditions: {num_conditions}, depth: {decision_depth}, outputs: {end_markers:?} }} => {span:?}",
+        )?;
+
+        for coverage::mcdc::ConditionSpan {
+            span,
+            condition_info:
+                coverage::mcdc::ConditionInfo { condition_id, true_next_id, false_next_id },
+            ..
+        } in conditions
+        {
+            writeln!(
+                w,
+                "{INDENT}{INDENT}condition {{ id: {condition_id:?}, true_id: {true_next_id:?}, false_id: {false_next_id:?} }} => {span:?}"
+            )?;
+        }
         did_print = true;
     }
 

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -9,6 +9,7 @@ use tracing::trace;
 use ty::print::PrettyPrinter;
 
 use super::graphviz::write_mir_fn_graphviz;
+use crate::mir::coverage::FunctionMCDCExtraInfo;
 use crate::mir::interpret::{
     AllocBytes, AllocId, Allocation, ConstAllocation, GlobalAlloc, Pointer, Provenance,
     alloc_range, read_target_uint,
@@ -687,12 +688,20 @@ fn write_function_coverage_info(
     function_coverage_info: &coverage::FunctionCoverageInfo,
     w: &mut dyn io::Write,
 ) -> io::Result<()> {
-    let coverage::FunctionCoverageInfo { mappings, .. } = function_coverage_info;
+    let coverage::FunctionCoverageInfo { mappings, mcdc_info, .. } = function_coverage_info;
 
     for coverage::Mapping { kind, span } in mappings {
         writeln!(w, "{INDENT}coverage {kind:?} => {span:?};")?;
     }
     writeln!(w)?;
+
+    if let Some(FunctionMCDCExtraInfo { bitmap_bits, num_temporaries }) = mcdc_info.as_ref() {
+        writeln!(
+            w,
+            "{INDENT}coverage (MC/DC: bitmap_bits={bitmap_bits}, num_temporaries={num_temporaries});"
+        )?;
+        writeln!(w)?;
+    }
 
     Ok(())
 }

--- a/compiler/rustc_mir_build/src/builder/coverageinfo.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo.rs
@@ -168,10 +168,13 @@ impl CoverageInfoBuilder {
         let Self { nots: _, markers: BlockMarkerGen { num_block_markers }, branch_info, mcdc_info } =
             self;
 
-        let branch_spans =
+        let mut branch_spans =
             branch_info.map(|branch_info| branch_info.branch_spans).unwrap_or_default();
 
-        let mcdc_spans = mcdc_info.map(MCDCInfoBuilder::into_done).unwrap_or_default();
+        let (mcdc_spans, standalone_branches) =
+            mcdc_info.map(MCDCInfoBuilder::into_done).unwrap_or_default();
+
+        branch_spans.extend(standalone_branches);
 
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.
@@ -186,14 +189,17 @@ impl CoverageInfoBuilder {
             ref mcdc_info,
         } = self;
 
-        let branch_spans = branch_info
+        let mut branch_spans = branch_info
             .as_ref()
             .map(|branch_info| branch_info.branch_spans.as_slice())
             .unwrap_or_default()
             .to_owned();
 
-        let mcdc_spans =
-            mcdc_info.as_ref().map(|mcdc_info| mcdc_info.as_done().to_vec()).unwrap_or_default();
+        let (mcdc_spans, standalone_branches) =
+            mcdc_info.as_ref().map(|mcdc_info| mcdc_info.as_done()).unwrap_or_default();
+
+        branch_spans.extend(standalone_branches.iter().cloned());
+        let mcdc_spans = mcdc_spans.to_vec();
 
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.

--- a/compiler/rustc_mir_build/src/builder/coverageinfo.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo.rs
@@ -8,7 +8,10 @@ use rustc_middle::thir::{ExprId, ExprKind, Pat, Thir};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::def_id::LocalDefId;
 
+use crate::builder::coverageinfo::mcdc::MCDCInfoBuilder;
 use crate::builder::{Builder, CFG};
+
+mod mcdc;
 
 /// Collects coverage-related information during MIR building, to eventually be
 /// turned into a function's [`CoverageInfoHi`] when MIR building is complete.
@@ -20,6 +23,9 @@ pub(crate) struct CoverageInfoBuilder {
 
     /// Present if branch coverage is enabled.
     branch_info: Option<BranchInfo>,
+
+    /// Present if MC/DC coverage is enabled.
+    mcdc_info: Option<MCDCInfoBuilder>,
 }
 
 #[derive(Default)]
@@ -78,6 +84,7 @@ impl CoverageInfoBuilder {
             nots: FxHashMap::default(),
             markers: BlockMarkerGen::default(),
             branch_info: tcx.sess.instrument_coverage_branch().then(BranchInfo::default),
+            mcdc_info: tcx.sess.instrument_coverage_mcdc().then(MCDCInfoBuilder::default),
         })
     }
 
@@ -129,38 +136,55 @@ impl CoverageInfoBuilder {
 
     fn register_two_way_branch<'tcx>(
         &mut self,
+        tcx: TyCtxt<'tcx>,
         cfg: &mut CFG<'tcx>,
         source_info: SourceInfo,
         true_block: BasicBlock,
         false_block: BasicBlock,
     ) {
-        // Bail out if branch coverage is not enabled.
-        let Some(branch_info) = self.branch_info.as_mut() else { return };
+        let mut inject_block_marker =
+            |bb: BasicBlock| self.markers.inject_block_marker(cfg, source_info, bb);
 
-        let true_marker = self.markers.inject_block_marker(cfg, source_info, true_block);
-        let false_marker = self.markers.inject_block_marker(cfg, source_info, false_block);
+        if let Some(mcdc_info) = self.mcdc_info.as_mut() {
+            // If MC/DC is enabled, register the branch via MCDC
+            let true_marker = inject_block_marker(true_block);
+            let false_marker = inject_block_marker(false_block);
 
-        branch_info.branch_spans.push(BranchSpan {
-            span: source_info.span,
-            true_marker,
-            false_marker,
-        });
+            mcdc_info.record_leaf_condition(tcx, source_info.span, true_marker, false_marker);
+        } else if let Some(branch_info) = self.branch_info.as_mut() {
+            // Else, if branch/condition is enabled, create a new branch span
+            let true_marker = inject_block_marker(true_block);
+            let false_marker = inject_block_marker(false_block);
+
+            branch_info.branch_spans.push(BranchSpan {
+                span: source_info.span,
+                true_marker,
+                false_marker,
+            });
+        }
     }
 
     pub(crate) fn into_done(self) -> Box<CoverageInfoHi> {
-        let Self { nots: _, markers: BlockMarkerGen { num_block_markers }, branch_info } = self;
+        let Self { nots: _, markers: BlockMarkerGen { num_block_markers }, branch_info, mcdc_info } =
+            self;
 
         let branch_spans =
             branch_info.map(|branch_info| branch_info.branch_spans).unwrap_or_default();
 
+        let mcdc_spans = mcdc_info.map(MCDCInfoBuilder::into_done).unwrap_or_default();
+
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.
-        Box::new(CoverageInfoHi { num_block_markers, branch_spans })
+        Box::new(CoverageInfoHi { num_block_markers, branch_spans, mcdc_spans })
     }
 
     pub(crate) fn as_done(&self) -> Box<CoverageInfoHi> {
-        let &Self { nots: _, markers: BlockMarkerGen { num_block_markers }, ref branch_info } =
-            self;
+        let &Self {
+            nots: _,
+            markers: BlockMarkerGen { num_block_markers },
+            ref branch_info,
+            ref mcdc_info,
+        } = self;
 
         let branch_spans = branch_info
             .as_ref()
@@ -168,9 +192,12 @@ impl CoverageInfoBuilder {
             .unwrap_or_default()
             .to_owned();
 
+        let mcdc_spans =
+            mcdc_info.as_ref().map(|mcdc_info| mcdc_info.as_done().to_vec()).unwrap_or_default();
+
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.
-        Box::new(CoverageInfoHi { num_block_markers, branch_spans })
+        Box::new(CoverageInfoHi { num_block_markers, branch_spans, mcdc_spans })
     }
 }
 
@@ -223,7 +250,13 @@ impl<'tcx> Builder<'_, 'tcx> {
             mir::TerminatorKind::if_(mir::Operand::Copy(place), true_block, false_block),
         );
 
-        coverage_info.register_two_way_branch(&mut self.cfg, source_info, true_block, false_block);
+        coverage_info.register_two_way_branch(
+            self.tcx,
+            &mut self.cfg,
+            source_info,
+            true_block,
+            false_block,
+        );
 
         let join_block = self.cfg.start_new_block();
         self.cfg.goto(true_block, source_info, join_block);
@@ -254,7 +287,13 @@ impl<'tcx> Builder<'_, 'tcx> {
 
         let source_info = SourceInfo { span: self.thir[expr_id].span, scope: self.source_scope };
 
-        coverage_info.register_two_way_branch(&mut self.cfg, source_info, then_block, else_block);
+        coverage_info.register_two_way_branch(
+            self.tcx,
+            &mut self.cfg,
+            source_info,
+            then_block,
+            else_block,
+        );
     }
 
     /// If branch coverage is enabled, inject marker statements into `true_block`
@@ -271,6 +310,12 @@ impl<'tcx> Builder<'_, 'tcx> {
         let Some(coverage_info) = self.coverage_info.as_mut() else { return };
 
         let source_info = SourceInfo { span: pattern.span, scope: self.source_scope };
-        coverage_info.register_two_way_branch(&mut self.cfg, source_info, true_block, false_block);
+        coverage_info.register_two_way_branch(
+            self.tcx,
+            &mut self.cfg,
+            source_info,
+            true_block,
+            false_block,
+        );
     }
 }

--- a/compiler/rustc_mir_build/src/builder/coverageinfo/mcdc.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo/mcdc.rs
@@ -1,0 +1,318 @@
+use rustc_middle::bug;
+use rustc_middle::mir::coverage::mcdc::{ConditionId, ConditionInfo, ConditionSpan, DecisionSpan};
+use rustc_middle::mir::coverage::BlockMarkerId;
+use rustc_middle::thir::LogicalOp;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+use tracing::instrument;
+
+use crate::builder::Builder;
+use crate::diagnostics::MCDCConditionNumberExceeded;
+
+/// This struct is responsible for tracking a visited decision, assigning
+/// [`ConditionId`]s to its conditions and building its BDD (Binary Decision
+/// Diagram), which are necessary for generating the MC/DC coverage mappings.
+///
+/// The ID assignment algorithm works by assigning an ID to the operands of the
+/// root operator, and then, via consecutive calls on the sub-expressions, if
+/// its a composite expression, re-assign its ID to its LHS, and assign a new
+/// ID to its RHS.
+///
+/// Example: "x = (A && B) || (C && D) || (D && F)"
+///
+///  Visit Depth1:
+///          (A && B) || (C && D) || (D && F)
+///          ^-------LHS--------^    ^-RHS--^
+///                  ID=1              ID=2
+///
+///  Visit LHS-Depth2:
+///          (A && B) || (C && D)
+///          ^-LHS--^    ^-RHS--^
+///            ID=1        ID=3
+///
+///  Visit LHS-Depth3:
+///           (A && B)
+///           LHS   RHS
+///           ID=1  ID=4
+///
+///  Visit RHS-Depth3:
+///                     (C && D)
+///                     LHS   RHS
+///                     ID=3  ID=5
+///
+///  Visit RHS-Depth2:              (D && F)
+///                                 LHS   RHS
+///                                 ID=2  ID=6
+///
+///  Visit Depth1:
+///          (A && B)  || (C && D)  || (D && F)
+///          ID=1  ID=4   ID=3  ID=5   ID=2  ID=6
+///
+#[derive(Debug, Default)]
+struct MCDCDecisionBuilder {
+    /// The stack of [`ConditionInfo`]s representing the BDD of the decision we
+    /// visited so far.
+    bdd_node_stack: Vec<ConditionInfo>,
+
+    /// The spans for leaf condition we already visited.
+    conditions: Vec<ConditionSpan>,
+
+    /// The decision span currently being built when visiting a decision, `None`
+    /// otherwise.
+    decision: Option<DecisionSpan>,
+}
+
+impl MCDCDecisionBuilder {
+    /// Record new condition nodes linked by `logical_op` in the BDD.
+    fn record_operator(&mut self, logical_op: LogicalOp, span: Span, decision_depth: u16) {
+        let decision = match self.decision.as_mut() {
+            Some(decision) => {
+                decision.span = decision.span.to(span);
+                decision
+            }
+            None => self.decision.insert(DecisionSpan {
+                span,
+                end_markers: Vec::new(),
+                decision_depth,
+                num_conditions: 0,
+            }),
+        };
+
+        // Top of the stack is not a leaf condition, pop it and stack both
+        // sides of the `logical_op` instead.
+        let parent_condition = self.bdd_node_stack.pop().unwrap_or_else(|| {
+            assert_eq!(decision.num_conditions, 0, "No condition means num_conditions should be 0");
+            decision.num_conditions += 1;
+            ConditionInfo {
+                condition_id: ConditionId::START,
+                true_next_id: None,
+                false_next_id: None,
+            }
+        });
+
+        let lhs_id = parent_condition.condition_id;
+        let rhs_id = ConditionId::from(decision.num_conditions);
+        decision.num_conditions += 1;
+
+        // If OP is AND, RHS will be checked only if LHS is true.
+        // If OP is OR, RHS will be checked only if LHS is false.
+        let lhs = match logical_op {
+            LogicalOp::And => ConditionInfo {
+                condition_id: lhs_id,
+                true_next_id: Some(rhs_id),
+                false_next_id: parent_condition.false_next_id,
+            },
+            LogicalOp::Or => ConditionInfo {
+                condition_id: lhs_id,
+                true_next_id: parent_condition.true_next_id,
+                false_next_id: Some(rhs_id),
+            },
+        };
+        let rhs = ConditionInfo {
+            condition_id: rhs_id,
+            true_next_id: parent_condition.true_next_id,
+            false_next_id: parent_condition.false_next_id,
+        };
+
+        self.bdd_node_stack.push(rhs);
+        self.bdd_node_stack.push(lhs);
+    }
+
+    /// Called upon encountering a leaf condition of the boolean expression.
+    ///
+    /// Pop the [`ConditionInfo`] at the top of the node stack and make an
+    /// [`ConditionSpan`] from it. If the stack is empty afterwards, it
+    /// means the decision was completely visited, so return the decision and
+    /// condition spans.
+    fn try_finish_decision(
+        &mut self,
+        span: Span,
+        true_marker: BlockMarkerId,
+        false_marker: BlockMarkerId,
+    ) -> Option<(DecisionSpan, Vec<ConditionSpan>)> {
+        let condition_info = self.bdd_node_stack.pop()?;
+        let Some(decision) = self.decision.as_mut() else {
+            bug!("decision should have been created by now");
+        };
+
+        // if true_next_id is None, it means that this condition's evaluation
+        // to true will make the decision true.
+        if condition_info.true_next_id.is_none() {
+            decision.end_markers.push(true_marker);
+        }
+        if condition_info.false_next_id.is_none() {
+            decision.end_markers.push(false_marker);
+        }
+
+        // The condition_info is a leaf condition, make it a branch span.
+        self.conditions.push(ConditionSpan { span, condition_info, true_marker, false_marker });
+
+        if self.bdd_node_stack.is_empty() {
+            // There is no more condition to the decision, return the resulting spans
+            let conditions = std::mem::take(&mut self.conditions);
+            self.decision.take().map(|decision| (decision, conditions))
+        } else {
+            None
+        }
+    }
+
+    /// Returns true if the builder is currently building a decision.
+    #[inline]
+    fn is_empty(&self) -> bool {
+        return self.decision.is_none();
+    }
+}
+
+/// MC/DC decision builder context for a function.
+///
+/// Holds a stack of [`MCDCDecisionBuilder`] to account for nested decisions.
+#[derive(Debug)]
+pub(crate) struct MCDCInfoBuilder {
+    /// Holds a stack of decision builders, to account for nested decisions.
+    ///
+    /// Example:
+    /// ```rust,ignore (illustrative)
+    /// if a && foo(b || c) {}
+    /// ```
+    ///
+    /// Here `b || c` is a different decision nested in `a && ...`.
+    /// To avoid mixing decisions, when we're building a decision and we visit
+    /// a "non-trivial" node (other than parentheses, deref, etc...), we push a
+    /// new builder on the stack.
+    decision_builder_stack: Vec<MCDCDecisionBuilder>,
+
+    /// The list of computed decisions so far.
+    decisions: Vec<(DecisionSpan, Vec<ConditionSpan>)>,
+}
+
+impl Default for MCDCInfoBuilder {
+    fn default() -> Self {
+        Self { decision_builder_stack: vec![MCDCDecisionBuilder::default()], decisions: Vec::new() }
+    }
+}
+
+impl MCDCInfoBuilder {
+    /// Decision depth is given as a u16 to reduce the size of the
+    /// `CoverageKind`, as it is very unlikely that the depth ever reaches
+    /// 2^16.
+    ///
+    /// Note: zero-indexed
+    #[inline]
+    fn decision_depth(&self) -> u16 {
+        match u16::try_from(self.decision_builder_stack.len()).map(|n| n.checked_sub(1)) {
+            Ok(Some(d)) => d,
+            Ok(None) => bug!("Unexpected empty decision builder stack"),
+            Err(e) => bug!(
+                "{e}: decision depth did not fit in u16, this is likely to be an instrumentation error"
+            ),
+        }
+    }
+
+    #[instrument(level = "debug", skip(self), fields(depth = MCDCInfoBuilder::decision_depth(self)))]
+    pub(crate) fn record_operator(&mut self, logical_op: LogicalOp, span: Span) {
+        let depth = self.decision_depth();
+
+        let Some(decision_builder) = self.decision_builder_stack.last_mut() else {
+            bug!("Unexpected empty decision builder stack")
+        };
+
+        decision_builder.record_operator(logical_op, span, depth);
+    }
+
+    #[instrument(level = "debug", skip(self, tcx), fields(depth = MCDCInfoBuilder::decision_depth(self)))]
+    pub(crate) fn record_leaf_condition(
+        &mut self,
+        tcx: TyCtxt<'_>,
+        span: Span,
+        true_marker: BlockMarkerId,
+        false_marker: BlockMarkerId,
+    ) {
+        let Some(decision_builder) = self.decision_builder_stack.last_mut() else {
+            bug!("Unexpected empty decision builder stack")
+        };
+
+        if let Some((decision, conditions)) =
+            decision_builder.try_finish_decision(span, true_marker, false_marker)
+        {
+            let num_conditions = conditions.len();
+            assert_eq!(
+                num_conditions, decision.num_conditions,
+                "decision.num_conditions should equal conditions.len()"
+            );
+
+            match num_conditions {
+                1..=ConditionId::MAX_AS_USIZE => self.decisions.push((decision, conditions)),
+
+                0 => bug!("decision has no condition"),
+
+                // LLVM does not support decisions with more conditions.
+                _ => tcx.dcx().emit_warn(MCDCConditionNumberExceeded {
+                    span: decision.span,
+                    max_conditions: ConditionId::MAX_AS_USIZE,
+                    num_conditions,
+                }),
+            }
+        }
+    }
+
+    /// Called when visiting inside a condition leaf, to correctly record
+    /// nested decisions.
+    #[inline]
+    #[instrument(level = "debug", skip(self), fields(before = MCDCInfoBuilder::decision_depth(self)))]
+    fn increment_depth(&mut self) {
+        self.decision_builder_stack.push(MCDCDecisionBuilder::default());
+    }
+
+    /// Called when stepping out of condition leaf.
+    #[inline]
+    #[instrument(level = "debug", skip(self), fields(before = MCDCInfoBuilder::decision_depth(self)))]
+    fn decrement_depth(&mut self) {
+        let Some(top_builder) = self.decision_builder_stack.pop() else {
+            bug!("Unexpected empty decision builder stack");
+        };
+        if !top_builder.is_empty() {
+            bug!("Popped a decision builder with unfinished decision in it")
+        }
+    }
+
+    #[inline]
+    #[instrument(level = "debug")]
+    pub(crate) fn into_done(self) -> Vec<(DecisionSpan, Vec<ConditionSpan>)> {
+        self.decisions
+    }
+
+    #[inline]
+    #[instrument(level = "debug")]
+    pub(crate) fn as_done(&self) -> &[(DecisionSpan, Vec<ConditionSpan>)] {
+        self.decisions.as_slice()
+    }
+}
+
+impl Builder<'_, '_> {
+    #[inline]
+    fn mcdc_info_as_mut(&mut self) -> Option<&mut MCDCInfoBuilder> {
+        self.coverage_info.as_mut().and_then(|cov_info| cov_info.mcdc_info.as_mut())
+    }
+
+    pub(crate) fn maybe_mcdc_record_operator(&mut self, logical_op: LogicalOp, span: Span) {
+        if let Some(mcdc_builder) = self.mcdc_info_as_mut() {
+            mcdc_builder.record_operator(logical_op, span);
+        }
+    }
+
+    // If MC/DC instrumentation is enabled, push a new MC/DC decision builder
+    // before calling `f(self)`, and pop it afterwards. Otherwise, simply run
+    // `f(self)`.
+    pub(crate) fn in_mcdc_sub_scope<T>(&mut self, mut f: impl FnMut(&mut Self) -> T) -> T {
+        if let Some(mcdc_builder) = self.mcdc_info_as_mut() {
+            mcdc_builder.increment_depth();
+        };
+
+        let result = f(self);
+
+        if let Some(mcdc_builder) = self.mcdc_info_as_mut() {
+            mcdc_builder.decrement_depth();
+        };
+        result
+    }
+}

--- a/compiler/rustc_mir_build/src/builder/coverageinfo/mcdc.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo/mcdc.rs
@@ -1,6 +1,6 @@
 use rustc_middle::bug;
 use rustc_middle::mir::coverage::mcdc::{ConditionId, ConditionInfo, ConditionSpan, DecisionSpan};
-use rustc_middle::mir::coverage::BlockMarkerId;
+use rustc_middle::mir::coverage::{BlockMarkerId, BranchSpan};
 use rustc_middle::thir::LogicalOp;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
@@ -8,6 +8,11 @@ use tracing::instrument;
 
 use crate::builder::Builder;
 use crate::diagnostics::MCDCConditionNumberExceeded;
+
+enum FinishedDecision {
+    MCDCDecision(DecisionSpan, Vec<ConditionSpan>),
+    StandaloneBranch(BranchSpan),
+}
 
 /// This struct is responsible for tracking a visited decision, assigning
 /// [`ConditionId`]s to its conditions and building its BDD (Binary Decision
@@ -129,8 +134,18 @@ impl MCDCDecisionBuilder {
         span: Span,
         true_marker: BlockMarkerId,
         false_marker: BlockMarkerId,
-    ) -> Option<(DecisionSpan, Vec<ConditionSpan>)> {
-        let condition_info = self.bdd_node_stack.pop()?;
+    ) -> Option<FinishedDecision> {
+        let Some(condition_info) = self.bdd_node_stack.pop() else {
+            // If there's no existing node, it means we didn't encounter a
+            // boolean operator above this condition, so it must be a
+            // single condition decision.
+            return Some(FinishedDecision::StandaloneBranch(BranchSpan {
+                span,
+                true_marker,
+                false_marker,
+            }));
+        };
+
         let Some(decision) = self.decision.as_mut() else {
             bug!("decision should have been created by now");
         };
@@ -150,7 +165,9 @@ impl MCDCDecisionBuilder {
         if self.bdd_node_stack.is_empty() {
             // There is no more condition to the decision, return the resulting spans
             let conditions = std::mem::take(&mut self.conditions);
-            self.decision.take().map(|decision| (decision, conditions))
+            self.decision
+                .take()
+                .map(|decision| FinishedDecision::MCDCDecision(decision, conditions))
         } else {
             None
         }
@@ -183,11 +200,19 @@ pub(crate) struct MCDCInfoBuilder {
 
     /// The list of computed decisions so far.
     decisions: Vec<(DecisionSpan, Vec<ConditionSpan>)>,
+
+    /// The list of extra branch span, i.e. 1-condition decisions we'd rather
+    /// instrument via branch instrumentation since it is equivalent.
+    standalone_branches: Vec<BranchSpan>,
 }
 
 impl Default for MCDCInfoBuilder {
     fn default() -> Self {
-        Self { decision_builder_stack: vec![MCDCDecisionBuilder::default()], decisions: Vec::new() }
+        Self {
+            decision_builder_stack: vec![MCDCDecisionBuilder::default()],
+            decisions: Vec::new(),
+            standalone_branches: Vec::new(),
+        }
     }
 }
 
@@ -231,27 +256,41 @@ impl MCDCInfoBuilder {
             bug!("Unexpected empty decision builder stack")
         };
 
-        if let Some((decision, conditions)) =
-            decision_builder.try_finish_decision(span, true_marker, false_marker)
-        {
-            let num_conditions = conditions.len();
-            assert_eq!(
-                num_conditions, decision.num_conditions,
-                "decision.num_conditions should equal conditions.len()"
-            );
+        match decision_builder.try_finish_decision(span, true_marker, false_marker) {
+            // Decision was completed, save it.
+            Some(FinishedDecision::MCDCDecision(decision, conditions)) => {
+                let num_conditions = conditions.len();
+                assert_eq!(
+                    num_conditions, decision.num_conditions,
+                    "decision.num_conditions should equal conditions.len()"
+                );
 
-            match num_conditions {
-                1..=ConditionId::MAX_AS_USIZE => self.decisions.push((decision, conditions)),
+                match num_conditions {
+                    1..=ConditionId::MAX_AS_USIZE => self.decisions.push((decision, conditions)),
 
-                0 => bug!("decision has no condition"),
+                    0 => bug!("decision has no condition"),
 
-                // LLVM does not support decisions with more conditions.
-                _ => tcx.dcx().emit_warn(MCDCConditionNumberExceeded {
-                    span: decision.span,
-                    max_conditions: ConditionId::MAX_AS_USIZE,
-                    num_conditions,
-                }),
+                    // LLVM does not support decisions with more conditions.
+                    _ => {
+                        tcx.dcx().emit_warn(MCDCConditionNumberExceeded {
+                            span: decision.span,
+                            max_conditions: ConditionId::MAX_AS_USIZE,
+                            num_conditions,
+                        });
+
+                        // Upon error, decision_builder should be in a
+                        // sound state for the next decision.
+                        debug_assert!(decision_builder.is_empty())
+                    }
+                }
             }
+            // Decision is a simple condition without an operator,
+            // save it to instrument it with branch coverage.
+            Some(FinishedDecision::StandaloneBranch(branch_span)) => {
+                self.standalone_branches.push(branch_span)
+            }
+            // Decision isn't complete yet
+            None => {}
         }
     }
 
@@ -277,14 +316,14 @@ impl MCDCInfoBuilder {
 
     #[inline]
     #[instrument(level = "debug")]
-    pub(crate) fn into_done(self) -> Vec<(DecisionSpan, Vec<ConditionSpan>)> {
-        self.decisions
+    pub(crate) fn into_done(self) -> (Vec<(DecisionSpan, Vec<ConditionSpan>)>, Vec<BranchSpan>) {
+        (self.decisions, self.standalone_branches)
     }
 
     #[inline]
     #[instrument(level = "debug")]
-    pub(crate) fn as_done(&self) -> &[(DecisionSpan, Vec<ConditionSpan>)] {
-        self.decisions.as_slice()
+    pub(crate) fn as_done(&self) -> (&[(DecisionSpan, Vec<ConditionSpan>)], &[BranchSpan]) {
+        (self.decisions.as_slice(), self.standalone_branches.as_slice())
     }
 }
 

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -160,6 +160,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let condition_scope = this.local_scope();
                 let source_info = this.source_info(expr.span);
 
+                // Build the binary decision diagram from for MC/DC purposes if
+                // enabled.
+                this.maybe_mcdc_record_operator(op, expr.span);
+
                 // We first evaluate the left-hand side of the predicate ...
                 let (then_block, else_block) =
                     this.in_if_then_scope(condition_scope, expr.span, |this| {

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -115,13 +115,17 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let expr_span = expr.span;
 
         match expr.kind {
-            ExprKind::LogicalOp { op: LogicalOp::And, lhs, rhs } => {
+            ExprKind::LogicalOp { op: op @ LogicalOp::And, lhs, rhs } => {
+                this.maybe_mcdc_record_operator(op, expr_span);
+
                 let lhs_then_block = this.then_else_break_inner(block, lhs, args).into_block();
                 let rhs_then_block =
                     this.then_else_break_inner(lhs_then_block, rhs, args).into_block();
                 rhs_then_block.unit()
             }
-            ExprKind::LogicalOp { op: LogicalOp::Or, lhs, rhs } => {
+            ExprKind::LogicalOp { op: op @ LogicalOp::Or, lhs, rhs } => {
+                this.maybe_mcdc_record_operator(op, expr_span);
+
                 let local_scope = this.local_scope();
                 let (lhs_success_block, failure_block) =
                     this.in_if_then_scope(local_scope, expr_span, |this| {
@@ -201,17 +205,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let temp_scope = args.temp_scope_override.unwrap_or_else(|| this.local_scope());
                 let mutability = Mutability::Mut;
 
-                let place = unpack!(
-                    block = this.as_temp(
-                        block,
-                        TempLifetime {
-                            temp_lifetime: Some(temp_scope),
-                            backwards_incompatible: None
-                        },
-                        expr_id,
-                        mutability
+                let place = this.in_mcdc_sub_scope(|this| {
+                    unpack!(
+                        block = this.as_temp(
+                            block,
+                            TempLifetime {
+                                temp_lifetime: Some(temp_scope),
+                                backwards_incompatible: None
+                            },
+                            expr_id,
+                            mutability
+                        )
                     )
-                );
+                });
 
                 let operand = Operand::Move(Place::from(place));
 

--- a/compiler/rustc_mir_build/src/diagnostics.rs
+++ b/compiler/rustc_mir_build/src/diagnostics.rs
@@ -1438,3 +1438,13 @@ pub(crate) struct ConstContinueUnknownJumpTarget {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag("number of conditions in decision ({$num_conditions}) exceeds limit ({$max_conditions}), so MC/DC analysis will not count this expression
+")]
+pub(crate) struct MCDCConditionNumberExceeded {
+    #[primary_span]
+    pub span: Span,
+    pub max_conditions: usize,
+    pub num_conditions: usize,
+}

--- a/compiler/rustc_mir_transform/src/check_inline.rs
+++ b/compiler/rustc_mir_transform/src/check_inline.rs
@@ -46,6 +46,16 @@ pub(super) fn is_inline_valid_on_fn<'tcx>(
         return Err("#[rustc_no_mir_inline]");
     }
 
+    // MC/DC coverage does not work properly with inlining, because the
+    // instrumenter adds temporary variables to the functions which aren't
+    // (yet?) taken in account when inlining.
+    //
+    // FIXME(peron): Consider a refinement of the condition to only prevent
+    // functions with MC/DC instrumentation from inlining.
+    if tcx.sess.instrument_coverage_mcdc() {
+        return Err("No inlining when MC/DC coverage is enabled");
+    }
+
     let ty = tcx.type_of(def_id);
     if match ty.instantiate_identity().skip_norm_wip().kind() {
         ty::FnDef(..) => tcx.fn_sig(def_id).instantiate_identity().skip_norm_wip().c_variadic(),

--- a/compiler/rustc_mir_transform/src/coverage/expansion.rs
+++ b/compiler/rustc_mir_transform/src/coverage/expansion.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet, IndexEntry};
 use rustc_middle::mir;
-use rustc_middle::mir::coverage::{BasicCoverageBlock, BranchSpan};
+use rustc_middle::mir::coverage::{BasicCoverageBlock, BranchSpan, mcdc};
 use rustc_span::{ExpnKind, Span, SyntaxContext};
 
 use crate::coverage::from_mir;
@@ -62,6 +62,9 @@ pub(crate) struct ExpnNode {
     /// Branch spans (recorded during MIR building) belonging to this expansion.
     pub(crate) branch_spans: Vec<BranchSpan>,
 
+    /// MC/DC spans (recorded during MIR building) belonging to this expansion.
+    pub(crate) mcdc_spans: Vec<(mcdc::DecisionSpan, Vec<mcdc::ConditionSpan>)>,
+
     /// Hole spans belonging to this expansion, to be carved out from the
     /// code spans during span refinement.
     pub(crate) hole_spans: Vec<Span>,
@@ -90,6 +93,7 @@ impl ExpnNode {
             minmax_bcbs: None,
 
             branch_spans: vec![],
+            mcdc_spans: vec![],
 
             hole_spans: vec![],
         }
@@ -171,12 +175,20 @@ pub(crate) fn build_expn_tree(
         node.hole_spans.push(hole_span);
     }
 
-    // Associate each branch span (recorded during MIR building) with its
-    // corresponding expansion tree node.
     if let Some(coverage_info_hi) = mir_body.coverage_info_hi.as_deref() {
+        // Associate each branch span (recorded during MIR building) with its
+        // corresponding expansion tree node.
         for branch_span in &coverage_info_hi.branch_spans {
             if let Some(node) = nodes.get_mut(&branch_span.span.ctxt()) {
                 node.branch_spans.push(BranchSpan::clone(branch_span));
+            }
+        }
+
+        // Associate spans of MCDC decisions to the expansion node of the
+        // decision span.
+        for (decision_span, condition_spans) in &coverage_info_hi.mcdc_spans {
+            if let Some(node) = nodes.get_mut(&decision_span.span.ctxt()) {
+                node.mcdc_spans.push((decision_span.clone(), condition_spans.clone()))
             }
         }
     }

--- a/compiler/rustc_mir_transform/src/coverage/from_mir.rs
+++ b/compiler/rustc_mir_transform/src/coverage/from_mir.rs
@@ -98,7 +98,11 @@ fn filtered_statement_span(statement: &Statement<'_>) -> Option<Span> {
         StatementKind::Coverage(CoverageKind::BlockMarker { .. }) => None,
 
         // These coverage statements should not exist prior to coverage instrumentation.
-        StatementKind::Coverage(CoverageKind::VirtualCounter { .. }) => bug!(
+        StatementKind::Coverage(
+            CoverageKind::VirtualCounter { .. }
+            | CoverageKind::MCDCTmpIdxUpdate { .. }
+            | CoverageKind::MCDCTestVectorBitmapUpdate { .. },
+        ) => bug!(
             "Unexpected coverage statement found during coverage instrumentation: {statement:?}"
         ),
     }

--- a/compiler/rustc_mir_transform/src/coverage/mappings.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mappings.rs
@@ -1,6 +1,7 @@
 use rustc_index::IndexVec;
 use rustc_middle::mir::coverage::{
-    BlockMarkerId, BranchSpan, CoverageInfoHi, CoverageKind, Mapping, MappingKind,
+    BlockMarkerId, BranchSpan, CoverageInfoHi, CoverageKind, FunctionMCDCExtraInfo, Mapping,
+    MappingKind,
 };
 use rustc_middle::mir::{self, BasicBlock, StatementKind};
 use rustc_middle::ty::TyCtxt;
@@ -9,6 +10,7 @@ use rustc_span::ExpnKind;
 use crate::coverage::expansion::{self, ExpnTree};
 use crate::coverage::graph::CoverageGraph;
 use crate::coverage::hir_info::ExtractedHirInfo;
+use crate::coverage::mcdc;
 use crate::coverage::spans::extract_refined_covspans;
 
 /// Indicates why mapping extraction failed, for debug-logging purposes.
@@ -21,6 +23,7 @@ pub(crate) enum MappingsError {
 #[derive(Default)]
 pub(crate) struct ExtractedMappings {
     pub(crate) mappings: Vec<Mapping>,
+    pub(crate) mcdc_data: Option<(Vec<mcdc::MCDCMetaMapping>, FunctionMCDCExtraInfo)>,
 }
 
 /// Extracts coverage-relevant spans from MIR, and uses them to create
@@ -40,14 +43,16 @@ pub(crate) fn extract_mappings_from_mir<'tcx>(
 
     extract_branch_mappings(mir_body, hir_info, graph, &expn_tree, &mut mappings);
 
-    if mappings.is_empty() {
+    let mcdc_data = mcdc::extract_mcdc_mappings(mir_body, hir_info, graph, &expn_tree);
+
+    if mappings.is_empty() && mcdc_data.is_none() {
         tracing::debug!("no mappings were extracted");
         return Err(MappingsError::NoMappings);
     }
-    Ok(ExtractedMappings { mappings })
+    Ok(ExtractedMappings { mappings, mcdc_data })
 }
 
-fn resolve_block_markers(
+pub(crate) fn resolve_block_markers(
     coverage_info_hi: &CoverageInfoHi,
     mir_body: &mir::Body<'_>,
 ) -> IndexVec<BlockMarkerId, Option<BasicBlock>> {

--- a/compiler/rustc_mir_transform/src/coverage/mcdc.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mcdc.rs
@@ -1,0 +1,372 @@
+//! MC/DC instrumentation enables MC/DC coverage to be performed on the
+//! program. That is, for each "decision" (a boolean expression with at least
+//! one logical operator), ensure that each "condition" (single operands of
+//! the expression) is independently proven to have an effect on the outcome of
+//! the decision. To do that, we need to :
+//! 1. Detect decisions and their conditions in the AST (THIR).
+//!
+//! 2. Instrument the BDD (Binary Decision Diagram) (subset of MIR
+//!     corresponding to the decision). The goal of this step is to make sure
+//!     that upon finishing the evaluation of a decision, the program saves a
+//!     trace of the test vector (i.e. the set of input values) that was just
+//!     given. There are 3 requirements to do this:
+//!     - Allocate a temporary variable during the evaluation of the
+//!         decision, which should represent the current test vector being
+//!         evaluated.
+//!     - Upon ending a decision, save the aforementioned temporary variable
+//!         somehow, so we know this input was exercised.
+//!     - When evaluating a condition within the decision, update the
+//!         aforementioned temporary variable to keep track of this specific
+//!         condition evaluation.
+//!     *Note* that it is necessary that all possible test vectors produce a
+//!     unique value.
+//!
+//! 3. Adapt the codegen. Once all the processing is done pass all the data
+//!     the backend needs to generate MC/DC entries.
+//!     For LLVM, that includes providing it with "mappings", that are needed
+//!     by the instrumentation backend, so the post-execution script can map
+//!     back the coverage data to actual places in the source code, and calls
+//!     to the `llvm.instrprof.mcdc.tvbitmapupdate` intrinsic were decisions
+//!     end.
+//!
+//! The implementation is detailed below :
+//!
+//! 1. Detection of boolean decisions and conditions. This phase happens in
+//!     `rustc_mir_build::builder::coverageinfo::mcdc` and it does 2 things.
+//!     First, it detects boolean expressions, keeps a representation of all of
+//!     them ([`rustc_middle::mir::coverage::mcdc::DecisionSpan`] and
+//!     [`rustc_middle::mir::coverage::mcdc::ConditionSpan`]) along with the
+//!     corresponding spans in the source code, and stores it in
+//!     [`rustc_middle::mir::coverage::CoverageInfoHi`].
+//!     Additionally, it alters the MIR building and inserts [`BlockMarkerId`]s
+//!     to keep track of which basic blocks are generated from this decisions.
+//!
+//! 2. Instrumentation of MIR. This phase happens mostly in this module.
+//!     First, [`extract_mcdc_mappings`] processes
+//!     [`rustc_middle::mir::coverage::mcdc::DecisionSpan`]s and
+//!     [`rustc_middle::mir::coverage::mcdc::ConditionSpan`]s to create
+//!     "meta-mappings", which are essentially the structures we will give to
+//!     LLVM but with some extra data we cannot get rid of just yet.
+//!     [`extract_mcdc_mappings`] is also responsible for computing the index
+//!     increment values of each condition outcome via
+//!     [`calc_test_vectors_index`].
+//!     > **Warning**: [`calc_test_vectors_index`] reimplements an algorithm
+//!         from LLVM and should be kept synced with it, otherwise, test
+//!         vectors may be wrongly indexed between compilation and LLVM
+//!         reporting.
+//!
+//!     Once index increments are computed, we inject
+//!     [`CoverageKind`]`::TmpIdxUpdate` and
+//!     [`CoverageKind`]`::TvBitmapUpdate` instructions in MIR, and generate
+//!     the [`Mapping`]s we'll be passing to LLVM.
+//!
+
+use std::collections::BTreeSet;
+
+use rustc_data_structures::fx::FxIndexMap;
+use rustc_index::IndexVec;
+use rustc_middle::mir;
+use rustc_middle::mir::coverage::mcdc::{ConditionId, ConditionInfo, ConditionSpan};
+use rustc_middle::mir::coverage::{
+    BasicCoverageBlock, BlockMarkerId, CoverageKind, FunctionMCDCExtraInfo, Mapping, MappingKind,
+};
+use rustc_span::{ExpnKind, Span};
+
+use crate::coverage::expansion::ExpnTree;
+use crate::coverage::graph::CoverageGraph;
+use crate::coverage::hir_info::ExtractedHirInfo;
+use crate::coverage::inject_statement;
+use crate::coverage::mappings::resolve_block_markers;
+
+pub(crate) type MCDCMetaMapping = (MCDCMetaDecisionMapping, Vec<MCDCMetaConditionMapping>);
+
+/// MC/DC Condition Mapping with extra data to compute `num_test_vectors`.
+#[derive(Debug)]
+pub(crate) struct MCDCMetaConditionMapping {
+    span: Span,
+    condition_info: ConditionInfo,
+    true_bcb: BasicCoverageBlock,
+    false_bcb: BasicCoverageBlock,
+    // Offset added to test vector idx if this branch is evaluated to true.
+    true_incr: usize,
+    // Offset added to test vector idx if this branch is evaluated to false.
+    false_incr: usize,
+}
+
+impl MCDCMetaConditionMapping {
+    fn new(
+        span: Span,
+        condition_info: ConditionInfo,
+        true_bcb: BasicCoverageBlock,
+        false_bcb: BasicCoverageBlock,
+    ) -> Self {
+        Self {
+            span,
+            condition_info,
+            true_bcb,
+            false_bcb,
+            true_incr: usize::MAX,
+            false_incr: usize::MAX,
+        }
+    }
+}
+
+impl From<MCDCMetaConditionMapping> for Mapping {
+    fn from(
+        MCDCMetaConditionMapping {
+            span,
+            condition_info,
+            true_bcb,
+            false_bcb,
+            ..
+        }: MCDCMetaConditionMapping,
+    ) -> Self {
+        Self {
+            kind: MappingKind::MCDCCondition { true_bcb, false_bcb, mcdc_mappings: condition_info },
+            span,
+        }
+    }
+}
+
+/// Holds all the information about an MC/DC decision mapping.
+/// Later transformed into a regular LLVM-equivalent mapping.
+#[derive(Debug)]
+pub(crate) struct MCDCMetaDecisionMapping {
+    span: Span,
+    /// Output basic blocks where the executed test vector should be saved.
+    end_bcbs: BTreeSet<BasicCoverageBlock>,
+    /// STARTING index of the decision in the function's MCDC bitmap.
+    bitmap_idx: u32,
+    num_conditions: u16,
+    num_test_vectors: usize,
+    decision_depth: u16,
+}
+
+impl From<MCDCMetaDecisionMapping> for Mapping {
+    fn from(
+        MCDCMetaDecisionMapping { span, bitmap_idx, num_conditions, num_test_vectors, .. }: MCDCMetaDecisionMapping,
+    ) -> Self {
+        // LLVM expects the ENDING bitmap index.
+        let bitmap_idx = bitmap_idx + num_test_vectors as u32;
+        Self { kind: MappingKind::MCDCDecision { bitmap_idx, num_conditions }, span }
+    }
+}
+
+#[derive(Default)]
+struct BitmapIndexGen {
+    idx: usize,
+}
+
+impl BitmapIndexGen {
+    #[inline(always)]
+    fn next(&mut self, num_tv: usize) -> Option<usize> {
+        let ret = self.idx;
+        let next_idx = ret + num_tv;
+
+        if next_idx < MCDC_MAX_BITMAP_SIZE {
+            self.idx = next_idx;
+            Some(ret)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the total number of bytes needed to accommodate for all the test
+    /// vectors of the function.
+    #[inline(always)]
+    fn total(self) -> usize {
+        self.idx
+    }
+}
+
+// LLVM uses `i32` to index the bitmap. Thus `i32::MAX` is the hard limit for
+// number of all test vectors in a function.
+const MCDC_MAX_BITMAP_SIZE: usize = i32::MAX as _;
+
+pub(crate) fn extract_mcdc_mappings(
+    mir_body: &mir::Body<'_>,
+    hir_info: &ExtractedHirInfo,
+    graph: &CoverageGraph,
+    expn_tree: &ExpnTree,
+) -> Option<(Vec<MCDCMetaMapping>, FunctionMCDCExtraInfo)> {
+    let Some(coverage_info_hi) = mir_body.coverage_info_hi.as_deref() else { return None };
+    let block_markers = resolve_block_markers(coverage_info_hi, mir_body);
+
+    // For now, ignore any MCDC decision span that was introduced by
+    // expansion. This makes things like assert macros less noisy.
+    // FIXME(peron): Investigate better expansion support.
+    let Some(node) = expn_tree.get(hir_info.body_span.ctxt()) else { return None };
+    if node.expn_kind != ExpnKind::Root {
+        return None;
+    }
+
+    // No decision to instrument, either because the function has no decision,
+    // or we didn't ask for MC/DC instrumentation.
+    if node.mcdc_spans.is_empty() {
+        return None;
+    }
+
+    let bcb_from_marker = |marker: BlockMarkerId| graph.bcb_from_bb(block_markers[marker]?);
+
+    let mut mcdc_mappings = vec![];
+    let mut bitmap_idx_gen = BitmapIndexGen::default();
+    let mut max_depth = 0;
+
+    for (decision, conditions) in node.mcdc_spans.iter() {
+        let end_bcbs = decision
+            .end_markers
+            .iter()
+            .map(|&marker| bcb_from_marker(marker))
+            .collect::<Option<BTreeSet<_>>>()?; // FIXME(renjisann): deal with bcb_from_marker errors.
+
+        let mut condition_meta_mappings = vec![];
+
+        for ConditionSpan { span, condition_info, true_marker, false_marker } in conditions {
+            let true_bcb = bcb_from_marker(*true_marker)?;
+            let false_bcb = bcb_from_marker(*false_marker)?;
+
+            condition_meta_mappings.push(MCDCMetaConditionMapping::new(
+                *span,
+                *condition_info,
+                true_bcb,
+                false_bcb,
+            ));
+        }
+
+        let num_test_vectors = calc_test_vectors_index(&mut condition_meta_mappings);
+        let Some(bitmap_idx) = bitmap_idx_gen.next(num_test_vectors) else {
+            tracing::debug!("Exceeded test vector limit");
+            return None;
+        };
+
+        let decision_meta_mapping = MCDCMetaDecisionMapping {
+            span: decision.span,
+            end_bcbs,
+            bitmap_idx: bitmap_idx as _,
+            num_conditions: decision.num_conditions as _,
+            num_test_vectors,
+            decision_depth: decision.decision_depth,
+        };
+
+        max_depth = max_depth.max(decision.decision_depth);
+
+        mcdc_mappings.push((decision_meta_mapping, condition_meta_mappings));
+    }
+
+    Some((
+        mcdc_mappings,
+        FunctionMCDCExtraInfo {
+            bitmap_bits: bitmap_idx_gen.total(),
+            num_temporaries: (max_depth as usize).saturating_add(1),
+        },
+    ))
+}
+
+pub(crate) fn inject_statements_for_decisions(
+    mir_body: &mut mir::Body<'_>,
+    graph: &CoverageGraph,
+    mappings: &Vec<(MCDCMetaDecisionMapping, Vec<MCDCMetaConditionMapping>)>,
+) {
+    for (decision, conditions) in mappings {
+        let &MCDCMetaDecisionMapping { ref end_bcbs, bitmap_idx, decision_depth, .. } = decision;
+
+        // Insert llvm.instrprof.mcdc.tvbitmap.update values.
+        for bcb in end_bcbs {
+            let leader_bb = graph[*bcb].leader_bb();
+            inject_statement(
+                mir_body,
+                CoverageKind::MCDCTestVectorBitmapUpdate { bitmap_idx, decision_depth },
+                leader_bb,
+            );
+        }
+
+        // Insert temporary variable updates for each visited condition.
+        let tmp_indexes_increments = conditions.iter().flat_map(
+            |MCDCMetaConditionMapping { true_bcb, false_bcb, true_incr, false_incr, .. }| {
+                [(true_bcb, true_incr), (false_bcb, false_incr)]
+            },
+        );
+
+        for (&bcb, &incr) in tmp_indexes_increments {
+            let leader_bb = graph[bcb].leader_bb();
+            inject_statement(
+                mir_body,
+                CoverageKind::MCDCTmpIdxUpdate { incr: incr as u32, decision_depth },
+                leader_bb,
+            );
+        }
+    }
+}
+
+// LLVM checks the executed test vector by accumulating indices of tested branches.
+// We calculate number of all possible test vectors of the decision and assign indices
+// to branches here.
+// See [the rfc](https://discourse.llvm.org/t/rfc-coverage-new-algorithm-and-file-format-for-mc-dc/76798/)
+// for more details about the algorithm.
+// This function is mostly like [`TVIdxBuilder::TvIdxBuilder`](https://github.com/llvm/llvm-project/blob/d594d9f7f4dc6eb748b3261917db689fdc348b96/llvm/lib/ProfileData/Coverage/CoverageMapping.cpp#L226)
+fn calc_test_vectors_index(conditions: &mut Vec<MCDCMetaConditionMapping>) -> usize {
+    let mut indegree_stats = IndexVec::<ConditionId, usize>::from_elem_n(0, conditions.len());
+
+    // `num_paths` is `width` described at the llvm rfc, which indicates how many paths reaching the condition node.
+    let mut num_paths_stats = IndexVec::<ConditionId, usize>::from_elem_n(0, conditions.len());
+    num_paths_stats[ConditionId::START] = 1;
+
+    let mut next_conditions = conditions
+        .iter_mut()
+        .map(|branch| {
+            let ConditionInfo { condition_id, true_next_id, false_next_id } = branch.condition_info;
+            [true_next_id, false_next_id]
+                .into_iter()
+                .flatten()
+                .for_each(|next_id| indegree_stats[next_id] += 1);
+            (condition_id, branch)
+        })
+        .collect::<FxIndexMap<_, _>>();
+    let mut queue =
+        std::collections::VecDeque::from_iter(next_conditions.swap_remove(&ConditionId::START));
+
+    let mut decision_end_nodes = Vec::new();
+
+    while let Some(branch) = queue.pop_front() {
+        let ConditionInfo { condition_id, true_next_id, false_next_id }: ConditionInfo =
+            branch.condition_info;
+
+        let (false_incr, true_incr) = (&mut branch.false_incr, &mut branch.true_incr);
+
+        // `width` of this branch
+        let this_paths_count = num_paths_stats[condition_id];
+
+        // Note. First check the false next to ensure conditions are touched in same order with llvm-cov.
+        for (next, incr) in [(false_next_id, false_incr), (true_next_id, true_incr)] {
+            if let Some(next_id) = next {
+                let next_paths_count = &mut num_paths_stats[next_id];
+                *incr = *next_paths_count;
+                *next_paths_count = next_paths_count.saturating_add(this_paths_count);
+                let next_indegree = &mut indegree_stats[next_id];
+                *next_indegree -= 1;
+                if *next_indegree == 0 {
+                    queue.push_back(next_conditions.swap_remove(&next_id).expect(
+                        "conditions with non-zero indegree before must be in next_conditions",
+                    ));
+                }
+            } else {
+                decision_end_nodes.push((this_paths_count, condition_id, incr));
+            }
+        }
+    }
+    assert!(next_conditions.is_empty(), "the decision tree has untouched nodes");
+    let mut cur_idx = 0;
+    // LLVM hopes the end nodes are sorted in descending order by `num_paths` so that it can
+    // optimize bitmap size for decisions in tree form such as `a && b && c && d && ...`.
+    decision_end_nodes.sort_by_key(|(num_paths, _, _)| usize::MAX - *num_paths);
+    for (num_paths, condition_id, index) in decision_end_nodes {
+        assert_eq!(
+            num_paths, num_paths_stats[condition_id],
+            "end nodes should not be updated since they were visited"
+        );
+        assert_eq!(*index, usize::MAX, "end nodes should not be assigned index before");
+        *index = cur_idx;
+        cur_idx += num_paths;
+    }
+    cur_idx
+}

--- a/compiler/rustc_mir_transform/src/coverage/mcdc.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mcdc.rs
@@ -60,6 +60,13 @@
 //!     [`CoverageKind`]`::TvBitmapUpdate` instructions in MIR, and generate
 //!     the [`Mapping`]s we'll be passing to LLVM.
 //!
+//! 3. Codegen. Happens in `rustc_codegen_ssa` and `rustc_codegen_llvm`.
+//!     At this step, `CoverageInfoBuilderMethods::init_coverage` generates
+//!     the required temporary variables, and
+//!     `CoverageInfoBuilderMethods::add_coverage` is then responsible for
+//!     translating the [`CoverageKind`] statements from MIR into their
+//!     corresponding LLVM instruction.
+//!
 
 use std::collections::BTreeSet;
 

--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -1,4 +1,4 @@
-use rustc_middle::mir::coverage::{CoverageKind, FunctionCoverageInfo};
+use rustc_middle::mir::coverage::{CoverageKind, FunctionCoverageInfo, Mapping};
 use rustc_middle::mir::{self, BasicBlock, Statement, StatementKind, TerminatorKind};
 use rustc_middle::ty::TyCtxt;
 use tracing::{debug, debug_span, trace};
@@ -13,6 +13,7 @@ mod from_mir;
 mod graph;
 mod hir_info;
 mod mappings;
+mod mcdc;
 pub(super) mod query;
 mod spans;
 #[cfg(test)]
@@ -72,7 +73,7 @@ fn instrument_function_for_coverage<'tcx>(tcx: TyCtxt<'tcx>, mir_body: &mut mir:
 
     ////////////////////////////////////////////////////
     // Extract coverage spans and other mapping info from MIR.
-    let ExtractedMappings { mappings } =
+    let ExtractedMappings { mut mappings, mcdc_data } =
         match mappings::extract_mappings_from_mir(tcx, mir_body, &hir_info, &graph) {
             Ok(m) => m,
             Err(error) => {
@@ -90,6 +91,18 @@ fn instrument_function_for_coverage<'tcx>(tcx: TyCtxt<'tcx>, mir_body: &mut mir:
     // Inject coverage statements into MIR.
     inject_coverage_statements(mir_body, &graph);
 
+    let mcdc_info = mcdc_data.map(|(mcdc_mappings, mcdc_info)| {
+        // Insert statements according to mappings meta data.
+        mcdc::inject_statements_for_decisions(mir_body, &graph, &mcdc_mappings);
+
+        // Make regular mappings from meta mappings and push them in the mapping list.
+        mappings.extend(mcdc_mappings.into_iter().flat_map(|(decision, conditions)| {
+            [decision.into()].into_iter().chain(conditions.into_iter().map(Mapping::from))
+        }));
+
+        mcdc_info
+    });
+
     mir_body.function_coverage_info = Some(Box::new(FunctionCoverageInfo {
         function_source_hash: hir_info.function_source_hash,
 
@@ -97,6 +110,7 @@ fn instrument_function_for_coverage<'tcx>(tcx: TyCtxt<'tcx>, mir_body: &mut mir:
         priority_list,
 
         mappings,
+        mcdc_info,
     }));
 }
 
@@ -108,7 +122,11 @@ fn inject_coverage_statements<'tcx>(mir_body: &mut mir::Body<'tcx>, graph: &Cove
     }
 }
 
-fn inject_statement(mir_body: &mut mir::Body<'_>, counter_kind: CoverageKind, bb: BasicBlock) {
+pub(crate) fn inject_statement(
+    mir_body: &mut mir::Body<'_>,
+    counter_kind: CoverageKind,
+    bb: BasicBlock,
+) {
     debug!("  injecting statement {counter_kind:?} for {bb:?}");
     let data = &mut mir_body[bb];
     let source_info = data.terminator().source_info;

--- a/compiler/rustc_mir_transform/src/coverage/query.rs
+++ b/compiler/rustc_mir_transform/src/coverage/query.rs
@@ -109,6 +109,13 @@ fn coverage_ids_info<'tcx>(
                 bcb_needs_counter.insert(true_bcb);
                 bcb_needs_counter.insert(false_bcb);
             }
+            MappingKind::MCDCCondition { true_bcb, false_bcb, .. } => {
+                // Not actually necessary for MC/DC, but needed to have branch
+                // coverage when instrumenting for MC/DC.
+                bcb_needs_counter.insert(true_bcb);
+                bcb_needs_counter.insert(false_bcb);
+            }
+            MappingKind::MCDCDecision { .. } => {}
         }
     }
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -190,6 +190,8 @@ pub enum CoverageLevel {
     /// instrumentation, so it might be removed in the future when MC/DC is
     /// sufficiently complete, or if it is making MC/DC changes difficult.
     Condition,
+    /// Instrument decisions for MC/DC coverage.
+    Mcdc,
 }
 
 // The different settings that the `-Z offload` flag can have.

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -849,7 +849,7 @@ mod desc {
     pub(crate) const parse_linker_flavor: &str = ::rustc_target::spec::LinkerFlavorCli::one_of();
     pub(crate) const parse_dump_mono_stats: &str = "`markdown` (default) or `json`";
     pub(crate) const parse_instrument_coverage: &str = parse_bool;
-    pub(crate) const parse_coverage_options: &str = "`block` | `branch` | `condition`";
+    pub(crate) const parse_coverage_options: &str = "`block` | `branch` | `condition` | `mcdc`";
     pub(crate) const parse_codegen_retag_options: &str =
         "either no value or a comma-separated list of settings: `no-precise-im`, `no-precise-pin`";
     pub(crate) const parse_instrument_mcount: &str =
@@ -1661,6 +1661,7 @@ pub mod parse {
                 "block" => slot.level = CoverageLevel::Block,
                 "branch" => slot.level = CoverageLevel::Branch,
                 "condition" => slot.level = CoverageLevel::Condition,
+                "mcdc" => slot.level = CoverageLevel::Mcdc,
                 "discard-all-spans-in-codegen" => slot.discard_all_spans_in_codegen = true,
                 _ => return false,
             }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -582,6 +582,11 @@ impl Session {
             && self.opts.unstable_opts.coverage_options.level >= CoverageLevel::Condition
     }
 
+    pub fn instrument_coverage_mcdc(&self) -> bool {
+        self.instrument_coverage()
+            && self.opts.unstable_opts.coverage_options.level >= CoverageLevel::Mcdc
+    }
+
     /// Provides direct access to the `CoverageOptions` struct, so that
     /// individual flags for debugging/testing coverage instrumetation don't
     /// need separate accessors.

--- a/src/doc/unstable-book/src/compiler-flags/coverage-options.md
+++ b/src/doc/unstable-book/src/compiler-flags/coverage-options.md
@@ -5,7 +5,7 @@ This option controls details of the coverage instrumentation performed by
 
 Multiple options can be passed, separated by commas. Valid options are:
 
-- `block`, `branch`, `condition`:
+- `block`, `branch`, `condition`, `mcdc`:
   Sets the level of coverage instrumentation.
   Setting the level will override any previously-specified level.
   - `block` (default):
@@ -15,3 +15,6 @@ Multiple options can be passed, separated by commas. Valid options are:
   - `condition`:
     In addition to branch coverage, also instruments some boolean expressions
     as branches, even if they are not directly used as branch conditions.
+  - `mcdc`:
+    In addition to condition coverage, also enables MC/DC instrumentation.
+    (Branch coverage instrumentation may differ in some cases.)

--- a/tests/coverage/mcdc/condition-limit.cov-map
+++ b/tests/coverage/mcdc/condition-limit.cov-map
@@ -1,0 +1,58 @@
+Function name: condition_limit::accept_7_conditions
+Raw bytes (192): 0x[01, 01, 08, 01, 05, 05, 09, 09, 0d, 0d, 11, 11, 15, 15, 19, 19, 1d, 01, 1d, 1b, 01, 06, 01, 00, 2c, 01, 01, 0a, 00, 0b, 01, 00, 0d, 00, 0e, 01, 00, 10, 00, 11, 01, 00, 13, 00, 14, 01, 00, 16, 00, 17, 01, 00, 19, 00, 1a, 01, 00, 1c, 00, 1d, 01, 00, 21, 00, 29, 01, 01, 08, 00, 09, 28, 08, 07, 00, 08, 00, 27, 30, 05, 02, 01, 07, 00, 00, 08, 00, 09, 05, 00, 0d, 00, 0e, 30, 09, 06, 07, 06, 00, 00, 0d, 00, 0e, 09, 00, 12, 00, 13, 30, 0d, 0a, 06, 05, 00, 00, 12, 00, 13, 0d, 00, 17, 00, 18, 30, 11, 0e, 05, 04, 00, 00, 17, 00, 18, 11, 00, 1c, 00, 1d, 30, 15, 12, 04, 03, 00, 00, 1c, 00, 1d, 15, 00, 21, 00, 22, 30, 19, 16, 03, 02, 00, 00, 21, 00, 22, 19, 00, 26, 00, 27, 30, 1d, 1a, 02, 00, 00, 00, 26, 00, 27, 1d, 00, 28, 02, 06, 1e, 02, 05, 00, 06, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/condition-limit.rs
+Number of expressions: 8
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 2 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 3 operands: lhs = Counter(3), rhs = Counter(4)
+- expression 4 operands: lhs = Counter(4), rhs = Counter(5)
+- expression 5 operands: lhs = Counter(5), rhs = Counter(6)
+- expression 6 operands: lhs = Counter(6), rhs = Counter(7)
+- expression 7 operands: lhs = Counter(0), rhs = Counter(7)
+Number of file 0 mappings: 27
+- Code(Counter(0)) at (prev + 6, 1) to (start + 0, 44)
+- Code(Counter(0)) at (prev + 1, 10) to (start + 0, 11)
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- Code(Counter(0)) at (prev + 0, 16) to (start + 0, 17)
+- Code(Counter(0)) at (prev + 0, 19) to (start + 0, 20)
+- Code(Counter(0)) at (prev + 0, 22) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 0, 25) to (start + 0, 26)
+- Code(Counter(0)) at (prev + 0, 28) to (start + 0, 29)
+- Code(Counter(0)) at (prev + 0, 33) to (start + 0, 41)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 9)
+- MCDCDecision { bitmap_idx: 8, conditions_num: 7 } at (prev + 0, 8) to (start + 0, 39)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 7, false_next_id: 0 } at (prev + 0, 8) to (start + 0, 9)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 14)
+- MCDCBranch { true: Counter(2), false: Expression(1, Sub), condition_id: 7, true_next_id: 6, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 14)
+    true  = c2
+    false = (c1 - c2)
+- Code(Counter(2)) at (prev + 0, 18) to (start + 0, 19)
+- MCDCBranch { true: Counter(3), false: Expression(2, Sub), condition_id: 6, true_next_id: 5, false_next_id: 0 } at (prev + 0, 18) to (start + 0, 19)
+    true  = c3
+    false = (c2 - c3)
+- Code(Counter(3)) at (prev + 0, 23) to (start + 0, 24)
+- MCDCBranch { true: Counter(4), false: Expression(3, Sub), condition_id: 5, true_next_id: 4, false_next_id: 0 } at (prev + 0, 23) to (start + 0, 24)
+    true  = c4
+    false = (c3 - c4)
+- Code(Counter(4)) at (prev + 0, 28) to (start + 0, 29)
+- MCDCBranch { true: Counter(5), false: Expression(4, Sub), condition_id: 4, true_next_id: 3, false_next_id: 0 } at (prev + 0, 28) to (start + 0, 29)
+    true  = c5
+    false = (c4 - c5)
+- Code(Counter(5)) at (prev + 0, 33) to (start + 0, 34)
+- MCDCBranch { true: Counter(6), false: Expression(5, Sub), condition_id: 3, true_next_id: 2, false_next_id: 0 } at (prev + 0, 33) to (start + 0, 34)
+    true  = c6
+    false = (c5 - c6)
+- Code(Counter(6)) at (prev + 0, 38) to (start + 0, 39)
+- MCDCBranch { true: Counter(7), false: Expression(6, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 38) to (start + 0, 39)
+    true  = c7
+    false = (c6 - c7)
+- Code(Counter(7)) at (prev + 0, 40) to (start + 2, 6)
+- Code(Expression(7, Sub)) at (prev + 2, 5) to (start + 0, 6)
+    = (c0 - c7)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c7
+

--- a/tests/coverage/mcdc/condition-limit.coverage
+++ b/tests/coverage/mcdc/condition-limit.coverage
@@ -1,0 +1,55 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2021
+   LL|       |//@ compile-flags: -Zcoverage-options=mcdc
+   LL|       |//@ llvm-cov-flags: --show-branches=count --show-mcdc
+   LL|       |
+   LL|      2|fn accept_7_conditions(bool_arr: [bool; 7]) {
+   LL|      2|    let [a, b, c, d, e, f, g] = bool_arr;
+   LL|      2|    if a && b && c && d && e && f && g {
+                          ^1   ^1   ^1   ^1   ^1   ^1
+  ------------------
+  |  Branch (LL:8): [True: 1, False: 1]
+  |  Branch (LL:13): [True: 1, False: 0]
+  |  Branch (LL:18): [True: 1, False: 0]
+  |  Branch (LL:23): [True: 1, False: 0]
+  |  Branch (LL:28): [True: 1, False: 0]
+  |  Branch (LL:33): [True: 1, False: 0]
+  |  Branch (LL:38): [True: 1, False: 0]
+  ------------------
+  |---> MC/DC Decision Region (LL:8) to (LL:39)
+  |
+  |  Number of Conditions: 7
+  |     Condition C1 --> (LL:8)
+  |     Condition C2 --> (LL:13)
+  |     Condition C3 --> (LL:18)
+  |     Condition C4 --> (LL:23)
+  |     Condition C5 --> (LL:28)
+  |     Condition C6 --> (LL:33)
+  |     Condition C7 --> (LL:38)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2, C3, C4, C5, C6, C7    Result
+  |  1 { F,  -,  -,  -,  -,  -,  -  = F      }
+  |  2 { T,  T,  T,  T,  T,  T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,2)
+  |  C2-Pair: not covered
+  |  C3-Pair: not covered
+  |  C4-Pair: not covered
+  |  C5-Pair: not covered
+  |  C6-Pair: not covered
+  |  C7-Pair: not covered
+  |  MC/DC Coverage for Decision: 14.29%
+  |
+  ------------------
+   LL|      1|        core::hint::black_box("hello");
+   LL|      1|    }
+   LL|      2|}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    accept_7_conditions([false; 7]);
+   LL|       |    accept_7_conditions([true; 7]);
+   LL|       |}
+

--- a/tests/coverage/mcdc/condition-limit.rs
+++ b/tests/coverage/mcdc/condition-limit.rs
@@ -1,0 +1,17 @@
+#![feature(coverage_attribute)]
+//@ edition: 2021
+//@ compile-flags: -Zcoverage-options=mcdc
+//@ llvm-cov-flags: --show-branches=count --show-mcdc
+
+fn accept_7_conditions(bool_arr: [bool; 7]) {
+    let [a, b, c, d, e, f, g] = bool_arr;
+    if a && b && c && d && e && f && g {
+        core::hint::black_box("hello");
+    }
+}
+
+#[coverage(off)]
+fn main() {
+    accept_7_conditions([false; 7]);
+    accept_7_conditions([true; 7]);
+}

--- a/tests/coverage/mcdc/if.cov-map
+++ b/tests/coverage/mcdc/if.cov-map
@@ -1,0 +1,223 @@
+Function name: if::mcdc_check_a
+Raw bytes (67): 0x[01, 01, 03, 01, 05, 05, 09, 01, 09, 09, 01, 0e, 01, 00, 22, 01, 01, 08, 00, 09, 28, 03, 02, 00, 08, 00, 0e, 30, 05, 02, 01, 02, 00, 00, 08, 00, 09, 05, 00, 0d, 00, 0e, 30, 09, 06, 02, 00, 00, 00, 0d, 00, 0e, 09, 00, 0f, 02, 06, 0a, 02, 0c, 02, 06, 01, 03, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/if.rs
+Number of expressions: 3
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(2)
+Number of file 0 mappings: 9
+- Code(Counter(0)) at (prev + 14, 1) to (start + 0, 34)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 9)
+- MCDCDecision { bitmap_idx: 3, conditions_num: 2 } at (prev + 0, 8) to (start + 0, 14)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 8) to (start + 0, 9)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 14)
+- MCDCBranch { true: Counter(2), false: Expression(1, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 14)
+    true  = c2
+    false = (c1 - c2)
+- Code(Counter(2)) at (prev + 0, 15) to (start + 2, 6)
+- Code(Expression(2, Sub)) at (prev + 2, 12) to (start + 2, 6)
+    = (c0 - c2)
+- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
+Highest counter ID seen: c2
+
+Function name: if::mcdc_check_b
+Raw bytes (67): 0x[01, 01, 03, 01, 05, 05, 09, 01, 09, 09, 01, 16, 01, 00, 22, 01, 01, 08, 00, 09, 28, 03, 02, 00, 08, 00, 0e, 30, 05, 02, 01, 02, 00, 00, 08, 00, 09, 05, 00, 0d, 00, 0e, 30, 09, 06, 02, 00, 00, 00, 0d, 00, 0e, 09, 00, 0f, 02, 06, 0a, 02, 0c, 02, 06, 01, 03, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/if.rs
+Number of expressions: 3
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(2)
+Number of file 0 mappings: 9
+- Code(Counter(0)) at (prev + 22, 1) to (start + 0, 34)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 9)
+- MCDCDecision { bitmap_idx: 3, conditions_num: 2 } at (prev + 0, 8) to (start + 0, 14)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 8) to (start + 0, 9)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 14)
+- MCDCBranch { true: Counter(2), false: Expression(1, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 14)
+    true  = c2
+    false = (c1 - c2)
+- Code(Counter(2)) at (prev + 0, 15) to (start + 2, 6)
+- Code(Expression(2, Sub)) at (prev + 2, 12) to (start + 2, 6)
+    = (c0 - c2)
+- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
+Highest counter ID seen: c2
+
+Function name: if::mcdc_check_both
+Raw bytes (67): 0x[01, 01, 03, 01, 05, 05, 09, 01, 09, 09, 01, 1e, 01, 00, 25, 01, 01, 08, 00, 09, 28, 03, 02, 00, 08, 00, 0e, 30, 05, 02, 01, 02, 00, 00, 08, 00, 09, 05, 00, 0d, 00, 0e, 30, 09, 06, 02, 00, 00, 00, 0d, 00, 0e, 09, 00, 0f, 02, 06, 0a, 02, 0c, 02, 06, 01, 03, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/if.rs
+Number of expressions: 3
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(2)
+Number of file 0 mappings: 9
+- Code(Counter(0)) at (prev + 30, 1) to (start + 0, 37)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 9)
+- MCDCDecision { bitmap_idx: 3, conditions_num: 2 } at (prev + 0, 8) to (start + 0, 14)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 8) to (start + 0, 9)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 14)
+- MCDCBranch { true: Counter(2), false: Expression(1, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 14)
+    true  = c2
+    false = (c1 - c2)
+- Code(Counter(2)) at (prev + 0, 15) to (start + 2, 6)
+- Code(Expression(2, Sub)) at (prev + 2, 12) to (start + 2, 6)
+    = (c0 - c2)
+- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
+Highest counter ID seen: c2
+
+Function name: if::mcdc_check_neither
+Raw bytes (67): 0x[01, 01, 03, 01, 05, 05, 09, 01, 09, 09, 01, 06, 01, 00, 28, 01, 01, 08, 00, 09, 28, 03, 02, 00, 08, 00, 0e, 30, 05, 02, 01, 02, 00, 00, 08, 00, 09, 05, 00, 0d, 00, 0e, 30, 09, 06, 02, 00, 00, 00, 0d, 00, 0e, 09, 00, 0f, 02, 06, 0a, 02, 0c, 02, 06, 01, 03, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/if.rs
+Number of expressions: 3
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(2)
+Number of file 0 mappings: 9
+- Code(Counter(0)) at (prev + 6, 1) to (start + 0, 40)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 9)
+- MCDCDecision { bitmap_idx: 3, conditions_num: 2 } at (prev + 0, 8) to (start + 0, 14)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 8) to (start + 0, 9)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 13) to (start + 0, 14)
+- MCDCBranch { true: Counter(2), false: Expression(1, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 14)
+    true  = c2
+    false = (c1 - c2)
+- Code(Counter(2)) at (prev + 0, 15) to (start + 2, 6)
+- Code(Expression(2, Sub)) at (prev + 2, 12) to (start + 2, 6)
+    = (c0 - c2)
+- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
+Highest counter ID seen: c2
+
+Function name: if::mcdc_check_not_tree_decision
+Raw bytes (90): 0x[01, 01, 07, 01, 05, 01, 17, 05, 09, 05, 09, 17, 0d, 05, 09, 01, 0d, 0b, 01, 30, 01, 00, 3b, 28, 05, 03, 03, 08, 00, 15, 01, 00, 09, 00, 0a, 30, 05, 02, 01, 02, 03, 00, 09, 00, 0a, 02, 00, 0e, 00, 0f, 30, 09, 06, 03, 02, 00, 00, 0e, 00, 0f, 17, 00, 14, 00, 15, 30, 0d, 12, 02, 00, 00, 00, 14, 00, 15, 0d, 00, 16, 02, 06, 1a, 02, 0c, 02, 06, 01, 03, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/if.rs
+Number of expressions: 7
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(0), rhs = Expression(5, Add)
+- expression 2 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 3 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 4 operands: lhs = Expression(5, Add), rhs = Counter(3)
+- expression 5 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 6 operands: lhs = Counter(0), rhs = Counter(3)
+Number of file 0 mappings: 11
+- Code(Counter(0)) at (prev + 48, 1) to (start + 0, 59)
+- MCDCDecision { bitmap_idx: 5, conditions_num: 3 } at (prev + 3, 8) to (start + 0, 21)
+- Code(Counter(0)) at (prev + 0, 9) to (start + 0, 10)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 3 } at (prev + 0, 9) to (start + 0, 10)
+    true  = c1
+    false = (c0 - c1)
+- Code(Expression(0, Sub)) at (prev + 0, 14) to (start + 0, 15)
+    = (c0 - c1)
+- MCDCBranch { true: Counter(2), false: Expression(1, Sub), condition_id: 3, true_next_id: 2, false_next_id: 0 } at (prev + 0, 14) to (start + 0, 15)
+    true  = c2
+    false = (c0 - (c1 + c2))
+- Code(Expression(5, Add)) at (prev + 0, 20) to (start + 0, 21)
+    = (c1 + c2)
+- MCDCBranch { true: Counter(3), false: Expression(4, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 20) to (start + 0, 21)
+    true  = c3
+    false = ((c1 + c2) - c3)
+- Code(Counter(3)) at (prev + 0, 22) to (start + 2, 6)
+- Code(Expression(6, Sub)) at (prev + 2, 12) to (start + 2, 6)
+    = (c0 - c3)
+- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
+Highest counter ID seen: c3
+
+Function name: if::mcdc_check_tree_decision
+Raw bytes (92): 0x[01, 01, 08, 01, 05, 05, 09, 05, 09, 05, 1f, 09, 0d, 09, 0d, 01, 1f, 09, 0d, 0b, 01, 26, 01, 00, 37, 01, 03, 08, 00, 09, 28, 04, 03, 00, 08, 00, 15, 30, 05, 02, 01, 02, 00, 00, 08, 00, 09, 05, 00, 0e, 00, 0f, 30, 09, 0a, 02, 00, 03, 00, 0e, 00, 0f, 0a, 00, 13, 00, 14, 30, 0d, 0e, 03, 00, 00, 00, 13, 00, 14, 1f, 00, 16, 02, 06, 1a, 02, 0c, 02, 06, 01, 03, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/if.rs
+Number of expressions: 8
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 2 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 3 operands: lhs = Counter(1), rhs = Expression(7, Add)
+- expression 4 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 5 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 6 operands: lhs = Counter(0), rhs = Expression(7, Add)
+- expression 7 operands: lhs = Counter(2), rhs = Counter(3)
+Number of file 0 mappings: 11
+- Code(Counter(0)) at (prev + 38, 1) to (start + 0, 55)
+- Code(Counter(0)) at (prev + 3, 8) to (start + 0, 9)
+- MCDCDecision { bitmap_idx: 4, conditions_num: 3 } at (prev + 0, 8) to (start + 0, 21)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 8) to (start + 0, 9)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 14) to (start + 0, 15)
+- MCDCBranch { true: Counter(2), false: Expression(2, Sub), condition_id: 2, true_next_id: 0, false_next_id: 3 } at (prev + 0, 14) to (start + 0, 15)
+    true  = c2
+    false = (c1 - c2)
+- Code(Expression(2, Sub)) at (prev + 0, 19) to (start + 0, 20)
+    = (c1 - c2)
+- MCDCBranch { true: Counter(3), false: Expression(3, Sub), condition_id: 3, true_next_id: 0, false_next_id: 0 } at (prev + 0, 19) to (start + 0, 20)
+    true  = c3
+    false = (c1 - (c2 + c3))
+- Code(Expression(7, Add)) at (prev + 0, 22) to (start + 2, 6)
+    = (c2 + c3)
+- Code(Expression(6, Sub)) at (prev + 2, 12) to (start + 2, 6)
+    = (c0 - (c2 + c3))
+- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
+Highest counter ID seen: c3
+
+Function name: if::mcdc_nested_if
+Raw bytes (139): 0x[01, 01, 0d, 01, 05, 01, 33, 05, 09, 05, 09, 05, 09, 05, 09, 33, 0d, 05, 09, 0d, 11, 33, 11, 05, 09, 01, 33, 05, 09, 11, 01, 3a, 01, 00, 2d, 01, 01, 08, 00, 09, 28, 03, 02, 00, 08, 00, 0e, 30, 05, 02, 01, 00, 02, 00, 08, 00, 09, 02, 00, 0d, 00, 0e, 30, 09, 2e, 02, 00, 00, 00, 0d, 00, 0e, 33, 01, 09, 00, 0c, 33, 00, 0d, 00, 15, 33, 01, 0c, 00, 0d, 28, 06, 02, 00, 0c, 00, 12, 30, 0d, 1a, 01, 02, 00, 00, 0c, 00, 0d, 0d, 00, 11, 00, 12, 30, 11, 22, 02, 00, 00, 00, 11, 00, 12, 11, 00, 13, 02, 0a, 26, 02, 09, 00, 0a, 2e, 01, 0c, 02, 06, 01, 03, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/if.rs
+Number of expressions: 13
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(0), rhs = Expression(12, Add)
+- expression 2 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 3 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 4 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 5 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 6 operands: lhs = Expression(12, Add), rhs = Counter(3)
+- expression 7 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 8 operands: lhs = Counter(3), rhs = Counter(4)
+- expression 9 operands: lhs = Expression(12, Add), rhs = Counter(4)
+- expression 10 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 11 operands: lhs = Counter(0), rhs = Expression(12, Add)
+- expression 12 operands: lhs = Counter(1), rhs = Counter(2)
+Number of file 0 mappings: 17
+- Code(Counter(0)) at (prev + 58, 1) to (start + 0, 45)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 9)
+- MCDCDecision { bitmap_idx: 3, conditions_num: 2 } at (prev + 0, 8) to (start + 0, 14)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 0, false_next_id: 2 } at (prev + 0, 8) to (start + 0, 9)
+    true  = c1
+    false = (c0 - c1)
+- Code(Expression(0, Sub)) at (prev + 0, 13) to (start + 0, 14)
+    = (c0 - c1)
+- MCDCBranch { true: Counter(2), false: Expression(11, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 14)
+    true  = c2
+    false = (c0 - (c1 + c2))
+- Code(Expression(12, Add)) at (prev + 1, 9) to (start + 0, 12)
+    = (c1 + c2)
+- Code(Expression(12, Add)) at (prev + 0, 13) to (start + 0, 21)
+    = (c1 + c2)
+- Code(Expression(12, Add)) at (prev + 1, 12) to (start + 0, 13)
+    = (c1 + c2)
+- MCDCDecision { bitmap_idx: 6, conditions_num: 2 } at (prev + 0, 12) to (start + 0, 18)
+- MCDCBranch { true: Counter(3), false: Expression(6, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 12) to (start + 0, 13)
+    true  = c3
+    false = ((c1 + c2) - c3)
+- Code(Counter(3)) at (prev + 0, 17) to (start + 0, 18)
+- MCDCBranch { true: Counter(4), false: Expression(8, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 17) to (start + 0, 18)
+    true  = c4
+    false = (c3 - c4)
+- Code(Counter(4)) at (prev + 0, 19) to (start + 2, 10)
+- Code(Expression(9, Sub)) at (prev + 2, 9) to (start + 0, 10)
+    = ((c1 + c2) - c4)
+- Code(Expression(11, Sub)) at (prev + 1, 12) to (start + 2, 6)
+    = (c0 - (c1 + c2))
+- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
+Highest counter ID seen: c4
+

--- a/tests/coverage/mcdc/if.coverage
+++ b/tests/coverage/mcdc/if.coverage
@@ -1,0 +1,287 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2021
+   LL|       |//@ compile-flags: -Zcoverage-options=mcdc
+   LL|       |//@ llvm-cov-flags: --show-branches=count --show-mcdc
+   LL|       |
+   LL|      2|fn mcdc_check_neither(a: bool, b: bool) {
+   LL|      2|    if a && b {
+                          ^0
+  ------------------
+  |  Branch (LL:8): [True: 0, False: 2]
+  |  Branch (LL:13): [True: 0, False: 0]
+  ------------------
+  |---> MC/DC Decision Region (LL:8) to (LL:14)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:8)
+  |     Condition C2 --> (LL:13)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |
+  |  C1-Pair: not covered
+  |  C2-Pair: not covered
+  |  MC/DC Coverage for Decision: 0.00%
+  |
+  ------------------
+   LL|      0|        say("a and b");
+   LL|      2|    } else {
+   LL|      2|        say("not both");
+   LL|      2|    }
+   LL|      2|}
+   LL|       |
+   LL|      2|fn mcdc_check_a(a: bool, b: bool) {
+   LL|      2|    if a && b {
+                          ^1
+  ------------------
+  |  Branch (LL:8): [True: 1, False: 1]
+  |  Branch (LL:13): [True: 1, False: 0]
+  ------------------
+  |---> MC/DC Decision Region (LL:8) to (LL:14)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:8)
+  |     Condition C2 --> (LL:13)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,2)
+  |  C2-Pair: not covered
+  |  MC/DC Coverage for Decision: 50.00%
+  |
+  ------------------
+   LL|      1|        say("a and b");
+   LL|      1|    } else {
+   LL|      1|        say("not both");
+   LL|      1|    }
+   LL|      2|}
+   LL|       |
+   LL|      2|fn mcdc_check_b(a: bool, b: bool) {
+   LL|      2|    if a && b {
+  ------------------
+  |  Branch (LL:8): [True: 2, False: 0]
+  |  Branch (LL:13): [True: 1, False: 1]
+  ------------------
+  |---> MC/DC Decision Region (LL:8) to (LL:14)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:8)
+  |     Condition C2 --> (LL:13)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { T,  F  = F      }
+  |  2 { T,  T  = T      }
+  |
+  |  C1-Pair: not covered
+  |  C2-Pair: covered: (1,2)
+  |  MC/DC Coverage for Decision: 50.00%
+  |
+  ------------------
+   LL|      1|        say("a and b");
+   LL|      1|    } else {
+   LL|      1|        say("not both");
+   LL|      1|    }
+   LL|      2|}
+   LL|       |
+   LL|      3|fn mcdc_check_both(a: bool, b: bool) {
+   LL|      3|    if a && b {
+                          ^2
+  ------------------
+  |  Branch (LL:8): [True: 2, False: 1]
+  |  Branch (LL:13): [True: 1, False: 1]
+  ------------------
+  |---> MC/DC Decision Region (LL:8) to (LL:14)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:8)
+  |     Condition C2 --> (LL:13)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  F  = F      }
+  |  3 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  ------------------
+   LL|      1|        say("a and b");
+   LL|      2|    } else {
+   LL|      2|        say("not both");
+   LL|      2|    }
+   LL|      3|}
+   LL|       |
+   LL|      4|fn mcdc_check_tree_decision(a: bool, b: bool, c: bool) {
+   LL|       |    // This expression is intentionally written in a way
+   LL|       |    // where 100% branch coverage indicates 100% mcdc coverage.
+   LL|      4|    if a && (b || c) {
+                           ^3   ^2
+  ------------------
+  |  Branch (LL:8): [True: 3, False: 1]
+  |  Branch (LL:14): [True: 1, False: 2]
+  |  Branch (LL:19): [True: 1, False: 1]
+  ------------------
+  |---> MC/DC Decision Region (LL:8) to (LL:21)
+  |
+  |  Number of Conditions: 3
+  |     Condition C1 --> (LL:8)
+  |     Condition C2 --> (LL:14)
+  |     Condition C3 --> (LL:19)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2, C3    Result
+  |  1 { F,  -,  -  = F      }
+  |  2 { T,  F,  F  = F      }
+  |  3 { T,  T,  -  = T      }
+  |  4 { T,  F,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  C3-Pair: covered: (2,4)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  ------------------
+   LL|      2|        say("pass");
+   LL|      2|    } else {
+   LL|      2|        say("reject");
+   LL|      2|    }
+   LL|      4|}
+   LL|       |
+   LL|      4|fn mcdc_check_not_tree_decision(a: bool, b: bool, c: bool) {
+   LL|       |    // Contradict to `mcdc_check_tree_decision`,
+   LL|       |    // 100% branch coverage of this expression does not indicate 100% mcdc coverage.
+   LL|      4|    if (a || b) && c {
+                           ^1
+  ------------------
+  |  Branch (LL:9): [True: 3, False: 1]
+  |  Branch (LL:14): [True: 1, False: 0]
+  |  Branch (LL:20): [True: 2, False: 2]
+  ------------------
+  |---> MC/DC Decision Region (LL:8) to (LL:21)
+  |
+  |  Number of Conditions: 3
+  |     Condition C1 --> (LL:9)
+  |     Condition C2 --> (LL:14)
+  |     Condition C3 --> (LL:20)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2, C3    Result
+  |  1 { T,  -,  F  = F      }
+  |  2 { T,  -,  T  = T      }
+  |  3 { F,  T,  T  = T      }
+  |
+  |  C1-Pair: not covered
+  |  C2-Pair: not covered
+  |  C3-Pair: covered: (1,2)
+  |  MC/DC Coverage for Decision: 33.33%
+  |
+  ------------------
+   LL|      2|        say("pass");
+   LL|      2|    } else {
+   LL|      2|        say("reject");
+   LL|      2|    }
+   LL|      4|}
+   LL|       |
+   LL|      3|fn mcdc_nested_if(a: bool, b: bool, c: bool) {
+   LL|      3|    if a || b {
+                          ^0
+  ------------------
+  |  Branch (LL:8): [True: 3, False: 0]
+  |  Branch (LL:13): [True: 0, False: 0]
+  ------------------
+  |---> MC/DC Decision Region (LL:8) to (LL:14)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:8)
+  |     Condition C2 --> (LL:13)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { T,  -  = T      }
+  |
+  |  C1-Pair: not covered
+  |  C2-Pair: not covered
+  |  MC/DC Coverage for Decision: 0.00%
+  |
+  ------------------
+   LL|      3|        say("a or b");
+   LL|      3|        if b && c {
+                              ^2
+  ------------------
+  |  Branch (LL:12): [True: 2, False: 1]
+  |  Branch (LL:17): [True: 1, False: 1]
+  ------------------
+  |---> MC/DC Decision Region (LL:12) to (LL:18)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:12)
+  |     Condition C2 --> (LL:17)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  F  = F      }
+  |  3 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  ------------------
+   LL|      1|            say("b and c");
+   LL|      2|        }
+   LL|      0|    } else {
+   LL|      0|        say("neither a nor b");
+   LL|      0|    }
+   LL|      3|}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    mcdc_check_neither(false, false);
+   LL|       |    mcdc_check_neither(false, true);
+   LL|       |
+   LL|       |    mcdc_check_a(true, true);
+   LL|       |    mcdc_check_a(false, true);
+   LL|       |
+   LL|       |    mcdc_check_b(true, true);
+   LL|       |    mcdc_check_b(true, false);
+   LL|       |
+   LL|       |    mcdc_check_both(false, true);
+   LL|       |    mcdc_check_both(true, true);
+   LL|       |    mcdc_check_both(true, false);
+   LL|       |
+   LL|       |    mcdc_check_tree_decision(false, true, true);
+   LL|       |    mcdc_check_tree_decision(true, true, false);
+   LL|       |    mcdc_check_tree_decision(true, false, false);
+   LL|       |    mcdc_check_tree_decision(true, false, true);
+   LL|       |
+   LL|       |    mcdc_check_not_tree_decision(false, true, true);
+   LL|       |    mcdc_check_not_tree_decision(true, true, false);
+   LL|       |    mcdc_check_not_tree_decision(true, false, false);
+   LL|       |    mcdc_check_not_tree_decision(true, false, true);
+   LL|       |
+   LL|       |    mcdc_nested_if(true, false, true);
+   LL|       |    mcdc_nested_if(true, true, true);
+   LL|       |    mcdc_nested_if(true, true, false);
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn say(message: &str) {
+   LL|       |    core::hint::black_box(message);
+   LL|       |}
+

--- a/tests/coverage/mcdc/if.rs
+++ b/tests/coverage/mcdc/if.rs
@@ -1,0 +1,102 @@
+#![feature(coverage_attribute)]
+//@ edition: 2021
+//@ compile-flags: -Zcoverage-options=mcdc
+//@ llvm-cov-flags: --show-branches=count --show-mcdc
+
+fn mcdc_check_neither(a: bool, b: bool) {
+    if a && b {
+        say("a and b");
+    } else {
+        say("not both");
+    }
+}
+
+fn mcdc_check_a(a: bool, b: bool) {
+    if a && b {
+        say("a and b");
+    } else {
+        say("not both");
+    }
+}
+
+fn mcdc_check_b(a: bool, b: bool) {
+    if a && b {
+        say("a and b");
+    } else {
+        say("not both");
+    }
+}
+
+fn mcdc_check_both(a: bool, b: bool) {
+    if a && b {
+        say("a and b");
+    } else {
+        say("not both");
+    }
+}
+
+fn mcdc_check_tree_decision(a: bool, b: bool, c: bool) {
+    // This expression is intentionally written in a way
+    // where 100% branch coverage indicates 100% mcdc coverage.
+    if a && (b || c) {
+        say("pass");
+    } else {
+        say("reject");
+    }
+}
+
+fn mcdc_check_not_tree_decision(a: bool, b: bool, c: bool) {
+    // Contradict to `mcdc_check_tree_decision`,
+    // 100% branch coverage of this expression does not indicate 100% mcdc coverage.
+    if (a || b) && c {
+        say("pass");
+    } else {
+        say("reject");
+    }
+}
+
+fn mcdc_nested_if(a: bool, b: bool, c: bool) {
+    if a || b {
+        say("a or b");
+        if b && c {
+            say("b and c");
+        }
+    } else {
+        say("neither a nor b");
+    }
+}
+
+#[coverage(off)]
+fn main() {
+    mcdc_check_neither(false, false);
+    mcdc_check_neither(false, true);
+
+    mcdc_check_a(true, true);
+    mcdc_check_a(false, true);
+
+    mcdc_check_b(true, true);
+    mcdc_check_b(true, false);
+
+    mcdc_check_both(false, true);
+    mcdc_check_both(true, true);
+    mcdc_check_both(true, false);
+
+    mcdc_check_tree_decision(false, true, true);
+    mcdc_check_tree_decision(true, true, false);
+    mcdc_check_tree_decision(true, false, false);
+    mcdc_check_tree_decision(true, false, true);
+
+    mcdc_check_not_tree_decision(false, true, true);
+    mcdc_check_not_tree_decision(true, true, false);
+    mcdc_check_not_tree_decision(true, false, false);
+    mcdc_check_not_tree_decision(true, false, true);
+
+    mcdc_nested_if(true, false, true);
+    mcdc_nested_if(true, true, true);
+    mcdc_nested_if(true, true, false);
+}
+
+#[coverage(off)]
+fn say(message: &str) {
+    core::hint::black_box(message);
+}

--- a/tests/coverage/mcdc/inlined_expressions.cov-map
+++ b/tests/coverage/mcdc/inlined_expressions.cov-map
@@ -1,0 +1,21 @@
+Function name: inlined_expressions::inlined_instance
+Raw bytes (55): 0x[01, 01, 02, 01, 05, 05, 09, 07, 01, 07, 01, 00, 2e, 01, 01, 05, 00, 06, 28, 03, 02, 00, 05, 00, 0b, 30, 05, 02, 01, 02, 00, 00, 05, 00, 06, 05, 00, 0a, 00, 0b, 30, 09, 06, 02, 00, 00, 00, 0a, 00, 0b, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/inlined_expressions.rs
+Number of expressions: 2
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+Number of file 0 mappings: 7
+- Code(Counter(0)) at (prev + 7, 1) to (start + 0, 46)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 6)
+- MCDCDecision { bitmap_idx: 3, conditions_num: 2 } at (prev + 0, 5) to (start + 0, 11)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 5) to (start + 0, 6)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 10) to (start + 0, 11)
+- MCDCBranch { true: Counter(2), false: Expression(1, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 10) to (start + 0, 11)
+    true  = c2
+    false = (c1 - c2)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c2
+

--- a/tests/coverage/mcdc/inlined_expressions.coverage
+++ b/tests/coverage/mcdc/inlined_expressions.coverage
@@ -1,0 +1,40 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2021
+   LL|       |//@ compile-flags: -Zcoverage-options=mcdc -Copt-level=z -Cllvm-args=--inline-threshold=0
+   LL|       |//@ llvm-cov-flags: --show-branches=count --show-mcdc
+   LL|       |
+   LL|       |#[inline(always)]
+   LL|      3|fn inlined_instance(a: bool, b: bool) -> bool {
+   LL|      3|    a && b
+                       ^2
+  ------------------
+  |  Branch (LL:5): [True: 2, False: 1]
+  |  Branch (LL:10): [True: 1, False: 1]
+  ------------------
+  |---> MC/DC Decision Region (LL:5) to (LL:11)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:5)
+  |     Condition C2 --> (LL:10)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  F  = F      }
+  |  3 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  ------------------
+   LL|      3|}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    let _ = inlined_instance(true, false);
+   LL|       |    let _ = inlined_instance(false, true);
+   LL|       |    let _ = inlined_instance(true, true);
+   LL|       |}
+

--- a/tests/coverage/mcdc/inlined_expressions.rs
+++ b/tests/coverage/mcdc/inlined_expressions.rs
@@ -1,0 +1,16 @@
+#![feature(coverage_attribute)]
+//@ edition: 2021
+//@ compile-flags: -Zcoverage-options=mcdc -Copt-level=z -Cllvm-args=--inline-threshold=0
+//@ llvm-cov-flags: --show-branches=count --show-mcdc
+
+#[inline(always)]
+fn inlined_instance(a: bool, b: bool) -> bool {
+    a && b
+}
+
+#[coverage(off)]
+fn main() {
+    let _ = inlined_instance(true, false);
+    let _ = inlined_instance(false, true);
+    let _ = inlined_instance(true, true);
+}

--- a/tests/coverage/mcdc/nested_if.cov-map
+++ b/tests/coverage/mcdc/nested_if.cov-map
@@ -1,0 +1,200 @@
+Function name: nested_if::doubly_nested_if_in_condition
+Raw bytes (175): 0x[01, 01, 0f, 01, 05, 05, 11, 05, 09, 05, 37, 09, 0d, 05, 09, 05, 1f, 09, 15, 15, 19, 05, 2b, 09, 19, 09, 0d, 05, 37, 09, 0d, 01, 11, 15, 01, 0e, 01, 00, 45, 01, 01, 08, 00, 09, 28, 09, 02, 00, 08, 00, 4e, 30, 05, 02, 01, 02, 00, 00, 08, 00, 09, 30, 11, 06, 02, 00, 00, 00, 0d, 00, 4e, 05, 00, 10, 00, 11, 28, 06, 02, 00, 10, 00, 36, 30, 09, 16, 01, 00, 02, 00, 10, 00, 11, 30, 0d, 32, 02, 00, 00, 00, 15, 00, 36, 16, 00, 18, 00, 19, 28, 03, 02, 00, 18, 00, 1e, 30, 15, 1a, 01, 02, 00, 00, 18, 00, 19, 15, 00, 1d, 00, 1e, 30, 19, 22, 02, 00, 00, 00, 1d, 00, 1e, 19, 00, 21, 00, 25, 26, 00, 2f, 00, 34, 37, 00, 39, 00, 3e, 32, 00, 48, 00, 4c, 11, 00, 4f, 02, 06, 3a, 02, 0c, 02, 06, 01, 03, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/nested_if.rs
+Number of expressions: 15
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(4)
+- expression 2 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 3 operands: lhs = Counter(1), rhs = Expression(13, Add)
+- expression 4 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 5 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 6 operands: lhs = Counter(1), rhs = Expression(7, Add)
+- expression 7 operands: lhs = Counter(2), rhs = Counter(5)
+- expression 8 operands: lhs = Counter(5), rhs = Counter(6)
+- expression 9 operands: lhs = Counter(1), rhs = Expression(10, Add)
+- expression 10 operands: lhs = Counter(2), rhs = Counter(6)
+- expression 11 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 12 operands: lhs = Counter(1), rhs = Expression(13, Add)
+- expression 13 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 14 operands: lhs = Counter(0), rhs = Counter(4)
+Number of file 0 mappings: 21
+- Code(Counter(0)) at (prev + 14, 1) to (start + 0, 69)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 9)
+- MCDCDecision { bitmap_idx: 9, conditions_num: 2 } at (prev + 0, 8) to (start + 0, 78)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 8) to (start + 0, 9)
+    true  = c1
+    false = (c0 - c1)
+- MCDCBranch { true: Counter(4), false: Expression(1, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 78)
+    true  = c4
+    false = (c1 - c4)
+- Code(Counter(1)) at (prev + 0, 16) to (start + 0, 17)
+- MCDCDecision { bitmap_idx: 6, conditions_num: 2 } at (prev + 0, 16) to (start + 0, 54)
+- MCDCBranch { true: Counter(2), false: Expression(5, Sub), condition_id: 1, true_next_id: 0, false_next_id: 2 } at (prev + 0, 16) to (start + 0, 17)
+    true  = c2
+    false = (c1 - c2)
+- MCDCBranch { true: Counter(3), false: Expression(12, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 21) to (start + 0, 54)
+    true  = c3
+    false = (c1 - (c2 + c3))
+- Code(Expression(5, Sub)) at (prev + 0, 24) to (start + 0, 25)
+    = (c1 - c2)
+- MCDCDecision { bitmap_idx: 3, conditions_num: 2 } at (prev + 0, 24) to (start + 0, 30)
+- MCDCBranch { true: Counter(5), false: Expression(6, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 24) to (start + 0, 25)
+    true  = c5
+    false = (c1 - (c2 + c5))
+- Code(Counter(5)) at (prev + 0, 29) to (start + 0, 30)
+- MCDCBranch { true: Counter(6), false: Expression(8, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 29) to (start + 0, 30)
+    true  = c6
+    false = (c5 - c6)
+- Code(Counter(6)) at (prev + 0, 33) to (start + 0, 37)
+- Code(Expression(9, Sub)) at (prev + 0, 47) to (start + 0, 52)
+    = (c1 - (c2 + c6))
+- Code(Expression(13, Add)) at (prev + 0, 57) to (start + 0, 62)
+    = (c2 + c3)
+- Code(Expression(12, Sub)) at (prev + 0, 72) to (start + 0, 76)
+    = (c1 - (c2 + c3))
+- Code(Counter(4)) at (prev + 0, 79) to (start + 2, 6)
+- Code(Expression(14, Sub)) at (prev + 2, 12) to (start + 2, 6)
+    = (c0 - c4)
+- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
+Highest counter ID seen: c6
+
+Function name: nested_if::nested_if_in_condition
+Raw bytes (123): 0x[01, 01, 0a, 01, 05, 05, 11, 05, 09, 05, 09, 05, 23, 09, 0d, 09, 0d, 05, 23, 09, 0d, 01, 11, 0f, 01, 06, 01, 00, 35, 01, 01, 08, 00, 09, 28, 06, 02, 00, 08, 00, 2e, 30, 05, 02, 01, 02, 00, 00, 08, 00, 09, 30, 11, 06, 02, 00, 00, 00, 0d, 00, 2e, 05, 00, 10, 00, 11, 28, 03, 02, 00, 10, 00, 16, 30, 09, 0e, 01, 00, 02, 00, 10, 00, 11, 0e, 00, 15, 00, 16, 30, 0d, 1e, 02, 00, 00, 00, 15, 00, 16, 23, 00, 19, 00, 1d, 1e, 00, 27, 00, 2c, 11, 00, 2f, 02, 06, 26, 02, 0c, 02, 06, 01, 03, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/nested_if.rs
+Number of expressions: 10
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(4)
+- expression 2 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 3 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 4 operands: lhs = Counter(1), rhs = Expression(8, Add)
+- expression 5 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 6 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 7 operands: lhs = Counter(1), rhs = Expression(8, Add)
+- expression 8 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 9 operands: lhs = Counter(0), rhs = Counter(4)
+Number of file 0 mappings: 15
+- Code(Counter(0)) at (prev + 6, 1) to (start + 0, 53)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 9)
+- MCDCDecision { bitmap_idx: 6, conditions_num: 2 } at (prev + 0, 8) to (start + 0, 46)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 8) to (start + 0, 9)
+    true  = c1
+    false = (c0 - c1)
+- MCDCBranch { true: Counter(4), false: Expression(1, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 46)
+    true  = c4
+    false = (c1 - c4)
+- Code(Counter(1)) at (prev + 0, 16) to (start + 0, 17)
+- MCDCDecision { bitmap_idx: 3, conditions_num: 2 } at (prev + 0, 16) to (start + 0, 22)
+- MCDCBranch { true: Counter(2), false: Expression(3, Sub), condition_id: 1, true_next_id: 0, false_next_id: 2 } at (prev + 0, 16) to (start + 0, 17)
+    true  = c2
+    false = (c1 - c2)
+- Code(Expression(3, Sub)) at (prev + 0, 21) to (start + 0, 22)
+    = (c1 - c2)
+- MCDCBranch { true: Counter(3), false: Expression(7, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 21) to (start + 0, 22)
+    true  = c3
+    false = (c1 - (c2 + c3))
+- Code(Expression(8, Add)) at (prev + 0, 25) to (start + 0, 29)
+    = (c2 + c3)
+- Code(Expression(7, Sub)) at (prev + 0, 39) to (start + 0, 44)
+    = (c1 - (c2 + c3))
+- Code(Counter(4)) at (prev + 0, 47) to (start + 2, 6)
+- Code(Expression(9, Sub)) at (prev + 2, 12) to (start + 2, 6)
+    = (c0 - c4)
+- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
+Highest counter ID seen: c4
+
+Function name: nested_if::nested_in_then_block_in_condition
+Raw bytes (175): 0x[01, 01, 0f, 01, 05, 05, 19, 05, 09, 05, 09, 05, 37, 09, 0d, 09, 0d, 37, 11, 09, 0d, 11, 15, 37, 15, 09, 0d, 05, 37, 09, 0d, 01, 19, 15, 01, 21, 01, 00, 52, 01, 01, 08, 00, 09, 28, 09, 02, 00, 08, 00, 4b, 30, 05, 02, 01, 02, 00, 00, 08, 00, 09, 30, 19, 06, 02, 00, 00, 00, 0d, 00, 4b, 05, 00, 10, 00, 11, 28, 03, 02, 00, 10, 00, 16, 30, 09, 0e, 01, 00, 02, 00, 10, 00, 11, 0e, 00, 15, 00, 16, 30, 0d, 32, 02, 00, 00, 00, 15, 00, 16, 37, 00, 1c, 00, 1d, 28, 06, 02, 00, 1c, 00, 22, 30, 11, 1e, 01, 02, 00, 00, 1c, 00, 1d, 11, 00, 21, 00, 22, 30, 15, 26, 02, 00, 00, 00, 21, 00, 22, 15, 00, 25, 00, 29, 2a, 00, 33, 00, 38, 32, 00, 44, 00, 49, 19, 00, 4c, 02, 06, 3a, 02, 0c, 02, 06, 01, 03, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/nested_if.rs
+Number of expressions: 15
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(6)
+- expression 2 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 3 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 4 operands: lhs = Counter(1), rhs = Expression(13, Add)
+- expression 5 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 6 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 7 operands: lhs = Expression(13, Add), rhs = Counter(4)
+- expression 8 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 9 operands: lhs = Counter(4), rhs = Counter(5)
+- expression 10 operands: lhs = Expression(13, Add), rhs = Counter(5)
+- expression 11 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 12 operands: lhs = Counter(1), rhs = Expression(13, Add)
+- expression 13 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 14 operands: lhs = Counter(0), rhs = Counter(6)
+Number of file 0 mappings: 21
+- Code(Counter(0)) at (prev + 33, 1) to (start + 0, 82)
+- Code(Counter(0)) at (prev + 1, 8) to (start + 0, 9)
+- MCDCDecision { bitmap_idx: 9, conditions_num: 2 } at (prev + 0, 8) to (start + 0, 75)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 8) to (start + 0, 9)
+    true  = c1
+    false = (c0 - c1)
+- MCDCBranch { true: Counter(6), false: Expression(1, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 75)
+    true  = c6
+    false = (c1 - c6)
+- Code(Counter(1)) at (prev + 0, 16) to (start + 0, 17)
+- MCDCDecision { bitmap_idx: 3, conditions_num: 2 } at (prev + 0, 16) to (start + 0, 22)
+- MCDCBranch { true: Counter(2), false: Expression(3, Sub), condition_id: 1, true_next_id: 0, false_next_id: 2 } at (prev + 0, 16) to (start + 0, 17)
+    true  = c2
+    false = (c1 - c2)
+- Code(Expression(3, Sub)) at (prev + 0, 21) to (start + 0, 22)
+    = (c1 - c2)
+- MCDCBranch { true: Counter(3), false: Expression(12, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 21) to (start + 0, 22)
+    true  = c3
+    false = (c1 - (c2 + c3))
+- Code(Expression(13, Add)) at (prev + 0, 28) to (start + 0, 29)
+    = (c2 + c3)
+- MCDCDecision { bitmap_idx: 6, conditions_num: 2 } at (prev + 0, 28) to (start + 0, 34)
+- MCDCBranch { true: Counter(4), false: Expression(7, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 28) to (start + 0, 29)
+    true  = c4
+    false = ((c2 + c3) - c4)
+- Code(Counter(4)) at (prev + 0, 33) to (start + 0, 34)
+- MCDCBranch { true: Counter(5), false: Expression(9, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 33) to (start + 0, 34)
+    true  = c5
+    false = (c4 - c5)
+- Code(Counter(5)) at (prev + 0, 37) to (start + 0, 41)
+- Code(Expression(10, Sub)) at (prev + 0, 51) to (start + 0, 56)
+    = ((c2 + c3) - c5)
+- Code(Expression(12, Sub)) at (prev + 0, 68) to (start + 0, 73)
+    = (c1 - (c2 + c3))
+- Code(Counter(6)) at (prev + 0, 76) to (start + 2, 6)
+- Code(Expression(14, Sub)) at (prev + 2, 12) to (start + 2, 6)
+    = (c0 - c6)
+- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
+Highest counter ID seen: c6
+
+Function name: nested_if::nested_single_condition_decision
+Raw bytes (88): 0x[01, 01, 05, 01, 05, 05, 0d, 05, 09, 05, 09, 01, 0d, 0c, 01, 16, 01, 00, 36, 01, 04, 08, 00, 09, 28, 03, 02, 00, 08, 00, 29, 30, 05, 02, 01, 02, 00, 00, 08, 00, 09, 30, 0d, 06, 02, 00, 00, 00, 0d, 00, 29, 05, 00, 10, 00, 11, 20, 09, 0e, 00, 10, 00, 11, 09, 00, 14, 00, 19, 0e, 00, 23, 00, 27, 0d, 00, 2a, 02, 06, 12, 02, 0c, 02, 06, 01, 03, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/nested_if.rs
+Number of expressions: 5
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(3)
+- expression 2 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 3 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 4 operands: lhs = Counter(0), rhs = Counter(3)
+Number of file 0 mappings: 12
+- Code(Counter(0)) at (prev + 22, 1) to (start + 0, 54)
+- Code(Counter(0)) at (prev + 4, 8) to (start + 0, 9)
+- MCDCDecision { bitmap_idx: 3, conditions_num: 2 } at (prev + 0, 8) to (start + 0, 41)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 8) to (start + 0, 9)
+    true  = c1
+    false = (c0 - c1)
+- MCDCBranch { true: Counter(3), false: Expression(1, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 41)
+    true  = c3
+    false = (c1 - c3)
+- Code(Counter(1)) at (prev + 0, 16) to (start + 0, 17)
+- Branch { true: Counter(2), false: Expression(3, Sub) } at (prev + 0, 16) to (start + 0, 17)
+    true  = c2
+    false = (c1 - c2)
+- Code(Counter(2)) at (prev + 0, 20) to (start + 0, 25)
+- Code(Expression(3, Sub)) at (prev + 0, 35) to (start + 0, 39)
+    = (c1 - c2)
+- Code(Counter(3)) at (prev + 0, 42) to (start + 2, 6)
+- Code(Expression(4, Sub)) at (prev + 2, 12) to (start + 2, 6)
+    = (c0 - c3)
+- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
+Highest counter ID seen: c3
+

--- a/tests/coverage/mcdc/nested_if.coverage
+++ b/tests/coverage/mcdc/nested_if.coverage
@@ -1,0 +1,257 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2021
+   LL|       |//@ compile-flags: -Zcoverage-options=mcdc
+   LL|       |//@ llvm-cov-flags: --show-branches=count --show-mcdc
+   LL|       |
+   LL|      4|fn nested_if_in_condition(a: bool, b: bool, c: bool) {
+   LL|      4|    if a && if b || c { true } else { false } {
+                             ^3   ^2  ^2            ^1
+  ------------------
+  |  Branch (LL:8): [True: 3, False: 1]
+  |  Branch (LL:13): [True: 2, False: 1]
+  |  Branch (LL:16): [True: 1, False: 2]
+  |  Branch (LL:21): [True: 1, False: 1]
+  ------------------
+  |---> MC/DC Decision Region (LL:8) to (LL:46)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:8)
+  |     Condition C2 --> (LL:13)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  F  = F      }
+  |  3 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  |---> MC/DC Decision Region (LL:16) to (LL:22)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:16)
+  |     Condition C2 --> (LL:21)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  F  = F      }
+  |  2 { T,  -  = T      }
+  |  3 { F,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,2)
+  |  C2-Pair: covered: (1,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  ------------------
+   LL|      2|        say("yes");
+   LL|      2|    } else {
+   LL|      2|        say("no");
+   LL|      2|    }
+   LL|      4|}
+   LL|       |
+   LL|      4|fn doubly_nested_if_in_condition(a: bool, b: bool, c: bool, d: bool) {
+   LL|      4|    if a && if b || if c && d { true } else { false } { false } else { true } {
+                             ^3      ^2   ^1  ^1            ^1        ^2             ^1
+  ------------------
+  |  Branch (LL:8): [True: 3, False: 1]
+  |  Branch (LL:13): [True: 1, False: 2]
+  |  Branch (LL:16): [True: 1, False: 2]
+  |  Branch (LL:21): [True: 1, False: 1]
+  |  Branch (LL:24): [True: 1, False: 1]
+  |  Branch (LL:29): [True: 1, False: 0]
+  ------------------
+  |---> MC/DC Decision Region (LL:8) to (LL:78)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:8)
+  |     Condition C2 --> (LL:13)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  F  = F      }
+  |  3 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  |---> MC/DC Decision Region (LL:16) to (LL:54)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:16)
+  |     Condition C2 --> (LL:21)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  F  = F      }
+  |  2 { T,  -  = T      }
+  |  3 { F,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,2)
+  |  C2-Pair: covered: (1,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  |---> MC/DC Decision Region (LL:24) to (LL:30)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:24)
+  |     Condition C2 --> (LL:29)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,2)
+  |  C2-Pair: not covered
+  |  MC/DC Coverage for Decision: 50.00%
+  |
+  ------------------
+   LL|      1|        say("yes");
+   LL|      3|    } else {
+   LL|      3|        say("no");
+   LL|      3|    }
+   LL|      4|}
+   LL|       |
+   LL|      3|fn nested_single_condition_decision(a: bool, b: bool) {
+   LL|       |    // Decision with only 1 decision should not be instrumented by MCDC because
+   LL|       |    // branch-coverage is equivalent to MCDC coverage in this case, and we don't
+   LL|       |    // want to waste bitmap space for this.
+   LL|      3|    if a && if b { false } else { true } {
+                             ^2  ^1             ^1
+  ------------------
+  |  Branch (LL:8): [True: 2, False: 1]
+  |  Branch (LL:13): [True: 1, False: 1]
+  |  Branch (LL:16): [True: 1, False: 1]
+  ------------------
+  |---> MC/DC Decision Region (LL:8) to (LL:41)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:8)
+  |     Condition C2 --> (LL:13)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  F  = F      }
+  |  3 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  ------------------
+   LL|      1|        say("yes");
+   LL|      2|    } else {
+   LL|      2|        say("no");
+   LL|      2|    }
+   LL|      3|}
+   LL|       |
+   LL|      7|fn nested_in_then_block_in_condition(a: bool, b: bool, c: bool, d: bool, e: bool) {
+   LL|      7|    if a && if b || c { if d && e { true } else { false } } else { false } {
+                             ^6   ^5     ^5   ^2  ^1            ^4               ^1
+  ------------------
+  |  Branch (LL:8): [True: 6, False: 1]
+  |  Branch (LL:13): [True: 1, False: 5]
+  |  Branch (LL:16): [True: 1, False: 5]
+  |  Branch (LL:21): [True: 4, False: 1]
+  |  Branch (LL:28): [True: 2, False: 3]
+  |  Branch (LL:33): [True: 1, False: 1]
+  ------------------
+  |---> MC/DC Decision Region (LL:8) to (LL:75)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:8)
+  |     Condition C2 --> (LL:13)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  F  = F      }
+  |  3 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  |---> MC/DC Decision Region (LL:16) to (LL:22)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:16)
+  |     Condition C2 --> (LL:21)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  F  = F      }
+  |  2 { T,  -  = T      }
+  |  3 { F,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,2)
+  |  C2-Pair: covered: (1,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  |---> MC/DC Decision Region (LL:28) to (LL:34)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:28)
+  |     Condition C2 --> (LL:33)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  F  = F      }
+  |  3 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  ------------------
+   LL|      1|        say("yes");
+   LL|      6|    } else {
+   LL|      6|        say("no");
+   LL|      6|    }
+   LL|      7|}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    nested_if_in_condition(true, false, false);
+   LL|       |    nested_if_in_condition(true, true, true);
+   LL|       |    nested_if_in_condition(true, false, true);
+   LL|       |    nested_if_in_condition(false, true, true);
+   LL|       |
+   LL|       |    doubly_nested_if_in_condition(true, false, false, true);
+   LL|       |    doubly_nested_if_in_condition(true, true, true, true);
+   LL|       |    doubly_nested_if_in_condition(true, false, true, true);
+   LL|       |    doubly_nested_if_in_condition(false, true, true, true);
+   LL|       |
+   LL|       |    nested_single_condition_decision(true, true);
+   LL|       |    nested_single_condition_decision(true, false);
+   LL|       |    nested_single_condition_decision(false, false);
+   LL|       |
+   LL|       |    nested_in_then_block_in_condition(false, false, false, false, false);
+   LL|       |    nested_in_then_block_in_condition(true, false, false, false, false);
+   LL|       |    nested_in_then_block_in_condition(true, true, false, false, false);
+   LL|       |    nested_in_then_block_in_condition(true, false, true, false, false);
+   LL|       |    nested_in_then_block_in_condition(true, false, true, true, false);
+   LL|       |    nested_in_then_block_in_condition(true, false, true, false, true);
+   LL|       |    nested_in_then_block_in_condition(true, false, true, true, true);
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn say(message: &str) {
+   LL|       |    core::hint::black_box(message);
+   LL|       |}
+

--- a/tests/coverage/mcdc/nested_if.rs
+++ b/tests/coverage/mcdc/nested_if.rs
@@ -1,0 +1,69 @@
+#![feature(coverage_attribute)]
+//@ edition: 2021
+//@ compile-flags: -Zcoverage-options=mcdc
+//@ llvm-cov-flags: --show-branches=count --show-mcdc
+
+fn nested_if_in_condition(a: bool, b: bool, c: bool) {
+    if a && if b || c { true } else { false } {
+        say("yes");
+    } else {
+        say("no");
+    }
+}
+
+fn doubly_nested_if_in_condition(a: bool, b: bool, c: bool, d: bool) {
+    if a && if b || if c && d { true } else { false } { false } else { true } {
+        say("yes");
+    } else {
+        say("no");
+    }
+}
+
+fn nested_single_condition_decision(a: bool, b: bool) {
+    // Decision with only 1 decision should not be instrumented by MCDC because
+    // branch-coverage is equivalent to MCDC coverage in this case, and we don't
+    // want to waste bitmap space for this.
+    if a && if b { false } else { true } {
+        say("yes");
+    } else {
+        say("no");
+    }
+}
+
+fn nested_in_then_block_in_condition(a: bool, b: bool, c: bool, d: bool, e: bool) {
+    if a && if b || c { if d && e { true } else { false } } else { false } {
+        say("yes");
+    } else {
+        say("no");
+    }
+}
+
+#[coverage(off)]
+fn main() {
+    nested_if_in_condition(true, false, false);
+    nested_if_in_condition(true, true, true);
+    nested_if_in_condition(true, false, true);
+    nested_if_in_condition(false, true, true);
+
+    doubly_nested_if_in_condition(true, false, false, true);
+    doubly_nested_if_in_condition(true, true, true, true);
+    doubly_nested_if_in_condition(true, false, true, true);
+    doubly_nested_if_in_condition(false, true, true, true);
+
+    nested_single_condition_decision(true, true);
+    nested_single_condition_decision(true, false);
+    nested_single_condition_decision(false, false);
+
+    nested_in_then_block_in_condition(false, false, false, false, false);
+    nested_in_then_block_in_condition(true, false, false, false, false);
+    nested_in_then_block_in_condition(true, true, false, false, false);
+    nested_in_then_block_in_condition(true, false, true, false, false);
+    nested_in_then_block_in_condition(true, false, true, true, false);
+    nested_in_then_block_in_condition(true, false, true, false, true);
+    nested_in_then_block_in_condition(true, false, true, true, true);
+}
+
+#[coverage(off)]
+fn say(message: &str) {
+    core::hint::black_box(message);
+}

--- a/tests/coverage/mcdc/non_control_flow.cov-map
+++ b/tests/coverage/mcdc/non_control_flow.cov-map
@@ -1,0 +1,186 @@
+Function name: non_control_flow::assign_3
+Raw bytes (89): 0x[01, 01, 04, 01, 05, 01, 0b, 05, 09, 09, 0d, 0c, 01, 15, 01, 00, 27, 01, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 28, 04, 03, 00, 0d, 00, 18, 30, 05, 02, 01, 00, 02, 00, 0d, 00, 0e, 02, 00, 12, 00, 13, 30, 09, 06, 02, 03, 00, 00, 12, 00, 13, 09, 00, 17, 00, 18, 30, 0d, 0e, 03, 00, 00, 00, 17, 00, 18, 01, 01, 05, 00, 0e, 01, 00, 0f, 00, 10, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/non_control_flow.rs
+Number of expressions: 4
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(0), rhs = Expression(2, Add)
+- expression 2 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 3 operands: lhs = Counter(2), rhs = Counter(3)
+Number of file 0 mappings: 12
+- Code(Counter(0)) at (prev + 21, 1) to (start + 0, 39)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- MCDCDecision { bitmap_idx: 4, conditions_num: 3 } at (prev + 0, 13) to (start + 0, 24)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 0, false_next_id: 2 } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Expression(0, Sub)) at (prev + 0, 18) to (start + 0, 19)
+    = (c0 - c1)
+- MCDCBranch { true: Counter(2), false: Expression(1, Sub), condition_id: 2, true_next_id: 3, false_next_id: 0 } at (prev + 0, 18) to (start + 0, 19)
+    true  = c2
+    false = (c0 - (c1 + c2))
+- Code(Counter(2)) at (prev + 0, 23) to (start + 0, 24)
+- MCDCBranch { true: Counter(3), false: Expression(3, Sub), condition_id: 3, true_next_id: 0, false_next_id: 0 } at (prev + 0, 23) to (start + 0, 24)
+    true  = c3
+    false = (c2 - c3)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 14)
+- Code(Counter(0)) at (prev + 0, 15) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c3
+
+Function name: non_control_flow::assign_3_bis
+Raw bytes (91): 0x[01, 01, 05, 01, 05, 05, 09, 01, 09, 01, 13, 09, 0d, 0c, 01, 1a, 01, 00, 2b, 01, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 28, 05, 03, 00, 0d, 00, 18, 30, 05, 02, 01, 03, 02, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 30, 09, 06, 03, 00, 02, 00, 12, 00, 13, 0a, 00, 17, 00, 18, 30, 0d, 0e, 02, 00, 00, 00, 17, 00, 18, 01, 01, 05, 00, 0e, 01, 00, 0f, 00, 10, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/non_control_flow.rs
+Number of expressions: 5
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 2 operands: lhs = Counter(0), rhs = Counter(2)
+- expression 3 operands: lhs = Counter(0), rhs = Expression(4, Add)
+- expression 4 operands: lhs = Counter(2), rhs = Counter(3)
+Number of file 0 mappings: 12
+- Code(Counter(0)) at (prev + 26, 1) to (start + 0, 43)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- MCDCDecision { bitmap_idx: 5, conditions_num: 3 } at (prev + 0, 13) to (start + 0, 24)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 3, false_next_id: 2 } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 18) to (start + 0, 19)
+- MCDCBranch { true: Counter(2), false: Expression(1, Sub), condition_id: 3, true_next_id: 0, false_next_id: 2 } at (prev + 0, 18) to (start + 0, 19)
+    true  = c2
+    false = (c1 - c2)
+- Code(Expression(2, Sub)) at (prev + 0, 23) to (start + 0, 24)
+    = (c0 - c2)
+- MCDCBranch { true: Counter(3), false: Expression(3, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 23) to (start + 0, 24)
+    true  = c3
+    false = (c0 - (c2 + c3))
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 14)
+- Code(Counter(0)) at (prev + 0, 15) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c3
+
+Function name: non_control_flow::assign_and
+Raw bytes (70): 0x[01, 01, 02, 01, 05, 05, 09, 0a, 01, 0b, 01, 00, 20, 01, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 28, 03, 02, 00, 0d, 00, 13, 30, 05, 02, 01, 02, 00, 00, 0d, 00, 0e, 05, 00, 12, 00, 13, 30, 09, 06, 02, 00, 00, 00, 12, 00, 13, 01, 01, 05, 00, 0e, 01, 00, 0f, 00, 10, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/non_control_flow.rs
+Number of expressions: 2
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+Number of file 0 mappings: 10
+- Code(Counter(0)) at (prev + 11, 1) to (start + 0, 32)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- MCDCDecision { bitmap_idx: 3, conditions_num: 2 } at (prev + 0, 13) to (start + 0, 19)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 18) to (start + 0, 19)
+- MCDCBranch { true: Counter(2), false: Expression(1, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 18) to (start + 0, 19)
+    true  = c2
+    false = (c1 - c2)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 14)
+- Code(Counter(0)) at (prev + 0, 15) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c2
+
+Function name: non_control_flow::assign_or
+Raw bytes (72): 0x[01, 01, 03, 01, 05, 01, 0b, 05, 09, 0a, 01, 10, 01, 00, 1f, 01, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 28, 03, 02, 00, 0d, 00, 13, 30, 05, 02, 01, 00, 02, 00, 0d, 00, 0e, 02, 00, 12, 00, 13, 30, 09, 06, 02, 00, 00, 00, 12, 00, 13, 01, 01, 05, 00, 0e, 01, 00, 0f, 00, 10, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/non_control_flow.rs
+Number of expressions: 3
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(0), rhs = Expression(2, Add)
+- expression 2 operands: lhs = Counter(1), rhs = Counter(2)
+Number of file 0 mappings: 10
+- Code(Counter(0)) at (prev + 16, 1) to (start + 0, 31)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- MCDCDecision { bitmap_idx: 3, conditions_num: 2 } at (prev + 0, 13) to (start + 0, 19)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 0, false_next_id: 2 } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Expression(0, Sub)) at (prev + 0, 18) to (start + 0, 19)
+    = (c0 - c1)
+- MCDCBranch { true: Counter(2), false: Expression(1, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 18) to (start + 0, 19)
+    true  = c2
+    false = (c0 - (c1 + c2))
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 14)
+- Code(Counter(0)) at (prev + 0, 15) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c2
+
+Function name: non_control_flow::foo
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 24, 01, 00, 18, 01, 01, 05, 00, 0e, 01, 00, 0f, 00, 10, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/non_control_flow.rs
+Number of expressions: 0
+Number of file 0 mappings: 4
+- Code(Counter(0)) at (prev + 36, 1) to (start + 0, 24)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 14)
+- Code(Counter(0)) at (prev + 0, 15) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c0
+
+Function name: non_control_flow::func_call
+Raw bytes (60): 0x[01, 01, 02, 01, 05, 05, 09, 08, 01, 28, 01, 00, 1f, 01, 01, 05, 00, 08, 01, 00, 09, 00, 0a, 28, 03, 02, 00, 09, 00, 0f, 30, 05, 02, 01, 02, 00, 00, 09, 00, 0a, 05, 00, 0e, 00, 0f, 30, 09, 06, 02, 00, 00, 00, 0e, 00, 0f, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/non_control_flow.rs
+Number of expressions: 2
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+Number of file 0 mappings: 8
+- Code(Counter(0)) at (prev + 40, 1) to (start + 0, 31)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 8)
+- Code(Counter(0)) at (prev + 0, 9) to (start + 0, 10)
+- MCDCDecision { bitmap_idx: 3, conditions_num: 2 } at (prev + 0, 9) to (start + 0, 15)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 9) to (start + 0, 10)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 14) to (start + 0, 15)
+- MCDCBranch { true: Counter(2), false: Expression(1, Sub), condition_id: 2, true_next_id: 0, false_next_id: 0 } at (prev + 0, 14) to (start + 0, 15)
+    true  = c2
+    false = (c1 - c2)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c2
+
+Function name: non_control_flow::right_comb_tree
+Raw bytes (121): 0x[01, 01, 05, 01, 05, 05, 09, 09, 0d, 0d, 11, 11, 15, 10, 01, 1f, 01, 00, 40, 01, 01, 09, 00, 0a, 01, 00, 0d, 00, 0e, 28, 06, 05, 00, 0d, 00, 2a, 30, 05, 02, 01, 02, 00, 00, 0d, 00, 0e, 05, 00, 13, 00, 14, 30, 09, 06, 02, 03, 00, 00, 13, 00, 14, 09, 00, 19, 00, 1a, 30, 0d, 0a, 03, 04, 00, 00, 19, 00, 1a, 0d, 00, 1f, 00, 20, 30, 11, 0e, 04, 05, 00, 00, 1f, 00, 20, 11, 00, 24, 00, 27, 30, 15, 12, 05, 00, 00, 00, 24, 00, 27, 01, 01, 05, 00, 0e, 01, 00, 0f, 00, 10, 01, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/non_control_flow.rs
+Number of expressions: 5
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
+- expression 2 operands: lhs = Counter(2), rhs = Counter(3)
+- expression 3 operands: lhs = Counter(3), rhs = Counter(4)
+- expression 4 operands: lhs = Counter(4), rhs = Counter(5)
+Number of file 0 mappings: 16
+- Code(Counter(0)) at (prev + 31, 1) to (start + 0, 64)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 0, 13) to (start + 0, 14)
+- MCDCDecision { bitmap_idx: 6, conditions_num: 5 } at (prev + 0, 13) to (start + 0, 42)
+- MCDCBranch { true: Counter(1), false: Expression(0, Sub), condition_id: 1, true_next_id: 2, false_next_id: 0 } at (prev + 0, 13) to (start + 0, 14)
+    true  = c1
+    false = (c0 - c1)
+- Code(Counter(1)) at (prev + 0, 19) to (start + 0, 20)
+- MCDCBranch { true: Counter(2), false: Expression(1, Sub), condition_id: 2, true_next_id: 3, false_next_id: 0 } at (prev + 0, 19) to (start + 0, 20)
+    true  = c2
+    false = (c1 - c2)
+- Code(Counter(2)) at (prev + 0, 25) to (start + 0, 26)
+- MCDCBranch { true: Counter(3), false: Expression(2, Sub), condition_id: 3, true_next_id: 4, false_next_id: 0 } at (prev + 0, 25) to (start + 0, 26)
+    true  = c3
+    false = (c2 - c3)
+- Code(Counter(3)) at (prev + 0, 31) to (start + 0, 32)
+- MCDCBranch { true: Counter(4), false: Expression(3, Sub), condition_id: 4, true_next_id: 5, false_next_id: 0 } at (prev + 0, 31) to (start + 0, 32)
+    true  = c4
+    false = (c3 - c4)
+- Code(Counter(4)) at (prev + 0, 36) to (start + 0, 39)
+- MCDCBranch { true: Counter(5), false: Expression(4, Sub), condition_id: 5, true_next_id: 0, false_next_id: 0 } at (prev + 0, 36) to (start + 0, 39)
+    true  = c5
+    false = (c4 - c5)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 14)
+- Code(Counter(0)) at (prev + 0, 15) to (start + 0, 16)
+- Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c5
+

--- a/tests/coverage/mcdc/non_control_flow.coverage
+++ b/tests/coverage/mcdc/non_control_flow.coverage
@@ -1,0 +1,224 @@
+   LL|       |#![feature(coverage_attribute)]
+   LL|       |//@ edition: 2021
+   LL|       |//@ compile-flags: -Zcoverage-options=mcdc
+   LL|       |//@ llvm-cov-flags: --show-branches=count --show-mcdc
+   LL|       |
+   LL|       |// This test ensures that boolean expressions that are not inside control flow
+   LL|       |// decisions are correctly instrumented.
+   LL|       |
+   LL|       |use core::hint::black_box;
+   LL|       |
+   LL|      3|fn assign_and(a: bool, b: bool) {
+   LL|      3|    let x = a && b;
+                               ^2
+  ------------------
+  |  Branch (LL:13): [True: 2, False: 1]
+  |  Branch (LL:18): [True: 1, False: 1]
+  ------------------
+  |---> MC/DC Decision Region (LL:13) to (LL:19)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:13)
+  |     Condition C2 --> (LL:18)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  F  = F      }
+  |  3 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  ------------------
+   LL|      3|    black_box(x);
+   LL|      3|}
+   LL|       |
+   LL|      3|fn assign_or(a: bool, b: bool) {
+   LL|      3|    let x = a || b;
+                               ^1
+  ------------------
+  |  Branch (LL:13): [True: 2, False: 1]
+  |  Branch (LL:18): [True: 0, False: 1]
+  ------------------
+  |---> MC/DC Decision Region (LL:13) to (LL:19)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:13)
+  |     Condition C2 --> (LL:18)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  F  = F      }
+  |  2 { T,  -  = T      }
+  |
+  |  C1-Pair: covered: (1,2)
+  |  C2-Pair: not covered
+  |  MC/DC Coverage for Decision: 50.00%
+  |
+  ------------------
+   LL|      3|    black_box(x);
+   LL|      3|}
+   LL|       |
+   LL|      4|fn assign_3(a: bool, b: bool, c: bool) {
+   LL|      4|    let x = a || b && c;
+                               ^2   ^1
+  ------------------
+  |  Branch (LL:13): [True: 2, False: 2]
+  |  Branch (LL:18): [True: 1, False: 1]
+  |  Branch (LL:23): [True: 1, False: 0]
+  ------------------
+  |---> MC/DC Decision Region (LL:13) to (LL:24)
+  |
+  |  Number of Conditions: 3
+  |     Condition C1 --> (LL:13)
+  |     Condition C2 --> (LL:18)
+  |     Condition C3 --> (LL:23)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2, C3    Result
+  |  1 { F,  F,  -  = F      }
+  |  2 { T,  -,  -  = T      }
+  |  3 { F,  T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,2)
+  |  C2-Pair: covered: (1,3)
+  |  C3-Pair: not covered
+  |  MC/DC Coverage for Decision: 66.67%
+  |
+  ------------------
+   LL|      4|    black_box(x);
+   LL|      4|}
+   LL|       |
+   LL|      4|fn assign_3_bis(a: bool, b: bool, c: bool) {
+   LL|      4|    let x = a && b || c;
+                               ^2   ^3
+  ------------------
+  |  Branch (LL:13): [True: 2, False: 2]
+  |  Branch (LL:18): [True: 1, False: 1]
+  |  Branch (LL:23): [True: 2, False: 1]
+  ------------------
+  |---> MC/DC Decision Region (LL:13) to (LL:24)
+  |
+  |  Number of Conditions: 3
+  |     Condition C1 --> (LL:13)
+  |     Condition C2 --> (LL:18)
+  |     Condition C3 --> (LL:23)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2, C3    Result
+  |  1 { T,  F,  F  = F      }
+  |  2 { F,  -,  T  = T      }
+  |  3 { T,  T,  -  = T      }
+  |
+  |  C1-Pair: not covered
+  |  C2-Pair: covered: (1,3)
+  |  C3-Pair: not covered
+  |  MC/DC Coverage for Decision: 33.33%
+  |
+  ------------------
+   LL|      4|    black_box(x);
+   LL|      4|}
+   LL|       |
+   LL|      3|fn right_comb_tree(a: bool, b: bool, c: bool, d: bool, e: bool) {
+   LL|      3|    let x = a && (b && (c && (d && (e))));
+                                ^2    ^1    ^1   ^1
+  ------------------
+  |  Branch (LL:13): [True: 2, False: 1]
+  |  Branch (LL:19): [True: 1, False: 1]
+  |  Branch (LL:25): [True: 1, False: 0]
+  |  Branch (LL:31): [True: 1, False: 0]
+  |  Branch (LL:36): [True: 1, False: 0]
+  ------------------
+  |---> MC/DC Decision Region (LL:13) to (LL:42)
+  |
+  |  Number of Conditions: 5
+  |     Condition C1 --> (LL:13)
+  |     Condition C2 --> (LL:19)
+  |     Condition C3 --> (LL:25)
+  |     Condition C4 --> (LL:31)
+  |     Condition C5 --> (LL:36)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2, C3, C4, C5    Result
+  |  1 { F,  -,  -,  -,  -  = F      }
+  |  2 { T,  F,  -,  -,  -  = F      }
+  |  3 { T,  T,  T,  T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  C3-Pair: not covered
+  |  C4-Pair: not covered
+  |  C5-Pair: not covered
+  |  MC/DC Coverage for Decision: 40.00%
+  |
+  ------------------
+   LL|      3|    black_box(x);
+   LL|      3|}
+   LL|       |
+   LL|      3|fn foo(a: bool) -> bool {
+   LL|      3|    black_box(a)
+   LL|      3|}
+   LL|       |
+   LL|      3|fn func_call(a: bool, b: bool) {
+   LL|      3|    foo(a && b);
+                           ^2
+  ------------------
+  |  Branch (LL:9): [True: 2, False: 1]
+  |  Branch (LL:14): [True: 1, False: 1]
+  ------------------
+  |---> MC/DC Decision Region (LL:9) to (LL:15)
+  |
+  |  Number of Conditions: 2
+  |     Condition C1 --> (LL:9)
+  |     Condition C2 --> (LL:14)
+  |
+  |  Executed MC/DC Test Vectors:
+  |
+  |     C1, C2    Result
+  |  1 { F,  -  = F      }
+  |  2 { T,  F  = F      }
+  |  3 { T,  T  = T      }
+  |
+  |  C1-Pair: covered: (1,3)
+  |  C2-Pair: covered: (2,3)
+  |  MC/DC Coverage for Decision: 100.00%
+  |
+  ------------------
+   LL|      3|}
+   LL|       |
+   LL|       |#[coverage(off)]
+   LL|       |fn main() {
+   LL|       |    assign_and(true, false);
+   LL|       |    assign_and(true, true);
+   LL|       |    assign_and(false, false);
+   LL|       |
+   LL|       |    assign_or(true, false);
+   LL|       |    assign_or(true, true);
+   LL|       |    assign_or(false, false);
+   LL|       |
+   LL|       |    assign_3(true, false, false);
+   LL|       |    assign_3(true, true, false);
+   LL|       |    assign_3(false, false, true);
+   LL|       |    assign_3(false, true, true);
+   LL|       |
+   LL|       |    assign_3_bis(true, false, false);
+   LL|       |    assign_3_bis(true, true, false);
+   LL|       |    assign_3_bis(false, false, true);
+   LL|       |    assign_3_bis(false, true, true);
+   LL|       |
+   LL|       |    right_comb_tree(false, false, false, true, true);
+   LL|       |    right_comb_tree(true, false, false, true, true);
+   LL|       |    right_comb_tree(true, true, true, true, true);
+   LL|       |
+   LL|       |    func_call(true, false);
+   LL|       |    func_call(true, true);
+   LL|       |    func_call(false, false);
+   LL|       |}
+

--- a/tests/coverage/mcdc/non_control_flow.rs
+++ b/tests/coverage/mcdc/non_control_flow.rs
@@ -1,0 +1,71 @@
+#![feature(coverage_attribute)]
+//@ edition: 2021
+//@ compile-flags: -Zcoverage-options=mcdc
+//@ llvm-cov-flags: --show-branches=count --show-mcdc
+
+// This test ensures that boolean expressions that are not inside control flow
+// decisions are correctly instrumented.
+
+use core::hint::black_box;
+
+fn assign_and(a: bool, b: bool) {
+    let x = a && b;
+    black_box(x);
+}
+
+fn assign_or(a: bool, b: bool) {
+    let x = a || b;
+    black_box(x);
+}
+
+fn assign_3(a: bool, b: bool, c: bool) {
+    let x = a || b && c;
+    black_box(x);
+}
+
+fn assign_3_bis(a: bool, b: bool, c: bool) {
+    let x = a && b || c;
+    black_box(x);
+}
+
+fn right_comb_tree(a: bool, b: bool, c: bool, d: bool, e: bool) {
+    let x = a && (b && (c && (d && (e))));
+    black_box(x);
+}
+
+fn foo(a: bool) -> bool {
+    black_box(a)
+}
+
+fn func_call(a: bool, b: bool) {
+    foo(a && b);
+}
+
+#[coverage(off)]
+fn main() {
+    assign_and(true, false);
+    assign_and(true, true);
+    assign_and(false, false);
+
+    assign_or(true, false);
+    assign_or(true, true);
+    assign_or(false, false);
+
+    assign_3(true, false, false);
+    assign_3(true, true, false);
+    assign_3(false, false, true);
+    assign_3(false, true, true);
+
+    assign_3_bis(true, false, false);
+    assign_3_bis(true, true, false);
+    assign_3_bis(false, false, true);
+    assign_3_bis(false, true, true);
+
+    right_comb_tree(false, false, false, true, true);
+    right_comb_tree(true, false, false, true, true);
+    right_comb_tree(true, true, true, true, true);
+
+    func_call(true, false);
+    func_call(true, true);
+    func_call(false, false);
+}

--- a/tests/ui/instrument-coverage/coverage-options.bad.stderr
+++ b/tests/ui/instrument-coverage/coverage-options.bad.stderr
@@ -1,2 +1,2 @@
-error: incorrect value `bad` for unstable option `coverage-options` - `block` | `branch` | `condition` was expected
+error: incorrect value `bad` for unstable option `coverage-options` - `block` | `branch` | `condition` | `mcdc` was expected
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
Follow-up of rust-lang/rust#161223
<!-- homu-ignore:end -->

Tracking issue: https://github.com/rust-lang/goals/issues/638

Finalize MC/DC implementation for boolean expressions.

1. Introduce FFI structures and functions for passing MC/DC mappings to LLVM
2. Transform MC/DC MIR statements into their corresponding LLVM instructions
4. Add tests

<!-- homu-ignore:start -->
r? @davidtwco
<!-- homu-ignore:end -->
