### PR TITLE
Unstable benchmark excluding setup feature

### DIFF
--- a/library/test/src/bench.rs
+++ b/library/test/src/bench.rs
@@ -1,7 +1,7 @@
 //! Benchmarking module.
 
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 use std::{cmp, io};
 
@@ -45,6 +45,27 @@ impl Bencher {
         }
 
         self.summary = Some(iter(&mut inner));
+    }
+
+    /// Callback for benchmark functions to run in their body with its setup excluded.
+    ///
+    /// `ctx` is passed as a mutuable reference to both `setup` and `inner`,
+    ///  allowing for state to be shared between the two.
+    /// `setup` runs before each call to `inner` and its result
+    /// is passed to `inner`, the time spent in setup is excluded
+    /// from the measurement.
+    ///
+    pub fn iter_excluding_setup<I, T, S, F>(&mut self, mut ctx: I, mut setup: S, mut inner: F)
+    where
+        S: FnMut(&mut I),
+        F: FnMut(&mut I) -> T,
+    {
+        if self.mode == BenchMode::Single {
+            ns_iter_setup_inner(&mut ctx, &mut setup, &mut inner, 1);
+            return;
+        }
+
+        self.summary = Some(iter_excluding_setup(ctx, &mut setup, &mut inner));
     }
 
     pub fn bench<F>(&mut self, mut f: F) -> Result<Option<stats::Summary>, String>
@@ -109,6 +130,9 @@ fn fmt_thousands_sep(mut n: f64, sep: char) -> String {
     output
 }
 
+static INSTANT_NOW_SAMPLE: LazyLock<Duration> =
+    LazyLock::new(|| (0..1000).map(|_| Instant::now().elapsed()).min().unwrap());
+
 fn ns_iter_inner<T, F>(inner: &mut F, k: u64) -> u64
 where
     F: FnMut() -> T,
@@ -117,15 +141,46 @@ where
     for _ in 0..k {
         black_box(inner());
     }
