### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_abi/src/layout/ty.rs
+++ b/compiler/rustc_abi/src/layout/ty.rs
@@ -120,7 +120,7 @@ pub trait TyAbiInterface<'a, C>: Sized + std::fmt::Debug + std::fmt::Display {
     fn is_tuple(this: TyAndLayout<'a, Self>) -> bool;
     fn is_unit(this: TyAndLayout<'a, Self>) -> bool;
     fn is_transparent(this: TyAndLayout<'a, Self>) -> bool;
-    fn is_complex_number(this: TyAndLayout<'a, Self>, cx: &C) -> bool;
+    fn is_complex_number_lang_item(this: TyAndLayout<'a, Self>, cx: &C) -> bool;
     fn is_scalable_vector(this: TyAndLayout<'a, Self>) -> bool;
     /// See [`TyAndLayout::pass_indirectly_in_non_rustic_abis`] for details.
     fn is_pass_indirectly_in_non_rustic_abis_flag_set(this: TyAndLayout<'a, Self>) -> bool;
@@ -228,11 +228,13 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         Ty::is_transparent(self)
     }
 
+    /// Returns `true` if this type needs to match the ABI of the C `_Complex` type. See
+    /// [`TyAndLayout::complex_number_primitive`] for details.
     pub fn is_complex_number<C>(self, cx: &C) -> bool
     where
         Ty: TyAbiInterface<'a, C> + Copy,
     {
-        Ty::is_complex_number(self.peel_transparent_wrappers(cx), cx)
+        self.complex_number_primitive(cx).is_some()
     }
 
     pub fn is_scalable_vector<C>(self) -> bool
@@ -299,23 +301,47 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
         found
     }
 
+    /// If this type should match the ABI of the C `_Complex` type, returns the primitive that is
+    /// used for its parts. This only returns `Some(T)` for `core::num::Complex<T>` where `T` is
+    /// either a float or an integer. `repr(transparent)` wrapper types are automatically handled.
+    pub fn complex_number_primitive<C>(&self, cx: &C) -> Option<Primitive>
+    where
+        Ty: TyAbiInterface<'a, C> + Copy,
+    {
+        let complex = self.peel_transparent_wrappers(cx);
+        if !Ty::is_complex_number_lang_item(complex, cx) {
+            return None;
+        }
+
+        let part = complex.field(cx, 0).peel_transparent_wrappers(cx);
+
+        if let BackendRepr::Scalar(scalar) = part.backend_repr {
+            // Only Complex<{ float }> and Complex<{ integer }> have special layout.
+            let primitive = scalar.primitive();
+            match primitive {
+                // Explicitly spell out all the float types so that any new ones have to be added to
+                // one of the match branches.
+                Primitive::Int(..)
+                | Primitive::Float(Float::F16 | Float::F32 | Float::F64 | Float::F128) => {
+                    Some(primitive)
+                }
+                Primitive::Pointer(..) => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Returns `Some` if this type has the ABI of the C `_Complex` type with float parts. See
+    /// [`TyAndLayout::complex_number_primitive`] for details.
     pub fn complex_float<C>(&self, cx: &C) -> Option<Float>
     where
         Ty: TyAbiInterface<'a, C> + Copy,
     {
-        if !Ty::is_complex_number(*self, cx) {
-            return None;
-        }
-
-        let BackendRepr::ScalarPair { a, b, .. } = self.backend_repr else {
-            return None;
-        };
-
-        debug_assert_eq!(a, b);
-
-        match a.primitive() {
-            Primitive::Float(f) => Some(f),
-            _ => None,
+        if let Some(Primitive::Float(float)) = self.complex_number_primitive(cx) {
+            Some(float)
+        } else {
+            None
         }
     }
 

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1321,11 +1321,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
                             span: data.span,
                         }
                     } else {
-                        self.emit_bad_parenthesized_trait_in_assoc_ty(data);
+                        let guar = self.emit_bad_parenthesized_trait_in_assoc_ty(data);
                         self.lower_angle_bracketed_parameter_data(
                             &data.as_angle_bracketed_args(),
                             ParamMode::Explicit,
-                            itctx,
+                            ImplTraitContext::AlreadyErrored(guar),
                         )
                         .0
                     }
@@ -1394,7 +1394,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
         }
     }
 
-    fn emit_bad_parenthesized_trait_in_assoc_ty(&self, data: &ParenthesizedArgs) {
+    fn emit_bad_parenthesized_trait_in_assoc_ty(
+        &self,
+        data: &ParenthesizedArgs,
+    ) -> ErrorGuaranteed {
         // Suggest removing empty parentheses: "Trait()" -> "Trait"
         let sub = if data.inputs.is_empty() {
             let parentheses_span =
@@ -1415,7 +1418,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 data.inputs.last().unwrap().span.shrink_to_hi().to(data.inputs_span.shrink_to_hi());
             AssocTyParenthesesSub::NotEmpty { open_param, close_param }
         };
-        self.dcx().emit_err(AssocTyParentheses { span: data.span, sub });
+        self.dcx().emit_err(AssocTyParentheses { span: data.span, sub })
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -1738,7 +1741,15 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         });
                         hir::TyKind::Err(guar)
                     }
-                    ImplTraitContext::AlreadyErrored(guar) => hir::TyKind::Err(guar),
+                    ImplTraitContext::AlreadyErrored(guar) => {
+                        // `GenericArgs::Parenthesized` stores its inputs as `Param`s, so the def
+                        // collector visits `impl Trait` in a universal context and creates a
+                        // `DefKind::TyParam`. During recovery we reinterpret these arguments as
+                        // angle-bracketed, where lowering may otherwise expect an opaque type.
+                        // The parenthesized syntax has already been rejected, so avoid lowering
+                        // this `impl Trait` with the inconsistent `DefKind`.
+                        hir::TyKind::Err(guar)
+                    }
                 }
             }
             TyKind::Pat(ty, pat) => {

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -411,6 +411,9 @@ enum ImplTraitContext {
     FeatureGated(ImplTraitPosition, Symbol),
     /// `impl Trait` is not accepted in this position.
     Disallowed(ImplTraitPosition),
+
+    /// An error has already been emitted for this type.
+    AlreadyErrored(ErrorGuaranteed),
 }
 
 /// Position in which `impl Trait` is disallowed.
@@ -1735,6 +1738,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         });
                         hir::TyKind::Err(guar)
                     }
+                    ImplTraitContext::AlreadyErrored(guar) => hir::TyKind::Err(guar),
                 }
             }
             TyKind::Pat(ty, pat) => {

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -338,12 +338,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         } else {
                             None
                         };
-                        self.dcx().emit_err(GenericTypeWithParentheses { span: data.span, sub });
+                        let guar = self
+                            .dcx()
+                            .emit_err(GenericTypeWithParentheses { span: data.span, sub });
                         (
                             self.lower_angle_bracketed_parameter_data(
                                 &data.as_angle_bracketed_args(),
                                 param_mode,
-                                itctx,
+                                ImplTraitContext::AlreadyErrored(guar),
                             )
                             .0,
                             false,

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -311,7 +311,7 @@ pub(super) fn op_to_const<'tcx>(
                     imm.layout.ty,
                 );
                 let msg = "`op_to_const` on an immediate scalar pair must only be used on slice references to the beginning of an actual allocation";
-                let ptr = a.to_pointer(ecx).expect(msg);
+                let ptr = a.to_pointer(ecx);
                 let (prov, offset) =
                     ptr.into_pointer_or_addr().expect(msg).prov_and_relative_offset();
                 let alloc_id = prov.alloc_id();

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -1019,12 +1019,7 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
         // (Do nothing on `None` provenance, that cannot store immutability anyway.)
         if let ty::Ref(_, ty, mutbl) = val.layout.ty.kind()
             && *mutbl == Mutability::Not
-            && val
-                .to_scalar_and_meta()
-                .0
-                .to_pointer(ecx)?
-                .provenance
-                .is_some_and(|p| !p.immutable())
+            && val.to_scalar_and_meta().0.to_pointer(ecx).provenance.is_some_and(|p| !p.immutable())
         {
             // That next check is expensive, that's why we have all the guards above.
             let is_immutable = ty.is_freeze(*ecx.tcx, ecx.typing_env());

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -848,7 +848,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 assert!(receiver_place.layout.is_unsized());
 
                 // Get the required information from the vtable.
-                let vptr = receiver_place.meta().unwrap_meta().to_pointer(self)?;
+                let vptr = receiver_place.meta().unwrap_meta().to_pointer(self);
                 let dyn_ty = self.get_ptr_vtable_ty(vptr, Some(receiver_trait))?;
                 let adjusted_recv = receiver_place.ptr();
 

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -293,7 +293,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         assert!(cast_to.ty.is_integral());
 
         let scalar = src.to_scalar();
-        let ptr = scalar.to_pointer(self)?;
+        let ptr = scalar.to_pointer(self);
         match ptr.into_pointer_or_addr() {
             Ok(ptr) => M::expose_provenance(self, ptr.provenance)?,
             Err(_) => {} // Do nothing, exposing an invalid pointer (`None` provenance) is a NOP.
@@ -464,8 +464,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 }
                 // Take apart the old pointer, and find the dynamic type.
                 let (old_data, old_vptr) = val.to_scalar_pair();
-                let old_data = old_data.to_pointer(self)?;
-                let old_vptr = old_vptr.to_pointer(self)?;
+                let old_data = old_data.to_pointer(self);
+                let old_vptr = old_vptr.to_pointer(self);
                 let ty = self.get_ptr_vtable_ty(old_vptr, Some(data_a))?;
 
                 // Sanity-check that `supertrait_vtable_slot` in this type's vtable indeed produces

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -488,7 +488,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 interp_ok(Some((full_size, full_align)))
             }
             ty::Dynamic(expected_trait, _) => {
-                let vtable = metadata.unwrap_meta().to_pointer(self)?;
+                let vtable = metadata.unwrap_meta().to_pointer(self);
                 // Read size and align from vtable (already checks size).
                 interp_ok(Some(self.get_vtable_size_and_align(vtable, Some(expected_trait))?))
             }

