### PR TITLE
Uplift rustfmt macro formatting fix

### DIFF
--- a/src/tools/rustfmt/src/macros.rs
+++ b/src/tools/rustfmt/src/macros.rs
@@ -454,7 +454,7 @@ pub(crate) fn rewrite_macro_def(
     };
 
     let mut header = if def.macro_rules {
-        let pos = context.snippet_provider.span_after(span, "macro_rules!");
+        let pos = context.snippet_provider.span_after(span, "!");
         vec![HeaderPart::new("macro_rules!", span.with_hi(pos))]
     } else {
         let macro_lo = context.snippet_provider.span_before(span, "macro");


### PR DESCRIPTION
This uplifts the fix for https://github.com/rust-lang/rustfmt/issues/6985 (https://github.com/rust-lang/rustfmt/pull/6990), which is a rustfmt ICE breaking multiple crates.

This should be backported to beta.