### PR TITLE
Remove jdno from infra-ci rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1605,7 +1605,6 @@ infra-ci = [
     "@Mark-Simulacrum",
     "@Kobzol",
     "@marcoieni",
-    "@jdno",
     "@jieyouxu",
     "@ubiratansoares"
 ]


### PR DESCRIPTION
Triagebot keeps assigning JD to infra PRs, but I don't think that he has been active in reviewing for the past few months. So I think it's better to remove him from the rotation, to avoid unnecessary rerolls.

CC @jdno

r? marcoieni