### PR TITLE
avoid overlapping const suggestions

### DIFF
--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -628,17 +628,19 @@ impl<'a> Parser<'a> {
                         }
 
                         // help: extract the expr into a `const VAL: _ = expr`
-                        let ident = match self.field {
-                            Some(field) => field.ident.as_str().to_uppercase(),
-                            None => "VAL".to_owned(),
-                        };
-                        err.subdiagnostic(UnexpectedExpressionInPatternSugg::Const {
-                            stmt_lo: line_lo,
-                            ident_span: expr_span,
-                            expr,
-                            ident,
-                            indentation,
-                        });
+                        if !line_lo.overlaps(expr_span) {
+                            let ident = match self.field {
+                                Some(field) => field.ident.as_str().to_uppercase(),
+                                None => "VAL".to_owned(),
+                            };
+                            err.subdiagnostic(UnexpectedExpressionInPatternSugg::Const {
+                                stmt_lo: line_lo,
+                                ident_span: expr_span,
+                                expr,
+                                ident,
+                                indentation,
+                            });
+                        }
                     },
                 );
             }

--- a/tests/ui/parser/recover/recover-pat-range-macro-span-overlap.rs
+++ b/tests/ui/parser/recover/recover-pat-range-macro-span-overlap.rs
@@ -1,0 +1,15 @@
+// test for issue - https://github.com/rust-lang/rust/issues/161213
+macro_rules! m {
+    ($value:expr) => {
+        enum Foo {
+            Bar = $value,
+            //~^ error: expected a pattern range bound, found an expression
+        }
+        fn main() {
+            match 0 {
+                0..Foo::Bar + $value | _ => (),
+            }
+        }
+    };
+}
+m!(1);

--- a/tests/ui/parser/recover/recover-pat-range-macro-span-overlap.stderr
+++ b/tests/ui/parser/recover/recover-pat-range-macro-span-overlap.stderr
@@ -1,0 +1,20 @@
+error: expected a pattern range bound, found an expression
+  --> $DIR/recover-pat-range-macro-span-overlap.rs:5:19
+   |
+LL |               Bar = $value,
+   |  ___________________^
+LL | |
+LL | |         }
+LL | |         fn main() {
+LL | |             match 0 {
+LL | |                 0..Foo::Bar + $value | _ => (),
+   | |_____________________________^ not a pattern
+...
+LL |   m!(1);
+   |   ----- in this macro invocation
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Avoid emitting the optional `const-extraction` suggestion when its **component spans** overlap, this avoids the compiler panic while still emitting the normal error and keeping the suggestion for cases where it can be
generated correctly

Fixes rust-lang/rust#161213