### PR TITLE
LLVM 24: configure float-abi via module flag

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -563,6 +563,17 @@ pub(crate) unsafe fn create_module<'ll>(
         );
     }
 
+    if llvm_version >= (24, 0, 0)
+        && let Some(floatabi) = sess.target.llvm_floatabi
+    {
+        llvm::add_module_flag_str(
+            llmod,
+            llvm::ModuleFlagMergeBehavior::Error,
+            "float-abi",
+            floatabi.desc(),
+        );
+    }
+
     // Add module flags specified via -Z llvm_module_flag
     for (key, value, merge_behavior) in &sess.opts.unstable_opts.llvm_module_flag {
         let merge_behavior = match merge_behavior.as_str() {

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -365,7 +365,9 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
 
   TargetOptions Options = codegen::InitTargetOptionsFromCodeGenFlags(Trip);
 
+#if LLVM_VERSION_LT(24, 0)
   Options.FloatABIType = FloatABIType;
+#endif
   Options.DataSections = DataSections;
   Options.FunctionSections = FunctionSections;
   Options.UniqueSectionNames = UniqueSectionNames;
@@ -439,7 +441,11 @@ extern "C" void LLVMRustAddLibraryInfo(LLVMTargetMachineRef T,
   if (DisableSimplifyLibCalls)
     TLII.disableAllFunctions();
   unwrap(PMR)->add(new TargetLibraryInfoWrapperPass(TLII));
-#if LLVM_VERSION_GE(22, 0)
+#if LLVM_VERSION_GE(24, 0)
+  unwrap(PMR)->add(new RuntimeLibraryInfoWrapper(
+      Options->ExceptionModel, Options->EABIVersion, Options->MCOptions.ABIName,
+      Options->VecLib));
+#elif LLVM_VERSION_GE(22, 0)
   unwrap(PMR)->add(new RuntimeLibraryInfoWrapper(
       TargetTriple, Options->ExceptionModel, Options->FloatABIType,
       Options->EABIVersion, Options->MCOptions.ABIName, Options->VecLib));

--- a/tests/codegen-llvm/float/abi-flag.rs
+++ b/tests/codegen-llvm/float/abi-flag.rs
@@ -1,0 +1,23 @@
+//@ add-minicore
+//@ min-llvm-version: 24
+//@ revisions: armhf armsf aarch64sf
+
+//@ [armhf] needs-llvm-components: arm
+//@ [armhf] compile-flags: --target=armv7-unknown-linux-gnueabihf
+
+//@ [armsf] needs-llvm-components: arm
+//@ [armsf] compile-flags: --target=armv7-unknown-linux-gnueabi
+
+//@ [aarch64sf] needs-llvm-components: aarch64
+//@ [aarch64sf] compile-flags: --target=aarch64-unknown-none-softfloat
+
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
+
+// rustc sets the module flag only for targets with an explicit `llvm_floatabi`,
+// which is (currently) only the case on ARM.
+
+// armhf: !{i32 1, !"float-abi", !"hard"}
+// armsf: !{i32 1, !"float-abi", !"soft"}
+// aarch64sf-NOT: !"float-abi"


### PR DESCRIPTION
`TargetOptions::FloatABIType` was removed in https://github.com/llvm/llvm-project/pull/215796

See https://github.com/llvm/llvm-project/pull/212985 for the corresponding clang change.

The `ModuleFlagMergeBehavior::Error` was copied from the clang implementation.

This currently relies on the string representation of Rust's [`FloatAbi` "target_spec_enum"](https://github.com/rust-lang/rust/blob/e71c0f1e3395b10a8c331317be1a5c107bdf7b2e/compiler/rustc_target/src/spec/mod.rs#L978-L986) matching LLVM. This seemed reasonable to me since the representation is quite straightforward ("soft" and "hard"), but let me know if you'd like an explicit `to_llvm_float_abi_str`, either defined in Rust or forwarding to `llvm::FloatABI::getABITypeName`.

Contrary to the clang implementation which only sets the module flag if it differs from the target default, we set it whenever the Rust target has an explicit float ABI set. See also discussion in [#t-compiler/llvm > float-abi module flag behavior](https://rust-lang.zulipchat.com/#narrow/channel/187780-t-compiler.2Fllvm/topic/float-abi.20module.20flag.20behavior/with/617279073).

The added test won't actually run on Rust's own CI until that updates to LLVM 24.

@rustbot label llvm-main

