### PR TITLE
remove scalar size mismatch interpreter error, make it an ICE instead

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -311,7 +311,7 @@ pub(super) fn op_to_const<'tcx>(
                     imm.layout.ty,
                 );
                 let msg = "`op_to_const` on an immediate scalar pair must only be used on slice references to the beginning of an actual allocation";
-                let ptr = a.to_pointer(ecx).expect(msg);
+                let ptr = a.to_pointer(ecx);
                 let (prov, offset) =
                     ptr.into_pointer_or_addr().expect(msg).prov_and_relative_offset();
                 let alloc_id = prov.alloc_id();

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -1019,12 +1019,7 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
         // (Do nothing on `None` provenance, that cannot store immutability anyway.)
         if let ty::Ref(_, ty, mutbl) = val.layout.ty.kind()
             && *mutbl == Mutability::Not
-            && val
-                .to_scalar_and_meta()
-                .0
-                .to_pointer(ecx)?
-                .provenance
-                .is_some_and(|p| !p.immutable())
+            && val.to_scalar_and_meta().0.to_pointer(ecx).provenance.is_some_and(|p| !p.immutable())
         {
             // That next check is expensive, that's why we have all the guards above.
             let is_immutable = ty.is_freeze(*ecx.tcx, ecx.typing_env());

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -848,7 +848,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 assert!(receiver_place.layout.is_unsized());
 
                 // Get the required information from the vtable.
-                let vptr = receiver_place.meta().unwrap_meta().to_pointer(self)?;
+                let vptr = receiver_place.meta().unwrap_meta().to_pointer(self);
                 let dyn_ty = self.get_ptr_vtable_ty(vptr, Some(receiver_trait))?;
                 let adjusted_recv = receiver_place.ptr();
 

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -293,7 +293,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         assert!(cast_to.ty.is_integral());
 
         let scalar = src.to_scalar();
-        let ptr = scalar.to_pointer(self)?;
+        let ptr = scalar.to_pointer(self);
         match ptr.into_pointer_or_addr() {
             Ok(ptr) => M::expose_provenance(self, ptr.provenance)?,
             Err(_) => {} // Do nothing, exposing an invalid pointer (`None` provenance) is a NOP.
@@ -464,8 +464,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 }
                 // Take apart the old pointer, and find the dynamic type.
                 let (old_data, old_vptr) = val.to_scalar_pair();
-                let old_data = old_data.to_pointer(self)?;
-                let old_vptr = old_vptr.to_pointer(self)?;
+                let old_data = old_data.to_pointer(self);
+                let old_vptr = old_vptr.to_pointer(self);
                 let ty = self.get_ptr_vtable_ty(old_vptr, Some(data_a))?;
 
                 // Sanity-check that `supertrait_vtable_slot` in this type's vtable indeed produces

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -488,7 +488,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 interp_ok(Some((full_size, full_align)))
             }
             ty::Dynamic(expected_trait, _) => {
-                let vtable = metadata.unwrap_meta().to_pointer(self)?;
+                let vtable = metadata.unwrap_meta().to_pointer(self);
                 // Read size and align from vtable (already checks size).
                 interp_ok(Some(self.get_vtable_size_and_align(vtable, Some(expected_trait))?))
             }

