### PR TITLE
Provide a `supertrait_def_ids()` function in rustc_type_ir's interner

### DIFF
--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -430,6 +430,10 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.impl_super_outlives(impl_def_id)
     }
 
+    fn supertrait_def_ids(self, trait_def_id: DefId) -> impl Iterator<Item = DefId> {
+        rustc_type_ir::elaborate::supertrait_def_ids(self, trait_def_id)
+    }
+
     fn impl_is_const(self, def_id: DefId) -> bool {
         debug_assert_matches!(self.def_kind(def_id), DefKind::Impl { of_trait: true });
         self.is_conditionally_const(def_id)

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -1109,7 +1109,8 @@ where
             .auto_traits()
             .into_iter()
             .chain(a_data.principal_def_id().into_iter().flat_map(|principal_def_id| {
-                elaborate::supertrait_def_ids(self.cx(), principal_def_id)
+                self.cx()
+                    .supertrait_def_ids(principal_def_id)
                     .filter(|def_id| self.cx().trait_is_auto(*def_id))
             }))
             .collect();

--- a/compiler/rustc_type_ir/src/elaborate.rs
+++ b/compiler/rustc_type_ir/src/elaborate.rs
@@ -318,6 +318,9 @@ impl<I: Interner, O: Elaboratable<I>> Iterator for Elaborator<I, O> {
 /// does not compute the full elaborated super-predicates but just the set of def-ids. It is used
 /// to identify which traits may define a given associated type to help avoid cycle errors,
 /// and to make size estimates for vtable layout computation.
+///
+/// rust-analyzer has a query for this, so don't use this function there.
+#[cfg(feature = "nightly")]
 pub fn supertrait_def_ids<I: Interner>(
     cx: I,
     trait_def_id: I::TraitId,

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -359,6 +359,9 @@ pub trait Interner:
         impl_def_id: Self::ImplId,
     ) -> ty::EarlyBinder<Self, impl IntoIterator<Item = Self::Clause>>;
 
+    fn supertrait_def_ids(self, trait_def_id: Self::TraitId)
+    -> impl Iterator<Item = Self::TraitId>;
+
     fn impl_is_const(self, def_id: Self::ImplId) -> bool;
     fn fn_is_const(self, def_id: Self::FunctionId) -> bool;
     fn closure_is_const(self, def_id: Self::ClosureId) -> bool;


### PR DESCRIPTION
rust-analyzer has a query for this, so we want to use it there. I don't know if using a query for this will be a perf win for rustc, but rust-analyzer already has this query for other reasons, so it feels a waste to not use it.

r? types

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
