### PR TITLE
skip when only one side have side_effects for zip

### DIFF
--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -384,7 +384,9 @@ where
                             self.b.next_back();
                         }
                     }
-                    debug_assert_eq!(self.a.size(), self.b.size());
+                    if A::MAY_HAVE_SIDE_EFFECT && B::MAY_HAVE_SIDE_EFFECT {
+                        debug_assert_eq!(self.a.size(), self.b.size());
+                    }
                 }
             }
             let i = self.len;

--- a/library/coretests/tests/iter/adapters/zip.rs
+++ b/library/coretests/tests/iter/adapters/zip.rs
@@ -370,3 +370,11 @@ fn test_issue_82291() {
     zip.next();
     assert_eq!(called.get(), 1);
 }
+
+#[test]
+fn test_zip_next_back_one_sided_side_effects_shorter() {
+    let a = [1u8, 2, 3];
+    let b = [1u8, 2, 3, 4, 5];
+    let mut it = a.iter().map(|x| *x).zip(b.iter());
+    let _ = it.next_back();
+}


### PR DESCRIPTION
fixes rust-lang/rust#161266 

- the `debug_assert_eq` in `zip.rs` panics when only one iterator has side effects and its the shorter one. just skip assert when both sides dont have side effects...