### PR TITLE
Doc: clarify how `Read::bytes` handling Interrupted errors

### DIFF
--- a/library/alloc/src/io/read.rs
+++ b/library/alloc/src/io/read.rs
@@ -488,6 +488,14 @@ pub trait Read {
     /// which can be very inefficient for data that's not in memory,
     /// such as `File`. Consider using a `BufReader` in such cases.
     ///
+    /// # Errors
+    ///
+    /// When the returned iterator calls [`Iterator::next`],
+    /// if it encounters an error of the kind [`ErrorKind::Interrupted`]
+    /// then the error is ignored and it will try to read the byte again.
+    ///
+    /// [`ErrorKind::Interrupted`]: crate::io::ErrorKind::Interrupted
+    ///
     /// # Examples
     ///
     /// `File`s implement `Read`:


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->


Fixes rust-lang/rust#161288