### PR TITLE
compiler: Account for default_sanitizers when comparing target modifiers

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -90,12 +90,16 @@ pub mod mitigation_coverage;
 
 mod target_modifier_consistency_check {
     use super::*;
-    pub(super) fn sanitizer(l: &TargetModifier, r: Option<&TargetModifier>) -> bool {
-        let mut lparsed: SanitizerSet = Default::default();
+    pub(super) fn sanitizer(
+        sess: &Session,
+        l: &TargetModifier,
+        r: Option<&TargetModifier>,
+    ) -> bool {
+        let mut lparsed: SanitizerSet = sess.target.options.default_sanitizers;
         let lval = if l.value_name.is_empty() { None } else { Some(l.value_name.as_str()) };
         parse::parse_sanitizers(&mut lparsed, lval);
 
-        let mut rparsed: SanitizerSet = Default::default();
+        let mut rparsed: SanitizerSet = sess.target.options.default_sanitizers;
         let rval = r.filter(|v| !v.value_name.is_empty()).map(|v| v.value_name.as_str());
         parse::parse_sanitizers(&mut rparsed, rval);
 
@@ -166,7 +170,7 @@ impl TargetModifier {
         match self.opt {
             OptionsTargetModifiers::UnstableOptions(unstable) => match unstable {
                 UnstableOptionsTargetModifiers::Sanitizer => {
-                    return target_modifier_consistency_check::sanitizer(self, other);
+                    return target_modifier_consistency_check::sanitizer(sess, self, other);
                 }
                 UnstableOptionsTargetModifiers::SanitizerCfiNormalizeIntegers => {
                     return target_modifier_consistency_check::sanitizer_cfi_normalize_integers(

--- a/tests/ui/target_modifiers/auxiliary/sanitizer_default_explicit.rs
+++ b/tests/ui/target_modifiers/auxiliary/sanitizer_default_explicit.rs
@@ -1,0 +1,10 @@
+// This represents an rlib where SCS is explicitly provided as a -Zsanitizer flag.
+
+//@ no-prefer-dynamic
+//@ compile-flags: --target riscv64gc-unknown-fuchsia -Zsanitizer=shadow-call-stack
+//@ needs-llvm-components: riscv
+//@ ignore-backends: gcc
+
+#![feature(no_core)]
+#![crate_type = "rlib"]
+#![no_core]

--- a/tests/ui/target_modifiers/auxiliary/sanitizer_default_implicit.rs
+++ b/tests/ui/target_modifiers/auxiliary/sanitizer_default_implicit.rs
@@ -1,0 +1,11 @@
+// This represents an rlib where SCS is not explicitly provided as a -Zsanitizer flag.
+// SCS is a default_sanitizer on riscv64gc-unknown-fuchsia.
+
+//@ no-prefer-dynamic
+//@ compile-flags: --target riscv64gc-unknown-fuchsia
+//@ needs-llvm-components: riscv
+//@ ignore-backends: gcc
+
+#![feature(no_core)]
+#![crate_type = "rlib"]
+#![no_core]

--- a/tests/ui/target_modifiers/auxiliary/sanitizer_non_default.rs
+++ b/tests/ui/target_modifiers/auxiliary/sanitizer_non_default.rs
@@ -1,0 +1,11 @@
+// This represents an rlib where CFI is explicitly provided as a -Zsanitizer flag.
+// CFI is not a default_sanitizer for riscv64gc-unknown-fuchsia.
+
+//@ no-prefer-dynamic
+//@ compile-flags: --target riscv64gc-unknown-fuchsia -Zsanitizer=cfi -Clinker-plugin-lto
+//@ needs-llvm-components: riscv
+//@ ignore-backends: gcc
+
+#![feature(no_core)]
+#![crate_type = "rlib"]
+#![no_core]

--- a/tests/ui/target_modifiers/sanitizer_default.explicit_mismatch.stderr
+++ b/tests/ui/target_modifiers/sanitizer_default.explicit_mismatch.stderr
@@ -1,0 +1,9 @@
+error: mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizer_default`
+   |
+   = help: the `-Zsanitizer` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
+   = note: `-Zsanitizer=shadow-call-stack` in this crate is incompatible with `-Zsanitizer=cfi` in dependency `sanitizer_non_default`
+   = help: set `-Zsanitizer=cfi` in this crate or `-Zsanitizer=shadow-call-stack` in `sanitizer_non_default`
+   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=sanitizer` to silence this error
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/target_modifiers/sanitizer_default.implicit_mismatch.stderr
+++ b/tests/ui/target_modifiers/sanitizer_default.implicit_mismatch.stderr
@@ -1,0 +1,9 @@
+error: mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizer_default`
+   |
+   = help: the `-Zsanitizer` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
+   = note: `-Zsanitizer` is unset in this crate which is incompatible with `-Zsanitizer=cfi` in dependency `sanitizer_non_default`
+   = help: set `-Zsanitizer=cfi` in this crate or unset `-Zsanitizer` in `sanitizer_non_default`
+   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=sanitizer` to silence this error
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/target_modifiers/sanitizer_default.rs
+++ b/tests/ui/target_modifiers/sanitizer_default.rs
@@ -1,0 +1,36 @@
+// Test that we do not get an ABI mismatch error when a default sanitizer is not
+// explicitly provided via a -Zsanitizer flag.
+//
+// riscv64gc-unknown-fuchsia has shadow-call-stack as a default sanitizer.
+// Compiling one crate without `-Zsanitizer` and another crate with the target's
+// default sanitizer explicitly specified (-Zsanitizer=shadow-call-stack)
+// must be accepted.
+
+//@ aux-build:sanitizer_default_implicit.rs
+//@ aux-build:sanitizer_default_explicit.rs
+//@ aux-build:sanitizer_non_default.rs
+//@ compile-flags: --target riscv64gc-unknown-fuchsia
+//@ needs-llvm-components: riscv
+//@ ignore-backends: gcc
+
+//@ revisions: implicit_default explicit_default implicit_mismatch explicit_mismatch
+//@[implicit_default] check-pass
+//@[explicit_default] compile-flags: -Zsanitizer=shadow-call-stack
+//@[explicit_default] check-pass
+//@[explicit_mismatch] compile-flags: -Zsanitizer=shadow-call-stack
+
+#![feature(no_core)]
+#![crate_type = "rlib"]
+#![no_core]
+
+#[cfg(any(implicit_default, explicit_default))]
+extern crate sanitizer_default_implicit;
+
+#[cfg(any(implicit_default, explicit_default))]
+extern crate sanitizer_default_explicit;
+
+// We still expect the normal mismatch error with a non-default sanitizer.
+#[cfg(any(implicit_mismatch, explicit_mismatch))]
+extern crate sanitizer_non_default;
+//[implicit_mismatch]~? ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizer_default`
+//[explicit_mismatch]~? ERROR mixing `-Zsanitizer` will cause an ABI mismatch in crate `sanitizer_default`


### PR DESCRIPTION
Prior to this PR, rustc would complain about mismatched ABIs if crates built with -Zsanitizer=shadow-call-stack were mixed with crates not built with -Zsanitizer=shadow-call-stack for the exact same target where SCS is one of the default_sanitizers. Rustc should also take into account default_sanitizers before doing the target modifiers checks.

AI: Gemini was used to initially help write tests for this PR. I edited some of it and reviewed it to the best of my ability before submitting.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
