### PR TITLE
Fix checking of LLVM prebuilt status

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1393,7 +1393,7 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
     if builder.config.llvm_enabled(target) {
         let building_llvm_is_expensive = prebuilt_llvm_output(builder, target).is_none();
 
-        let skip_llvm = (builder.kind == Kind::Check) && building_llvm_is_expensive;
+        let skip_llvm = (cargo.kind() == Kind::Check) && building_llvm_is_expensive;
         if !skip_llvm {
             rustc_llvm_env(builder, cargo, target)
         }

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -168,7 +168,13 @@ pub fn prebuilt_llvm_output(builder: &Builder<'_>, target: TargetSelection) -> O
             kind: LlvmKind::External,
         });
     }
-    None
+
+    // If LLVM is not available from CI, not externally, it is still possible that it was already
+    // built locally before. In that case we still treat it as prebuilt config.
+    match get_locally_built_llvm_build_status(builder, target) {
+        LlvmBuildStatus::AlreadyBuilt(output) => Some(output),
+        LlvmBuildStatus::ShouldBuild(_) => None,
+    }
 }
 
 /// This returns whether we've already previously built LLVM.
@@ -186,6 +192,16 @@ pub fn get_llvm_build_status(builder: &Builder<'_>, target: TargetSelection) -> 
     // If submodules are disabled, this does nothing.
     builder.config.update_submodule("src/llvm-project");
 
+    get_locally_built_llvm_build_status(builder, target)
+}
+
+/// Return build status of LLVM, considering only the (possibly) locally built LLVM.
+///
+/// Calling this function should never attempt to checkout the LLVM submodule.
+fn get_locally_built_llvm_build_status(
+    builder: &Builder<'_>,
+    target: TargetSelection,
+) -> LlvmBuildStatus {
     let out_dir = builder.llvm_out(target);
 
     let build_llvm_config = if let Some(build_llvm_config) = builder

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -152,6 +152,7 @@ pub(crate) struct Cargo {
     build_compiler_stage: u32,
     extra_rustflags: Vec<String>,
     profile: Option<&'static str>,
+    kind: Kind,
 }
 
 impl Cargo {
@@ -201,6 +202,10 @@ impl Cargo {
 
     pub(crate) fn into_cmd(self) -> BootstrapCommand {
         self.into()
+    }
+
+    pub(crate) fn kind(&self) -> Kind {
+        self.kind
     }
 
     /// Same as [`Cargo::new`] except this one doesn't configure the linker with
@@ -1530,6 +1535,7 @@ impl Builder<'_> {
             build_compiler_stage,
             extra_rustflags,
             profile,
+            kind: cmd_kind,
         }
     }
 }

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2704,8 +2704,7 @@ mod snapshot {
             ctx.config("clippy")
                 .path("miri")
                 .stage(1)
-                .render_steps(), @r"
-        [build] llvm <host>
+                .render_steps(), @"
         [check] rustc 0 <host> -> rustc 1 <host>
         [clippy] rustc 0 <host> -> miri 1 <host>
         ");


### PR DESCRIPTION
This regressed in https://github.com/rust-lang/rust/pull/160916.

I'll start from the end. There was a pre-existing bug (fixed by the second commit of this PR), where if we do `x check library`, we have `builder.kind == Kind::Check`, but we are actually building things (like the compiler) during that bootstrap invocation. But bootstrap was only checking the builder kind before, and in that case it would skip building LLVM, *unless* it was already built locally previously. On PR CI, and perhaps always (because build steps executed during check likely only occur during `x check library`, which requires *building* the compiler anyway), the LLVM was built locally anyway, so this bug was hidden away. This also removes an unnecessary LLVM build when running Clippy on the rustc_private tools.

However, after https://github.com/rust-lang/rust/pull/160916, this was no longer case, because it stopped treating locally built LLVM as being prebuilt (which, in and of itself, is kinda a bug). Because when we check the compiler, we want to avoid building (and checking out!) LLVM. Before https://github.com/rust-lang/rust/pull/160916, bootstrap considered a *previously locally built* LLVM to be available as a prebuilt `llvm-config`, and in that case configured `LLVM_CONFIG` for `rustc_llvm`. Because all PR CI bootstrap invocations that do `check` actually built LLVM prior doing a build, this worked, somehow, but broke after my PR.

Should unblock https://github.com/rust-lang/rust/pull/161466.

r? jieyouxu
