### PR TITLE
Use better generic type parameter names for `Extend` and `FromIterator`

### DIFF
--- a/library/alloc/src/boxed/iter.rs
+++ b/library/alloc/src/boxed/iter.rs
@@ -93,55 +93,55 @@ impl<S: ?Sized + AsyncIterator + Unpin> AsyncIterator for Box<S> {
     }
 }
 
-/// This implementation is required to make sure that the `Box<[I]>: IntoIterator`
+/// This implementation is required to make sure that the `Box<[T]>: IntoIterator`
 /// implementation doesn't overlap with `IntoIterator for T where T: Iterator` blanket.
 #[stable(feature = "boxed_slice_into_iter", since = "1.80.0")]
-impl<I, A: Allocator> !Iterator for Box<[I], A> {}
+impl<T, A: Allocator> !Iterator for Box<[T], A> {}
 
-/// This implementation is required to make sure that the `&Box<[I]>: IntoIterator`
+/// This implementation is required to make sure that the `&Box<[T]>: IntoIterator`
 /// implementation doesn't overlap with `IntoIterator for T where T: Iterator` blanket.
 #[stable(feature = "boxed_slice_into_iter", since = "1.80.0")]
-impl<'a, I, A: Allocator> !Iterator for &'a Box<[I], A> {}
+impl<'a, T, A: Allocator> !Iterator for &'a Box<[T], A> {}
 
-/// This implementation is required to make sure that the `&mut Box<[I]>: IntoIterator`
+/// This implementation is required to make sure that the `&mut Box<[T]>: IntoIterator`
 /// implementation doesn't overlap with `IntoIterator for T where T: Iterator` blanket.
 #[stable(feature = "boxed_slice_into_iter", since = "1.80.0")]
-impl<'a, I, A: Allocator> !Iterator for &'a mut Box<[I], A> {}
+impl<'a, T, A: Allocator> !Iterator for &'a mut Box<[T], A> {}
 
 // Note: the `#[rustc_skip_during_method_dispatch(boxed_slice)]` on `trait IntoIterator`
 // hides this implementation from explicit `.into_iter()` calls on editions < 2024,
 // so those calls will still resolve to the slice implementation, by reference.
 #[stable(feature = "boxed_slice_into_iter", since = "1.80.0")]
-impl<I, A: Allocator> IntoIterator for Box<[I], A> {
-    type IntoIter = vec::IntoIter<I, A>;
-    type Item = I;
-    fn into_iter(self) -> vec::IntoIter<I, A> {
+impl<T, A: Allocator> IntoIterator for Box<[T], A> {
+    type IntoIter = vec::IntoIter<T, A>;
+    type Item = T;
+    fn into_iter(self) -> vec::IntoIter<T, A> {
         self.into_vec().into_iter()
     }
 }
 
 #[stable(feature = "boxed_slice_into_iter", since = "1.80.0")]
-impl<'a, I, A: Allocator> IntoIterator for &'a Box<[I], A> {
-    type IntoIter = slice::Iter<'a, I>;
-    type Item = &'a I;
-    fn into_iter(self) -> slice::Iter<'a, I> {
+impl<'a, T, A: Allocator> IntoIterator for &'a Box<[T], A> {
+    type IntoIter = slice::Iter<'a, T>;
+    type Item = &'a T;
+    fn into_iter(self) -> slice::Iter<'a, T> {
         self.iter()
     }
 }
 
 #[stable(feature = "boxed_slice_into_iter", since = "1.80.0")]
-impl<'a, I, A: Allocator> IntoIterator for &'a mut Box<[I], A> {
-    type IntoIter = slice::IterMut<'a, I>;
-    type Item = &'a mut I;
-    fn into_iter(self) -> slice::IterMut<'a, I> {
+impl<'a, T, A: Allocator> IntoIterator for &'a mut Box<[T], A> {
+    type IntoIter = slice::IterMut<'a, T>;
+    type Item = &'a mut T;
+    fn into_iter(self) -> slice::IterMut<'a, T> {
         self.iter_mut()
     }
 }
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "boxed_slice_from_iter", since = "1.32.0")]
-impl<I> FromIterator<I> for Box<[I]> {
-    fn from_iter<T: IntoIterator<Item = I>>(iter: T) -> Self {
+impl<T> FromIterator<T> for Box<[T]> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         iter.into_iter().collect::<Vec<_>>().into_boxed_slice()
     }
 }
