### PR TITLE
Add regression tests for a few fixed issues with E-needs-test

### DIFF
--- a/tests/ui-fulldeps/lto-with-rustc-private.rs
+++ b/tests/ui-fulldeps/lto-with-rustc-private.rs
@@ -1,0 +1,14 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/45689>.
+
+//@ build-fail
+//@ compile-flags: -Clto
+//@ normalize-stderr: "error: crate .* required.*\n(   .*\n)*\n" -> ""
+//@ normalize-stderr: "aborting due to [0-9]+" -> "aborting due to NUMBER"
+//@ dont-require-annotations: ERROR
+
+#![feature(rustc_private)]
+
+extern crate rustc_errors;
+//~? ERROR crate `rustc_errors` required to be available in rlib format
+
+fn main() {}

--- a/tests/ui-fulldeps/lto-with-rustc-private.stderr
+++ b/tests/ui-fulldeps/lto-with-rustc-private.stderr
@@ -1,0 +1,2 @@
+error: aborting due to NUMBER previous errors
+

--- a/tests/ui/diagnostic-width/elided-span-with-hard-tabs.rs
+++ b/tests/ui/diagnostic-width/elided-span-with-hard-tabs.rs
@@ -1,0 +1,11 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/146398>.
+
+// The panic happens while the JSON emitter fills in its `rendered` field, which is the
+// path `cargo` takes, so this has to be checked with the default JSON error format.
+//@ compile-flags: --diagnostic-width=30
+// ignore-tidy-file-tab
+
+fn main() {
+    let _: &[u8] = [0,												0];
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/diagnostic-width/elided-span-with-hard-tabs.stderr
+++ b/tests/ui/diagnostic-width/elided-span-with-hard-tabs.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/elided-span-with-hard-tabs.rs:9:20
+   |
+LL | ..._: &[u8] = [0,     ...      0];
+   |       -----   ^^^^^^^^...^^^^^^^^ expected `&[u8]`, found `[{integer}; 2]`
+   |       |
+   |       expected due to this
+   |
+help: consider borrowing here
+   |
+LL |     let _: &[u8] = &[0,                                                0];
+   |                    +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/macros/auxiliary/nested-macro-rules-definition.rs
+++ b/tests/ui/macros/auxiliary/nested-macro-rules-definition.rs
@@ -1,0 +1,15 @@
+pub struct ProjectileCreated;
+pub struct NotificationChannel<E>(std::marker::PhantomData<E>);
+
+// The inner `macro_rules!` is what later reports a span from this crate while the
+// diagnostic is being rendered against the downstream crate's source.
+macro_rules! define_trigger_system {
+    ($(( $field:ident, $ty:ident, $channel:ident )),* $(,)?) => {
+        #[macro_export]
+        macro_rules! all_trigger_fields {
+            ($submacro:ident) => { $submacro!($( ( $field, $ty, $channel ) ),*) }
+        }
+    };
+}
+
+define_trigger_system!((projectile_created, ProjectileCreated, NotificationChannel),);

--- a/tests/ui/macros/cross-crate-nested-macro-rules-span.rs
+++ b/tests/ui/macros/cross-crate-nested-macro-rules-span.rs
@@ -1,0 +1,18 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/66805>.
+
+//@ aux-build: nested-macro-rules-definition.rs
+
+extern crate nested_macro_rules_definition;
+use nested_macro_rules_definition::*;
+
+macro_rules! make_event_subscription {
+    ($(( $field:ident, $ty:ident, $channel:ident )),*) => {
+        pub struct EventSubscription($($channel<nested_macro_rules_definition::$ty>::ReaderId),*);
+        //~^ ERROR ambiguous associated type
+    };
+}
+
+all_trigger_fields!(make_event_subscription);
+//~^ ERROR macros that expand to items must be delimited with braces or followed by a semicolon
+
+fn main() {}

--- a/tests/ui/macros/cross-crate-nested-macro-rules-span.stderr
+++ b/tests/ui/macros/cross-crate-nested-macro-rules-span.stderr
@@ -1,0 +1,27 @@
+error: macros that expand to items must be delimited with braces or followed by a semicolon
+  --> $DIR/cross-crate-nested-macro-rules-span.rs:15:1
+   |
+LL | all_trigger_fields!(make_event_subscription);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `all_trigger_fields` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0223]: ambiguous associated type
+  --> $DIR/cross-crate-nested-macro-rules-span.rs:10:40
+   |
+LL |         pub struct EventSubscription($($channel<nested_macro_rules_definition::$ty>::ReaderId),*);
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | all_trigger_fields!(make_event_subscription);
+   | -------------------------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `make_event_subscription` which comes from the expansion of the macro `all_trigger_fields` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: if there were a trait named `Example` with associated type `ReaderId` implemented for `nested_macro_rules_definition::NotificationChannel<ProjectileCreated>`, you could use the fully-qualified path
+   |
+LL -         pub struct EventSubscription($($channel<nested_macro_rules_definition::$ty>::ReaderId),*);
+LL +         pub struct EventSubscription($(<nested_macro_rules_definition::NotificationChannel<ProjectileCreated> as Example>::ReaderId),*);
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0223`.

--- a/tests/ui/numbers-arithmetic/wrapping-ops-under-mir-opts.rs
+++ b/tests/ui/numbers-arithmetic/wrapping-ops-under-mir-opts.rs
@@ -1,0 +1,11 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/82646>.
+
+//@ run-pass
+//@ compile-flags: -Zmir-opt-level=2 -Coverflow-checks=on
+
+fn main() {
+    assert_eq!(1_u32.wrapping_sub(2), u32::MAX);
+    assert_eq!(u32::MAX.wrapping_add(2), 1);
+    assert_eq!(i32::MIN.wrapping_sub(1), i32::MAX);
+    assert_eq!(2_u32.wrapping_mul(u32::MAX), u32::MAX - 1);
+}

--- a/tests/ui/proc-macro/auxiliary/panicking-attribute.rs
+++ b/tests/ui/proc-macro/auxiliary/panicking-attribute.rs
@@ -1,0 +1,8 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn tester(_: TokenStream, _: TokenStream) -> TokenStream {
+    panic!();
+}

--- a/tests/ui/proc-macro/panicking-inner-attribute-macro.rs
+++ b/tests/ui/proc-macro/panicking-inner-attribute-macro.rs
@@ -1,0 +1,8 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/99478>.
+
+//@ proc-macro: panicking-attribute.rs
+//@ compile-flags: --crate-type=lib
+
+#![feature(custom_inner_attributes)]
+#![panicking_attribute::tester]
+//~^ ERROR custom attribute panicked

--- a/tests/ui/proc-macro/panicking-inner-attribute-macro.stderr
+++ b/tests/ui/proc-macro/panicking-inner-attribute-macro.stderr
@@ -1,0 +1,10 @@
+error: custom attribute panicked
+  --> $DIR/panicking-inner-attribute-macro.rs:7:1
+   |
+LL | #![panicking_attribute::tester]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: message: explicit panic
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Closes rust-lang/rust#45689.
Closes rust-lang/rust#66805.
Closes rust-lang/rust#82646.
Closes rust-lang/rust#99478.
Closes rust-lang/rust#146398.

LLM disclosure: I used an LLM to identify best candidate issues (labelled as E-needs-test, unclaimed, with sensible reproducible examples etc)

All the tests have been verified to pass in the current nightly and reproduce in the nightlies in which they were reported to fail in/released around the date of the issues’ creation.