### PR TITLE
Add regression test for normalization failure on erased closure in async block

### DIFF
--- a/tests/ui/traits/next-solver/normalize-erased-closure-in-async-151299.rs
+++ b/tests/ui/traits/next-solver/normalize-erased-closure-in-async-151299.rs
@@ -1,0 +1,14 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/151299>.
+// An invalid `impl Future` awaited inside a nested async block used to ICE with
+// "Failed to normalize" in normalize_erasing_regions.
+//@ edition: 2024
+//@ compile-flags: -Zvalidate-mir -Znext-solver=globally
+
+fn invalid_future() -> impl Future {}
+//~^ ERROR `()` is not a future
+
+fn create_complex_future() -> impl Future {
+    async { &|| async { invalid_future().await } }
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/normalize-erased-closure-in-async-151299.stderr
+++ b/tests/ui/traits/next-solver/normalize-erased-closure-in-async-151299.stderr
@@ -1,0 +1,11 @@
+error[E0277]: `()` is not a future
+  --> $DIR/normalize-erased-closure-in-async-151299.rs:7:24
+   |
+LL | fn invalid_future() -> impl Future {}
+   |                        ^^^^^^^^^^^ `()` is not a future
+   |
+   = help: the trait `Future` is not implemented for `()`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Closes rust-lang/rust#151299