### PR TITLE
chore: bump to cc@1.4.3 for rustc_llvm and library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,13 +543,14 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1437,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
@@ -2202,7 +2203,7 @@ dependencies = [
  "jsonpath-rust",
  "regex",
  "serde_json",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -3951,7 +3952,7 @@ dependencies = [
  "rustc_span",
  "rustc_target",
  "serde_json",
- "shlex",
+ "shlex 1.3.0",
  "tracing",
  "windows 0.61.3",
 ]
@@ -4320,7 +4321,7 @@ version = "0.0.0"
 dependencies = [
  "cc",
  "libc",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -5337,6 +5338,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"

--- a/compiler/rustc_llvm/Cargo.toml
+++ b/compiler/rustc_llvm/Cargo.toml
@@ -11,7 +11,7 @@ libc = "0.2.73"
 [build-dependencies]
 # tidy-alphabetical-start
 # `cc` updates often break things, so we pin it here.
-cc = "=1.2.16"
+cc = "=1.4.3"
 shlex = "1.3.0"
 # tidy-alphabetical-end
 

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -40,10 +40,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -87,6 +88,12 @@ dependencies = [
  "rustc-std-workspace-core",
  "windows-sys",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "foldhash"
@@ -314,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "std"

--- a/library/profiler_builtins/Cargo.toml
+++ b/library/profiler_builtins/Cargo.toml
@@ -12,4 +12,4 @@ doc = false
 
 [build-dependencies]
 # Pinned so `cargo update` bumps don't cause breakage
-cc = "=1.2.0"
+cc = "=1.4.3"

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -4,13 +4,16 @@ use std::sync::OnceLock;
 use std::{env, fs};
 
 use super::{Builder, Kind};
+use crate::core::build_steps::compile::is_lto_stage;
 use crate::core::build_steps::llvm::prebuilt_llvm_output;
 use crate::core::build_steps::test;
 use crate::core::build_steps::tool::SourceType;
 use crate::core::compiler::Compiler;
 use crate::core::config::flags::{Color, Subcommand};
 use crate::core::config::toml::pgo::PgoConfig;
-use crate::core::config::{CompressDebuginfo, Config, DryRun, SplitDebuginfo, TargetSelection};
+use crate::core::config::{
+    CompressDebuginfo, Config, DryRun, RustcLto, SplitDebuginfo, TargetSelection,
+};
 use crate::core::session::{CLang, GitRepo, Mode, RemapScheme};
 use crate::utils::build_stamp;
 use crate::utils::exec::{BootstrapCommand, command};
@@ -446,10 +449,34 @@ impl Cargo {
             let cc = ccacheify(&builder.cc(target));
             self.command.env(format!("CC_{triple_underscored}"), &cc);
 
+            // Compiling C deps, like jemalloc and llvm-wrapper, should be with
+            // the same LTO mode as the Rust code they are linked into.
+            //
+            // Std's C deps, e.g. compiler_builtins, ship inside rlibs that
+            // end users consume directly. Building with `-flto` may break
+            // non-LLVM linkers or mismatch on bitcode versions. Therefore we
+            // must not build std in LTO mode here.
+            let lto_cflag = if matches!(self.mode, Mode::Rustc | Mode::ToolRustcPrivate)
+                && is_lto_stage(&self.compiler)
+                && builder.cc_tool(target).is_like_clang()
+            {
+                match builder.config.rust_lto {
+                    RustcLto::Thin => Some("-flto=thin"),
+                    RustcLto::Fat => Some("-flto=full"),
+                    RustcLto::ThinLocal | RustcLto::Off => None,
+                }
+            } else {
+                None
+            };
+
             // Extend `CXXFLAGS_$TARGET` with our extra flags.
             let env = format!("CFLAGS_{triple_underscored}");
             let mut cflags =
                 builder.cc_unhandled_cflags(target, GitRepo::Rustc, CLang::C).join(" ");
+            if let Some(lto_cflag) = lto_cflag {
+                cflags.push(' ');
+                cflags.push_str(lto_cflag);
+            }
             if let Ok(var) = std::env::var(&env) {
                 cflags.push(' ');
                 cflags.push_str(&var);
@@ -471,6 +498,10 @@ impl Cargo {
                 let env = format!("CXXFLAGS_{triple_underscored}");
                 let mut cxxflags =
                     builder.cc_unhandled_cflags(target, GitRepo::Rustc, CLang::Cxx).join(" ");
+                if let Some(lto_cflag) = lto_cflag {
+                    cxxflags.push(' ');
+                    cxxflags.push_str(lto_cflag);
+                }
                 if let Ok(var) = std::env::var(&env) {
                     cxxflags.push(' ');
                     cxxflags.push_str(&var);

--- a/src/ci/docker/host-aarch64/dist-aarch64-linux/Dockerfile
+++ b/src/ci/docker/host-aarch64/dist-aarch64-linux/Dockerfile
@@ -101,3 +101,7 @@ ENV SCRIPT="python3 ../x.py build --set rust.debug=true opt-dist && \
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=clang
 ENV LIBCURL_NO_PKG_CONFIG="1"
 ENV DIST_REQUIRE_ALL_TOOLS="1"
+
+# FIXME: Without this, LLVMgold.so incorrectly resolves to the system
+# libstdc++, instead of the one we build.
+ENV LD_PRELOAD=/rustroot/lib64/libstdc++.so.6

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -526,6 +526,7 @@ const PERMITTED_STDLIB_DEPENDENCIES: &[&str] = &[
     "cfg-if",
     "compiler_builtins",
     "dlmalloc",
+    "find-msvc-tools", // via cc
     "foldhash", // FIXME: only appears in Cargo.lock due to https://github.com/rust-lang/cargo/issues/10801
     "fortanix-sgx-abi",
     "getopts",


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161260)*
<!-- homu-ignore:end -->

### What is this?

Old cc-rs derives this from the `-Clto` rustflag on its own.
`cc@1.2.39` starts gating that behind `-Clinker-plugin-lto`,
which bootstrap doesn't pass.
Therefore,
we need to pass this flag explicitly to keep LTO mode.

This also enables LTO for aarch64-linux.
Previously it never succeeded because it used system linker and the flag probe failed.
See <https://github.com/rust-lang/rust/pull/161260#issuecomment-5355995502>.

Previous efforts:

* https://github.com/rust-lang/rust/pull/146186
* https://github.com/rust-lang/rust/pull/155438

I personally want this because of cc 1.3.0+ has the support of Cargo `-Ztrim-paths`,
which helps what I am experimenting in <https://github.com/rust-lang/rust/pull/161049>.

### How to review

Commit by commit. 

To keep commits bisect-able,
I added the first commit without cc bump.
clang should be fine with duplicate `-flto` flags.

One thing I am not certain is whether we should probe `-flto` flag in this case,
or just make this fail if `-flto` isn't supported.
(I assume `-flto` is quote widely supported)

r? Kobzol

---

🤖 **LLM disclosure:** I used LLM for the experiment of <https://github.com/rust-lang/rust/pull/161049>, but not the bootstrap LTO change in this PR.


