### PR TITLE
make ARM maintainers pingable

### DIFF
--- a/src/doc/rustc/src/platform-support/aarch64-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/aarch64-unknown-linux-gnu.md
@@ -6,7 +6,7 @@ Target for 64-bit little endian ARMv8-A Linux 4.1+ programs using glibc 2.17+.
 
 ## Target maintainers
 
-- [@rust-lang/arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+- [arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
     - Use `@rustbot ping arm-maintainers` to ping us
 
 [arm_maintainers]: https://github.com/rust-lang/team/blob/master/teams/arm-maintainers.toml

--- a/src/doc/rustc/src/platform-support/aarch64-unknown-none.md
+++ b/src/doc/rustc/src/platform-support/aarch64-unknown-none.md
@@ -15,7 +15,7 @@ Processors in this family include the [Arm Cortex-A35, 53, 76, etc][aarch64-cpus
 ## Target maintainers
 
 - [Rust Embedded Devices Working Group Arm Team]
-- [@rust-lang/arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+- [arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
     - Use `@rustbot ping arm-maintainers` to ping us
 
 [Rust Embedded Devices Working Group Arm Team]: https://github.com/rust-embedded/wg?tab=readme-ov-file#the-arm-team

--- a/src/doc/rustc/src/platform-support/aarch64v8r-unknown-none.md
+++ b/src/doc/rustc/src/platform-support/aarch64v8r-unknown-none.md
@@ -15,7 +15,7 @@ For Armv8-R CPUs running in AArch32 mode (such as the Arm Cortex-R52), see
 ## Target maintainers
 
 - [Rust Embedded Devices Working Group Arm Team]
-- [@rust-lang/arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+- [arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
     - Use `@rustbot ping arm-maintainers` to ping us
 
 [Rust Embedded Devices Working Group Arm Team]: https://github.com/rust-embedded/wg?tab=readme-ov-file#the-arm-team

--- a/src/doc/rustc/src/platform-support/armv7-unknown-linux-gnueabi.md
+++ b/src/doc/rustc/src/platform-support/armv7-unknown-linux-gnueabi.md
@@ -7,7 +7,7 @@ Target for 32-bit little endian ARMv7-A Linux 3.2+ programs using glibc 2.17+.
 
 ## Target maintainers
 
-- [@rust-lang/arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+- [arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
     - Use `@rustbot ping arm-maintainers` to ping us
 
 [arm_maintainers]: https://github.com/rust-lang/team/blob/master/teams/arm-maintainers.toml

--- a/src/doc/rustc/src/platform-support/armv7a-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv7a-none-eabi.md
@@ -22,7 +22,7 @@ See [`arm-none-eabi`](arm-none-eabi.md) for information applicable to all
 ## Target maintainers
 
 - [Rust Embedded Devices Working Group Arm Team]
-- [@rust-lang/arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+- [arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
     - Use `@rustbot ping arm-maintainers` to ping us
 
 [Rust Embedded Devices Working Group Arm Team]: https://github.com/rust-embedded/wg?tab=readme-ov-file#the-arm-team

--- a/src/doc/rustc/src/platform-support/armv7r-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv7r-none-eabi.md
@@ -20,7 +20,7 @@ See [`arm-none-eabi`](arm-none-eabi.md) for information applicable to all
 
 - [@chrisnc](https://github.com/chrisnc)
 - [Rust Embedded Devices Working Group Arm Team]
-- [@rust-lang/arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+- [arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
     - Use `@rustbot ping arm-maintainers` to ping us
 
 [Rust Embedded Devices Working Group Arm Team]: https://github.com/rust-embedded/wg?tab=readme-ov-file#the-arm-team

--- a/src/doc/rustc/src/platform-support/armv8r-none-eabihf.md
+++ b/src/doc/rustc/src/platform-support/armv8r-none-eabihf.md
@@ -24,7 +24,7 @@ For Armv8-R CPUs running in AArch64 mode (such as the Arm Cortex-R82), see
 
 - [@chrisnc](https://github.com/chrisnc)
 - [Rust Embedded Devices Working Group Arm Team]
-- [@rust-lang/arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+- [arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
     - Use `@rustbot ping arm-maintainers` to ping us
 
 [Rust Embedded Devices Working Group Arm Team]: https://github.com/rust-embedded/wg?tab=readme-ov-file#the-arm-team

--- a/src/doc/rustc/src/platform-support/thumbv7em-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/thumbv7em-none-eabi.md
@@ -23,7 +23,7 @@ See [`arm-none-eabi`](arm-none-eabi.md) for information applicable to all
 ## Target maintainers
 
 - [Rust Embedded Devices Working Group Arm Team](https://github.com/rust-embedded/wg?tab=readme-ov-file#the-arm-team)
-- [@rust-lang/arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+- [arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
     - Use `@rustbot ping arm-maintainers` to ping us
 
 [arm_maintainers]: https://github.com/rust-lang/team/blob/master/teams/arm-maintainers.toml

--- a/src/doc/rustc/src/platform-support/thumbv7m-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/thumbv7m-none-eabi.md
@@ -24,7 +24,7 @@ only option because there is no FPU support in [Armv7-M].
 ## Target maintainers
 
 - [Rust Embedded Devices Working Group Arm Team](https://github.com/rust-embedded/wg?tab=readme-ov-file#the-arm-team)
-- [@rust-lang/arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+- [arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
     - Use `@rustbot ping arm-maintainers` to ping us
 
 [arm_maintainers]: https://github.com/rust-lang/team/blob/master/teams/arm-maintainers.toml

--- a/src/doc/rustc/src/platform-support/thumbv8m.base-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/thumbv8m.base-none-eabi.md
@@ -24,7 +24,7 @@ only option because there is no FPU support in [Armv8-M] Baseline.
 ## Target maintainers
 
 - [Rust Embedded Devices Working Group Arm Team](https://github.com/rust-embedded/wg?tab=readme-ov-file#the-arm-team)
-- [@rust-lang/arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+- [arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
     - Use `@rustbot ping arm-maintainers` to ping us
 
 [arm_maintainers]: https://github.com/rust-lang/team/blob/master/teams/arm-maintainers.toml

--- a/src/doc/rustc/src/platform-support/thumbv8m.main-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/thumbv8m.main-none-eabi.md
@@ -27,7 +27,7 @@ See [`arm-none-eabi`](arm-none-eabi.md) for information applicable to all
 ## Target maintainers
 
 - [Rust Embedded Devices Working Group Arm Team](https://github.com/rust-embedded/wg?tab=readme-ov-file#the-arm-team)
-- [@rust-lang/arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+- [arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
     - Use `@rustbot ping arm-maintainers` to ping us
 
 [arm_maintainers]: https://github.com/rust-lang/team/blob/master/teams/arm-maintainers.toml

--- a/src/doc/rustc/src/platform-support/unknown-uefi.md
+++ b/src/doc/rustc/src/platform-support/unknown-uefi.md
@@ -15,7 +15,7 @@ Available targets:
 
 - [@dvdhrm](https://github.com/dvdhrm)
 - [@nicholasbishop](https://github.com/nicholasbishop)
-- (for `aarch64-unknown-uefi` only) [@rust-lang/arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+- (for `aarch64-unknown-uefi` only) [arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
     - Use `@rustbot ping arm-maintainers` to ping us
 
 [arm_maintainers]: https://github.com/rust-lang/team/blob/master/teams/arm-maintainers.toml

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -97,6 +97,13 @@ Thanks! <3
 """
 label = "O-ARM"
 
+[ping.arm-maintainers]
+message = """\
+Dear ARM Maintainers, your feedback has been requested on this issue/PR.
+Thanks! <3
+"""
+label = "O-ARM"
+
 [ping.loongarch]
 message = """\
 Hey LoongArch Group! This issue has been identified as a good "LoongArch candidate".


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/153720 added the suggestion to ping ARM maintainers via rustbot, but that doesn't actually work currently. I hope this is the right way to set up triagebot.

Also, the target pages make it look like there is a `@rust-lang/arm-maintainers` GH team, which does not actually exist.

Cc @davidtwco 