### PR TITLE
[compiletest] Use the correct rustc lib directory for query_rustc_output

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2372,6 +2372,7 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
         cmd.arg("--rustc-path").arg(builder.rustc(test_compiler));
         if let Some(query_compiler) = query_compiler {
             cmd.arg("--query-rustc-path").arg(builder.rustc(query_compiler));
+            cmd.arg("--query-rustc-lib-path").arg(builder.rustc_libdir(query_compiler));
         }
 
         // Minicore auxiliary lib for `no_core` tests that need `core` stubs in cross-compilation

--- a/src/tools/compiletest/src/cli.rs
+++ b/src/tools/compiletest/src/cli.rs
@@ -126,6 +126,9 @@ struct Args {
     /// Path to rustc to use for querying target information.
     #[arg(long)]
     query_rustc_path: Option<Utf8PathBuf>,
+    /// Path to shared libraries for querying target information.
+    #[arg(long)]
+    query_rustc_lib_path: Option<Utf8PathBuf>,
     /// Path to rustdoc to use for compiling.
     #[arg(long)]
     rustdoc_path: Option<Utf8PathBuf>,
@@ -486,6 +489,7 @@ pub(crate) fn parse_config(args: Vec<String>) -> Config {
         profiler_runtime: args.profiler_runtime,
 
         python: args.python,
+        query_rustc_lib_path: args.query_rustc_lib_path,
         query_rustc_path: args.query_rustc_path,
         remote_test_client: args.remote_test_client,
         run,

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -362,6 +362,11 @@ pub(crate) struct Config {
     /// (in case the JSON format has changed since the last bootstrap bump).
     pub(crate) query_rustc_path: Option<Utf8PathBuf>,
 
+    /// Path to the libraries needed to run the compiler at [`Self::query_rustc_path`].
+    ///
+    /// If unset, [`Self::host_compile_lib_path`] will be used instead.
+    pub(crate) query_rustc_lib_path: Option<Utf8PathBuf>,
+
     /// Path to the `rustdoc`-under-test. Like [`Self::rustc_path`], this `rustdoc` is *staged*.
     pub(crate) rustdoc_path: Option<Utf8PathBuf>,
 
@@ -1194,7 +1199,10 @@ pub(crate) fn query_rustc_output(
     let query_rustc_path = config.query_rustc_path.as_deref().unwrap_or(&config.rustc_path);
 
     let mut command = Command::new(query_rustc_path);
-    add_dylib_path(&mut command, iter::once(&config.host_compile_lib_path));
+    add_dylib_path(
+        &mut command,
+        iter::once(config.query_rustc_lib_path.as_deref().unwrap_or(&config.host_compile_lib_path)),
+    );
     command.args(&config.target_rustcflags).args(args);
     command.env("RUSTC_BOOTSTRAP", "1");
     command.envs(envs);

--- a/src/tools/compiletest/src/rustdoc_gui_test.rs
+++ b/src/tools/compiletest/src/rustdoc_gui_test.rs
@@ -66,6 +66,7 @@ fn incomplete_config_for_rustdoc_gui_test() -> Config {
         run_make_support_rlib: Default::default(),
         run_make_support_rmeta: Default::default(),
         query_rustc_path: Default::default(),
+        query_rustc_lib_path: Default::default(),
         rustdoc_path: Default::default(),
         coverage_dump_path: Default::default(),
         python: Default::default(),


### PR DESCRIPTION
ui-fulldeps tests are built with the stage0 compiler, but invoke the stage1 compiler to determine target features. This caused segfaults on my machine, as the stage1 compiler (which uses LLVM 23) was run with the stage0 lib directory (which has LLVM 22):

```
Testing stage0 with compiletest suite=ui-fulldeps mode=ui (aarch64-apple-darwin)
FATAL: failed to run DYLD_LIBRARY_PATH="/Users/keljonathan/code/rust/build/aarch64-apple-darwin/stage0/lib:/Users/keljonathan/code/rust/build/aarch64-apple-darwin/bootstrap-tools/aarch64-apple-darwin/release/build/run_make_support/1bb3eeb38bc010bc/out" RUSTC_BOOTSTRAP="1" "/Users/keljonathan/code/rust/build/aarch64-apple-darwin/stage1/bin/rustc" "-Crpath" "-Cdebuginfo=0" "-Alinker_messages" "--print=all-target-specs-json" "-Zunstable-options"
--- stdout

--- stderr
error: rustc interrupted by SIGSEGV, printing backtrace
```

<details><summary>Backtrace</summary>
<p>

```
0   librustc_driver-18049a207bb38ba8.dy 0x000000010e09e9b8 _RNvNtCsfNrGi27GPxl_17rustc_driver_impl14signal_handler17print_stack_trace + 140
1   libsystem_platform.dylib            0x0000000184c7d744 _sigtramp + 56
2   libLLVM.dylib                       0x000000011a9e22e0 _ZNK4llvm15MCSubtargetInfo13checkFeaturesENS_9StringRefE + 40
3   librustc_driver-18049a207bb38ba8.dy 0x000000010e44c798 LLVMRustHasFeature + 104
4   librustc_driver-18049a207bb38ba8.dy 0x000000010e3c4e34 _RINvXs0_NtNtNtCsk8HLZXaYIk4_4core4iter8adapters3mapINtB6_3MapINtNtB8_7flatten7FlatMapINtNtB8_6filter6FilterINtNtNtBc_5slice4iter4IterTReNtNtCs79s86CIooN0_12rustc_target15target_features9StabilityRSB28_EENCINvNtCses5MBT5CPFU_17rustc_codegen_ssa15target_features24internal_target_featuresKj2_NCNvNtCsgXm2bqwPj4W_18rustc_codegen_llvm9llvm_util13target_config0NCB4G_s_0E0EIBO_INtNtNtNtCs99cPMl0y5Ob_3std11collections4hash3set8IntoIterB28_ENCNCB3h_s_00ENCB3h_s_0ENCINvXs8_NtCsdLs5ZkLaCXa_9hashbrown3setINtB7v_7HashSetNtNtCsSGoTcZpb2F_10rustc_span6symbol6SymbolNtCs5ZGGmiYplBm_10rustc_hash13FxBuildHasherEINtNtNtBa_6traits7collect6ExtendB8e_E6extendBX_E0ENtNtB9I_8iterator8Iterator4folduNCINvNvBar_8for_each4callTB8e_uENCINvXs1i_NtB7x_3mapINtBbD_7HashMapB8e_uB8V_EIB9E_Bbm_E6extendBN_E0E0EB4K_ + 880
5   librustc_driver-18049a207bb38ba8.dy 0x000000010e2ad884 _RINvXs1i_NtCsdLs5ZkLaCXa_9hashbrown3mapINtB7_7HashMapNtNtCsSGoTcZpb2F_10rustc_span6symbol6SymboluNtCs5ZGGmiYplBm_10rustc_hash13FxBuildHasherEINtNtNtNtCsk8HLZXaYIk4_4core4iter6traits7collect6ExtendTBP_uEE6extendINtNtNtB2m_8adapters3map3MapINtNtB3r_7flatten7FlatMapINtNtB3r_6filter6FilterINtNtNtB2o_5slice4iter4IterTReNtNtCs79s86CIooN0_12rustc_target15target_features9StabilityRSB52_EENCINvNtCses5MBT5CPFU_17rustc_codegen_ssa15target_features24internal_target_featuresKj2_NCNvNtCsgXm2bqwPj4W_18rustc_codegen_llvm9llvm_util13target_config0NCB7A_s_0E0EIB3n_INtNtNtNtCs99cPMl0y5Ob_3std11collections4hash3set8IntoIterB52_ENCNCB6b_s_00ENCB6b_s_0ENCINvXs8_NtB9_3setINtBaq_7HashSetBP_B1x_EIB2g_BP_E6extendB3O_E0EEB7E_ + 344
6   librustc_driver-18049a207bb38ba8.dy 0x000000010e2b1ec4 _RINvXs8_NtCsdLs5ZkLaCXa_9hashbrown3setINtB6_7HashSetNtNtCsSGoTcZpb2F_10rustc_span6symbol6SymbolNtCs5ZGGmiYplBm_10rustc_hash13FxBuildHasherEINtNtNtNtCsk8HLZXaYIk4_4core4iter6traits7collect6ExtendBO_E6extendINtNtNtB2k_8adapters7flatten7FlatMapINtNtB3m_6filter6FilterINtNtNtB2m_5slice4iter4IterTReNtNtCs79s86CIooN0_12rustc_target15target_features9StabilityRSB4G_EENCINvNtCses5MBT5CPFU_17rustc_codegen_ssa15target_features24internal_target_featuresKj2_NCNvNtCsgXm2bqwPj4W_18rustc_codegen_llvm9llvm_util13target_config0NCB7e_s_0E0EINtNtB3m_3map3MapINtNtNtNtCs99cPMl0y5Ob_3std11collections4hash3set8IntoIterB4G_ENCNCB5P_s_00ENCB5P_s_0EEB7i_ + 68
7   librustc_driver-18049a207bb38ba8.dy 0x000000010e2bfa90 _RINvNtCses5MBT5CPFU_17rustc_codegen_ssa15target_features24internal_target_featuresKj2_NCNvNtCsgXm2bqwPj4W_18rustc_codegen_llvm9llvm_util13target_config0NCB1o_s_0EB1s_ + 148
8   librustc_driver-18049a207bb38ba8.dy 0x000000010e2fb918 _RNvNtCsgXm2bqwPj4W_18rustc_codegen_llvm9llvm_util13target_config + 68
9   librustc_driver-18049a207bb38ba8.dy 0x000000010e292fb0 _RNvNtCs6x0lOIkloew_15rustc_interface4util17add_configuration + 48
10  librustc_driver-18049a207bb38ba8.dy 0x000000010e06b204 _RINvMs_Csfkr8sXZt4uY_10scoped_tlsINtB5_9ScopedKeyNtCsSGoTcZpb2F_10rustc_span14SessionGlobalsE3setNCNCNCINvNtCs6x0lOIkloew_15rustc_interface4util26run_in_thread_with_globalsNCINvB1G_31run_in_thread_pool_with_globalsNCINvNtB1I_9interface12run_compileruNCNvCsfNrGi27GPxl_17rustc_driver_impl12run_compiler0Es0_0uE0uE000uEB44_ + 1112
11  librustc_driver-18049a207bb38ba8.dy 0x000000010e090914 _RINvCsSGoTcZpb2F_10rustc_span27create_session_globals_thenuNCNCNCINvNtCs6x0lOIkloew_15rustc_interface4util26run_in_thread_with_globalsNCINvB14_31run_in_thread_pool_with_globalsNCINvNtB16_9interface12run_compileruNCNvCsfNrGi27GPxl_17rustc_driver_impl12run_compiler0Es0_0uE0uE000EB3s_ + 168
12  librustc_driver-18049a207bb38ba8.dy 0x000000010e07823c _RINvNtNtCs99cPMl0y5Ob_3std3sys9backtrace28___rust_begin_short_backtraceNCNCINvNtCs6x0lOIkloew_15rustc_interface4util26run_in_thread_with_globalsNCINvB1e_31run_in_thread_pool_with_globalsNCINvNtB1g_9interface12run_compileruNCNvCsfNrGi27GPxl_17rustc_driver_impl12run_compiler0Es0_0uE0uE00uEB3C_ + 112
13  librustc_driver-18049a207bb38ba8.dy 0x000000010e04efa4 _RNSNvYNCINvNtNtCs99cPMl0y5Ob_3std6thread9lifecycle15spawn_uncheckedNCNCINvNtCs6x0lOIkloew_15rustc_interface4util26run_in_thread_with_globalsNCINvB1a_31run_in_thread_pool_with_globalsNCINvNtB1c_9interface12run_compileruNCNvCsfNrGi27GPxl_17rustc_driver_impl12run_compiler0Es0_0uE0uE00uEs_0INtNtNtCsk8HLZXaYIk4_4core3ops8function6FnOnceuE9call_once6vtableB3y_ + 208
14  librustc_driver-18049a207bb38ba8.dy 0x0000000111697118 _RNvNvMs0_NtNtNtCs99cPMl0y5Ob_3std3sys6thread4unixNtB7_6Thread3new12thread_start + 392
15  libsystem_pthread.dylib             0x0000000184c73c58 _pthread_start + 136
16  libsystem_pthread.dylib             0x0000000184c6ec1c thread_start + 8

note: we would appreciate a report at https://github.com/rust-lang/rust
help: you can increase rustc's stack size by setting RUST_MIN_STACK=33554432


thread 'main' (3571716) panicked at src/tools/compiletest/src/common.rs:1209:9:
fatal error
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/std/src/panicking.rs:679:5
   1: core::panicking::panic_fmt
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/core/src/panicking.rs:80:14
   2: query_rustc_output
             at ./src/tools/compiletest/src/diagnostics.rs:14:9
   3: new
             at ./src/tools/compiletest/src/common.rs:925:77
   4: {closure#0}
             at ./src/tools/compiletest/src/common.rs:792:41
   5: {closure#0}<compiletest::common::TargetCfgs, compiletest::common::{impl#5}::target_cfgs::{closure_env#0}>
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/std/src/sync/once_lock.rs:321:50
   6: {closure#0}<compiletest::common::TargetCfgs, std::sync::once_lock::{impl#0}::get_or_init::{closure_env#0}<compiletest::common::TargetCfgs, compiletest::common::{impl#5}::target_cfgs::{closure_env#0}>, !>
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/std/src/sync/once_lock.rs:543:19
   7: {closure#0}<std::sync::once_lock::{impl#0}::initialize::{closure_env#0}<compiletest::common::TargetCfgs, std::sync::once_lock::{impl#0}::get_or_init::{closure_env#0}<compiletest::common::TargetCfgs, compiletest::common::{impl#5}::target_cfgs::{closure_env#0}>, !>>
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/std/src/sync/once.rs:226:40
   8: <std::sys::sync::once::queue::Once>::call
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/std/src/sys/sync/once/queue.rs:225:21
   9: call_once_force<std::sync::once_lock::{impl#0}::initialize::{closure_env#0}<compiletest::common::TargetCfgs, std::sync::once_lock::{impl#0}::get_or_init::{closure_env#0}<compiletest::common::TargetCfgs, compiletest::common::{impl#5}::target_cfgs::{closure_env#0}>, !>>
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/std/src/sync/once.rs:226:20
  10: initialize<compiletest::common::TargetCfgs, std::sync::once_lock::{impl#0}::get_or_init::{closure_env#0}<compiletest::common::TargetCfgs, compiletest::common::{impl#5}::target_cfgs::{closure_env#0}>, !>
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/std/src/sync/once_lock.rs:542:19
  11: get_or_try_init<compiletest::common::TargetCfgs, std::sync::once_lock::{impl#0}::get_or_init::{closure_env#0}<compiletest::common::TargetCfgs, compiletest::common::{impl#5}::target_cfgs::{closure_env#0}>, !>
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/std/src/sync/once_lock.rs:410:14
  12: get_or_init<compiletest::common::TargetCfgs, compiletest::common::{impl#5}::target_cfgs::{closure_env#0}>
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/std/src/sync/once_lock.rs:321:20
  13: target_cfgs
             at ./src/tools/compiletest/src/common.rs:792:26
  14: prepare_conditions
             at ./src/tools/compiletest/src/directives/cfg.rs:121:23
  15: load
             at ./src/tools/compiletest/src/directives.rs:50:29
  16: collect_and_make_tests
             at ./src/tools/compiletest/src/lib.rs:186:17
  17: run_tests
             at ./src/tools/compiletest/src/lib.rs:103:22
  18: main
             at ./src/tools/compiletest/src/cli.rs:30:5
  19: call_once<fn(), ()>
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

</p>
</details> 

Note that `DYLD_LIBRARY_PATH` contains `rust/build/aarch64-apple-darwin/stage0/lib`, while the compiler we're executing is `rust/build/aarch64-apple-darwin/stage1/bin/rustc`.

This PR fixes the issue by providing compiletest with the correct lib directory to use when querying the stage1 compiler.

I expect the problem will go away again once rust-lang/rust#161325 is merged and stage0 and stage1 use the same LLVM version, but this PR ensures it won't be a problem for the next LLVM bump.

I encountered a similar issue building the unstable book, which I am planning to submit a followup PR for.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
