### PR TITLE
Optimize memchr with NEON

### DIFF
--- a/library/core/src/slice/memchr.rs
+++ b/library/core/src/slice/memchr.rs
@@ -3,7 +3,9 @@
 
 use crate::intrinsics::const_eval_select;
 
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 const LO_USIZE: usize = usize::repeat_u8(0x01);
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 const HI_USIZE: usize = usize::repeat_u8(0x80);
 const USIZE_BYTES: usize = size_of::<usize>();
 
@@ -14,6 +16,7 @@ const USIZE_BYTES: usize = size_of::<usize>();
 /// "The idea is to subtract one from each of the bytes and then look for
 /// bytes where the borrow propagated all the way to the most significant
 /// bit."
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 #[inline]
 const fn contains_zero_byte(x: usize) -> bool {
     x.wrapping_sub(LO_USIZE) & !x & HI_USIZE != 0
@@ -25,7 +28,7 @@ const fn contains_zero_byte(x: usize) -> bool {
 pub const fn memchr(x: u8, text: &[u8]) -> Option<usize> {
     // Fast path for small slices.
     let result =
-        if text.len() < 2 * USIZE_BYTES { memchr_naive(x, text) } else { memchr_aligned(x, text) };
+        if text.len() < 2 * USIZE_BYTES { memchr_naive(x, text) } else { memchr_wide(x, text) };
     if let Some(index) = result {
         // SAFETY: Both implementations only return an index from within `text`.
         unsafe { crate::hint::assert_unchecked(index < text.len()) };
@@ -50,7 +53,7 @@ const fn memchr_naive(x: u8, text: &[u8]) -> Option<usize> {
 }
 
 #[rustc_allow_const_fn_unstable(const_eval_select)] // fallback impl has same behavior
-const fn memchr_aligned(x: u8, text: &[u8]) -> Option<usize> {
+const fn memchr_wide(x: u8, text: &[u8]) -> Option<usize> {
     // The runtime version behaves the same as the compiletime version, it's
     // just more optimized.
     const_eval_select!(
@@ -58,68 +61,156 @@ const fn memchr_aligned(x: u8, text: &[u8]) -> Option<usize> {
         if const {
             memchr_naive(x, text)
         } else {
-            // Scan for a single byte value by reading two `usize` words at a time.
-            //
-            // Split `text` in three parts
-            // - unaligned initial part, before the first word aligned address in text
-            // - body, scan by 2 words at a time
-            // - the last remaining part, < 2 word size
-
-            // search up to an aligned boundary
-            let len = text.len();
-            let ptr = text.as_ptr();
-            let mut offset = ptr.align_offset(USIZE_BYTES);
-
-            if offset > 0 {
-                offset = offset.min(len);
-                let slice = &text[..offset];
-                if let Some(index) = memchr_naive(x, slice) {
-                    return Some(index);
-                }
-            }
-
-            // search the body of the text
-            let repeated_x = usize::repeat_u8(x);
-            while offset <= len - 2 * USIZE_BYTES {
-                // SAFETY: the while's predicate guarantees a distance of at least 2 * usize_bytes
-                // between the offset and the end of the slice.
-                unsafe {
-                    let u = *(ptr.add(offset) as *const usize);
-                    let v = *(ptr.add(offset + USIZE_BYTES) as *const usize);
-
-                    // break if there is a matching byte
-                    let zu = contains_zero_byte(u ^ repeated_x);
-                    let zv = contains_zero_byte(v ^ repeated_x);
-                    if zu || zv {
-                        break;
-                    }
-                }
-                offset += USIZE_BYTES * 2;
-            }
-
-            // Find the byte after the point the body loop stopped.
-            // FIXME(const-hack): Use `?` instead.
-            // FIXME(const-hack, fee1-dead): use range slicing
-            let slice =
-            // SAFETY: offset is within bounds
-                unsafe { super::from_raw_parts(text.as_ptr().add(offset), text.len() - offset) };
-            if let Some(i) = memchr_naive(x, slice) { Some(offset + i) } else { None }
+            #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+            { memchr_vectored(x, text) }
+            #[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
+            { memchr_aligned(x, text) }
         }
     )
+}
+
+/// Scan for a single byte value by reading two `usize` words at a time.
+///
+/// Only called from the runtime arm of `memchr_wide`'s `const_eval_select`,
+/// so it does not need to be (and cannot be: `align_offset`) a `const fn`.
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
+fn memchr_aligned(x: u8, text: &[u8]) -> Option<usize> {
+    // Split `text` in three parts
+    // - unaligned initial part, before the first word aligned address in text
+    // - body, scan by 2 words at a time
+    // - the last remaining part, < 2 word size
+
+    // search up to an aligned boundary
+    let len = text.len();
+    let ptr = text.as_ptr();
+    let mut offset = ptr.align_offset(USIZE_BYTES);
+
+    if offset > 0 {
+        offset = offset.min(len);
+        let slice = &text[..offset];
+        if let Some(index) = memchr_naive(x, slice) {
+            return Some(index);
+        }
+    }
+
+    // search the body of the text
+    let repeated_x = usize::repeat_u8(x);
+    while offset <= len - 2 * USIZE_BYTES {
+        // SAFETY: the while's predicate guarantees a distance of at least 2 * usize_bytes
+        // between the offset and the end of the slice.
+        unsafe {
+            let u = *(ptr.add(offset) as *const usize);
+            let v = *(ptr.add(offset + USIZE_BYTES) as *const usize);
+
+            // break if there is a matching byte
+            let zu = contains_zero_byte(u ^ repeated_x);
+            let zv = contains_zero_byte(v ^ repeated_x);
+            if zu || zv {
+                break;
+            }
+        }
+        offset += USIZE_BYTES * 2;
+    }
+
+    // Find the byte after the point the body loop stopped.
+    // LLVM cannot prove `offset <= len` here, so `&text[offset..]`
+    // emits an unreachable  bounds-check panic branch.
+    // SAFETY: offset is within bounds
+    let slice = unsafe { super::from_raw_parts(ptr.add(offset), len - offset) };
+    memchr_naive(x, slice).map(|i| offset + i)
+}
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+const CHUNK_SIZE: usize = 64;
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+const VECTOR_SIZE: usize = 16;
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[inline]
+fn chunk_contains(x: u8, chunk: &[u8; CHUNK_SIZE]) -> bool {
+    use crate::simd::cmp::SimdPartialEq;
+    use crate::simd::u8x16;
+
+    let needle = u8x16::splat(x);
+    let (vectors, _) = chunk.as_chunks::<VECTOR_SIZE>();
+    let any = u8x16::from_array(vectors[0]).simd_eq(needle)
+        | u8x16::from_array(vectors[1]).simd_eq(needle)
+        | u8x16::from_array(vectors[2]).simd_eq(needle)
+        | u8x16::from_array(vectors[3]).simd_eq(needle);
+    any.any()
+}
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[inline]
+fn vector_contains(x: u8, vector: &[u8; VECTOR_SIZE]) -> bool {
+    use crate::simd::cmp::SimdPartialEq;
+    use crate::simd::u8x16;
+
+    u8x16::from_array(*vector).simd_eq(u8x16::splat(x)).any()
+}
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[inline]
+fn memchr_vectored(x: u8, text: &[u8]) -> Option<usize> {
+    // Main loop: one any-match reduction per 64 bytes, so the long-latency
+    // horizontal reduction runs once per four vectors rather than per load.
+    let (chunks, _) = text.as_chunks::<CHUNK_SIZE>();
+    let mut offset = 0;
+    for chunk in chunks {
+        if chunk_contains(x, chunk) {
+            break;
+        }
+        offset += CHUNK_SIZE;
+    }
+
+    // SAFETY: `offset` advances by whole chunks of the `as_chunks`
+    // decomposition, so `offset <= text.len()`.
+    unsafe { crate::hint::assert_unchecked(offset <= text.len()) };
+
+    // Single-vector steps: sweep the tail left by the unrolled loop, and
+    // narrow a 64-byte hit down to the 16-byte block containing the match.
+    let (vectors, _) = text[offset..].as_chunks::<VECTOR_SIZE>();
+    for vector in vectors {
+        if vector_contains(x, vector) {
+            break;
+        }
+        offset += VECTOR_SIZE;
+    }
+
+    // SAFETY: as above, `offset` only advanced by whole vectors.
+    unsafe { crate::hint::assert_unchecked(offset <= text.len()) };
+
+    // Exact index recovery within the candidate 16-byte block, or the final
+    // < 16-byte scalar tail.
+    match text[offset..].iter().position(|&b| b == x) {
+        Some(i) => Some(offset + i),
+        None => None,
+    }
 }
 
 /// Returns the last index matching the byte `x` in `text`.
 #[inline]
 #[must_use]
 pub fn memrchr(x: u8, text: &[u8]) -> Option<usize> {
-    let result = memrchr_aligned(x, text);
+    let result = {
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            memrchr_vectored(x, text)
+        }
+        #[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
+        {
+            memrchr_aligned(x, text)
+        }
+    };
     if let Some(index) = result {
-        // SAFETY: `memrchr_aligned` only returns the index of a matching byte in `text`.
+        // SAFETY: every implementation only returns the index of a matching byte in `text`.
         unsafe { crate::hint::assert_unchecked(index < text.len()) };
     }
     result
 }
 
+#[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
 fn memrchr_aligned(x: u8, text: &[u8]) -> Option<usize> {
     // Scan for a single byte value by reading two `usize` words at a time.
     //
@@ -170,4 +261,34 @@ fn memrchr_aligned(x: u8, text: &[u8]) -> Option<usize> {
 
     // Find the byte before the point the body loop stopped.
     text[..offset].iter().rposition(|elt| *elt == x)
+}
+
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[inline]
+fn memrchr_vectored(x: u8, text: &[u8]) -> Option<usize> {
+    let (_, chunks) = text.as_rchunks::<CHUNK_SIZE>();
+    let mut end = text.len();
+    for chunk in chunks.iter().rev() {
+        if chunk_contains(x, chunk) {
+            break;
+        }
+        end -= CHUNK_SIZE;
+    }
+
+    // SAFETY: `end` decreases by whole chunks of the `as_rchunks`
+    // decomposition, so `end <= text.len()`.
+    unsafe { crate::hint::assert_unchecked(end <= text.len()) };
+
+    let (_, vectors) = text[..end].as_rchunks::<VECTOR_SIZE>();
+    for vector in vectors.iter().rev() {
+        if vector_contains(x, vector) {
+            break;
+        }
+        end -= VECTOR_SIZE;
+    }
+
+    // SAFETY: as above, `end` only decreased by whole vectors.
+    unsafe { crate::hint::assert_unchecked(end <= text.len()) };
+
+    text[..end].iter().rposition(|&b| b == x)
 }

--- a/library/coretests/benches/lib.rs
+++ b/library/coretests/benches/lib.rs
@@ -9,6 +9,7 @@
 #![feature(iter_next_chunk)]
 #![feature(iter_advance_by)]
 #![feature(num_internals)]
+#![feature(slice_internals)]
 #![feature(uint_gather_scatter_bits)]
 #![allow(internal_features)]
 

--- a/library/coretests/benches/slice.rs
+++ b/library/coretests/benches/slice.rs
@@ -171,3 +171,79 @@ fn fold_to_last(b: &mut Bencher) {
     let slice: &[i32] = &[0; 1024];
     b.iter(|| black_box(slice).iter().fold(None, |_, r| Some(NonNull::from(r))));
 }
+
+mod memchr_benches {
+    use core::slice::memchr::{memchr, memrchr};
+
+    use test::{Bencher, black_box};
+
+    // Match-position buckets per length: none (pure throughput), first
+    // (latency floor), and last (full scan + exact index recovery).
+    macro_rules! memchr_benches {
+        ($($name:ident, $len:expr;)+) => {
+            $(
+                mod $name {
+                    use super::*;
+
+                    const LEN: usize = $len;
+                    const NEEDLE: u8 = b'z';
+
+                    fn buf(matches: &[usize]) -> Vec<u8> {
+                        let mut v = vec![0x55u8; LEN];
+                        for &m in matches {
+                            v[m] = NEEDLE;
+                        }
+                        v
+                    }
+
+                    #[bench]
+                    fn fwd_match_none(b: &mut Bencher) {
+                        let v = buf(&[]);
+                        b.iter(|| black_box(memchr(black_box(NEEDLE), black_box(&v))));
+                    }
+
+                    #[bench]
+                    fn fwd_match_first(b: &mut Bencher) {
+                        let v = buf(&[0]);
+                        b.iter(|| black_box(memchr(black_box(NEEDLE), black_box(&v))));
+                    }
+
+                    #[bench]
+                    fn fwd_match_last(b: &mut Bencher) {
+                        let v = buf(&[LEN - 1]);
+                        b.iter(|| black_box(memchr(black_box(NEEDLE), black_box(&v))));
+                    }
+
+                    #[bench]
+                    fn rev_match_none(b: &mut Bencher) {
+                        let v = buf(&[]);
+                        b.iter(|| black_box(memrchr(black_box(NEEDLE), black_box(&v))));
+                    }
+
+                    #[bench]
+                    fn rev_match_first(b: &mut Bencher) {
+                        // Worst case for memrchr: scans the whole buffer backwards.
+                        let v = buf(&[0]);
+                        b.iter(|| black_box(memrchr(black_box(NEEDLE), black_box(&v))));
+                    }
+
+                    #[bench]
+                    fn rev_match_last(b: &mut Bencher) {
+                        let v = buf(&[LEN - 1]);
+                        b.iter(|| black_box(memrchr(black_box(NEEDLE), black_box(&v))));
+                    }
+                }
+            )+
+        };
+    }
+
+    memchr_benches! {
+        len_0016, 16;
+        len_0032, 32;
+        len_0064, 64;
+        len_0256, 256;
+        len_1k, 1024;
+        len_4k, 4096;
+        len_64k, 65536;
+    }
+}

--- a/library/coretests/tests/slice.rs
+++ b/library/coretests/tests/slice.rs
@@ -1891,6 +1891,90 @@ pub mod memchr {
             assert_eq!(Some(pos - start), memrchr(needle, &data[start..]));
         }
     }
+
+    // Differential matrix across lengths, alignments, needles and match
+    // shapes, verifying the platform-specific (SWAR/NEON/SVE) paths against
+    // a naive scalar scan. `memchr` must return the first match and
+    // `memrchr` the last.
+    #[test]
+    fn exhaustive_matrix() {
+        const MAX_LEN: usize = 1024;
+        let lengths = [
+            0usize, 1, 2, 7, 8, 15, 16, 17, 31, 32, 33, 47, 48, 63, 64, 65, 95, 96, 127, 128, 129,
+            255, 256, 257, 511, 512, 1023, 1024,
+        ];
+        let needles = [0x00u8, 0x55, 0x80, 0xff, b'z'];
+        let mut backing = [0u8; MAX_LEN + 16];
+
+        for len in lengths {
+            for align in 0..=16usize {
+                for x in needles {
+                    let filler = if x == 0x55 { 0xAA } else { 0x55 };
+                    let mut positions: Vec<Option<usize>> = vec![None];
+                    for p in [
+                        0usize,
+                        1,
+                        15,
+                        16,
+                        17,
+                        31,
+                        32,
+                        63,
+                        64,
+                        65,
+                        len.wrapping_sub(2),
+                        len.wrapping_sub(1),
+                    ] {
+                        if p < len {
+                            positions.push(Some(p));
+                        }
+                    }
+
+                    for pos in positions {
+                        let buf = &mut backing[align..align + len];
+                        buf.fill(filler);
+                        if let Some(p) = pos {
+                            buf[p] = x;
+                        }
+                        let buf = &backing[align..align + len];
+                        let expected_first = buf.iter().position(|&b| b == x);
+                        let expected_last = buf.iter().rposition(|&b| b == x);
+                        assert_eq!(
+                            memchr(x, buf),
+                            expected_first,
+                            "memchr len={len} align={align} x={x:#x} pos={pos:?}"
+                        );
+                        assert_eq!(
+                            memrchr(x, buf),
+                            expected_last,
+                            "memrchr len={len} align={align} x={x:#x} pos={pos:?}"
+                        );
+                    }
+
+                    // Multiple matches: first + middle + last must not
+                    // confuse first/last recovery.
+                    if len >= 3 {
+                        let buf = &mut backing[align..align + len];
+                        buf.fill(filler);
+                        buf[0] = x;
+                        buf[len / 2] = x;
+                        buf[len - 1] = x;
+                        let buf = &backing[align..align + len];
+                        assert_eq!(
+                            memchr(x, buf),
+                            Some(0),
+                            "memchr multi len={len} align={align} x={x:#x}"
+                        );
+                        assert_eq!(
+                            memrchr(x, buf),
+                            Some(len - 1),
+                            "memrchr multi len={len} align={align} x={x:#x}"
+                        );
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Result:

## 1. memchr: 
Benchmark | Length | Before (ns/iter) | After (ns/iter) | Speedup (x)
-- | -- | -- | -- | --
fwd_match_first | 16 | 3.80 | 3.45 | 1.10
  | 32 | 3.79 | 3.45 | 1.10
  | 64 | 3.79 | 3.80 | 1.0
  | 256 | 3.80 | 3.80 | 1.0
  | 1k | 3.80 | 3.80 | 1.0
  | 4k | 3.79 | 3.80 | 1.0
  | 64k | 3.79 | 3.80 | 1.0
fwd_match_last | 16 | 9.66 | 9.32 | 1.04
  | 32 | 10.01 | 9.66 | 1.04
  | 64 | 12.65 | 11.41 | 1.11
  | 256 | 28.74 | 14.15 | 2.03
  | 1k | 89.09 | 31.60 | 2.82
  | 4k | 336.51 | 90.49 | 3.72
  | 64k | 5098.57 | 1761.04 | 2.90
fwd_match_none | 16 | 3.45 | 3.11 | 1.11
  | 32 | 4.17 | 3.45 | 1.21
  | 64 | 6.25 | 3.45 | 1.81
  | 256 | 21.11 | 6.56 | 3.22
  | 1k | 81.11 | 27.22 | 2.98
  | 4k | 321.08 | 92.32 | 3.48
  | 64k | 5107.51 | 1389.31 | 3.68
rev_match_first | 16 | 10.39 | 8.06 | 1.29
  | 32 | 12.42 | 8.51 | 1.46
  | 64 | 16.67 | 10.92 | 1.53
  | 256 | 30.79 | 13.06 | 2.36
  | 1k | 93.71 | 31.24 | 3.00
  | 4k | 350.16 | 85.71 | 4.09
  | 64k | 5364.25 | 1638.84 | 3.27
rev_match_last | 16 | 4.36 | 2.11 | 2.07
  | 32 | 4.35 | 2.11 | 2.06
  | 64 | 4.30 | 3.14 | 1.37
  | 256 | 4.34 | 3.12 | 1.39
  | 1k | 4.29 | 3.13 | 1.37
  | 4k | 4.30 | 3.12 | 1.38
  | 64k | 4.29 | 3.34 | 1.28
rev_match_none | 16 | 4.23 | 2.21 | 1.91
  | 32 | 6.79 | 2.25 | 3.02
  | 64 | 7.78 | 2.87 | 2.71
  | 256 | 23.83 | 6.99 | 3.41
  | 1k | 86.16 | 23.19 | 3.72
  | 4k | 346.42 | 83.58 | 4.14
  | 64k | 5368.44 | 1704.41 | 3.15

## 2 pattern

Benchmark | Before (ns/iter) | After (ns/iter) | Speedup (x)
-- | -- | -- | --
find_1byte_str_long_match_end | 5180.74 | 1182.60 | 4.38
rfind_char_long_nomatch | 5351.41 | 1279.11 | 4.18
rfind_1byte_str_long_nomatch | 5391.75 | 1302.14 | 4.14
find_char_long_match_end | 5096.61 | 1242.24 | 4.10
find_1byte_str_long_nomatch | 5172.59 | 1286.60 | 4.02
find_char_long_nomatch | 5104.69 | 1318.24 | 3.87
split_char_sparse | 14326.42 | 4654.07 | 3.08
split_1byte_str_sparse | 16889.26 | 7111.13 | 2.37
split_char_multibyte_haystack | 69253.86 | 62913.94 | 1.10
split_1byte_str_multibyte_haystack | 80609.83 | 78901.17 | 1.02
find_str_worst_case | 1482.15 | 1460.42 | 1.01
split_char_dense | 42748.78 | 43158.21 | 0.99
find_str | 7090.74 | 7093.10 | 1.00
find_char_early_return | 7787.22 | 7784.51 | 1.00
starts_with_str | 4597.53 | 4599.39 | 1.00
starts_with_char | 4598.04 | 4598.76 | 1.00
ends_with_str | 4598.14 | 4599.04 | 1.00
ends_with_char | 4597.97 | 4600.08 | 1.00
find_1byte_str_short_haystack | 9242.62 | 9314.57 | 0.99
split_1byte_str_dense | 54059.19 | 55237.39 | 0.98
find_1byte_str_early_return | 11512.55 | 12162.06 | 0.95
find_char_short_haystack | 5313.39 | 5569.64 | 0.95
rfind_str_worst_case | 23512.81 | 24622.20 | 0.95
rfind_str | 5708.62 | 6225.30 | 0.92