@@ -149,7 +149,7 @@ impl<I> FromIterator<I> for Box<[I]> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "boxed_str_from_iter", since = "1.80.0")]
 impl FromIterator<char> for Box<str> {
-    fn from_iter<T: IntoIterator<Item = char>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = char>>(iter: I) -> Self {
         String::from_iter(iter).into_boxed_str()
     }
 }
@@ -157,7 +157,7 @@ impl FromIterator<char> for Box<str> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "boxed_str_from_iter", since = "1.80.0")]
 impl<'a> FromIterator<&'a char> for Box<str> {
-    fn from_iter<T: IntoIterator<Item = &'a char>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = &'a char>>(iter: I) -> Self {
         String::from_iter(iter).into_boxed_str()
     }
 }
@@ -165,7 +165,7 @@ impl<'a> FromIterator<&'a char> for Box<str> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "boxed_str_from_iter", since = "1.80.0")]
 impl<'a> FromIterator<&'a str> for Box<str> {
-    fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = &'a str>>(iter: I) -> Self {
         String::from_iter(iter).into_boxed_str()
     }
 }
@@ -173,7 +173,7 @@ impl<'a> FromIterator<&'a str> for Box<str> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "boxed_str_from_iter", since = "1.80.0")]
 impl FromIterator<String> for Box<str> {
-    fn from_iter<T: IntoIterator<Item = String>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = String>>(iter: I) -> Self {
         String::from_iter(iter).into_boxed_str()
     }
 }
@@ -181,7 +181,7 @@ impl FromIterator<String> for Box<str> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "boxed_str_from_iter", since = "1.80.0")]
 impl<A: Allocator> FromIterator<Box<str, A>> for Box<str> {
-    fn from_iter<T: IntoIterator<Item = Box<str, A>>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = Box<str, A>>>(iter: I) -> Self {
         String::from_iter(iter).into_boxed_str()
     }
 }
@@ -189,7 +189,7 @@ impl<A: Allocator> FromIterator<Box<str, A>> for Box<str> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "boxed_str_from_iter", since = "1.80.0")]
 impl<'a> FromIterator<Cow<'a, str>> for Box<str> {
-    fn from_iter<T: IntoIterator<Item = Cow<'a, str>>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = Cow<'a, str>>>(iter: I) -> Self {
         String::from_iter(iter).into_boxed_str()
     }
 }

--- a/library/alloc/src/bstr.rs
+++ b/library/alloc/src/bstr.rs
@@ -281,7 +281,7 @@ impl<'a> From<&'a ByteString> for Cow<'a, ByteStr> {
 #[unstable(feature = "bstr", issue = "134915")]
 impl FromIterator<char> for ByteString {
     #[inline]
-    fn from_iter<T: IntoIterator<Item = char>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = char>>(iter: I) -> Self {
         ByteString(iter.into_iter().collect::<String>().into_bytes())
     }
 }
