### PR TITLE
Construct paramenvs from an iterator

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -285,7 +285,7 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
             let place = &self.move_data.move_paths[mpi].place;
             let ty = place.ty(self.body, self.infcx.tcx).ty;
 
-            if self.infcx.param_env.caller_bounds().iter().any(|c| {
+            if self.infcx.param_env.caller_bounds().any(|c| {
                 c.as_trait_clause().is_some_and(|pred| {
                     pred.skip_binder().self_ty() == ty && self.infcx.tcx.is_fn_trait(pred.def_id())
                 })

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -238,7 +238,7 @@ fn compare_method_clause_entailment<'tcx>(
 
     let hybrid_clauses = hybrid_clauses.into_iter().map(Unnormalized::skip_norm_wip);
     let normalize_cause = traits::ObligationCause::misc(impl_m_span, impl_m_def_id);
-    let param_env = ty::ParamEnv::new(tcx.mk_clauses_from_iter(hybrid_clauses));
+    let param_env = ty::ParamEnv::new(tcx, hybrid_clauses);
     // NOTE(-Zhigher-ranked-assumptions): The `hybrid_preds`
     // should be well-formed. However, using them may result in
     // region errors as we currently don't track placeholder
@@ -494,7 +494,7 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
         .into_iter()
         .chain(tcx.clauses_of(trait_m.def_id).instantiate_own(tcx, trait_to_impl_args))
         .map(|(clause, _)| clause.skip_norm_wip());
-    let param_env = ty::ParamEnv::new(tcx.mk_clauses_from_iter(hybrid_clauses));
+    let param_env = ty::ParamEnv::new(tcx, hybrid_clauses);
     let param_env = traits::normalize_param_env_or_error(
         tcx,
         param_env,
@@ -2230,7 +2230,7 @@ fn compare_const_clause_entailment<'tcx>(
     );
     let hybrid_clauses = hybrid_clauses.into_iter().map(Unnormalized::skip_norm_wip);
 
-    let param_env = ty::ParamEnv::new(tcx.mk_clauses_from_iter(hybrid_clauses));
+    let param_env = ty::ParamEnv::new(tcx, hybrid_clauses);
     let param_env = traits::normalize_param_env_or_error(
         tcx,
         param_env,
@@ -2380,7 +2380,7 @@ fn compare_type_clause_entailment<'tcx>(
     }
 
     let hybrid_clauses = hybrid_clauses.into_iter().map(Unnormalized::skip_norm_wip);
-    let param_env = ty::ParamEnv::new(tcx.mk_clauses_from_iter(hybrid_clauses));
+    let param_env = ty::ParamEnv::new(tcx, hybrid_clauses);
     let param_env = traits::normalize_param_env_or_error(tcx, param_env, normalize_cause);
     debug!(?param_env);
 
@@ -2741,7 +2741,7 @@ fn param_env_with_gat_bounds<'tcx>(
         };
     }
 
-    ty::ParamEnv::new(tcx.mk_clauses(&clauses))
+    ty::ParamEnv::new(tcx, clauses)
 }
 
 /// Manually check here that `async fn foo()` wasn't matched against `fn foo()`,

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -254,7 +254,7 @@ fn compare_method_clause_entailment<'tcx>(
     //
     // cc trait-system-refactor-initiative/issues/166.
     let param_env = traits::normalize_param_env_or_error(tcx, param_env, normalize_cause);
-    debug!(caller_bounds=?param_env.caller_bounds());
+    debug!(?param_env);
 
     let infcx = &tcx.infer_ctxt().build(TypingMode::non_body_analysis());
     let ocx = ObligationCtxt::new_with_diagnostics(infcx);
@@ -2382,7 +2382,7 @@ fn compare_type_clause_entailment<'tcx>(
     let hybrid_clauses = hybrid_clauses.into_iter().map(Unnormalized::skip_norm_wip);
     let param_env = ty::ParamEnv::new(tcx.mk_clauses_from_iter(hybrid_clauses));
     let param_env = traits::normalize_param_env_or_error(tcx, param_env, normalize_cause);
-    debug!(caller_bounds=?param_env.caller_bounds());
+    debug!(?param_env);
 
     let infcx = tcx.infer_ctxt().build(TypingMode::non_body_analysis());
     let ocx = ObligationCtxt::new_with_diagnostics(&infcx);
@@ -2627,7 +2627,7 @@ fn param_env_with_gat_bounds<'tcx>(
 ) -> ty::ParamEnv<'tcx> {
     let param_env = tcx.param_env(impl_ty.def_id);
     let container_id = impl_ty.container_id(tcx);
