### PR TITLE
`allow(non_camel_case_types)` in `minicore.rs`

### DIFF
--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -35,7 +35,7 @@
     asm_experimental_arch,
     unboxed_closures
 )]
-#![allow(unused, improper_ctypes_definitions, internal_features)]
+#![allow(unused, improper_ctypes_definitions, internal_features, non_camel_case_types)]
 #![no_std]
 #![no_core]
 


### PR DESCRIPTION
Currently we get a large number of warnings for `c_void` and the vector type aliases. This file has good reason to deviate from normal naming conventions.

r? jieyouxu 