### PR TITLE
[EXPERIMENT] Use `SmallVec` in `GoalStalledOn`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4506,7 +4506,7 @@ dependencies = [
  "rustc_macros",
  "rustc_type_ir",
  "rustc_type_ir_macros",
- "thin-vec",
+ "smallvec",
  "tracing",
 ]
 

--- a/compiler/rustc_middle/src/traits/solve.rs
+++ b/compiler/rustc_middle/src/traits/solve.rs
@@ -104,6 +104,6 @@ mod size_asserts {
 
     use super::*;
     // tidy-alphabetical-start
-    static_assert_size!(GoalStalledOn<'_>, 56);
+    static_assert_size!(GoalStalledOn<'_>, 88);
     // tidy-alphabetical-end
 }

--- a/compiler/rustc_next_trait_solver/Cargo.toml
+++ b/compiler/rustc_next_trait_solver/Cargo.toml
@@ -11,7 +11,7 @@ rustc_index = { path = "../rustc_index", default-features = false }
 rustc_macros = { path = "../rustc_macros", optional = true }
 rustc_type_ir = { path = "../rustc_type_ir", default-features = false }
 rustc_type_ir_macros = { path = "../rustc_type_ir_macros" }
-thin-vec = "0.2.19"
+smallvec = { version = "1.8.1", features = ["union"] }
 tracing = "0.1"
 # tidy-alphabetical-end
 
@@ -23,5 +23,6 @@ nightly = [
     "dep:rustc_macros",
     "rustc_index/nightly",
     "rustc_type_ir/nightly",
+    "smallvec/may_dangle",
 ]
 # tidy-alphabetical-end

--- a/compiler/rustc_next_trait_solver/src/canonical/canonicalizer.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/canonicalizer.rs
@@ -8,7 +8,7 @@ use rustc_type_ir::{
     Flags, InferCtxtLike, Interner, PlaceholderConst, PlaceholderType, Region, TypeFlags,
     TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt,
 };
-use thin_vec::ThinVec;
+use smallvec::SmallVec;
 
 use crate::delegate::SolverDelegate;
 
@@ -201,7 +201,7 @@ impl<'a, D: SolverDelegate<Interner = I>, I: Interner> Canonicalizer<'a, D, I> {
     pub(super) fn canonicalize_input<P: TypeFoldable<I>>(
         delegate: &'a D,
         input: QueryInput<I, P>,
-    ) -> (ThinVec<I::GenericArg>, ty::Canonical<I, QueryInput<I, P>>) {
+    ) -> (SmallVec<[I::GenericArg; 2]>, ty::Canonical<I, QueryInput<I, P>>) {
         // First canonicalize the `param_env` while keeping `'static`. This produces a
         // canonicalizer that can canonicalize the rest of the input without keeping `'static`.
         let (param_env, mut rest_canonicalizer) =
@@ -271,7 +271,9 @@ impl<'a, D: SolverDelegate<Interner = I>, I: Interner> Canonicalizer<'a, D, I> {
         ty::BoundVar::from(idx)
     }
 
-    fn finalize(mut self) -> (ty::UniverseIndex, ThinVec<I::GenericArg>, I::CanonicalVarKinds) {
+    fn finalize(
+        mut self,
+    ) -> (ty::UniverseIndex, SmallVec<[I::GenericArg; 2]>, I::CanonicalVarKinds) {
         // See the rustc-dev-guide section about how we deal with universes
         // during canonicalization in the new solver.
         let max_universe = match self.canonicalize_mode {

--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -21,7 +21,7 @@ use rustc_type_ir::{
     self as ty, Canonical, CanonicalVarKind, CanonicalVarValues, InferCtxtLike, Interner, Region,
     TypeFoldable, TypingMode, TypingModeEqWrapper, eager_resolve_vars,
 };
-use thin_vec::ThinVec;
+use smallvec::SmallVec;
 use tracing::instrument;
 
 use crate::delegate::SolverDelegate;
@@ -58,7 +58,7 @@ pub(super) fn canonicalize_goal<D, I>(
     goal: Goal<I, I::Predicate>,
     opaque_types: &[(ty::OpaqueTypeKey<I>, I::Ty)],
     typing_mode: TypingMode<I>,
-) -> (ThinVec<I::GenericArg>, CanonicalInput<I, I::Predicate>)
+) -> (SmallVec<[I::GenericArg; 2]>, CanonicalInput<I, I::Predicate>)
 where
     D: SolverDelegate<Interner = I>,
     I: Interner,
@@ -578,7 +578,7 @@ pub fn instantiate_canonical_state<D, I, T>(
     span: I::Span,
     param_env: I::ParamEnv,
     prev_universe: ty::UniverseIndex,
-    orig_values: &mut ThinVec<I::GenericArg>,
+    orig_values: &mut SmallVec<[I::GenericArg; 2]>,
     state: inspect::CanonicalState<I, T>,
 ) -> T
 where

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -19,7 +19,7 @@ use rustc_type_ir::{
     OpaqueTypeKey, PredicateKind, Region, TypeFoldable, TypeSuperVisitable, TypeVisitable,
     TypeVisitableExt, TypeVisitor, TypingMode, eager_resolve_vars,
 };
-use thin_vec::ThinVec;
+use smallvec::SmallVec;
 use tracing::{Level, debug, instrument, trace, warn};
 
 use super::has_only_region_constraints;
@@ -838,11 +838,11 @@ where
         &self,
         canonical_goal: CanonicalInput<I>,
         maybe_info: MaybeInfo,
-        stalled_vars: ThinVec<I::GenericArg>,
+        stalled_vars: SmallVec<[I::GenericArg; 2]>,
         previously_succeeded_in_erased: SucceededInErased<I>,
     ) -> GoalStalledOn<I> {
         // Remove the canonicalized universal vars, since we only care about stalled existentials.
-        let mut sub_roots = ThinVec::new();
+        let mut sub_roots = SmallVec::new();
         let stalled_vars = stalled_vars
             .into_iter()
             .filter_map(|arg| match arg.kind() {

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -22,7 +22,7 @@ use rustc_middle::ty::{
 };
 use rustc_next_trait_solver::solve::{GoalStalledOn, GoalStalledOnOpaques, TyOrConstInferVar};
 use rustc_span::{DUMMY_SP, Span};
-use thin_vec::{ThinVec, thin_vec};
+use smallvec::{SmallVec, smallvec};
 
 use crate::traits::{EvaluateConstErr, ObligationCause, sizedness_fast_path, specialization_graph};
 
@@ -56,12 +56,12 @@ impl<'tcx> SolverDelegate<'tcx> {
 /// Create a [`ComputeGoalFastPathOutcome`] signalling the goal is stalled
 /// on a list of [`ty::GenericArg`]
 fn goal_stalled_on_args<'tcx>(
-    stalled_vars: ThinVec<TyOrConstInferVar>,
+    stalled_vars: SmallVec<[TyOrConstInferVar; 2]>,
 ) -> ComputeGoalFastPathOutcome<'tcx> {
     ComputeGoalFastPathOutcome::TriviallyStalled {
         stalled_on: GoalStalledOn {
             stalled_vars,
-            sub_roots: ThinVec::new(),
+            sub_roots: SmallVec::new(),
             stalled_maybe_info: MaybeInfo::AMBIGUOUS,
             opaques: GoalStalledOnOpaques::No,
         },
@@ -72,12 +72,12 @@ fn goal_stalled_on_args<'tcx>(
 /// on a list of [`ty::GenericArg`] *or* the opaque type storage being nonempty.
 ///
 fn goal_stalled_on_args_or_nonempty_opaques<'tcx>(
-    stalled_vars: ThinVec<TyOrConstInferVar>,
+    stalled_vars: SmallVec<[TyOrConstInferVar; 2]>,
 ) -> ComputeGoalFastPathOutcome<'tcx> {
     ComputeGoalFastPathOutcome::TriviallyStalled {
         stalled_on: GoalStalledOn {
             stalled_vars,
-            sub_roots: ThinVec::new(),
+            sub_roots: SmallVec::new(),
             stalled_maybe_info: MaybeInfo::AMBIGUOUS,
             opaques: GoalStalledOnOpaques::Yes {
                 num_opaques_in_storage: 0,
@@ -91,7 +91,7 @@ fn goal_stalled_on_args_or_nonempty_opaques<'tcx>(
 }
 
 struct CollectNonRegionInfer<'tcx> {
-    infers: ThinVec<ty::GenericArg<'tcx>>,
+    infers: SmallVec<[ty::GenericArg<'tcx>; 2]>,
     visited: FxHashSet<Ty<'tcx>>,
 }
 
@@ -164,7 +164,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                 // FIXME: Properly consider opaques here.
                 && self.known_no_opaque_types_in_storage()
                 {
-                    goal_stalled_on_args_or_nonempty_opaques(thin_vec![TyOrConstInferVar::Ty(vid)])
+                    goal_stalled_on_args_or_nonempty_opaques(smallvec![TyOrConstInferVar::Ty(vid)])
                 } else if trait_pred.polarity() == ty::PredicatePolarity::Positive {
                     match self.0.tcx.as_lang_item(trait_pred.def_id()) {
                         Some(LangItem::Sized) | Some(LangItem::MetaSized) => {
@@ -259,7 +259,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                 match (self.shallow_resolve(a).kind(), self.shallow_resolve(b).kind()) {
                     (&ty::Infer(ty::TyVar(a_vid)), &ty::Infer(ty::TyVar(b_vid))) => {
                         self.sub_unify_ty_vids_raw(a_vid, b_vid);
-                        goal_stalled_on_args(thin_vec![
+                        goal_stalled_on_args(smallvec![
                             TyOrConstInferVar::Ty(a_vid),
                             TyOrConstInferVar::Ty(b_vid),
                         ])
@@ -274,7 +274,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
 
                 let arg = self.shallow_resolve_const(ct);
                 if let Some(vid) = arg.ct_vid() {
-                    goal_stalled_on_args(thin_vec![TyOrConstInferVar::Const(vid)])
+                    goal_stalled_on_args(smallvec![TyOrConstInferVar::Const(vid)])
                 } else {
                     Outcome::NoFastPath
                 }
@@ -288,7 +288,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                 if arg.is_trivially_wf(self.tcx) {
                     Outcome::TriviallyHolds
                 } else if arg.is_infer() {
-                    goal_stalled_on_args(thin_vec![
+                    goal_stalled_on_args(smallvec![
                         TyOrConstInferVar::maybe_from_term::<TyCtxt<'tcx>>(arg)
                             .expect("its an infer var"),
                     ])

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -452,8 +452,6 @@ mod size_asserts {
 
     use super::*;
     // tidy-alphabetical-start
-    // Before #160005 this pair was greater than 128 bytes, which triggered the use of (slow)
-    // `memcpy` for moving elements of `PendingObligations`.
-    static_assert_size!((PredicateObligation<'_>, Option<GoalStalledOn<TyCtxt<'_>>>), 104);
+    static_assert_size!((PredicateObligation<'_>, Option<GoalStalledOn<TyCtxt<'_>>>), 136);
     // tidy-alphabetical-end
 }

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -19,7 +19,7 @@ use rustc_middle::{bug, ty};
 use rustc_next_trait_solver::canonical::instantiate_canonical_state;
 use rustc_next_trait_solver::solve::{MaybeCause, MaybeInfo, SolverDelegateEvalExt as _, inspect};
 use rustc_span::Span;
-use thin_vec::ThinVec;
+use smallvec::SmallVec;
 use tracing::instrument;
 
 use crate::solve::delegate::SolverDelegate;
@@ -31,7 +31,7 @@ pub struct InspectConfig {
 pub struct InspectGoal<'a, 'tcx> {
     infcx: &'a SolverDelegate<'tcx>,
     depth: usize,
-    orig_values: ThinVec<ty::GenericArg<'tcx>>,
+    orig_values: SmallVec<[ty::GenericArg<'tcx>; 2]>,
     prev_universe: ty::UniverseIndex,
     goal: Goal<'tcx, ty::Predicate<'tcx>>,
     result: Result<Certainty, NoSolution>,

--- a/compiler/rustc_type_ir/Cargo.toml
+++ b/compiler/rustc_type_ir/Cargo.toml
@@ -20,9 +20,7 @@ rustc_macros = { path = "../rustc_macros", optional = true }
 rustc_serialize = { path = "../rustc_serialize", optional = true }
 rustc_span = { path = "../rustc_span", optional = true }
 rustc_type_ir_macros = { path = "../rustc_type_ir_macros" }
-smallvec = { version = "1.8.1", default-features = false, features = [
-    "const_generics",
-] }
+smallvec = { version = "1.8.1", default-features = false, features = ["const_generics", "union"] }
 thin-vec = "0.2.19"
 tracing = "0.1"
 # tidy-alphabetical-end
@@ -40,7 +38,6 @@ nightly = [
     "rustc_index/nightly",
     "rustc_type_ir_macros/nightly",
     "smallvec/may_dangle",
-    "smallvec/union",
     "thin-vec/unstable",
 ]
 # tidy-alphabetical-end

--- a/compiler/rustc_type_ir/src/canonical.rs
+++ b/compiler/rustc_type_ir/src/canonical.rs
@@ -8,7 +8,7 @@ use rustc_macros::{Decodable_NoContext, Encodable_NoContext, StableHash_NoContex
 use rustc_type_ir_macros::{
     GenericTypeVisitable, Lift_Generic, TypeFoldable_Generic, TypeVisitable_Generic,
 };
-use thin_vec::ThinVec;
+use smallvec::SmallVec;
 
 use crate::data_structures::{DelayedMap, HashMap};
 use crate::inherent::*;
@@ -374,7 +374,7 @@ pub struct CanonicalParamEnvCacheEntry<I: Interner> {
     // Note: this `param_env` is the canonicalized form of the key for this entry in the enclosing
     // `CanonicalParamEnvCache`.
     pub param_env: I::ParamEnv,
-    pub variables: ThinVec<I::GenericArg>,
+    pub variables: SmallVec<[I::GenericArg; 2]>,
     pub variable_lookup_table: HashMap<I::GenericArg, usize>,
     pub var_kinds: Vec<CanonicalVarKind<I>>,
 }
@@ -383,7 +383,7 @@ pub struct CanonicalParamEnvCacheEntry<I: Interner> {
 /// this state is reused by many canonicalizers from a single `InferCtxt`.
 #[derive_where(Default; I: Interner)]
 pub struct CanonicalizerState<I: Interner> {
-    pub variables: ThinVec<I::GenericArg>,
+    pub variables: SmallVec<[I::GenericArg; 2]>,
     pub var_kinds: Vec<CanonicalVarKind<I>>,
     pub variable_lookup_table: HashMap<I::GenericArg, usize>,
 

--- a/compiler/rustc_type_ir/src/solve/inspect.rs
+++ b/compiler/rustc_type_ir/src/solve/inspect.rs
@@ -19,7 +19,7 @@
 
 use derive_where::derive_where;
 use rustc_type_ir_macros::{GenericTypeVisitable, TypeFoldable_Generic, TypeVisitable_Generic};
-use thin_vec::ThinVec;
+use smallvec::SmallVec;
 
 use crate::solve::{CandidateSource, Certainty, Goal, GoalSource, QueryResult};
 use crate::{Canonical, CanonicalVarValues, Interner};
@@ -49,7 +49,7 @@ pub type CanonicalState<I, T> = Canonical<I, State<I, T>>;
 #[derive_where(PartialEq, Eq, Hash; I: Interner)]
 pub struct GoalEvaluation<I: Interner> {
     pub uncanonicalized_goal: Goal<I, I::Predicate>,
-    pub orig_values: ThinVec<I::GenericArg>,
+    pub orig_values: SmallVec<[I::GenericArg; 2]>,
     pub final_revision: I::Probe,
     pub result: QueryResult<I>,
 }

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -10,7 +10,7 @@ use rustc_macros::{Decodable_NoContext, Encodable_NoContext, StableHash, StableH
 use rustc_type_ir_macros::{
     GenericTypeVisitable, Lift_Generic, TypeFoldable_Generic, TypeVisitable_Generic,
 };
-use thin_vec::ThinVec;
+use smallvec::SmallVec;
 use tracing::debug;
 
 use crate::inherent::*;
@@ -1007,11 +1007,9 @@ pub enum GoalStalledOnOpaques<I: Interner> {
 /// The conditions that must change for a goal to warrant
 #[derive_where(Clone, Debug; I: Interner)]
 pub struct GoalStalledOn<I: Interner> {
-    // `ThinVec` is important for performance. See #160005.
-    pub stalled_vars: ThinVec<TyOrConstInferVar>,
-    // `ThinVec` is important for performance. See #160005.
-    pub sub_roots: ThinVec<TyVid>,
-    /// The `MaybeInfo` that will be returned on subsequent evaluations if this
+    pub stalled_vars: SmallVec<[TyOrConstInferVar; 2]>,
+    pub sub_roots: SmallVec<[TyVid; 4]>,
+    /// The certainty that will be returned on subsequent evaluations if this
     /// goal remains stalled.
     pub stalled_maybe_info: MaybeInfo,
     pub opaques: GoalStalledOnOpaques<I>,


### PR DESCRIPTION
It makes `GoalStalledOn` bigger, reversing rust-lang/rust#160005, but that's not a problem any more because rust-lang/rust#160479 massively reduced the number of `GoalStalledOn` copy operations, and inline operations are cheaper.