### PR TITLE
Skip computing extra liveness info if borrow_set is empty

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
@@ -46,7 +46,13 @@ pub(super) fn generate<'tcx>(
     // unlike NLLs.
     // We do record these regions in the polonius context, since they're used to differentiate
     // relevant and boring locals, which is a key distinction used later in diagnostics.
-    if typeck.tcx().sess.opts.unstable_opts.polonius.is_next_enabled() {
+    // This additional liveness information is ultimately used for *loan* liveness,
+    // so we don't need to compute it when there are no loans.
+    // FIXME: this NLL optimization idea, to reduce work to relevant locals only, still makes sense
+    // for polonius, and should be investigated to improve liveness performance.
+    if typeck.tcx().sess.opts.unstable_opts.polonius.is_next_enabled()
+        && typeck.borrow_set.len() > 0
+    {
         let (_, boring_locals) =
             compute_relevant_live_locals(typeck.tcx(), &free_regions, typeck.body);
         typeck.polonius_context.as_mut().unwrap().boring_nll_locals =

--- a/tests/ui/drop/dropck-normalize-errors.polonius.stderr
+++ b/tests/ui/drop/dropck-normalize-errors.polonius.stderr
@@ -74,6 +74,23 @@ help: this trait has no implementations, consider adding one
 LL | trait NonImplementedTrait {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0277]: the trait bound `NonImplementedStruct: NonImplementedTrait` is not satisfied
+  --> $DIR/dropck-normalize-errors.rs:20:28
+   |
+LL | fn make_a_decoder<'a>() -> ADecoder<'a> {
+   |                            ^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `NonImplementedTrait` is not implemented for `NonImplementedStruct`
+  --> $DIR/dropck-normalize-errors.rs:15:1
+   |
+LL | struct NonImplementedStruct;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: this trait has no implementations, consider adding one
+  --> $DIR/dropck-normalize-errors.rs:12:1
+   |
+LL | trait NonImplementedTrait {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/drop/dropck-normalize-errors.rs
+++ b/tests/ui/drop/dropck-normalize-errors.rs
@@ -19,7 +19,7 @@ pub struct ADecoder<'a> {
 }
 fn make_a_decoder<'a>() -> ADecoder<'a> {
     //~^ ERROR the trait bound
-    //[nll]~| ERROR the trait bound
+    //~| ERROR the trait bound
     panic!()
 }
 

--- a/tests/ui/wf/hir-wf-check-erase-regions.polonius.stderr
+++ b/tests/ui/wf/hir-wf-check-erase-regions.polonius.stderr
@@ -37,6 +37,17 @@ help: the trait `Iterator` is implemented for `&mut I`
 note: required by a bound in `Flatten`
   --> $SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL
 
-error: aborting due to 3 previous errors
+error[E0277]: `&T` is not an iterator
+  --> $DIR/hir-wf-check-erase-regions.rs:16:27
+   |
+LL |     fn into_iter(self) -> Self::IntoIter {
+   |                           ^^^^^^^^^^^^^^ `&T` is not an iterator
+   |
+   = help: the trait `Iterator` is not implemented for `&T`
+help: the trait `Iterator` is implemented for `&mut I`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   = note: required for `&T` to implement `IntoIterator`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/wf/hir-wf-check-erase-regions.rs
+++ b/tests/ui/wf/hir-wf-check-erase-regions.rs
@@ -15,7 +15,7 @@ impl<'a, T, const N: usize> IntoIterator for &'a Table<T, N> {
 
     fn into_iter(self) -> Self::IntoIter {
         //~^ ERROR `&'a T` is not an iterator
-        //[nll]~| ERROR `&T` is not an iterator
+        //~| ERROR `&T` is not an iterator
         unimplemented!()
     }
 }


### PR DESCRIPTION
With polonius alpha, we currently compute liveness for a larger set of locals than NLL. However, this extra liveness only matters if there are borrows; so we can skip the extra work if there aren't any.

r? lqd