### PR TITLE
core/num: Implement feature `float_nan_to`

### DIFF
--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1602,6 +1602,33 @@ impl f128 {
     pub const fn algebraic_rem(self, rhs: f128) -> f128 {
         intrinsics::frem_algebraic(self, rhs)
     }
+
+    /// Returns `self` if the value is not NaN, otherwise returns `replacement`
+    /// if `self` is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(f128)]
+    /// #![feature(float_nan_to)]
+    /// # #[cfg(target_has_reliable_f128)] {
+    ///
+    /// let n = f128::NAN;
+    /// let x = 2.0f128;
+    /// let y = f128::INFINITY;
+    ///
+    /// assert_eq!(n.nan_to(0.0f128), 0.0f128);
+    /// assert_eq!(x.nan_to(0.0f128), 2.0f128);
+    /// assert_eq!(y.nan_to(0.0f128), f128::INFINITY);
+    /// # }
+    /// ```
+    #[must_use = "method returns a new float and does not mutate the original value"]
+    #[unstable(feature = "float_nan_to", issue = "161248")]
+    #[rustc_const_unstable(feature = "float_nan_to", issue = "161248")]
+    #[inline]
+    pub const fn nan_to(self, replacement: f128) -> f128 {
+        if self.is_nan() { replacement } else { self }
+    }
 }
 
 // Functions in this module fall into `core_float_math`

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1588,6 +1588,33 @@ impl f16 {
     pub const fn algebraic_rem(self, rhs: f16) -> f16 {
         intrinsics::frem_algebraic(self, rhs)
     }
+
+    /// Returns `self` if the value is not NaN, otherwise returns `replacement`
+    /// if `self` is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(f16)]
+    /// #![feature(float_nan_to)]
+    /// # #[cfg(target_has_reliable_f16)] {
+    ///
+    /// let n = f16::NAN;
+    /// let x = 2.0f16;
+    /// let y = f16::INFINITY;
+    ///
+    /// assert_eq!(n.nan_to(0.0f16), 0.0f16);
+    /// assert_eq!(x.nan_to(0.0f16), 2.0f16);
+    /// assert_eq!(y.nan_to(0.0f16), f16::INFINITY);
+    /// # }
+    /// ```
+    #[must_use = "method returns a new float and does not mutate the original value"]
+    #[unstable(feature = "float_nan_to", issue = "161248")]
+    #[rustc_const_unstable(feature = "float_nan_to", issue = "161248")]
+    #[inline]
+    pub const fn nan_to(self, replacement: f16) -> f16 {
+        if self.is_nan() { replacement } else { self }
+    }
 }
 
 // Functions in this module fall into `core_float_math`

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1783,6 +1783,30 @@ impl f32 {
     pub const fn algebraic_rem(self, rhs: f32) -> f32 {
         intrinsics::frem_algebraic(self, rhs)
     }
+
+    /// Returns `self` if the value is not NaN, otherwise returns `replacement`
+    /// if `self` is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(float_nan_to)]
+    ///
+    /// let n = f32::NAN;
+    /// let x = 2.0f32;
+    /// let y = f32::INFINITY;
+    ///
+    /// assert_eq!(n.nan_to(0.0f32), 0.0f32);
+    /// assert_eq!(x.nan_to(0.0f32), 2.0f32);
+    /// assert_eq!(y.nan_to(0.0f32), f32::INFINITY);
+    /// ```
+    #[must_use = "method returns a new float and does not mutate the original value"]
+    #[unstable(feature = "float_nan_to", issue = "161248")]
+    #[rustc_const_unstable(feature = "float_nan_to", issue = "161248")]
+    #[inline]
+    pub const fn nan_to(self, replacement: f32) -> f32 {
+        if self.is_nan() { replacement } else { self }
+    }
 }
 
 /// Experimental implementations of floating point functions in `core`.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1763,6 +1763,30 @@ impl f64 {
     pub const fn algebraic_rem(self, rhs: f64) -> f64 {
         intrinsics::frem_algebraic(self, rhs)
     }
+
+    /// Returns `self` if the value is not NaN, otherwise returns `replacement`
+    /// if `self` is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(float_nan_to)]
+    ///
+    /// let n = f64::NAN;
+    /// let x = 2.0f64;
+    /// let y = f64::INFINITY;
+    ///
+    /// assert_eq!(n.nan_to(0.0f64), 0.0f64);
+    /// assert_eq!(x.nan_to(0.0f64), 2.0f64);
+    /// assert_eq!(y.nan_to(0.0f64), f64::INFINITY);
+    /// ```
+    #[must_use = "method returns a new float and does not mutate the original value"]
+    #[unstable(feature = "float_nan_to", issue = "161248")]
+    #[rustc_const_unstable(feature = "float_nan_to", issue = "161248")]
+    #[inline]
+    pub const fn nan_to(self, replacement: f64) -> f64 {
+        if self.is_nan() { replacement } else { self }
+    }
 }
 
 #[unstable(feature = "core_float_math", issue = "137578")]


### PR DESCRIPTION
Accepted ACP: https://github.com/rust-lang/libs-team/issues/787
Tracking issue: https://github.com/rust-lang/rust/issues/161248

Add function `nan_to` on `f16`, `f32`, `f64`, `f128` which replaces NaN values with a user-specified value or returns the original value if it is not a NaN.

---

No LLM use.
