### PR TITLE
Improve diagnostics for references to closures

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -210,6 +210,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
                 steps
             }),
+            infer_closure_kind: Box::new(|closure_def_id| {
+                self.infer_closure_kind_for_diagnostic(closure_def_id)
+            }),
         }
     }
 }

--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -81,6 +81,83 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // it's our job to process these.
         assert!(self.deferred_call_resolutions.borrow().is_empty());
     }
+
+    pub(crate) fn infer_closure_kind_for_diagnostic(
+        &self,
+        closure_def_id: LocalDefId,
+    ) -> Option<(ty::ClosureKind, Option<(Span, Place<'tcx>)>)> {
+        let hir_id = self.tcx.local_def_id_to_hir_id(closure_def_id);
+        let hir::Node::Expr(expr) = self.tcx.hir_node_by_def_id(closure_def_id) else {
+            return None;
+        };
+        let hir::ExprKind::Closure(&hir::Closure {
+            capture_clause,
+            body: body_id,
+            explicit_captures,
+            ..
+        }) = expr.kind
+        else {
+            return None;
+        };
+        let body = self.tcx.hir_body(body_id);
+
+        // We cannot reliably infer the closure kind if there are nested closures whose
+        // captures have not yet been analyzed.
+        struct HasNestedClosure(bool);
+        impl<'v> Visitor<'v> for HasNestedClosure {
+            fn visit_expr(&mut self, expr: &'v hir::Expr<'v>) {
+                if matches!(expr.kind, hir::ExprKind::Closure(..)) {
+                    self.0 = true;
+                    return;
+                }
+                intravisit::walk_expr(self, expr);
+            }
+        }
+        let mut has_nested = HasNestedClosure(false);
+        has_nested.visit_body(body);
+        if has_nested.0 {
+            return None;
+        }
+
+        let closure_fcx = FnCtxt::new(self, self.tcx.param_env(closure_def_id), closure_def_id);
+
+        let mut delegate = InferBorrowKind {
+            fcx: &closure_fcx,
+            closure_def_id,
+            capture_information: Default::default(),
+            fake_reads: Default::default(),
+        };
+
+        let _ = euv::ExprUseVisitor::new(&closure_fcx, &mut delegate).consume_body(body);
+
+        for capture in explicit_captures {
+            let place = closure_fcx.place_for_root_variable(closure_def_id, capture.var_hir_id);
+            delegate.consume(&PlaceWithHirId { hir_id: capture.var_hir_id, place }, hir_id);
+        }
+
+        let (_, closure_kind, mut origin) = self
+            .process_collected_capture_information(capture_clause, &delegate.capture_information);
+
+        // Bail out if a by-value capture has unresolved inference variables, since
+        // fallback might later resolve the type to `Copy` (making the closure `Fn`).
+        if closure_kind == ty::ClosureKind::FnOnce {
+            for (place, capture_info) in &delegate.capture_information {
+                if matches!(capture_info.capture_kind, ty::UpvarCapture::ByValue)
+                    && place.ty().has_infer()
+                {
+                    return None;
+                }
+            }
+        }
+
+        if !enable_precise_capture(expr.span) {
+            if let Some((_, ref mut place)) = origin {
+                place.projections.clear();
+            }
+        }
+
+        Some((closure_kind, origin))
+    }
 }
 
 /// Intermediate format to store the hir_id pointing to the use that resulted in the

--- a/compiler/rustc_trait_selection/src/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/mod.rs
@@ -25,6 +25,14 @@ pub struct TypeErrCtxt<'a, 'tcx> {
     pub diverging_fallback_has_occurred: bool,
 
     pub autoderef_steps: Box<dyn Fn(Ty<'tcx>) -> Vec<(Ty<'tcx>, PredicateObligations<'tcx>)> + 'a>,
+    pub infer_closure_kind: Box<
+        dyn Fn(
+                rustc_hir::def_id::LocalDefId,
+            ) -> Option<(
+                ty::ClosureKind,
+                Option<(rustc_span::Span, rustc_middle::hir::place::Place<'tcx>)>,
+            )> + 'a,
+    >,
 }
 
 #[extension(pub trait InferCtxtErrorExt<'tcx>)]
@@ -41,6 +49,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 debug_assert!(false, "shouldn't be using autoderef_steps outside of typeck");
                 vec![(ty, PredicateObligations::new())]
             }),
