### PR TITLE
Implement `AsMut<T>` and `AsRef<T>` for `!`.

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -863,6 +863,28 @@ const impl AsMut<str> for str {
     }
 }
 
+#[stable(feature = "never_type", since = "CURRENT_RUSTC_VERSION")]
+#[expect(
+    clippy::explicit_auto_deref,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/17713"
+)]
+impl<T: ?Sized> AsRef<T> for ! {
+    fn as_ref(&self) -> &T {
+        *self
+    }
+}
+
+#[stable(feature = "never_type", since = "CURRENT_RUSTC_VERSION")]
+#[expect(
+    clippy::explicit_auto_deref,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/17713"
+)]
+impl<T: ?Sized> AsMut<T> for ! {
+    fn as_mut(&mut self) -> &mut T {
+        *self
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // THE NO-ERROR ERROR TYPE
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.pre2021.stderr
+++ b/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.pre2021.stderr
@@ -1,16 +1,11 @@
-error[E0277]: the trait bound `!: AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied
+error[E0277]: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied
   --> $DIR/generic-with-implicit-hrtb-without-dyn.rs:7:13
    |
 LL | fn ice() -> impl AsRef<Fn(&())> {
-   |             ^^^^^^^^^^^^^^^^^^^ the trait `AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not implemented for `!`
+   |             ^^^^^^^^^^^^^^^^^^^ the trait `AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not implemented for `()`
 ...
-LL |     todo!()
-   |     ------- return type was inferred to be `!` here
-   |
-help: `!` can be coerced to any type; consider casting it to a concrete type that implements the trait
-   |
-LL |     todo!() as /* Type */
-   |             +++++++++++++
+LL |     ()
+   |     -- return type was inferred to be `()` here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.rs
+++ b/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.rs
@@ -5,10 +5,10 @@
 #![allow(warnings)]
 
 fn ice() -> impl AsRef<Fn(&())> {
-    //[pre2021]~^ ERROR: the trait bound `!: AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied [E0277]
+    //[pre2021]~^ ERROR: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied [E0277]
     //[edition2021]~^^ ERROR: expected a type, found a trait [E0782]
     //[edition2021]~| ERROR: expected a type, found a trait [E0782]
-    todo!()
+    ()
 }
 
 fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161253)*
<!-- homu-ignore:end -->

This will allow e.g. `&[!]` to satisfy `&[T] where T: AsRef<str>`. It follows the recommendation from the never documentation:

> When writing your own traits, `!` should have an `impl` whenever there is an obvious `impl` which doesn’t `panic!`.

— <https://doc.rust-lang.org/1.97.1/std/primitive.never.html#-and-traits>

A class of use case for these impls is:

* some code is generic over `T: AsRef<SomeOtherType>`,
* and is still useful in the case where there are no `T`s, because it takes `Option<T>` or `&[T]` or any other input that can be empty or never-called, yet still do things with other inputs,

in which case providing `T = !` is slightly better than the alternative of providing an inhabited placeholder type, because it ensures that the generic code is compiled with knowledge of the fact that that there will never be any `T`s, even if the specific code that cares about whether there are any `T`s doesn’t get inlined into the call site that doesn’t provide any `T`s.

---

The test `tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.rs` had to be updated because it depended on this impl not existing. I’ve confirmed that the modified test still functions as a regression test by compiling it in nightly-2022-08-28 and seeing it ICE.

Tracking issue for never: rust-lang/rust#35121
(This change has no ACP or tracking issue of its own; I assume it is simple enough that T-libs-api can just accept or reject this PR, and the implementation will be stable when `!` is stable.)

@rustbot label -T-libs +T-libs-api +F-never_type