### PR TITLE
Fix `#[repr(transparent)]` wrapper types not working with `Complex<T>`

### DIFF
--- a/compiler/rustc_abi/src/layout/ty.rs
+++ b/compiler/rustc_abi/src/layout/ty.rs
@@ -120,7 +120,7 @@ pub trait TyAbiInterface<'a, C>: Sized + std::fmt::Debug + std::fmt::Display {
     fn is_tuple(this: TyAndLayout<'a, Self>) -> bool;
     fn is_unit(this: TyAndLayout<'a, Self>) -> bool;
     fn is_transparent(this: TyAndLayout<'a, Self>) -> bool;
-    fn is_complex_number(this: TyAndLayout<'a, Self>, cx: &C) -> bool;
+    fn is_complex_number_lang_item(this: TyAndLayout<'a, Self>, cx: &C) -> bool;
     fn is_scalable_vector(this: TyAndLayout<'a, Self>) -> bool;
     /// See [`TyAndLayout::pass_indirectly_in_non_rustic_abis`] for details.
     fn is_pass_indirectly_in_non_rustic_abis_flag_set(this: TyAndLayout<'a, Self>) -> bool;
@@ -228,11 +228,13 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         Ty::is_transparent(self)
     }
 
+    /// Returns `true` if this type needs to match the ABI of the C `_Complex` type. See
+    /// [`TyAndLayout::complex_number_primitive`] for details.
     pub fn is_complex_number<C>(self, cx: &C) -> bool
     where
         Ty: TyAbiInterface<'a, C> + Copy,
     {
-        Ty::is_complex_number(self.peel_transparent_wrappers(cx), cx)
+        self.complex_number_primitive(cx).is_some()
     }
 
     pub fn is_scalable_vector<C>(self) -> bool
@@ -299,23 +301,47 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         found
     }
 
+    /// If this type should match the ABI of the C `_Complex` type, returns the primitive that is
+    /// used for its parts. This only returns `Some(T)` for `core::num::Complex<T>` where `T` is
+    /// either a float or an integer. `repr(transparent)` wrapper types are automatically handled.
+    pub fn complex_number_primitive<C>(&self, cx: &C) -> Option<Primitive>
+    where
+        Ty: TyAbiInterface<'a, C> + Copy,
+    {
+        let complex = self.peel_transparent_wrappers(cx);
+        if !Ty::is_complex_number_lang_item(complex, cx) {
+            return None;
+        }
+
+        let part = complex.field(cx, 0).peel_transparent_wrappers(cx);
+
+        if let BackendRepr::Scalar(scalar) = part.backend_repr {
+            // Only Complex<{ float }> and Complex<{ integer }> have special layout.
+            let primitive = scalar.primitive();
+            match primitive {
+                // Explicitly spell out all the float types so that any new ones have to be added to
+                // one of the match branches.
+                Primitive::Int(..)
+                | Primitive::Float(Float::F16 | Float::F32 | Float::F64 | Float::F128) => {
+                    Some(primitive)
+                }
+                Primitive::Pointer(..) => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Returns `Some` if this type has the ABI of the C `_Complex` type with float parts. See
+    /// [`TyAndLayout::complex_number_primitive`] for details.
     pub fn complex_float<C>(&self, cx: &C) -> Option<Float>
     where
         Ty: TyAbiInterface<'a, C> + Copy,
     {
-        if !Ty::is_complex_number(*self, cx) {
-            return None;
-        }
-
-        let BackendRepr::ScalarPair { a, b, .. } = self.backend_repr else {
-            return None;
-        };
-
-        debug_assert_eq!(a, b);
-
-        match a.primitive() {
-            Primitive::Float(f) => Some(f),
-            _ => None,
+        if let Some(Primitive::Float(float)) = self.complex_number_primitive(cx) {
+            Some(float)
+        } else {
+            None
         }
     }
 

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1213,18 +1213,10 @@ where
         matches!(this.ty.kind(), ty::Adt(def, _) if def.repr().transparent())
     }
 
-    /// Does this type have a layout compatible with C `_Complex`?
-    ///
-    /// The value must be of type `core::num::Complex<T>` where `T` is numeric.
-    fn is_complex_number(this: TyAndLayout<'tcx>, cx: &C) -> bool {
-        let ty::Adt(def, generic_args) = this.ty.kind() else { return false };
-
-        if !cx.tcx().is_lang_item(def.did(), LangItem::Complex) {
-            return false;
-        }
-
-        // Only Complex<{ float }> and Complex<{ integer }> have special layout.
-        generic_args.type_at(0).is_numeric()
+    /// Is this type `core::num::Complex<T>`?
+    fn is_complex_number_lang_item(this: TyAndLayout<'tcx>, cx: &C) -> bool {
+        let Some(def) = this.ty.ty_adt_def() else { return false };
+        cx.tcx().is_lang_item(def.did(), LangItem::Complex)
     }
 
     fn is_scalable_vector(this: TyAndLayout<'tcx>) -> bool {

--- a/tests/codegen-llvm/complex-abi.rs
+++ b/tests/codegen-llvm/complex-abi.rs
@@ -342,12 +342,61 @@ pub extern "C" fn cplx_i64(x: Complex<i64>) -> Complex<i64> {
 struct Wrapper<T>(T);
 
 #[no_mangle]
-pub extern "C" fn wrapper_cplx_i64(x: Wrapper<Complex<i64>>) -> Wrapper<Complex<i64>> {
+pub extern "C" fn wrapper_cplx_i64(
+    x: Wrapper<Complex<Wrapper<i64>>>,
+) -> Wrapper<Complex<Wrapper<i64>>> {
+    // AARCH64:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
+    // AARCH64_DARWIN: define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
+    // AARCH64_MSVC:   define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
+    // AIX:            define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // ARM64EC:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
+    // ARM:            define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
+    // BPF:            define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
+    // CSKY:           define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [4 x i32] {{.*}})
     // I686:           define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
+    // LOONGARCH32:    define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
+    // LOONGARCH64:    define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
+    // MIPS64EL:       define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // MIPS:           define{{.*}} { i64, i64 } @wrapper_cplx_i64(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
+    // NVPTX:          define{{.*}} { i64, i64 } @wrapper_cplx_i64(ptr {{.*}} byval({ i64, i64 }) {{.*}})
+    // POWERPC64:      define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // POWERPC64LE:    define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // POWERPC:        define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
+    // RISCV32:        define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
+    // RISCV64:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
+    // S390X:          define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
+    // SPARC64:        define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // SPARC:          define{{.*}} { i64, i64 } @wrapper_cplx_i64(ptr {{.*}} byval({ i64, i64 }) {{.*}})
+    // WASM32:         define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
+    // WASM64:         define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
     // WIN32_GNU:      define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
     // WIN32_MSVC:     define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
     // WINDOWS_GNU:    define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // WINDOWS_MSVC:   define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // X86_64:         define{{.*}} { i64, i64 } @wrapper_cplx_i64({ i64, i64 } {{.*}})
+    x
+}
+
+#[no_mangle]
+pub extern "C" fn wrapper_cplx_f16(
+    x: Wrapper<Complex<Wrapper<f16>>>,
+) -> Wrapper<Complex<Wrapper<f16>>> {
+    // AARCH64:        define{{.*}} { half, half } @wrapper_cplx_f16([2 x half] {{.*}})
+    // AARCH64_DARWIN: define{{.*}} { half, half } @wrapper_cplx_f16([2 x half] {{.*}})
+    // AARCH64_MSVC:   define{{.*}} { half, half } @wrapper_cplx_f16([2 x half] {{.*}})
+    // ARM64EC:        define{{.*}} { half, half } @wrapper_cplx_f16([2 x half] {{.*}})
+    // ARM:            define{{.*}} i32 @wrapper_cplx_f16([1 x i32] {{.*}})
+    // I686:           define{{.*}} <2 x half> @wrapper_cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
+    // LOONGARCH32:    define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})
+    // LOONGARCH64:    define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})
+    // NVPTX:          define{{.*}} { half, half } @wrapper_cplx_f16(ptr {{.*}} byval({ half, half }) {{.*}})
+    // RISCV32:        define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})
+    // RISCV64:        define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})
+    // S390X:          define{{.*}} void @wrapper_cplx_f16(ptr {{.*}} sret({ half, half }) {{.*}}, ptr {{.*}})
+    // WIN32_GNU:      define{{.*}} <2 x half> @wrapper_cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
+    // WIN32_MSVC:     define{{.*}} <2 x half> @wrapper_cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
+    // WINDOWS_GNU:    define{{.*}} i32 @wrapper_cplx_f16(i32 {{.*}})
+    // WINDOWS_MSVC:   define{{.*}} i32 @wrapper_cplx_f16(i32 {{.*}})
+    // X86_64:         define{{.*}} float @wrapper_cplx_f16(float {{.*}})
     x
 }


### PR DESCRIPTION
This PR fixes handling of `#[repr(transparent)]` types both containing `Complex<T>` and containing the `T` with `Complex<T>`. I've also added a test case for where this was showing up in the `x86` ABI.

r? @folkertdev