### PR TITLE
Fix SIMD ABI check for Arm MVE

### DIFF
--- a/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
@@ -65,10 +65,10 @@ fn do_check_simd_vector_abi<'tcx>(
         let size = arg_abi.layout.size;
         match passes_vectors_by_value(&arg_abi.mode, &arg_abi.layout.backend_repr) {
             UsesVectorRegisters::FixedVector => {
-                let feature_def = tcx.sess.target.features_for_correct_fixed_length_vector_abi();
+                let features_def = tcx.sess.target.features_for_correct_fixed_length_vector_abi();
                 // Find the first feature that provides at least this vector size.
-                let feature = match feature_def.iter().find(|(bits, _)| size.bits() <= *bits) {
-                    Some((_, feature)) => feature,
+                let features = match features_def.iter().find(|(bits, _)| size.bits() <= *bits) {
+                    Some((_, features)) => features,
                     None => {
                         let (span, _hir_id) = loc();
                         tcx.dcx().emit_err(diagnostics::AbiErrorUnsupportedVectorType {
@@ -79,11 +79,14 @@ fn do_check_simd_vector_abi<'tcx>(
                         continue;
                     }
                 };
-                if !feature.is_empty() && !have_feature(Symbol::intern(feature)) {
+                if !features.is_empty()
+                    && !features.iter().any(|feature| have_feature(Symbol::intern(feature)))
+                {
                     let (span, _hir_id) = loc();
                     tcx.dcx().emit_err(diagnostics::AbiErrorDisabledVectorType {
                         span,
-                        required_feature: feature,
+                        // FIXME: If there are multiple features, we should suggest "features[0] or features[1] ...".
+                        required_feature: features[0],
                         ty: arg_abi.layout.ty,
                         is_call,
                         is_scalable: false,

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -1101,51 +1101,54 @@ pub fn feature_to_arch_names(feature: &str) -> Vec<&'static str> {
 // These arrays represent the least-constraining feature that is required for vector types up to a
 // certain size to have their "proper" ABI on each architecture.
 // Note that they must be kept sorted by vector size.
-const X86_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[(128, "sse"), (256, "avx"), (512, "avx512f")]; // FIXME: might need changes for AVX10.
-const AARCH64_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[(128, "neon")];
+type FeaturesForCorrectFixedLengthVectorAbi = &'static [(u64, &'static [&'static str])];
+const X86_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: FeaturesForCorrectFixedLengthVectorAbi =
+    &[(128, &["sse"]), (256, &["avx"]), (512, &["avx512f"])]; // FIXME: might need changes for AVX10.
+const AARCH64_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: FeaturesForCorrectFixedLengthVectorAbi =
+    &[(128, &["neon"])];
 
-const ARM_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[(128, "neon"), (128, "mve")];
+const ARM_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: FeaturesForCorrectFixedLengthVectorAbi =
+    &[(128, &["neon", "mve"])];
 
-const AMDGPU_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[(1024, "")];
-const POWERPC_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[(128, "altivec")];
-const WASM_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[(128, "simd128")];
-const S390X_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[(128, "vector")];
-const RISCV_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] = &[
-    (32, "zvl32b"),
-    (64, "zvl64b"),
-    (128, "zvl128b"),
-    (256, "zvl256b"),
-    (512, "zvl512b"),
-    (1024, "zvl1024b"),
-    (2048, "zvl2048b"),
-    (4096, "zvl4096b"),
-    (8192, "zvl8192b"),
-    (16384, "zvl16384b"),
-    (32768, "zvl32768b"),
-    (65536, "zvl65536b"),
-];
+const AMDGPU_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: FeaturesForCorrectFixedLengthVectorAbi =
+    &[(1024, &[])];
+const POWERPC_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: FeaturesForCorrectFixedLengthVectorAbi =
+    &[(128, &["altivec"])];
+const WASM_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: FeaturesForCorrectFixedLengthVectorAbi =
+    &[(128, &["simd128"])];
+const S390X_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: FeaturesForCorrectFixedLengthVectorAbi =
+    &[(128, &["vector"])];
+const RISCV_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: FeaturesForCorrectFixedLengthVectorAbi =
+    &[
+        (32, &["zvl32b"]),
+        (64, &["zvl64b"]),
+        (128, &["zvl128b"]),
+        (256, &["zvl256b"]),
+        (512, &["zvl512b"]),
+        (1024, &["zvl1024b"]),
+        (2048, &["zvl2048b"]),
+        (4096, &["zvl4096b"]),
+        (8192, &["zvl8192b"]),
+        (16384, &["zvl16384b"]),
+        (32768, &["zvl32768b"]),
+        (65536, &["zvl65536b"]),
+    ];
 // Always error on SPARC, as the necessary target features cannot be enabled in Rust at the moment.
-const SPARC_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[/*(64, "vis")*/];
+const SPARC_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: FeaturesForCorrectFixedLengthVectorAbi =
+    &[/*(64, &["vis"])*/];
 
-const HEXAGON_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] = &[
-    (512, "hvx-length64b"),   // HvxVector in 64-byte mode
-    (1024, "hvx-length128b"), // HvxVector in 128-byte mode, or HvxVectorPair in 64-byte mode
-    (2048, "hvx-length128b"), // HvxVectorPair in 128-byte mode
-];
-const MIPS_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[(128, "msa")];
-const CSKY_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[(128, "vdspv1")];
-const LOONGARCH_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[(128, "lsx"), (256, "lasx")];
+const HEXAGON_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: FeaturesForCorrectFixedLengthVectorAbi =
+    &[
+        (512, &["hvx-length64b"]),   // HvxVector in 64-byte mode
+        (1024, &["hvx-length128b"]), // HvxVector in 128-byte mode, or HvxVectorPair in 64-byte mode
+        (2048, &["hvx-length128b"]), // HvxVectorPair in 128-byte mode
+    ];
+const MIPS_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: FeaturesForCorrectFixedLengthVectorAbi =
+    &[(128, &["msa"])];
+const CSKY_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI: FeaturesForCorrectFixedLengthVectorAbi =
+    &[(128, &["vdspv1"])];
+const LOONGARCH_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI:
+    FeaturesForCorrectFixedLengthVectorAbi = &[(128, &["lsx"]), (256, &["lasx"])];
 
 #[derive(Copy, Clone, Debug)]
 pub struct FeatureConstraints {
@@ -1189,7 +1192,9 @@ impl Target {
             .collect::<FxHashMap<_, _>>()
     }
 
-    pub fn features_for_correct_fixed_length_vector_abi(&self) -> &'static [(u64, &'static str)] {
+    pub fn features_for_correct_fixed_length_vector_abi(
+        &self,
+    ) -> FeaturesForCorrectFixedLengthVectorAbi {
         match &self.arch {
             Arch::X86 | Arch::X86_64 => X86_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,
             Arch::AArch64 | Arch::Arm64EC => AARCH64_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI,

--- a/tests/ui/abi/simd-abi-checks-arm.rs
+++ b/tests/ui/abi/simd-abi-checks-arm.rs
@@ -1,0 +1,26 @@
+//! Ensure we trigger abi_unsupported_vector_types for target features that are usually enabled
+//! on a target via the base CPU, but disabled in this file via a `-C` flag.
+//@ compile-flags: --crate-type=rlib --target=armv7-unknown-linux-gnueabihf
+//@ add-minicore
+//@ build-fail
+//@ needs-llvm-components: arm
+//@ ignore-backends: gcc
+#![feature(no_core, arm_target_feature)]
+#![no_core]
+#![allow(improper_ctypes_definitions)]
+
+extern crate minicore;
+use minicore::simd::Simd;
+
+#[no_mangle]
+pub unsafe extern "C" fn f(_: Simd<i32, 4>) {
+    //~^ ERROR: this function definition uses SIMD vector type `Simd<i32, 4>` which (with the chosen ABI) requires the `neon` target feature, which is not enabled
+}
+
+#[no_mangle]
+#[target_feature(enable = "neon")]
+pub unsafe extern "C" fn neon(_: Simd<i32, 4>) {}
+
+#[no_mangle]
+#[target_feature(enable = "mve")]
+pub unsafe extern "C" fn mve(_: Simd<i32, 4>) {}

--- a/tests/ui/abi/simd-abi-checks-arm.stderr
+++ b/tests/ui/abi/simd-abi-checks-arm.stderr
@@ -1,0 +1,10 @@
+error: this function definition uses SIMD vector type `Simd<i32, 4>` which (with the chosen ABI) requires the `neon` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-arm.rs:16:1
+   |
+LL | pub unsafe extern "C" fn f(_: Simd<i32, 4>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
+   |
+   = help: consider enabling it globally (`-C target-feature=+neon`) or locally (`#[target_feature(enable="neon")]`)
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

https://github.com/rust-lang/rust/pull/158405 added `(128, "mve")` to `ARM_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI`, but it was always be ignored because abi_check only check the first one:

https://github.com/rust-lang/rust/blob/19523e0188270ed9b30336831116acc84adaca3f/compiler/rustc_target/src/target_features.rs#L1110-L1111

https://github.com/rust-lang/rust/blob/19523e0188270ed9b30336831116acc84adaca3f/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs#L69-L70

And the following error occurs:

```
error: this function definition uses SIMD vector type `Simd<i32, 4>` which (with the chosen ABI) requires the `neon` target feature, which is not enabled
  --> $DIR/simd-abi-checks-arm.rs:27:1
   |
LL | pub unsafe extern "C" fn mve(_: Simd<i32, 4>) {}
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
   |
   = help: consider enabling it globally (`-C target-feature=+neon`) or locally (`#[target_feature(enable="neon")]`)
```

This PR fixes the above error for `#[target_feature(enable = "mve")]` functions, but I couldn't find a way to fix the AbiErrorDisabledVectorType to suggest two target feature, o the message for when neither target feature is being used still only refers to neon (I left FIXME comment about this).



r? @RalfJung (Thanks for finding this!)


@rustbot label +O-arm +A-target-feature