### PR TITLE
implement `Add` and `Sub` for `Complex`

### DIFF
--- a/library/core/src/num/complex.rs
+++ b/library/core/src/num/complex.rs
@@ -1,5 +1,7 @@
+use crate::ops::{Add, Sub};
+
 /// A complex number.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[unstable(feature = "complex_numbers", issue = "154023")]
 #[repr(C)]
 #[lang = "complex"]
@@ -16,5 +18,41 @@ impl<T> Complex<T> {
     #[must_use]
     pub fn new(re: T, im: T) -> Complex<T> {
         Complex { re, im }
+    }
+}
+
+#[unstable(feature = "complex_numbers", issue = "154023")]
+impl<T: Add> Add<Self> for Complex<T> {
+    type Output = Complex<T::Output>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Complex::new(self.re + rhs.re, self.im + rhs.im)
+    }
+}
+
+#[unstable(feature = "complex_numbers", issue = "154023")]
+impl<T: Add<Output = T>> Add<T> for Complex<T> {
+    type Output = Complex<T::Output>;
+
+    fn add(self, rhs: T) -> Self::Output {
+        Complex::new(self.re + rhs, self.im)
+    }
+}
+
+#[unstable(feature = "complex_numbers", issue = "154023")]
+impl<T: Sub> Sub<Self> for Complex<T> {
+    type Output = Complex<T::Output>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Complex::new(self.re - rhs.re, self.im - rhs.im)
+    }
+}
+
+#[unstable(feature = "complex_numbers", issue = "154023")]
+impl<T: Sub<Output = T>> Sub<T> for Complex<T> {
+    type Output = Complex<T::Output>;
+
+    fn sub(self, rhs: T) -> Self::Output {
+        Complex::new(self.re - rhs, self.im)
     }
 }

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -16,6 +16,7 @@
 #![feature(clone_to_uninit)]
 #![feature(cmp_minmax)]
 #![feature(cmp_splat)]
+#![feature(complex_numbers)]
 #![feature(const_array)]
 #![feature(const_bool)]
 #![feature(const_cell_traits)]

--- a/library/coretests/tests/num/complex.rs
+++ b/library/coretests/tests/num/complex.rs
@@ -1,0 +1,44 @@
+use core::num::{Complex, Wrapping};
+
+#[test]
+fn complex_addition() {
+    let a = Complex::new(1, 2);
+    let b = Complex::new(3, 4);
+    assert_eq!(a + b, Complex::new(a.re + b.re, a.im + b.im));
+    assert_eq!(a + b, b + a);
+    assert_eq!(a + 8, Complex::new(a.re + 8, a.im));
+
+    let a = Complex::new(Wrapping(1u8), Wrapping(2));
+    let b = Complex::new(Wrapping(3u8), Wrapping(4));
+    assert_eq!(a + b, Complex::new(a.re + b.re, a.im + b.im));
+    assert_eq!(a + b, b + a);
+    let c = a + Wrapping(u8::MAX);
+    assert_eq!(c, Complex::new(a.re + Wrapping(u8::MAX), a.im));
+    assert_eq!(c.re.0, 1u8.wrapping_add(u8::MAX));
+
+    let a = Complex::new(1.0, 2.0);
+    let b = Complex::new(3.0, 4.0);
+    assert_eq!(a + b, Complex::new(a.re + b.re, a.im + b.im));
+    assert_eq!(a + b, b + a);
+    assert_eq!(a + 8.0, Complex::new(a.re + 8.0, a.im));
+}
+
+#[test]
+fn complex_subtraction() {
+    let a = Complex::new(1, 2);
+    let b = Complex::new(3, 4);
+    assert_eq!(a - b, Complex::new(a.re - b.re, a.im - b.im));
+    assert_eq!(a - 8, Complex::new(a.re - 8, a.im));
+
+    let a = Complex::new(Wrapping(1u8), Wrapping(2));
+    let b = Complex::new(Wrapping(3u8), Wrapping(4));
+    assert_eq!(a - b, Complex::new(a.re - b.re, a.im - b.im));
+    let c = a - Wrapping(u8::MAX);
+    assert_eq!(c, Complex::new(a.re - Wrapping(u8::MAX), a.im));
+    assert_eq!(c.re.0, 1u8.wrapping_sub(u8::MAX));
+
+    let a = Complex::new(1.0, 2.0);
+    let b = Complex::new(3.0, 4.0);
+    assert_eq!(a - b, Complex::new(a.re - b.re, a.im - b.im));
+    assert_eq!(a - 8.0, Complex::new(a.re - 8.0, a.im));
+}

--- a/library/coretests/tests/num/mod.rs
+++ b/library/coretests/tests/num/mod.rs
@@ -24,6 +24,7 @@ mod u8;
 mod bignum;
 mod carryless_mul;
 mod cast;
+mod complex;
 mod const_from;
 mod dec2flt;
 mod float_ieee754_flt2dec_dec2flt;


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161227)*
<!-- homu-ignore:end -->

tracking issue: https://github.com/rust-lang/rust/issues/154023

Adds the `Add` and `Sub` implementations described in the tracking issue. Some notes 

- I also added a derive for `Eq`, which is useful for `Complex<{integer}>`
- The versions that add/sub by a scalar need a `Copy` bound. That seems fine for most actual use cases. 

Apparently `num_complex` will `Clone` in these operations https://docs.rs/num-complex/latest/num_complex/struct.Complex.html#impl-Add%3CT%3E-for-%26Complex%3CT%3E, but that seems unlike `core` to me. Anyhow, libs can re-litigate that later.