### PR TITLE
Ignore target feature test when LLVM fails to compile minicore

### DIFF
--- a/tests/ui/target-feature/abi-required-target-feature-missing-in-target-cpu.rs
+++ b/tests/ui/target-feature/abi-required-target-feature-missing-in-target-cpu.rs
@@ -9,6 +9,10 @@
 //@[arm] compile-flags: --target=armv8r-none-eabihf -Ctarget-cpu=cortex-r4
 //@[arm] needs-llvm-components: arm
 
+// LLVM 24 refuses to compile ARM minicore due to mismatched target features.
+// FIXME(#161276): With LLVM rejecting this, we should make Rust's own warning an error.
+//@[arm] max-llvm-major-version: 23
+
 // For now this is just a warning.
 //@ build-pass
 //@ ignore-backends: gcc


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/111334 made LLVM reject certain target feature + ABI mismatches (ARM hard / soft float) which means that minicore now [fails to build](https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/48076/canvas?sid=01a00f60-fa22-4f35-a854-0b6d1c302123) with errors like `error: <unknown>:0:0: in function _RNvXsc_Cs4Af2OiBEA1T_8minicoreiNtB5_3Add3add i32 (i32, i32): calling convention is hard-float, but floating-point registers are unavailable`

This PR ignores the test where this currently happens on LLVM 24, assuming that if LLVM is now rejecting this, we should turn the rust-side warning into an error as well. Created https://github.com/rust-lang/rust/issues/161276 to track that.

r? @RalfJung (since you worked ~recently on these, including migrating them to minicore)

@rustbot label llvm-main