### PR TITLE
Fix ordering for `default impl` check in the new solver

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -562,14 +562,7 @@ where
             )
             .map_err_to_rerun()?
             {
-                Ok(candidate) => {
-                    // For every `default impl`, there's always a non-default `impl`
-                    // that will *also* apply. There's no reason to register a candidate
-                    // for this impl, since it is *not* proof that the trait goal holds.
-                    if !cx.impl_is_default(impl_def_id) {
-                        candidates.push(candidate);
-                    }
-                }
+                Ok(candidate) => candidates.push(candidate),
                 Err(NoSolution) => {}
             }
 
@@ -1179,13 +1172,6 @@ where
             let cx = self.cx();
             let goal_trait_ref = goal.predicate.trait_ref(cx);
             cx.for_each_blanket_impl(goal.predicate.trait_def_id(cx), |impl_def_id| {
-                // For every `default impl`, there's always a non-default `impl`
-                // that will *also* apply. There's no reason to register a candidate
-                // for this impl, since it is *not* proof that the trait goal holds.
-                if cx.impl_is_default(impl_def_id) {
-                    return Ok(());
-                }
-
                 match G::consider_impl_candidate(
                     self,
                     goal,

--- a/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
@@ -149,6 +149,13 @@ where
             return Err(NoSolution.into());
         }
 
+        // For every `default impl`, there's always a non-default `impl` that will *also* apply.
+        // There's no reason to register a candidate for this impl, since it is *not* proof that
+        // the trait goal holds.
+        if cx.impl_is_default(impl_def_id) {
+            return Err(NoSolution.into());
+        }
+
         let impl_polarity = cx.impl_polarity(impl_def_id);
         let certainty = match impl_polarity {
             ty::ImplPolarity::Negative => return Err(NoSolution.into()),

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to.rs
@@ -267,6 +267,13 @@ where
             return Err(NoSolution.into());
         }
 
+        // For every `default impl`, there's always a non-default `impl` that will *also* apply.
+        // There's no reason to register a candidate for this impl, since it is *not* proof that
+        // the trait goal holds.
+        if cx.impl_is_default(impl_def_id) {
+            return Err(NoSolution.into());
+        }
+
         // We have to ignore negative impls when projecting.
         let impl_polarity = cx.impl_polarity(impl_def_id);
         match impl_polarity {

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -73,6 +73,13 @@ where
             return Err(NoSolution.into());
         }
 
+        // For every `default impl`, there's always a non-default `impl` that will *also* apply.
+        // There's no reason to register a candidate for this impl, since it is *not* proof that
+        // the trait goal holds.
+        if cx.impl_is_default(impl_def_id) {
+            return Err(NoSolution.into());
+        }
+
         // An upper bound of the certainty of this goal, used to lower the certainty
         // of reservation impl to ambiguous during coherence.
         let impl_polarity = cx.impl_polarity(impl_def_id);

--- a/tests/ui/specialization/defaultimpl/out-of-order-2.rs
+++ b/tests/ui/specialization/defaultimpl/out-of-order-2.rs
@@ -1,0 +1,20 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+// Regression test for the ICE in #160994, caused by an ordering issue in the new trait solver.
+
+#![feature(specialization)]
+
+trait Foo {
+    type Out;
+}
+
+impl Foo for bool {
+    type Out = ();
+}
+
+default impl<T> Foo for T {}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161268)*
<!-- homu-ignore:end -->

The second commit of rust-lang/rust#160605 moved the `default impl` check later, for better performance, which introduced a regression. This commit moves the check a little earlier, so it is after the `args_may_unify` call (thus retaining the perf benefit) but before the `probe_trait_candidate` (which has side-effects).

The check is now duplicated in three `GoalKind::consider_impl_candidate` methods, which is unfortunate, but it fits in with the existing duplicated code in those methods. And it means another copy of the check (in `try_assemble_bounds_via_registered_opaques`) can be removed.

Fixes rust-lang/rust#160994.

r? @lcnr