### PR TITLE
Relax codgen test variable regex

### DIFF
--- a/tests/codegen-llvm/try_question_mark_nop.rs
+++ b/tests/codegen-llvm/try_question_mark_nop.rs
@@ -105,7 +105,7 @@ pub fn option_nop_match_64(x: Option<u64>) -> Option<u64> {
 pub fn option_nop_traits_64(x: Option<u64>) -> Option<u64> {
     // CHECK: start:
     // CHECK-NEXT: %[[TRUNC:[0-9]+]] = trunc nuw i64 %0 to i1
-    // CHECK-NEXT: %[[SEL:\.[0-9]+]] = select i1 %[[TRUNC]], i64 %1, i64 undef
+    // CHECK-NEXT: %[[SEL:\.[0-9]*]] = select i1 %[[TRUNC]], i64 %1, i64 undef
     // CHECK-NEXT: insertvalue { i64, i64 }
     // CHECK-NEXT: insertvalue { i64, i64 }
     // CHECK-NEXT: ret { i64, i64 }


### PR DESCRIPTION
I'm not entirely sure what change on the LLVM side caused this, but it's now producing `%. = select i1 %2, i64 %1, i64 undef`. [ci failure](https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/48104/list?sid=01a01563-0b1a-4a00-a555-a0f42f19caf3&tab=output)

@rustbot label llvm-main

r? @durin42 