### PR TITLE
Re-export `core::fmt::NumBuffer` in `alloc` (and `std`)

### DIFF
--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -595,6 +595,8 @@
 pub use core::fmt::Alignment;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::Error;
+#[stable(feature = "fmt_numbuffer", since = "CURRENT_RUSTC_VERSION")]
+pub use core::fmt::NumBuffer;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{Arguments, write};
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
We just stabilized `core::fmt::NumBuffer` in Rust 1.98, but it seems to be a simple oversight that this was not also re-exported in `alloc::fmt` (and `std` just re-exports that whole module). Let's correct that.

I'm marking this stable right away, although I don't think the later `since` version will be properly rendered in docs for a re-export. I'm not sure it's worth trying to clarify that in freeform documentation.