--- a/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics/simd.rs
@@ -260,7 +260,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                         }
                         Op::SaturatingOp(mir_op) => self.saturating_arith(mir_op, &left, &right)?,
                         Op::WrappingOffset => {
-                            let ptr = left.to_scalar().to_pointer(self)?;
+                            let ptr = left.to_scalar().to_pointer(self);
                             let offset_count = right.to_scalar().to_target_isize(self)?;
                             let pointee_ty = left.layout.ty.builtin_deref(true).unwrap();
 

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -1641,7 +1641,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             Ok(int) => interp_ok(int.is_null()),
             Err(_) => {
                 // We can't cast this pointer to an integer. Can only happen during CTFE.
-                let ptr = scalar.to_pointer(self)?;
+                let ptr = scalar.to_pointer(self);
                 match self.ptr_try_get_alloc_id(ptr, 0) {
                     Ok((alloc_id, offset, _)) => {
                         let info = self.get_alloc_info(alloc_id);

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -697,7 +697,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         &self,
         op: &impl Projectable<'tcx, M::Provenance>,
     ) -> InterpResult<'tcx, Pointer<Option<M::Provenance>>> {
-        self.read_scalar(op)?.to_pointer(self)
+        interp_ok(self.read_scalar(op)?.to_pointer(self))
     }
     /// Read a pointer-sized unsigned integer from a place.
     pub fn read_target_usize(

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -7,7 +7,6 @@ use either::{Either, Left, Right};
 use rustc_abi as abi;
 use rustc_abi::{BackendRepr, HasDataLayout, Size};
 use rustc_hir::def::Namespace;
-use rustc_middle::mir::interpret::ScalarSizeMismatch;
 use rustc_middle::ty::layout::{HasTyCtxt, HasTypingEnv, TyAndLayout};
 use rustc_middle::ty::print::{FmtPrinter, PrettyPrinter};
 use rustc_middle::ty::{ConstInt, ScalarInt, Ty, TyCtxt};
@@ -342,12 +341,7 @@ impl<'tcx, Prov: Provenance> ImmTy<'tcx, Prov> {
     #[inline]
     pub fn to_scalar_int(&self) -> InterpResult<'tcx, ScalarInt> {
         let s = self.to_scalar().to_scalar_int()?;
-        if s.size() != self.layout.size {
-            throw_ub!(ScalarSizeMismatch(ScalarSizeMismatch {
-                target_size: self.layout.size.bytes(),
-                data_size: s.size().bytes(),
-            }));
-        }
+        assert_eq!(s.size(), self.layout.size, "scalar immediate size does not match layout");
         interp_ok(s)
     }
 

--- a/compiler/rustc_const_eval/src/interpret/operator.rs
+++ b/compiler/rustc_const_eval/src/interpret/operator.rs
@@ -324,7 +324,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         match bin_op {
             // Pointer ops that are always supported.
             Offset => {
-                let ptr = left.to_scalar().to_pointer(self)?;
+                let ptr = left.to_scalar().to_pointer(self);
                 let pointee_ty = left.layout.ty.builtin_deref(true).unwrap();
                 let pointee_layout = self.layout_of(pointee_ty)?;
                 assert!(pointee_layout.is_sized());

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -435,7 +435,7 @@ where
 
         // `imm_ptr_to_mplace` is called on raw pointers even if they don't actually get dereferenced;
         // we hence can't call `size_and_align_of` since that asserts more validity than we want.
-        let ptr = ptr.to_pointer(self)?;
+        let ptr = ptr.to_pointer(self);
         interp_ok(self.ptr_with_meta_to_mplace(ptr, meta, layout, /*unaligned*/ false))
     }
 
@@ -522,7 +522,7 @@ where
                     let tail = self.tcx.struct_tail_for_codegen(mplace.layout.ty, self.typing_env);
                     match tail.kind() {
                         ty::Dynamic(data, _) => {
-                            let vtable = mplace.meta().unwrap_meta().to_pointer(self)?;
+                            let vtable = mplace.meta().unwrap_meta().to_pointer(self);
                             self.get_ptr_vtable_ty(vtable, Some(data))?;
                         }
                         ty::Slice(..) | ty::Str | ty::Foreign(..) => {

--- a/compiler/rustc_const_eval/src/interpret/traits.rs
+++ b/compiler/rustc_const_eval/src/interpret/traits.rs
@@ -112,7 +112,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             matches!(mplace.layout.ty.kind(), ty::Dynamic(_, _)),
             "`unpack_dyn_trait` only makes sense on `dyn*` types"
         );
-        let vtable = mplace.meta().unwrap_meta().to_pointer(self)?;
+        let vtable = mplace.meta().unwrap_meta().to_pointer(self);
         let ty = self.get_ptr_vtable_ty(vtable, Some(expected_trait))?;
         // This is a kind of transmute, from a place with unsized type and metadata to
         // a place with sized type and no metadata.

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -530,7 +530,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
         let tail = self.ecx.tcx.struct_tail_for_codegen(pointee.ty, self.ecx.typing_env);
         match tail.kind() {
             ty::Dynamic(data, _) => {
-                let vtable = meta.unwrap_meta().to_pointer(self.ecx)?;
+                let vtable = meta.unwrap_meta().to_pointer(self.ecx);
                 // Make sure it is a genuine vtable pointer for the right trait.
                 try_validation!(
                     self.ecx.get_ptr_vtable_ty(vtable, Some(data)),
@@ -930,7 +930,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
 
                 // If we check references recursively, also check that this points to a function.
                 if let Some(_) = self.ref_tracking {
-                    let ptr = scalar.to_pointer(self.ecx)?;
+                    let ptr = scalar.to_pointer(self.ecx);
                     let _fn = try_validation!(
                         self.ecx.get_ptr_fn(ptr),
                         self.path,

--- a/compiler/rustc_middle/src/mir/consts.rs
+++ b/compiler/rustc_middle/src/mir/consts.rs
@@ -154,7 +154,7 @@ impl ConstValue {
                         /* read_provenance */ true,
                     )
                     .ok()?;
-                let ptr = ptr.to_pointer(&tcx).discard_err()?;
+                let ptr = ptr.to_pointer(&tcx);
                 let len = a
                     .read_scalar(
                         &tcx,

--- a/compiler/rustc_middle/src/mir/interpret/allocation.rs
+++ b/compiler/rustc_middle/src/mir/interpret/allocation.rs
@@ -21,8 +21,8 @@ use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
 use super::{
     AllocId, BadBytesAccess, CtfeProvenance, InterpErrorKind, InterpResult, Pointer, Provenance,
-    ResourceExhaustionInfo, Scalar, ScalarSizeMismatch, UndefinedBehaviorInfo, UnsupportedOpInfo,
-    interp_ok, read_target_uint, write_target_uint,
+    ResourceExhaustionInfo, Scalar, UndefinedBehaviorInfo, UnsupportedOpInfo, interp_ok,
+    read_target_uint, write_target_uint,
 };
 use crate::ty;
 
@@ -303,8 +303,6 @@ impl<'tcx> ConstAllocation<'tcx> {
 /// is added when converting to `InterpError`.
 #[derive(Debug)]
 pub enum AllocError {
-    /// A scalar had the wrong size.
-    ScalarSizeMismatch(ScalarSizeMismatch),
     /// Encountered a pointer where we needed raw bytes.
     ReadPointerAsInt(Option<BadBytesAccess>),
     /// Partially copying a pointer.
@@ -314,19 +312,10 @@ pub enum AllocError {
 }
 pub type AllocResult<T = ()> = Result<T, AllocError>;
 
-impl From<ScalarSizeMismatch> for AllocError {
-    fn from(s: ScalarSizeMismatch) -> Self {
-        AllocError::ScalarSizeMismatch(s)
-    }
-}
-
 impl AllocError {
     pub fn to_interp_error<'tcx>(self, alloc_id: AllocId) -> InterpErrorKind<'tcx> {
         use AllocError::*;
         match self {
-            ScalarSizeMismatch(s) => {
-                InterpErrorKind::UndefinedBehavior(UndefinedBehaviorInfo::ScalarSizeMismatch(s))
-            }
             ReadPointerAsInt(info) => InterpErrorKind::Unsupported(
                 UnsupportedOpInfo::ReadPointerAsInt(info.map(|b| (alloc_id, b))),
             ),
@@ -753,7 +742,7 @@ impl<Prov: Provenance, Extra, Bytes: AllocBytes> Allocation<Prov, Extra, Bytes> 
 
         // `to_bits_or_ptr_internal` is the right method because we just want to store this data
         // as-is into memory. This also double-checks that `val.size()` matches `range.size`.
-        let (bytes, provenance) = match val.to_bits_or_ptr_internal(range.size)? {
+        let (bytes, provenance) = match val.to_bits_or_ptr_internal(range.size) {
             Right(ptr) => {
                 let (provenance, offset) = ptr.into_raw_parts();
                 (u128::from(offset.bytes()), Some(provenance))

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -312,13 +312,6 @@ pub struct BadBytesAccess {
     pub bad: AllocRange,
 }
 
-/// Information about a size mismatch.
-#[derive(Debug)]
-pub struct ScalarSizeMismatch {
-    pub target_size: u64,
-    pub data_size: u64,
-}
-
 /// Information about a misaligned pointer.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, Debug)]
 pub struct Misalignment {
@@ -417,8 +410,6 @@ pub enum UndefinedBehaviorInfo<'tcx> {
     InvalidUninitBytes(Option<(AllocId, BadBytesAccess)>),
     /// Working with a local that is not currently live.
     DeadLocal,
-    /// Data size is not equal to target size.
-    ScalarSizeMismatch(ScalarSizeMismatch),
     /// A discriminant of an uninhabited enum variant is written.
     UninhabitedEnumVariantWritten(VariantIdx),
     /// An uninhabited enum variant is projected.
@@ -625,12 +616,6 @@ impl<'tcx> fmt::Display for UndefinedBehaviorInfo<'tcx> {
                 uninit = info.bad,
             ),
             DeadLocal => write!(f, "accessing a dead local variable"),
-            ScalarSizeMismatch(mismatch) => write!(
-                f,
-                "scalar size mismatch: expected {target_size} bytes but got {data_size} bytes instead",
-                target_size = mismatch.target_size,
-                data_size = mismatch.data_size,
-            ),
             UninhabitedEnumVariantWritten(_) => {
                 write!(f, "writing discriminant of an uninhabited enum variant")
             }

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -37,8 +37,8 @@ pub use self::error::{
     BadBytesAccess, CheckAlignMsg, CheckInAllocMsg, ErrorHandled, EvalStaticInitializerRawResult,
     EvalToAllocationRawResult, EvalToConstValueResult, EvalToValTreeResult, InterpErrorInfo,
     InterpErrorKind, InterpResult, InvalidMetaKind, InvalidProgramInfo, MachineStopType,
-    Misalignment, ReportedErrorInfo, ResourceExhaustionInfo, ScalarSizeMismatch,
-    UndefinedBehaviorInfo, UnsupportedOpInfo, ValTreeCreationError, interp_ok,
+    Misalignment, ReportedErrorInfo, ResourceExhaustionInfo, UndefinedBehaviorInfo,
+    UnsupportedOpInfo, ValTreeCreationError, interp_ok,
 };
 pub use self::pointer::{CtfeProvenance, Pointer, PointerArithmetic, Provenance};
 pub use self::value::Scalar;

--- a/compiler/rustc_middle/src/mir/interpret/value.rs
+++ b/compiler/rustc_middle/src/mir/interpret/value.rs
@@ -7,8 +7,7 @@ use rustc_apfloat::ieee::{Double, Half, Quad, Single};
 use rustc_macros::{StableHash, TyDecodable, TyEncodable};
 
 use super::{
-    AllocId, CtfeProvenance, InterpResult, Pointer, PointerArithmetic, Provenance,
-    ScalarSizeMismatch, interp_ok,
+    AllocId, CtfeProvenance, InterpResult, Pointer, PointerArithmetic, Provenance, interp_ok,
 };
 use crate::ty::ScalarInt;
 
@@ -237,25 +236,20 @@ impl<Prov> Scalar<Prov> {
     /// This throws UB (instead of ICEing) on a size mismatch since size mismatches can arise in
     /// Miri when someone declares a function that we shim (such as `malloc`) with a wrong type.
     #[inline]
-    pub fn to_bits_or_ptr_internal(
-        self,
-        target_size: Size,
-    ) -> Result<Either<u128, Pointer<Prov>>, ScalarSizeMismatch> {
+    pub fn to_bits_or_ptr_internal(self, target_size: Size) -> Either<u128, Pointer<Prov>> {
         assert_ne!(target_size.bytes(), 0, "you should never look at the bits of a ZST");
-        Ok(match self {
-            Scalar::Int(int) => Left(int.try_to_bits(target_size).map_err(|size| {
-                ScalarSizeMismatch { target_size: target_size.bytes(), data_size: size.bytes() }
-            })?),
+        match self {
+            Scalar::Int(int) => Left(int.to_bits(target_size)),
             Scalar::Ptr(ptr, sz) => {
-                if target_size.bytes() != u64::from(sz) {
-                    return Err(ScalarSizeMismatch {
-                        target_size: target_size.bytes(),
-                        data_size: sz.into(),
-                    });
-                }
+                assert_eq!(
+                    target_size.bytes(),
+                    u64::from(sz),
+                    "Scalar is a pointer but expected size {}",
+                    target_size.bytes()
+                );
                 Right(ptr)
             }
-        })
+        }
     }
 
     #[inline]
@@ -269,10 +263,7 @@ impl<Prov> Scalar<Prov> {
 
 impl<'tcx, Prov: Provenance> Scalar<Prov> {
     pub fn to_pointer(self, cx: &impl HasDataLayout) -> InterpResult<'tcx, Pointer<Option<Prov>>> {
-        match self
-            .to_bits_or_ptr_internal(cx.pointer_size())
-            .map_err(|s| err_ub!(ScalarSizeMismatch(s)))?
-        {
+        match self.to_bits_or_ptr_internal(cx.pointer_size()) {
             Right(ptr) => interp_ok(ptr.into()),
             Left(bits) => {
                 let addr = u64::try_from(bits).unwrap();
@@ -330,15 +321,7 @@ impl<'tcx, Prov: Provenance> Scalar<Prov> {
     #[inline]
     pub fn to_bits(self, target_size: Size) -> InterpResult<'tcx, u128> {
         assert_ne!(target_size.bytes(), 0, "you should never look at the bits of a ZST");
-        self.to_scalar_int()?
-            .try_to_bits(target_size)
-            .map_err(|size| {
-                err_ub!(ScalarSizeMismatch(ScalarSizeMismatch {
-                    target_size: target_size.bytes(),
-                    data_size: size.bytes(),
-                }))
-            })
-            .into()
+        interp_ok(self.to_scalar_int()?.to_bits(target_size))
     }
 
     pub fn to_bool(self) -> InterpResult<'tcx, bool> {

--- a/compiler/rustc_middle/src/mir/interpret/value.rs
+++ b/compiler/rustc_middle/src/mir/interpret/value.rs
@@ -262,12 +262,12 @@ impl<Prov> Scalar<Prov> {
 }
 
 impl<'tcx, Prov: Provenance> Scalar<Prov> {
-    pub fn to_pointer(self, cx: &impl HasDataLayout) -> InterpResult<'tcx, Pointer<Option<Prov>>> {
+    pub fn to_pointer(self, cx: &impl HasDataLayout) -> Pointer<Option<Prov>> {
         match self.to_bits_or_ptr_internal(cx.pointer_size()) {
-            Right(ptr) => interp_ok(ptr.into()),
+            Right(ptr) => ptr.into(),
             Left(bits) => {
                 let addr = u64::try_from(bits).unwrap();
-                interp_ok(Pointer::without_provenance(addr))
+                Pointer::without_provenance(addr)
             }
         }
     }

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -260,26 +260,19 @@ impl ScalarInt {
         Self::try_from_uint(i, tcx.data_layout.pointer_size())
     }
 
-    /// Try to convert this ScalarInt to the raw underlying bits.
-    /// Fails if the size is wrong. Generally a wrong size should lead to a panic,
-    /// but Miri sometimes wants to be resilient to size mismatches,
-    /// so the interpreter will generally use this `try` method.
-    #[inline]
-    pub fn try_to_bits(self, target_size: Size) -> Result<u128, Size> {
-        assert_ne!(target_size.bytes(), 0, "you should never look at the bits of a ZST");
-        if target_size.bytes() == u64::from(self.size.get()) {
-            self.check_data();
-            Ok(self.data)
-        } else {
-            Err(self.size())
-        }
-    }
-
+    /// Convert this ScalarInt to the underlying bits.
     #[inline]
     pub fn to_bits(self, target_size: Size) -> u128 {
-        self.try_to_bits(target_size).unwrap_or_else(|size| {
-            bug!("expected int of size {}, but got size {}", target_size.bytes(), size.bytes())
-        })
+        assert_ne!(target_size.bytes(), 0, "you should never look at the bits of a ZST");
+        assert_eq!(
+            target_size.bytes(),
+            u64::from(self.size.get()),
+            "ScalarInt has size {} but expected {}",
+            self.size,
+            target_size.bytes(),
+        );
+        self.check_data();
+        self.data
     }
 
     /// Extracts the bits from the scalar without checking the size.

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1213,18 +1213,10 @@ where
         matches!(this.ty.kind(), ty::Adt(def, _) if def.repr().transparent())
     }
 
-    /// Does this type have a layout compatible with C `_Complex`?
-    ///
-    /// The value must be of type `core::num::Complex<T>` where `T` is numeric.
-    fn is_complex_number(this: TyAndLayout<'tcx>, cx: &C) -> bool {
-        let ty::Adt(def, generic_args) = this.ty.kind() else { return false };
-
-        if !cx.tcx().is_lang_item(def.did(), LangItem::Complex) {
-            return false;
-        }
-
-        // Only Complex<{ float }> and Complex<{ integer }> have special layout.
-        generic_args.type_at(0).is_numeric()
+    /// Is this type `core::num::Complex<T>`?
+    fn is_complex_number_lang_item(this: TyAndLayout<'tcx>, cx: &C) -> bool {
+        let Some(def) = this.ty.ty_adt_def() else { return false };
+        cx.tcx().is_lang_item(def.did(), LangItem::Complex)
     }
 
     fn is_scalable_vector(this: TyAndLayout<'tcx>) -> bool {

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -720,7 +720,7 @@ impl<'a, 'tcx> TOFinder<'a, 'tcx> {
                 // had in the previous arm. All we can conclude is that the replacement condition
                 // `discr != value` can be threaded, and nothing else.
                 if c.polarity == Polarity::Ne
-                    && let Ok(value) = c.value.try_to_bits(discr_layout.size)
+                    && let value = c.value.to_bits(discr_layout.size)
                     && targets.all_values().contains(&value.into())
                 {
                     edges_fulfilling_condition.insert(targets.otherwise());

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -120,7 +120,7 @@ struct MarkSymbolVisitor<'tcx> {
     scanned: FxHashSet<(LocalDefId, ComesFromAllowExpect)>,
     live_symbols: LocalDefIdSet,
     repr_unconditionally_treats_fields_as_live: bool,
-    repr_has_repr_simd: bool,
+    repr_has_repr_simd_or_scalable: bool,
     in_pat: bool,
     ignore_variant_stack: Vec<DefId>,
     // maps from ADTs to ignored derived traits (e.g. Debug and Clone)
@@ -466,16 +466,17 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
 
         let unconditionally_treated_fields_as_live =
             self.repr_unconditionally_treats_fields_as_live;
-        let had_repr_simd = self.repr_has_repr_simd;
+        let had_repr_simd_or_scalable = self.repr_has_repr_simd_or_scalable;
         self.repr_unconditionally_treats_fields_as_live = false;
-        self.repr_has_repr_simd = false;
+        self.repr_has_repr_simd_or_scalable = false;
         let walk_result = match node {
             Node::Item(item) => match item.kind {
                 hir::ItemKind::Struct(..) | hir::ItemKind::Union(..) => {
                     let def = self.tcx.adt_def(item.owner_id);
                     self.repr_unconditionally_treats_fields_as_live =
                         def.repr().c() || def.repr().transparent();
-                    self.repr_has_repr_simd = def.repr().simd();
+                    self.repr_has_repr_simd_or_scalable =
+                        def.repr().simd() || def.repr().scalable();
 
                     intravisit::walk_item(self, item)
                 }
@@ -524,7 +525,7 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
             Node::OpaqueTy(opaq) => intravisit::walk_opaque_ty(self, opaq),
             _ => ControlFlow::Continue(()),
         };
-        self.repr_has_repr_simd = had_repr_simd;
+        self.repr_has_repr_simd_or_scalable = had_repr_simd_or_scalable;
         self.repr_unconditionally_treats_fields_as_live = unconditionally_treated_fields_as_live;
 
         walk_result
@@ -599,11 +600,13 @@ impl<'tcx> Visitor<'tcx> for MarkSymbolVisitor<'tcx> {
     fn visit_variant_data(&mut self, def: &'tcx hir::VariantData<'tcx>) -> Self::Result {
         let tcx = self.tcx;
         let unconditionally_treat_fields_as_live = self.repr_unconditionally_treats_fields_as_live;
-        let has_repr_simd = self.repr_has_repr_simd;
+        let has_repr_simd_or_scalable = self.repr_has_repr_simd_or_scalable;
         let effective_visibilities = &tcx.effective_visibilities(());
         let live_fields = def.fields().iter().filter_map(|f| {
             let def_id = f.def_id;
-            if unconditionally_treat_fields_as_live || (f.is_positional() && has_repr_simd) {
+            if unconditionally_treat_fields_as_live
+                || (f.is_positional() && has_repr_simd_or_scalable)
+            {
                 return Some(def_id);
             }
             if !effective_visibilities.is_reachable(f.hir_id.owner.def_id) {
@@ -982,7 +985,7 @@ fn live_symbols_and_ignored_derived_traits(
         scanned: Default::default(),
         live_symbols: Default::default(),
         repr_unconditionally_treats_fields_as_live: false,
-        repr_has_repr_simd: false,
+        repr_has_repr_simd_or_scalable: false,
         in_pat: false,
         ignore_variant_stack: vec![],
         ignored_derived_traits: Default::default(),

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -567,7 +567,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                 // Don't add underscore imports to `single_imports`
                 // because they cannot define any usable names.
                 if target.name != kw::Underscore {
-                    self.r.per_ns(|this, ns| {
+                    self.r.per_ns_mut(|this, ns| {
                         let key = BindingKey::new(IdentKey::new(target), ns);
                         this.resolution_or_default(current_module.to_module(), key, target.span)
                             .borrow_mut(this)

--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -559,7 +559,7 @@ impl Resolver<'_, '_> {
         let mut check_redundant_imports = FxIndexSet::default();
         for module in &self.local_modules {
             for (_key, resolution) in self.resolutions(module.to_module()).iter() {
-                if let Some(decl) = resolution.borrow(self).best_decl()
+                if let Some(decl) = resolution.borrow_checked(self).best_decl()
                     && let DeclKind::Import { import, .. } = decl.kind
                     && let ImportKind::Single { id, .. } = import.kind
                 {

--- a/compiler/rustc_resolve/src/diagnostics/impls.rs
+++ b/compiler/rustc_resolve/src/diagnostics/impls.rs
@@ -1873,7 +1873,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     self.resolutions(parent_scope.module).iter().any(|(key, name_resolution)| {
                         if key.ns == TypeNS
                             && key.ident == *ident
-                            && let Some(decl) = name_resolution.borrow(self).best_decl()
+                            && let Some(decl) = name_resolution.borrow_checked(self).best_decl()
                         {
                             match decl.res() {
                                 // No disambiguation needed if the identically named item we
@@ -3634,7 +3634,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 let mut res = false;
                 let m = r.expect_module(parent_module);
                 if m.is_local() {
-                    for importer in m.glob_importers.borrow(r).iter() {
+                    for importer in m.glob_importers.borrow_checked(r).iter() {
                         if let Some(next_parent_module) = importer.parent_scope.module.opt_def_id()
                         {
                             if next_parent_module == module

--- a/compiler/rustc_resolve/src/effective_visibilities.rs
+++ b/compiler/rustc_resolve/src/effective_visibilities.rs
@@ -129,7 +129,7 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
             let Some(decl) = name_resolution.borrow(self.r).best_decl() else {
                 continue;
             };
-            self.update_decl_chain(decl, ParentId::Def(module_id));
+            self.update_decl_chain(decl, ParentId::Def(module_id), &mut FxHashSet::default());
         }
     }
 
@@ -137,24 +137,23 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
     /// Set the given effective visibility level to `Level::Direct` and
     /// sets the rest of the `use` chain to `Level::Reexported` until
     /// we hit the actual exported item.
-    fn update_decl_chain(&mut self, mut decl: Decl<'ra>, mut parent_id: ParentId<'ra>) {
+    fn update_decl_chain(
+        &mut self,
+        mut decl: Decl<'ra>,
+        mut parent_id: ParentId<'ra>,
+        seen_most_visible: &mut FxHashSet<Decl<'ra>>,
+    ) {
         let priv_vis = |this: &Self, parent_id, decl| match parent_id {
             ParentId::Def(_) => this.current_private_vis,
             ParentId::Import(_) => this.r.private_vis_decl(decl),
         };
         while let DeclKind::Import { source_decl, .. } = decl.kind {
             self.update_import(decl, parent_id, priv_vis(self, parent_id, decl));
-            if let Some(max_vis_decl) = decl.ambiguity_vis_max.get() {
-                // The name is exported with the visibility of the most visible declaration
-                // in its ambiguous glob set (see `DeclData::vis`), so everything on that
-                // declaration's reexport chain, including the final item, must get its
-                // effective visibility from that declaration as well. Otherwise the item
-                // would be considered unreachable by dead code analysis and metadata
-                // encoding despite being exported (see the regression test
-                // `ambiguous-import-visibility-globglob-mir.rs`).
-                // This also avoids the most visible import in an ambiguous glob set
-                // being reported as unused.
-                self.update_decl_chain(max_vis_decl, parent_id);
+            // `ambiguity_vis_max` can cycle on mutual globs; follow each once.
+            if let Some(most_visible) = decl.ambiguity_vis_max.get()
+                && seen_most_visible.insert(most_visible)
+            {
+                self.update_decl_chain(most_visible, parent_id, seen_most_visible);
             }
             parent_id = ParentId::Import(decl);
             decl = source_decl;

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1290,7 +1290,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
         // Check if one of glob imports can still define the name,
         // if it can then our "no resolution" result is not determined and can be invalidated.
-        for glob_import in module.globs.borrow(&self).iter() {
+        for glob_import in module.globs.borrow_checked(&self).iter() {
             if ignore_import == Some(*glob_import) {
                 continue;
             }

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -468,7 +468,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 || max_vis.get().is_none_or(|max_vis| vis.greater_than(max_vis, self.tcx)))
         {
             // `set` can't fail because this can only happen during "write_import_resolutions"
-            max_vis.set(Some(vis), self)
+            max_vis.set_checked(Some(vis), self)
         }
 
         self.arenas.alloc_decl(DeclData {
@@ -585,7 +585,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 && glob_decl.ambiguity.get().is_none()
             {
                 // Do not lose glob ambiguities when re-fetching the glob.
-                glob_decl.ambiguity.set(Some((old_ambig, true)), self);
+                glob_decl.ambiguity.set_checked(Some((old_ambig, true)), self);
             }
             glob_decl
         } else if glob_decl.res() != old_glob_decl.res() {
@@ -593,7 +593,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 || self.is_rustybuzz_0_4_0(old_glob_decl, glob_decl)
                 || self.is_pdf_0_9_0(old_glob_decl, glob_decl)
                 || self.is_net2_0_2_39(old_glob_decl, glob_decl);
-            old_glob_decl.ambiguity.set(Some((glob_decl, warning)), self);
+            old_glob_decl.ambiguity.set_checked(Some((glob_decl, warning)), self);
             old_glob_decl
         } else if let old_vis = old_glob_decl.vis()
             && let vis = glob_decl.vis()
@@ -602,17 +602,17 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             // We are glob-importing the same item but with a different visibility.
             // All visibilities here are ordered because all of them are ancestors of `module`.
             if vis.greater_than(old_vis, self.tcx) {
-                old_glob_decl.ambiguity_vis_max.set(Some(glob_decl), self);
+                old_glob_decl.ambiguity_vis_max.set_checked(Some(glob_decl), self);
             } else if let old_min_vis = old_glob_decl.min_vis()
                 && old_min_vis != vis
                 && old_min_vis.greater_than(vis, self.tcx)
             {
-                old_glob_decl.ambiguity_vis_min.set(Some(glob_decl), self);
+                old_glob_decl.ambiguity_vis_min.set_checked(Some(glob_decl), self);
             }
             old_glob_decl
         } else if glob_decl.is_ambiguity_recursive() && !old_glob_decl.is_ambiguity_recursive() {
             // Overwriting a non-ambiguous glob import with an ambiguous glob import.
-            old_glob_decl.ambiguity.set(Some((glob_decl, true)), self);
+            old_glob_decl.ambiguity.set_checked(Some((glob_decl, true)), self);
             old_glob_decl
         } else {
             old_glob_decl
@@ -1011,7 +1011,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     pub(crate) fn lint_reexports(&mut self, exported_ambiguities: FxHashSet<Decl<'ra>>) {
         for module in &self.local_modules {
             for (key, resolution) in self.resolutions(module.to_module()).iter() {
-                let resolution = resolution.borrow(self);
+                let resolution = resolution.borrow_checked(self);
                 let Some(binding) = resolution.best_decl() else { continue };
 
                 // Report "cannot reexport" errors for exotic cases involving macros 2.0
@@ -1808,7 +1808,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 .resolutions(module)
                 .iter()
                 .filter_map(|(key, resolution)| {
-                    let res = resolution.borrow(self);
+                    let res = resolution.borrow_checked(self);
                     let decl = res.determined_decl()?;
                     let mut key = *key;
                     let scope = match key.ident.ctxt.update_unchecked(|ctxt| {
@@ -1874,7 +1874,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         ambig_module_children: &mut LocalDefIdMap<Vec<AmbigModChild>>,
     ) {
         // Since import resolution is finished, globs will not define any more names.
-        *module.globs.borrow_mut(self) = Vec::new();
+        *module.globs.borrow_mut_checked(self) = Vec::new();
 
         let Some(def_id) = module.opt_def_id() else { return };
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -769,7 +769,7 @@ impl<'ra> ModuleData<'ra> {
     }
 
     fn has_unexpanded_invocations<'tcx>(&self, r: &Resolver<'ra, 'tcx>) -> bool {
-        !self.unexpanded_invocations.borrow(r).is_empty()
+        !self.unexpanded_invocations.borrow_checked(r).is_empty()
     }
 
     fn res(&self) -> Option<Res> {
@@ -794,7 +794,7 @@ impl<'ra> Module<'ra> {
         mut f: impl FnMut(&R, IdentKey, Span, Namespace, Decl<'ra>),
     ) {
         for (key, name_resolution) in resolver.as_ref().resolutions(self).iter() {
-            let name_resolution = name_resolution.borrow(resolver.as_ref());
+            let name_resolution = name_resolution.borrow_checked(resolver.as_ref());
             if let Some(decl) = name_resolution.best_decl() {
                 f(resolver, key.ident, name_resolution.orig_ident_span, key.ns, decl);
             }
@@ -816,7 +816,7 @@ impl<'ra> Module<'ra> {
 
     /// This modifies `self` in place. The traits will be stored in `self.traits`.
     fn ensure_traits<'tcx>(self, resolver: &Resolver<'ra, 'tcx>) {
-        let mut traits = self.traits.borrow_mut(resolver.as_ref());
+        let mut traits = self.traits.borrow_mut_checked(resolver);
         if traits.is_none() {
             let mut collected_traits = Vec::new();
             self.for_each_child(resolver, |r, ident, _, ns, mut decl| {
@@ -2184,7 +2184,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
     fn resolutions(&self, module: Module<'ra>) -> CmRef<'ra, ResolutionTable<'ra>> {
         match &module.0.0.lazy_resolutions {
-            Resolutions::Local(local_res) => local_res.borrow(self),
+            Resolutions::Local(local_res) => local_res.borrow_checked(self),
             Resolutions::Extern(extern_res) => {
                 // It is fine to return a `CmRef::Untracked`, we never give out a `&mut`
                 // to an external table.
@@ -2197,7 +2197,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
     }
 
-    fn resolutions_mut(&self, module: Module<'ra>) -> RefMut<'ra, ResolutionTable<'ra>> {
+    fn resolutions_mut(&mut self, module: Module<'ra>) -> RefMut<'ra, ResolutionTable<'ra>> {
         match &module.0.0.lazy_resolutions {
             Resolutions::Local(local_res) => local_res.borrow_mut(self),
             Resolutions::Extern(_) => {
@@ -2213,12 +2213,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         module: Module<'ra>,
         key: BindingKey,
     ) -> Option<CmRef<'ra, NameResolution<'ra>>> {
-        self.resolutions(module).get(&key).map(|resolution| resolution.0.borrow(self))
+        self.resolutions(module).get(&key).map(|resolution| resolution.0.borrow_checked(self))
     }
 
     #[track_caller]
     fn resolution_or_default(
-        &self,
+        &mut self,
         module: Module<'ra>,
         key: BindingKey,
         orig_ident_span: Span,
@@ -2908,10 +2908,11 @@ mod ref_mut {
             self.0.get()
         }
 
-        pub(crate) fn update<'ra, 'tcx>(&self, r: &Resolver<'ra, 'tcx>, f: impl FnOnce(T) -> T)
-        where
-            T: Copy,
-        {
+        pub(crate) fn update<'ra, 'tcx>(
+            &self,
+            r: &mut Resolver<'ra, 'tcx>,
+            f: impl FnOnce(T) -> T,
+        ) {
             let old = self.get();
             self.set(f(old), r);
         }
@@ -2922,10 +2923,15 @@ mod ref_mut {
             CmCell(Cell::new(value))
         }
 
-        pub(crate) fn set<'ra, 'tcx>(&self, val: T, r: &Resolver<'ra, 'tcx>) {
-            if r.speculative_flag.is_speculative() {
-                panic!("not allowed to mutate a `CmCell` during speculative resolution")
-            }
+        pub(crate) fn set<'ra, 'tcx>(&self, val: T, _: &mut Resolver<'ra, 'tcx>) {
+            self.0.set(val);
+        }
+
+        pub(crate) fn set_checked<'ra, 'tcx>(&self, val: T, r: &Resolver<'ra, 'tcx>) {
+            assert!(
+                !r.speculative_flag.is_speculative(),
+                "Cannot mutate `CmCell` during speculative resolution"
+            );
             self.0.set(val);
         }
 
@@ -2983,23 +2989,43 @@ mod ref_mut {
         }
 
         #[track_caller]
-        pub(crate) fn borrow_mut<'ra, 'tcx>(&self, r: &Resolver<'ra, 'tcx>) -> RefMut<'_, T> {
+        pub(crate) fn borrow_mut<'ra, 'tcx>(&self, r: &mut Resolver<'ra, 'tcx>) -> RefMut<'_, T> {
             self.try_borrow_mut(r).unwrap()
+        }
+
+        #[track_caller]
+        pub(crate) fn borrow_mut_checked<'ra, 'tcx>(
+            &self,
+            r: &Resolver<'ra, 'tcx>,
+        ) -> RefMut<'_, T> {
+            self.try_borrow_mut_checked(r).unwrap()
+        }
+
+        #[track_caller]
+        pub(crate) fn try_borrow_mut_checked<'ra, 'tcx>(
+            &self,
+            r: &Resolver<'ra, 'tcx>,
+        ) -> Result<RefMut<'_, T>, BorrowMutError> {
+            assert!(
+                !r.speculative_flag.is_speculative(),
+                "Cannot mutate `CmRefCell` state/value during speculative resolution"
+            );
+            self.0.try_borrow_mut()
         }
 
         #[track_caller]
         pub(crate) fn try_borrow_mut<'ra, 'tcx>(
             &self,
-            r: &Resolver<'ra, 'tcx>,
+            _: &mut Resolver<'ra, 'tcx>,
         ) -> Result<RefMut<'_, T>, BorrowMutError> {
-            if r.speculative_flag.is_speculative() {
-                panic!("not allowed to mutably borrow a `CmRefCell` during speculative resolution");
-            }
             self.0.try_borrow_mut()
         }
 
-        #[track_caller]
-        pub(crate) fn borrow<'ra, 'tcx>(&self, r: &Resolver<'ra, 'tcx>) -> CmRef<'_, T> {
+        pub(crate) fn borrow<'ra, 'tcx>(&self, _: &mut Resolver<'ra, 'tcx>) -> Ref<'_, T> {
+            self.0.borrow()
+        }
+
+        pub(crate) fn borrow_checked<'ra, 'tcx>(&self, r: &Resolver<'ra, 'tcx>) -> CmRef<'_, T> {
             if r.speculative_flag.is_speculative() {
                 // `try_borrow_unguarded` is unsafe because it returns a `&T` instead
                 // of `Ref<'_, T>`. It does provides an extra check to make sure no live

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -861,7 +861,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 PathResult::Module(..) => unreachable!(),
             };
 
-            self.multi_segment_macro_resolutions.borrow_mut(&self).push((
+            self.multi_segment_macro_resolutions.borrow_mut_checked(&self).push((
                 path,
                 path_span,
                 kind,
@@ -888,7 +888,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 return Err(Determinacy::Undetermined);
             }
 
-            self.single_segment_macro_resolutions.borrow_mut(&self).push((
+            self.single_segment_macro_resolutions.borrow_mut_checked(&self).push((
                 path[0].ident,
                 kind,
                 *parent_scope,

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -933,6 +933,10 @@ impl SyntaxContext {
     /// This is used to test whether a lint should not even begin to figure out whether it should
     /// be reported on the current node.
     pub fn in_external_macro(self, sm: &SourceMap) -> bool {
+        // fast path to avoid locking/expn-data read: the root context is not in a macro
+        if self.is_root() {
+            return false;
+        }
         let expn_data = self.outer_expn_data();
         match expn_data.kind {
             ExpnKind::Root

--- a/src/ci/citool/Cargo.lock
+++ b/src/ci/citool/Cargo.lock
@@ -134,6 +134,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
@@ -181,6 +187,7 @@ dependencies = [
  "flate2",
  "glob-match",
  "insta",
+ "jiff",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -301,6 +308,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -590,6 +628,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +751,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,7 +830,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -914,6 +1020,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1234,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/ci/citool/Cargo.toml
+++ b/src/ci/citool/Cargo.toml
@@ -11,6 +11,7 @@ csv = "1"
 diff = "0.1"
 flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] } # For feature flag only
 glob-match = "0.2"
+jiff = { version = "0.2", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1"

--- a/src/ci/citool/src/analysis.rs
+++ b/src/ci/citool/src/analysis.rs
@@ -237,17 +237,24 @@ pub fn output_largest_job_duration_changes(
     let mut changes: Vec<Entry> = vec![];
     for (job, metrics) in job_metrics {
         if let Some(parent) = &metrics.parent {
-            let duration_before = parent
-                .invocations
-                .iter()
-                .map(|i| BuildStep::from_invocation(i).duration)
-                .sum::<Duration>();
-            let duration_after = metrics
-                .current
-                .invocations
-                .iter()
-                .map(|i| BuildStep::from_invocation(i).duration)
-                .sum::<Duration>();
+            // Try to get duration from GitHub, if it fails, compute it from bootstrap metrics.
+            let duration_before =
+                job_info_resolver.get_job_duration(job, parent).unwrap_or_else(|| {
+                    parent
+                        .invocations
+                        .iter()
+                        .map(|i| BuildStep::from_invocation(i).duration)
+                        .sum::<Duration>()
+                });
+            let duration_after =
+                job_info_resolver.get_job_duration(job, &metrics.current).unwrap_or_else(|| {
+                    metrics
+                        .current
+                        .invocations
+                        .iter()
+                        .map(|i| BuildStep::from_invocation(i).duration)
+                        .sum::<Duration>()
+                });
             let pct_change = duration_after.as_secs_f64() / duration_before.as_secs_f64();
             let pct_change = pct_change * 100.0;
             // Normalize around 100, to get + for regression and - for improvements

--- a/src/ci/citool/src/analysis.rs
+++ b/src/ci/citool/src/analysis.rs
@@ -237,7 +237,9 @@ pub fn output_largest_job_duration_changes(
     let mut changes: Vec<Entry> = vec![];
     for (job, metrics) in job_metrics {
         if let Some(parent) = &metrics.parent {
-            // Try to get duration from GitHub, if it fails, compute it from bootstrap metrics.
+            // Try to get duration from GitHub.
+            // If it fails, treat the duration as zero - it should be obvious in the post-merge
+            // report that something failed in that case.
             let duration_before =
                 job_info_resolver.get_job_duration(job, parent).unwrap_or(Duration::ZERO);
             let duration_after =

--- a/src/ci/citool/src/analysis.rs
+++ b/src/ci/citool/src/analysis.rs
@@ -239,22 +239,9 @@ pub fn output_largest_job_duration_changes(
         if let Some(parent) = &metrics.parent {
             // Try to get duration from GitHub, if it fails, compute it from bootstrap metrics.
             let duration_before =
-                job_info_resolver.get_job_duration(job, parent).unwrap_or_else(|| {
-                    parent
-                        .invocations
-                        .iter()
-                        .map(|i| BuildStep::from_invocation(i).duration)
-                        .sum::<Duration>()
-                });
+                job_info_resolver.get_job_duration(job, parent).unwrap_or(Duration::ZERO);
             let duration_after =
-                job_info_resolver.get_job_duration(job, &metrics.current).unwrap_or_else(|| {
-                    metrics
-                        .current
-                        .invocations
-                        .iter()
-                        .map(|i| BuildStep::from_invocation(i).duration)
-                        .sum::<Duration>()
-                });
+                job_info_resolver.get_job_duration(job, &metrics.current).unwrap_or(Duration::ZERO);
             let pct_change = duration_after.as_secs_f64() / duration_before.as_secs_f64();
             let pct_change = pct_change * 100.0;
             // Normalize around 100, to get + for regression and - for improvements

--- a/src/ci/citool/src/github.rs
+++ b/src/ci/citool/src/github.rs
@@ -96,7 +96,7 @@ impl JobInfoResolver {
             self.get_job_data(metadata, job_name).and_then(|job| {
                 let start = job.started_at?;
                 let end = job.completed_at?;
-                let duration = Duration::try_from(end - start).ok()?;
+                let duration = Duration::try_from(end - start).unwrap_or(Duration::ZERO);
                 Some(duration)
             })
         })

--- a/src/ci/citool/src/github.rs
+++ b/src/ci/citool/src/github.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use anyhow::Context;
 use build_helper::metrics::{CiMetadata, JsonRoot};
@@ -60,6 +61,8 @@ struct WorkflowRunJobsResponse {
 struct GitHubJob {
     name: String,
     id: u64,
+    started_at: Option<jiff::Timestamp>,
+    completed_at: Option<jiff::Timestamp>,
 }
 
 /// Can be used to resolve information about GitHub Actions jobs.
@@ -78,22 +81,34 @@ impl JobInfoResolver {
     /// Get a link to a job summary for the given job name and bootstrap execution.
     pub fn get_job_summary_link(&mut self, job_name: &str, metrics: &JsonRoot) -> Option<String> {
         metrics.ci_metadata.as_ref().and_then(|metadata| {
-            self.get_job_id(metadata, job_name).map(|job_id| {
+            self.get_job_data(metadata, job_name).map(|job| {
                 format!(
-                    "https://github.com/{}/actions/runs/{}#summary-{job_id}",
-                    metadata.repository, metadata.workflow_run_id
+                    "https://github.com/{}/actions/runs/{}#summary-{}",
+                    metadata.repository, metadata.workflow_run_id, job.id
                 )
             })
         })
     }
 
-    fn get_job_id(&mut self, ci_metadata: &CiMetadata, job_name: &str) -> Option<u64> {
+    /// Get duration of the given job.
+    pub fn get_job_duration(&mut self, job_name: &str, metrics: &JsonRoot) -> Option<Duration> {
+        metrics.ci_metadata.as_ref().and_then(|metadata| {
+            self.get_job_data(metadata, job_name).and_then(|job| {
+                let start = job.started_at?;
+                let end = job.completed_at?;
+                let duration = Duration::try_from(end - start).ok()?;
+                Some(duration)
+            })
+        })
+    }
+
+    fn get_job_data(&mut self, ci_metadata: &CiMetadata, job_name: &str) -> Option<&GitHubJob> {
         if let Some(job) = self
             .workflow_job_cache
             .get(&ci_metadata.workflow_run_id)
             .and_then(|jobs| jobs.iter().find(|j| j.name == job_name))
         {
-            return Some(job.id);
+            return Some(job);
         }
 
         let jobs = self
@@ -101,9 +116,12 @@ impl JobInfoResolver {
             .get_workflow_run_jobs(&ci_metadata.repository, ci_metadata.workflow_run_id)
             .inspect_err(|e| eprintln!("Cannot download workflow jobs: {e:?}"))
             .ok()?;
-        let job_id = jobs.iter().find(|j| j.name == job_name).map(|j| j.id);
         // Save the cache even if the job name was not found, it could be useful for further lookups
         self.workflow_job_cache.insert(ci_metadata.workflow_run_id, jobs);
-        job_id
+        self.workflow_job_cache
+            .get(&ci_metadata.workflow_run_id)
+            .unwrap()
+            .iter()
+            .find(|j| j.name == job_name)
     }
 }

--- a/src/ci/citool/src/github.rs
+++ b/src/ci/citool/src/github.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -103,25 +104,18 @@ impl JobInfoResolver {
     }
 
     fn get_job_data(&mut self, ci_metadata: &CiMetadata, job_name: &str) -> Option<&GitHubJob> {
-        if let Some(job) = self
-            .workflow_job_cache
-            .get(&ci_metadata.workflow_run_id)
-            .and_then(|jobs| jobs.iter().find(|j| j.name == job_name))
-        {
-            return Some(job);
+        match self.workflow_job_cache.entry(ci_metadata.workflow_run_id) {
+            Entry::Occupied(jobs) => jobs.into_mut().iter().find(|j| j.name == job_name),
+            Entry::Vacant(entry) => {
+                let jobs = self
+                    .client
+                    .get_workflow_run_jobs(&ci_metadata.repository, ci_metadata.workflow_run_id)
+                    .inspect_err(|e| eprintln!("Cannot download workflow jobs: {e:?}"))
+                    .ok()?;
+                // Save the cache even if the job name was not found, it could be useful for further lookups
+                let jobs = entry.insert(jobs);
+                jobs.iter().find(|j| j.name == job_name)
+            }
         }
-
-        let jobs = self
-            .client
-            .get_workflow_run_jobs(&ci_metadata.repository, ci_metadata.workflow_run_id)
-            .inspect_err(|e| eprintln!("Cannot download workflow jobs: {e:?}"))
-            .ok()?;
-        // Save the cache even if the job name was not found, it could be useful for further lookups
-        self.workflow_job_cache.insert(ci_metadata.workflow_run_id, jobs);
-        self.workflow_job_cache
-            .get(&ci_metadata.workflow_run_id)
-            .unwrap()
-            .iter()
-            .find(|j| j.name == job_name)
     }
 }

--- a/src/ci/citool/src/github.rs
+++ b/src/ci/citool/src/github.rs
@@ -97,6 +97,9 @@ impl JobInfoResolver {
             self.get_job_data(metadata, job_name).and_then(|job| {
                 let start = job.started_at?;
                 let end = job.completed_at?;
+
+                // If `end` is for whatever reason earlier than `start`, then we assume that the
+                // duration is zero, because we do not want negative durations.
                 let duration = Duration::try_from(end - start).unwrap_or(Duration::ZERO);
                 Some(duration)
             })

--- a/src/tools/miri/src/helpers.rs
+++ b/src/tools/miri/src/helpers.rs
@@ -739,7 +739,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     {
         let this = self.eval_context_ref();
         let (ptr, len) = slice.to_scalar_pair();
-        let ptr = ptr.to_pointer(this)?;
+        let ptr = ptr.to_pointer(this);
         let len = len.to_target_usize(this)?;
         let bytes = this.read_bytes_ptr_strip_provenance(ptr, Size::from_bytes(len))?;
         interp_ok(bytes)

--- a/src/tools/miri/src/operator.rs
+++ b/src/tools/miri/src/operator.rs
@@ -54,7 +54,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Add | Sub | BitOr | BitAnd | BitXor => {
                 assert!(left.layout.ty.is_raw_ptr());
                 assert_eq!(right.layout.ty, this.tcx.types.usize);
-                let ptr = left.to_scalar().to_pointer(this)?;
+                let ptr = left.to_scalar().to_pointer(this);
                 // We do the actual operation with usize-typed scalars.
                 let left = ImmTy::from_uint(ptr.addr().bytes(), this.machine.layouts.usize);
                 let result = this.binary_op(bin_op, &left, right)?;

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -684,8 +684,12 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "memchr" => {
-                let [ptr, val, num] =
-                    this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                let [ptr, val, num] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(*const _, i32, usize) -> *const _),
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let ptr = this.read_pointer(ptr)?;
                 let val = this.read_scalar(val)?.to_i32()?;
                 let num = this.read_target_usize(num)?;
@@ -709,8 +713,12 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "memrchr" => {
                 this.check_target_os(&[Os::Linux, Os::Android, Os::FreeBsd], link_name)?;
 
-                let [ptr, val, num] =
-                    this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                let [ptr, val, num] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(*const _, i32, usize) -> *const _),
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let ptr = this.read_pointer(ptr)?;
                 let val = this.read_scalar(val)?.to_i32()?;
                 let num = this.read_target_usize(num)?;

--- a/src/tools/miri/src/shims/global_ctor.rs
+++ b/src/tools/miri/src/shims/global_ctor.rs
@@ -71,7 +71,7 @@ impl<'tcx> GlobalCtorState<'tcx> {
                     if let Some((ctor, span)) = ctors.pop() {
                         let this = this.eval_context_mut();
 
-                        let ctor = ctor.to_scalar().to_pointer(this)?;
+                        let ctor = ctor.to_scalar().to_pointer(this);
                         let thread_callback = this.get_ptr_fn(ctor)?.as_instance()?;
 
                         // The signature of this function is `unsafe extern "C" fn()`.

--- a/src/tools/miri/src/shims/tls.rs
+++ b/src/tools/miri/src/shims/tls.rs
@@ -353,7 +353,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn schedule_windows_tls_dtor(&mut self, dtor: ImmTy<'tcx>, span: Span) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
-        let dtor = dtor.to_scalar().to_pointer(this)?;
+        let dtor = dtor.to_scalar().to_pointer(this);
         let thread_callback = this.get_ptr_fn(dtor)?.as_instance()?;
 
         // FIXME: Technically, the reason should be `DLL_PROCESS_DETACH` when the main thread exits

--- a/src/tools/miri/src/shims/unix/linux_like/thread.rs
+++ b/src/tools/miri/src/shims/unix/linux_like/thread.rs
@@ -39,7 +39,7 @@ pub fn prctl<'tcx>(
             let thread = ecx.pthread_self()?;
             let len = Scalar::from_target_usize(TASK_COMM_LEN, ecx);
             ecx.check_ptr_access(
-                name.to_pointer(ecx)?,
+                name.to_pointer(ecx),
                 Size::from_bytes(TASK_COMM_LEN),
                 CheckInAllocMsg::MemoryAccess,
             )?;

--- a/src/tools/miri/src/shims/unix/thread.rs
+++ b/src/tools/miri/src/shims/unix/thread.rs
@@ -106,7 +106,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let Ok(thread) = this.thread_id_try_from(thread) else {
             return interp_ok(ThreadNameResult::ThreadNotFound);
         };
-        let name = name.to_pointer(this)?;
+        let name = name.to_pointer(this);
         let mut name = this.read_c_str(name)?.to_owned();
 
         // Comparing with `>=` to account for null terminator.
@@ -140,7 +140,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let Ok(thread) = this.thread_id_try_from(thread) else {
             return interp_ok(ThreadNameResult::ThreadNotFound);
         };
-        let name_out = name_out.to_pointer(this)?;
+        let name_out = name_out.to_pointer(this);
         let len = len.to_target_usize(this)?;
 
         // FIXME: we should use the program name if the thread name is not set

--- a/src/tools/miri/tests/fail/shims/shim_arg_size.rs
+++ b/src/tools/miri/tests/fail/shims/shim_arg_size.rs
@@ -5,6 +5,6 @@ fn main() {
     }
 
     unsafe {
-        memchr(std::ptr::null(), 0, 0); //~ ERROR: Undefined Behavior: scalar size mismatch
+        memchr(std::ptr::null(), 0, 0); //~ ERROR: parameter #2 has type i32 passing argument of type u8
     };
 }

--- a/src/tools/miri/tests/fail/shims/shim_arg_size.stderr
+++ b/src/tools/miri/tests/fail/shims/shim_arg_size.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: scalar size mismatch: expected 4 bytes but got 1 bytes instead
+error: Undefined Behavior: calling a function whose parameter #2 has type i32 passing argument of type u8
   --> tests/fail/shims/shim_arg_size.rs:LL:CC
    |
 LL |         memchr(std::ptr::null(), 0, 0);
@@ -6,6 +6,8 @@ LL |         memchr(std::ptr::null(), 0, 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
+   = help: if you think this code should be accepted anyway, please report an issue with Miri
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/codegen-llvm/complex-abi.rs
+++ b/tests/codegen-llvm/complex-abi.rs
@@ -342,12 +342,61 @@ pub extern "C" fn cplx_i64(x: Complex<i64>) -> Complex<i64> {
 struct Wrapper<T>(T);
 
 #[no_mangle]
-pub extern "C" fn wrapper_cplx_i64(x: Wrapper<Complex<i64>>) -> Wrapper<Complex<i64>> {
+pub extern "C" fn wrapper_cplx_i64(
+    x: Wrapper<Complex<Wrapper<i64>>>,
+) -> Wrapper<Complex<Wrapper<i64>>> {
+    // AARCH64:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
+    // AARCH64_DARWIN: define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
+    // AARCH64_MSVC:   define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
+    // AIX:            define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // ARM64EC:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
+    // ARM:            define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
+    // BPF:            define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
+    // CSKY:           define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [4 x i32] {{.*}})
     // I686:           define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
+    // LOONGARCH32:    define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
+    // LOONGARCH64:    define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
+    // MIPS64EL:       define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // MIPS:           define{{.*}} { i64, i64 } @wrapper_cplx_i64(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
+    // NVPTX:          define{{.*}} { i64, i64 } @wrapper_cplx_i64(ptr {{.*}} byval({ i64, i64 }) {{.*}})
+    // POWERPC64:      define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // POWERPC64LE:    define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // POWERPC:        define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
+    // RISCV32:        define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
+    // RISCV64:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
+    // S390X:          define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}})
+    // SPARC64:        define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // SPARC:          define{{.*}} { i64, i64 } @wrapper_cplx_i64(ptr {{.*}} byval({ i64, i64 }) {{.*}})
+    // WASM32:         define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
+    // WASM64:         define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
     // WIN32_GNU:      define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
     // WIN32_MSVC:     define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}} byval([16 x i8]) {{.*}})
     // WINDOWS_GNU:    define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // WINDOWS_MSVC:   define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // X86_64:         define{{.*}} { i64, i64 } @wrapper_cplx_i64({ i64, i64 } {{.*}})
+    x
+}
+
+#[no_mangle]
+pub extern "C" fn wrapper_cplx_f16(
+    x: Wrapper<Complex<Wrapper<f16>>>,
+) -> Wrapper<Complex<Wrapper<f16>>> {
+    // AARCH64:        define{{.*}} { half, half } @wrapper_cplx_f16([2 x half] {{.*}})
+    // AARCH64_DARWIN: define{{.*}} { half, half } @wrapper_cplx_f16([2 x half] {{.*}})
+    // AARCH64_MSVC:   define{{.*}} { half, half } @wrapper_cplx_f16([2 x half] {{.*}})
+    // ARM64EC:        define{{.*}} { half, half } @wrapper_cplx_f16([2 x half] {{.*}})
+    // ARM:            define{{.*}} i32 @wrapper_cplx_f16([1 x i32] {{.*}})
+    // I686:           define{{.*}} <2 x half> @wrapper_cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
+    // LOONGARCH32:    define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})
+    // LOONGARCH64:    define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})
+    // NVPTX:          define{{.*}} { half, half } @wrapper_cplx_f16(ptr {{.*}} byval({ half, half }) {{.*}})
+    // RISCV32:        define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})
+    // RISCV64:        define{{.*}} { half, half } @wrapper_cplx_f16(half {{.*}}, half {{.*}})
+    // S390X:          define{{.*}} void @wrapper_cplx_f16(ptr {{.*}} sret({ half, half }) {{.*}}, ptr {{.*}})
+    // WIN32_GNU:      define{{.*}} <2 x half> @wrapper_cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
+    // WIN32_MSVC:     define{{.*}} <2 x half> @wrapper_cplx_f16(ptr {{.*}} byval([4 x i8]) {{.*}})
+    // WINDOWS_GNU:    define{{.*}} i32 @wrapper_cplx_f16(i32 {{.*}})
+    // WINDOWS_MSVC:   define{{.*}} i32 @wrapper_cplx_f16(i32 {{.*}})
+    // X86_64:         define{{.*}} float @wrapper_cplx_f16(float {{.*}})
     x
 }

--- a/tests/ui/imports/ambiguous-import-visibility-globglob-cycle.rs
+++ b/tests/ui/imports/ambiguous-import-visibility-globglob-cycle.rs
@@ -1,0 +1,30 @@
+// issue: rust-lang/rust#160685
+// Mutual globs of the same item cycle through `ambiguity_vis_max`.
+
+#![feature(rustc_attrs)]
+#![allow(internal_features)]
+#![deny(dead_code)]
+
+pub mod axiomatic {
+    use super::*; // not pub
+    pub use self::own::*;
+
+    pub mod own {
+        pub use super::*;
+        pub use super::orphan::*;
+    }
+
+    pub mod orphan {
+        pub use super::private::CollectionDescriptor;
+    }
+
+    mod private {
+        #[rustc_effective_visibility]
+        pub struct CollectionDescriptor {}
+        //~^ ERROR Direct: pub(in crate::axiomatic), Reexported: pub, Reachable: pub, ReachableThroughImplTrait: pub
+    }
+}
+
+pub use axiomatic::orphan::*;
+
+fn main() {}

--- a/tests/ui/imports/ambiguous-import-visibility-globglob-cycle.stderr
+++ b/tests/ui/imports/ambiguous-import-visibility-globglob-cycle.stderr
@@ -1,0 +1,8 @@
+error: Direct: pub(in crate::axiomatic), Reexported: pub, Reachable: pub, ReachableThroughImplTrait: pub
+  --> $DIR/ambiguous-import-visibility-globglob-cycle.rs:23:9
+   |
+LL |         pub struct CollectionDescriptor {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/imports/ambiguous-import-visibility-globglob-mir.rs
+++ b/tests/ui/imports/ambiguous-import-visibility-globglob-mir.rs
@@ -1,11 +1,6 @@
-// Regression test for the 1.96 -> 1.97 stable-to-stable regression: an item exported
-// only through a public glob, and also glob-imported with restricted visibility through
-// a private facade, lost its exported effective visibility. The defining crate then
-// skipped encoding its optimized MIR (and warned dead_code) while name resolution still
-// exported the item and it remained `cross_crate_inlinable`, so downstream crates failed
-// with "missing optimized MIR". This test pins the missing-MIR half; the dead_code half
-// is checked by the sibling test `ambiguous-import-visibility-globglob-reachable.rs`
-// (via its `#![deny(dead_code)]`).
+// issue: rust-lang/rust#159038
+// Downstream missing optimized MIR when a restricted glob wins the slot.
+// Dead code: `ambiguous-import-visibility-globglob-reachable.rs`.
 
 //@ build-pass
 //@ aux-build:ambiguous-import-visibility-globglob-mir.rs

--- a/tests/ui/imports/ambiguous-import-visibility-globglob-reachable.rs
+++ b/tests/ui/imports/ambiguous-import-visibility-globglob-reachable.rs
@@ -1,9 +1,5 @@
-// Regression test for the 1.96 -> 1.97 stable-to-stable regression: an item exported
-// only through a public glob, and also glob-imported with restricted visibility through
-// a private facade, lost its exported effective visibility while name resolution still
-// exported it. Downstream: spurious dead_code in this crate, "missing optimized MIR" in
-// dependent crates (see ambiguous-import-visibility-globglob-mir.rs). The public glob
-// declaration must drive the effective visibility of the whole reexport chain.
+// issue: rust-lang/rust#159038
+// A restricted glob in the slot must not hide a more public glob of the same item.
 
 #![feature(rustc_attrs)]
 #![allow(internal_features)]

--- a/tests/ui/imports/ambiguous-import-visibility-globglob-reachable.stderr
+++ b/tests/ui/imports/ambiguous-import-visibility-globglob-reachable.stderr
@@ -1,5 +1,5 @@
 error: Direct: pub(crate), Reexported: pub, Reachable: pub, ReachableThroughImplTrait: pub
-  --> $DIR/ambiguous-import-visibility-globglob-reachable.rs:14:5
+  --> $DIR/ambiguous-import-visibility-globglob-reachable.rs:10:5
    |
 LL |     pub fn f() {}
    |     ^^^^^^^^^^

--- a/tests/ui/imports/auxiliary/ambiguous-import-visibility-globglob-mir.rs
+++ b/tests/ui/imports/auxiliary/ambiguous-import-visibility-globglob-mir.rs
@@ -1,7 +1,4 @@
-// An item exported only through a public glob, while also glob-imported into the
-// same module through a facade with restricted visibility. The restricted duplicate
-// must not make `f` unreachable: its optimized MIR must still be encoded for
-// downstream crates (it is `cross_crate_inlinable`).
+// Restricted glob must not stop `f` from being encoded.
 
 mod inner {
     pub fn f() -> u32 {

--- a/tests/ui/scalable-vectors/dead-code.rs
+++ b/tests/ui/scalable-vectors/dead-code.rs
@@ -1,0 +1,9 @@
+//@ check-pass
+//@ only-aarch64
+#![allow(nonstandard_style)]
+#![crate_type = "lib"]
+#![deny(dead_code)]
+#![feature(rustc_attrs)]
+
+#[rustc_scalable_vector(4)]
+pub struct svint32_t(i32);

--- a/tests/ui/statics/unsized-static-without-body-index-141804.rs
+++ b/tests/ui/statics/unsized-static-without-body-index-141804.rs
@@ -1,0 +1,12 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/141804>.
+// Indexing an unsized `static` declared without a body used to ICE in const eval
+// with "primitive read not possible for type".
+
+fn foo() {
+    static symbol: [u32];
+    //~^ ERROR free static item without body
+    //~| ERROR the size for values of type `[u32]` cannot be known at compilation time
+    symbol[0];
+}
+
+fn main() {}

--- a/tests/ui/statics/unsized-static-without-body-index-141804.stderr
+++ b/tests/ui/statics/unsized-static-without-body-index-141804.stderr
@@ -1,0 +1,20 @@
+error: free static item without body
+  --> $DIR/unsized-static-without-body-index-141804.rs:6:5
+   |
+LL |     static symbol: [u32];
+   |     ^^^^^^^^^^^^^^^^^^^^-
+   |                         |
+   |                         help: provide a definition for the static: `= <expr>;`
+
+error[E0277]: the size for values of type `[u32]` cannot be known at compilation time
+  --> $DIR/unsized-static-without-body-index-141804.rs:6:5
+   |
+LL |     static symbol: [u32];
+   |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u32]`
+   = note: statics and constants must have a statically known size
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/target-feature/abi-required-target-feature-missing-in-target-cpu.rs
+++ b/tests/ui/target-feature/abi-required-target-feature-missing-in-target-cpu.rs
@@ -9,6 +9,10 @@
 //@[arm] compile-flags: --target=armv8r-none-eabihf -Ctarget-cpu=cortex-r4
 //@[arm] needs-llvm-components: arm
 
+// LLVM 24 refuses to compile ARM minicore due to mismatched target features.
+// FIXME(#161276): With LLVM rejecting this, we should make Rust's own warning an error.
+//@[arm] max-llvm-major-version: 23
+
 // For now this is just a warning.
 //@ build-pass
 //@ ignore-backends: gcc

--- a/tests/ui/traits/next-solver/normalize-erased-closure-in-async-151299.rs
+++ b/tests/ui/traits/next-solver/normalize-erased-closure-in-async-151299.rs
@@ -1,0 +1,14 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/151299>.
+// An invalid `impl Future` awaited inside a nested async block used to ICE with
+// "Failed to normalize" in normalize_erasing_regions.
+//@ edition: 2024
+//@ compile-flags: -Zvalidate-mir -Znext-solver=globally
+
+fn invalid_future() -> impl Future {}
+//~^ ERROR `()` is not a future
+
+fn create_complex_future() -> impl Future {
+    async { &|| async { invalid_future().await } }
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/normalize-erased-closure-in-async-151299.stderr
+++ b/tests/ui/traits/next-solver/normalize-erased-closure-in-async-151299.stderr
@@ -1,0 +1,11 @@
+error[E0277]: `()` is not a future
+  --> $DIR/normalize-erased-closure-in-async-151299.rs:7:24
+   |
+LL | fn invalid_future() -> impl Future {}
+   |                        ^^^^^^^^^^^ `()` is not a future
+   |
+   = help: the trait `Future` is not implemented for `()`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/typeck/parenthesized-type-params-in-paths.rs
+++ b/tests/ui/typeck/parenthesized-type-params-in-paths.rs
@@ -39,3 +39,8 @@ fn foo<X:Default>() {
     let d : X() = Default::default();
     //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
 }
+
+struct A<T>(T);
+
+fn issue_161062() -> A(impl Sized) {}
+//~^ ERROR parenthesized type parameters may only be used with a `Fn` trait

--- a/tests/ui/typeck/parenthesized-type-params-in-paths.rs
+++ b/tests/ui/typeck/parenthesized-type-params-in-paths.rs
@@ -44,3 +44,12 @@ struct A<T>(T);
 
 fn issue_161062() -> A(impl Sized) {}
 //~^ ERROR parenthesized type parameters may only be used with a `Fn` trait
+
+trait Trait {
+    type Assoc<T>;
+}
+
+fn issue_161062_assoc_constraint() -> &'static dyn Trait<Assoc(impl Sized) = usize> {
+    //~^ ERROR parenthesized generic arguments cannot be used in associated type constraints
+    loop {}
+}

--- a/tests/ui/typeck/parenthesized-type-params-in-paths.stderr
+++ b/tests/ui/typeck/parenthesized-type-params-in-paths.stderr
@@ -58,6 +58,18 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
 LL |     let d : X() = Default::default();
    |             ^^^ only `Fn` traits may use parentheses
 
-error: aborting due to 10 previous errors
+error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
+  --> $DIR/parenthesized-type-params-in-paths.rs:45:22
+   |
+LL | fn issue_161062() -> A(impl Sized) {}
+   |                      ^^^^^^^^^^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL - fn issue_161062() -> A(impl Sized) {}
+LL + fn issue_161062() -> A<impl Sized> {}
+   |
+
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0214`.

--- a/tests/ui/typeck/parenthesized-type-params-in-paths.stderr
+++ b/tests/ui/typeck/parenthesized-type-params-in-paths.stderr
@@ -70,6 +70,18 @@ LL - fn issue_161062() -> A(impl Sized) {}
 LL + fn issue_161062() -> A<impl Sized> {}
    |
 
-error: aborting due to 11 previous errors
+error: parenthesized generic arguments cannot be used in associated type constraints
+  --> $DIR/parenthesized-type-params-in-paths.rs:52:58
+   |
+LL | fn issue_161062_assoc_constraint() -> &'static dyn Trait<Assoc(impl Sized) = usize> {
+   |                                                          ^^^^^^^^^^^^^^^^^
+   |
+help: use angle brackets instead
+   |
+LL - fn issue_161062_assoc_constraint() -> &'static dyn Trait<Assoc(impl Sized) = usize> {
+LL + fn issue_161062_assoc_constraint() -> &'static dyn Trait<Assoc<impl Sized> = usize> {
+   |
+
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0214`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#161024 (resolving cyclic glob vis-max)
 - rust-lang/rust#161231 (passes: `rustc_scalable_vector` fields are not dead)
 - rust-lang/rust#161238 (remove scalar size mismatch interpreter error, make it an ICE instead)
 - rust-lang/rust#160345 (Resolver: add `checked` methods for `Cm(Ref)Cell`)
 - rust-lang/rust#161129 (Avoid ICE when recovering parenthesized type parameters)
 - rust-lang/rust#161235 (Compute job time in post-merge-report from the actual GitHub duration)
 - rust-lang/rust#161239 (Fix `#[repr(transparent)]` wrapper types not working with `Complex<T>`)
 - rust-lang/rust#161244 (Add regression test for indexing an unsized static without a body)
 - rust-lang/rust#161257 (Ignore target feature test when LLVM fails to compile minicore)
 - rust-lang/rust#161258 (perf: return early from in_external_macro for root contexts)
 - rust-lang/rust#161278 (Add regression test for normalization failure on erased closure in async block)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=161024,161231,161238,160345,161129,161235,161239,161244,161257,161258,161278)
<!-- homu-ignore:end -->

