### PR TITLE
Fix the kernel example in core's offload docs

### DIFF
--- a/library/core/src/offload.md
+++ b/library/core/src/offload.md
@@ -5,14 +5,41 @@ and `offload!` macros, see their respective documentation.
 The `offload_kernel` macro can be applied to a function to generate the necessary code to launch a
 kernel on the target device.
 
+The two targets name the indices differently, and only `nvptx` has them as `unsafe`, hence the
+`cfg`.
+
 ```rust,ignore (optional component)
+#![feature(gpu_offload)]
+#![cfg_attr(target_arch = "amdgpu", feature(stdarch_amdgpu))]
+#![cfg_attr(target_arch = "nvptx64", feature(stdarch_nvptx))]
+use core::offload::offload_kernel;
+
+#[cfg(target_arch = "amdgpu")]
+fn global_idx_x() -> u32 {
+    use core::arch::amdgpu::{workgroup_id_x, workitem_id_x};
+    // This has to match the first value of `thread_dim`, because on AMD there is no
+    // workgroup-size query. If they disagree the indices break silently: collisions if
+    // it is smaller, unwritten gaps if it is larger.
+    const THREADS_PER_GROUP: u32 = 64;
+    workitem_id_x() + workgroup_id_x() * THREADS_PER_GROUP
+}
+
+#[cfg(target_arch = "nvptx64")]
+fn global_idx_x() -> u32 {
+    use core::arch::nvptx::{_block_dim_x, _block_idx_x, _thread_idx_x};
+    // SAFETY:
+    // the `cfg` guarantees we are on nvptx64, where these intrinsics always exist, and
+    // they are special-register reads that do not touch memory
+    unsafe { _thread_idx_x() + _block_idx_x() * _block_dim_x() }
+}
+
 #[offload_kernel]
 fn kernel(x: *mut [f64; 256]) {
     // SAFETY:
     // calling our `arch` functions and dereferencing a raw pointer is unsafe
     unsafe {
         let n = (*x).len();
-        let i = (thread_idx_x() + block_idx_x() * block_dim_x()) as usize;
+        let i = global_idx_x() as usize;
         if i < n {
             (*x)[i] = i as f64;
         }
@@ -27,7 +54,8 @@ workgroup and thread dimensions, and the arguments to forward to the device.
 let mut x = [0.0f64; 256];
 core::offload::offload! {
     kernel = kernel,
-    workgroup_dim = [256, 1, 1],
+    workgroup_dim = [4, 1, 1],
+    thread_dim = [64, 1, 1],
     args = (&mut x as *mut [f64; 256],),
 }
 ```
@@ -38,3 +66,6 @@ For precise information on the underlying `offload` intrinsic, see its respectiv
 
 - Usage is restricted to types supported by the current device-mapping implementation.
 - Functions accepting dyn Trait are not supported.
+- Thread indices are not portable between targets, and `amdgpu` does not know its own
+  workgroup size, so a kernel for both GPUs needs the `cfg` shim and has to repeat
+  `thread_dim` as a constant.


### PR DESCRIPTION
The kernel example in `library/core/src/offload.md` calls three names that do not exist on any target: `thread_idx_x()`, `block_idx_x()` and `block_dim_x()`.

| | `core::arch::amdgpu` | `core::arch::nvptx` |
|---|---|---|
| thread index | `workitem_id_x()`, safe | `_thread_idx_x()`, `unsafe` |
| block index | `workgroup_id_x()`, safe | `_block_idx_x()`, `unsafe` |
| workgroup size | not available | `_block_dim_x()`, `unsafe` |

Renaming is not enough, so this is fixed with a `cfg` shim plus a constant. Verified by compiling for `gfx1100` and `sm_120`, with no warnings.

The `ignore` stays, because `offload!` does not compile without `-Zoffload=` or `-Clto=fat`.

r? @ZuseZ4

<!-- homu-ignore:start -->
I found the bug using an LLM to read a paper and run some quick tests, but the investigation and the changes after that are all my own. I also used a Spanish to English translator to make sure this reads correctly (or so I hope); I don't know whether the translator uses AI of some kind.
<!-- homu-ignore:end -->