### PR TITLE
Assorted bootstrap LLVM refactors (part 4/N)

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -21,7 +21,7 @@ use tracing::span;
 
 use crate::core::backend::CodegenBackendKind;
 use crate::core::build_steps::gcc::{Gcc, GccOutput, GccTargetPair};
-use crate::core::build_steps::llvm::{LlvmFromCi, prebuilt_llvm_output};
+use crate::core::build_steps::llvm::{LlvmFromCi, LlvmKind, prebuilt_llvm_output};
 use crate::core::build_steps::tool::{RustcPrivateCompilers, SourceType, copy_lld_artifacts};
 use crate::core::build_steps::{dist, llvm};
 use crate::core::builder::{
@@ -2201,7 +2201,7 @@ impl CommandLineStep for Assemble {
 
                     if !src_path.exists() {
                         // When using `download-ci-llvm`, some of the tools may not exist, so skip trying to copy them.
-                        if builder.config.llvm_ci_mode.download_from_ci() {
+                        if llvm_output.kind() == LlvmKind::DownloadedFromCi {
                             eprintln!("{} does not exist; skipping copy", src_path.display());
                             continue;
                         }

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -26,7 +26,7 @@ use crate::core::build_steps::compile::{
 use crate::core::build_steps::doc::DocumentationFormat;
 use crate::core::build_steps::gcc::GccTargetPair;
 use crate::core::build_steps::llvm::{
-    LLVM_CI_LINK_TYPE_PATH, LlvmBuildStatus, get_llvm_build_status,
+    LLVM_CI_LINK_TYPE_PATH, LlvmBuildStatus, LlvmKind, get_llvm_build_status,
 };
 use crate::core::build_steps::tool::{
     self, RustcPrivateCompilers, ToolTargetBuildMode, get_tool_target_compiler,
@@ -2526,12 +2526,7 @@ fn maybe_install_llvm(
     // If the LLVM is coming from ourselves (just from CI) though, we
     // still want to install it, as it otherwise won't be available.
 
-    // FIXME: this should be simplified once we stop pre-setting LLVM CI llvm-config during
-    // config parsing.
-    let is_system_llvm =
-        builder.config.target_config.get(&target).and_then(|t| t.llvm_config.as_ref()).is_some()
-            && !(builder.config.llvm_ci_mode.download_from_ci()
-                && builder.config.is_host_target(target));
+    let is_system_llvm = llvm.llvm_output().kind() == LlvmKind::External;
     if is_system_llvm {
         trace!("system LLVM requested, no install");
         return false;
@@ -2713,11 +2708,10 @@ impl CommandLineStep for LlvmTools {
 
         let target = self.target;
 
+        let llvm_output = builder.ensure(crate::core::build_steps::llvm::Llvm { target });
+
         // Run only if a custom llvm-config is not used
-        if let Some(config) = builder.config.target_config.get(&target)
-            && !builder.config.llvm_ci_mode.download_from_ci()
-            && config.llvm_config.is_some()
-        {
+        if llvm_output.kind() == LlvmKind::External {
             builder.info(&format!("Skipping LlvmTools ({target}): external LLVM"));
             return None;
         }
@@ -2725,8 +2719,6 @@ impl CommandLineStep for LlvmTools {
         if !builder.config.dry_run() {
             builder.require_submodule("src/llvm-project", None);
         }
-
-        let llvm_output = builder.ensure(crate::core::build_steps::llvm::Llvm { target });
 
         let mut tarball = Tarball::new(builder, "llvm-tools", &target.triple);
         tarball.set_overlay(OverlayKind::Llvm);
@@ -2739,7 +2731,7 @@ impl CommandLineStep for LlvmTools {
             for tool in tools_to_install(&builder.paths) {
                 let exe = src_bindir.join(exe(tool, target));
                 // When using `download-ci-llvm`, some of the tools may not exist, so skip trying to copy them.
-                if !exe.exists() && builder.config.llvm_ci_mode.download_from_ci() {
+                if !exe.exists() && llvm_output.kind() == LlvmKind::DownloadedFromCi {
                     eprintln!("{} does not exist; skipping copy", exe.display());
                     continue;
                 }

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -32,7 +32,7 @@ use crate::utils::helpers::{
 /// Path where a file containing the link type (dynamic or static) is stored in the LLVM CI tarball.
 pub const LLVM_CI_LINK_TYPE_PATH: &str = "link-type.txt";
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum LlvmKind {
     /// The LLVM was built from in-tree sources
     BuiltLocally,

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -151,13 +151,7 @@ impl LdFlags {
 ///
 /// Calling this function should never attempt to checkout the LLVM submodule.
 pub fn prebuilt_llvm_output(builder: &Builder<'_>, target: TargetSelection) -> Option<LlvmOutput> {
-    // Try to download LLVM from CI, if possible
-    let llvm_ci = builder.ensure(LlvmFromCi { target });
-    if let Some(llvm) = llvm_ci {
-        return Some(llvm.output);
-    }
-
-    // If it is not available, use an externally provided LLVM
+    // Use an externally provided LLVM, if available
     if let Some(config) = builder.config.target_config.get(&target)
         && let Some(ref s) = config.llvm_config
     {
@@ -176,6 +170,12 @@ pub fn prebuilt_llvm_output(builder: &Builder<'_>, target: TargetSelection) -> O
             llvm_root_dir,
             kind: LlvmKind::External,
         });
+    }
+
+    // If external LLVM is not configured, try to download LLVM from CI, if possible
+    let llvm_ci = builder.ensure(LlvmFromCi { target });
+    if let Some(llvm) = llvm_ci {
+        return Some(llvm.output);
     }
 
     // If LLVM is not available from CI nor externally, it is still possible that it was already
@@ -256,21 +256,6 @@ fn llvm_output_dir(builder: &Builder<'_>, target: TargetSelection) -> PathBuf {
 }
 
 fn try_download_ci_llvm(builder: &Builder<'_>, target: TargetSelection) -> Option<DownloadedLlvm> {
-    if builder.config.llvm_ci_mode.requests_download_from_ci()
-        && let Some(config) = builder.config.target_config.get(&target)
-    {
-        if config.llvm_config.is_some() {
-            panic!(
-                "Cannot configure `llvm-config` for {target} when using `llvm.download-ci-llvm`",
-            );
-        }
-        if config.llvm_filecheck.is_some() {
-            panic!(
-                "Cannot configure `llvm-filecheck` for {target} when using `llvm.download-ci-llvm`"
-            );
-        }
-    }
-
     match builder.config.llvm_ci_mode {
         LlvmCiMode::BuildLocally => return None,
         LlvmCiMode::Download => {}

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -256,22 +256,48 @@ fn llvm_output_dir(builder: &Builder<'_>, target: TargetSelection) -> PathBuf {
 }
 
 fn try_download_ci_llvm(builder: &Builder<'_>, target: TargetSelection) -> Option<DownloadedLlvm> {
+    if builder.config.llvm_ci_mode.requests_download_from_ci()
+        && let Some(config) = builder.config.target_config.get(&target)
+    {
+        if config.llvm_config.is_some() {
+            panic!(
+                "Cannot configure `llvm-config` for {target} when using `llvm.download-ci-llvm`",
+            );
+        }
+        if config.llvm_filecheck.is_some() {
+            panic!(
+                "Cannot configure `llvm-filecheck` for {target} when using `llvm.download-ci-llvm`"
+            );
+        }
+    }
+
     match builder.config.llvm_ci_mode {
         LlvmCiMode::BuildLocally => return None,
-        LlvmCiMode::DownloadFromCi => {}
+        LlvmCiMode::Download => {}
+        LlvmCiMode::DownloadIfUnchanged => {
+            builder.config.update_submodule("src/llvm-project");
+
+            // Check for untracked changes in `src/llvm-project` and other important places.
+            let has_changes = builder.config.has_changes_from_upstream(LLVM_INVALIDATION_PATHS);
+            if has_changes {
+                builder.info("Warning: LLVM will not be downloaded because of local changes");
+                return None;
+            }
+        }
     }
 
     // FIXME: this should eventually be relaxed
     if target != builder.host_target {
-        crate::debug!("LLVM not available on CI for non-host target {target}");
+        builder
+            .info(&format!("Warning: LLVM will not be downloaded for a non-host target {target}"));
         return None;
     }
 
     if !is_ci_llvm_available_for_target(&target, builder.config.llvm_assertions) {
-        crate::debug!(
-            "LLVM not available on CI for target={target} and assertions={}",
+        builder.info(&format!(
+            "Warning: LLVM not available on CI for target={target} and assertions={}",
             builder.config.llvm_assertions
-        );
+        ));
         return None;
     }
 

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -286,13 +286,6 @@ fn try_download_ci_llvm(builder: &Builder<'_>, target: TargetSelection) -> Optio
         }
     }
 
-    // FIXME: this should eventually be relaxed
-    if target != builder.host_target {
-        builder
-            .info(&format!("Warning: LLVM will not be downloaded for a non-host target {target}"));
-        return None;
-    }
-
     if !is_ci_llvm_available_for_target(&target, builder.config.llvm_assertions) {
         builder.info(&format!(
             "Warning: LLVM not available on CI for target={target} and assertions={}",
@@ -301,7 +294,7 @@ fn try_download_ci_llvm(builder: &Builder<'_>, target: TargetSelection) -> Optio
         return None;
     }
 
-    let ci_llvm = builder.config.maybe_download_host_ci_llvm()?;
+    let ci_llvm = builder.config.maybe_download_ci_llvm(target)?;
     let link_shared = if !builder.config.dry_run() {
         let link_type = t!(
             std::fs::read_to_string(ci_llvm.join(LLVM_CI_LINK_TYPE_PATH)),
@@ -314,7 +307,7 @@ fn try_download_ci_llvm(builder: &Builder<'_>, target: TargetSelection) -> Optio
 
     Some(DownloadedLlvm {
         output: LlvmOutput {
-            llvm_config: ci_llvm.join("bin").join(exe("llvm-config", builder.host_target)),
+            llvm_config: ci_llvm.join("bin").join(exe("llvm-config", target)),
             link_shared,
             llvm_root_dir: ci_llvm,
             kind: LlvmKind::DownloadedFromCi,
@@ -431,8 +424,12 @@ impl Step for LlvmFromCi {
 
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         let llvm_ci = try_download_ci_llvm(builder, self.target)?;
+
         // Sanity check
-        check_llvm_version(builder, llvm_ci.output.llvm_config());
+        if builder.host_target == self.target {
+            check_llvm_version(builder, llvm_ci.output.llvm_config());
+        }
+
         Some(llvm_ci)
     }
 }

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -425,7 +425,7 @@ impl Step for LlvmFromCi {
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         let llvm_ci = try_download_ci_llvm(builder, self.target)?;
 
-        // Sanity check
+        // Sanity check (we execute the llvm-config, so we can only do it on the host target).
         if builder.host_target == self.target {
             check_llvm_version(builder, llvm_ci.output.llvm_config());
         }

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -15,6 +15,7 @@ use tracing::instrument;
 
 pub(crate) use self::cargo::{Cargo, apply_pgo, cargo_profile_var};
 use crate::core::build_steps::compile::{Std, StdLink, looks_like_codegen_backend};
+use crate::core::build_steps::llvm::{LlvmKind, get_llvm_build_status};
 use crate::core::build_steps::tool::RustcPrivateCompilers;
 use crate::core::build_steps::{
     check, clean, clippy, compile, dist, doc, gcc, install, llvm, run, setup, test, tool, vendor,
@@ -1399,7 +1400,10 @@ Alternatively, you can set `build.local-rebuild=true` and use a stage0 compiler 
         let mut dylib_dirs = vec![self.rustc_libdir(compiler)];
 
         // Ensure that the downloaded LLVM libraries can be found.
-        if self.config.llvm_ci_mode.download_from_ci() {
+        // FIXME: the libraries should be added elsewhere, not in this function...
+        if get_llvm_build_status(self, compiler.host).llvm_output().kind()
+            == LlvmKind::DownloadedFromCi
+        {
             let ci_llvm_lib = self.out.join(compiler.host).join("ci-llvm").join("lib");
             dylib_dirs.push(ci_llvm_lib);
         }

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -5,6 +5,7 @@ use build_helper::stage0_parser::parse_stage0_file;
 use llvm::get_llvm_build_status;
 
 use super::*;
+use crate::core::build_steps::llvm::LlvmKind;
 use crate::core::config::Config;
 use crate::utils::cache::ExecutedStep;
 use crate::utils::helpers::get_host_target;
@@ -293,15 +294,14 @@ fn test_prebuilt_llvm_config_path_resolution() {
         "#,
     );
 
-    // CI-LLVM isn't always available; check if it's enabled before testing.
-    if config.llvm_ci_mode.download_from_ci() {
-        let sess = Session::new(config.clone());
-        let builder = Builder::new(&sess);
+    let sess = Session::new(config.clone());
+    let builder = Builder::new(&sess);
 
-        let actual = get_llvm_build_status(&builder, builder.config.host_target)
-            .llvm_output()
-            .llvm_config()
-            .to_path_buf();
+    let llvm = get_llvm_build_status(&builder, builder.config.host_target);
+    let llvm = llvm.llvm_output();
+    // CI-LLVM isn't always available; check if it's enabled before testing.
+    if llvm.kind() == LlvmKind::DownloadedFromCi {
+        let actual = llvm.llvm_config().to_path_buf();
         let expected = builder
             .out
             .join(builder.config.host_target)

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -27,11 +27,9 @@ use serde::Deserialize;
 use tracing::{instrument, span};
 
 use crate::core::backend::CodegenBackendKind;
-use crate::core::build_steps::llvm;
 use crate::core::build_steps::llvm::{LLVM_INVALIDATION_PATHS, LlvmKind, LlvmOutput};
 use crate::core::build_steps::test::failed_tests::collect_previously_failed_tests;
 use crate::core::config::flags::{Color, Flags, Subcommand, Warnings};
-use crate::core::config::macros::check_ci_llvm;
 use crate::core::config::target_selection::TargetSelectionList;
 use crate::core::config::toml::TomlConfig;
 use crate::core::config::toml::build::{Build, Tool};
@@ -1059,23 +1057,37 @@ impl Config {
             }
         }
 
-        let llvm_from_ci = parse_download_ci_llvm(
-            &dwn_ctx,
-            &rust_info,
-            &download_rustc_commit,
-            llvm_download_ci_llvm,
-            llvm_assertions,
-        );
+        let llvm_ci_mode = parse_download_ci_llvm(llvm_download_ci_llvm);
 
-        // FIXME: llvm_ci_mode should eventually represent what was used in the config, not the
-        // dynamic value used for determining whether it is actually available.
-        let llvm_ci_mode =
-            if llvm_from_ci { LlvmCiMode::DownloadFromCi } else { LlvmCiMode::BuildLocally };
+        // Sanity checks
+        match llvm_ci_mode {
+            LlvmCiMode::DownloadIfUnchanged => {
+                if rust_info.is_from_tarball() {
+                    // Git is needed for running "if-unchanged" logic.
+                    panic!("ERROR: 'if-unchanged' is only compatible with Git managed sources.");
+                }
+            }
+            LlvmCiMode::Download => {
+                if cfg!(not(test))
+                    && ci_env.is_running_in_ci()
+                    && CiEnv::is_rust_lang_managed_ci_job()
+                {
+                    // On rust-lang CI, we must always rebuild LLVM if there were any modifications to it
+                    panic!(
+                        "`llvm.download-ci-llvm` cannot be set to `true` on CI. Use `if-unchanged` instead."
+                    );
+                }
+            }
+            LlvmCiMode::BuildLocally => {
+                if download_rustc_commit.is_some() {
+                    panic!(
+                        "`llvm.download-ci-llvm` cannot be set to `false` if `rust.download-rustc` is set to `true` or `if-unchanged`."
+                    );
+                }
+            }
+        }
 
-        let is_host_system_llvm =
-            target_config.get(&host_target).and_then(|c| c.llvm_config.as_ref()).is_some();
-
-        if llvm_from_ci {
+        if llvm_ci_mode.requests_download_from_ci() {
             let warn = |option: &str| {
                 println!(
                     "WARNING: `{option}` will only be used on `compiler/rustc_llvm` build, not for the LLVM build."
@@ -1108,12 +1120,10 @@ impl Config {
                     "HELP: To use `llvm.libzstd` for LLVM/LLD builds, set `download-ci-llvm` option to false."
                 );
             }
-
-            if let Some(target) = target_config.get(&host_target) {
-                check_ci_llvm!(target.llvm_config);
-                check_ci_llvm!(target.llvm_filecheck);
-            }
         }
+
+        let is_host_system_llvm =
+            target_config.get(&host_target).and_then(|c| c.llvm_config.as_ref()).is_some();
 
         for (target, linker_override) in default_linux_linker_overrides() {
             // If the user overrode the default Linux linker, do not apply bootstrap defaults
@@ -1386,8 +1396,7 @@ NOTE: Please add `--stage 2` to your command line, or if you're sure you want to
         // If we're building with ThinLTO on, by default we want to link
         // to LLVM shared, to avoid re-doing ThinLTO (which happens in
         // the link step) with each stage.
-        let llvm_link_shared =
-            llvm_link_shared.or((!llvm_from_ci && llvm_thin_lto.unwrap_or(false)).then_some(true));
+        let llvm_link_shared = llvm_link_shared.or(llvm_thin_lto.unwrap_or(false).then_some(true));
 
         Config {
             // tidy-alphabetical-start
@@ -1736,10 +1745,7 @@ NOTE: Please add `--stage 2` to your command line, or if you're sure you want to
                 Some(commit) => {
                     self.download_ci_rustc(commit);
 
-                    let llvm_ci_requested = match self.llvm_ci_mode {
-                        LlvmCiMode::BuildLocally => false,
-                        LlvmCiMode::DownloadFromCi => true
-                    };
+                    let llvm_ci_requested = self.llvm_ci_mode.requests_download_from_ci();
                     // CI-rustc can't be used without CI-LLVM. If LLVM Ci is requested, but the
                     // LLVM submodule has changes, it is an error.
                     // FIXME: this whole logic should be refactored to not use
@@ -2427,62 +2433,17 @@ pub fn git_config(stage0_metadata: &build_helper::stage0_parser::Stage0) -> GitC
     }
 }
 
-pub fn parse_download_ci_llvm<'a>(
-    dwn_ctx: impl AsRef<DownloadContext<'a>>,
-    rust_info: &channel::GitInfo,
-    download_rustc_commit: &Option<String>,
-    download_ci_llvm: Option<StringOrBool>,
-    asserts: bool,
-) -> bool {
-    let dwn_ctx = dwn_ctx.as_ref();
+pub fn parse_download_ci_llvm(download_ci_llvm: Option<StringOrBool>) -> LlvmCiMode {
     let download_ci_llvm = download_ci_llvm.unwrap_or(StringOrBool::Bool(true));
-
-    let if_unchanged = || {
-        if rust_info.is_from_tarball() {
-            // Git is needed for running "if-unchanged" logic.
-            println!("ERROR: 'if-unchanged' is only compatible with Git managed sources.");
-            helpers::exit_process(1);
-        }
-
-        // Fetching the LLVM submodule is unnecessary for self-tests.
-        if cfg!(not(test)) {
-            update_submodule(dwn_ctx, rust_info, "src/llvm-project");
-        }
-
-        // Check for untracked changes in `src/llvm-project` and other important places.
-        let has_changes = has_changes_from_upstream(dwn_ctx, LLVM_INVALIDATION_PATHS);
-
-        // Return false if there are untracked changes, otherwise check if CI LLVM is available.
-        if has_changes {
-            false
-        } else {
-            llvm::is_ci_llvm_available_for_target(&dwn_ctx.host_target, asserts)
-        }
-    };
-
     match download_ci_llvm {
         StringOrBool::Bool(b) => {
-            if !b && download_rustc_commit.is_some() {
-                panic!(
-                    "`llvm.download-ci-llvm` cannot be set to `false` if `rust.download-rustc` is set to `true` or `if-unchanged`."
-                );
+            if b {
+                LlvmCiMode::Download
+            } else {
+                LlvmCiMode::BuildLocally
             }
-
-            if cfg!(not(test))
-                && b
-                && dwn_ctx.is_running_on_ci()
-                && CiEnv::is_rust_lang_managed_ci_job()
-            {
-                // On rust-lang CI, we must always rebuild LLVM if there were any modifications to it
-                panic!(
-                    "`llvm.download-ci-llvm` cannot be set to `true` on CI. Use `if-unchanged` instead."
-                );
-            }
-
-            // If download-ci-llvm=true we also want to check that CI llvm is available
-            b && llvm::is_ci_llvm_available_for_target(&dwn_ctx.host_target, asserts)
         }
-        StringOrBool::String(s) if s == "if-unchanged" => if_unchanged(),
+        StringOrBool::String(s) if s == "if-unchanged" => LlvmCiMode::DownloadIfUnchanged,
         StringOrBool::String(other) => {
             panic!("unrecognized option for download-ci-llvm: {other:?}")
         }

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1008,6 +1008,11 @@ impl Config {
                     target.llvm_has_rust_patches = Some(patches);
                 }
                 if let Some(ref s) = target_llvm_filecheck {
+                    if target_llvm_config.is_none() {
+                        panic!(
+                            "You must also configure `llvm-config` when setting `llvm-filecheck` for target {triple}",
+                        );
+                    }
                     target.llvm_filecheck = Some(src.join(s));
                 }
                 target.llvm_libunwind = target_llvm_libunwind.as_ref().map(|v| {

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1736,18 +1736,18 @@ NOTE: Please add `--stage 2` to your command line, or if you're sure you want to
                 Some(commit) => {
                     self.download_ci_rustc(commit);
 
-                    // CI-rustc can't be used without CI-LLVM. If `self.llvm_from_ci` is false, it means the "if-unchanged"
-                    // logic has detected some changes in the LLVM submodule (download-ci-llvm=false can't happen here as
-                    // we don't allow it while parsing the configuration).
-                    if !self.llvm_ci_mode.download_from_ci() {
-                        // This happens when LLVM submodule is updated in CI, we should disable ci-rustc without an error
-                        // to not break CI. For non-CI environments, we should return an error.
-                        if self.is_running_on_ci() {
-                            println!("WARNING: LLVM submodule has changes, `download-rustc` will be disabled.");
-                            return None;
-                        } else {
-                            panic!("ERROR: LLVM submodule has changes, `download-rustc` can't be used.");
-                        }
+                    let llvm_ci_requested = match self.llvm_ci_mode {
+                        LlvmCiMode::BuildLocally => false,
+                        LlvmCiMode::DownloadFromCi => true
+                    };
+                    // CI-rustc can't be used without CI-LLVM. If LLVM Ci is requested, but the
+                    // LLVM submodule has changes, it is an error.
+                    // FIXME: this whole logic should be refactored to not use
+                    // `has_changes_from_upstream` explicitly
+                    if llvm_ci_requested && self.has_changes_from_upstream(LLVM_INVALIDATION_PATHS) {
+                        // download-ci-rustc should not be used on CI at the moment
+                        assert!(self.is_running_on_ci());
+                        panic!("ERROR: LLVM submodule has changes, `download-rustc` can't be used.");
                     }
 
                     if let Some(config_path) = &self.config {

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1746,7 +1746,7 @@ NOTE: Please add `--stage 2` to your command line, or if you're sure you want to
                     self.download_ci_rustc(commit);
 
                     let llvm_ci_requested = self.llvm_ci_mode.requests_download_from_ci();
-                    // CI-rustc can't be used without CI-LLVM. If LLVM Ci is requested, but the
+                    // CI-rustc can't be used without CI-LLVM. If CI LLVM is requested, but the
                     // LLVM submodule has changes, it is an error.
                     // FIXME: this whole logic should be refactored to not use
                     // `has_changes_from_upstream` explicitly

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1752,7 +1752,7 @@ NOTE: Please add `--stage 2` to your command line, or if you're sure you want to
                     // `has_changes_from_upstream` explicitly
                     if llvm_ci_requested && self.has_changes_from_upstream(LLVM_INVALIDATION_PATHS) {
                         // download-ci-rustc should not be used on CI at the moment
-                        assert!(self.is_running_on_ci());
+                        assert!(!self.is_running_on_ci());
                         panic!("ERROR: LLVM submodule has changes, `download-rustc` can't be used.");
                     }
 

--- a/src/bootstrap/src/core/config/macros.rs
+++ b/src/bootstrap/src/core/config/macros.rs
@@ -136,15 +136,4 @@ macro_rules! define_config {
     }
 }
 
-macro_rules! check_ci_llvm {
-    ($name:expr) => {
-        assert!(
-            $name.is_none(),
-            "setting {} is incompatible with download-ci-llvm.",
-            stringify!($name).replace("_", "-")
-        );
-    };
-}
-
-pub(crate) use check_ci_llvm;
 pub(crate) use define_config;

--- a/src/bootstrap/src/core/config/mod.rs
+++ b/src/bootstrap/src/core/config/mod.rs
@@ -380,7 +380,9 @@ pub enum LlvmCiMode {
 }
 
 impl LlvmCiMode {
-    pub fn download_from_ci(&self) -> bool {
+    /// Return true if the user has requested LLVM to be downloaded from CI.
+    /// **Note:** this does not mean that it will be actually downloaded.
+    pub fn requests_download_from_ci(&self) -> bool {
         match self {
             LlvmCiMode::BuildLocally => false,
             LlvmCiMode::DownloadFromCi => true,

--- a/src/bootstrap/src/core/config/mod.rs
+++ b/src/bootstrap/src/core/config/mod.rs
@@ -373,10 +373,13 @@ pub enum GccCiMode {
 pub enum LlvmCiMode {
     /// Build LLVM from the local `src/llvm-project` submodule.
     BuildLocally,
+    /// Try to download LLVM from CI if the `src/llvm-project` submodule
+    /// (and some other files that affect LLVM's build) are not modified in git.
+    DownloadIfUnchanged,
     /// Try to download LLVM from CI.
     /// If it is not available on CI, it will be built locally instead.
     #[default]
-    DownloadFromCi,
+    Download,
 }
 
 impl LlvmCiMode {
@@ -385,7 +388,7 @@ impl LlvmCiMode {
     pub fn requests_download_from_ci(&self) -> bool {
         match self {
             LlvmCiMode::BuildLocally => false,
-            LlvmCiMode::DownloadFromCi => true,
+            LlvmCiMode::Download | LlvmCiMode::DownloadIfUnchanged => true,
         }
     }
 }

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -11,9 +11,11 @@ use clap::CommandFactory;
 use super::flags::Flags;
 use super::toml::change_id::ChangeIdWrapper;
 use super::toml::rust::parse_codegen_backends;
-use super::{Config, DebuggerPath, RUSTC_IF_UNCHANGED_ALLOWED_PATHS};
+use super::{Config, DebuggerPath, LlvmCiMode, RUSTC_IF_UNCHANGED_ALLOWED_PATHS};
+use crate::Build;
 use crate::core::build_steps::clippy::{LintConfig, get_clippy_rules_in_order};
-use crate::core::build_steps::llvm::LLVM_INVALIDATION_PATHS;
+use crate::core::build_steps::llvm::{LLVM_INVALIDATION_PATHS, LlvmKind, get_llvm_build_status};
+use crate::core::builder::Builder;
 use crate::core::config::flags::Subcommand;
 use crate::core::config::{
     BootstrapOverrideLld, ChangeId, CompilerBuiltins, Target, TargetSelection,
@@ -35,21 +37,28 @@ fn modified(upstream: impl Into<String>, changes: &[&str]) -> PathFreshness {
 #[test]
 fn download_ci_llvm() {
     let config = TestCtx::new().config("check").create_config();
-    assert!(!config.llvm_ci_mode.download_from_ci());
+    assert_eq!(config.llvm_ci_mode, LlvmCiMode::BuildLocally);
 
     // this doesn't make sense, as we are overriding it later.
     let if_unchanged_config = TestCtx::new()
         .config("check")
         .with_default_toml_config("llvm.download-ci-llvm = \"if-unchanged\"")
         .create_config();
-    if if_unchanged_config.llvm_ci_mode.download_from_ci() && if_unchanged_config.is_running_on_ci()
-    {
-        let has_changes = if_unchanged_config.has_changes_from_upstream(LLVM_INVALIDATION_PATHS);
+    if if_unchanged_config.is_running_on_ci() {
+        let build = Build::new(config.clone());
+        let builder = Builder::new(&build);
 
-        assert!(
-            !has_changes,
-            "CI LLVM can't be enabled with 'if-unchanged' while there are changes in LLVM submodule."
-        );
+        let llvm = get_llvm_build_status(&builder, builder.config.host_target);
+        let llvm = llvm.llvm_output();
+        if llvm.kind() == LlvmKind::DownloadedFromCi {
+            let has_changes =
+                if_unchanged_config.has_changes_from_upstream(LLVM_INVALIDATION_PATHS);
+
+            assert!(
+                !has_changes,
+                "CI LLVM can't be enabled with 'if-unchanged' while there are changes in LLVM submodule."
+            );
+        }
     }
 }
 
@@ -163,7 +172,7 @@ fn override_toml() {
             .collect(),
         "setting dictionary value"
     );
-    assert!(!config.llvm_ci_mode.download_from_ci());
+    assert!(matches!(config.llvm_ci_mode, LlvmCiMode::BuildLocally));
     assert!(!config.download_rustc());
 }
 

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -12,7 +12,6 @@ use super::flags::Flags;
 use super::toml::change_id::ChangeIdWrapper;
 use super::toml::rust::parse_codegen_backends;
 use super::{Config, DebuggerPath, LlvmCiMode, RUSTC_IF_UNCHANGED_ALLOWED_PATHS};
-use crate::Build;
 use crate::core::build_steps::clippy::{LintConfig, get_clippy_rules_in_order};
 use crate::core::build_steps::llvm::{LLVM_INVALIDATION_PATHS, LlvmKind, get_llvm_build_status};
 use crate::core::builder::Builder;
@@ -20,6 +19,7 @@ use crate::core::config::flags::Subcommand;
 use crate::core::config::{
     BootstrapOverrideLld, ChangeId, CompilerBuiltins, Target, TargetSelection,
 };
+use crate::core::session::Session;
 use crate::utils::tests::TestCtx;
 use crate::utils::tests::git::git_test;
 
@@ -45,7 +45,7 @@ fn download_ci_llvm() {
         .with_default_toml_config("llvm.download-ci-llvm = \"if-unchanged\"")
         .create_config();
     if if_unchanged_config.is_running_on_ci() {
-        let build = Build::new(config.clone());
+        let build = Session::new(config.clone());
         let builder = Builder::new(&build);
 
         let llvm = get_llvm_build_status(&builder, builder.config.host_target);

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -172,7 +172,7 @@ fn override_toml() {
             .collect(),
         "setting dictionary value"
     );
-    assert!(matches!(config.llvm_ci_mode, LlvmCiMode::BuildLocally));
+    std::assert_matches!(config.llvm_ci_mode, LlvmCiMode::BuildLocally);
     assert!(!config.download_rustc());
 }
 

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -268,15 +268,15 @@ impl Config {
         download_component(dwn_ctx, &self.out, mode, filename, prefix, key, destination);
     }
 
-    /// Attempts to download LLVM from CI for the **host target**.
+    /// Attempts to download LLVM from CI for the given **target**.
     /// Returns a path to the downloaded and extracted directory.
-    pub(crate) fn maybe_download_host_ci_llvm(&self) -> Option<PathBuf> {
+    pub(crate) fn maybe_download_ci_llvm(&self, target: TargetSelection) -> Option<PathBuf> {
         // Never try to download CI LLVM during unit tests.
         if cfg!(test) {
             return None;
         }
 
-        let llvm_root = self.out.join(self.host_target).join("ci-llvm");
+        let llvm_root = self.out.join(target).join("ci-llvm");
         let llvm_freshness =
             detect_llvm_freshness(self, self.rust_info.is_managed_git_subrepository());
         self.do_if_verbose(|| {
@@ -296,7 +296,7 @@ impl Config {
         let stamp_key = format!("{}{}", llvm_sha, self.llvm_assertions);
         let llvm_stamp = BuildStamp::new(&llvm_root).with_prefix("llvm").add_stamp(stamp_key);
         if !llvm_stamp.is_up_to_date() && !self.dry_run() {
-            self.download_ci_llvm(&llvm_root, &llvm_sha);
+            self.download_ci_llvm(&llvm_root, target, &llvm_sha);
 
             if self.should_fix_bins_and_dylibs() {
                 for entry in t!(fs::read_dir(llvm_root.join("bin"))) {
@@ -315,7 +315,7 @@ impl Config {
             let now = std::time::SystemTime::now();
             let file_times = fs::FileTimes::new().set_accessed(now).set_modified(now);
 
-            let llvm_config = llvm_root.join("bin").join(exe("llvm-config", self.host_target));
+            let llvm_config = llvm_root.join("bin").join(exe("llvm-config", target));
             t!(crate::utils::helpers::set_file_times(llvm_config, file_times));
 
             if self.should_fix_bins_and_dylibs() {
@@ -353,13 +353,13 @@ impl Config {
         Some(llvm_root)
     }
 
-    fn download_ci_llvm(&self, llvm_root: &Path, llvm_sha: &str) {
+    fn download_ci_llvm(&self, llvm_root: &Path, target: TargetSelection, llvm_sha: &str) {
         // For unit tests, downloading should have been blocked by `maybe_download_ci_llvm`.
         assert!(cfg!(not(test)), "unit tests shouldn't be downloading CI LLVM");
 
         let llvm_assertions = self.llvm_assertions;
 
-        let cache_prefix = format!("llvm-{llvm_sha}-{llvm_assertions}");
+        let cache_prefix = format!("llvm-{}-{llvm_sha}-{llvm_assertions}", target.triple);
         let cache_dst =
             self.bootstrap_cache_path.as_ref().cloned().unwrap_or_else(|| self.out.join("cache"));
 
@@ -373,20 +373,23 @@ impl Config {
             &self.stage0_metadata.config.artifacts_server
         };
         let version = self.artifact_version_part(llvm_sha);
-        let filename = format!("rust-dev-{}-{}.tar.xz", version, self.host_target.triple);
+        let filename = format!("rust-dev-{}-{}.tar.xz", version, target.triple);
         let tarball = rustc_cache.join(&filename);
         if !tarball.exists() {
-            let help_on_error = "ERROR: failed to download llvm from ci
+            let help_on_error = format!(
+                "ERROR: failed to download llvm from CI for `{target}`
 
     HELP: There could be two reasons behind this:
-        1) The host triple is not supported for `download-ci-llvm`.
+        1) `{target}` is not supported for `download-ci-llvm`.
         2) Old builds get deleted after a certain time.
     HELP: In either case, disable `download-ci-llvm` in your bootstrap.toml:
 
     [llvm]
     download-ci-llvm = false
-    ";
-            self.download_file(&format!("{base}/{llvm_sha}/{filename}"), &tarball, help_on_error);
+    ",
+                target = target.triple
+            );
+            self.download_file(&format!("{base}/{llvm_sha}/{filename}"), &tarball, &help_on_error);
         }
         self.unpack(&tarball, llvm_root, "rust-dev");
     }

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -110,7 +110,7 @@ pub(crate) fn check(sess: &mut Session) {
     if cfg!(not(test))
         && !sess.config.dry_run()
         && !sess.host_target.is_msvc()
-        && sess.config.llvm_ci_mode.download_from_ci()
+        && sess.config.llvm_ci_mode.requests_download_from_ci()
     {
         let builder = Builder::new(sess);
         let libcxx_version = builder.ensure(tool::LibcxxVersionTool { target: sess.host_target });
@@ -138,7 +138,7 @@ pub(crate) fn check(sess: &mut Session) {
     }
 
     // We need cmake, but only if we're actually building LLVM or sanitizers.
-    let building_llvm = !sess.config.llvm_ci_mode.download_from_ci()
+    let building_llvm = !sess.config.llvm_ci_mode.requests_download_from_ci()
         && !sess.config.local_rebuild
         && sess.hosts.iter().any(|host| {
             sess.config.llvm_enabled(*host)


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161290)*
<!-- homu-ignore:end -->

Continuation on https://github.com/rust-lang/rust/pull/161247.

This PR completely removes handling of git changes or LLVM downloads from config parsing, and moves it into the `LlvmFromCi` step. Thanks to that, we now also allow downloading LLVM for non-host targets.

There is one annoyance related to that, and that is that `download-ci-llvm` now applies to all targets for which you try to build LLVM (d'uh), but that also means that if (for whatever reason) LLVM fails to be downloaded from CI, the build will fail. So if you build for target T2 from target T1:
- If you want to download T1, but build T2, that's not possible to express.
- If T2 fails to be downloaded, the build fails, even if it could be built locally.

I think that we mostly have four options how to deal with this:
1. Just ignore it and wait to see if someone complains.
2. Revert the change and always download only for the host target. Worked so far. However, downloading LLVM for non-host targets would be quite useful for further bootstrap improvements and refactorings, because the current logic around sysroots and libdirs is.. convoluted, to say the last, and making cross-compilation easier would help with that a lot.
3. Allow specifying `download-ci-llvm` *per target* in the target config section. So that you can say that you want to download for T1, but build for T2.
4. Make download failures non-fatal, and cause them to trigger a local build. This would also help with removing the hacky `is_ci_llvm_available_for_target` logic, which hard-codes a bunch of targets to "know" which ones offer LLVM and which don't. We could just try to download, and if the result is 404, then we print a warning and continue with building (but this is slightly orthogonal, we can do this even if we don't make LLVM build failures non-fatal).

I think that 3 or 4 would be the best solution, perhaps slightly opting for 4. If we get a 404, there's no way we can download, so we build instead. If we get a different error, we still make the failed download fail the build. And only if someone has a use-case for 3, we'd add the new config.

Already before this PR, we did this:
```
// If download-ci-llvm=true we also want to check that CI llvm is available
b && llvm::is_ci_llvm_available_for_target(&dwn_ctx.host_target, asserts)
```
so if LLVM wasn't available, we just silently reverted from `download-ci-llvm=true` to `download-ci-llvm=false`. The 4. proposal would just generalize that, to actually check whether the LLVM files are present on the CDN or not.

The problem with 4. is that you can't really set any custom build options for LLVM though, because if you also enable `download-ci-llvm`, the config sanity check will tell you to GTFO :( So we would probably need to make some changes there.

r? jieyouxu