### PR TITLE
libtest: Allow passing --test-threads and --color multiple times, with later arguments overriding earlier

### DIFF
--- a/library/test/src/cli.rs
+++ b/library/test/src/cli.rs
@@ -66,7 +66,7 @@ fn optgroups() -> getopts::Options {
             "don't capture stdout/stderr of each \
              task, allow printing directly",
         )
-        .optopt(
+        .optmulti(
             "",
             "test-threads",
             "Number of threads used for running tests \
@@ -383,8 +383,9 @@ fn get_shuffle_seed(matches: &getopts::Matches, allow_unstable: bool) -> OptPart
 }
 
 fn get_test_threads(matches: &getopts::Matches) -> OptPartRes<Option<usize>> {
-    let test_threads = match matches.opt_str("test-threads") {
-        Some(n_str) => match n_str.parse::<usize>() {
+    let mut last_test_threads = None;
+    for n_str in matches.opt_strs("test-threads") {
+        last_test_threads = match n_str.parse::<usize>() {
             Ok(0) => return Err("argument for --test-threads must not be 0".to_string()),
             Ok(n) => Some(n),
             Err(e) => {
@@ -393,11 +394,10 @@ fn get_test_threads(matches: &getopts::Matches) -> OptPartRes<Option<usize>> {
                      (error: {e})"
                 ));
             }
-        },
-        None => None,
-    };
+        };
+    }
 
-    Ok(test_threads)
+    Ok(last_test_threads)
 }
 
 fn get_format(

--- a/library/test/src/cli.rs
+++ b/library/test/src/cli.rs
@@ -87,7 +87,7 @@ fn optgroups() -> getopts::Options {
              Alias to --format=terse",
         )
         .optflag("", "exact", "Exactly match filters rather than by substring")
-        .optopt(
+        .optmulti(
             "",
             "color",
             "Configure coloring of output:
@@ -433,20 +433,21 @@ fn get_format(
 }
 
 fn get_color_config(matches: &getopts::Matches) -> OptPartRes<ColorConfig> {
-    let color = match matches.opt_str("color").as_deref() {
-        Some("auto") | None => ColorConfig::AutoColor,
-        Some("always") => ColorConfig::AlwaysColor,
-        Some("never") => ColorConfig::NeverColor,
+    let mut last_color = ColorConfig::AutoColor;
+    for color in matches.opt_strs("color") {
+        last_color = match color.as_str() {
+            "auto" => ColorConfig::AutoColor,
+            "always" => ColorConfig::AlwaysColor,
+            "never" => ColorConfig::NeverColor,
+            v => {
+                return Err(format!(
+                    "argument for --color must be auto, always, or never (was {v})"
+                ));
+            }
+        };
+    }
 
-        Some(v) => {
-            return Err(format!(
-                "argument for --color must be auto, always, or never (was \
-                 {v})"
-            ));
-        }
-    };
-
-    Ok(color)
+    Ok(last_color)
 }
 
 fn get_nocapture(matches: &getopts::Matches) -> OptPartRes<bool> {


### PR DESCRIPTION
Cargo would like to be able to pass these arguments, without breaking the ability for the user to do the same and override cargo's value. Currently, the option only allows one instance, failing if it sees multiple.

Accept `--test-threads=N` and `--color=...` multiple times, and have the last instance win.