-    start.elapsed().as_nanos() as u64
+    start.elapsed().as_nanos().saturating_sub(INSTANT_NOW_SAMPLE.as_nanos()) as u64
+}
+
+fn ns_iter_setup_inner<I, T, S, F>(ctx: &mut I, setup: &mut S, inner: &mut F, k: u64) -> u64
+where
+    S: FnMut(&mut I),
+    F: FnMut(&mut I) -> T,
+{
+    let now_sample = INSTANT_NOW_SAMPLE.as_nanos() as i64;
+    let mut total = 0i64;
+    for _ in 0..k {
+        // setup is not included in timing
+        black_box(setup(ctx));
+        // start timing after setup is complete
+        let start = Instant::now();
+        black_box(inner(ctx));
+        total += start.elapsed().as_nanos() as i64;
+    }
+    (total - k as i64 * now_sample).max(0) as u64
 }
 
 pub fn iter<T, F>(inner: &mut F) -> stats::Summary
 where
     F: FnMut() -> T,
 {
+    iter_inner(&mut |k| ns_iter_inner(inner, k))
+}
+
+pub fn iter_excluding_setup<I, T, S, F>(mut ctx: I, setup: &mut S, inner: &mut F) -> stats::Summary
+where
+    S: FnMut(&mut I),
+    F: FnMut(&mut I) -> T,
+{
+    iter_inner(&mut |k| ns_iter_setup_inner(&mut ctx, setup, inner, k))
+}
+
+#[inline]
+fn iter_inner(ns_iter: &mut impl FnMut(u64) -> u64) -> stats::Summary {
     // Initial bench run to get ballpark figure.
-    let ns_single = ns_iter_inner(inner, 1);
+    let ns_single = ns_iter(1);
 
     // Try to estimate iter count for 1ms falling back to 1m
     // iterations if first run took < 1ns.
@@ -145,14 +200,14 @@ where
         let loop_start = Instant::now();
 
         for p in &mut *samples {
-            *p = ns_iter_inner(inner, n) as f64 / n as f64;
+            *p = ns_iter(n) as f64 / n as f64;
         }
 
         stats::winsorize(samples, 5.0);
         let summ = stats::Summary::new(samples);
 
         for p in &mut *samples {
-            let ns = ns_iter_inner(inner, 5 * n);
+            let ns = ns_iter(5 * n);
             *p = ns as f64 / (5 * n) as f64;
         }
 

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -763,6 +763,25 @@ fn test_bench_once_iter() {
 }
 
 #[test]
+fn test_bench_once_iter_excluding_setup() {
+    fn f(b: &mut Bencher) -> Result<(), String> {
+        b.iter_excluding_setup(
+            Vec::with_capacity(64),
+            |v| {
+                v.clear();
+                v.extend(0..64);
+            },
+            |v| {
+                v.iter_mut().for_each(|x| *x += 1);
+                assert_eq!(v.iter().sum::<usize>(), (1..65).sum());
+            },
+        );
+        Ok(())
+    }
+    bench::run_once(f).unwrap();
+}
+
+#[test]
 fn test_bench_no_iter() {
     fn f(_: &mut Bencher) -> Result<(), String> {
         Ok(())


### PR DESCRIPTION
This PR tries to resolve a missing feature by adding a new benchmarking method `iter_excluding_setup`.

This idea came from working on `vec::retain` algorithm when I noticed that benchmark has about 15% noise of preparing the benchmark data:

```rust
    let mut v = Vec::with_capacity(100000);

    b.iter(|| {
        v.clear();
        v.extend(black_box(1..=100000));
        v.retain(|x| x & 1 == 0)
    });
```

This includes time to `clear` and `extend` in benchmark time, which is not our benchmark target.
As an algorithm improves through development this preparation noise increases and benchmark time becomes less reliable.

With this feature we can rewrite it as following:
```rust
    b.iter_excluding_setup(
        Vec::with_capacity(100000),
        |v| {
            v.clear();
            v.extend(1..=100000);
        },
        |v| v.retain(|x| x & 1 == 0),
    );
```
In contrary, `iter_excluding_setup` times exactly the retain part and ignores preparation phase.
```
    vec::bench_retain_100000      43740.52ns/iter +/- 7667.35
    vec::bench_retain_100000_original 50763.95ns/iter +/- 6600.93
```


To achieve this we need to account for `Instant::now` syscall overhead. I tested with both average and minimum sample of 1000 runs. I think worst case `min` is more reliable than average. an empty functions benchmarks around 0ns-3ns on my laptop's 5850U cpu which is IMHO acceptable.

If we account that `Instant::now()` is 20ns, 1000 runs will be calculated in 20 microseconds once and will be reused after that, which is not a concern for any benchmark.

I also removed single `Instant::now()` sample from current `iter` benchmarks to try to slightly improve its accuracy for single runs or small benchmarks.

This feature is also applicable and needed in current string benchmarks in `alloctests/benches` when allocation time is included in `insert` benchmarks resulting in about 100% noise:
```
    string::bench_insert_char_long      28.12ns/iter  +/- 4.51
    string::bench_insert_char_long_original  55.20ns/iter  +/- 6.21
    string::bench_insert_char_short     27.04ns/iter  +/- 5.25
    string::bench_insert_char_short_original 48.79ns/iter  +/- 6.16
    string::bench_insert_str_long       29.96ns/iter  +/- 7.37
    string::bench_insert_str_long_original   54.21ns/iter +/- 29.19
    string::bench_insert_str_short      30.72ns/iter  +/- 6.36
    string::bench_insert_str_short_original  48.78ns/iter  +/- 8.15
```
Rewrite with excluding setup sample:
```rust
#[bench]
fn bench_insert_char_short_original(b: &mut Bencher) {
    let s = "Hello, World!";
    b.iter(|| {
        let mut x = String::from(s);
        black_box(&mut x).insert(black_box(6), black_box(' '));
        x
    })
}

#[bench]
fn bench_insert_char_short(b: &mut Bencher) {
    let s = "Hello, World!";
    b.iter_excluding_setup(
        String::new(),
        |x| *x = String::from(s),
        |x| black_box(x).insert(black_box(6), black_box(' ')),
    )
}
```

We can also use this feature to benchmark exactly allocation and deallocation of an object, for example:
```rust
#[bench]
fn deallocate(b: &mut Bencher) {
    b.iter_excluding_setup(
        None,
        |v| *v = Some(Arc::new(0usize)),
        |v| {
            _ = black_box(v).take();
        },
    );
}

#[bench]
fn allocate(b: &mut Bencher) {
    b.iter_excluding_setup(
        None,
        |v| *v = None,
        |v| {
            *v = black_box(Some(Arc::new(0usize)));
        },
    );
}
```
```
    arc::allocate    7.68ns/iter +/- 3.11
    arc::deallocate 10.11ns/iter +/- 2.51
```
This is currently impossible to do with current available features, It will be also useful in benchmarking more complex data structures like hashmaps and linked lists too. (hash collisions, empty hashmap insertion, deallocation, allocation, etc.)

I only need this features to improve rust library itself, and there is no need for stabilization.