### PR TITLE
Remove `impl DebugWithContext for BorrowckDomain`

### DIFF
--- a/compiler/rustc_borrowck/src/dataflow.rs
+++ b/compiler/rustc_borrowck/src/dataflow.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_index::bit_set::{DenseBitSet, MixedBitSet};
 use rustc_middle::mir::{self, BasicBlock, Body, CallReturnPlaces, Location, Place};
@@ -16,7 +14,8 @@ use crate::{BorrowSet, PlaceConflictBias, PlaceExt, RegionInferenceContext, plac
 
 // This analysis is different to most others. Its results aren't computed with
 // `iterate_to_fixpoint`, but are instead composed from the results of three sub-analyses that are
-// computed individually with `iterate_to_fixpoint`.
+// computed individually with `iterate_to_fixpoint`. Because it's faster that way than having a
+// single analysis where the domain has three components.
 pub(crate) struct Borrowck<'a, 'tcx> {
     pub(crate) borrows: Borrows<'a, 'tcx>,
     pub(crate) uninits: MaybeUninitializedPlaces<'a, 'tcx>,
@@ -100,47 +99,6 @@ impl JoinSemiLattice for BorrowckDomain {
     fn join(&mut self, _other: &Self) -> bool {
         // This is only reachable from `iterate_to_fixpoint`, which this analysis doesn't use.
         unreachable!();
-    }
-}
-
-impl<'tcx, C> DebugWithContext<C> for BorrowckDomain
-where
-    C: rustc_mir_dataflow::move_paths::HasMoveData<'tcx>,
-{
-    fn fmt_with(&self, ctxt: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("borrows: ")?;
-        self.borrows.fmt_with(ctxt, f)?;
-        f.write_str(" uninits: ")?;
-        self.uninits.fmt_with(ctxt, f)?;
-        f.write_str(" ever_inits: ")?;
-        self.ever_inits.fmt_with(ctxt, f)?;
-        Ok(())
-    }
-
-    fn fmt_diff_with(&self, old: &Self, ctxt: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self == old {
-            return Ok(());
-        }
-
-        if self.borrows != old.borrows {
-            f.write_str("borrows: ")?;
-            self.borrows.fmt_diff_with(&old.borrows, ctxt, f)?;
-            f.write_str("\n")?;
-        }
-
-        if self.uninits != old.uninits {
-            f.write_str("uninits: ")?;
-            self.uninits.fmt_diff_with(&old.uninits, ctxt, f)?;
-            f.write_str("\n")?;
-        }
-
-        if self.ever_inits != old.ever_inits {
-            f.write_str("ever_inits: ")?;
-            self.ever_inits.fmt_diff_with(&old.ever_inits, ctxt, f)?;
-            f.write_str("\n")?;
-        }
-
-        Ok(())
     }
 }
 


### PR DESCRIPTION
Only `iterate_to_fixpoint` requires `Domain: DebugWithContext<Self>`; `visit_results` does not. And `Borrowck` is an unusual analysis that never calls `iterate_to_fixpoint`; instead its results are composed from the results of the three sub-analyses.

r? @cjgillot