### PR TITLE
Fix extra spaces in format_into documentation examples

### DIFF
--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -269,8 +269,8 @@ macro_rules! impl_Display {
             #[doc = concat!("let n1 = 32", stringify!($Signed), ";")]
             /// assert_eq!(n1.format_into(&mut buf), "32");
             ///
-            #[doc = concat!("let n2 = ", stringify!($Signed::MAX), ";")]
-            #[doc = concat!("assert_eq!(n2.format_into(&mut buf), ", stringify!($Signed::MAX), ".to_string());")]
+            #[doc = concat!("let n2 = ", stringify!($Signed), "::MAX;")]
+            #[doc = concat!("assert_eq!(n2.format_into(&mut buf), ", stringify!($Signed), "::MAX.to_string());")]
             /// ```
             #[stable(feature = "int_format_into", since = "1.98.0")]
             pub fn format_into(self, buf: &mut NumBuffer<Self>) -> &str {
@@ -313,8 +313,8 @@ macro_rules! impl_Display {
             #[doc = concat!("let n1 = 32", stringify!($Unsigned), ";")]
             /// assert_eq!(n1.format_into(&mut buf), "32");
             ///
-            #[doc = concat!("let n2 = ", stringify!($Unsigned::MAX), ";")]
-            #[doc = concat!("assert_eq!(n2.format_into(&mut buf), ", stringify!($Unsigned::MAX), ".to_string());")]
+            #[doc = concat!("let n2 = ", stringify!($Unsigned), "::MAX;")]
+            #[doc = concat!("assert_eq!(n2.format_into(&mut buf), ", stringify!($Unsigned), "::MAX.to_string());")]
             /// ```
             #[stable(feature = "int_format_into", since = "1.98.0")]
             pub fn format_into(self, buf: &mut NumBuffer<Self>) -> &str {


### PR DESCRIPTION
Fixes rust-lang/rust#161436.

`stringify!($Signed::MAX)` (with an `ident` metavariable) renders the path with spaces around `::`, so the `format_into` doc examples showed e.g. `let n2 = usize :: MAX;`. Splitting the metavariable and the `::MAX` suffix renders the intended `let n2 = usize::MAX;`.

Applied to both the signed and unsigned `impl_Display!` expansions.

Note: this change was prepared with LLM assistance (the patch matches the fix proposed in the issue) and should be reviewed as such.