+            infer_closure_kind: Box::new(|_| None),
         }
     }
 }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -996,18 +996,25 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
         }
 
-        let self_ty = trait_pred.self_ty().skip_binder();
+        let original_self_ty = trait_pred.self_ty().skip_binder();
+        let peeled_self_ty = original_self_ty.peel_refs();
 
-        let (expected_kind, trait_prefix) =
+        let is_ref_to_closure = matches!(original_self_ty.kind(), ty::Ref(..))
+            && matches!(peeled_self_ty.kind(), ty::Closure(..));
+
+        let self_ty = if is_ref_to_closure { peeled_self_ty } else { original_self_ty };
+
+        let (expected_kind, is_async) =
             if let Some(expected_kind) = self.tcx.fn_trait_kind_from_def_id(trait_pred.def_id()) {
-                (expected_kind, "")
+                (expected_kind, false)
             } else if let Some(expected_kind) =
                 self.tcx.async_fn_trait_kind_from_def_id(trait_pred.def_id())
             {
-                (expected_kind, "Async")
+                (expected_kind, true)
             } else {
                 return None;
             };
+        let trait_prefix = if is_async { "Async" } else { "" };
 
         let (closure_def_id, found_args, has_self_borrows) = match *self_ty.kind() {
             ty::Closure(def_id, args) => {
@@ -1036,7 +1043,20 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             return None;
         }
 
-        if let Some(found_kind) = self.closure_kind(self_ty)
+        let mut found_kind = self.closure_kind(self_ty);
+        let mut kind_origin = None;
+
+        if found_kind.is_none()
+            && is_ref_to_closure
+            && !is_async
+            && let Some(local_def_id) = closure_def_id.as_local()
+            && let Some((inferred_kind, origin)) = (self.infer_closure_kind)(local_def_id)
+        {
+            found_kind = Some(inferred_kind);
+            kind_origin = origin;
+        }
+
+        if let Some(found_kind) = found_kind
             && !found_kind.extends(expected_kind)
         {
             let mut err = self.report_closure_error(
@@ -1045,6 +1065,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 found_kind,
                 expected_kind,
                 trait_prefix,
+                kind_origin,
             );
             self.note_obligation_cause(&mut err, &obligation);
             return Some(err.emit());
@@ -3526,6 +3547,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         found_kind: ty::ClosureKind,
         kind: ty::ClosureKind,
         trait_prefix: &'static str,
+        kind_origin: Option<(Span, rustc_middle::hir::place::Place<'tcx>)>,
     ) -> Diag<'a> {
         let closure_span = self.tcx.def_span(closure_def_id);
 
@@ -3541,25 +3563,29 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
         // Additional context information explaining why the closure only implements
         // a particular trait.
-        if let Some(typeck_results) = &self.typeck_results {
-            let hir_id = self.tcx.local_def_id_to_hir_id(closure_def_id.expect_local());
-            match (found_kind, typeck_results.closure_kind_origins().get(hir_id)) {
-                (ty::ClosureKind::FnOnce, Some((span, place))) => {
-                    err.fn_once_label = Some(ClosureFnOnceLabel {
-                        span: *span,
-                        place: ty::place_to_string_for_capture(self.tcx, place),
-                        trait_prefix,
-                    })
-                }
-                (ty::ClosureKind::FnMut, Some((span, place))) => {
-                    err.fn_mut_label = Some(ClosureFnMutLabel {
-                        span: *span,
-                        place: ty::place_to_string_for_capture(self.tcx, place),
-                        trait_prefix,
-                    })
-                }
-                _ => {}
+        let origin = kind_origin.or_else(|| {
+            let typeck_results = self.typeck_results.as_ref()?;
+            let local_def_id = closure_def_id.as_local()?;
+            let hir_id = self.tcx.local_def_id_to_hir_id(local_def_id);
+            typeck_results.closure_kind_origins().get(hir_id).cloned()
+        });
+
+        match (found_kind, origin) {
+            (ty::ClosureKind::FnOnce, Some((span, place))) => {
+                err.fn_once_label = Some(ClosureFnOnceLabel {
+                    span,
+                    place: ty::place_to_string_for_capture(self.tcx, &place),
+                    trait_prefix,
+                })
             }
+            (ty::ClosureKind::FnMut, Some((span, place))) => {
+                err.fn_mut_label = Some(ClosureFnMutLabel {
+                    span,
+                    place: ty::place_to_string_for_capture(self.tcx, &place),
+                    trait_prefix,
+                })
+            }
+            _ => {}
         }
 
         self.dcx().create_err(err)

--- a/tests/ui/closures/closure-ref-fn-kind-mismatch-issue-161327.rs
+++ b/tests/ui/closures/closure-ref-fn-kind-mismatch-issue-161327.rs
@@ -1,0 +1,73 @@
+fn req_fn(_: impl Fn(&'static str) -> String) {}
+fn req_fn_mut(_: impl FnMut(&'static str) -> String) {}
+
+fn test_fn_mut_passed_as_mut_ref_to_fn() {
+    let mut v = Vec::new();
+    let mut accumulate = |x| {
+        //~^ ERROR E0525
+        v.push(x);
+        v.join("/")
+    };
+    req_fn(&mut accumulate);
+}
+
+fn test_fn_once_passed_as_mut_ref_to_fn() {
+    let s = String::new();
+    let mut consume = move |_x| {
+        //~^ ERROR E0525
+        drop(s);
+        String::new()
+    };
+    req_fn(&mut consume);
+}
+
+fn test_fn_once_passed_as_mut_ref_to_fn_mut() {
+    let s = String::new();
+    let mut consume = move |_x| {
+        //~^ ERROR E0525
+        drop(s);
+        String::new()
+    };
+    req_fn_mut(&mut consume);
+}
+
+fn test_double_ref_fn_mut_passed_to_fn() {
+    let mut v = Vec::new();
+    let mut accumulate = |x| {
+        //~^ ERROR E0525
+        v.push(x);
+        v.join("/")
+    };
+    req_fn(&mut &mut accumulate);
+}
+
+fn test_fn_passed_as_mut_ref_to_fn() {
+    let mut pure_closure = |x: &'static str| x.to_string();
+    req_fn(&mut pure_closure);
+    //~^ ERROR E0277
+}
+
+fn test_nested_closure_conservative_fallback() {
+    let mut v = Vec::new();
+    let s = String::new();
+    let mut outer = |_x| {
+        v.push("a");
+        let inner = || drop(s);
+        inner();
+        v.join("/")
+    };
+    req_fn(&mut outer);
+    //~^ ERROR E0277
+}
+
+fn test_unresolved_integer_fallback_copy() {
+    let x = 0;
+    let mut c = |_x| {
+        let _y = x;
+        String::new()
+    };
+    req_fn(&mut c);
+    //~^ ERROR E0277
+}
+
+fn main() {}

--- a/tests/ui/closures/closure-ref-fn-kind-mismatch-issue-161327.stderr
+++ b/tests/ui/closures/closure-ref-fn-kind-mismatch-issue-161327.stderr
@@ -1,0 +1,145 @@
+error[E0525]: expected a closure that implements the `Fn` trait, but this closure only implements `FnMut`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:6:26
+   |
+LL |     let mut accumulate = |x| {
+   |                          ^^^ this closure implements `FnMut`, not `Fn`
+LL |
+LL |         v.push(x);
+   |         - closure is `FnMut` because it mutates the variable `v` here
+...
+LL |     req_fn(&mut accumulate);
+   |     ------ --------------- the requirement to implement `Fn` derives from here
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `req_fn`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:1:19
+   |
+LL | fn req_fn(_: impl Fn(&'static str) -> String) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `req_fn`
+
+error[E0525]: expected a closure that implements the `Fn` trait, but this closure only implements `FnOnce`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:16:23
+   |
+LL |     let mut consume = move |_x| {
+   |                       ^^^^^^^^^ this closure implements `FnOnce`, not `Fn`
+LL |
+LL |         drop(s);
+   |              - closure is `FnOnce` because it moves the variable `s` out of its environment
+...
+LL |     req_fn(&mut consume);
+   |     ------ ------------ the requirement to implement `Fn` derives from here
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `req_fn`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:1:19
+   |
+LL | fn req_fn(_: impl Fn(&'static str) -> String) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `req_fn`
+
+error[E0525]: expected a closure that implements the `FnMut` trait, but this closure only implements `FnOnce`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:26:23
+   |
+LL |     let mut consume = move |_x| {
+   |                       ^^^^^^^^^ this closure implements `FnOnce`, not `FnMut`
+LL |
+LL |         drop(s);
+   |              - closure is `FnOnce` because it moves the variable `s` out of its environment
+...
+LL |     req_fn_mut(&mut consume);
+   |     ----------      ------- the requirement to implement `FnMut` derives from here
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = note: required for `&mut {closure@$DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:26:23: 26:32}` to implement `FnMut(&'static str)`
+note: required by a bound in `req_fn_mut`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:2:23
+   |
+LL | fn req_fn_mut(_: impl FnMut(&'static str) -> String) {}
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `req_fn_mut`
+
+error[E0525]: expected a closure that implements the `Fn` trait, but this closure only implements `FnMut`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:36:26
+   |
+LL |     let mut accumulate = |x| {
+   |                          ^^^ this closure implements `FnMut`, not `Fn`
+LL |
+LL |         v.push(x);
+   |         - closure is `FnMut` because it mutates the variable `v` here
+...
+LL |     req_fn(&mut &mut accumulate);
+   |     ------ -------------------- the requirement to implement `Fn` derives from here
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `req_fn`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:1:19
+   |
+LL | fn req_fn(_: impl Fn(&'static str) -> String) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `req_fn`
+
+error[E0277]: expected an `Fn(&'static str)` closure, found `&mut {closure@$DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:45:28: 45:45}`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:46:12
+   |
+LL |     req_fn(&mut pure_closure);
+   |     ------ ^^^^^^^^^^^^^^^^^ expected an `Fn(&'static str)` closure, found `&mut {closure@$DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:45:28: 45:45}`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Fn(&'static str)` is not implemented for `&mut {closure@$DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:45:28: 45:45}`
+note: required by a bound in `req_fn`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:1:19
+   |
+LL | fn req_fn(_: impl Fn(&'static str) -> String) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `req_fn`
+help: consider removing the leading `&`-reference
+   |
+LL -     req_fn(&mut pure_closure);
+LL +     req_fn(pure_closure);
+   |
+
+error[E0277]: expected an `Fn(&'static str)` closure, found `&mut {closure@$DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:53:21: 53:25}`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:59:12
+   |
+LL |     req_fn(&mut outer);
+   |     ------ ^^^^^^^^^^ expected an `Fn(&'static str)` closure, found `&mut {closure@$DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:53:21: 53:25}`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Fn(&'static str)` is not implemented for `&mut {closure@$DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:53:21: 53:25}`
+note: required by a bound in `req_fn`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:1:19
+   |
+LL | fn req_fn(_: impl Fn(&'static str) -> String) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `req_fn`
+help: consider removing the leading `&`-reference
+   |
+LL -     req_fn(&mut outer);
+LL +     req_fn(outer);
+   |
+
+error[E0277]: expected an `Fn(&'static str)` closure, found `&mut {closure@$DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:65:17: 65:21}`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:69:12
+   |
+LL |     req_fn(&mut c);
+   |     ------ ^^^^^^ expected an `Fn(&'static str)` closure, found `&mut {closure@$DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:65:17: 65:21}`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Fn(&'static str)` is not implemented for `&mut {closure@$DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:65:17: 65:21}`
+note: required by a bound in `req_fn`
+  --> $DIR/closure-ref-fn-kind-mismatch-issue-161327.rs:1:19
+   |
+LL | fn req_fn(_: impl Fn(&'static str) -> String) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `req_fn`
+help: consider removing the leading `&`-reference
+   |
+LL -     req_fn(&mut c);
+LL +     req_fn(c);
+   |
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0277, E0525.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes rust-lang/rust#161327
When passing a reference to a closure that fails an `Fn*` bound (e.g. `&mut c` where `c` is an `FnMut` closure passed to a function expecting `impl Fn`, or an `FnOnce` closure passed where `FnMut` is expected), rustc currently suggests removing the leading `&`. If the underlying closure doesn't implement the required trait in the first place, that suggestion is misleading because removing the reference still won't make it satisfy the bound.
This PR makes `emit_specialized_closure_kind_error` peel references to closures so we can emit E0525 and point out the mutation/move that caused the mismatch. Since closure kind inference hasn't run yet when checking the call arguments, we run a quick capture pass on-demand to figure out the actual closure kind.
To be conservative:
- We bail out to E0277 if there are nested closures in the body (since we don't know their captures yet).
- We bail out to E0277 if a by-value capture has an unresolved type variable (like `{integer}`) that might turn out to be `Copy` after fallback.
- If the closure actually satisfies the expected trait (e.g. a genuine `Fn` closure wrapped in `&mut` passed to `Fn`), `found_kind.extends(expected_kind)` holds, so we keep E0277 and the valid remove-ref suggestion.