@@ -289,7 +289,7 @@ impl FromIterator<char> for ByteString {
 #[unstable(feature = "bstr", issue = "134915")]
 impl FromIterator<u8> for ByteString {
     #[inline]
-    fn from_iter<T: IntoIterator<Item = u8>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = u8>>(iter: I) -> Self {
         ByteString(iter.into_iter().collect())
     }
 }
@@ -297,7 +297,7 @@ impl FromIterator<u8> for ByteString {
 #[unstable(feature = "bstr", issue = "134915")]
 impl<'a> FromIterator<&'a str> for ByteString {
     #[inline]
-    fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = &'a str>>(iter: I) -> Self {
         ByteString(iter.into_iter().collect::<String>().into_bytes())
     }
 }
@@ -305,7 +305,7 @@ impl<'a> FromIterator<&'a str> for ByteString {
 #[unstable(feature = "bstr", issue = "134915")]
 impl<'a> FromIterator<&'a [u8]> for ByteString {
     #[inline]
-    fn from_iter<T: IntoIterator<Item = &'a [u8]>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = &'a [u8]>>(iter: I) -> Self {
         let mut buf = Vec::new();
         for b in iter {
             buf.extend_from_slice(b);
@@ -317,7 +317,7 @@ impl<'a> FromIterator<&'a [u8]> for ByteString {
 #[unstable(feature = "bstr", issue = "134915")]
 impl<'a> FromIterator<&'a ByteStr> for ByteString {
     #[inline]
-    fn from_iter<T: IntoIterator<Item = &'a ByteStr>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = &'a ByteStr>>(iter: I) -> Self {
         let mut buf = Vec::new();
         for b in iter {
             buf.extend_from_slice(&b.0);
@@ -329,7 +329,7 @@ impl<'a> FromIterator<&'a ByteStr> for ByteString {
 #[unstable(feature = "bstr", issue = "134915")]
 impl FromIterator<ByteString> for ByteString {
     #[inline]
-    fn from_iter<T: IntoIterator<Item = ByteString>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = ByteString>>(iter: I) -> Self {
         let mut buf = Vec::new();
         for mut b in iter {
             buf.append(&mut b.0);

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -2541,7 +2541,7 @@ impl<K: Ord, V> FromIterator<(K, V)> for BTreeMap<K, V> {
     ///
     /// If the iterator produces any pairs with equal keys,
     /// all but one of the corresponding values will be dropped.
-    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> BTreeMap<K, V> {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> BTreeMap<K, V> {
         let mut inputs: Vec<_> = iter.into_iter().collect();
 
         if inputs.is_empty() {
@@ -2557,7 +2557,7 @@ impl<K: Ord, V> FromIterator<(K, V)> for BTreeMap<K, V> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<K: Ord, V, A: Allocator + Clone> Extend<(K, V)> for BTreeMap<K, V, A> {
     #[inline]
-    fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
+    fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
         iter.into_iter().for_each(move |(k, v)| {
             self.insert(k, v);
         });

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2480,7 +2480,7 @@ impl<'a> FromIterator<Cow<'a, str>> for String {
 #[cfg(not(no_global_oom_handling))]
 #[unstable(feature = "ascii_char", issue = "110998")]
 impl FromIterator<core::ascii::Char> for String {
-    fn from_iter<T: IntoIterator<Item = core::ascii::Char>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = core::ascii::Char>>(iter: I) -> Self {
         let buf = iter.into_iter().map(core::ascii::Char::to_u8).collect();
         // SAFETY: `buf` is guaranteed to be valid UTF-8 because the `core::ascii::Char` type
         // only contains ASCII values (0x00-0x7F), which are valid UTF-8.
@@ -2491,7 +2491,7 @@ impl FromIterator<core::ascii::Char> for String {
 #[cfg(not(no_global_oom_handling))]
 #[unstable(feature = "ascii_char", issue = "110998")]
 impl<'a> FromIterator<&'a core::ascii::Char> for String {
-    fn from_iter<T: IntoIterator<Item = &'a core::ascii::Char>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = &'a core::ascii::Char>>(iter: I) -> Self {
         let buf = iter.into_iter().copied().map(core::ascii::Char::to_u8).collect();
         // SAFETY: `buf` is guaranteed to be valid UTF-8 because the `core::ascii::Char` type
         // only contains ASCII values (0x00-0x7F), which are valid UTF-8.
@@ -3332,7 +3332,7 @@ impl<'a> FromIterator<String> for Cow<'a, str> {
 #[cfg(not(no_global_oom_handling))]
 #[unstable(feature = "ascii_char", issue = "110998")]
 impl<'a> FromIterator<core::ascii::Char> for Cow<'a, str> {
-    fn from_iter<T: IntoIterator<Item = core::ascii::Char>>(it: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = core::ascii::Char>>(it: I) -> Self {
         Cow::Owned(FromIterator::from_iter(it))
     }
 }

--- a/library/alloc/src/wtf8/mod.rs
+++ b/library/alloc/src/wtf8/mod.rs
@@ -423,7 +423,7 @@ impl Wtf8Buf {
 /// This replaces surrogate code point pairs with supplementary code points,
 /// like concatenating ill-formed UTF-16 strings effectively would.
 impl FromIterator<CodePoint> for Wtf8Buf {
-    fn from_iter<T: IntoIterator<Item = CodePoint>>(iter: T) -> Wtf8Buf {
+    fn from_iter<I: IntoIterator<Item = CodePoint>>(iter: I) -> Wtf8Buf {
         let mut string = Wtf8Buf::new();
         string.extend(iter);
         string
@@ -435,7 +435,7 @@ impl FromIterator<CodePoint> for Wtf8Buf {
 /// This replaces surrogate code point pairs with supplementary code points,
 /// like concatenating ill-formed UTF-16 strings effectively would.
 impl Extend<CodePoint> for Wtf8Buf {
-    fn extend<T: IntoIterator<Item = CodePoint>>(&mut self, iter: T) {
+    fn extend<I: IntoIterator<Item = CodePoint>>(&mut self, iter: I) {
         let iterator = iter.into_iter();
         let (low, _high) = iterator.size_hint();
         // Lower bound of one byte per code point (ASCII only)

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -371,7 +371,7 @@ const impl<I: [const] Iterator> IntoIterator for I {
 ///     // This is a bit simpler with the concrete type signature: we can call
 ///     // extend on anything which can be turned into an Iterator which gives
 ///     // us i32s. Because we need i32s to put into MyCollection.
-///     fn extend<T: IntoIterator<Item=i32>>(&mut self, iter: T) {
+///     fn extend<I: IntoIterator<Item=i32>>(&mut self, iter: I) {
 ///
 ///         // The implementation is very straightforward: loop through the
 ///         // iterator, and add() each element to ourselves.
@@ -452,7 +452,7 @@ pub trait Extend<T> {
 
 #[stable(feature = "extend_for_unit", since = "1.28.0")]
 impl Extend<()> for () {
-    fn extend<T: IntoIterator<Item = ()>>(&mut self, iter: T) {
+    fn extend<I: IntoIterator<Item = ()>>(&mut self, iter: I) {
         iter.into_iter().for_each(drop)
     }
     fn extend_one(&mut self, _item: ()) {}
@@ -620,7 +620,7 @@ macro_rules! impl_extend_tuple {
         where
             $($extend_ty: Extend<$ty>,)+
         {
-            fn extend<T: IntoIterator<Item = ($($ty,)+)>>(&mut self, iter: T) {
+            fn extend<Iter: IntoIterator<Item = ($($ty,)+)>>(&mut self, iter: Iter) {
                 default_extend(self, iter)
             }
 

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -97,41 +97,41 @@ use super::TrustedLen;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented(
     on(
-        Self = "&[{A}]",
+        Self = "&[{T}]",
         message = "a slice of type `{Self}` cannot be built since we need to store the elements somewhere",
-        label = "try explicitly collecting into a `Vec<{A}>`",
+        label = "try explicitly collecting into a `Vec<{T}>`",
     ),
     on(
-        all(A = "{integer}", any(Self = "&[{integral}]",)),
+        all(T = "{integer}", any(Self = "&[{integral}]",)),
         message = "a slice of type `{Self}` cannot be built since we need to store the elements somewhere",
-        label = "try explicitly collecting into a `Vec<{A}>`",
+        label = "try explicitly collecting into a `Vec<{T}>`",
     ),
     on(
-        Self = "[{A}]",
+        Self = "[{T}]",
         message = "a slice of type `{Self}` cannot be built since `{Self}` has no definite size",
-        label = "try explicitly collecting into a `Vec<{A}>`",
+        label = "try explicitly collecting into a `Vec<{T}>`",
     ),
     on(
-        all(A = "{integer}", any(Self = "[{integral}]",)),
+        all(T = "{integer}", any(Self = "[{integral}]",)),
         message = "a slice of type `{Self}` cannot be built since `{Self}` has no definite size",
-        label = "try explicitly collecting into a `Vec<{A}>`",
+        label = "try explicitly collecting into a `Vec<{T}>`",
     ),
     on(
-        Self = "[{A}; _]",
+        Self = "[{T}; _]",
         message = "an array of type `{Self}` cannot be built directly from an iterator",
-        label = "try collecting into a `Vec<{A}>`, then using `.try_into()`",
+        label = "try collecting into a `Vec<{T}>`, then using `.try_into()`",
     ),
     on(
-        all(A = "{integer}", any(Self = "[{integral}; _]",)),
+        all(T = "{integer}", any(Self = "[{integral}; _]",)),
         message = "an array of type `{Self}` cannot be built directly from an iterator",
-        label = "try collecting into a `Vec<{A}>`, then using `.try_into()`",
+        label = "try collecting into a `Vec<{T}>`, then using `.try_into()`",
     ),
     message = "a value of type `{Self}` cannot be built from an iterator \
-               over elements of type `{A}`",
-    label = "value of type `{Self}` cannot be built from `std::iter::Iterator<Item={A}>`"
+               over elements of type `{T}`",
+    label = "value of type `{Self}` cannot be built from `std::iter::Iterator<Item={T}>`"
 )]
 #[rustc_diagnostic_item = "FromIterator"]
-pub trait FromIterator<A>: Sized {
+pub trait FromIterator<T>: Sized {
     /// Creates a value from an iterator.
     ///
     /// See the [module-level documentation] for more.
@@ -149,7 +149,7 @@ pub trait FromIterator<A>: Sized {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "from_iter_fn"]
-    fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self;
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self;
 }
 
 /// Conversion into an [`Iterator`].

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -394,7 +394,7 @@ const impl<I: [const] Iterator> IntoIterator for I {
 /// assert_eq!("MyCollection([5, 6, 7, 1, 2, 3])", format!("{c:?}"));
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait Extend<A> {
+pub trait Extend<T> {
     /// Extends a collection with the contents of an iterator.
     ///
     /// As this is the only required method for this trait, the [trait-level] docs
@@ -413,11 +413,11 @@ pub trait Extend<A> {
     /// assert_eq!("abcdef", &message);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn extend<T: IntoIterator<Item = A>>(&mut self, iter: T);
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I);
 
     /// Extends a collection with exactly one element.
     #[unstable(feature = "extend_one", issue = "72631")]
-    fn extend_one(&mut self, item: A) {
+    fn extend_one(&mut self, item: T) {
         self.extend(Some(item));
     }
 
@@ -442,7 +442,7 @@ pub trait Extend<A> {
     // This method is for internal usage only. It is only on the trait because of specialization's limitations.
     #[unstable(feature = "extend_one_unchecked", issue = "none")]
     #[doc(hidden)]
-    unsafe fn extend_one_unchecked(&mut self, item: A)
+    unsafe fn extend_one_unchecked(&mut self, item: T)
     where
         Self: Sized,
     {

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -465,7 +465,7 @@
 //! [`Option`] of a collection of each contained value of the original
 //! [`Option`] values, or [`None`] if any of the elements was [`None`].
 //!
-//! [impl-FromIterator]: Option#impl-FromIterator%3COption%3CA%3E%3E-for-Option%3CV%3E
+//! [impl-FromIterator]: Option#impl-FromIterator%3COption%3CT%3E%3E-for-Option%3CV%3E
 //!
 //! ```
 //! let v = [Some(2), Some(4), None, Some(8)];
@@ -2786,7 +2786,7 @@ unsafe impl<A: TrustedLen> TrustedLen for OptionFlatten<A> {}
 /////////////////////////////////////////////////////////////////////////////
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
+impl<T, V: FromIterator<T>> FromIterator<Option<T>> for Option<V> {
     /// Takes each element in the [`Iterator`]: if it is [`None`][Option::None],
     /// no further elements are taken, and the [`None`][Option::None] is
     /// returned. Should no [`None`][Option::None] occur, a container of type
@@ -2848,7 +2848,7 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
     /// Since the third element caused an underflow, no further elements were taken,
     /// so the final value of `shared` is 6 (= `3 + 2 + 1`), not 16.
     #[inline]
-    fn from_iter<I: IntoIterator<Item = Option<A>>>(iter: I) -> Option<V> {
+    fn from_iter<I: IntoIterator<Item = Option<T>>>(iter: I) -> Option<V> {
         iter::try_process(iter.into_iter(), |i| i.collect())
     }
 }

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -511,7 +511,7 @@
 //! [`Result`] of a collection of each contained value of the original
 //! [`Result`] values, or [`Err`] if any of the elements was [`Err`].
 //!
-//! [impl-FromIterator]: Result#impl-FromIterator%3CResult%3CA,+E%3E%3E-for-Result%3CV,+E%3E
+//! [impl-FromIterator]: Result#impl-FromIterator%3CResult%3CT,+E%3E%3E-for-Result%3CV,+E%3E
 //!
 //! ```
 //! let v = [Ok(2), Ok(4), Err("err!"), Ok(8)];
@@ -2112,7 +2112,7 @@ unsafe impl<A> TrustedLen for IntoIter<A> {}
 /////////////////////////////////////////////////////////////////////////////
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A, E, V: FromIterator<A>> FromIterator<Result<A, E>> for Result<V, E> {
+impl<T, E, V: FromIterator<T>> FromIterator<Result<T, E>> for Result<V, E> {
     /// Takes each element in the `Iterator`: if it is an `Err`, no further
     /// elements are taken, and the `Err` is returned. Should no `Err` occur, a
     /// container with the values of each `Result` is returned.
@@ -2156,7 +2156,7 @@ impl<A, E, V: FromIterator<A>> FromIterator<Result<A, E>> for Result<V, E> {
     /// Since the third element caused an underflow, no further elements were taken,
     /// so the final value of `shared` is 6 (= `3 + 2 + 1`), not 16.
     #[inline]
-    fn from_iter<I: IntoIterator<Item = Result<A, E>>>(iter: I) -> Result<V, E> {
+    fn from_iter<I: IntoIterator<Item = Result<T, E>>>(iter: I) -> Result<V, E> {
         iter::try_process(iter.into_iter(), |i| i.collect())
     }
 }

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -516,7 +516,7 @@ macro_rules! extend_items {
         $(
             #[stable(feature = "token_stream_extend_ts_items", since = "1.92.0")]
             impl Extend<$item> for TokenStream {
-                fn extend<T: IntoIterator<Item = $item>>(&mut self, iter: T) {
+                fn extend<I: IntoIterator<Item = $item>>(&mut self, iter: I) {
                     self.extend(iter.into_iter().map(TokenTree::$item));
                 }
             }

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -3010,7 +3010,7 @@ where
     ///
     /// If the iterator produces any pairs with equal keys,
     /// all but one of the corresponding values will be dropped.
-    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> HashMap<K, V, S> {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> HashMap<K, V, S> {
         let mut map = HashMap::with_hasher(Default::default());
         map.extend(iter);
         map
@@ -3027,7 +3027,7 @@ where
     A: Allocator,
 {
     #[inline]
-    fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
+    fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
         self.base.extend(iter)
     }
 
@@ -3051,7 +3051,7 @@ where
     A: Allocator,
 {
     #[inline]
-    fn extend<T: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: T) {
+    fn extend<I: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: I) {
         self.base.extend(iter)
     }
 

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1815,7 +1815,7 @@ impl FromStr for OsString {
 #[stable(feature = "osstring_extend", since = "1.52.0")]
 impl Extend<OsString> for OsString {
     #[inline]
-    fn extend<T: IntoIterator<Item = OsString>>(&mut self, iter: T) {
+    fn extend<I: IntoIterator<Item = OsString>>(&mut self, iter: I) {
         for s in iter {
             self.push(&s);
         }
@@ -1825,7 +1825,7 @@ impl Extend<OsString> for OsString {
 #[stable(feature = "osstring_extend", since = "1.52.0")]
 impl<'a> Extend<&'a OsStr> for OsString {
     #[inline]
-    fn extend<T: IntoIterator<Item = &'a OsStr>>(&mut self, iter: T) {
+    fn extend<I: IntoIterator<Item = &'a OsStr>>(&mut self, iter: I) {
         for s in iter {
             self.push(s);
         }
@@ -1835,7 +1835,7 @@ impl<'a> Extend<&'a OsStr> for OsString {
 #[stable(feature = "osstring_extend", since = "1.52.0")]
 impl<'a> Extend<Cow<'a, OsStr>> for OsString {
     #[inline]
-    fn extend<T: IntoIterator<Item = Cow<'a, OsStr>>>(&mut self, iter: T) {
+    fn extend<I: IntoIterator<Item = Cow<'a, OsStr>>>(&mut self, iter: I) {
         for s in iter {
             self.push(&s);
         }

--- a/tests/ui/suggestions/missing-assoc-fn.stderr
+++ b/tests/ui/suggestions/missing-assoc-fn.stderr
@@ -19,7 +19,7 @@ error[E0046]: not all trait items implemented, missing: `from_iter`
 LL | impl FromIterator<()> for X {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `from_iter` in implementation
    |
-   = help: implement the missing item: `fn from_iter<T: IntoIterator<Item = ()>>(_: T) -> Self { todo!() }`
+   = help: implement the missing item: `fn from_iter<I: IntoIterator<Item = ()>>(_: I) -> Self { todo!() }`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/semi-suggestion-when-stmt-and-expr-span-equal.stderr
+++ b/tests/ui/suggestions/semi-suggestion-when-stmt-and-expr-span-equal.stderr
@@ -20,7 +20,7 @@ LL |         .collect::<String>();
    |          required by a bound introduced by this call
    |
    = help: the trait `FromIterator<()>` is not implemented for `String`
-   = help: `String` implements trait `FromIterator<A>`:
+   = help: `String` implements trait `FromIterator<T>`:
              FromIterator<&char>
              FromIterator<&std::ascii::Char>
              FromIterator<&str>


### PR DESCRIPTION
<!-- homu-ignore:start -->
Okay, first some context:

When talking about the `Extend` trait in a recent meeting, it got really confusing to talk about properties of the `Extend` trait for a moment because the naming convention on the trait was ***so weird***. It's defined as `Extend<A>` and has a method `extend<T>`. But most generic implementations of it look like <code>impl\<T> Extend\<T> for <em>…iterator-type…</em></code>, calling the item type `T`.

I think `T` is quite sensible for the item type here, so let's change it in the trait definition as well!

That means that `<T>` for the `extend` method must go away.. what is that anyway? Yes, it't the `IntoIterator` parameter that you extend with. Why isn't that just `I` anyway? Let's choose that! It will be more consistent with existing things like `impl<I: Iterator> IntoIterator for I` for instance. Or e.g. all of *these…* 🦀

<img height="500" src="https://github.com/user-attachments/assets/94a02176-ceeb-45f9-b13d-fbaad522eff6" />

I've then also noticed `FromIterator` has the same problem of calling the item `A` and using `T: IntoIterator`. Let's change that, too.

....and then of course, there are a “handful” of implementations of these methods that *did* just copy the signature for `fn extend<T>` or `fn from_iter<T>`, so I guess I'm fixing these as well.

---

TL;DR:
<!-- homu-ignore:end -->
Change
```rs
pub trait Extend<A> {
    fn extend<T: IntoIterator<Item = A>>(&mut self, iter: T);
    …
}
```
to
```rs
pub trait Extend<T> {
    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I);
    …
}
```

to be more consistent with common use of `T` as the item type in containers, and their `Extend` impls; and use `I` as the name for the `IntoIterator` type.

<!-- homu-ignore:start -->
(first commit)

then <!-- homu-ignore:end -->also do the basically the same thing for `FromIterator<A>`→`FromIterator<T>` as well

<!-- homu-ignore:start -->
(second commit)

Finally, adjust <!-- homu-ignore:start -->~~a few~~ a lot of <!-- homu-ignore:end -->cases of these parameters in trait impls for the abovementioned traits.
<!-- homu-ignore:start -->

(third commit)

<!-- homu-ignore:end -->
These changes obviously don't change/break behavior of the traits and its users, but the improve the way the documentation of the traits renders (the improvement is the more sensible and more consistent names for the parameters). The only downside I'm aware of (besides that this is touching quite a few files..<!-- homu-ignore:start --> though I don't feel quite as strongly about all those impls needing change as about the trait definition itself<!-- homu-ignore:end -->) is that this does affect some link anchor names in *some* cases. E.g.
```diff
- impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
+ impl<T, V: FromIterator<T>> FromIterator<Option<T>> for Option<V> {
```
would mean that [doc.rust-lang.org/core/iter/trait.FromIterator.html#impl-FromIterator<Option\<A>>-for-Option\<V>](https://doc.rust-lang.org/core/iter/trait.FromIterator.html#impl-FromIterator%3COption%3CA%3E%3E-for-Option%3CV%3E) no longer works, as it changes `…#impl-FromIterator<Option<A>>-for-Option<V>` to `…#impl-FromIterator<Option<T>>-for-Option<V>`