### PR TITLE
Add regression test for indexing an unsized static without a body

### DIFF
--- a/tests/ui/statics/unsized-static-without-body-index-141804.rs
+++ b/tests/ui/statics/unsized-static-without-body-index-141804.rs
@@ -1,0 +1,12 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/141804>.
+// Indexing an unsized `static` declared without a body used to ICE in const eval
+// with "primitive read not possible for type".
+
+fn foo() {
+    static symbol: [u32];
+    //~^ ERROR free static item without body
+    //~| ERROR the size for values of type `[u32]` cannot be known at compilation time
+    symbol[0];
+}
+
+fn main() {}

--- a/tests/ui/statics/unsized-static-without-body-index-141804.stderr
+++ b/tests/ui/statics/unsized-static-without-body-index-141804.stderr
@@ -1,0 +1,20 @@
+error: free static item without body
+  --> $DIR/unsized-static-without-body-index-141804.rs:6:5
+   |
+LL |     static symbol: [u32];
+   |     ^^^^^^^^^^^^^^^^^^^^-
+   |                         |
+   |                         help: provide a definition for the static: `= <expr>;`
+
+error[E0277]: the size for values of type `[u32]` cannot be known at compilation time
+  --> $DIR/unsized-static-without-body-index-141804.rs:6:5
+   |
+LL |     static symbol: [u32];
+   |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u32]`
+   = note: statics and constants must have a statically known size
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Closes rust-lang/rust#141804
r? compiler