### PR TITLE
Configure LLM policy URL for triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1581,6 +1581,7 @@ cc = ["@rust-lang/wg-const-eval"]
 [assign]
 warn_non_default_branch.enable = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
+llm_policy_url = "https://forge.rust-lang.org/policies/llm-usage.html"
 
 [[assign.warn_non_default_branch.exceptions]]
 title = "[beta"


### PR DESCRIPTION
Implemented in https://github.com/rust-lang/triagebot/pull/2486, documented in https://github.com/rust-lang/rust-forge/pull/1099.

CC @jyn514

r? Urgau
