### PR TITLE
add a cache to the `WfPredicates` visitor

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -10,8 +10,8 @@ use rustc_hir::attrs::lang_items::LangItem;
 use rustc_infer::traits::{ObligationCauseCode, PredicateObligations};
 use rustc_middle::bug;
 use rustc_middle::ty::{
-    self, GenericArgsRef, Term, TermKind, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable,
-    TypeVisitableExt, TypeVisitor,
+    self, DelayedSet, GenericArgsRef, Term, TermKind, Ty, TyCtxt, TypeSuperVisitable,
+    TypeVisitable, TypeVisitableExt, TypeVisitor,
 };
 use rustc_session::diagnostics::feature_err;
 use rustc_span::def_id::{DefId, LocalDefId};
@@ -77,6 +77,7 @@ pub fn obligations<'tcx>(
         out: PredicateObligations::new(),
         recursion_depth,
         item: None,
+        visited_tys: Default::default(),
     };
     wf.add_wf_preds_for_term(term);
     debug!("wf::obligations({:?}, body_def_id={:?}) = {:?}", term, body_def_id, wf.out);
@@ -114,6 +115,7 @@ pub fn unnormalized_obligations<'tcx>(
         out: PredicateObligations::new(),
         recursion_depth: 0,
         item: None,
+        visited_tys: Default::default(),
     };
     wf.add_wf_preds_for_term(term);
     Some(wf.out)
@@ -139,6 +141,7 @@ pub fn trait_obligations<'tcx>(
         out: PredicateObligations::new(),
         recursion_depth: 0,
         item: Some(item),
+        visited_tys: Default::default(),
     };
     wf.add_wf_preds_for_trait_pred(trait_pred, Elaborate::All);
     debug!(obligations = ?wf.out);
@@ -166,6 +169,7 @@ pub fn clause_obligations<'tcx>(
         out: PredicateObligations::new(),
         recursion_depth: 0,
         item: None,
+        visited_tys: Default::default(),
     };
 
     // It's ok to skip the binder here because wf code is prepared for it
@@ -210,6 +214,7 @@ struct WfPredicates<'a, 'tcx> {
     out: PredicateObligations<'tcx>,
     recursion_depth: usize,
     item: Option<&'tcx hir::Item<'tcx>>,
+    visited_tys: DelayedSet<Ty<'tcx>>,
 }
 
 /// Controls whether we "elaborate" supertraits and so forth on the WF
@@ -721,6 +726,10 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
 impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
     fn visit_ty(&mut self, t: Ty<'tcx>) -> Self::Result {
         debug!("wf bounds for t={:?} t.kind={:#?}", t, t.kind());
+
+        if !self.visited_tys.insert(t) {
+            return;
+        }
 
         let tcx = self.tcx();
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161274)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Part of speeding up compiling `ReShell` with `-Znext-solver`, see https://github.com/rust-lang/trait-system-refactor-initiative/issues/272 and [#t-types/trait-system-refactor > more &#96;reshell&#96; slowness](https://rust-lang.zulipchat.com/#narrow/channel/364551-t-types.2Ftrait-system-refactor/topic/more.20.60reshell.60.20slowness/with/616484452).

The PR changes the `WfPredicates` visitor to only collect new bounds for unique types. That is, if we have a type like:

```
type T0 = Map<Then<Whitespace, Whitespace>>
type T1 = Map<Then<T0, T0>>
type T2 = Map<Then<T1, T1>>
...
type T_N = Map<Then<T_N-1, T_N-1>>
```

etc., the visitor used to end up collecting one WF obligation for each path from `T_N` to its `Whitespace` leaves, even though WF of a type (I believe) doesn't depend on the path the visitor took to get there, which allows us to deduplicate by Ty. Not deduplicating caused us to go O(2^N) here.

next-solver is still about ~5x slower than the old solver on the third reproducer due to some other hidden quadratics, and fixing that seems to be more involved, but I think this PR will still be ✨ An Improvement.

r? lcnr