### PR TITLE
 rustdoc: Correctly handle reexports when --document-private-items is used

### DIFF
--- a/src/librustdoc/passes/strip_priv_imports.rs
+++ b/src/librustdoc/passes/strip_priv_imports.rs
@@ -14,6 +14,11 @@ pub(crate) const STRIP_PRIV_IMPORTS: Pass = Pass {
 
 pub(crate) fn strip_priv_imports(krate: clean::Crate, cx: &mut DocContext<'_>) -> clean::Crate {
     let is_json_output = cx.is_json_output();
-    ImportStripper { tcx: cx.tcx, is_json_output, document_hidden: cx.document_hidden() }
-        .fold_crate(krate)
+    ImportStripper {
+        tcx: cx.tcx,
+        is_json_output,
+        document_hidden: cx.document_hidden(),
+        document_private: cx.document_private(),
+    }
+    .fold_crate(krate)
 }

--- a/src/librustdoc/passes/strip_private.rs
+++ b/src/librustdoc/passes/strip_private.rs
@@ -29,9 +29,13 @@ pub(crate) fn strip_private(mut krate: clean::Crate, cx: &mut DocContext<'_>) ->
             is_json_output,
             tcx: cx.tcx,
         };
-        krate =
-            ImportStripper { tcx: cx.tcx, is_json_output, document_hidden: cx.document_hidden() }
-                .fold_crate(stripper.fold_crate(krate));
+        krate = ImportStripper {
+            tcx: cx.tcx,
+            is_json_output,
+            document_hidden: cx.document_hidden(),
+            document_private: cx.document_private(),
+        }
+        .fold_crate(stripper.fold_crate(krate));
     }
 
     // strip all impls referencing private items

--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -268,6 +268,7 @@ pub(crate) struct ImportStripper<'tcx> {
     pub(crate) tcx: TyCtxt<'tcx>,
     pub(crate) is_json_output: bool,
     pub(crate) document_hidden: bool,
+    pub(crate) document_private: bool,
 }
 
 impl ImportStripper<'_> {
@@ -290,6 +291,7 @@ impl DocFolder for ImportStripper<'_> {
                 debug!("ImportStripper: stripping {:?}", i.name);
                 None
             }
+            clean::ImportItem(imp) if self.document_private => Some(self.fold_item_recur(i)),
             // clean::ImportItem(_) if !self.document_hidden && i.is_doc_hidden() => None,
             clean::ExternCrateItem { .. } | clean::ImportItem(..)
                 if i.visibility(self.tcx) != Some(Visibility::Public) =>

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -470,7 +470,13 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         let tcx = self.cx.tcx;
 
         let def_id = item.owner_id.to_def_id();
-        let is_pub = tcx.visibility(def_id).is_public();
+        // Explanations: if the item is public, nothing more to check. If not, then we check if
+        // we're documenting private item. If we are, then we want all items, except if it's a
+        // `use`. In this case, we want to check if it's a reexport. To do so, we check if there is
+        // a `pub(...)` part with its `vis_span` field.
+        let is_pub = tcx.visibility(def_id).is_public()
+            || (self.cx.document_private()
+                && (!matches!(item.kind, hir::ItemKind::Use(..)) || !item.vis_span.is_empty()));
 
         if is_pub {
             self.store_path(item.owner_id.to_def_id());

--- a/tests/rustdoc-html/inline_local/document-private-reexports.rs
+++ b/tests/rustdoc-html/inline_local/document-private-reexports.rs
@@ -1,0 +1,41 @@
+// Test ensures that when we use the `--document-private-items` option, reexports
+// work the same as for "public" items.
+// Regression test for <https://github.com/rust-lang/rust/issues/159109>.
+
+//@ compile-flags: --document-private-items
+
+#![crate_name = "foo"]
+
+//@ has 'foo/index.html'
+// The three reexports and the `not_hidden` (private) module.
+//@ count - '//*[@class="item-table"]/dt' 4
+//@ has - '//*[@class="item-table"]/dt/a[@href="not_hidden/index.html"]' 'not_hidden'
+//@ has - '//*[@class="item-table"]/dt/a[@href="struct.Top.html"]' 'Top'
+//@ has - '//*[@class="item-table"]/dt/a[@href="struct.NotHidden.html"]' 'NotHidden'
+//@ has - '//*[@class="item-table"]/dt/a[@href="struct.Hidden2.html"]' 'Hidden2'
+
+#[doc(hidden)]
+pub(crate) struct TopHidden;
+
+#[doc(inline)]
+pub(crate) use TopHidden as Top;
+
+#[doc(hidden)]
+mod hidden {
+    pub(crate) struct NotHidden;
+}
+
+pub(crate) use self::hidden::NotHidden;
+// Since there is no `pub` of any kind, we don't display it.
+use self::hidden::NotHidden as X;
+
+mod not_hidden {
+    #[doc(hidden)]
+    pub(crate) struct Hidden;
+}
+
+#[doc(inline)]
+pub(crate) use self::not_hidden::Hidden as Hidden2;
+// Since there is no `pub` of any kind, we don't display it, even if there is `doc(inline)`.
+#[doc(inline)]
+use self::not_hidden::Hidden;

--- a/tests/rustdoc-html/inline_local/glob-private-document-private-items.rs
+++ b/tests/rustdoc-html/inline_local/glob-private-document-private-items.rs
@@ -17,14 +17,14 @@ pub use mod1::*;
 //@ has foo/index.html
 //@ hasraw - "mod1"
 //@ hasraw - "Mod1Public"
-//@ !hasraw - "Mod1Private"
-//@ !hasraw - "mod2"
+//@ hasraw - "Mod1Private"
+//@ hasraw - "mod2"
 //@ hasraw - "Mod2Public"
-//@ !hasraw - "Mod2Private"
+//@ hasraw - "Mod2Private"
 //@ has foo/struct.Mod1Public.html
-//@ !has foo/struct.Mod1Private.html
+//@ has foo/struct.Mod1Private.html
 //@ has foo/struct.Mod2Public.html
-//@ !has foo/struct.Mod2Private.html
+//@ has foo/struct.Mod2Private.html
 
 //@ has foo/mod1/index.html
 //@ hasraw - "mod2"
@@ -43,6 +43,6 @@ pub use mod1::*;
 //@ has foo/mod1/mod2/struct.Mod2Public.html
 //@ has foo/mod1/mod2/struct.Mod2Private.html
 
-//@ !has foo/mod2/index.html
-//@ !has foo/mod2/struct.Mod2Public.html
-//@ !has foo/mod2/struct.Mod2Private.html
+//@ has foo/mod2/index.html
+//@ has foo/mod2/struct.Mod2Public.html
+//@ has foo/mod2/struct.Mod2Private.html


### PR DESCRIPTION
Fixes rust-lang/rust#159109.

This PR makes the (private) reexport work like the public ones when the `--document-private-items` option is used. I still differentiate between imports (`use`) and reexports (`pub(...) use`) in this PR as I don't think we should display imports.

r? @Urgau 