### PR TITLE
Add test for parallel compiler reproducible build

### DIFF
--- a/tests/run-make/parallel-reproducible-build/rmake.rs
+++ b/tests/run-make/parallel-reproducible-build/rmake.rs
@@ -1,0 +1,35 @@
+//@ needs-target-std
+//@ ignore-cross-compile
+//@ ignore-windows-gnu
+// GNU Linker for Windows is non-deterministic. (from `reproducible-build-2` test in this suite)
+
+use std::rc::Rc;
+
+use run_make_support::{bin_name, is_windows_msvc, rfs, run_in_tmpdir, rustc};
+
+/// Test that parallel compiler produces identical binaries.
+fn main() {
+    const FILE_NAME: &str = "static-muts-issue-140413";
+    let bin_name = bin_name(FILE_NAME);
+
+    let mut reference = None;
+
+    for _ in 0..10 {
+        // Tmp dir as previous runs affect output binary on windows.
+        run_in_tmpdir(|| {
+            let mut rustc = rustc();
+            rustc.input(format!("{FILE_NAME}.rs")).arg("-Zthreads=50").output(&bin_name);
+
+            if is_windows_msvc() {
+                rustc.arg("-Clink-arg=/Brepro");
+            }
+
+            rustc.run();
+
+            let current = Rc::new(rfs::read(&bin_name));
+            reference.get_or_insert(Rc::clone(&current));
+
+            assert_eq!(Some(current), reference);
+        });
+    }
+}

--- a/tests/run-make/parallel-reproducible-build/static-muts-issue-140413.rs
+++ b/tests/run-make/parallel-reproducible-build/static-muts-issue-140413.rs
@@ -1,0 +1,20 @@
+// Checks that mutable static items can have mutable slices and other references
+
+pub static mut TEST: &'static mut [isize] = &mut [1];
+pub static mut EMPTY: &'static mut [isize] = &mut [];
+pub static mut INT: &'static mut isize = &mut 1;
+
+// And the same for raw pointers.
+
+pub static mut TEST_RAW: *mut [isize] = &mut [1isize] as *mut _;
+pub static mut EMPTY_RAW: *mut [isize] = &mut [] as *mut _;
+pub static mut INT_RAW: *mut isize = &mut 1isize as *mut _;
+
+pub fn main() {
+    unsafe {
+        TEST[0] += 1;
+        assert_eq!(TEST[0], 2);
+        *INT_RAW += 1;
+        assert_eq!(*INT_RAW, 2);
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161353)*
<!-- homu-ignore:end -->

Adds a test for reproducible binaries when using parallel compiler.

Confirmed with bisection and manual testing that rust-lang/rust#144722 fixed rust-lang/rust#140413, added test fails before commit (075ce31bd39c68b911edda233f0af3f40113212b) from rust-lang/rust#144722.
```rust
********************************************************************************
Regression in nightly-2025-08-14
********************************************************************************

fetching https://static.rust-lang.org/dist/2025-08-13/channel-rust-nightly-git-commit-hash.txt
nightly manifest 2025-08-13: 40 B / 40 B [============================================================================================================================================================================] 100.00 % 357.18 KB/s converted 2025-08-13 to 8e62bfd311791bfd9dca886abdfbab07ec54d8b4
fetching https://static.rust-lang.org/dist/2025-08-14/channel-rust-nightly-git-commit-hash.txt
nightly manifest 2025-08-14: 40 B / 40 B [============================================================================================================================================================================] 100.00 % 123.86 KB/s converted 2025-08-14 to 3672a55b7cfd0a12e7097197b6242872473ffaa7
looking for regression commit between 2025-08-13 and 2025-08-14
fetching (via remote github) commits from max(8e62bfd311791bfd9dca886abdfbab07ec54d8b4, 2025-08-11) to 3672a55b7cfd0a12e7097197b6242872473ffaa7
ending github query because we found starting sha: 8e62bfd311791bfd9dca886abdfbab07ec54d8b4
get_commits_between returning commits, len: 7
  commit[0] 2025-08-12: Auto merge of #144678 - jdonszelmann:no-mangle-extern, r=bjorn3
  commit[1] 2025-08-12: Auto merge of #145295 - Kobzol:unify-stages, r=jieyouxu
  commit[2] 2025-08-13: Auto merge of #145093 - nikic:dead-on-return, r=nnethercote
  commit[3] 2025-08-13: Auto merge of #145334 - Kobzol:rollup-fs5a133, r=Kobzol
  commit[4] 2025-08-13: Auto merge of #144722 - ywxt:parallel-reproducibile, r=SparrowLii
  commit[5] 2025-08-13: Auto merge of #145298 - nikic:llvm21-rc3, r=cuviper
  commit[6] 2025-08-13: Auto merge of #145366 - GuillaumeGomez:rollup-v0a6v3u, r=GuillaumeGomez
```

Fixes rust-lang/rust#140413.

r? @petrochenkov