### PR TITLE
Assorted bootstrap LLVM refactors (part 3/N)

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1435,7 +1435,8 @@ fn rustc_llvm_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetSelect
         cargo.env("LLVM_OFFLOAD", "1");
     }
 
-    cargo.env("LLVM_CONFIG", llvm_output.llvm_config());
+    // This always has to be the host LLVM config, because it is executed by rustc_llvm
+    cargo.env("LLVM_CONFIG", builder.host_llvm_config());
 
     // Some LLVM linker flags (-L and -l) may be needed to link `rustc_llvm`. Its build script
     // expects these to be passed via the `LLVM_LINKER_FLAGS` env variable, separated by

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1435,7 +1435,7 @@ fn rustc_llvm_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetSelect
         cargo.env("LLVM_OFFLOAD", "1");
     }
 
-    cargo.env("LLVM_CONFIG", &llvm_output.host_llvm_config);
+    cargo.env("LLVM_CONFIG", llvm_output.llvm_config());
 
     // Some LLVM linker flags (-L and -l) may be needed to link `rustc_llvm`. Its build script
     // expects these to be passed via the `LLVM_LINKER_FLAGS` env variable, separated by
@@ -2130,7 +2130,8 @@ impl CommandLineStep for Assemble {
             if !builder.config.dry_run() && builder.config.llvm_tools_enabled {
                 trace!("LLVM tools enabled");
 
-                let host_llvm_bin_dir = command(&llvm_output.host_llvm_config)
+                let host_llvm = builder.ensure(llvm::Llvm { target: builder.host_target });
+                let host_llvm_bin_dir = command(host_llvm.llvm_config())
                     .arg("--bindir")
                     .cached()
                     .run_capture_stdout(builder)
@@ -2153,10 +2154,10 @@ impl CommandLineStep for Assemble {
                         // where the LLVM config is located
                         external_llvm_config.parent().unwrap().to_path_buf()
                     } else {
-                        // If we have built LLVM locally, then take the path of the host bindir
+                        // If not, then take the path of the host bindir of the host LLVM,
                         // relative to its output build directory, and then apply it to the target
                         // LLVM output build directory.
-                        let host_llvm_out = builder.llvm_out(builder.host_target);
+                        let host_llvm_out = host_llvm.root_dir();
                         let target_llvm_out = llvm_output.root_dir();
                         if let Ok(relative_path) =
                             Path::new(&host_llvm_bin_dir).strip_prefix(host_llvm_out)
@@ -2285,7 +2286,7 @@ impl CommandLineStep for Assemble {
 
         if builder.config.llvm_offload && !builder.config.dry_run() {
             debug!("`llvm_offload` requested");
-            if let Some(_llvm_config) = builder.llvm_config(builder.config.host_target) {
+            if builder.is_llvm_enabled_for(builder.config.host_target) {
                 let rust_offload =
                     builder.ensure(llvm::RustOffload { target: build_compiler.host });
                 let target_libdir =

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2542,7 +2542,7 @@ fn maybe_install_llvm(
     // paths and we don't want those in the sysroot (as we're expecting
     // unversioned paths).
     if target.contains("apple-darwin") && llvm.llvm_output().link_shared() {
-        let src_libdir = builder.llvm_out(target).join("lib");
+        let src_libdir = llvm.llvm_output().root_dir().join("lib");
         let llvm_dylib_path = src_libdir.join("libLLVM.dylib");
         if llvm_dylib_path.exists() {
             builder.install(&llvm_dylib_path, dst_libdir, FileType::NativeLibrary);
@@ -2578,7 +2578,7 @@ fn maybe_install_llvm(
         builder.do_if_verbose(|| println!("running {cmd:?}"));
         let files = cmd.run_capture_stdout(builder).stdout();
         let build_llvm_out = &builder.llvm_out(builder.config.host_target);
-        let target_llvm_out = &builder.llvm_out(target);
+        let target_llvm_out = llvm.llvm_output().root_dir();
         for file in files.trim_end().split(' ') {
             // If we're not using a custom LLVM, make sure we package for the target.
             let file = if let Ok(relative_path) = Path::new(file).strip_prefix(build_llvm_out) {

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2547,8 +2547,8 @@ fn maybe_install_llvm(
         if llvm_dylib_path.exists() {
             builder.install(&llvm_dylib_path, dst_libdir, FileType::NativeLibrary);
 
-            if install_symlink && let Some(llvm_config_path) = &builder.llvm_config(target) {
-                let major = llvm::get_llvm_version_major(builder, llvm_config_path);
+            if install_symlink {
+                let major = llvm::get_llvm_version_major(builder, &builder.host_llvm_config());
                 let versioned_name = match &builder.config.llvm_version_suffix {
                     Some(version_suffix) => format!("libLLVM-{major}{version_suffix}.dylib"),
                     None => {
@@ -2567,18 +2567,17 @@ fn maybe_install_llvm(
             }
         }
         !builder.config.dry_run()
-    } else if let llvm::LlvmBuildStatus::AlreadyBuilt(llvm::LlvmOutput {
-        host_llvm_config, ..
-    }) = llvm
-    {
+    } else if let llvm::LlvmBuildStatus::AlreadyBuilt(llvm_output) = llvm {
         trace!("LLVM already built, installing LLVM files");
-        let mut cmd = command(host_llvm_config);
+
+        let host_llvm = builder.ensure(llvm::Llvm { target: builder.host_target });
+        let mut cmd = command(host_llvm.llvm_config());
         cmd.cached();
         cmd.arg("--libfiles");
         builder.do_if_verbose(|| println!("running {cmd:?}"));
         let files = cmd.run_capture_stdout(builder).stdout();
-        let build_llvm_out = &builder.llvm_out(builder.config.host_target);
-        let target_llvm_out = llvm.llvm_output().root_dir();
+        let build_llvm_out = host_llvm.root_dir();
+        let target_llvm_out = llvm_output.root_dir();
         for file in files.trim_end().split(' ') {
             // If we're not using a custom LLVM, make sure we package for the target.
             let file = if let Ok(relative_path) = Path::new(file).strip_prefix(build_llvm_out) {

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -178,7 +178,7 @@ pub fn prebuilt_llvm_output(builder: &Builder<'_>, target: TargetSelection) -> O
         });
     }
 
-    // If LLVM is not available from CI, not externally, it is still possible that it was already
+    // If LLVM is not available from CI nor externally, it is still possible that it was already
     // built locally before. In that case we still treat it as prebuilt config.
     match get_locally_built_llvm_build_status(builder, target) {
         LlvmBuildStatus::AlreadyBuilt(output) => Some(output),
@@ -1725,8 +1725,8 @@ impl CommandLineStep for Lld {
             // Use the host llvm-tblgen binary.
             cfg.define(
                 "LLVM_TABLEGEN_EXE",
-                llvm_output
-                    .llvm_config()
+                builder
+                    .host_llvm_config()
                     .with_file_name("llvm-tblgen")
                     .with_extension(EXE_EXTENSION),
             );

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -161,7 +161,10 @@ pub fn prebuilt_llvm_output(builder: &Builder<'_>, target: TargetSelection) -> O
     if let Some(config) = builder.config.target_config.get(&target)
         && let Some(ref s) = config.llvm_config
     {
-        check_llvm_version(builder, s);
+        // We execute the llvm-config, and we can only do that on the host target
+        if target == builder.host_target {
+            check_llvm_version(builder, s);
+        }
         let llvm_config = s.to_path_buf();
         let mut llvm_root_dir = llvm_config.clone();
         llvm_root_dir.pop();
@@ -648,9 +651,9 @@ impl CommandLineStep for Llvm {
 
         // https://llvm.org/docs/HowToCrossCompileLLVM.html
         if !builder.config.is_host_target(target) {
-            let llvm_output = builder.ensure(Llvm { target: builder.config.host_target });
+            let llvm_host = builder.ensure(Llvm { target: builder.config.host_target });
             if !builder.config.dry_run() {
-                let llvm_bindir = command(llvm_output.llvm_config())
+                let llvm_bindir = command(llvm_host.llvm_config())
                     .arg("--bindir")
                     .cached()
                     .run_capture_stdout(builder)
@@ -663,9 +666,9 @@ impl CommandLineStep for Llvm {
                 // LLVM_NM is required for cross compiling using MSVC
                 cfg.define("LLVM_NM", host_bin.join("llvm-nm").with_extension(EXE_EXTENSION));
             }
-            cfg.define("LLVM_CONFIG_PATH", llvm_output.llvm_config());
+            cfg.define("LLVM_CONFIG_PATH", llvm_host.llvm_config());
             if builder.config.llvm_clang {
-                let build_bin = llvm_output.root_dir().join("bin");
+                let build_bin = llvm_host.root_dir().join("bin");
                 let clang_tblgen = build_bin.join("clang-tblgen").with_extension(EXE_EXTENSION);
                 if !builder.config.dry_run() && !clang_tblgen.exists() {
                     panic!("unable to find {}", clang_tblgen.display());

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -202,7 +202,7 @@ fn get_locally_built_llvm_build_status(
     builder: &Builder<'_>,
     target: TargetSelection,
 ) -> LlvmBuildStatus {
-    let out_dir = builder.llvm_out(target);
+    let out_dir = llvm_output_dir(builder, target);
 
     let build_llvm_config = if let Some(build_llvm_config) = builder
         .config
@@ -212,7 +212,7 @@ fn get_locally_built_llvm_build_status(
     {
         build_llvm_config
     } else {
-        let mut llvm_config_ret_dir = builder.llvm_out(builder.config.host_target);
+        let mut llvm_config_ret_dir = llvm_output_dir(builder, builder.config.host_target);
         llvm_config_ret_dir.push("bin");
         llvm_config_ret_dir.join(exe("llvm-config", builder.config.host_target))
     };
@@ -250,6 +250,13 @@ fn get_locally_built_llvm_build_status(
     }
 
     LlvmBuildStatus::ShouldBuild(LlvmBuildInfo { stamp, output: res })
+}
+
+/// Output directory of *locally built* LLVM for the given `target`.
+/// Should only be used within this module, when building LLVM (or related tools).
+/// Otherwise, you should ensure the `Llvm` step and read its root directory.
+fn llvm_output_dir(builder: &Builder<'_>, target: TargetSelection) -> PathBuf {
+    builder.config.out.join(target).join("llvm")
 }
 
 fn try_download_ci_llvm(builder: &Builder<'_>, target: TargetSelection) -> Option<DownloadedLlvm> {
@@ -667,7 +674,7 @@ impl CommandLineStep for Llvm {
             cfg.define("LLVM_CONFIG_PATH", host_llvm_config);
             if builder.config.llvm_clang {
                 let build_bin =
-                    builder.llvm_out(builder.config.host_target).join("build").join("bin");
+                    llvm_output_dir(builder, builder.config.host_target).join("build").join("bin");
                 let clang_tblgen = build_bin.join("clang-tblgen").with_extension(EXE_EXTENSION);
                 if !builder.config.dry_run() && !clang_tblgen.exists() {
                     panic!("unable to find {}", clang_tblgen.display());
@@ -1383,7 +1390,7 @@ impl CommandLineStep for OmpOffload {
             // `src/llvm-project` submodule instead.
             let mut cflags = CcFlags::default();
             if !builder.config.llvm_clang {
-                let base = builder.llvm_out(target).join("include");
+                let base = llvm_output_dir(builder, target).join("include");
                 let inc_dir = base.display();
                 cflags.push_all(format!(" -I {inc_dir}"));
             }
@@ -1420,7 +1427,7 @@ impl CommandLineStep for OmpOffload {
                 .define("LLVM_ENABLE_ASSERTIONS", "ON")
                 .define("LLVM_INCLUDE_TESTS", "OFF")
                 .define("OFFLOAD_INCLUDE_TESTS", "OFF")
-                .define("LLVM_ROOT", builder.llvm_out(target).join("build"))
+                .define("LLVM_ROOT", llvm_output_dir(builder, target).join("build"))
                 .define("LLVM_DIR", llvm_output.cmake_dir())
                 .define("LLVM_DEFAULT_TARGET_TRIPLE", omp_target);
             if let Some(p) = offload_clang_dir.clone() {

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -45,9 +45,7 @@ pub enum LlvmKind {
 /// Result of building or downloading LLVM artifacts.
 #[derive(Clone)]
 pub struct LlvmOutput {
-    /// Path to llvm-config binary.
-    /// NB: This is always the host llvm-config!
-    pub host_llvm_config: PathBuf,
+    llvm_config: PathBuf,
     link_shared: bool,
     llvm_root_dir: PathBuf,
     kind: LlvmKind,
@@ -73,6 +71,14 @@ impl LlvmOutput {
     /// How was the LLVM produced?
     pub fn kind(&self) -> LlvmKind {
         self.kind
+    }
+
+    /// Path to the `llvm-config` binary.
+    ///
+    /// Note that this binary might not be executable on the current host, if LLVM was built for a
+    /// different target.
+    pub fn llvm_config(&self) -> &Path {
+        &self.llvm_config
     }
 }
 
@@ -156,13 +162,13 @@ pub fn prebuilt_llvm_output(builder: &Builder<'_>, target: TargetSelection) -> O
         && let Some(ref s) = config.llvm_config
     {
         check_llvm_version(builder, s);
-        let host_llvm_config = s.to_path_buf();
-        let mut llvm_root_dir = host_llvm_config.clone();
+        let llvm_config = s.to_path_buf();
+        let mut llvm_root_dir = llvm_config.clone();
         llvm_root_dir.pop();
         llvm_root_dir.pop();
 
         return Some(LlvmOutput {
-            host_llvm_config,
+            llvm_config,
             link_shared: llvm_link_shared(&builder.config),
             llvm_root_dir,
             kind: LlvmKind::External,
@@ -204,21 +210,8 @@ fn get_locally_built_llvm_build_status(
 ) -> LlvmBuildStatus {
     let out_dir = llvm_output_dir(builder, target);
 
-    let build_llvm_config = if let Some(build_llvm_config) = builder
-        .config
-        .target_config
-        .get(&builder.config.host_target)
-        .and_then(|config| config.llvm_config.clone())
-    {
-        build_llvm_config
-    } else {
-        let mut llvm_config_ret_dir = llvm_output_dir(builder, builder.config.host_target);
-        llvm_config_ret_dir.push("bin");
-        llvm_config_ret_dir.join(exe("llvm-config", builder.config.host_target))
-    };
-
     let res = LlvmOutput {
-        host_llvm_config: build_llvm_config,
+        llvm_config: out_dir.join("bin").join(exe("llvm-config", target)),
         link_shared: llvm_link_shared(&builder.config),
         llvm_root_dir: out_dir.clone(),
         kind: LlvmKind::BuiltLocally,
@@ -292,7 +285,7 @@ fn try_download_ci_llvm(builder: &Builder<'_>, target: TargetSelection) -> Optio
 
     Some(DownloadedLlvm {
         output: LlvmOutput {
-            host_llvm_config: ci_llvm.join("bin").join(exe("llvm-config", builder.host_target)),
+            llvm_config: ci_llvm.join("bin").join(exe("llvm-config", builder.host_target)),
             link_shared,
             llvm_root_dir: ci_llvm,
             kind: LlvmKind::DownloadedFromCi,
@@ -410,7 +403,7 @@ impl Step for LlvmFromCi {
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         let llvm_ci = try_download_ci_llvm(builder, self.target)?;
         // Sanity check
-        check_llvm_version(builder, &llvm_ci.output.host_llvm_config);
+        check_llvm_version(builder, llvm_ci.output.llvm_config());
         Some(llvm_ci)
     }
 }
@@ -655,10 +648,9 @@ impl CommandLineStep for Llvm {
 
         // https://llvm.org/docs/HowToCrossCompileLLVM.html
         if !builder.config.is_host_target(target) {
-            let LlvmOutput { host_llvm_config, .. } =
-                builder.ensure(Llvm { target: builder.config.host_target });
+            let llvm_output = builder.ensure(Llvm { target: builder.config.host_target });
             if !builder.config.dry_run() {
-                let llvm_bindir = command(&host_llvm_config)
+                let llvm_bindir = command(llvm_output.llvm_config())
                     .arg("--bindir")
                     .cached()
                     .run_capture_stdout(builder)
@@ -671,10 +663,9 @@ impl CommandLineStep for Llvm {
                 // LLVM_NM is required for cross compiling using MSVC
                 cfg.define("LLVM_NM", host_bin.join("llvm-nm").with_extension(EXE_EXTENSION));
             }
-            cfg.define("LLVM_CONFIG_PATH", host_llvm_config);
+            cfg.define("LLVM_CONFIG_PATH", llvm_output.llvm_config());
             if builder.config.llvm_clang {
-                let build_bin =
-                    llvm_output_dir(builder, builder.config.host_target).join("build").join("bin");
+                let build_bin = llvm_output.root_dir().join("bin");
                 let clang_tblgen = build_bin.join("clang-tblgen").with_extension(EXE_EXTENSION);
                 if !builder.config.dry_run() && !clang_tblgen.exists() {
                     panic!("unable to find {}", clang_tblgen.display());
@@ -713,7 +704,13 @@ impl CommandLineStep for Llvm {
 
         // Helper to find the name of LLVM's shared library on darwin and linux.
         let find_llvm_lib_name = |extension| {
-            let major = get_llvm_version_major(builder, &output.host_llvm_config);
+            let llvm_config = if target == builder.host_target {
+                output.llvm_config().to_path_buf()
+            } else {
+                builder.ensure(Llvm { target: builder.host_target }).llvm_config().to_path_buf()
+            };
+
+            let major = get_llvm_version_major(builder, &llvm_config);
             match &llvm_version_suffix {
                 Some(version_suffix) => format!("libLLVM-{major}{version_suffix}.{extension}"),
                 None => format!("libLLVM-{major}.{extension}"),
@@ -763,6 +760,7 @@ impl CommandLineStep for Llvm {
     }
 }
 
+/// This has to be called with the **host** llvm-config!
 pub fn get_llvm_version(builder: &Builder<'_>, llvm_config: &Path) -> String {
     command(llvm_config)
         .arg("--version")
@@ -773,6 +771,7 @@ pub fn get_llvm_version(builder: &Builder<'_>, llvm_config: &Path) -> String {
         .to_owned()
 }
 
+/// This has to be called with the **host** llvm-config!
 pub fn get_llvm_version_major(builder: &Builder<'_>, llvm_config: &Path) -> u8 {
     let version = get_llvm_version(builder, llvm_config);
     let major_str = version.split_once('.').expect("Failed to parse LLVM version").0;
@@ -1139,8 +1138,7 @@ impl CommandLineStep for RustOffload {
 
         let out_dir = builder.out.join(self.target.triple).join("rust-offload");
 
-        let llvm_version_major =
-            llvm::get_llvm_version_major(builder, &llvm_output.host_llvm_config);
+        let llvm_version_major = get_llvm_version_major(builder, &builder.host_llvm_config());
         let lib_ext = std::env::consts::DLL_EXTENSION;
         let lib_rust_offload = format!("libRustOffload-{llvm_version_major}");
         let build_dir = out_dir.join(libdir(target));
@@ -1163,7 +1161,7 @@ impl CommandLineStep for RustOffload {
 
         cfg.out_dir(&out_dir)
             .profile(profile)
-            .env("LLVM_CONFIG_REAL", &llvm_output.host_llvm_config)
+            .env("LLVM_CONFIG_REAL", llvm_output.llvm_config())
             .define("LLVM_DIR", llvm_output.cmake_dir());
 
         cfg.build();
@@ -1247,7 +1245,7 @@ impl CommandLineStep for OmpOffload {
         }
         let target = self.target;
 
-        let llvm_output = builder.ensure(Llvm { target: self.target });
+        let llvm_output = builder.ensure(Llvm { target });
 
         // Running cmake twice in the same folder is known to cause issues, like deleting existing
         // binaries. We therefore write our offload artifacts into it's own folder, instead of
@@ -1390,7 +1388,7 @@ impl CommandLineStep for OmpOffload {
             // `src/llvm-project` submodule instead.
             let mut cflags = CcFlags::default();
             if !builder.config.llvm_clang {
-                let base = llvm_output_dir(builder, target).join("include");
+                let base = llvm_output.root_dir().join("include");
                 let inc_dir = base.display();
                 cflags.push_all(format!(" -I {inc_dir}"));
             }
@@ -1423,11 +1421,11 @@ impl CommandLineStep for OmpOffload {
             // runtime to simplify our build. So far, these are still under development.
             cfg.out_dir(&out_dir)
                 .profile(profile)
-                .env("LLVM_CONFIG_REAL", &llvm_output.host_llvm_config)
+                .env("LLVM_CONFIG_REAL", llvm_output.llvm_config())
                 .define("LLVM_ENABLE_ASSERTIONS", "ON")
                 .define("LLVM_INCLUDE_TESTS", "OFF")
                 .define("OFFLOAD_INCLUDE_TESTS", "OFF")
-                .define("LLVM_ROOT", llvm_output_dir(builder, target).join("build"))
+                .define("LLVM_ROOT", llvm_output.root_dir().join("build"))
                 .define("LLVM_DIR", llvm_output.cmake_dir())
                 .define("LLVM_DEFAULT_TARGET_TRIPLE", omp_target);
             if let Some(p) = offload_clang_dir.clone() {
@@ -1531,8 +1529,7 @@ impl CommandLineStep for Enzyme {
         let out_dir = builder.out.join(self.target.triple).join("enzyme");
         let stamp = BuildStamp::new(&out_dir).with_prefix("enzyme").add_stamp(smart_stamp_hash);
 
-        let llvm_version_major =
-            llvm::get_llvm_version_major(builder, &llvm_output.host_llvm_config);
+        let llvm_version_major = llvm::get_llvm_version_major(builder, &builder.host_llvm_config());
         let lib_ext = std::env::consts::DLL_EXTENSION;
         let libenzyme = format!("libEnzyme-{llvm_version_major}");
         let build_dir = out_dir.join(libdir(target));
@@ -1593,7 +1590,7 @@ impl CommandLineStep for Enzyme {
 
         cfg.out_dir(&out_dir)
             .profile(profile)
-            .env("LLVM_CONFIG_REAL", &llvm_output.host_llvm_config)
+            .env("LLVM_CONFIG_REAL", llvm_output.llvm_config())
             .define("LLVM_ENABLE_ASSERTIONS", "ON")
             .define("ENZYME_EXTERNAL_SHARED_LIB", "ON")
             .define("ENZYME_BC_LOADER", "OFF")
@@ -1646,13 +1643,13 @@ impl CommandLineStep for Lld {
         // we usually expect here is `./build/$triple/ci-llvm/`, with the binaries in its `bin`
         // subfolder. We check if that's the case, and if LLD's binary already exists there next to
         // `llvm-config`: if so, we can use it instead of building LLVM/LLD from source.
-        let ci_llvm_bin = llvm_output.host_llvm_config.parent().unwrap();
-        if ci_llvm_bin.is_dir() && ci_llvm_bin.file_name().unwrap() == "bin" {
-            let lld_path = ci_llvm_bin.join(exe("lld", target));
+        if matches!(llvm_output.kind, LlvmKind::DownloadedFromCi) {
+            let bin_dir = llvm_output.root_dir().join("bin");
+            let lld_path = bin_dir.join(exe("lld", target));
             if lld_path.exists() {
                 // The following steps copying `lld` as `rust-lld` to the sysroot, expect it in the
                 // `bin` subfolder of this step's out dir.
-                return ci_llvm_bin.parent().unwrap().to_path_buf();
+                return bin_dir.parent().unwrap().to_path_buf();
             }
         }
 
@@ -1726,7 +1723,7 @@ impl CommandLineStep for Lld {
             cfg.define(
                 "LLVM_TABLEGEN_EXE",
                 llvm_output
-                    .host_llvm_config
+                    .llvm_config()
                     .with_file_name("llvm-tblgen")
                     .with_extension(EXE_EXTENSION),
             );
@@ -1769,8 +1766,7 @@ impl CommandLineStep for Sanitizers {
             return runtimes;
         }
 
-        let LlvmOutput { host_llvm_config, .. } =
-            builder.ensure(Llvm { target: builder.config.host_target });
+        let llvm_host = builder.ensure(Llvm { target: builder.config.host_target });
 
         static STAMP_HASH_MEMO: OnceLock<String> = OnceLock::new();
         let smart_stamp_hash = STAMP_HASH_MEMO.get_or_init(|| {
@@ -1809,7 +1805,7 @@ impl CommandLineStep for Sanitizers {
         cfg.define("COMPILER_RT_BUILD_XRAY", "OFF");
         cfg.define("COMPILER_RT_DEFAULT_TARGET_ONLY", "ON");
         cfg.define("COMPILER_RT_USE_LIBCXX", "OFF");
-        cfg.define("LLVM_CONFIG_PATH", &host_llvm_config);
+        cfg.define("LLVM_CONFIG_PATH", llvm_host.llvm_config());
 
         if self.target.contains("ohos") {
             cfg.define("COMPILER_RT_USE_BUILTINS_LIBRARY", "ON");

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -1337,7 +1337,7 @@ impl CommandLineStep for OmpOffload {
         // alternative is that the user sets the offload_clang_dir path, in which case they hopefully point
         // to a suitable clang, otherwise the build will fail.
         let clang_bin_dir = if builder.config.llvm_clang {
-            llvm_output.host_llvm_config.parent().map(Path::to_path_buf)
+            llvm_output.llvm_config().parent().map(Path::to_path_buf)
         } else {
             // We expect the following (default) structure of the offload_clang_dir:
             // <prefix>/lib/cmake/clang, with a ClangConfig.cmake inside.

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2763,8 +2763,8 @@ Please disable assertions with `rust.debug-assertions = false`.
         if builder.config.llvm_enabled(test_compiler.host) {
             let llvm_output = builder.ensure(llvm::Llvm { target: builder.config.host_target });
             if !builder.config.dry_run() {
-                let llvm_version = get_llvm_version(builder, &llvm_output.host_llvm_config);
-                let llvm_components = command(&llvm_output.host_llvm_config)
+                let llvm_version = get_llvm_version(builder, llvm_output.llvm_config());
+                let llvm_components = command(llvm_output.llvm_config())
                     .cached()
                     .arg("--components")
                     .run_capture_stdout(builder)
@@ -2785,7 +2785,7 @@ Please disable assertions with `rust.debug-assertions = false`.
             // separate compilations. We can add LLVM's library path to the
             // rustc args as a workaround.
             if !builder.config.dry_run() && suite.ends_with("fulldeps") {
-                let llvm_libdir = command(&llvm_output.host_llvm_config)
+                let llvm_libdir = command(llvm_output.llvm_config())
                     .cached()
                     .arg("--libdir")
                     .run_capture_stdout(builder)
@@ -2806,7 +2806,7 @@ Please disable assertions with `rust.debug-assertions = false`.
                 // (The coverage-run tests also need these tools to process
                 // coverage reports.)
                 let llvm_bin_path = llvm_output
-                    .host_llvm_config
+                    .llvm_config()
                     .parent()
                     .expect("Expected llvm-config to be contained in directory");
                 assert!(llvm_bin_path.is_dir());

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2676,7 +2676,8 @@ Please disable assertions with `rust.debug-assertions = false`.
         }
 
         if helpers::forcing_clang_based_tests() {
-            let clang_exe = builder.llvm_out(target).join("bin").join("clang");
+            let llvm = builder.ensure(llvm::Llvm { target });
+            let clang_exe = llvm.root_dir().join("bin").join("clang");
             cmd.arg("--run-clang-based-tests-with").arg(clang_exe);
         }
 

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1296,10 +1296,13 @@ impl Builder<'_> {
         // separate Cargo projects. We can add LLVM's library path to the
         // rustc args as a workaround.
         if (mode == Mode::ToolRustcPrivate || mode == Mode::Codegen)
-            && let Some(llvm_config) = self.llvm_config(target)
+            && self.is_llvm_enabled_for(target)
         {
-            let llvm_libdir_raw =
-                command(llvm_config).cached().arg("--libdir").run_capture_stdout(self).stdout();
+            let llvm_libdir_raw = command(self.host_llvm_config())
+                .cached()
+                .arg("--libdir")
+                .run_capture_stdout(self)
+                .stdout();
             let llvm_libdir = llvm_libdir_raw.trim();
             if target.is_msvc() {
                 rustflags.arg(&format!("-Clink-arg=-LIBPATH:{llvm_libdir}"));

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1511,40 +1511,17 @@ Alternatively, you can set `build.local-rebuild=true` and use a stage0 compiler 
         cmd
     }
 
-    /// Return the path to `llvm-config` for the target, if it exists.
+    /// Returns true is LLVM is enabled for the given target and we are supposed to build it.
     ///
-    /// Note that this returns `None` if LLVM is disabled, or if we're in a
+    /// Note that this returns false if LLVM is disabled, or if we're in a
     /// check build or dry-run, where there's no need to build all of LLVM.
-    ///
-    /// FIXME(@kobzol)
-    /// **WARNING**: This actually returns the **HOST** LLVM config, not LLVM config for the given
-    /// *target*.
-    pub fn llvm_config(&self, target: TargetSelection) -> Option<PathBuf> {
-        if self.config.llvm_enabled(target) && self.kind != Kind::Check && !self.config.dry_run() {
-            let llvm::LlvmOutput { host_llvm_config, .. } = self.ensure(llvm::Llvm { target });
-            if host_llvm_config.is_file() {
-                return Some(host_llvm_config);
-            }
-        }
-        None
+    pub fn is_llvm_enabled_for(&self, target: TargetSelection) -> bool {
+        self.config.llvm_enabled(target) && self.kind != Kind::Check && !self.config.dry_run()
     }
 
-    /// Root output directory of LLVM for `target`
-    ///
-    /// Note that if LLVM is configured externally then the directory returned
-    /// will likely be empty.
-    pub fn llvm_out(&self, target: TargetSelection) -> PathBuf {
-        // We don't want to eagerly build LLVM by calling this function, so we only check if it
-        // was already downloaded from CI.
-        // The first part of the condition ensures that we don't download LLVM for non-host targets
-        // from CI eagerly (FIXME: this could be relaxed in the future).
-        if self.config.is_host_target(target)
-            && let Some(llvm_ci) = self.ensure(llvm::LlvmFromCi { target })
-        {
-            llvm_ci.output.root_dir().to_path_buf()
-        } else {
-            self.out.join(target).join("llvm")
-        }
+    /// Return the `llvm-config` for the host target, so that it is executable.
+    pub fn host_llvm_config(&self) -> PathBuf {
+        self.ensure(llvm::Llvm { target: self.host_target }).llvm_config().to_owned()
     }
 
     /// Updates all submodules, and exits with an error if submodule

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -245,7 +245,7 @@ fn test_prebuilt_llvm_config_path_resolution() {
     let build = Build::new(config);
     let builder = Builder::new(&build);
 
-    let expected = PathBuf::from("/some/path/to/llvm-config");
+    let host_llvm_config = PathBuf::from("/some/path/to/llvm-config");
 
     let actual =
         get_llvm_build_status(&builder, TargetSelection::from_user("arm-unknown-linux-gnueabihf"))
@@ -253,14 +253,17 @@ fn test_prebuilt_llvm_config_path_resolution() {
             .llvm_config()
             .to_path_buf();
     let actual = drop_win_disk_prefix_if_present(actual);
-    assert_ne!(expected, actual);
+    assert_ne!(
+        host_llvm_config, actual,
+        "llvm-config should be returned for the given target, not the host"
+    );
 
     let actual = get_llvm_build_status(&builder, builder.config.host_target)
         .llvm_output()
         .llvm_config()
         .to_path_buf();
     let actual = drop_win_disk_prefix_if_present(actual);
-    assert_eq!(expected, actual);
+    assert_eq!(host_llvm_config, actual);
 
     let config = configure(
         r#"

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -250,17 +250,16 @@ fn test_prebuilt_llvm_config_path_resolution() {
     let actual =
         get_llvm_build_status(&builder, TargetSelection::from_user("arm-unknown-linux-gnueabihf"))
             .llvm_output()
-            .host_llvm_config
-            .clone();
+            .llvm_config()
+            .to_path_buf();
     let actual = drop_win_disk_prefix_if_present(actual);
-    assert_eq!(expected, actual);
+    assert_ne!(expected, actual);
 
     let actual = get_llvm_build_status(&builder, builder.config.host_target)
         .llvm_output()
-        .host_llvm_config
-        .clone();
+        .llvm_config()
+        .to_path_buf();
     let actual = drop_win_disk_prefix_if_present(actual);
-    assert_eq!(expected, actual);
     assert_eq!(expected, actual);
 
     let config = configure(
@@ -275,8 +274,8 @@ fn test_prebuilt_llvm_config_path_resolution() {
 
     let actual = get_llvm_build_status(&builder, builder.config.host_target)
         .llvm_output()
-        .host_llvm_config
-        .clone();
+        .llvm_config()
+        .to_path_buf();
     let expected = builder
         .out
         .join(builder.config.host_target)
@@ -298,8 +297,8 @@ fn test_prebuilt_llvm_config_path_resolution() {
 
         let actual = get_llvm_build_status(&builder, builder.config.host_target)
             .llvm_output()
-            .host_llvm_config
-            .clone();
+            .llvm_config()
+            .to_path_buf();
         let expected = builder
             .out
             .join(builder.config.host_target)


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161247)*
<!-- homu-ignore:end -->

Continuation of https://github.com/rust-lang/rust/pull/160916.

This PR removes the `llvm_out` function, and makes it explicit when we need to build the host LLVM.

Before, bootstrap used to just arbitrarily run a `llvm-config` binary, even though it might not have been executable on the given host. Now, if we need to execute it, the host LLVM will always be explicitly built. It is possible that there are some cases where this will build LLVM where it didn't before, but that should only happen if you were on a target A, built LLVM for target B, and by sheer luck A could execute code for B (where A != B).
In any case, it is now explicit, so if we encounter such situation, we can fix it without depending on implicit assumptions (well, there are still thousands of other assumptions, but you get my point).

After this, I'll work on centralizing the sanity checking of downloading LLVM inside the `LlvmFromCi` step, which will allow us to log the exact reason why `download-ci-llvm` might not have been applied, and also enable downloading LLVM from CI for non-host targets.

r? jieyouxu
