### PR TITLE
Update expect messages in path docs to better follow guidelines

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3329,7 +3329,7 @@ impl Path {
     /// use std::path::Path;
     ///
     /// let path = Path::new("/Minas/tirith");
-    /// let metadata = path.metadata().expect("metadata call failed");
+    /// let metadata = path.metadata().expect("the path should point to an existing file or directory");
     /// println!("{:?}", metadata.file_type());
     /// ```
     #[stable(feature = "path_ext", since = "1.5.0")]
@@ -3348,7 +3348,7 @@ impl Path {
     /// use std::path::Path;
     ///
     /// let path = Path::new("/Minas/tirith");
-    /// let metadata = path.symlink_metadata().expect("symlink_metadata call failed");
+    /// let metadata = path.symlink_metadata().expect("the path should exist");
     /// println!("{:?}", metadata.file_type());
     /// ```
     #[stable(feature = "path_ext", since = "1.5.0")]
@@ -3483,7 +3483,7 @@ impl Path {
     /// use std::path::Path;
     ///
     /// let path = Path::new("/laputa/sky_castle.rs");
-    /// let path_link = path.read_link().expect("read_link call failed");
+    /// let path_link = path.read_link().expect("the path should be an existing symbolic link");
     /// ```
     #[stable(feature = "path_ext", since = "1.5.0")]
     #[inline]
@@ -3504,7 +3504,7 @@ impl Path {
     /// use std::path::Path;
     ///
     /// let path = Path::new("/laputa");
-    /// for entry in path.read_dir().expect("read_dir call failed") {
+    /// for entry in path.read_dir().expect("the path should point to an existing directory") {
     ///     if let Ok(entry) = entry {
     ///         println!("{:?}", entry.path());
     ///     }
@@ -3569,7 +3569,7 @@ impl Path {
     ///
     /// ```no_run
     /// use std::path::Path;
-    /// assert!(!Path::new("does_not_exist.txt").try_exists().expect("Can't check existence of file does_not_exist.txt"));
+    /// assert!(!Path::new("does_not_exist.txt").try_exists().expect("the path's existence should be verifiable"));
     /// assert!(Path::new("/root/secret_file.txt").try_exists().is_err());
     /// ```
     ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
Updates the `.expect()` messages in `library/std/src/path.rs`
to better follow the guidance for `expect` messages.

Related to rust-lang/rust#159751.