### PR TITLE
Fix Take side effects for empty random access

### DIFF
--- a/library/core/src/iter/adapters/take.rs
+++ b/library/core/src/iter/adapters/take.rs
@@ -312,6 +312,11 @@ impl<I: Iterator + TrustedRandomAccess> SpecTake for Take<I> {
     {
         let mut acc = init;
         let end = self.n.min(self.iter.size());
+
+        if end == 0 && I::MAY_HAVE_SIDE_EFFECT {
+            let _ = self.iter.next();
+        }
+
         for i in 0..end {
             // SAFETY: i < end <= self.iter.size() and we discard the iterator at the end
             let val = unsafe { self.iter.__iterator_get_unchecked(i) };
@@ -323,6 +328,11 @@ impl<I: Iterator + TrustedRandomAccess> SpecTake for Take<I> {
     #[inline]
     fn spec_for_each<F: FnMut(Self::Item)>(mut self, mut f: F) {
         let end = self.n.min(self.iter.size());
+
+        if end == 0 && I::MAY_HAVE_SIDE_EFFECT {
+            let _ = self.iter.next();
+        }
+
         for i in 0..end {
             // SAFETY: i < end <= self.iter.size() and we discard the iterator at the end
             let val = unsafe { self.iter.__iterator_get_unchecked(i) };

--- a/library/coretests/tests/iter/adapters/take.rs
+++ b/library/coretests/tests/iter/adapters/take.rs
@@ -323,3 +323,31 @@ fn test_iterator_take_count() {
         .count();
     assert_eq!(counted, yielded.len());
 }
+
+#[test]
+fn test_take_side_effects_after_skip() {
+    let mut for_each_calls = 0;
+    [1, 2, 3]
+        .iter()
+        .map(|&x| {
+            for_each_calls += 1;
+            x
+        })
+        .skip(3)
+        .take(100)
+        .for_each(drop);
+
+    let mut fold_calls = 0;
+    [1, 2, 3]
+        .iter()
+        .map(|&x| {
+            fold_calls += 1;
+            x
+        })
+        .skip(3)
+        .take(100)
+        .fold((), |(), _| ());
+
+    assert_eq!(for_each_calls, 3);
+    assert_eq!(fold_calls, 3);
+}


### PR DESCRIPTION
Fixes rust-lang/rust#161350 

The TrustedRandomAccess implementations of Take::for_each and Take::fold could skip observable side effects when the inner iterator was empty after skip.

When MAY_HAVE_SIDE_EFFECT is set, make a single next call before returning from the empty random-access case so that the skipped elements are still processed.

Added a regression test covering both for_each and fold.

Tests:
.\x.ps1 test coretests --test-args take
.\x.ps1 fmt --check