### PR TITLE
Include startup crt objects on WASI for more outputs

### DIFF
--- a/compiler/rustc_target/src/spec/crt_objects.rs
+++ b/compiler/rustc_target/src/spec/crt_objects.rs
@@ -7,13 +7,13 @@
 //!
 //! | Pre-link CRT objects | glibc                  | musl                   | bionic           | mingw             | wasi         |
 //! |----------------------|------------------------|------------------------|------------------|-------------------|--------------|
-//! | dynamic-nopic-exe    | crt1, crti, crtbegin   | crt1, crti, crtbegin   | crtbegin_dynamic | crt2, crtbegin    | crt1         |
-//! | dynamic-pic-exe      | Scrt1, crti, crtbeginS | Scrt1, crti, crtbeginS | crtbegin_dynamic | crt2, crtbegin    | crt1         |
-//! | static-nopic-exe     | crt1, crti, crtbeginT  | crt1, crti, crtbegin   | crtbegin_static  | crt2, crtbegin    | crt1         |
-//! | static-pic-exe       | rcrt1, crti, crtbeginS | rcrt1, crti, crtbeginS | crtbegin_dynamic | crt2, crtbegin    | crt1         |
-//! | dynamic-dylib        | crti, crtbeginS        | crti, crtbeginS        | crtbegin_so      | dllcrt2, crtbegin | -            |
-//! | static-dylib (gcc)   | crti, crtbeginT        | crti, crtbeginS        | crtbegin_so      | dllcrt2, crtbegin | -            |
-//! | static-dylib (clang) | crti, crtbeginT        | N/A                    | crtbegin_static  | dllcrt2, crtbegin | -            |
+//! | dynamic-nopic-exe    | crt1, crti, crtbegin   | crt1, crti, crtbegin   | crtbegin_dynamic | crt2, crtbegin    | crt1-command |
+//! | dynamic-pic-exe      | Scrt1, crti, crtbeginS | Scrt1, crti, crtbeginS | crtbegin_dynamic | crt2, crtbegin    | crt1-command |
+//! | static-nopic-exe     | crt1, crti, crtbeginT  | crt1, crti, crtbegin   | crtbegin_static  | crt2, crtbegin    | crt1-command |
+//! | static-pic-exe       | rcrt1, crti, crtbeginS | rcrt1, crti, crtbeginS | crtbegin_dynamic | crt2, crtbegin    | crt1-command |
+//! | dynamic-dylib        | crti, crtbeginS        | crti, crtbeginS        | crtbegin_so      | dllcrt2, crtbegin | crt1-reactor |
+//! | static-dylib (gcc)   | crti, crtbeginT        | crti, crtbeginS        | crtbegin_so      | dllcrt2, crtbegin | crt1-reactor |
+//! | static-dylib (clang) | crti, crtbeginT        | N/A                    | crtbegin_static  | dllcrt2, crtbegin | ctr1-reactor |
 //! | wasi-reactor-exe     | N/A                    | N/A                    | N/A              | N/A               | crt1-reactor |
 //!
 //! | Post-link CRT objects | glibc         | musl          | bionic         | mingw  | wasi |
@@ -127,6 +127,8 @@ pub(super) fn pre_wasi_self_contained() -> CrtObjects {
         (LinkOutputKind::StaticNoPicExe, &["crt1-command.o"]),
         (LinkOutputKind::StaticPicExe, &["crt1-command.o"]),
         (LinkOutputKind::WasiReactorExe, &["crt1-reactor.o"]),
+        (LinkOutputKind::DynamicDylib, &["crt1-reactor.o"]),
+        (LinkOutputKind::StaticDylib, &["crt1-reactor.o"]),
     ])
 }
 

--- a/src/tools/run-make-support/src/external_deps/rustc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustc.rs
@@ -397,6 +397,13 @@ impl Rustc {
         self
     }
 
+    /// Specify `-C link-self-contained={y,n}`.
+    pub fn link_self_contained(&mut self, enabled: bool) -> &mut Self {
+        let enabled = if enabled { "y" } else { "n" };
+        self.cmd.arg(format!("-Clink-self-contained={enabled}"));
+        self
+    }
+
     pub fn split_dwarf_out_dir(&mut self, out_dir: Option<&str>) -> &mut Self {
         if let Some(out_dir) = out_dir {
             self.cmd.arg(format!("-Zsplit-dwarf-out-dir={out_dir}"));

--- a/tests/run-make/wasm-export-all-symbols/rmake.rs
+++ b/tests/run-make/wasm-export-all-symbols/rmake.rs
@@ -19,7 +19,10 @@ fn test(args: &[&str]) {
     rustc().input("foo.rs").target("wasm32-wasip1").args(args).run();
     rustc().input("main.rs").target("wasm32-wasip1").args(args).run();
 
-    verify_exports(Path::new("foo.wasm"), &[("foo", Func), ("FOO", Global), ("memory", Memory)]);
+    verify_exports(
+        Path::new("foo.wasm"),
+        &[("foo", Func), ("FOO", Global), ("memory", Memory), ("_initialize", Func)],
+    );
     verify_exports(
         Path::new("main.wasm"),
         &[

--- a/tests/run-make/wasm-symbols-not-exported/rmake.rs
+++ b/tests/run-make/wasm-symbols-not-exported/rmake.rs
@@ -28,7 +28,7 @@ fn verify_symbols(path: &Path) {
                 if e.kind != wasmparser::ExternalKind::Func {
                     continue;
                 }
-                if e.name == "foo" {
+                if e.name == "foo" || e.name == "_initialize" {
                     continue;
                 }
                 panic!("unexpected export {e:?}");

--- a/tests/run-make/wasm-unexpected-features/rmake.rs
+++ b/tests/run-make/wasm-unexpected-features/rmake.rs
@@ -15,6 +15,7 @@ fn main() {
         .linker_plugin_lto("on")
         .link_arg("--import-memory")
         .extern_("minicore", path("libminicore.rlib"))
+        .link_self_contained(false)
         .run();
     verify_features(Path::new("foo.wasm"));
 }


### PR DESCRIPTION
This commit adds the `crt1-reactor.o` object file in the list of pre-link-crt-objects for the `{Dynamic,Static}Dylib` output kinds for WASI targets. These previously were omitted I believe by accident and this means that the conventional `_initialize` function is not present which runs constructor functions, for example. This is additionally needed for the upcoming wasip3 target where this startup object file is more load bearing than it was previously and will become required.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
