### PR TITLE
[experiment] Use DenseBitSetStorage to store MixedBitSet::Small inline

### DIFF
--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -2,10 +2,11 @@ use std::marker::PhantomData;
 use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 use std::rc::Rc;
 use std::{fmt, iter, slice};
-use smallvec::SmallVec;
+
 use Chunk::*;
 #[cfg(feature = "nightly")]
 use rustc_macros::{Decodable_NoContext, Encodable_NoContext};
+use smallvec::SmallVec;
 
 use crate::{Idx, IndexVec};
 
@@ -89,7 +90,7 @@ impl<T, S> DenseBitSet<T, S> {
     }
 }
 
-pub trait DenseBitSetStorage: AsRef<[Word]> + AsMut<[Word]> + DerefMut<Target=[Word]> {}
+pub trait DenseBitSetStorage: AsRef<[Word]> + AsMut<[Word]> + DerefMut<Target = [Word]> {}
 
 impl DenseBitSetStorage for Vec<Word> {}
 impl<const N: usize> DenseBitSetStorage for SmallVec<[Word; N]> {}

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -76,9 +76,9 @@ fn inclusive_start_end<T: Idx>(
 ///
 #[cfg_attr(feature = "nightly", derive(Decodable_NoContext, Encodable_NoContext))]
 #[derive(Eq, PartialEq, Hash)]
-pub struct DenseBitSet<T> {
+pub struct DenseBitSet<T, S = Vec<Word>> {
     domain_size: usize,
-    words: Vec<Word>,
+    words: S,
     marker: PhantomData<T>,
 }
 

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -102,12 +102,14 @@ pub struct ArrayStorage<const N: usize> {
     inner: [Word; N],
 }
 impl<const N: usize> AsRef<[Word]> for ArrayStorage<N> {
+    #[inline]
     fn as_ref(&self) -> &[Word] {
         &self.inner
     }
 }
 
 impl<const N: usize> AsMut<[Word]> for ArrayStorage<N> {
+    #[inline]
     fn as_mut(&mut self) -> &mut [Word] {
         &mut self.inner
     }
@@ -115,12 +117,14 @@ impl<const N: usize> AsMut<[Word]> for ArrayStorage<N> {
 
 impl<const N: usize> Deref for ArrayStorage<N> {
     type Target = [Word];
+    #[inline]
     fn deref(&self) -> &[Word] {
         self.inner.as_ref()
     }
 }
 
 impl<const N: usize> DerefMut for ArrayStorage<N> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner.as_mut()
     }

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 use std::rc::Rc;
 use std::{fmt, iter, slice};
-
+use smallvec::SmallVec;
 use Chunk::*;
 #[cfg(feature = "nightly")]
 use rustc_macros::{Decodable_NoContext, Encodable_NoContext};
@@ -89,6 +89,43 @@ impl<T, S> DenseBitSet<T, S> {
     }
 }
 
+pub trait DenseBitSetStorage: AsRef<[Word]> + AsMut<[Word]> + DerefMut<Target=[Word]> {}
+
+impl DenseBitSetStorage for Vec<Word> {}
+impl<const N: usize> DenseBitSetStorage for SmallVec<[Word; N]> {}
+
+// workaround because arrays don't implement DerefMut
+#[repr(transparent)]
+pub struct ArrayStorage<const N: usize> {
+    inner: [Word; N],
+}
+impl<const N: usize> AsRef<[Word]> for ArrayStorage<N> {
+    fn as_ref(&self) -> &[Word] {
+        &self.inner
+    }
+}
+
+impl<const N: usize> AsMut<[Word]> for ArrayStorage<N> {
+    fn as_mut(&mut self) -> &mut [Word] {
+        &mut self.inner
+    }
+}
+
+impl<const N: usize> Deref for ArrayStorage<N> {
+    type Target = [Word];
+    fn deref(&self) -> &[Word] {
+        self.inner.as_ref()
+    }
+}
+
+impl<const N: usize> DerefMut for ArrayStorage<N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner.as_mut()
+    }
+}
+
+impl<const N: usize> DenseBitSetStorage for ArrayStorage<N> {}
+
 impl<T: Idx> DenseBitSet<T> {
     /// Creates a new, empty bitset with a given `domain_size`.
     #[inline]
@@ -108,7 +145,7 @@ impl<T: Idx> DenseBitSet<T> {
     }
 }
 
