### PR TITLE
Enable overflow checks in `rustc_thread_pool`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,13 +60,6 @@ exclude = [
   "obj",
 ]
 
-[profile.release.package.rustc_thread_pool]
-# The rustc fork of Rayon has deadlock detection code which intermittently
-# causes overflows in the CI (see https://github.com/rust-lang/rust/issues/90227)
-# so we turn overflow checks off for now.
-# FIXME: This workaround should be removed once #90227 is fixed.
-overflow-checks = false
-
 # These are very thin wrappers around executing lld with the right binary name.
 # Basically nothing within them can go wrong without having been explicitly logged anyway.
 # We ship these in every rustc tarball and even after compression they add up


### PR DESCRIPTION
For CI run, maybe it will work (it seems like it worked).

Fixes rust-lang/rust#90227.

r? @petrochenkov