--- a/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
@@ -260,7 +260,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                         }
                         Op::SaturatingOp(mir_op) => self.saturating_arith(mir_op, &left, &right)?,
                         Op::WrappingOffset => {
-                            let ptr = left.to_scalar().to_pointer(self)?;
+                            let ptr = left.to_scalar().to_pointer(self);
                             let offset_count = right.to_scalar().to_target_isize(self)?;
                             let pointee_ty = left.layout.ty.builtin_deref(true).unwrap();
 

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -1641,7 +1641,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             Ok(int) => interp_ok(int.is_null()),
             Err(_) => {
                 // We can't cast this pointer to an integer. Can only happen during CTFE.
-                let ptr = scalar.to_pointer(self)?;
+                let ptr = scalar.to_pointer(self);
                 match self.ptr_try_get_alloc_id(ptr, 0) {
                     Ok((alloc_id, offset, _)) => {
                         let info = self.get_alloc_info(alloc_id);

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -697,7 +697,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         &self,
         op: &impl Projectable<'tcx, M::Provenance>,
     ) -> InterpResult<'tcx, Pointer<Option<M::Provenance>>> {
-        self.read_scalar(op)?.to_pointer(self)
+        interp_ok(self.read_scalar(op)?.to_pointer(self))
     }
     /// Read a pointer-sized unsigned integer from a place.
     pub fn read_target_usize(

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -7,7 +7,6 @@ use either::{Either, Left, Right};
 use rustc_abi as abi;
 use rustc_abi::{BackendRepr, HasDataLayout, Size};
 use rustc_hir::def::Namespace;
-use rustc_middle::mir::interpret::ScalarSizeMismatch;
 use rustc_middle::ty::layout::{HasTyCtxt, HasTypingEnv, TyAndLayout};
 use rustc_middle::ty::print::{FmtPrinter, PrettyPrinter};
 use rustc_middle::ty::{ConstInt, ScalarInt, Ty, TyCtxt};
@@ -342,12 +341,7 @@ impl<'tcx, Prov: Provenance> ImmTy<'tcx, Prov> {
     #[inline]
     pub fn to_scalar_int(&self) -> InterpResult<'tcx, ScalarInt> {
         let s = self.to_scalar().to_scalar_int()?;
-        if s.size() != self.layout.size {
-            throw_ub!(ScalarSizeMismatch(ScalarSizeMismatch {
-                target_size: self.layout.size.bytes(),
-                data_size: s.size().bytes(),
-            }));
-        }
+        assert_eq!(s.size(), self.layout.size, "scalar immediate size does not match layout");
         interp_ok(s)
     }
 

--- a/compiler/rustc_const_eval/src/interpret/operator.rs
+++ b/compiler/rustc_const_eval/src/interpret/operator.rs
@@ -324,7 +324,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         match bin_op {
             // Pointer ops that are always supported.
             Offset => {
-                let ptr = left.to_scalar().to_pointer(self)?;
+                let ptr = left.to_scalar().to_pointer(self);
                 let pointee_ty = left.layout.ty.builtin_deref(true).unwrap();
                 let pointee_layout = self.layout_of(pointee_ty)?;
                 assert!(pointee_layout.is_sized());

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -435,7 +435,7 @@ where
 
         // `imm_ptr_to_mplace` is called on raw pointers even if they don't actually get dereferenced;
         // we hence can't call `size_and_align_of` since that asserts more validity than we want.
-        let ptr = ptr.to_pointer(self)?;
+        let ptr = ptr.to_pointer(self);
         interp_ok(self.ptr_with_meta_to_mplace(ptr, meta, layout, /*unaligned*/ false))
     }
 
@@ -522,7 +522,7 @@ where
                     let tail = self.tcx.struct_tail_for_codegen(mplace.layout.ty, self.typing_env);
                     match tail.kind() {
                         ty::Dynamic(data, _) => {
-                            let vtable = mplace.meta().unwrap_meta().to_pointer(self)?;
+                            let vtable = mplace.meta().unwrap_meta().to_pointer(self);
                             self.get_ptr_vtable_ty(vtable, Some(data))?;
                         }
                         ty::Slice(..) | ty::Str | ty::Foreign(..) => {

--- a/compiler/rustc_const_eval/src/interpret/traits.rs
+++ b/compiler/rustc_const_eval/src/interpret/traits.rs
@@ -112,7 +112,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             matches!(mplace.layout.ty.kind(), ty::Dynamic(_, _)),
             "`unpack_dyn_trait` only makes sense on `dyn*` types"
         );
-        let vtable = mplace.meta().unwrap_meta().to_pointer(self)?;
+        let vtable = mplace.meta().unwrap_meta().to_pointer(self);
         let ty = self.get_ptr_vtable_ty(vtable, Some(expected_trait))?;
         // This is a kind of transmute, from a place with unsized type and metadata to
         // a place with sized type and no metadata.

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -530,7 +530,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
         let tail = self.ecx.tcx.struct_tail_for_codegen(pointee.ty, self.ecx.typing_env);
         match tail.kind() {
             ty::Dynamic(data, _) => {
-                let vtable = meta.unwrap_meta().to_pointer(self.ecx)?;
+                let vtable = meta.unwrap_meta().to_pointer(self.ecx);
                 // Make sure it is a genuine vtable pointer for the right trait.
                 try_validation!(
                     self.ecx.get_ptr_vtable_ty(vtable, Some(data)),
@@ -930,7 +930,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
 
                 // If we check references recursively, also check that this points to a function.
                 if let Some(_) = self.ref_tracking {
-                    let ptr = scalar.to_pointer(self.ecx)?;
+                    let ptr = scalar.to_pointer(self.ecx);
                     let _fn = try_validation!(
                         self.ecx.get_ptr_fn(ptr),
                         self.path,

--- a/compiler/rustc_middle/src/mir/consts.rs
+++ b/compiler/rustc_middle/src/mir/consts.rs
@@ -154,7 +154,7 @@ impl ConstValue {
                         /* read_provenance */ true,
                     )
                     .ok()?;
-                let ptr = ptr.to_pointer(&tcx).discard_err()?;
+                let ptr = ptr.to_pointer(&tcx);
                 let len = a
                     .read_scalar(
                         &tcx,

--- a/compiler/rustc_middle/src/mir/interpret/allocation.rs
+++ b/compiler/rustc_middle/src/mir/interpret/allocation.rs
@@ -21,8 +21,8 @@ use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
 use super::{
     AllocId, BadBytesAccess, CtfeProvenance, InterpErrorKind, InterpResult, Pointer, Provenance,
-    ResourceExhaustionInfo, Scalar, ScalarSizeMismatch, UndefinedBehaviorInfo, UnsupportedOpInfo,
-    interp_ok, read_target_uint, write_target_uint,
+    ResourceExhaustionInfo, Scalar, UndefinedBehaviorInfo, UnsupportedOpInfo, interp_ok,
+    read_target_uint, write_target_uint,
 };
 use crate::ty;
 
@@ -303,8 +303,6 @@ impl<'tcx> ConstAllocation<'tcx> {
 /// is added when converting to `InterpError`.
 #[derive(Debug)]
 pub enum AllocError {
-    /// A scalar had the wrong size.
-    ScalarSizeMismatch(ScalarSizeMismatch),
     /// Encountered a pointer where we needed raw bytes.
     ReadPointerAsInt(Option<BadBytesAccess>),
     /// Partially copying a pointer.
@@ -314,19 +312,10 @@ pub enum AllocError {
 }
 pub type AllocResult<T = ()> = Result<T, AllocError>;
 
-impl From<ScalarSizeMismatch> for AllocError {
-    fn from(s: ScalarSizeMismatch) -> Self {
-        AllocError::ScalarSizeMismatch(s)
-    }
-}
-
 impl AllocError {
     pub fn to_interp_error<'tcx>(self, alloc_id: AllocId) -> InterpErrorKind<'tcx> {
         use AllocError::*;
         match self {
-            ScalarSizeMismatch(s) => {
-                InterpErrorKind::UndefinedBehavior(UndefinedBehaviorInfo::ScalarSizeMismatch(s))
-            }
             ReadPointerAsInt(info) => InterpErrorKind::Unsupported(
                 UnsupportedOpInfo::ReadPointerAsInt(info.map(|b| (alloc_id, b))),
             ),
@@ -753,7 +742,7 @@ impl<Prov: Provenance, Extra, Bytes: AllocBytes> Allocation<Prov, Extra, Bytes> 
 
         // `to_bits_or_ptr_internal` is the right method because we just want to store this data
         // as-is into memory. This also double-checks that `val.size()` matches `range.size`.
-        let (bytes, provenance) = match val.to_bits_or_ptr_internal(range.size)? {
+        let (bytes, provenance) = match val.to_bits_or_ptr_internal(range.size) {
             Right(ptr) => {
                 let (provenance, offset) = ptr.into_raw_parts();
                 (u128::from(offset.bytes()), Some(provenance))

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -312,13 +312,6 @@ pub struct BadBytesAccess {
     pub bad: AllocRange,
 }
 
-/// Information about a size mismatch.
-#[derive(Debug)]
-pub struct ScalarSizeMismatch {
-    pub target_size: u64,
-    pub data_size: u64,
-}
-
 /// Information about a misaligned pointer.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
 pub struct Misalignment {
@@ -417,8 +410,6 @@ pub enum UndefinedBehaviorInfo<'tcx> {
     InvalidUninitBytes(Option<(AllocId, BadBytesAccess)>),
     /// Working with a local that is not currently live.
     DeadLocal,
-    /// Data size is not equal to target size.
-    ScalarSizeMismatch(ScalarSizeMismatch),
     /// A discriminant of an uninhabited enum variant is written.
     UninhabitedEnumVariantWritten(VariantIdx),
     /// An uninhabited enum variant is projected.
@@ -625,12 +616,6 @@ impl<'tcx> fmt::Display for UndefinedBehaviorInfo<'tcx> {
                 uninit = info.bad,
             ),
             DeadLocal => write!(f, "accessing a dead local variable"),
-            ScalarSizeMismatch(mismatch) => write!(
-                f,
-                "scalar size mismatch: expected {target_size} bytes but got {data_size} bytes instead",
-                target_size = mismatch.target_size,
-                data_size = mismatch.data_size,
-            ),
             UninhabitedEnumVariantWritten(_) => {
                 write!(f, "writing discriminant of an uninhabited enum variant")
             }

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -37,8 +37,8 @@ pub use self::error::{
     BadBytesAccess, CheckAlignMsg, CheckInAllocMsg, ErrorHandled, EvalStaticInitializerRawResult,
     EvalToAllocationRawResult, EvalToConstValueResult, EvalToValTreeResult, InterpErrorInfo,
     InterpErrorKind, InterpResult, InvalidMetaKind, InvalidProgramInfo, MachineStopType,
-    Misalignment, ReportedErrorInfo, ResourceExhaustionInfo, ScalarSizeMismatch,
-    UndefinedBehaviorInfo, UnsupportedOpInfo, ValTreeCreationError, interp_ok,
+    Misalignment, ReportedErrorInfo, ResourceExhaustionInfo, UndefinedBehaviorInfo,
+    UnsupportedOpInfo, ValTreeCreationError, interp_ok,
 };
 pub use self::pointer::{CtfeProvenance, Pointer, PointerArithmetic, Provenance};
 pub use self::value::Scalar;

--- a/compiler/rustc_middle/src/mir/interpret/value.rs
+++ b/compiler/rustc_middle/src/mir/interpret/value.rs
@@ -7,8 +7,7 @@ use rustc_apfloat::ieee::{Double, Half, Quad, Single};
 use rustc_macros::{StableHash, TyDecodable, TyEncodable};
 
 use super::{
-    AllocId, CtfeProvenance, InterpResult, Pointer, PointerArithmetic, Provenance,
-    ScalarSizeMismatch, interp_ok,
+    AllocId, CtfeProvenance, InterpResult, Pointer, PointerArithmetic, Provenance, interp_ok,
 };
 use crate::ty::ScalarInt;
 
@@ -237,25 +236,20 @@ impl<Prov> Scalar<Prov> {
     /// This throws UB (instead of ICEing) on a size mismatch since size mismatches can arise in
     /// Miri when someone declares a function that we shim (such as `malloc`) with a wrong type.
     #[inline]
-    pub fn to_bits_or_ptr_internal(
-        self,
-        target_size: Size,
-    ) -> Result<Either<u128, Pointer<Prov>>, ScalarSizeMismatch> {
+    pub fn to_bits_or_ptr_internal(self, target_size: Size) -> Either<u128, Pointer<Prov>> {
         assert_ne!(target_size.bytes(), 0, "you should never look at the bits of a ZST");
-        Ok(match self {
-            Scalar::Int(int) => Left(int.try_to_bits(target_size).map_err(|size| {
-                ScalarSizeMismatch { target_size: target_size.bytes(), data_size: size.bytes() }
-            })?),
+        match self {
+            Scalar::Int(int) => Left(int.to_bits(target_size)),
             Scalar::Ptr(ptr, sz) => {
-                if target_size.bytes() != u64::from(sz) {
-                    return Err(ScalarSizeMismatch {
-                        target_size: target_size.bytes(),
-                        data_size: sz.into(),
-                    });
-                }
+                assert_eq!(
+                    target_size.bytes(),
+                    u64::from(sz),
+                    "Scalar is a pointer but expected size {}",
+                    target_size.bytes()
+                );
                 Right(ptr)
             }
-        })
+        }
     }
 
     #[inline]
@@ -269,10 +263,7 @@ impl<Prov> Scalar<Prov> {
 
 impl<'tcx, Prov: Provenance> Scalar<Prov> {
     pub fn to_pointer(self, cx: &impl HasDataLayout) -> InterpResult<'tcx, Pointer<Option<Prov>>> {
-        match self
-            .to_bits_or_ptr_internal(cx.pointer_size())
-            .map_err(|s| err_ub!(ScalarSizeMismatch(s)))?
-        {
+        match self.to_bits_or_ptr_internal(cx.pointer_size()) {
             Right(ptr) => interp_ok(ptr.into()),
             Left(bits) => {
                 let addr = u64::try_from(bits).unwrap();
@@ -330,15 +321,7 @@ impl<'tcx, Prov: Provenance> Scalar<Prov> {
     #[inline]
     pub fn to_bits(self, target_size: Size) -> InterpResult<'tcx, u128> {
         assert_ne!(target_size.bytes(), 0, "you should never look at the bits of a ZST");
-        self.to_scalar_int()?
-            .try_to_bits(target_size)
-            .map_err(|size| {
-                err_ub!(ScalarSizeMismatch(ScalarSizeMismatch {
-                    target_size: target_size.bytes(),
-                    data_size: size.bytes(),
-                }))
-            })
-            .into()
+        interp_ok(self.to_scalar_int()?.to_bits(target_size))
     }
 
     pub fn to_bool(self) -> InterpResult<'tcx, bool> {

--- a/compiler/rustc_middle/src/mir/interpret/value.rs
+++ b/compiler/rustc_middle/src/mir/interpret/value.rs
@@ -262,12 +262,12 @@ impl<Prov> Scalar<Prov> {
 }
 
 impl<'tcx, Prov: Provenance> Scalar<Prov> {
-    pub fn to_pointer(self, cx: &impl HasDataLayout) -> InterpResult<'tcx, Pointer<Option<Prov>>> {
+    pub fn to_pointer(self, cx: &impl HasDataLayout) -> Pointer<Option<Prov>> {
         match self.to_bits_or_ptr_internal(cx.pointer_size()) {
-            Right(ptr) => interp_ok(ptr.into()),
+            Right(ptr) => ptr.into(),
             Left(bits) => {
                 let addr = u64::try_from(bits).unwrap();
-                interp_ok(Pointer::without_provenance(addr))
+                Pointer::without_provenance(addr)
             }
         }
     }

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -260,26 +260,19 @@ impl ScalarInt {
         Self::try_from_uint(i, tcx.data_layout.pointer_size())
     }
 
-    /// Try to convert this ScalarInt to the raw underlying bits.
-    /// Fails if the size is wrong. Generally a wrong size should lead to a panic,
-    /// but Miri sometimes wants to be resilient to size mismatches,
-    /// so the interpreter will generally use this `try` method.
-    #[inline]
-    pub fn try_to_bits(self, target_size: Size) -> Result<u128, Size> {
-        assert_ne!(target_size.bytes(), 0, "you should never look at the bits of a ZST");
-        if target_size.bytes() == u64::from(self.size.get()) {
-            self.check_data();
-            Ok(self.data)
-        } else {
-            Err(self.size())
-        }
-    }
-
+    /// Convert this ScalarInt to the underlying bits.
     #[inline]
     pub fn to_bits(self, target_size: Size) -> u128 {
-        self.try_to_bits(target_size).unwrap_or_else(|size| {
-            bug!("expected int of size {}, but got size {}", target_size.bytes(), size.bytes())
-        })
+        assert_ne!(target_size.bytes(), 0, "you should never look at the bits of a ZST");
+        assert_eq!(
+            target_size.bytes(),
+            u64::from(self.size.get()),
+            "ScalarInt has size {} but expected {}",
+            self.size,
+            target_size.bytes(),
+        );
+        self.check_data();
+        self.data
     }
 
     /// Extracts the bits from the scalar without checking the size.

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -720,7 +720,7 @@ impl<'a, 'tcx> TOFinder<'a, 'tcx> {
                 // had in the previous arm. All we can conclude is that the replacement condition
                 // `discr != value` can be threaded, and nothing else.
                 if c.polarity == Polarity::Ne
-                    && let Ok(value) = c.value.try_to_bits(discr_layout.size)
+                    && let value = c.value.to_bits(discr_layout.size)
                     && targets.all_values().contains(&value.into())
                 {
                     edges_fulfilling_condition.insert(targets.otherwise());

--- a/src/tools/miri/src/helpers.rs
+++ b/src/tools/miri/src/helpers.rs
@@ -739,7 +739,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     {
         let this = self.eval_context_ref();
         let (ptr, len) = slice.to_scalar_pair();
-        let ptr = ptr.to_pointer(this)?;
+        let ptr = ptr.to_pointer(this);
         let len = len.to_target_usize(this)?;
         let bytes = this.read_bytes_ptr_strip_provenance(ptr, Size::from_bytes(len))?;
         interp_ok(bytes)

--- a/src/tools/miri/src/operator.rs
+++ b/src/tools/miri/src/operator.rs
@@ -54,7 +54,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Add | Sub | BitOr | BitAnd | BitXor => {
                 assert!(left.layout.ty.is_raw_ptr());
                 assert_eq!(right.layout.ty, this.tcx.types.usize);
-                let ptr = left.to_scalar().to_pointer(this)?;
+                let ptr = left.to_scalar().to_pointer(this);
                 // We do the actual operation with usize-typed scalars.
                 let left = ImmTy::from_uint(ptr.addr().bytes(), this.machine.layouts.usize);
                 let result = this.binary_op(bin_op, &left, right)?;

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -684,8 +684,12 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "memchr" => {
-                let [ptr, val, num] =
-                    this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                let [ptr, val, num] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(*const _, i32, usize) -> *const _),
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let ptr = this.read_pointer(ptr)?;
                 let val = this.read_scalar(val)?.to_i32()?;
                 let num = this.read_target_usize(num)?;
@@ -709,8 +713,12 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "memrchr" => {
                 this.check_target_os(&[Os::Linux, Os::Android, Os::FreeBsd], link_name)?;
 
-                let [ptr, val, num] =
-                    this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                let [ptr, val, num] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(*const _, i32, usize) -> *const _),
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let ptr = this.read_pointer(ptr)?;
                 let val = this.read_scalar(val)?.to_i32()?;
                 let num = this.read_target_usize(num)?;

--- a/src/tools/miri/src/shims/global_ctor.rs
+++ b/src/tools/miri/src/shims/global_ctor.rs
@@ -71,7 +71,7 @@ impl<'tcx> GlobalCtorState<'tcx> {
                     if let Some((ctor, span)) = ctors.pop() {
                         let this = this.eval_context_mut();
 
-                        let ctor = ctor.to_scalar().to_pointer(this)?;
+                        let ctor = ctor.to_scalar().to_pointer(this);
                         let thread_callback = this.get_ptr_fn(ctor)?.as_instance()?;
 
                         // The signature of this function is `unsafe extern "C" fn()`.

--- a/src/tools/miri/src/shims/tls.rs
+++ b/src/tools/miri/src/shims/tls.rs
@@ -353,7 +353,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn schedule_windows_tls_dtor(&mut self, dtor: ImmTy<'tcx>, span: Span) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
-        let dtor = dtor.to_scalar().to_pointer(this)?;
+        let dtor = dtor.to_scalar().to_pointer(this);
         let thread_callback = this.get_ptr_fn(dtor)?.as_instance()?;
 
         // FIXME: Technically, the reason should be `DLL_PROCESS_DETACH` when the main thread exits

--- a/src/tools/miri/src/shims/unix/linux_like/thread.rs
+++ b/src/tools/miri/src/shims/unix/linux_like/thread.rs
@@ -39,7 +39,7 @@ pub fn prctl<'tcx>(
             let thread = ecx.pthread_self()?;
             let len = Scalar::from_target_usize(TASK_COMM_LEN, ecx);
             ecx.check_ptr_access(
-                name.to_pointer(ecx)?,
+                name.to_pointer(ecx),
                 Size::from_bytes(TASK_COMM_LEN),
                 CheckInAllocMsg::MemoryAccess,
             )?;

--- a/src/tools/miri/src/shims/unix/thread.rs
+++ b/src/tools/miri/src/shims/unix/thread.rs
@@ -106,7 +106,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let Ok(thread) = this.thread_id_try_from(thread) else {
             return interp_ok(ThreadNameResult::ThreadNotFound);
         };
-        let name = name.to_pointer(this)?;
+        let name = name.to_pointer(this);
         let mut name = this.read_c_str(name)?.to_owned();
 
         // Comparing with `>=` to account for null terminator.
@@ -140,7 +140,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let Ok(thread) = this.thread_id_try_from(thread) else {
             return interp_ok(ThreadNameResult::ThreadNotFound);
         };
-        let name_out = name_out.to_pointer(this)?;
+        let name_out = name_out.to_pointer(this);
         let len = len.to_target_usize(this)?;
 
         // FIXME: we should use the program name if the thread name is not set

--- a/src/tools/miri/tests/fail/shims/shim_arg_size.rs
+++ b/src/tools/miri/tests/fail/shims/shim_arg_size.rs
@@ -5,6 +5,6 @@ fn main() {
     }
 
     unsafe {
-        memchr(std::ptr::null(), 0, 0); //~ ERROR: Undefined Behavior: scalar size mismatch
+        memchr(std::ptr::null(), 0, 0); //~ ERROR: parameter #2 has type i32 passing argument of type u8
     };
 }

--- a/src/tools/miri/tests/fail/shims/shim_arg_size.stderr
+++ b/src/tools/miri/tests/fail/shims/shim_arg_size.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: scalar size mismatch: expected 4 bytes but got 1 bytes instead
+error: Undefined Behavior: calling a function whose parameter #2 has type i32 passing argument of type u8
   --> tests/fail/shims/shim_arg_size.rs:LL:CC
    |
 LL |         memchr(std::ptr::null(), 0, 0);
@@ -6,6 +6,8 @@ LL |         memchr(std::ptr::null(), 0, 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
+   = help: if you think this code should be accepted anyway, please report an issue with Miri
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 


### PR DESCRIPTION
This error was added in https://github.com/rust-lang/rust/pull/71569 to deal with ICEs on incorrect Miri shim signatures. However, that was a partial fix: if the signature is "even more incorrect", using a non-scalar type where the type should be scalar, we still ICE. The proper fix is tracked in https://github.com/rust-lang/miri/issues/3842, and that is already used for a good chunk of our shims.

I don't think it's worth keeping around the old, incomplete check here, so let's get rid of it.

Sadly, the `to_$int` methods on `Scalar` still return a `Result` as they must still error if the scalar is a pointer and we are in const-eval where we cannot turn that pointer into an integer. We should probably use `ScalarInt` in a lot more places where we currently use `Scalar` to statically exclude this case... but that's a change for another time.