-impl<T: Idx, S: DerefMut<Target = [Word]>> DenseBitSet<T, S> {
+impl<T: Idx, S: DenseBitSetStorage> DenseBitSet<T, S> {
     /// Clear all elements.
     #[inline]
     pub fn clear(&mut self) {
@@ -135,7 +172,7 @@ impl<T: Idx, S: DerefMut<Target = [Word]>> DenseBitSet<T, S> {
 
     /// Is `self` is a (non-strict) superset of `other`?
     #[inline]
-    pub fn superset<OS: Deref<Target = [Word]>>(&self, other: &DenseBitSet<T, OS>) -> bool {
+    pub fn superset<OS: DenseBitSetStorage>(&self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         self.words.iter().zip(&*other.words).all(|(a, b)| (a & b) == *b)
     }
@@ -286,7 +323,7 @@ impl<T: Idx, S: DerefMut<Target = [Word]>> DenseBitSet<T, S> {
     }
 
     /// Sets `self = self | !other`.
-    pub fn union_not<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) {
+    pub fn union_not<OS: DenseBitSetStorage>(&mut self, other: &DenseBitSet<T, OS>) {
         assert_eq!(self.domain_size, other.domain_size);
 
         // FIXME(Zalathar): If we were to forcibly _set_ all excess bits before
@@ -301,19 +338,19 @@ impl<T: Idx, S: DerefMut<Target = [Word]>> DenseBitSet<T, S> {
     }
 
     /// Returns true if `self` was modified.
-    pub fn union<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
+    pub fn union<OS: DenseBitSetStorage>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         update_words(&mut self.words, &other.words, |a, b| a | b)
     }
 
     /// Returns true if `self` was modified.
-    pub fn subtract<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
+    pub fn subtract<OS: DenseBitSetStorage>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         update_words(&mut self.words, &other.words, |a, b| a & !b)
     }
 
     /// Returns true if `self` was modified.
-    pub fn intersect<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
+    pub fn intersect<OS: DenseBitSetStorage>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         update_words(&mut *self.words, &other.words, |a, b| a & b)
     }
@@ -340,13 +377,13 @@ impl<T, S: Clone> Clone for DenseBitSet<T, S> {
     }
 }
 
-impl<T: Idx, S: DerefMut<Target = [Word]>> fmt::Debug for DenseBitSet<T, S> {
+impl<T: Idx, S: DenseBitSetStorage> fmt::Debug for DenseBitSet<T, S> {
     fn fmt(&self, w: &mut fmt::Formatter<'_>) -> fmt::Result {
         w.debug_list().entries(self.iter()).finish()
     }
 }
 
-impl<T: Idx, S: DerefMut<Target = [Word]>> ToString for DenseBitSet<T, S> {
+impl<T: Idx, S: DenseBitSetStorage> ToString for DenseBitSet<T, S> {
     fn to_string(&self) -> String {
         let mut result = String::new();
         let mut sep = '[';

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -1119,6 +1119,8 @@ where
 /// will panic if the bitsets have differing domain sizes.
 #[derive(PartialEq, Eq)]
 pub enum MixedBitSet<T> {
+    Empty,
+    Tiny(DenseBitSet<T, ArrayStorage<1>>),
     Small(DenseBitSet<T, ArrayStorage<2>>),
     Large(ChunkedBitSet<T>),
 }
@@ -1126,6 +1128,8 @@ pub enum MixedBitSet<T> {
 impl<T> MixedBitSet<T> {
     pub fn domain_size(&self) -> usize {
         match self {
+            MixedBitSet::Empty => 0,
+            MixedBitSet::Tiny(set) => set.domain_size() ,
             MixedBitSet::Small(set) => set.domain_size(),
             MixedBitSet::Large(set) => set.domain_size(),
         }
@@ -1135,7 +1139,12 @@ impl<T> MixedBitSet<T> {
 impl<T: Idx> MixedBitSet<T> {
     #[inline]
     pub fn new_empty(domain_size: usize) -> MixedBitSet<T> {
-        if num_words(domain_size) <= 2 {
+        let num_words = num_words(domain_size);
+        if num_words == 0 {
+            MixedBitSet::Empty
+        } else if num_words == 1 {
+            MixedBitSet::Tiny(DenseBitSet::new_empty_in_array(domain_size))
+        } else if num_words <= 2 {
             MixedBitSet::Small(DenseBitSet::new_empty_in_array(domain_size))
         } else {
             MixedBitSet::Large(ChunkedBitSet::new_empty(domain_size))
@@ -1145,6 +1154,8 @@ impl<T: Idx> MixedBitSet<T> {
     #[inline]
     pub fn is_empty(&self) -> bool {
         match self {
+            MixedBitSet::Empty => true,
+            MixedBitSet::Tiny(set) => set.is_empty(),
             MixedBitSet::Small(set) => set.is_empty(),
             MixedBitSet::Large(set) => set.is_empty(),
         }
@@ -1153,6 +1164,8 @@ impl<T: Idx> MixedBitSet<T> {
     #[inline]
     pub fn contains(&self, elem: T) -> bool {
         match self {
+            MixedBitSet::Empty => panic!("contains on empty"),
+            MixedBitSet::Tiny(set) => set.contains(elem),
             MixedBitSet::Small(set) => set.contains(elem),
             MixedBitSet::Large(set) => set.contains(elem),
         }
@@ -1161,6 +1174,8 @@ impl<T: Idx> MixedBitSet<T> {
     #[inline]
     pub fn insert(&mut self, elem: T) -> bool {
         match self {
+            MixedBitSet::Empty => panic!("insert on empty"),
+            MixedBitSet::Tiny(set) => set.insert(elem),
             MixedBitSet::Small(set) => set.insert(elem),
             MixedBitSet::Large(set) => set.insert(elem),
         }
@@ -1168,6 +1183,8 @@ impl<T: Idx> MixedBitSet<T> {
 
     pub fn insert_all(&mut self) {
         match self {
+            MixedBitSet::Empty => {},
+            MixedBitSet::Tiny(set) => set.insert_all(),
             MixedBitSet::Small(set) => set.insert_all(),
             MixedBitSet::Large(set) => set.insert_all(),
         }
@@ -1176,6 +1193,8 @@ impl<T: Idx> MixedBitSet<T> {
     #[inline]
     pub fn remove(&mut self, elem: T) -> bool {
         match self {
+            MixedBitSet::Empty => panic!("remove on empty"),
+            MixedBitSet::Tiny(set) => set.remove(elem),
             MixedBitSet::Small(set) => set.remove(elem),
             MixedBitSet::Large(set) => set.remove(elem),
         }
@@ -1183,6 +1202,8 @@ impl<T: Idx> MixedBitSet<T> {
 
     pub fn iter(&self) -> MixedBitIter<'_, T> {
         match self {
+            MixedBitSet::Empty => MixedBitIter::Empty,
+            MixedBitSet::Tiny(set) => MixedBitIter::Tiny(set.iter()),
             MixedBitSet::Small(set) => MixedBitIter::Small(set.iter()),
             MixedBitSet::Large(set) => MixedBitIter::Large(set.iter()),
         }
@@ -1191,6 +1212,8 @@ impl<T: Idx> MixedBitSet<T> {
     #[inline]
     pub fn clear(&mut self) {
         match self {
+            MixedBitSet::Empty => {},
+            MixedBitSet::Tiny(set) => set.clear(),
             MixedBitSet::Small(set) => set.clear(),
             MixedBitSet::Large(set) => set.clear(),
         }
@@ -1199,6 +1222,8 @@ impl<T: Idx> MixedBitSet<T> {
     /// Returns true if `self` was modified.
     pub fn union(&mut self, other: &MixedBitSet<T>) -> bool {
         match (self, other) {
+            (MixedBitSet::Empty, MixedBitSet::Empty) => false,
+            (MixedBitSet::Tiny(set), MixedBitSet::Tiny(other)) => set.union(other),
             (MixedBitSet::Small(set), MixedBitSet::Small(other)) => set.union(other),
             (MixedBitSet::Large(set), MixedBitSet::Large(other)) => set.union(other),
             _ => panic!("MixedBitSet size mismatch"),
@@ -1208,6 +1233,8 @@ impl<T: Idx> MixedBitSet<T> {
     /// Returns true if `self` was modified.
     pub fn subtract(&mut self, other: &MixedBitSet<T>) -> bool {
         match (self, other) {
+            (MixedBitSet::Empty, MixedBitSet::Empty) => false,
+            (MixedBitSet::Tiny(set), MixedBitSet::Tiny(other)) => set.subtract(other),
             (MixedBitSet::Small(set), MixedBitSet::Small(other)) => set.subtract(other),
             (MixedBitSet::Large(set), MixedBitSet::Large(other)) => set.subtract(other),
             _ => panic!("MixedBitSet size mismatch"),
@@ -1218,6 +1245,8 @@ impl<T: Idx> MixedBitSet<T> {
 impl<T> Clone for MixedBitSet<T> {
     fn clone(&self) -> Self {
         match self {
+            MixedBitSet::Empty => MixedBitSet::Empty,
+            MixedBitSet::Tiny(set) => MixedBitSet::Tiny(set.clone()),
             MixedBitSet::Small(set) => MixedBitSet::Small(set.clone()),
             MixedBitSet::Large(set) => MixedBitSet::Large(set.clone()),
         }
@@ -1229,6 +1258,8 @@ impl<T> Clone for MixedBitSet<T> {
     /// faster implementation, which is important because this function is hot.
     fn clone_from(&mut self, from: &Self) {
         match (self, from) {
+            (MixedBitSet::Empty, MixedBitSet::Empty) => {},
+            (MixedBitSet::Tiny(set), MixedBitSet::Tiny(from)) => set.clone_from(from),
             (MixedBitSet::Small(set), MixedBitSet::Small(from)) => set.clone_from(from),
             (MixedBitSet::Large(set), MixedBitSet::Large(from)) => set.clone_from(from),
             _ => panic!("MixedBitSet size mismatch"),
@@ -1239,6 +1270,8 @@ impl<T> Clone for MixedBitSet<T> {
 impl<T: Idx> fmt::Debug for MixedBitSet<T> {
     fn fmt(&self, w: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            MixedBitSet::Empty => DenseBitSet::<T>::new_empty(0).fmt(w),
+            MixedBitSet::Tiny(set) => set.fmt(w),
             MixedBitSet::Small(set) => set.fmt(w),
             MixedBitSet::Large(set) => set.fmt(w),
         }
@@ -1246,6 +1279,8 @@ impl<T: Idx> fmt::Debug for MixedBitSet<T> {
 }
 
 pub enum MixedBitIter<'a, T: Idx> {
+    Empty,
+    Tiny(BitIter<'a, T>),
     Small(BitIter<'a, T>),
     Large(ChunkedBitIter<'a, T>),
 }
@@ -1254,6 +1289,8 @@ impl<'a, T: Idx> Iterator for MixedBitIter<'a, T> {
     type Item = T;
     fn next(&mut self) -> Option<T> {
         match self {
+            MixedBitIter::Empty => None,
+            MixedBitIter::Tiny(iter) => iter.next(),
             MixedBitIter::Small(iter) => iter.next(),
             MixedBitIter::Large(iter) => iter.next(),
         }

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -97,6 +97,7 @@ impl<const N: usize> DenseBitSetStorage for SmallVec<[Word; N]> {}
 
 // workaround because arrays don't implement DerefMut
 #[repr(transparent)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ArrayStorage<const N: usize> {
     inner: [Word; N],
 }
@@ -126,6 +127,14 @@ impl<const N: usize> DerefMut for ArrayStorage<N> {
 }
 
 impl<const N: usize> DenseBitSetStorage for ArrayStorage<N> {}
+
+impl<T: Idx, const N: usize> DenseBitSet<T, ArrayStorage<N>> {
+    /// Creates a new, empty bitset with a given `domain_size`.
+    #[inline]
+    pub fn new_empty_in_array(domain_size: usize) -> DenseBitSet<T, ArrayStorage<N>> {
+        DenseBitSet { domain_size, words: ArrayStorage { inner: [0; N] }, marker: PhantomData }
+    }
+}
 
 impl<T: Idx> DenseBitSet<T> {
     /// Creates a new, empty bitset with a given `domain_size`.
@@ -1106,7 +1115,7 @@ where
 /// will panic if the bitsets have differing domain sizes.
 #[derive(PartialEq, Eq)]
 pub enum MixedBitSet<T> {
-    Small(DenseBitSet<T>),
+    Small(DenseBitSet<T, ArrayStorage<2>>),
     Large(ChunkedBitSet<T>),
 }
 
@@ -1122,8 +1131,8 @@ impl<T> MixedBitSet<T> {
 impl<T: Idx> MixedBitSet<T> {
     #[inline]
     pub fn new_empty(domain_size: usize) -> MixedBitSet<T> {
-        if domain_size <= CHUNK_BITS {
-            MixedBitSet::Small(DenseBitSet::new_empty(domain_size))
+        if num_words(domain_size) <= 2 {
+            MixedBitSet::Small(DenseBitSet::new_empty_in_array(domain_size))
         } else {
             MixedBitSet::Large(ChunkedBitSet::new_empty(domain_size))
         }

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::ops::{Bound, Range, RangeBounds};
+use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 use std::rc::Rc;
 use std::{fmt, iter, slice};
 
@@ -82,7 +82,7 @@ pub struct DenseBitSet<T, S = Vec<Word>> {
     marker: PhantomData<T>,
 }
 
-impl<T> DenseBitSet<T> {
+impl<T, S> DenseBitSet<T, S> {
     /// Gets the domain size.
     pub fn domain_size(&self) -> usize {
         self.domain_size
@@ -108,7 +108,7 @@ impl<T: Idx> DenseBitSet<T> {
     }
 }
 
-impl<T: Idx> DenseBitSet<T> {
+impl<T: Idx, S: DerefMut<Target = [Word]>> DenseBitSet<T, S> {
     /// Clear all elements.
     #[inline]
     pub fn clear(&mut self) {
@@ -135,9 +135,9 @@ impl<T: Idx> DenseBitSet<T> {
 
     /// Is `self` is a (non-strict) superset of `other`?
     #[inline]
-    pub fn superset(&self, other: &DenseBitSet<T>) -> bool {
+    pub fn superset<OS: Deref<Target = [Word]>>(&self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
-        self.words.iter().zip(&other.words).all(|(a, b)| (a & b) == *b)
+        self.words.iter().zip(&*other.words).all(|(a, b)| (a & b) == *b)
     }
 
     /// Is the set empty?
@@ -286,7 +286,7 @@ impl<T: Idx> DenseBitSet<T> {
     }
 
     /// Sets `self = self | !other`.
-    pub fn union_not(&mut self, other: &DenseBitSet<T>) {
+    pub fn union_not<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) {
         assert_eq!(self.domain_size, other.domain_size);
 
         // FIXME(Zalathar): If we were to forcibly _set_ all excess bits before
@@ -301,21 +301,21 @@ impl<T: Idx> DenseBitSet<T> {
     }
 
     /// Returns true if `self` was modified.
-    pub fn union(&mut self, other: &DenseBitSet<T>) -> bool {
+    pub fn union<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         update_words(&mut self.words, &other.words, |a, b| a | b)
     }
 
     /// Returns true if `self` was modified.
-    pub fn subtract(&mut self, other: &DenseBitSet<T>) -> bool {
+    pub fn subtract<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         update_words(&mut self.words, &other.words, |a, b| a & !b)
     }
 
     /// Returns true if `self` was modified.
-    pub fn intersect(&mut self, other: &DenseBitSet<T>) -> bool {
+    pub fn intersect<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
-        update_words(&mut self.words, &other.words, |a, b| a & b)
+        update_words(&mut *self.words, &other.words, |a, b| a & b)
     }
 }
 
@@ -325,7 +325,7 @@ impl<T: Idx> From<GrowableBitSet<T>> for DenseBitSet<T> {
     }
 }
 
-impl<T> Clone for DenseBitSet<T> {
+impl<T, S: Clone> Clone for DenseBitSet<T, S> {
     fn clone(&self) -> Self {
         DenseBitSet {
             domain_size: self.domain_size,
@@ -340,13 +340,13 @@ impl<T> Clone for DenseBitSet<T> {
     }
 }
 
-impl<T: Idx> fmt::Debug for DenseBitSet<T> {
+impl<T: Idx, S: DerefMut<Target = [Word]>> fmt::Debug for DenseBitSet<T, S> {
     fn fmt(&self, w: &mut fmt::Formatter<'_>) -> fmt::Result {
         w.debug_list().entries(self.iter()).finish()
     }
 }
 
-impl<T: Idx> ToString for DenseBitSet<T> {
+impl<T: Idx, S: DerefMut<Target = [Word]>> ToString for DenseBitSet<T, S> {
     fn to_string(&self) -> String {
         let mut result = String::new();
         let mut sep = '[';
@@ -355,7 +355,7 @@ impl<T: Idx> ToString for DenseBitSet<T> {
 
         // i tracks how many bits we have printed so far.
         let mut i = 0;
-        for word in &self.words {
+        for word in &*self.words {
             let mut word = *word;
             for _ in 0..WORD_BYTES {
                 // for each byte in `word`:

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -106,7 +106,9 @@ impl<T: Idx> DenseBitSet<T> {
         result.clear_excess_bits();
         result
     }
+}
 
+impl<T: Idx> DenseBitSet<T> {
     /// Clear all elements.
     #[inline]
     pub fn clear(&mut self) {

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -505,6 +505,18 @@ enum Chunk {
 #[cfg(target_pointer_width = "64")]
 crate::static_assert_size!(Chunk, 16);
 
+#[cfg(target_pointer_width = "64")]
+crate::static_assert_size!(MixedBitSet<usize>, 32);
+
+#[cfg(target_pointer_width = "64")]
+crate::static_assert_size!(DenseBitSet<usize>, 32);
+
+#[cfg(target_pointer_width = "64")]
+crate::static_assert_size!(DenseBitSet<usize, usize>, 16);
+
+#[cfg(target_pointer_width = "64")]
+crate::static_assert_size!(DenseBitSet<usize, [Word;2]>, 24);
+
 impl<T> ChunkedBitSet<T> {
     pub fn domain_size(&self) -> usize {
         self.domain_size

--- a/compiler/rustc_mir_dataflow/src/framework/fmt.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/fmt.rs
@@ -134,6 +134,8 @@ where
 {
     fn fmt_with(&self, ctxt: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            MixedBitSet::Empty => DenseBitSet::<T>::new_empty(0).fmt_with(ctxt, f),
+            MixedBitSet::Tiny(set) => set.fmt_with(ctxt, f),
             MixedBitSet::Small(set) => set.fmt_with(ctxt, f),
             MixedBitSet::Large(set) => set.fmt_with(ctxt, f),
         }
@@ -141,6 +143,8 @@ where
 
     fn fmt_diff_with(&self, old: &Self, ctxt: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match (self, old) {
+            (MixedBitSet::Empty, MixedBitSet::Empty) => DenseBitSet::<T>::new_empty(0).fmt_diff_with(&DenseBitSet::<T>::new_empty(0), ctxt, f),
+            (MixedBitSet::Tiny(set), MixedBitSet::Tiny(old)) => set.fmt_diff_with(old, ctxt, f),
             (MixedBitSet::Small(set), MixedBitSet::Small(old)) => set.fmt_diff_with(old, ctxt, f),
             (MixedBitSet::Large(set), MixedBitSet::Large(old)) => set.fmt_diff_with(old, ctxt, f),
             _ => panic!("MixedBitSet size mismatch"),

--- a/compiler/rustc_mir_dataflow/src/framework/fmt.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/fmt.rs
@@ -4,7 +4,7 @@
 use std::fmt;
 
 use rustc_index::Idx;
-use rustc_index::bit_set::{ChunkedBitSet, DenseBitSet, MixedBitSet};
+use rustc_index::bit_set::{ChunkedBitSet, DenseBitSet, DenseBitSetStorage, MixedBitSet};
 
 use super::lattice::MaybeReachable;
 
@@ -73,9 +73,10 @@ where
 
 // Impls
 
-impl<T, C> DebugWithContext<C> for DenseBitSet<T>
+impl<T, C, S: DenseBitSetStorage> DebugWithContext<C> for DenseBitSet<T, S>
 where
     T: Idx + DebugWithContext<C>,
+    DenseBitSet<T, S>: Eq
 {
     fn fmt_with(&self, ctxt: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_set().entries(self.iter().map(|i| DebugWithAdapter { this: i, ctxt })).finish()

--- a/compiler/rustc_mir_dataflow/src/framework/fmt.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/fmt.rs
@@ -76,7 +76,7 @@ where
 impl<T, C, S: DenseBitSetStorage> DebugWithContext<C> for DenseBitSet<T, S>
 where
     T: Idx + DebugWithContext<C>,
-    DenseBitSet<T, S>: Eq
+    DenseBitSet<T, S>: Eq,
 {
     fn fmt_with(&self, ctxt: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_set().entries(self.iter().map(|i| DebugWithAdapter { this: i, ctxt })).finish()


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Depends on the base from https://github.com/rust-lang/rust/pull/161345, uses slightly different design with a new DenseBitSetStorage trait, that makes it somewhat easier to thread generic params through the codebase.

We use this new design to store `MixedBitSet::Small` variant inline in 2-word array, instead of Heap.

I'm not super happy about this test case for 2 reasons

 1.  `MixedBitSet` is not really a good example of the target use case for this abstraction

But it's also hottest usage of small `DenseBitSet` so I hope I'll see some effect compared to https://github.com/rust-lang/rust/pull/161345 (which was tested on roughly second hottest small bitset on `serde`).

 2. This requires me to change threshold for `Small` bitsets, which might have side effects that mask the potential improvements
 
But according to my measurements, `::Small` variant is almost always <=2 words in our benchmark suite. I believe there's at most 1 case where it is 4 words (maybe none, but line numbers changed since I measured this so I'm not sure).