### PR TITLE
Cleanup: Move impl of `#[rustc_dump_object_lifetime_defaults]`

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/dump.rs
+++ b/compiler/rustc_hir_analysis/src/collect/dump.rs
@@ -3,6 +3,7 @@ use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::{find_attr, intravisit};
 use rustc_middle::hir::nested_filter;
+use rustc_middle::middle::resolve_bound_vars::ObjectLifetimeDefault;
 use rustc_middle::ty::{self, TyCtxt, TypeVisitableExt, Unnormalized};
 use rustc_span::sym;
 
@@ -21,6 +22,30 @@ pub(crate) fn generics(tcx: TyCtxt<'_>) {
             let generics = tcx.generics_of(did);
             diag.span_note(tcx.def_span(did), format!("{generics:#?}"));
             diag.emit();
+        }
+    }
+}
+
+pub(crate) fn object_lifetime_defaults(tcx: TyCtxt<'_>) {
+    for def_id in tcx.hir_crate_items(()).definitions() {
+        if def_id == hir::def_id::CRATE_DEF_ID {
+            continue;
+        }
+
+        if !find_attr!(tcx, def_id, RustcDumpObjectLifetimeDefaults) {
+            continue;
+        }
+
+        for param in &tcx.generics_of(def_id).own_params {
+            let ty::GenericParamDefKind::Type { .. } = param.kind else { continue };
+            let default = tcx.object_lifetime_default(param.def_id);
+            let repr = match default {
+                ObjectLifetimeDefault::Empty => "Empty".to_owned(),
+                ObjectLifetimeDefault::Static => "'static".to_owned(),
+                ObjectLifetimeDefault::Param(def_id) => tcx.item_name(def_id).to_string(),
+                ObjectLifetimeDefault::Ambiguous => "Ambiguous".to_owned(),
+            };
+            tcx.dcx().span_err(tcx.def_span(param.def_id), repr);
         }
     }
 }

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -203,13 +203,16 @@ pub fn check_crate(tcx: TyCtxt<'_>) {
 
     if tcx.features().rustc_attrs() {
         tcx.sess.time("dumping_rustc_attr_data", || {
-            outlives::dump::inferred_outlives(tcx);
-            variance::dump::variances(tcx);
-            collect::dump::generics(tcx);
-            collect::dump::opaque_hidden_types(tcx);
+            // tidy-alphabetical-start
             collect::dump::clauses_and_item_bounds(tcx);
             collect::dump::def_parents(tcx);
+            collect::dump::generics(tcx);
+            collect::dump::object_lifetime_defaults(tcx);
+            collect::dump::opaque_hidden_types(tcx);
             collect::dump::vtables(tcx);
+            outlives::dump::inferred_outlives(tcx);
+            variance::dump::variances(tcx);
+            // tidy-alphabetical-end
         });
     }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -30,7 +30,6 @@ use rustc_hir::{
 };
 use rustc_macros::Diagnostic;
 use rustc_middle::hir::nested_filter;
-use rustc_middle::middle::resolve_bound_vars::ObjectLifetimeDefault;
 use rustc_middle::query::Providers;
 use rustc_middle::traits::ObligationCause;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
@@ -195,9 +194,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             AttributeKind::Deprecated { span: attr_span, .. } => {
                 self.check_deprecated(hir_id, *attr_span, target)
             }
-            AttributeKind::RustcDumpObjectLifetimeDefaults => {
-                self.check_dump_object_lifetime_defaults(hir_id);
-            }
             AttributeKind::Naked(..) => self.check_naked(hir_id, target),
             AttributeKind::NonExhaustive(attr_span) => {
                 self.check_non_exhaustive(*attr_span, span, target, item)
@@ -337,6 +333,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             AttributeKind::RustcDumpInferredOutlives => (),
             AttributeKind::RustcDumpItemBounds => (),
             AttributeKind::RustcDumpLayout(..) => (),
+            AttributeKind::RustcDumpObjectLifetimeDefaults => (),
             AttributeKind::RustcDumpSymbolName(..) => (),
             AttributeKind::RustcDumpUserArgs => (),
             AttributeKind::RustcDumpVariances => (),
@@ -782,23 +779,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 }
             }
             _ => {}
-        }
-    }
-
-    /// Debugging aid for the `object_lifetime_default` query.
-    fn check_dump_object_lifetime_defaults(&self, hir_id: HirId) {
-        let tcx = self.tcx;
-        let Some(owner_id) = hir_id.as_owner() else { return };
-        for param in &tcx.generics_of(owner_id.def_id).own_params {
-            let ty::GenericParamDefKind::Type { .. } = param.kind else { continue };
-            let default = tcx.object_lifetime_default(param.def_id);
-            let repr = match default {
-                ObjectLifetimeDefault::Empty => "Empty".to_owned(),
-                ObjectLifetimeDefault::Static => "'static".to_owned(),
-                ObjectLifetimeDefault::Param(def_id) => tcx.item_name(def_id).to_string(),
-                ObjectLifetimeDefault::Ambiguous => "Ambiguous".to_owned(),
-            };
-            tcx.dcx().span_err(tcx.def_span(param.def_id), repr);
         }
     }
 


### PR DESCRIPTION
Module `rustc_passes::check_attr` hosts *validity checks* for attributes (that can't be impl'ed in `rustc_attr_parsing` (yet)). However on main, the *actual impl* of `#[rustc_dump_object_lifetime_defaults]` lives there, too, which is wrong. Move it closer to the provider of the corresponding query (`object_lifetime_defaults`) which lives in `rustc_hir_analysis`. IIRC the eventual goal is to remove `check_attr` entirely in favor of `rustc_attr_parsing` if possible, meaning the impl probably *has* to move in the future anyway. Let's do it now.

<sub>(No LLM was used in the creation of this PR)</sub>