### PR TITLE
Only suggest `RUST_MIN_STACK` if maybe stack overflow

### DIFF
--- a/compiler/rustc_driver_impl/src/signal_handler.rs
+++ b/compiler/rustc_driver_impl/src/signal_handler.rs
@@ -115,7 +115,8 @@ unsafe extern "C" fn print_stack_trace(signum: libc::c_int) {
     written += rem.len() + 1;
 
     let random_depth = || 8 * 16; // chosen by random diceroll (2d20)
-    if (cyclic || stack.len() > random_depth()) && signum == libc::SIGSEGV {
+    let maybe_stack_overflow = (cyclic || stack.len() > random_depth()) && signum == libc::SIGSEGV;
+    if maybe_stack_overflow {
         // technically speculation, but assert it with confidence anyway.
         // rustc only arrived in this signal handler because bad things happened
         // and this message is for explaining it's not the programmer's fault
@@ -128,7 +129,7 @@ unsafe extern "C" fn print_stack_trace(signum: libc::c_int) {
     }
     raw_errln!("note: we would appreciate a report at https://github.com/rust-lang/rust");
     written += 1;
-    if signum == libc::SIGSEGV {
+    if maybe_stack_overflow {
         // get the current stack size WITHOUT blocking and double it
         let new_size = STACK_SIZE.get().copied().unwrap_or(DEFAULT_STACK_SIZE) * 2;
         raw_errln!(


### PR DESCRIPTION
Alternatively we could make the wording of the help message note the uncertainty.