### PR TITLE
Tighten the language used for documenting `TargetOptions::llvm_abiname`

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2651,8 +2651,8 @@ pub struct TargetOptions {
     /// Use LLVM intrinsic for mcount function name
     pub llvm_mcount_intrinsic: Option<StaticCow<str>>,
 
-    /// LLVM ABI name, corresponds to the '-mabi' parameter available in multilib C compilers
-    /// and the `-target-abi` flag in llc. In the LLVM API this is `MCOptions.ABIName`.
+    /// LLVM ABI name, corresponds to the '-mabi' parameter available in multilib C compilers and
+    /// the `-target-abi` flag in llc. In the LLVM API this is `MCTargetOptions::ABIName`.
     pub llvm_abiname: LlvmAbi,
 
     /// Control the float ABI to use, for architectures that support it. The only architecture we


### PR DESCRIPTION
`MCOptions` is the name of the variable commonly used for instances of `MCTargetOptions`. Use the proper type name instead. It should make finding the [documentation](https://llvm.org/doxygen/classllvm_1_1MCTargetOptions.html) for the struct a bit easier.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
