### PR TITLE
rustdoc: enable scrolling only on table/code

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -527,7 +527,7 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for TableWrapper<'a, I> {
         Some(match event {
             Event::Start(Tag::Table(t)) => {
                 self.stored_events.push_back(Event::Start(Tag::Table(t)));
-                Event::Html(CowStr::Borrowed("<div>"))
+                Event::Html(CowStr::Borrowed(r#"<div class="table">"#))
             }
             Event::End(TagEnd::Table) => {
                 self.stored_events.push_back(Event::Html(CowStr::Borrowed("</div>")));

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1098,7 +1098,7 @@ rustdoc-topbar {
 	position: relative;
 }
 
-.docblock > :not(.more-examples-toggle):not(.example-wrap) {
+.docblock pre, .docblock div.table {
 	max-width: 100%;
 	overflow-x: auto;
 }

--- a/tests/rustdoc-gui/list-margins.goml
+++ b/tests/rustdoc-gui/list-margins.goml
@@ -1,5 +1,6 @@
 // This test ensures that the documentation list markers are correctly placed.
-// It also serves as a regression test for <https://github.com/rust-lang/rust/issues/130622>.
+// It also serves as a regression test for <https://github.com/rust-lang/rust/issues/130622>
+// and <https://github.com/rust-lang/rust/issues/161144>
 
 go-to: "file://" + |DOC_PATH| + "/test_docs/long_list/index.html"
 show-text: true
@@ -9,3 +10,12 @@ assert-css: (".docblock li p:not(last-child)", {"margin-bottom": "4.8px"})
 assert-css: (".docblock li p + p:last-child", {"margin-bottom": "0px"})
 // 0.4em
 assert-css: (".docblock li", {"margin-bottom": "6.4px"})
+
+// check that the list is allowed to overflow
+assert-css: ("details.toggle", {"overflow": "visible"})
+assert-css: (".docblock", {"overflow": "visible"})
+assert-css: (".docblock ol", {"overflow": "visible"})
+assert-css: (".docblock ol li", {"overflow": "visible"})
+store-position: ("main", {"x": main_x})
+store-position: (".docblock ol li::marker", {"x": marker_x})
+assert: |main_x| <= |marker_x|

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -679,12 +679,12 @@ pub mod long_list {
     //!
     //! Another list:
     //!
-    //! * [`TryFromBytes`](#a) indicates that a type may safely be converted from certain byte
-    //!   sequence (conditional on runtime checks)
-    //! * [`FromZeros`](#a) indicates that a sequence of zero bytes represents a valid instance of
-    //!   a type
-    //! * [`FromBytes`](#a) indicates that a type may safely be converted from an arbitrary byte
-    //!   sequence
+    //! 100. [`TryFromBytes`](#a) indicates that a type may safely be converted from certain byte
+    //!      sequence (conditional on runtime checks)
+    //! 101. [`FromZeros`](#a) indicates that a sequence of zero bytes represents a valid instance of
+    //!      a type
+    //! 102. [`FromBytes`](#a) indicates that a type may safely be converted from an arbitrary byte
+    //!      sequence
 }
 
 pub struct ImplDoc;


### PR DESCRIPTION
This is a fix for a problem that hit `<ol>`, where the digits were truncated at the edge of the scroll container.

Fixes https://github.com/rust-lang/rust/issues/161144

<img width="1552" height="923" alt="Screenshot 2026-08-18 at 21 08 12" src="https://github.com/user-attachments/assets/4825a756-0068-42e8-99f2-8a57cc17f234" />

None of this code was written with an LLM, but, supposedly, one was used in the above issue thread for root cause analysis.