### PR TITLE
break rustc_expand-rustc_middle dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4055,17 +4055,27 @@ dependencies = [
  "rustc_lexer",
  "rustc_lint_defs",
  "rustc_macros",
- "rustc_middle",
  "rustc_parse",
  "rustc_proc_macro",
  "rustc_serialize",
  "rustc_session",
  "rustc_span",
  "rustc_structures",
- "scoped-tls",
  "smallvec",
  "thin-vec",
  "tracing",
+]
+
+[[package]]
+name = "rustc_expand_queries"
+version = "0.0.0"
+dependencies = [
+ "rustc_ast",
+ "rustc_expand",
+ "rustc_middle",
+ "rustc_proc_macro",
+ "rustc_span",
+ "scoped-tls",
 ]
 
 [[package]]
@@ -4271,6 +4281,7 @@ dependencies = [
  "rustc_data_structures",
  "rustc_errors",
  "rustc_expand",
+ "rustc_expand_queries",
  "rustc_feature",
  "rustc_fs_util",
  "rustc_hir",

--- a/compiler/rustc_expand/Cargo.toml
+++ b/compiler/rustc_expand/Cargo.toml
@@ -20,7 +20,6 @@ rustc_hir = { path = "../rustc_hir" }
 rustc_lexer = { path = "../rustc_lexer" }
 rustc_lint_defs = { path = "../rustc_lint_defs" }
 rustc_macros = { path = "../rustc_macros" }
-rustc_middle = { path = "../rustc_middle" }
 rustc_parse = { path = "../rustc_parse" }
 # We must use the proc_macro version that we will compile proc-macros against,
 # not the one from our own sysroot.
@@ -29,7 +28,6 @@ rustc_serialize = { path = "../rustc_serialize" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_structures = { path = "../rustc_structures" }
-scoped-tls = "1.0"
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
 thin-vec = "0.2.19"
 tracing = "0.1"

--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -23,7 +23,3 @@ pub mod config;
 pub mod expand;
 pub mod module;
 pub mod proc_macro;
-
-pub fn provide(providers: &mut rustc_middle::query::Providers) {
-    providers.derive_macro_expansion = proc_macro::provide_derive_macro_expansion;
-}

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -6,7 +6,6 @@ use rustc_attr_ir::diagnostic::{CustomDiagnostic, Directive, FormatArgs};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{Applicability, Diag, DiagCtxtHandle, DiagMessage, pluralize};
 use rustc_macros::Subdiagnostic;
-use rustc_middle::bug;
 use rustc_parse::parser::{Parser, Recovery, token_descr};
 use rustc_session::parse::ParseSess;
 use rustc_span::source_map::SourceMap;
@@ -203,7 +202,7 @@ impl BestFailure {
 impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'matcher> {
     fn prepare(&mut self, which_matcher: WhichMatcher, matcher: &'matcher [MatcherLoc]) {
         if self.current.is_some() {
-            bug!("`Self::after_arm()` was not called to clean up context");
+            panic!("`Self::after_arm()` was not called to clean up context");
         }
 
         self.current = Some((which_matcher, matcher));
@@ -236,12 +235,12 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
             }
             Failure => {
                 if self.best_failure.is_none() {
-                    bug!("A matching failure occurred but `Self::failure()` was not called");
+                    panic!("A matching failure occurred but `Self::failure()` was not called");
                 }
             }
             Ambiguity => {
                 if self.result.is_none() {
-                    bug!("An ambiguity error occurred but `Self::ambiguity()` was not called");
+                    panic!("An ambiguity error occurred but `Self::ambiguity()` was not called");
                 }
             }
             ErrorReported(guar) => self.result = Some((self.root_span, guar)),
@@ -253,7 +252,7 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
 
     fn failure(&mut self, parser: &Parser<'_>) {
         let Some((which_matcher, _)) = self.current else {
-            bug!("`Self::prepare()` was not called to initialize context");
+            panic!("`Self::prepare()` was not called to initialize context");
         };
 
         let mut token = parser.token;
@@ -290,7 +289,7 @@ impl<'dcx, 'matcher> Tracker<'matcher> for CollectTrackerAndEmitter<'dcx, 'match
 
     fn ambiguity(&mut self, parser: &Parser<'_>) {
         let Some((_, matcher)) = self.current else {
-            bug!("`Self::prepare()` was not called to initialize context");
+            panic!("`Self::prepare()` was not called to initialize context");
         };
 
         #[expect(

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -80,7 +80,6 @@ pub(crate) use ParseResult::*;
 use rustc_ast::token::{self, DocComment, NonterminalKind, Token, TokenKind};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{Diag, ErrorGuaranteed};
-use rustc_middle::span_bug;
 use rustc_parse::parser::{ParseNtResult, Parser, token_descr};
 use rustc_span::{Ident, MacroRulesNormalizedIdent, Span};
 
@@ -732,17 +731,14 @@ impl TtParser {
         // `NamedParseResult`. Otherwise, it's an error.
         let mut ret_val = FxHashMap::default();
         for loc in matcher {
-            if let &MatcherLoc::MetaVarDecl { span, bind, .. } = loc
+            if let &MatcherLoc::MetaVarDecl { bind, .. } = loc
                 && ret_val
                     .insert(MacroRulesNormalizedIdent::new(bind), res.next().unwrap())
                     .is_some()
             {
                 // Duplicate binds are checked for when the macro definition is processed,
                 // and should have prevented the definition from ever being used.
-                span_bug!(
-                    span,
-                    "duplicate meta-variable binding went undetected at macro definition"
-                )
+                panic!("duplicate meta-variable binding went undetected at macro definition")
             }
         }
         ret_val

--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -1,8 +1,8 @@
 use rustc_ast as ast;
 use rustc_ast::tokenstream::TokenStream;
+use rustc_data_structures::AtomicRef;
 use rustc_data_structures::profiling::TimingGuard;
 use rustc_errors::ErrorGuaranteed;
-use rustc_middle::ty::{self, TyCtxt};
 use rustc_parse::parser::{AllowConstBlockItems, ForceCollect, Parser};
 use rustc_proc_macro as pm;
 use rustc_session::Session;
@@ -113,14 +113,7 @@ impl MultiItemModifier for DeriveProcMacro {
         let res = if ecx.sess.opts.incremental.is_some()
             && ecx.sess.opts.unstable_opts.cache_proc_macros
         {
-            ty::tls::with(|tcx| {
-                let input = &*tcx.arena.alloc(input);
-                let key: (LocalExpnId, &TokenStream) = (invoc_id, input);
-
-                QueryDeriveExpandCtx::enter(ecx, self.client, move || {
-                    tcx.derive_macro_expansion(key).cloned()
-                })
-            })
+            (*EXPAND_DERIVE_MACRO_CACHED)(invoc_id, input, ecx, self.client)
         } else {
             expand_derive_macro(invoc_id, input, ecx, self.client)
         };
@@ -163,24 +156,9 @@ impl MultiItemModifier for DeriveProcMacro {
     }
 }
 
-/// Provide a query for computing the output of a derive macro.
-pub(super) fn provide_derive_macro_expansion<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    key: (LocalExpnId, &'tcx TokenStream),
-) -> Result<&'tcx TokenStream, ()> {
-    let (invoc_id, input) = key;
-
-    // Make sure that we invalidate the query when the crate defining the proc macro changes
-    let _ = tcx.crate_hash(invoc_id.expn_data().macro_def_id.unwrap().krate);
-
-    QueryDeriveExpandCtx::with(|ecx, client| {
-        expand_derive_macro(invoc_id, input.clone(), ecx, client).map(|ts| &*tcx.arena.alloc(ts))
-    })
-}
-
 type DeriveClient = pm::bridge::client::Client;
 
-fn expand_derive_macro(
+pub fn expand_derive_macro(
     invoc_id: LocalExpnId,
     input: TokenStream,
     ecx: &mut ExtCtxt<'_>,
@@ -216,47 +194,12 @@ fn expand_derive_macro(
     }
 }
 
-/// Stores the context necessary to expand a derive proc macro via a query.
-struct QueryDeriveExpandCtx {
-    /// Type-erased version of `&mut ExtCtxt`
-    expansion_ctx: *mut (),
-    client: DeriveClient,
-}
-
-impl QueryDeriveExpandCtx {
-    /// Store the extension context and the client into the thread local value.
-    /// It will be accessible via the `with` method while `f` is active.
-    fn enter<F, R>(ecx: &mut ExtCtxt<'_>, client: DeriveClient, f: F) -> R
-    where
-        F: FnOnce() -> R,
-    {
-        // We need erasure to get rid of the lifetime
-        let ctx = Self { expansion_ctx: ecx as *mut _ as *mut (), client };
-        DERIVE_EXPAND_CTX.set(&ctx, f)
-    }
-
-    /// Accesses the thread local value of the derive expansion context.
-    /// Must be called while the `enter` function is active.
-    fn with<F, R>(f: F) -> R
-    where
-        F: for<'a, 'b> FnOnce(&'b mut ExtCtxt<'a>, DeriveClient) -> R,
-    {
-        DERIVE_EXPAND_CTX.with(|ctx| {
-            let ectx = {
-                let casted = ctx.expansion_ctx.cast::<ExtCtxt<'_>>();
-                // SAFETY: We can only get the value from `with` while the `enter` function
-                // is active (on the callstack), and that function's signature ensures that the
-                // lifetime is valid.
-                // If `with` is called at some other time, it will panic due to usage of
-                // `scoped_tls::with`.
-                unsafe { casted.as_mut().unwrap() }
-            };
-
-            f(ectx, ctx.client)
-        })
-    }
-}
-
-// When we invoke a query to expand a derive proc macro, we need to provide it with the expansion
-// context and derive Client. We do that using a thread-local.
-scoped_tls::scoped_thread_local!(static DERIVE_EXPAND_CTX: QueryDeriveExpandCtx);
+pub static EXPAND_DERIVE_MACRO_CACHED: AtomicRef<
+    fn(LocalExpnId, TokenStream, &mut ExtCtxt<'_>, DeriveClient) -> Result<TokenStream, ()>,
+> = AtomicRef::new(
+    &(|_, _, _: &mut ExtCtxt<'_>, _| -> Result<_, _> {
+        panic!(
+            "`EXPAND_DERIVE_MACRO_CACHED` callback was not setup; it must be set in `rustc_interface::callbacks`"
+        )
+    } as _),
+);

--- a/compiler/rustc_expand_queries/Cargo.toml
+++ b/compiler/rustc_expand_queries/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rustc_expand_queries"
+version = "0.0.0"
+edition = "2024"
+build = false
+
+[lib]
+doctest = false
+
+[dependencies]
+# tidy-alphabetical-start
+rustc_ast = { path = "../rustc_ast" }
+rustc_expand = { path = "../rustc_expand" }
+rustc_middle = { path = "../rustc_middle" }
+# We must use the proc_macro version that we will compile proc-macros against,
+# not the one from our own sysroot.
+rustc_proc_macro = { path = "../rustc_proc_macro" }
+rustc_span = { path = "../rustc_span" }
+scoped-tls = "1.0"
+# tidy-alphabetical-end

--- a/compiler/rustc_expand_queries/src/derive.rs
+++ b/compiler/rustc_expand_queries/src/derive.rs
@@ -1,0 +1,82 @@
+use rustc_ast::tokenstream::TokenStream;
+use rustc_expand::base::ExtCtxt;
+use rustc_middle::ty::{TyCtxt, tls};
+use rustc_proc_macro as pm;
+use rustc_span::LocalExpnId;
+
+type DeriveClient = pm::bridge::client::Client;
+
+/// Stores the context necessary to expand a derive proc macro via a query.
+struct QueryDeriveExpandCtx {
+    /// Type-erased version of `&mut ExtCtxt`
+    expansion_ctx: *mut (),
+    client: DeriveClient,
+}
+
+impl QueryDeriveExpandCtx {
+    /// Store the extension context and the client into the thread local value.
+    /// It will be accessible via the `with` method while `f` is active.
+    fn enter<F, R>(ecx: &mut ExtCtxt<'_>, client: DeriveClient, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        // We need erasure to get rid of the lifetime
+        let ctx = Self { expansion_ctx: ecx as *mut _ as *mut (), client };
+        DERIVE_EXPAND_CTX.set(&ctx, f)
+    }
+
+    /// Accesses the thread local value of the derive expansion context.
+    /// Must be called while the `enter` function is active.
+    fn with<F, R>(f: F) -> R
+    where
+        F: for<'a, 'b> FnOnce(&'b mut ExtCtxt<'a>, DeriveClient) -> R,
+    {
+        DERIVE_EXPAND_CTX.with(|ctx| {
+            let ectx = {
+                let casted = ctx.expansion_ctx.cast::<ExtCtxt<'_>>();
+                // SAFETY: We can only get the value from `with` while the `enter` function
+                // is active (on the callstack), and that function's signature ensures that the
+                // lifetime is valid.
+                // If `with` is called at some other time, it will panic due to usage of
+                // `scoped_tls::with`.
+                unsafe { casted.as_mut().unwrap() }
+            };
+
+            f(ectx, ctx.client)
+        })
+    }
+}
+
+// When we invoke a query to expand a derive proc macro, we need to provide it with the expansion
+// context and derive Client. We do that using a thread-local.
+scoped_tls::scoped_thread_local!(static DERIVE_EXPAND_CTX: QueryDeriveExpandCtx);
+
+pub(crate) fn expand_derive_macro_cached(
+    invoc_id: LocalExpnId,
+    input: TokenStream,
+    ecx: &mut ExtCtxt<'_>,
+    client: DeriveClient,
+) -> Result<TokenStream, ()> {
+    tls::with(|tcx| {
+        let input = &*tcx.arena.alloc(input);
+        let key: (LocalExpnId, &TokenStream) = (invoc_id, input);
+
+        QueryDeriveExpandCtx::enter(ecx, client, move || tcx.derive_macro_expansion(key).cloned())
+    })
+}
+
+/// Provide a query for computing the output of a derive macro.
+pub(crate) fn derive_macro_expansion<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    key: (LocalExpnId, &'tcx TokenStream),
+) -> Result<&'tcx TokenStream, ()> {
+    let (invoc_id, input) = key;
+
+    // Make sure that we invalidate the query when the crate defining the proc macro changes
+    let _ = tcx.crate_hash(invoc_id.expn_data().macro_def_id.unwrap().krate);
+
+    QueryDeriveExpandCtx::with(|ecx, client| {
+        rustc_expand::proc_macro::expand_derive_macro(invoc_id, input.clone(), ecx, client)
+            .map(|ts| &*tcx.arena.alloc(ts))
+    })
+}

--- a/compiler/rustc_expand_queries/src/lib.rs
+++ b/compiler/rustc_expand_queries/src/lib.rs
@@ -1,0 +1,13 @@
+#![allow(internal_features, reason = "proc macro internals")]
+#![feature(proc_macro_internals)]
+
+mod derive;
+
+pub fn setup_callbacks() {
+    rustc_expand::proc_macro::EXPAND_DERIVE_MACRO_CACHED
+        .swap(&(derive::expand_derive_macro_cached as _));
+}
+
+pub fn provide(providers: &mut rustc_middle::query::Providers) {
+    providers.derive_macro_expansion = derive::derive_macro_expansion;
+}

--- a/compiler/rustc_interface/Cargo.toml
+++ b/compiler/rustc_interface/Cargo.toml
@@ -20,6 +20,7 @@ rustc_crate_store = { path = "../rustc_crate_store" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_expand = { path = "../rustc_expand" }
+rustc_expand_queries = { path = "../rustc_expand_queries" }
 rustc_feature = { path = "../rustc_feature" }
 rustc_fs_util = { path = "../rustc_fs_util" }
 rustc_hir = { path = "../rustc_hir" }

--- a/compiler/rustc_interface/src/callbacks.rs
+++ b/compiler/rustc_interface/src/callbacks.rs
@@ -91,4 +91,5 @@ pub fn setup_callbacks() {
     rustc_hir::def_id::DEF_ID_DEBUG.swap(&(def_id_debug as fn(_, &mut fmt::Formatter<'_>) -> _));
     rustc_errors::TRACK_DIAGNOSTIC.swap(&(track_diagnostic as _));
     rustc_feature::TRACK_FEATURE.swap(&(track_feature as _));
+    rustc_expand_queries::setup_callbacks();
 }

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -907,7 +907,7 @@ pub static DEFAULT_QUERY_PROVIDERS: LazyLock<Providers> = LazyLock::new(|| {
     providers.queries.proc_macro_decls_static = |tcx, _| tcx.hir_crate_items(()).proc_macro_decls();
     rustc_ast_lowering::provide(&mut providers.queries);
     limits::provide(&mut providers.queries);
-    rustc_expand::provide(&mut providers.queries);
+    rustc_expand_queries::provide(&mut providers.queries);
     rustc_const_eval::provide(providers);
     rustc_middle::hir::provide(&mut providers.queries);
     rustc_borrowck::provide(&mut providers.queries);

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_bench.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_bench.snap
@@ -45,6 +45,7 @@ expression: bench
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_compiler.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_build_compiler.snap
@@ -27,6 +27,7 @@ expression: build compiler
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check.snap
@@ -29,6 +29,7 @@ expression: check
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_compiler.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_compiler.snap
@@ -29,6 +29,7 @@ expression: check compiler
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_compiletest_include_default_paths.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_check_compiletest_include_default_paths.snap
@@ -29,6 +29,7 @@ expression: check compiletest --include-default-paths
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_clippy.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_clippy.snap
@@ -44,6 +44,7 @@ expression: clippy
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_fix.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_fix.snap
@@ -29,6 +29,7 @@ expression: fix
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
@@ -93,6 +93,7 @@ expression: test
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
@@ -90,6 +90,7 @@ expression: test --skip=coverage
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_map.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_map.snap
@@ -93,6 +93,7 @@ expression: test --skip=coverage-map
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_run.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage_run.snap
@@ -93,6 +93,7 @@ expression: test --skip=coverage-run
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
@@ -54,6 +54,7 @@ expression: test --skip=tests
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_coverage.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_coverage.snap
@@ -90,6 +90,7 @@ expression: test --skip=tests/coverage
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_etc.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests_etc.snap
@@ -38,6 +38,7 @@ expression: test --skip=tests --skip=library --skip=tidyselftest
     - Set({compiler/rustc_error_messages})
     - Set({compiler/rustc_errors})
     - Set({compiler/rustc_expand})
+    - Set({compiler/rustc_expand_queries})
     - Set({compiler/rustc_feature})
     - Set({compiler/rustc_fs_util})
     - Set({compiler/rustc_graphviz})

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -1600,7 +1600,7 @@ mod snapshot {
         insta::assert_snapshot!(
             ctx.config("check")
                 .path("compiler")
-                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (77 crates)");
+                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (78 crates)");
     }
 
     #[test]
@@ -1626,7 +1626,7 @@ mod snapshot {
             ctx.config("check")
                 .path("compiler")
                 .stage(1)
-                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (77 crates)");
+                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (78 crates)");
     }
 
     #[test]
@@ -1640,7 +1640,7 @@ mod snapshot {
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
-        [check] rustc 1 <host> -> rustc 2 <host> (77 crates)
+        [check] rustc 1 <host> -> rustc 2 <host> (78 crates)
         ");
     }
 
@@ -1656,7 +1656,7 @@ mod snapshot {
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
         [check] rustc 1 <host> -> std 1 <target1>
-        [check] rustc 1 <host> -> rustc 2 <target1> (77 crates)
+        [check] rustc 1 <host> -> rustc 2 <target1> (78 crates)
         [check] rustc 1 <host> -> rustc 2 <target1>
         [check] rustc 1 <host> -> Rustdoc 2 <target1>
         [check] rustc 1 <host> -> rustc_codegen_cranelift 2 <target1>
@@ -1753,7 +1753,7 @@ mod snapshot {
             ctx.config("check")
                 .paths(&["library", "compiler"])
                 .args(&args)
-                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (77 crates)");
+                .render_steps(), @"[check] rustc 0 <host> -> rustc 1 <host> (78 crates)");
     }
 
     #[test]
@@ -2982,7 +2982,7 @@ mod snapshot {
     #[test]
     fn fix_compiler() {
         let ctx = TestCtx::new();
-        insta::assert_snapshot!(ctx.config("fix").path("compiler").render_steps(), @"[fix] rustc 0 <host> -> rustc 1 <host> (77 crates)");
+        insta::assert_snapshot!(ctx.config("fix").path("compiler").render_steps(), @"[fix] rustc 0 <host> -> rustc 1 <host> (78 crates)");
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161263)*
<!-- homu-ignore:end -->

Back in https://github.com/rust-lang/rust/pull/145354 (cc @Kobzol), support for caching derive macros was added. With this, rustc_expand was made to depend on rustc_middle.

This PR breaks that dependency so that rustc_expand and rustc_builtin_macros can compile in parallel with rustc_middle. 

The timing graph goes from this:
<img width="451" height="438" alt="image" src="https://github.com/user-attachments/assets/2d48b0d4-443c-4ec8-b4f0-a6412e86a62f" />


to this:
<img width="456" height="309" alt="image" src="https://github.com/user-attachments/assets/66519857-fa65-4794-ad66-aa565170e196" />

Note that the interval where we're exclusively compiling rustc_middle has become much shorter.
Full graphs here: 
[cargo-timing-main.html](https://github.com/user-attachments/files/31157361/cargo-timing-main.html)
[cargo-timing-expand2.html](https://github.com/user-attachments/files/31157373/cargo-timing-expand2.html)

It's somewhat hard to benchmark reliably but a full bootstrap is about 5-10 seconds faster overall, on a machine with an Amd Ryzen 5900x 12-core processor.
