### PR TITLE
Allow running EC2 jobs locally

### DIFF
--- a/src/ci/citool/src/jobs.rs
+++ b/src/ci/citool/src/jobs.rs
@@ -44,7 +44,7 @@ impl Job {
     }
 
     fn is_linux(&self) -> bool {
-        self.os.contains("ubuntu")
+        self.os.contains("ubuntu") || self.os.contains("linux")
     }
 }
 
@@ -414,7 +414,10 @@ pub fn find_linux_job<'a>(jobs: &'a [Job], name: &str) -> anyhow::Result<&'a Job
         ));
     };
     if !job.is_linux() {
-        return Err(anyhow::anyhow!("Only Linux jobs can be executed locally"));
+        return Err(anyhow::anyhow!(
+            "Only Linux jobs can be executed locally, os `{}` is not linux",
+            job.os
+        ));
     }
 
     Ok(job)


### PR DESCRIPTION
The command
```
cargo run --manifest-path src/ci/citool/Cargo.toml run-local dist-x86_64-linux
```
Fails locally with the error "Only Linux jobs can be executed locally", which I think is not correct.
The os is displayed as `ec2-x86_64ami-c8a.8xlarge-x64-linux-$github.run_id-$github.run_attempt`.
This was my hack to fix it, but I'm not sure if the problem should be fixed here or whether the os string is wrong