### PR TITLE
Use bitset for locals_with_use_data

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/liveness/local_use_map.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/local_use_map.rs
@@ -1,4 +1,5 @@
 use rustc_index::IndexVec;
+use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::visit::{PlaceContext, Visitor};
 use rustc_middle::mir::{Body, Local, Location};
 use rustc_mir_dataflow::points::{DenseLocationMap, PointIndex};
@@ -97,9 +98,11 @@ impl LocalUseMap {
             return local_use_map;
         }
 
-        let mut locals_with_use_data: IndexVec<Local, bool> =
-            IndexVec::from_elem(false, &body.local_decls);
-        live_locals.iter().for_each(|&local| locals_with_use_data[local] = true);
+        let mut locals_with_use_data: DenseBitSet<Local> =
+            DenseBitSet::new_empty(body.local_decls.len());
+        live_locals.iter().for_each(|&local| {
+            locals_with_use_data.insert(local);
+        });
 
         LocalUseMapBuild { local_use_map: &mut local_use_map, location_map, locals_with_use_data }
             .visit_body(body);
@@ -134,12 +137,12 @@ struct LocalUseMapBuild<'me> {
     // obtained the same information from `live_locals` but we want to
     // avoid repeatedly calling `Vec::contains()` (see `LocalUseMap` for
     // the rationale on the time-memory trade-off we're favoring here).
-    locals_with_use_data: IndexVec<Local, bool>,
+    locals_with_use_data: DenseBitSet<Local>,
 }
 
 impl Visitor<'_> for LocalUseMapBuild<'_> {
     fn visit_local(&mut self, local: Local, context: PlaceContext, location: Location) {
-        if self.locals_with_use_data[local]
+        if self.locals_with_use_data.contains(local)
             && let Some(def_use) = def_use::categorize(context)
         {
             let first_appearance = match def_use {


### PR DESCRIPTION
There seems to be very little reason to use Vec of bools, the whole map allocates space for every element anyway.

Not sure how is impactful this is, I noticed it randomly in the code, but this seems like cleaner way to do it (and more common in the compiler codebase)

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
