### PR TITLE
remove rustc_error_messages dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4385,7 +4385,6 @@ dependencies = [
  "rustc_ast_ir",
  "rustc_crate_store",
  "rustc_data_structures",
- "rustc_error_messages",
  "rustc_errors",
  "rustc_feature",
  "rustc_graphviz",

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -17,7 +17,6 @@ rustc_ast = { path = "../rustc_ast" }
 rustc_ast_ir = { path = "../rustc_ast_ir" }
 rustc_crate_store = { path = "../rustc_crate_store" }
 rustc_data_structures = { path = "../rustc_data_structures" }
-rustc_error_messages = { path = "../rustc_error_messages" }          # Used for intra-doc links
 rustc_errors = { path = "../rustc_errors" }
 rustc_feature = { path = "../rustc_feature" }
 rustc_graphviz = { path = "../rustc_graphviz" }

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
 use rustc_data_structures::intern::Interned;
-use rustc_error_messages::MultiSpan;
 use rustc_macros::StableHash;
+use rustc_span::Span;
 use rustc_type_ir::walk::TypeWalker;
 use rustc_type_ir::{self as ir, TypeFlags, WithCachedTypeInfo};
 
@@ -142,9 +142,9 @@ impl<'tcx> Const<'tcx> {
 
     /// Like [Ty::new_error_with_message] but for constants.
     #[track_caller]
-    pub fn new_error_with_message<S: Into<MultiSpan>>(
+    pub fn new_error_with_message(
         tcx: TyCtxt<'tcx>,
-        span: S,
+        span: Span,
         msg: impl Into<Cow<'static, str>>,
     ) -> Const<'tcx> {
         let reported = tcx.dcx().span_delayed_bug(span, msg);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
