### PR TITLE
doc: document safety requirements for core WTF-8

### DIFF
--- a/library/core/src/wtf8.rs
+++ b/library/core/src/wtf8.rs
@@ -49,7 +49,9 @@ impl fmt::Debug for CodePoint {
 impl CodePoint {
     /// Unsafely creates a new `CodePoint` without checking the value.
     ///
-    /// Only use when `value` is known to be less than or equal to 0x10FFFF.
+    /// # Safety
+    ///
+    /// `value` must be less than or equal to 0x10FFFF.
     #[inline]
     pub unsafe fn from_u32_unchecked(value: u32) -> CodePoint {
         // SAFETY: Guaranteed by caller.
@@ -210,8 +212,9 @@ impl Wtf8 {
 
     /// Creates a WTF-8 slice from a WTF-8 byte slice.
     ///
-    /// Since the byte slice is not checked for valid WTF-8, this functions is
-    /// marked unsafe.
+    /// # Safety
+    ///
+    /// `value` must contain well-formed WTF-8.
     #[inline]
     pub unsafe fn from_bytes_unchecked(value: &[u8]) -> &Wtf8 {
         // SAFETY: start with &[u8], end with fancy &[u8]
@@ -220,8 +223,9 @@ impl Wtf8 {
 
     /// Creates a mutable WTF-8 slice from a mutable WTF-8 byte slice.
     ///
-    /// Since the byte slice is not checked for valid WTF-8, this functions is
-    /// marked unsafe.
+    /// # Safety
+    ///
+    /// `value` must contain well-formed WTF-8.
     #[inline]
     pub unsafe fn from_mut_bytes_unchecked(value: &mut [u8]) -> &mut Wtf8 {
         // SAFETY: start with &mut [u8], end with fancy &mut [u8]


### PR DESCRIPTION
This PR is a follow-up to rust-lang/rust#160824, and serves as a complementry of `Wtf8` in `alloc` . This PR currently fixes the wtf8 module in `core`, because I noticed that some unsafe APIs in this file do not provide a `safety section`. Therefore, before discharging the call sites, we need to first add the safety section. This PR performs that fix.

This PR is related to unstable feature `Wtf8` but this feature don't have relevant tracking issue.