-    let mut clauses = param_env.caller_bounds().to_vec();
+    let mut clauses = param_env.caller_bounds().collect::<Vec<_>>();
 
     // for RPITITs, we should install predicates that allow us to project all
     // of the RPITITs associated with the same body. This is because checking

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
@@ -145,7 +145,7 @@ pub(crate) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
         .into_iter()
         .chain(tcx.clauses_of(trait_m.def_id).instantiate_own(tcx, trait_m_to_impl_m_args))
         .map(|(clause, _)| clause.skip_norm_wip());
-    let param_env = ty::ParamEnv::new(tcx.mk_clauses_from_iter(hybrid_clauses));
+    let param_env = ty::ParamEnv::new(tcx, hybrid_clauses);
     let param_env = normalize_param_env_or_error(tcx, param_env, ObligationCause::dummy());
 
     let ref infcx = tcx.infer_ctxt().build(TypingMode::non_body_analysis());

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -574,8 +574,8 @@ fn augment_param_env<'tcx>(
         return param_env;
     }
 
-    let bounds = tcx
-        .mk_clauses_from_iter(param_env.caller_bounds().iter().chain(new_clauses.iter().copied()));
+    let bounds =
+        tcx.mk_clauses_from_iter(param_env.caller_bounds().chain(new_clauses.iter().copied()));
     // FIXME(compiler-errors): Perhaps there is a case where we need to normalize this
     // i.e. traits::normalize_param_env_or_error
     ty::ParamEnv::new(bounds)

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -574,11 +574,10 @@ fn augment_param_env<'tcx>(
         return param_env;
     }
 
-    let bounds =
-        tcx.mk_clauses_from_iter(param_env.caller_bounds().chain(new_clauses.iter().copied()));
+    let bounds = param_env.caller_bounds().chain(new_clauses.iter().copied());
     // FIXME(compiler-errors): Perhaps there is a case where we need to normalize this
     // i.e. traits::normalize_param_env_or_error
