### PR TITLE
Remove a bunch of unnecessary explicit lifetimes

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -262,7 +262,7 @@ impl<'tcx> ItemCtxt<'tcx> {
         ItemCtxt::new_internal(tcx, item_def_id, true)
     }
 
-    pub(crate) fn lower_ty(&self, hir_ty: &hir::Ty<'tcx>) -> Ty<'tcx> {
+    pub(crate) fn lower_ty(&self, hir_ty: &hir::Ty<'_>) -> Ty<'tcx> {
         self.lowerer().lower_ty(hir_ty)
     }
 
@@ -451,7 +451,7 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
         &self,
         span: Span,
         item_def_id: DefId,
-        item_segment: &rustc_hir::PathSegment<'tcx>,
+        item_segment: &rustc_hir::PathSegment<'_>,
         poly_trait_ref: ty::PolyTraitRef<'tcx>,
     ) -> Result<(DefId, ty::GenericArgsRef<'tcx>), ErrorGuaranteed> {
         if let Some(trait_ref) = poly_trait_ref.no_bound_vars() {
@@ -549,7 +549,7 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
 
     fn lower_fn_sig(
         &self,
-        decl: &hir::FnDecl<'tcx>,
+        decl: &hir::FnDecl<'_>,
         _generics: Option<&hir::Generics<'_>>,
         hir_id: rustc_hir::HirId,
         _hir_ty: Option<&hir::Ty<'_>>,

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -107,7 +107,7 @@ fn collect_bounds<'a, 'tcx>(
 
 fn collect_sizedness_bounds<'tcx>(
     tcx: TyCtxt<'tcx>,
-    hir_bounds: &'tcx [hir::GenericBound<'tcx>],
+    hir_bounds: &[hir::GenericBound<'_>],
     context: ImpliedBoundsContext<'tcx>,
     span: Span,
 ) -> CollectedSizednessBounds {
@@ -150,7 +150,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         bounds: &mut Vec<(ty::Clause<'tcx>, Span)>,
         self_ty: Ty<'tcx>,
-        hir_bounds: &'tcx [hir::GenericBound<'tcx>],
+        hir_bounds: &[hir::GenericBound<'_>],
         context: ImpliedBoundsContext<'tcx>,
         span: Span,
     ) {
@@ -212,7 +212,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         bounds: &mut Vec<(ty::Clause<'tcx>, Span)>,
         self_ty: Ty<'tcx>,
-        hir_bounds: &[hir::GenericBound<'tcx>],
+        hir_bounds: &[hir::GenericBound<'_>],
         context: ImpliedBoundsContext<'tcx>,
         span: Span,
     ) {
@@ -229,7 +229,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         trait_: LangItem,
         bounds: &mut Vec<(ty::Clause<'tcx>, Span)>,
         self_ty: Ty<'tcx>,
-        hir_bounds: &[hir::GenericBound<'tcx>],
+        hir_bounds: &[hir::GenericBound<'_>],
         context: ImpliedBoundsContext<'tcx>,
         span: Span,
     ) {
@@ -251,10 +251,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     }
 
     /// Returns `true` if default trait bound should be added.
-    fn should_add_default_traits<'a>(
+    fn should_add_default_traits(
         &self,
         trait_def_id: DefId,
-        hir_bounds: &'a [hir::GenericBound<'tcx>],
+        hir_bounds: &[hir::GenericBound<'_>],
         context: ImpliedBoundsContext<'tcx>,
     ) -> bool {
         let collected = collect_bounds(hir_bounds, context, trait_def_id);
@@ -308,7 +308,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     /// There is an implied binder around `param_ty` and `hir_bounds`.
     /// See `lower_poly_trait_ref` for more details.
     #[instrument(level = "debug", skip(self, hir_bounds, bounds))]
-    pub(crate) fn lower_bounds<'hir, I: IntoIterator<Item = &'hir hir::GenericBound<'tcx>>>(
+    pub(crate) fn lower_bounds<'a, I: IntoIterator<Item = &'a hir::GenericBound<'a>>>(
         &self,
         param_ty: Ty<'tcx>,
         hir_bounds: I,
@@ -316,9 +316,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         bound_vars: &'tcx ty::List<ty::BoundVariableKind<'tcx>>,
         predicate_filter: PredicateFilter,
         overlapping_assoc_constraints: OverlappingAsssocItemConstraints,
-    ) where
-        'tcx: 'hir,
-    {
+    ) {
         for hir_bound in hir_bounds {
             // In order to avoid cycles, when we're lowering `SelfTraitThatDefines`,
             // we skip over any traits that don't define the given associated type.
@@ -379,7 +377,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         hir_ref_id: hir::HirId,
         trait_ref: ty::PolyTraitRef<'tcx>,
-        constraint: &hir::AssocItemConstraint<'tcx>,
+        constraint: &hir::AssocItemConstraint<'_>,
         bounds: &mut Vec<(ty::Clause<'tcx>, Span)>,
         duplicates: Option<&mut FxIndexMap<DefId, Span>>,
         path_span: Span,
@@ -616,7 +614,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
     /// Lower a type, possibly specially handling the type if it's a return type notation
     /// which we otherwise deny in other positions.
-    pub fn lower_ty_maybe_return_type_notation(&self, hir_ty: &hir::Ty<'tcx>) -> Ty<'tcx> {
+    pub fn lower_ty_maybe_return_type_notation(&self, hir_ty: &hir::Ty<'_>) -> Ty<'tcx> {
         let hir::TyKind::Path(qpath) = hir_ty.kind else {
             return self.lower_ty(hir_ty);
         };

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
@@ -37,7 +37,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         span: Span,
         hir_id: hir::HirId,
-        hir_bounds: &[hir::PolyTraitRef<'tcx>],
+        hir_bounds: &[hir::PolyTraitRef<'_>],
         lifetime: &hir::Lifetime,
         syntax: TraitObjectSyntax,
     ) -> Ty<'tcx> {
@@ -569,7 +569,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         span: Span,
         hir_id: hir::HirId,
-        hir_bounds: &[hir::PolyTraitRef<'tcx>],
+        hir_bounds: &[hir::PolyTraitRef<'_>],
     ) -> Option<ErrorGuaranteed> {
         struct TraitObjectWithoutDyn<'a, 'tcx> {
             span: Span,
@@ -871,7 +871,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         span: Span,
         hir_id: hir::HirId,
-        hir_bounds: &[hir::PolyTraitRef<'tcx>],
+        hir_bounds: &[hir::PolyTraitRef<'_>],
         diag: &mut Diag<'_>,
     ) -> bool {
         let tcx = self.tcx();

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -120,7 +120,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         assoc_tag: ty::AssocTag,
         assoc_ident: Ident,
         span: Span,
-        constraint: Option<&hir::AssocItemConstraint<'tcx>>,
+        constraint: Option<&hir::AssocItemConstraint<'_>>,
     ) -> ErrorGuaranteed
     where
         I: Iterator<Item = ty::PolyTraitRef<'tcx>>,
@@ -349,7 +349,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         assoc_tag: ty::AssocTag,
         ident: Ident,
         span: Span,
-        constraint: Option<&hir::AssocItemConstraint<'tcx>>,
+        constraint: Option<&hir::AssocItemConstraint<'_>>,
     ) -> ErrorGuaranteed {
         let tcx = self.tcx();
 
@@ -415,7 +415,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         assoc_tag: ty::AssocTag,
         assoc_ident: Ident,
         span: Span,
-        constraint: Option<&hir::AssocItemConstraint<'tcx>>,
+        constraint: Option<&hir::AssocItemConstraint<'_>>,
     ) -> ErrorGuaranteed {
         let tcx = self.tcx();
 
@@ -544,7 +544,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         trait_def_id: DefId,
         span: Span,
-        item_segment: &hir::PathSegment<'tcx>,
+        item_segment: &hir::PathSegment<'_>,
         assoc_tag: ty::AssocTag,
     ) -> ErrorGuaranteed {
         let tcx = self.tcx();

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -199,13 +199,13 @@ pub trait HirTyLowerer<'tcx> {
         &self,
         span: Span,
         item_def_id: DefId,
-        item_segment: &hir::PathSegment<'tcx>,
+        item_segment: &hir::PathSegment<'_>,
         poly_trait_ref: ty::PolyTraitRef<'tcx>,
     ) -> Result<(DefId, GenericArgsRef<'tcx>), ErrorGuaranteed>;
 
     fn lower_fn_sig(
         &self,
-        decl: &hir::FnDecl<'tcx>,
+        decl: &hir::FnDecl<'_>,
         generics: Option<&hir::Generics<'_>>,
         hir_id: HirId,
         hir_ty: Option<&hir::Ty<'_>>,
@@ -366,13 +366,13 @@ pub struct GenericArgCountResult {
 /// Its only consumer is [`generics::lower_generic_args`].
 /// Read its documentation to learn more.
 pub trait GenericArgsLowerer<'a, 'tcx> {
-    fn args_for_def_id(&mut self, def_id: DefId) -> (Option<&'a GenericArgs<'tcx>>, bool);
+    fn args_for_def_id(&mut self, def_id: DefId) -> (Option<&'a GenericArgs<'a>>, bool);
 
     fn provided_kind(
         &mut self,
         preceding_args: &[ty::GenericArg<'tcx>],
         param: &ty::GenericParamDef,
-        arg: &GenericArg<'tcx>,
+        arg: &GenericArg<'_>,
     ) -> ty::GenericArg<'tcx>;
 
     fn inferred_kind(
@@ -625,7 +625,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         span: Span,
         def_id: DefId,
-        item_segment: &hir::PathSegment<'tcx>,
+        item_segment: &hir::PathSegment<'_>,
     ) -> GenericArgsRef<'tcx> {
         let (args, _) = self.lower_generic_args_of_path(span, def_id, &[], item_segment, None);
         if let Some(c) = item_segment.args().constraints.first() {
@@ -674,7 +674,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         span: Span,
         def_id: DefId,
         parent_args: &[ty::GenericArg<'tcx>],
-        segment: &hir::PathSegment<'tcx>,
+        segment: &hir::PathSegment<'_>,
         self_ty: Option<Ty<'tcx>>,
     ) -> (GenericArgsRef<'tcx>, GenericArgCountResult) {
         // If the type is parameterized by this region, then replace this
@@ -718,7 +718,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         struct GenericArgsCtxt<'a, 'tcx> {
             lowerer: &'a dyn HirTyLowerer<'tcx>,
             def_id: DefId,
-            generic_args: &'a GenericArgs<'tcx>,
+            generic_args: &'a GenericArgs<'a>,
             span: Span,
             infer_args: bool,
             create_synth_args: bool,
@@ -726,7 +726,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         }
 
         impl<'a, 'tcx> GenericArgsLowerer<'a, 'tcx> for GenericArgsCtxt<'a, 'tcx> {
-            fn args_for_def_id(&mut self, did: DefId) -> (Option<&'a GenericArgs<'tcx>>, bool) {
+            fn args_for_def_id(&mut self, did: DefId) -> (Option<&'a GenericArgs<'a>>, bool) {
                 if did == self.def_id {
                     (Some(self.generic_args), self.infer_args)
                 } else {
@@ -739,7 +739,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 &mut self,
                 preceding_args: &[ty::GenericArg<'tcx>],
                 param: &ty::GenericParamDef,
-                arg: &GenericArg<'tcx>,
+                arg: &GenericArg<'_>,
             ) -> ty::GenericArg<'tcx> {
                 let tcx = self.lowerer.tcx();
 
@@ -749,7 +749,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     }
                 }
 
-                let handle_ty_args = |has_default, ty: &hir::Ty<'tcx>| {
+                let handle_ty_args = |has_default, ty: &hir::Ty<'_>| {
                     if has_default {
                         tcx.check_optional_stability(
                             param.def_id,
@@ -896,7 +896,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         span: Span,
         item_def_id: DefId,
-        item_segment: &hir::PathSegment<'tcx>,
+        item_segment: &hir::PathSegment<'_>,
         parent_args: GenericArgsRef<'tcx>,
     ) -> GenericArgsRef<'tcx> {
         let (args, _) =
@@ -959,7 +959,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             modifiers: hir::TraitBoundModifiers { constness, polarity },
             trait_ref,
             span,
-        }: &hir::PolyTraitRef<'tcx>,
+        }: &hir::PolyTraitRef<'_>,
         self_ty: Ty<'tcx>,
         bounds: &mut Vec<(ty::Clause<'tcx>, Span)>,
         predicate_filter: PredicateFilter,
@@ -1182,7 +1182,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         span: Span,
         trait_def_id: DefId,
         self_ty: Ty<'tcx>,
-        trait_segment: &hir::PathSegment<'tcx>,
+        trait_segment: &hir::PathSegment<'_>,
         is_impl: bool,
     ) -> ty::TraitRef<'tcx> {
         self.report_internal_fn_trait(span, trait_def_id, trait_segment, is_impl);
@@ -1211,7 +1211,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         span: Span,
         def_id: DefId,
-        item_segment: &hir::PathSegment<'tcx>,
+        item_segment: &hir::PathSegment<'_>,
     ) -> Ty<'tcx> {
         let tcx = self.tcx();
         let args = self.lower_generic_args_of_path_segment(span, def_id, item_segment);
@@ -1348,7 +1348,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         assoc_tag: ty::AssocTag,
         assoc_ident: Ident,
         span: Span,
-        constraint: Option<&hir::AssocItemConstraint<'tcx>>,
+        constraint: Option<&hir::AssocItemConstraint<'_>>,
     ) -> Result<ty::PolyTraitRef<'tcx>, ErrorGuaranteed>
     where
         I: Iterator<Item = ty::PolyTraitRef<'tcx>>,
@@ -1419,8 +1419,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     pub fn lower_type_relative_ty_path(
         &self,
         self_ty: Ty<'tcx>,
-        hir_self_ty: &'tcx hir::Ty<'tcx>,
-        segment: &'tcx hir::PathSegment<'tcx>,
+        hir_self_ty: &hir::Ty<'_>,
+        segment: &hir::PathSegment<'_>,
         qpath_hir_id: HirId,
         span: Span,
         permit_variants: PermitVariants,
@@ -1461,8 +1461,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     fn lower_type_relative_const_path(
         &self,
         self_ty: Ty<'tcx>,
-        hir_self_ty: &'tcx hir::Ty<'tcx>,
-        segment: &'tcx hir::PathSegment<'tcx>,
+        hir_self_ty: &hir::Ty<'_>,
+        segment: &hir::PathSegment<'_>,
         qpath_hir_id: HirId,
         span: Span,
     ) -> Result<Const<'tcx>, ErrorGuaranteed> {
@@ -1507,8 +1507,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     fn lower_type_relative_path(
         &self,
         self_ty: Ty<'tcx>,
-        hir_self_ty: &'tcx hir::Ty<'tcx>,
-        segment: &'tcx hir::PathSegment<'tcx>,
+        hir_self_ty: &hir::Ty<'_>,
+        segment: &hir::PathSegment<'_>,
         qpath_hir_id: HirId,
         span: Span,
         mode: LowerTypeRelativePathMode,
@@ -1612,9 +1612,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     fn resolve_type_relative_path(
         &self,
         self_ty: Ty<'tcx>,
-        hir_self_ty: &'tcx hir::Ty<'tcx>,
+        hir_self_ty: &hir::Ty<'_>,
         assoc_tag: ty::AssocTag,
-        segment: &'tcx hir::PathSegment<'tcx>,
+        segment: &hir::PathSegment<'_>,
         qpath_hir_id: HirId,
         span: Span,
         variant_def_id: Option<DefId>,
@@ -1679,7 +1679,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     /// Search for inherent associated items for use at the type level.
     fn probe_inherent_assoc_item(
         &self,
-        segment: &hir::PathSegment<'tcx>,
+        segment: &hir::PathSegment<'_>,
         adt_did: DefId,
         self_ty: Ty<'tcx>,
         block: HirId,
@@ -1904,8 +1904,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         span: Span,
         opt_self_ty: Option<Ty<'tcx>>,
         item_def_id: DefId,
-        trait_segment: Option<&hir::PathSegment<'tcx>>,
-        item_segment: &hir::PathSegment<'tcx>,
+        trait_segment: Option<&hir::PathSegment<'_>>,
+        item_segment: &hir::PathSegment<'_>,
     ) -> Ty<'tcx> {
         match self.lower_resolved_assoc_item_path(
             span,
@@ -1929,8 +1929,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         span: Span,
         opt_self_ty: Option<Ty<'tcx>>,
         item_def_id: DefId,
-        trait_segment: Option<&hir::PathSegment<'tcx>>,
-        item_segment: &hir::PathSegment<'tcx>,
+        trait_segment: Option<&hir::PathSegment<'_>>,
+        item_segment: &hir::PathSegment<'_>,
     ) -> Result<Const<'tcx>, ErrorGuaranteed> {
         let tcx = self.tcx();
         let (item_def_id, item_args) = self.lower_resolved_assoc_item_path(
@@ -1957,8 +1957,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         span: Span,
         opt_self_ty: Option<Ty<'tcx>>,
         item_def_id: DefId,
-        trait_segment: Option<&hir::PathSegment<'tcx>>,
-        item_segment: &hir::PathSegment<'tcx>,
+        trait_segment: Option<&hir::PathSegment<'_>>,
+        item_segment: &hir::PathSegment<'_>,
         assoc_tag: ty::AssocTag,
     ) -> Result<(DefId, GenericArgsRef<'tcx>), ErrorGuaranteed> {
         let tcx = self.tcx();
@@ -2183,7 +2183,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     pub fn lower_resolved_ty_path(
         &self,
         opt_self_ty: Option<Ty<'tcx>>,
-        path: &hir::Path<'tcx>,
+        path: &hir::Path<'_>,
         hir_id: HirId,
         permit_variants: PermitVariants,
     ) -> Ty<'tcx> {
@@ -2381,7 +2381,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
     /// Lower a [`hir::ConstArg`] to a (type-level) [`ty::Const`].
     #[instrument(skip(self), level = "debug")]
-    pub fn lower_const_arg(&self, const_arg: &hir::ConstArg<'tcx>, ty: Ty<'tcx>) -> Const<'tcx> {
+    pub fn lower_const_arg(&self, const_arg: &hir::ConstArg<'_>, ty: Ty<'tcx>) -> Const<'tcx> {
         let tcx = self.tcx();
 
         if let hir::ConstArgKind::Anon(anon) = &const_arg.kind {
@@ -2475,7 +2475,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
     fn lower_const_arg_array(
         &self,
-        array_expr: &'tcx hir::ConstArgArrayExpr<'tcx>,
+        array_expr: &hir::ConstArgArrayExpr<'_>,
         ty: Ty<'tcx>,
     ) -> Const<'tcx> {
         let tcx = self.tcx();
@@ -2524,8 +2524,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     fn lower_const_arg_tuple_call(
         &self,
         hir_id: HirId,
-        qpath: hir::QPath<'tcx>,
-        args: &'tcx [&'tcx hir::ConstArg<'tcx>],
+        qpath: hir::QPath<'_>,
+        args: &[&hir::ConstArg<'_>],
         span: Span,
     ) -> Const<'tcx> {
         let tcx = self.tcx();
@@ -2625,7 +2625,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
     fn lower_const_arg_tup(
         &self,
-        exprs: &'tcx [&'tcx hir::ConstArg<'tcx>],
+        exprs: &[&hir::ConstArg<'_>],
         ty: Ty<'tcx>,
         span: Span,
     ) -> Const<'tcx> {
@@ -2667,8 +2667,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     fn lower_const_arg_struct(
         &self,
         hir_id: HirId,
-        qpath: hir::QPath<'tcx>,
-        inits: &'tcx [&'tcx hir::ConstArgExprField<'tcx>],
+        qpath: hir::QPath<'_>,
+        inits: &[&hir::ConstArgExprField<'_>],
         span: Span,
     ) -> Const<'tcx> {
         // FIXME(mgca): try to deduplicate this function with
@@ -2809,7 +2809,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
     pub fn lower_path_for_struct_expr(
         &self,
-        qpath: hir::QPath<'tcx>,
+        qpath: hir::QPath<'_>,
         path_span: Span,
         hir_id: HirId,
     ) -> ResolvedStructPath<'tcx> {
@@ -2846,7 +2846,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     fn lower_resolved_const_path(
         &self,
         opt_self_ty: Option<Ty<'tcx>>,
-        path: &hir::Path<'tcx>,
+        path: &hir::Path<'_>,
         hir_id: HirId,
     ) -> Const<'tcx> {
         let tcx = self.tcx();
@@ -3152,7 +3152,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         }
     }
 
-    fn lower_delegation_ty(&self, infer: hir::InferDelegation<'tcx>) -> Ty<'tcx> {
+    fn lower_delegation_ty(&self, infer: hir::InferDelegation<'_>) -> Ty<'tcx> {
         match infer {
             hir::InferDelegation::DefId(def_id) => {
                 self.tcx().type_of(def_id).instantiate_identity().skip_norm_wip()
@@ -3170,7 +3170,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
     /// Lower a type from the HIR to our internal notion of a type.
     #[instrument(level = "debug", skip(self), ret)]
-    pub fn lower_ty(&self, hir_ty: &hir::Ty<'tcx>) -> Ty<'tcx> {
+    pub fn lower_ty(&self, hir_ty: &hir::Ty<'_>) -> Ty<'tcx> {
         let tcx = self.tcx();
 
         let result_ty = match &hir_ty.kind {
@@ -3428,7 +3428,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         &self,
         ty: Ty<'tcx>,
         ty_span: Span,
-        pat: &hir::TyPat<'tcx>,
+        pat: &hir::TyPat<'_>,
     ) -> Result<ty::PatternKind<'tcx>, ErrorGuaranteed> {
         let tcx = self.tcx();
         match pat.kind {
@@ -3669,7 +3669,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         hir_id: HirId,
         safety: hir::Safety,
         abi: rustc_abi::ExternAbi,
-        decl: &hir::FnDecl<'tcx>,
+        decl: &hir::FnDecl<'_>,
         generics: Option<&hir::Generics<'_>>,
         hir_ty: Option<&hir::Ty<'_>>,
     ) -> ty::PolyFnSig<'tcx> {

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -226,7 +226,7 @@ pub fn check_crate(tcx: TyCtxt<'_>) {
 /// It's used in rustdoc and Clippy.
 ///
 /// </div>
-pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, hir_ty: &hir::Ty<'tcx>) -> Ty<'tcx> {
+pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, hir_ty: &hir::Ty<'_>) -> Ty<'tcx> {
     // In case there are any projections, etc., find the "environment"
     // def-ID that will be used to determine the traits/predicates in
     // scope. This is derived from the enclosing item-like thing.
@@ -240,7 +240,7 @@ pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, hir_ty: &hir::Ty<'tcx>) -> Ty<'tcx> {
 // FIXME(const_generics): having special methods for rustdoc in `rustc_hir_analysis` is cursed
 pub fn lower_const_arg_for_rustdoc<'tcx>(
     tcx: TyCtxt<'tcx>,
-    hir_ct: &hir::ConstArg<'tcx>,
+    hir_ct: &hir::ConstArg<'_>,
     ty: Ty<'tcx>,
 ) -> Const<'tcx> {
     let env_def_id = tcx.hir_get_parent_item(hir_ct.hir_id);

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -569,7 +569,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    pub(crate) fn lower_ty(&self, hir_ty: &hir::Ty<'tcx>) -> LoweredTy<'tcx> {
+    pub(crate) fn lower_ty(&self, hir_ty: &hir::Ty<'_>) -> LoweredTy<'tcx> {
         let ty = self.lowerer().lower_ty(hir_ty);
         self.register_wf_obligation(ty.into(), hir_ty.span, ObligationCauseCode::WellFormed(None));
         LoweredTy::from_raw(self, hir_ty.span, ty)
@@ -629,7 +629,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     pub(crate) fn lower_const_arg(
         &self,
-        const_arg: &'tcx hir::ConstArg<'tcx>,
+        const_arg: &hir::ConstArg<'_>,
         ty: Ty<'tcx>,
     ) -> ty::Const<'tcx> {
         let ct = self.lowerer().lower_const_arg(const_arg, ty);
@@ -1346,7 +1346,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 &mut self,
                 preceding_args: &[ty::GenericArg<'tcx>],
                 param: &ty::GenericParamDef,
-                arg: &GenericArg<'tcx>,
+                arg: &GenericArg<'_>,
             ) -> ty::GenericArg<'tcx> {
                 match (&param.kind, arg) {
                     (GenericParamDefKind::Lifetime, GenericArg::Lifetime(lt)) => self

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -387,7 +387,7 @@ impl<'tcx> HirTyLowerer<'tcx> for FnCtxt<'_, 'tcx> {
         &self,
         span: Span,
         item_def_id: DefId,
-        item_segment: &rustc_hir::PathSegment<'tcx>,
+        item_segment: &rustc_hir::PathSegment<'_>,
         poly_trait_ref: ty::PolyTraitRef<'tcx>,
     ) -> Result<(DefId, ty::GenericArgsRef<'tcx>), ErrorGuaranteed> {
         let trait_ref = self.instantiate_binder_with_fresh_vars(
@@ -452,7 +452,7 @@ impl<'tcx> HirTyLowerer<'tcx> for FnCtxt<'_, 'tcx> {
 
     fn lower_fn_sig(
         &self,
-        decl: &rustc_hir::FnDecl<'tcx>,
+        decl: &rustc_hir::FnDecl<'_>,
         _generics: Option<&rustc_hir::Generics<'_>>,
         _hir_id: rustc_hir::HirId,
         _hir_ty: Option<&hir::Ty<'_>>,

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -451,7 +451,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                 &mut self,
                 preceding_args: &[ty::GenericArg<'tcx>],
                 param: &ty::GenericParamDef,
-                arg: &GenericArg<'tcx>,
+                arg: &GenericArg<'_>,
             ) -> ty::GenericArg<'tcx> {
                 match (&param.kind, arg) {
                     (GenericParamDefKind::Lifetime, GenericArg::Lifetime(lt)) => self

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -265,7 +265,7 @@ fn generate_item_with_correct_attrs(
 }
 
 fn clean_generic_bound<'tcx>(
-    bound: &hir::GenericBound<'tcx>,
+    bound: &hir::GenericBound<'_>,
     cx: &mut DocContext<'tcx>,
 ) -> Option<GenericBound> {
     Some(match bound {
@@ -509,7 +509,7 @@ fn clean_middle_term<'tcx>(
 
 fn clean_hir_term<'tcx>(
     assoc_item: Option<DefId>,
-    term: &hir::Term<'tcx>,
+    term: &hir::Term<'_>,
     cx: &mut DocContext<'tcx>,
 ) -> Term {
     match term {
@@ -657,8 +657,8 @@ enum ParamDefaults {
 
 fn clean_generic_param<'tcx>(
     cx: &mut DocContext<'tcx>,
-    generics: Option<&hir::Generics<'tcx>>,
-    param: &hir::GenericParam<'tcx>,
+    generics: Option<&hir::Generics<'_>>,
+    param: &hir::GenericParam<'_>,
 ) -> GenericParamDef {
     let (name, kind) = match param.kind {
         hir::GenericParamKind::Lifetime { .. } => {
@@ -1161,7 +1161,7 @@ fn clean_function<'tcx>(
 
 fn clean_params<'tcx>(
     cx: &mut DocContext<'tcx>,
-    decl: &hir::FnDecl<'tcx>,
+    decl: &hir::FnDecl<'_>,
     idents: &[Option<Ident>],
     postprocess: impl Fn(Option<Ident>) -> Option<Symbol>,
 ) -> Vec<Parameter> {
@@ -1197,7 +1197,7 @@ fn clean_params_via_body<'tcx>(
 
 fn clean_fn_decl_with_params<'tcx>(
     cx: &mut DocContext<'tcx>,
-    decl: &hir::FnDecl<'tcx>,
+    decl: &hir::FnDecl<'_>,
     header: Option<&hir::FnHeader>,
     params: Vec<Parameter>,
 ) -> FnDecl {
@@ -1253,14 +1253,14 @@ fn clean_poly_fn_sig<'tcx>(
     FnDecl { inputs: params, output, c_variadic: sig.skip_binder().c_variadic() }
 }
 
-fn clean_trait_ref<'tcx>(trait_ref: &hir::TraitRef<'tcx>, cx: &mut DocContext<'tcx>) -> Path {
+fn clean_trait_ref<'tcx>(trait_ref: &hir::TraitRef<'_>, cx: &mut DocContext<'tcx>) -> Path {
     let path = clean_path(trait_ref.path, cx);
     register_res(cx, path.res);
     path
 }
 
 fn clean_poly_trait_ref<'tcx>(
-    poly_trait_ref: &hir::PolyTraitRef<'tcx>,
+    poly_trait_ref: &hir::PolyTraitRef<'_>,
     cx: &mut DocContext<'tcx>,
 ) -> PolyTrait {
     PolyTrait {
@@ -1610,8 +1610,8 @@ pub(crate) fn clean_middle_assoc_item(assoc_item: &ty::AssocItem, cx: &mut DocCo
 
 fn first_non_private_clean_path<'tcx>(
     cx: &mut DocContext<'tcx>,
-    path: &hir::Path<'tcx>,
-    new_path_segments: &'tcx [hir::PathSegment<'tcx>],
+    path: &hir::Path<'_>,
+    new_path_segments: &[hir::PathSegment<'_>],
     new_path_span: rustc_span::Span,
 ) -> Path {
     let new_hir_path =
@@ -1639,7 +1639,7 @@ fn first_non_private_clean_path<'tcx>(
 fn first_non_private<'tcx>(
     cx: &mut DocContext<'tcx>,
     hir_id: hir::HirId,
-    path: &hir::Path<'tcx>,
+    path: &hir::Path<'_>,
 ) -> Option<Path> {
     let target_def_id = path.res.opt_def_id()?;
     let (parent_def_id, ident) = match &path.segments {
@@ -1727,7 +1727,7 @@ fn first_non_private<'tcx>(
     None
 }
 
-fn clean_qpath<'tcx>(hir_ty: &hir::Ty<'tcx>, cx: &mut DocContext<'tcx>) -> Type {
+fn clean_qpath<'tcx>(hir_ty: &hir::Ty<'_>, cx: &mut DocContext<'tcx>) -> Type {
     let hir::Ty { hir_id, span, ref kind } = *hir_ty;
     let hir::TyKind::Path(qpath) = kind else { unreachable!() };
 
@@ -1815,7 +1815,7 @@ fn clean_qpath<'tcx>(hir_ty: &hir::Ty<'tcx>, cx: &mut DocContext<'tcx>) -> Type 
 
 fn maybe_expand_private_type_alias<'tcx>(
     cx: &mut DocContext<'tcx>,
-    path: &hir::Path<'tcx>,
+    path: &hir::Path<'_>,
 ) -> Option<Type> {
     let Res::Def(DefKind::TyAlias, def_id) = path.res else { return None };
     // Substitute private type aliases
@@ -1885,7 +1885,7 @@ fn maybe_expand_private_type_alias<'tcx>(
     }))
 }
 
-pub(crate) fn clean_ty<'tcx>(ty: &hir::Ty<'tcx>, cx: &mut DocContext<'tcx>) -> Type {
+pub(crate) fn clean_ty<'tcx>(ty: &hir::Ty<'_>, cx: &mut DocContext<'tcx>) -> Type {
     use rustc_hir::*;
 
     match ty.kind {
@@ -2637,7 +2637,7 @@ fn clean_variant_data<'tcx>(
     Variant { discriminant, kind }
 }
 
-fn clean_path<'tcx>(path: &hir::Path<'tcx>, cx: &mut DocContext<'tcx>) -> Path {
+fn clean_path<'tcx>(path: &hir::Path<'_>, cx: &mut DocContext<'tcx>) -> Path {
     Path {
         res: path.res,
         segments: path.segments.iter().map(|x| clean_path_segment(x, cx)).collect(),
@@ -2646,7 +2646,7 @@ fn clean_path<'tcx>(path: &hir::Path<'tcx>, cx: &mut DocContext<'tcx>) -> Path {
 
 fn clean_generic_args<'tcx>(
     trait_did: Option<DefId>,
-    generic_args: &hir::GenericArgs<'tcx>,
+    generic_args: &hir::GenericArgs<'_>,
     cx: &mut DocContext<'tcx>,
 ) -> GenericArgs {
     match generic_args.parenthesized {
@@ -2694,10 +2694,7 @@ fn clean_generic_args<'tcx>(
     }
 }
 
-fn clean_path_segment<'tcx>(
-    path: &hir::PathSegment<'tcx>,
-    cx: &mut DocContext<'tcx>,
-) -> PathSegment {
+fn clean_path_segment<'tcx>(path: &hir::PathSegment<'_>, cx: &mut DocContext<'tcx>) -> PathSegment {
     let trait_did = match path.res {
         hir::def::Res::Def(DefKind::Trait | DefKind::TraitAlias, did) => Some(did),
         _ => None,
@@ -2706,7 +2703,7 @@ fn clean_path_segment<'tcx>(
 }
 
 fn clean_bare_fn_ty<'tcx>(
-    bare_fn: &hir::FnPtrTy<'tcx>,
+    bare_fn: &hir::FnPtrTy<'_>,
     cx: &mut DocContext<'tcx>,
 ) -> BareFunctionDecl {
     let (generic_params, decl) = enter_impl_trait(cx, |cx| {
@@ -2735,7 +2732,7 @@ fn clean_bare_fn_ty<'tcx>(
 }
 
 fn clean_unsafe_binder_ty<'tcx>(
-    unsafe_binder_ty: &hir::UnsafeBinderTy<'tcx>,
+    unsafe_binder_ty: &hir::UnsafeBinderTy<'_>,
     cx: &mut DocContext<'tcx>,
 ) -> UnsafeBinderTy {
     let generic_params = unsafe_binder_ty
@@ -3166,7 +3163,7 @@ fn clean_use_statement<'tcx>(
 fn clean_use_statement_inner<'tcx>(
     import: &hir::Item<'tcx>,
     name: Option<Symbol>,
-    path: &hir::Path<'tcx>,
+    path: &hir::Path<'_>,
     kind: hir::UseKind,
     cx: &mut DocContext<'tcx>,
     inlined_names: &mut FxHashSet<(ItemType, Symbol)>,
@@ -3322,7 +3319,7 @@ fn clean_maybe_renamed_foreign_item<'tcx>(
 
 fn clean_assoc_item_constraint<'tcx>(
     trait_did: DefId,
-    constraint: &hir::AssocItemConstraint<'tcx>,
+    constraint: &hir::AssocItemConstraint<'_>,
     cx: &mut DocContext<'tcx>,
 ) -> AssocItemConstraint {
     AssocItemConstraint {


### PR DESCRIPTION
Both rustdoc and hir ty lowering only process the HIR, they never store any of those nodes anywhere.

The reason I did this is that I'm refactoring `hir::ItemKind::Use`, and for rustdoc's processing of it it is more convenient to create a bunch of values on the stack and reference them, but right now rustdoc was expecting `'tcx` lifetimes everywhere.