### PR TITLE
[bootstrap] Don't reverse the order of dylib search path entries

### DIFF
--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -141,11 +141,8 @@ pub fn libdir(target: TargetSelection) -> &'static str {
 /// Adds a list of lookup paths to `cmd`'s dynamic library lookup path.
 /// If the dylib_path_var is already set for this cmd, the old value will be overwritten!
 pub fn add_dylib_path(path: Vec<PathBuf>, cmd: &mut BootstrapCommand) {
-    let mut list = dylib_path();
-    for path in path {
-        list.insert(0, path);
-    }
-    cmd.env(dylib_path_var(), t!(env::join_paths(list)));
+    let paths = path.into_iter().chain(dylib_path());
+    cmd.env(dylib_path_var(), t!(env::join_paths(paths)));
 }
 
 pub struct TimeIt(bool, Instant);


### PR DESCRIPTION
The `add_dylib_path` helper function prepends paths to the beginning of the dynamic linker search path, but it reverses their order while doing so. This is surprising and undocumented, and seems to be unexpected by several callers of this function.

Particularly, [`rustc_lib_paths`](https://github.com/rust-lang/rust/blob/f7d782a3be46d6bb4b9792fe69a61db389ba1769/src/bootstrap/src/core/builder/mod.rs#L1375) appends the `ci-llvm` path to the list it returns; reversing the order puts `ci-llvm` at a higher priority than the compiler's lib directory. On my system, this currently causes `./x test` to fail (when building the unstable book), because the stage0 compiler is run using CI LLVM instead of stage0 LLVM (which are currently different because stage0 is on LLVM 22 while main is on LLVM 23).

Might be worth a try build as this change could potentially cause issues if there is somewhere we depend on this ordering reversal. I checked all the call-sites (and ran `./x test` locally) and I don't think anyone *intentionally* relied on the ordering being reversed. I did find one snippet that concerned me (from rust-lang/rust#144303, cc @Kobzol):

https://github.com/rust-lang/rust/blob/f7d782a3be46d6bb4b9792fe69a61db389ba1769/src/bootstrap/src/core/build_steps/test.rs#L437-L448  

The comment states we're inserting `builder.rustc_libdir(tested_compiler)` at the highest priority in the search path, but because `add_dylib_path` reversed the ordering, it's actually inserted at the *lowest* priority. I don't know how to reproduce the issue this was supposed to fix, so I can't be sure that this PR doesn't cause a regression.

Follow-up to rust-lang/rust#161335. r? @jieyouxu 

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
