### PR TITLE
make target feature ABI check a hard error on ARM

### DIFF
--- a/compiler/rustc_interface/src/diagnostics.rs
+++ b/compiler/rustc_interface/src/diagnostics.rs
@@ -122,13 +122,16 @@ pub(crate) struct MultipleOutputTypesToStdout;
 #[diag(
     "target feature `{$feature}` must be {$enabled} to ensure that the ABI of the current target can be implemented correctly"
 )]
-#[note(
-    "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
-)]
-#[note("for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>")]
 pub(crate) struct AbiRequiredTargetFeature<'a> {
     pub feature: &'a str,
     pub enabled: &'a str,
+    #[note(
+        "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
+    )]
+    #[note(
+        "for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>"
+    )]
+    pub fcw: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -29,7 +29,7 @@ use rustc_span::edition::Edition;
 use rustc_span::source_map::SourceMapInputs;
 use rustc_span::{SessionGlobals, Symbol, sym};
 use rustc_structures::CrateType;
-use rustc_target::spec::Target;
+use rustc_target::spec::{Arch, Target};
 use tracing::info;
 
 use crate::diagnostics;
@@ -102,16 +102,36 @@ pub(crate) fn check_abi_required_features(sess: &Session) {
         );
     }
 
+    // Make this a hard error on ARM since starting with LLVM24, the backend will otherwise
+    // emit a (less friendly) hard error.
+    let hard_error = matches!(sess.target.arch, Arch::Arm);
+
     for feature in abi_feature_constraints.required {
         if !sess.internal_target_features.contains(&Symbol::intern(feature)) {
-            sess.dcx()
-                .emit_warn(diagnostics::AbiRequiredTargetFeature { feature, enabled: "enabled" });
+            let diag = diagnostics::AbiRequiredTargetFeature {
+                feature,
+                enabled: "enabled",
+                fcw: !hard_error,
+            };
+            if hard_error {
+                sess.dcx().emit_err(diag);
+            } else {
+                sess.dcx().emit_warn(diag);
+            }
         }
     }
     for feature in abi_feature_constraints.incompatible {
         if sess.internal_target_features.contains(&Symbol::intern(feature)) {
-            sess.dcx()
-                .emit_warn(diagnostics::AbiRequiredTargetFeature { feature, enabled: "disabled" });
+            let diag = diagnostics::AbiRequiredTargetFeature {
+                feature,
+                enabled: "disabled",
+                fcw: !hard_error,
+            };
+            if hard_error {
+                sess.dcx().emit_err(diag);
+            } else {
+                sess.dcx().emit_warn(diag);
+            }
         }
     }
 }

--- a/tests/ui/target-feature/abi-required-target-feature-missing-in-target-cpu.arm.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-missing-in-target-cpu.arm.stderr
@@ -1,7 +1,4 @@
-warning: target feature `fpregs` must be enabled to ensure that the ABI of the current target can be implemented correctly
-   |
-   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+error: target feature `fpregs` must be enabled to ensure that the ABI of the current target can be implemented correctly
 
-warning: 1 warning emitted
+error: aborting due to 1 previous error
 

--- a/tests/ui/target-feature/abi-required-target-feature-missing-in-target-cpu.rs
+++ b/tests/ui/target-feature/abi-required-target-feature-missing-in-target-cpu.rs
@@ -9,14 +9,14 @@
 //@[arm] compile-flags: --target=armv8r-none-eabihf -Ctarget-cpu=cortex-r4
 //@[arm] needs-llvm-components: arm
 
-// LLVM 24 refuses to compile ARM minicore due to mismatched target features.
-// FIXME(#161276): With LLVM rejecting this, we should make Rust's own warning an error.
-//@[arm] max-llvm-major-version: 23
+// On x86 this is just a warning.
+//@[x86] check-pass
+//@[arm] check-fail
 
-// For now this is just a warning.
-//@ build-pass
 //@ ignore-backends: gcc
 //@ add-minicore
+// Don't inherit the target-cpu above for minicore, to avoid errors when building that.
+//@ minicore-compile-flags: -Ctarget-cpu=generic
 
 #![feature(no_core)]
 #![no_core]
@@ -24,4 +24,5 @@
 extern crate minicore;
 use minicore::*;
 
-//~? WARN must be enabled to ensure that the ABI of the current target can be implemented correctly
+//[x86]~? WARN must be enabled to ensure that the ABI of the current target can be implemented correctly
+//[arm]~? ERROR must be enabled to ensure that the ABI of the current target can be implemented correctly


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161280)*
<!-- homu-ignore:end -->

With LLVM 24, we now (finally) get hard errors from the backend for "you want ABI X but the target features required for that ABI are missing", at least on the ARM backend:
```
error: <unknown>:0:0: in function _RNvXsc_Cs4Af2OiBEA1T_8minicoreiNtB5_3Add3add i32 (i32, i32): calling convention is hard-float, but floating-point registers are unavailable
```
That's not a pretty error, so let's make rust emit a hard error before we even get there -- just on ARM for now, matching LLVM. We have emitted a future-compat error for this since Rust 1.86 (https://github.com/rust-lang/rust/pull/136147, https://github.com/rust-lang/rust/pull/134794). I'm not making it a hard error everywhere since for other targets we are still figuring out the exact things we have to check, and it's better to do that without risking new hard errors.

For ARM, the exact check we are doing is:
- every target must set `llvm_floatabi` to either "soft" or "hard"
- on softfloat targets, no check is needed
- on hardfloat targets, the "fpregs" target feature is *required* and the the "soft-float" target feature is *forbidden*

Since this is a new hard error, this probably requires FCP. I am not sure for which team -- @rust-lang/lang is often involved for target feature things, but this is mostly about rejecting invalid `-C` flags which are handled by t-compiler (@davidtwco @BoxyUwU).

Fixes https://github.com/rust-lang/rust/issues/161276
Tracking issue rust-lang/rust#116344
Cc @TimNN