### PR TITLE
Reflect current PR title names for subtree syncs in triagebot no-merges

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1807,7 +1807,7 @@ dep-bumps = [
 # ------------------------------------------------------------------------------
 
 [no-merges]
-exclude_titles = ["Rollup of", "subtree update", "Subtree update"]
+exclude_titles = ["Rollup of", "subtree update", "Subtree update", "subtree sync", "Subtree sync"]
 labels = ["has-merge-commits", "S-waiting-on-author"]
 
 [github-releases]


### PR DESCRIPTION
Noticed that the current PR title names for subtree syncs seems to have changed (or at least for some) and is now "Subtree sync" (or it's lower-cased variant).

Let's update the triagebot config so the merge commit handler don't for those expected cases.

- https://github.com/rust-lang/rust/pull/157533#issuecomment-4639219811
- https://github.com/rust-lang/rust/pull/155978#issuecomment-4347647470

<!-- homu-ignore:start -->
r? @bjorn3 cc @GuillaumeGomez 
<!-- homu-ignore:end -->
