### PR TITLE
Double-word align `_Unwind_Exception`

### DIFF
--- a/library/unwind/src/types.rs
+++ b/library/unwind/src/types.rs
@@ -42,6 +42,12 @@ pub const unwinder_private_data_size: usize = cfg_select! {
 };
 
 #[repr(C)]
+// The Itanium C++ ABI requires this type to have "double-word" alignment,
+// which libunwind and libgcc interpret as the maximum alignment of any
+// scalar type on the current target.
+#[cfg_attr(target_pointer_width = "16", repr(align(4)))]
+#[cfg_attr(target_pointer_width = "32", repr(align(8)))]
+#[cfg_attr(target_pointer_width = "64", repr(align(16)))]
 pub struct _Unwind_Exception {
     pub exception_class: _Unwind_Exception_Class,
     pub exception_cleanup: _Unwind_Exception_Cleanup_Fn,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

The [Itanium C++ ABI spec](https://itanium-cxx-abi.github.io/cxx-abi/abi-eh.html) states that the `_Unwind_Exception` type must be double-word aligned (see Section 1.2). The missing alignment option does not seem to cause problems when a) using Rust's panic mechanism (because the exception object passed to `_Unwind_RaiseException` is [heap-allocated](https://github.com/rust-lang/rust/blob/f7d782a3be46d6bb4b9792fe69a61db389ba1769/library/panic_unwind/src/gcc.rs#L62) and thus double-word aligned by accident---although this is not guaranteed) or b) when linking against libgcc's unwinder.

Most people don't need to unwind stacks themselves, so case (a) usually applies; and case (b) is the default for the `amd64-unknown-linux-gnu` target. Thus, misalignments seem unlikely to cause trouble in practice. However, I recently copied over some of the type definitions in `library/unwind` into a personal project, built `rustc` with `rust.llvm-libunwind = "system"`, and installed LLVM's `libunwind-24-dev`. Calling `_Unwind_RaiseException` with a thread-local `_Unwind_Exception`  object led to a segfault due to the too-small default alignment. So `libunwind` seems to depend on the double-word alignment.

N.B.: Both `libunwind` and `libgcc` have comments [1, 2] saying that the "double-word" alignment is a bit ambiguous when interpreted in a target-agnostic sense, and they both add  `__attribute__((__aligned__))` to `_Unwind_Exception`, with no specific alignment value (the default is the maximum alignment of any integer type). Rust doesn't have such a "default" alignment, so I interpreted "double-word" in a target-dependent manner via `cfg_attr` + the `target_pointer_width` feature.

\[1]: https://github.com/llvm/llvm-project/blob/196786fa5fe4225539678fc7904a383eca05374e/libunwind/include/unwind_itanium.h#L41
\[2]: https://github.com/gcc-mirror/gcc/blob/50a2eb56b9a350ecced4db4942e92d463dab8d8f/libgcc/unwind-generic.h#L106