-    ty::ParamEnv::new(bounds)
+    ty::ParamEnv::new(tcx, bounds)
 }
 
 /// We use the following trait as an example throughout this function.

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -307,13 +307,11 @@ impl<'tcx> HirTyLowerer<'tcx> for FnCtxt<'_, 'tcx> {
         let span = tcx.def_span(def_id);
 
         ty::EarlyBinder::bind_iter(tcx.arena.alloc_from_iter(
-            self.param_env.caller_bounds().iter().filter_map(|clause| {
-                match clause.kind().skip_binder() {
-                    ty::ClauseKind::Trait(data) if data.self_ty().is_param(index) => {
-                        Some((ty::set_aliases_to_non_rigid(tcx, clause).skip_norm_wip(), span))
-                    }
-                    _ => None,
+            self.param_env.caller_bounds().filter_map(|clause| match clause.kind().skip_binder() {
+                ty::ClauseKind::Trait(data) if data.self_ty().is_param(index) => {
+                    Some((ty::set_aliases_to_non_rigid(tcx, clause).skip_norm_wip(), span))
                 }
+                _ => None,
             }),
         ))
     }

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1034,7 +1034,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         // We use `DeepRejectCtxt` here which may return false positive on where clauses
         // with alias self types. We need to later on reject these as inherent candidates
         // in `consider_probe`.
-        let bounds = self.param_env.caller_bounds().iter().filter_map(|clause| {
+        let bounds = self.param_env.caller_bounds().filter_map(|clause| {
             let bound_clause = clause.kind();
             match bound_clause.skip_binder() {
                 ty::ClauseKind::Trait(trait_predicate) => DeepRejectCtxt::relate_rigid_rigid(tcx)

--- a/compiler/rustc_infer/src/infer/outlives/mod.rs
+++ b/compiler/rustc_infer/src/infer/outlives/mod.rs
@@ -20,7 +20,7 @@ pub mod obligations;
 pub mod test_type_match;
 pub(crate) mod verify;
 
-#[instrument(level = "debug", skip(param_env), ret)]
+#[instrument(level = "debug", skip(param_env))]
 pub fn explicit_outlives_bounds<'tcx>(
     param_env: ty::ParamEnv<'tcx>,
 ) -> impl Iterator<Item = OutlivesBound<'tcx>> {

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -306,7 +306,7 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for ty::SymbolName<'tcx> {
 impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for ty::ParamEnv<'tcx> {
     fn decode(d: &mut D) -> Self {
         let caller_bounds = Decodable::decode(d);
-        ty::ParamEnv::new(caller_bounds)
+        ty::ParamEnv { caller_bounds }
     }
 }
 

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -204,7 +204,7 @@ impl<'tcx, E: TyEncoder<'tcx>> Encodable<E> for CtfeProvenance {
 
 impl<'tcx, E: TyEncoder<'tcx>> Encodable<E> for ty::ParamEnv<'tcx> {
     fn encode(&self, e: &mut E) {
-        self.caller_bounds().encode(e);
+        self.caller_bounds.encode(e);
     }
 }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -43,8 +43,8 @@ use rustc_hir::def::{CtorKind, CtorOf, DefKind, DocLinkResMap, LifetimeRes, Res}
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LocalDefId, LocalDefIdMap};
 use rustc_hir::definitions::PerParentDisambiguatorState;
 use rustc_hir::{self as hir, MissingLifetimeKind, attrs as attr, find_attr};
-use rustc_index::IndexVec;
 use rustc_index::bit_set::BitMatrix;
+use rustc_index::{IndexVec, static_assert_size};
 pub use rustc_lint_defs::RegisteredTools;
 use rustc_macros::{
     BlobDecodable, Decodable, Encodable, StableHash, TyDecodable, TyEncodable, TypeFoldable,
@@ -1154,6 +1154,11 @@ pub struct ParamEnv<'tcx> {
     /// Use the `caller_bounds()` method to access.
     caller_bounds: Clauses<'tcx>,
 }
+
+// Empty ParamEnv's are super common (like, 100x more common than nonempty pnes),
+// so we want to not carry around too much data in this common case.
+// Make sure that a ParamEnv is no bigger than a single pointer, always.
+static_assert_size!(ParamEnv<'_>, std::mem::size_of::<usize>());
 
 impl<'tcx> rustc_type_ir::inherent::ParamEnv<TyCtxt<'tcx>> for ParamEnv<'tcx> {
     fn caller_bounds(self) -> impl inherent::SliceLike<Item = ty::Clause<'tcx>> {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1161,7 +1161,7 @@ pub struct ParamEnv<'tcx> {
 static_assert_size!(ParamEnv<'_>, std::mem::size_of::<usize>());
 
 impl<'tcx> rustc_type_ir::inherent::ParamEnv<TyCtxt<'tcx>> for ParamEnv<'tcx> {
-    fn caller_bounds(self) -> impl inherent::SliceLike<Item = ty::Clause<'tcx>> {
+    fn caller_bounds(self) -> impl Iterator<Item = ty::Clause<'tcx>> {
         self.caller_bounds()
     }
 }
@@ -1179,8 +1179,13 @@ impl<'tcx> ParamEnv<'tcx> {
     }
 
     #[inline]
-    pub fn caller_bounds(self) -> Clauses<'tcx> {
-        self.caller_bounds
+    pub fn caller_bounds(self) -> impl Iterator<Item = ty::Clause<'tcx>> + Clone {
+        self.caller_bounds.iter()
+    }
+
+    #[inline]
+    pub fn is_empty(self) -> bool {
+        self.caller_bounds.as_slice().is_empty()
     }
 
     /// Construct a trait environment with the given set of predicates.

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1175,7 +1175,7 @@ impl<'tcx> ParamEnv<'tcx> {
     /// [param_env_guide]: https://rustc-dev-guide.rust-lang.org/typing_parameter_envs.html
     #[inline]
     pub fn empty() -> Self {
-        Self::new(ListWithCachedTypeInfo::empty())
+        Self { caller_bounds: ListWithCachedTypeInfo::empty() }
     }
 
     #[inline]
@@ -1190,8 +1190,11 @@ impl<'tcx> ParamEnv<'tcx> {
 
     /// Construct a trait environment with the given set of predicates.
     #[inline]
-    pub fn new(caller_bounds: Clauses<'tcx>) -> Self {
-        ParamEnv { caller_bounds }
+    pub fn new(
+        tcx: TyCtxt<'tcx>,
+        caller_bounds: impl IntoIterator<Item = ty::Clause<'tcx>>,
+    ) -> Self {
+        ParamEnv { caller_bounds: tcx.mk_clauses_from_iter(caller_bounds.into_iter()) }
     }
 
     /// Creates a pair of param-env and value for use in queries.
@@ -1206,7 +1209,7 @@ impl<'tcx> ParamEnv<'tcx> {
         if tcx.next_trait_solver_globally() {
             self
         } else {
-            ParamEnv::new(tcx.reveal_opaque_types_in_bounds(self.caller_bounds))
+            ParamEnv::new(tcx, tcx.reveal_opaque_types_in_bounds(self.caller_bounds).iter())
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -268,7 +268,7 @@ impl<'a, 'tcx> Lift<TyCtxt<'tcx>> for ty::ParamEnv<'a> {
     type Lifted = ty::ParamEnv<'tcx>;
 
     fn lift_to_interner(self, tcx: TyCtxt<'tcx>) -> Self::Lifted {
-        ty::ParamEnv::new(tcx.lift(self.caller_bounds))
+        ty::ParamEnv { caller_bounds: tcx.lift(self.caller_bounds) }
     }
 }
 

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -268,7 +268,7 @@ impl<'a, 'tcx> Lift<TyCtxt<'tcx>> for ty::ParamEnv<'a> {
     type Lifted = ty::ParamEnv<'tcx>;
 
     fn lift_to_interner(self, tcx: TyCtxt<'tcx>) -> Self::Lifted {
-        ty::ParamEnv::new(tcx.lift(self.caller_bounds()))
+        ty::ParamEnv::new(tcx.lift(self.caller_bounds))
     }
 }
 

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -333,7 +333,7 @@ impl ParamConst {
 
     #[instrument(level = "debug")]
     pub fn find_const_ty_from_env<'tcx>(self, env: ParamEnv<'tcx>) -> Ty<'tcx> {
-        let mut candidates = env.caller_bounds().iter().filter_map(|clause| {
+        let mut candidates = env.caller_bounds().filter_map(|clause| {
             // `ConstArgHasType` are never desugared to be higher ranked.
             match clause.kind().skip_binder() {
                 ty::ClauseKind::ConstArgHasType(param_ct, ty) => {

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -705,7 +705,7 @@ where
         candidates: &mut Vec<Candidate<I>>,
         failed_candidate_info: &mut FailedCandidateInfo,
     ) -> Result<(), RerunNonErased> {
-        for assumption in goal.param_env.caller_bounds().iter() {
+        for assumption in goal.param_env.caller_bounds() {
             match G::probe_and_consider_param_env_candidate(self, goal, assumption)? {
                 Ok(candidate) => candidates.push(candidate),
                 Err(head_usages) => {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -1542,7 +1542,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     } else {
                         DefIdOrName::Name("type parameter")
                     };
-                    param_env.caller_bounds().iter().find_map(|clause| {
+                    param_env.caller_bounds().find_map(|clause| {
                         if let ty::ClauseKind::Projection(proj) = clause.kind().skip_binder()
                             && self
                                 .tcx

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -237,7 +237,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             })
             .collect::<Vec<ty::Clause<'tcx>>>();
         let full_user_env = ty::ParamEnv::new(
-            tcx.mk_clauses_from_iter(orig_env.caller_bounds().iter().chain(field_clauses)),
+            tcx.mk_clauses_from_iter(orig_env.caller_bounds().chain(field_clauses)),
         );
 
         let fresh_args = infcx.fresh_args_for_item(DUMMY_SP, adt_def.did());
@@ -325,8 +325,8 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             polarity: ty::ClausePolarity::Positive,
         }));
 
-        let computed_clauses = param_env.caller_bounds().iter();
-        let mut user_computed_clauses: FxIndexSet<_> = user_env.caller_bounds().iter().collect();
+        let computed_clauses = param_env.caller_bounds();
+        let mut user_computed_clauses: FxIndexSet<_> = user_env.caller_bounds().collect();
 
         let mut new_env = param_env;
         let dummy_cause = ObligationCause::dummy();

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -236,9 +236,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                 .upcast(tcx)
             })
             .collect::<Vec<ty::Clause<'tcx>>>();
-        let full_user_env = ty::ParamEnv::new(
-            tcx.mk_clauses_from_iter(orig_env.caller_bounds().chain(field_clauses)),
-        );
+        let full_user_env = ty::ParamEnv::new(tcx, orig_env.caller_bounds().chain(field_clauses));
 
         let fresh_args = infcx.fresh_args_for_item(DUMMY_SP, adt_def.did());
         let fresh_ty = ty::EarlyBinder::bind(tcx, ty).instantiate(tcx, fresh_args).skip_norm_wip();
@@ -403,11 +401,10 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                 tcx,
                 computed_clauses.clone().chain(user_computed_clauses.iter().cloned()),
             );
-            new_env = ty::ParamEnv::new(tcx.mk_clauses_from_iter(normalized_preds));
+            new_env = ty::ParamEnv::new(tcx, normalized_preds);
         }
 
-        let final_user_env =
-            ty::ParamEnv::new(tcx.mk_clauses_from_iter(user_computed_clauses.into_iter()));
+        let final_user_env = ty::ParamEnv::new(tcx, user_computed_clauses.into_iter());
         debug!(
             "evaluate_nested_obligations(ty={:?}, trait_did={:?}): succeeded with '{:?}' \
              '{:?}'",

--- a/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
+++ b/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
@@ -733,7 +733,7 @@ fn receiver_is_dispatchable<'tcx>(
 
         normalize_param_env_or_error(
             tcx,
-            ty::ParamEnv::new(tcx.mk_clauses(&clauses)),
+            ty::ParamEnv::new(tcx, clauses),
             ObligationCause::dummy_with_span(tcx.def_span(method.def_id)),
         )
     };

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -353,7 +353,7 @@ fn do_normalize_clauses<'tcx>(
     {
         let elaborated_env = ty::set_type_aliases_to_rigid(tcx, elaborated_env);
         let elaborated_env = set_projection_term_to_non_rigid(tcx, elaborated_env.caller_bounds());
-        ty::ParamEnv::new(tcx.mk_clauses_from_iter(elaborated_env))
+        ty::ParamEnv::new(tcx, elaborated_env)
     } else {
         elaborated_env
     };
@@ -403,7 +403,7 @@ fn do_normalize_clauses<'tcx>(
     //
     // FIXME: We should avoid interning clauses both here and at the
     // caller sites. We should also avoid cloning if possible.
-    let normalized_env = ty::ParamEnv::new(tcx.mk_clauses(&clauses));
+    let normalized_env = ty::ParamEnv::new(tcx, clauses.iter().copied());
     let _errors = infcx.resolve_regions(cause.body_def_id, normalized_env, []);
     match infcx.fully_resolve(clauses.clone()) {
         Ok(clauses) => clauses,
@@ -525,7 +525,7 @@ pub fn normalize_param_env_or_error<'tcx>(
 
     debug!("normalize_param_env_or_error: elaborated-clauses={:?}", clauses);
 
-    let elaborated_env = ty::ParamEnv::new(tcx.mk_clauses(&clauses));
+    let elaborated_env = ty::ParamEnv::new(tcx, clauses.iter().copied());
     if !elaborated_env.has_aliases() {
         return elaborated_env;
     }
@@ -566,14 +566,14 @@ pub fn normalize_param_env_or_error<'tcx>(
     // here. I believe they should not matter, because we are ignoring TypeOutlives param-env
     // clauses here anyway. Keeping them here anyway because it seems safer.
     let outlives_env = non_outlives_clauses.iter().chain(&outlives_clauses).cloned();
-    let outlives_env = ty::ParamEnv::new(tcx.mk_clauses_from_iter(outlives_env));
+    let outlives_env = ty::ParamEnv::new(tcx, outlives_env);
     let outlives_clauses = do_normalize_clauses(tcx, cause, outlives_env, outlives_clauses);
     debug!("normalize_param_env_or_error: outlives clauses={:?}", outlives_clauses);
 
     let mut clauses = non_outlives_clauses;
     clauses.extend(outlives_clauses);
     debug!("normalize_param_env_or_error: final clauses={:?}", clauses);
-    ty::ParamEnv::new(tcx.mk_clauses(&clauses))
+    ty::ParamEnv::new(tcx, clauses)
 }
 
 #[derive(Debug)]

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -790,7 +790,7 @@ fn assemble_candidates_from_param_env<'cx, 'tcx>(
         obligation,
         candidate_set,
         ProjectionCandidate::ParamEnv,
-        obligation.param_env.caller_bounds().iter(),
+        obligation.param_env.caller_bounds(),
         false,
     );
 }

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -280,7 +280,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             .obligation
             .param_env
             .caller_bounds()
-            .iter()
             .filter_map(|c| c.as_trait_clause())
             // Micro-optimization: filter out predicates with different polarities.
             .filter(|p| p.polarity() == stack.obligation.predicate.polarity());

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1011,7 +1011,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     ) -> Result<EvaluationResult, OverflowError> {
         if !self.typing_mode().is_coherence()
             && obligation.is_global()
-            && obligation.param_env.caller_bounds().iter().all(|bound| bound.has_param())
+            && obligation.param_env.caller_bounds().all(|bound| bound.has_param())
         {
             // If a param env has no global bounds, global obligations do not
             // depend on its particular value in order to work, so we can clear

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -203,10 +203,7 @@ fn fulfill_implication<'tcx>(
         debug!(
             "fulfill_implication: for impls on {:?} and {:?}, \
                  could not fulfill: {:?} given {:?}",
-            source_trait_ref,
-            target_trait_ref,
-            errors,
-            param_env.caller_bounds().collect::<Vec<_>>()
+            source_trait_ref, target_trait_ref, errors, param_env
         );
         return Err(NoSolution);
     }
@@ -334,10 +331,7 @@ pub(super) fn specializes(
         debug!(
             "fulfill_implication: for impls on {:?} and {:?}, \
                  could not fulfill: {:?} given {:?}",
-            specializing_impl_trait_ref,
-            parent_impl_trait_ref,
-            errors,
-            param_env.caller_bounds().collect::<Vec<_>>()
+            specializing_impl_trait_ref, parent_impl_trait_ref, errors, param_env
         );
         return false;
     }
@@ -370,10 +364,7 @@ pub(super) fn specializes(
             debug!(
                 "fulfill_implication: for impls on {:?} and {:?}, \
                  could not fulfill: {:?} given {:?}",
-                specializing_impl_trait_ref,
-                parent_impl_trait_ref,
-                errors,
-                param_env.caller_bounds().collect::<Vec<_>>()
+                specializing_impl_trait_ref, parent_impl_trait_ref, errors, param_env
             );
             return false;
         }

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -206,7 +206,7 @@ fn fulfill_implication<'tcx>(
             source_trait_ref,
             target_trait_ref,
             errors,
-            param_env.caller_bounds()
+            param_env.caller_bounds().collect::<Vec<_>>()
         );
         return Err(NoSolution);
     }
@@ -337,7 +337,7 @@ pub(super) fn specializes(
             specializing_impl_trait_ref,
             parent_impl_trait_ref,
             errors,
-            param_env.caller_bounds()
+            param_env.caller_bounds().collect::<Vec<_>>()
         );
         return false;
     }
@@ -373,7 +373,7 @@ pub(super) fn specializes(
                 specializing_impl_trait_ref,
                 parent_impl_trait_ref,
                 errors,
-                param_env.caller_bounds()
+                param_env.caller_bounds().collect::<Vec<_>>()
             );
             return false;
         }

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -130,7 +130,7 @@ fn map_error<'tcx>(
             // This is sometimes not a compile error if there are trivially false where clauses.
             // See `tests/ui/layout/trivial-bounds-sized.rs` for an example.
             assert!(field.layout.is_unsized(), "invalid layout error {err:#?}");
-            if cx.typing_env.param_env.caller_bounds().is_empty() {
+            if cx.typing_env.param_env.is_empty() {
                 cx.tcx().dcx().delayed_bug(format!(
                     "encountered unexpected unsized field in layout of {ty:?}: {field:#?}"
                 ));
@@ -829,7 +829,7 @@ fn layout_of_uncached<'tcx>(
             // Due to trivial bounds, this can even be the case if the alias does not reference
             // any generic parameters, e.g. a `for<'a> u32: Trait<'a>` where-bound means that
             // `<u32 as Trait<'static>>::Assoc` is rigid.
-            let err = if ty.has_param() || !cx.typing_env.param_env.caller_bounds().is_empty() {
+            let err = if ty.has_param() || !cx.typing_env.param_env.is_empty() {
                 LayoutError::TooGeneric(ty)
             } else {
                 LayoutError::ReferencesError(cx.tcx().dcx().delayed_bug(format!(
@@ -850,7 +850,7 @@ fn record_layout_for_printing<'tcx>(cx: &LayoutCx<'tcx>, layout: TyAndLayout<'tc
     // Ignore layouts that are done with non-empty environments or
     // non-monomorphic layouts, as the user only wants to see the stuff
     // resulting from the final codegen session.
-    if layout.ty.has_non_region_param() || !cx.typing_env.param_env.caller_bounds().is_empty() {
+    if layout.ty.has_non_region_param() || !cx.typing_env.param_env.is_empty() {
         return;
     }
 

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -197,7 +197,7 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
 
     let local_did = def_id.as_local().unwrap_or(CRATE_DEF_ID);
 
-    let unnormalized_env = ty::ParamEnv::new(tcx.mk_clauses(&clauses));
+    let unnormalized_env = ty::ParamEnv::new(tcx, clauses);
 
     let cause = traits::ObligationCause::misc(tcx.def_span(def_id), local_did);
     traits::normalize_param_env_or_error(tcx, unnormalized_env, cause)

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -1258,7 +1258,7 @@ impl<I: Interner> PlaceholderConst<I> {
     }
 
     pub fn find_const_ty_from_env(self, env: I::ParamEnv) -> I::Ty {
-        let mut candidates = env.caller_bounds().iter().filter_map(|clause| {
+        let mut candidates = env.caller_bounds().filter_map(|clause| {
             // `ConstArgHasType` are never desugared to be higher ranked.
             match clause.kind().skip_binder() {
                 ty::ClauseKind::ConstArgHasType(placeholder_ct, ty) => {

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -589,7 +589,7 @@ where
     Infcx: InferCtxtLike<Interner = I>,
 {
     // Iterate through all goals in param_env to find the one that has the same symbol.
-    for clause in param_env.caller_bounds().iter() {
+    for clause in param_env.caller_bounds() {
         if let ty::ClauseKind::UnstableFeature(sym) = clause.kind().skip_binder() {
             if sym == symbol {
                 return true;

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -618,7 +618,7 @@ pub trait AdtDef<I: Interner>: Copy + Debug + Hash + Eq {
 
 #[rust_analyzer::prefer_underscore_import]
 pub trait ParamEnv<I: Interner>: Copy + Debug + Hash + Eq + TypeFoldable<I> {
-    fn caller_bounds(self) -> impl SliceLike<Item = I::Clause>;
+    fn caller_bounds(self) -> impl Iterator<Item = I::Clause>;
 }
 
 #[rust_analyzer::prefer_underscore_import]

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -173,11 +173,10 @@ fn clean_param_env<'tcx>(
         .collect();
 
     // FIXME(#111101): Incorporate the explicit predicates of the item here...
-    let item_clauses: FxIndexSet<_> = tcx.param_env(item_def_id).caller_bounds().iter().collect();
+    let item_clauses: FxIndexSet<_> = tcx.param_env(item_def_id).caller_bounds().collect();
     let where_predicates = cx.with_exact_param_env(param_env, |cx| {
         param_env
             .caller_bounds()
-            .iter()
             // FIXME: ...which hopefully allows us to simplify this:
             .filter(|clause| {
                 !item_clauses.contains(clause)

--- a/src/tools/clippy/clippy_lints/src/derive/derive_partial_eq_without_eq.rs
+++ b/src/tools/clippy/clippy_lints/src/derive/derive_partial_eq_without_eq.rs
@@ -76,14 +76,18 @@ fn typing_env_for_derived_eq(tcx: TyCtxt<'_>, did: DefId, eq_trait_id: DefId) ->
         }
     }
 
-    let param_env = ParamEnv::new(tcx.mk_clauses_from_iter(ty_clauses.iter().map(|&(c, _)| c).chain(
-        params.iter().filter(|&&(_, needs_eq)| needs_eq).map(|&(param, _)| {
-            ClauseKind::Trait(TraitClause {
-                trait_ref: ty::TraitRef::new(tcx, eq_trait_id, [tcx.mk_param_from_def(param)]),
-                polarity: ty::ClausePolarity::Positive,
-            })
-            .upcast(tcx)
-        }),
-    )));
+    let param_env = ParamEnv::new(
+        tcx,
+        ty_clauses
+            .iter()
+            .map(|&(c, _)| c)
+            .chain(params.iter().filter(|&&(_, needs_eq)| needs_eq).map(|&(param, _)| {
+                ClauseKind::Trait(TraitClause {
+                    trait_ref: ty::TraitRef::new(tcx, eq_trait_id, [tcx.mk_param_from_def(param)]),
+                    polarity: ty::ClausePolarity::Positive,
+                })
+                .upcast(tcx)
+            })),
+    );
     ty::TypingEnv::new(param_env, ty::TypingMode::non_body_analysis())
 }

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_to_owned.rs
@@ -544,16 +544,15 @@ fn can_change_type<'a>(cx: &LateContext<'a>, mut expr: &'a Expr<'a>, mut ty: Ty<
                             return false;
                         }
 
-                        let mut trait_clauses =
-                            cx.tcx.param_env(callee_def_id).caller_bounds().iter().filter(|clause| {
-                                if let ClauseKind::Trait(trait_predicate) = clause.kind().skip_binder()
-                                    && trait_predicate.trait_ref.self_ty() == param_ty
-                                {
-                                    true
-                                } else {
-                                    false
-                                }
-                            });
+                        let mut trait_clauses = cx.tcx.param_env(callee_def_id).caller_bounds().filter(|clause| {
+                            if let ClauseKind::Trait(trait_predicate) = clause.kind().skip_binder()
+                                && trait_predicate.trait_ref.self_ty() == param_ty
+                            {
+                                true
+                            } else {
+                                false
+                            }
+                        });
 
                         let new_subst = cx
                             .tcx

--- a/src/tools/clippy/clippy_lints/src/needless_borrows_for_generic_args.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_borrows_for_generic_args.rs
@@ -184,7 +184,7 @@ fn needless_borrow_count<'tcx>(
         .instantiate_identity()
         .skip_norm_wip()
         .skip_binder();
-    let clauses = cx.tcx.param_env(fn_id).caller_bounds();
+    let clauses = cx.tcx.param_env(fn_id).caller_bounds().collect::<Vec<_>>();
     let projection_predicates = clauses
         .iter()
         .filter_map(|clause| {
@@ -271,7 +271,7 @@ fn needless_borrow_count<'tcx>(
             return false;
         }
 
-        clauses.iter().all(|clause| {
+        clauses.iter().all(|&clause| {
             if let ClauseKind::Trait(trait_predicate) = clause.kind().skip_binder()
                 && cx
                     .tcx

--- a/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
@@ -120,7 +120,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
         let sized_trait = need!(cx.tcx.lang_items().sized_trait());
         let meta_sized_trait = need!(cx.tcx.lang_items().meta_sized_trait());
 
-        let preds = traits::elaborate(cx.tcx, cx.param_env.caller_bounds().iter())
+        let preds = traits::elaborate(cx.tcx, cx.param_env.caller_bounds())
             .filter(|c| !c.is_global())
             .filter_map(|clause| {
                 // Note that we do not want to deal with qualified clauses here.

--- a/src/tools/clippy/clippy_lints/src/useless_conversion.rs
+++ b/src/tools/clippy/clippy_lints/src/useless_conversion.rs
@@ -343,8 +343,7 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
                             && let Some(self_ty) = inputs.first()
                             && let ty::Ref(_, _, Mutability::Mut) = self_ty.kind()
                             && let Some(second_ty) = inputs.get(1)
-                            && let clauses = cx.tcx.param_env(def_id).caller_bounds()
-                            && clauses.iter().any(|clause| {
+                            && cx.tcx.param_env(def_id).caller_bounds().any(|clause| {
                                 if let ty::ClauseKind::Trait(trait_pred) = clause.kind().skip_binder() {
                                     trait_pred.self_ty() == *second_ty
                                         && cx.tcx.lang_items().fn_mut_trait() == Some(trait_pred.def_id())

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -35,7 +35,7 @@ pub fn is_min_const_fn<'tcx>(cx: &LateContext<'tcx>, body: &Body<'tcx>, msrv: Ms
     if !msrv.meets(cx, msrvs::CONST_FN_TRAIT_BOUND)
         && let Some(sized_did) = cx.tcx.lang_items().sized_trait()
         && let Some(meta_sized_did) = cx.tcx.lang_items().meta_sized_trait()
-        && cx.tcx.param_env(def_id).caller_bounds().iter().any(|bound| {
+        && cx.tcx.param_env(def_id).caller_bounds().any(|bound| {
             bound.as_trait_clause().is_some_and(|clause| {
                 let did = clause.def_id();
                 did != sized_did && did != meta_sized_did


### PR DESCRIPTION
r? @lcnr

Change things so paramenvs are created from iterators instead of already interned lists. In theory this may sometimes cause re-interning, but I haven't seen any performance change because of it. The advantage is that doing the interning becomes private API of paramenvs, so we can change how it works (by for example, compressing the paramenv in the future).

> [!NOTE]
> I've not used an LLM for any part of this PR, or any other PR I make. This includes any related work like research. 
