### PR TITLE
Add some `rustc_type_ir` comments

### DIFF
--- a/compiler/rustc_next_trait_solver/src/delegate.rs
+++ b/compiler/rustc_next_trait_solver/src/delegate.rs
@@ -7,6 +7,22 @@ use rustc_type_ir::solve::{
 };
 use rustc_type_ir::{self as ty, CanonicalizerState, InferCtxtLike, Interner, TypeFoldable};
 
+/// `SolverDelegate` is one of the two traits in the `rustc_type_ir` shared abstraction layer
+/// between rustc and rust-analyzer abstracting over the [InferCtxt][inferctxt-doc], which had to be
+/// split due to coherence reasons:
+/// - `SolverDelegate` contains the parts depending on trait-solving logic, to provide functionality
+///   in `rustc_trait_selection`, and is implemented by a [simple wrapper over
+///   `InferCtxt`][inferctxt-wrapper-doc] there,
+/// - [InferCtxtLike] contains the other parts, and is implemented [directly on
+///   `InferCtxt`][inferctxtlike-impl-doc].
+///
+/// More information can also be found in the dedicated chapter in the dev-guide, in [this
+/// section][dev-guide].
+///
+/// [inferctxt-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxt.html
+/// [inferctxt-wrapper-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_trait_selection/solve/delegate/struct.SolverDelegate.html
+/// [inferctxtlike-impl-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxt.html#impl-InferCtxtLike-for-InferCtxt%3C'tcx%3E
+/// [dev-guide]: https://rustc-dev-guide.rust-lang.org/solve/sharing-crates-with-rust-analyzer.html#trait-inferctxtlike-and-trait-solverdelegate
 pub trait SolverDelegate: Deref<Target = Self::Infcx> + Sized {
     type Infcx: InferCtxtLike<Interner = Self::Interner>;
     type Interner: Interner;

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -362,6 +362,22 @@ impl<I: Interner> From<TypingMode<I, CantBeErased>> for TypingMode<I, MayBeErase
     }
 }
 
+/// `InferCtxtLike` is one of the two traits abstracting over the [InferCtxt][inferctxt-doc], which
+/// had to be split due to coherence reasons:
+/// - `InferCtxtLike`] contains the parts that have to live in `rustc_infer`, and thus aren't only
+///   about trait-solving. It is implemented [directly on `InferCtxt`][inferctxtlike-impl-doc],
+/// - [SolverDelegate][solverdelegate-doc] contains the parts depending on trait-solving logic, to
+///   provide functionality in `rustc_trait_selection`, and is implemented by a [simple wrapper over
+///   `InferCtxt`][inferctxt-wrapper-doc] there.
+///
+/// More information can also be found in the dedicated chapter in the dev-guide, in [this
+/// section][dev-guide].
+///
+/// [inferctxt-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxt.html
+/// [inferctxtlike-impl-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxt.html#impl-InferCtxtLike-for-InferCtxt%3C'tcx%3E
+/// [solverdelegate-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_next_trait_solver/delegate/trait.SolverDelegate.html
+/// [inferctxt-wrapper-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_trait_selection/solve/delegate/struct.SolverDelegate.html
+/// [dev-guide]: https://rustc-dev-guide.rust-lang.org/solve/sharing-crates-with-rust-analyzer.html#trait-inferctxtlike-and-trait-solverdelegate
 #[cfg_attr(feature = "nightly", rustc_diagnostic_item = "type_ir_infer_ctxt_like")]
 pub trait InferCtxtLike: Sized {
     type Interner: Interner;

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -24,6 +24,26 @@ use crate::{
     TraitRef, search_graph,
 };
 
+/// The central trait in the shared abstraction layer, specifying all implementation-specific
+/// details for rustc and rust-analyzer.
+///
+/// Among its essential responsibilities:
+/// - it specifies the concrete types used by each implementation via its associated types; these
+///   form the backbone of how each compiler frontend instantiates the shared IR.
+/// - it provides the context required by the solver (e.g., querying lang items, enumerating all
+///   blanket impls for a trait)
+/// - it implements [IrPrint] for formatting and tracing.
+///
+/// In rustc, it is [implemented by TyCtxt][interner-impl-doc]. In rust-analyzer, the implementing
+/// type is named [DbInterner][dbinterner-code] (as it performs most interning through the salsa
+/// database).
+///
+/// More information can also be found in the dedicated chapter in the dev-guide, in [this
+/// section][dev-guide].
+///
+/// [interner-impl-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.TyCtxt.html#impl-Interner-for-TyCtxt%3C'tcx%3E
+/// [dbinterner-code]: https://github.com/rust-lang/rust-analyzer/blob/a50c1ccc9cf3dab1afdc857a965a9992fbad7a53/crates/hir-ty/src/next_solver/interner.rs#L272
+/// [dev-guide]: https://rustc-dev-guide.rust-lang.org/solve/sharing-crates-with-rust-analyzer.html#trait-interner
 #[cfg_attr(feature = "nightly", rustc_diagnostic_item = "type_ir_interner")]
 pub trait Interner:
     Sized

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -1,3 +1,24 @@
+//! This crate is an abstraction layer, shared between rustc and rust-analyzer, to help with the
+//! overlapping responsibilities (like type inference and trait solving), reduce duplication, and
+//! maintain consistent behavior between the two implementations.
+//!
+//! It defines fundamental interfaces for types, predicates, and the context required by the next
+//! trait solver.
+//!
+//! Both rustc and rust-analyzer immplement these traits for their own concrete implementations, and
+//! `rustc_next_trait_solver` is written to be generic over these abstractions.
+//!
+//! In addition to these interfaces, it also contains components built on top of the abstraction
+//! layer, for example elaboration logic, and the search graph machinery used by the solver, as well
+//! as items that do not need compiler-specific implementations.
+//!
+//! Note that rust-analyzer is built with a stable compiler, while rustc uses unstable features, so
+//! this crate and some of its dependencies need to separate unstable code under the `nightly`
+//! feature.
+//!
+//! There are more details available in a [dedicated dev-guide
+//! chapter](https://rustc-dev-guide.rust-lang.org/solve/sharing-crates-with-rust-analyzer.html).
+
 #![cfg_attr(feature = "nightly", rustc_diagnostic_item = "type_ir")]
 // tidy-alphabetical-start
 #![allow(rustc::direct_use_of_rustc_type_ir)]

--- a/src/doc/rustc-dev-guide/src/solve/sharing-crates-with-rust-analyzer.md
+++ b/src/doc/rustc-dev-guide/src/solve/sharing-crates-with-rust-analyzer.md
@@ -29,7 +29,7 @@ Since these crates are not published on `crates.io` as part of the compiler's no
 process, rust-analyzer maintains its own publishing pipeline.
 It uses the [rustc-auto-publish script][rustc-auto-publish] to publish these crates to `crates.io`
 with the prefix `ra-ap-rustc_*`
-(for example: https://crates.io/crates/ra-ap-rustc_next_trait_solver).
+(for example: <https://crates.io/crates/ra-ap-rustc_next_trait_solver>).
 rust-analyzer then depends on these re-published crates in its own build.
 
 For trait solving specifically, the primary shared crates are `rustc_type_ir` and


### PR DESCRIPTION
This PR adds a few comments to `rustc_type_ir`, some of its key components, and `SolverDelegate`. These are the most important and common traits one encounters and some docs will be helpful. Most of it is coming from the prose in https://rustc-dev-guide.rust-lang.org/solve/sharing-crates-with-rust-analyzer.html