### PR TITLE
sugg: point at the string literal missing the closing quote

### DIFF
--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -94,6 +94,7 @@ pub(crate) fn lex_token_trees<'psess, 'src>(
         override_span,
         nbsp_is_whitespace: false,
         last_lifetime: None,
+        first_multiline_str: None,
         token: Token::dummy(),
         diag_info: TokenTreeDiagInfo::default(),
     };
@@ -139,6 +140,11 @@ struct Lexer<'psess, 'src> {
     /// Track the `Span` for the leading `'` of the last lifetime. Used for
     /// diagnostics to detect possible typo where `"` was meant.
     last_lifetime: Option<Span>,
+
+    /// Span of the first string literal in this file that contains an unescaped
+    /// newline, i.e. that spans multiple lines. Used to point at the likely
+    /// culprit when a later string literal turns out to be unterminated.
+    first_multiline_str: Option<Span>,
 
     /// The current token.
     token: Token,
@@ -757,7 +763,7 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
     }
 
     fn cook_lexer_literal(
-        &self,
+        &mut self,
         start: BytePos,
         end: BytePos,
         kind: rustc_lexer::LiteralKind,
@@ -796,14 +802,24 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
                 self.cook_quoted(token::Byte, Mode::Byte, start, end, 2, 1) // b' '
             }
             rustc_lexer::LiteralKind::Str { terminated } => {
-                if !terminated {
-                    self.dcx()
+                if terminated {
+                    self.maybe_record_multiline_str(start, end);
+                } else {
+                    let mut err = self
+                        .dcx()
                         .struct_span_fatal(
                             self.mk_sp(start, end),
                             "unterminated double quote string",
                         )
-                        .with_code(E0765)
-                        .emit()
+                        .with_code(E0765);
+                    if let Some(span) = self.first_multiline_str {
+                        err.span_note(
+                            span,
+                            "this string literal spans multiple lines; a missing closing `\"` \
+                             here could be the cause",
+                        );
+                    }
+                    err.emit()
                 }
                 self.cook_quoted(token::Str, Mode::Str, start, end, 1, 1) // " "
             }
@@ -914,6 +930,32 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
     #[inline]
     fn src_index(&self, pos: BytePos) -> usize {
         (pos - self.start_pos).to_usize()
+    }
+
+    /// A string literal containing an unescaped newline is legal, but rare. It is also exactly
+    /// what forgetting a closing `"` produces: the lexer runs on to the *next* `"` in the file,
+    /// which may be many lines below, and the mismatch only surfaces later as an unterminated
+    /// string. Remember the first such literal so we can point at it from that error.
+    fn maybe_record_multiline_str(&mut self, start: BytePos, end: BytePos) {
+        if self.first_multiline_str.is_some() {
+            return;
+        }
+        // Trim the delimiting quotes.
+        let mut chars = self.str_from_to(start + BytePos(1), end - BytePos(1)).chars();
+        while let Some(c) = chars.next() {
+            match c {
+                // An escape, possibly a `\<newline>` line continuation. Either way the newline
+                // was written deliberately, so skip over it.
+                '\\' => {
+                    chars.next();
+                }
+                '\n' => {
+                    self.first_multiline_str = Some(self.mk_sp(start, end));
+                    return;
+                }
+                _ => {}
+            }
+        }
     }
 
     /// Slice of the source text from `start` up to but excluding `self.pos`,

--- a/tests/ui/parser/unterminated-string-line-continuation.rs
+++ b/tests/ui/parser/unterminated-string-line-continuation.rs
@@ -1,0 +1,11 @@
+//! A backslash at the end of a line continues a string literal onto the next line on purpose, so
+//! such a literal must not be blamed for a later unterminated string.
+//!
+//! See <https://github.com/rust-lang/rust/issues/97001>.
+
+fn main() {
+    let _ = "this one is \
+             deliberately split";
+    let _ = "unterminated;
+}
+//~^^ ERROR unterminated double quote string

--- a/tests/ui/parser/unterminated-string-line-continuation.stderr
+++ b/tests/ui/parser/unterminated-string-line-continuation.stderr
@@ -1,0 +1,12 @@
+error[E0765]: unterminated double quote string
+  --> $DIR/unterminated-string-line-continuation.rs:9:13
+   |
+LL |       let _ = "unterminated;
+   |  _____________^
+LL | | }
+LL | |
+   | |_____________________________________________^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0765`.

--- a/tests/ui/parser/unterminated-string-multiline-note.rs
+++ b/tests/ui/parser/unterminated-string-multiline-note.rs
@@ -1,0 +1,14 @@
+//@ edition: 2021
+//! Forgetting a closing quote makes the lexer run on to the next quote in the file, so the
+//! "unterminated double quote string" error is reported far below the actual mistake. Check that
+//! the first string literal spanning multiple lines is called out as the likely culprit.
+//!
+//! Regression test for <https://github.com/rust-lang/rust/issues/97001>.
+
+fn main() {
+    hello("world);
+    // a bunch of code was here
+    env("FLAGS", "-help")
+    //~^ ERROR prefix `help` is unknown
+    //~| ERROR unterminated double quote string
+}

--- a/tests/ui/parser/unterminated-string-multiline-note.stderr
+++ b/tests/ui/parser/unterminated-string-multiline-note.stderr
@@ -1,0 +1,33 @@
+error: prefix `help` is unknown
+  --> $DIR/unterminated-string-multiline-note.rs:11:20
+   |
+LL |     env("FLAGS", "-help")
+   |                    ^^^^ unknown prefix
+   |
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     env("FLAGS", "-help ")
+   |                        +
+
+error[E0765]: unterminated double quote string
+  --> $DIR/unterminated-string-multiline-note.rs:11:24
+   |
+LL |       env("FLAGS", "-help")
+   |  ________________________^
+...  |
+LL | | }
+   | |__^
+   |
+note: this string literal spans multiple lines; a missing closing `"` here could be the cause
+  --> $DIR/unterminated-string-multiline-note.rs:9:11
+   |
+LL |       hello("world);
+   |  ___________^
+LL | |     // a bunch of code was here
+LL | |     env("FLAGS", "-help")
+   | |_________^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0765`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/97001

Considering the following code

```rust
fn main() {
hello("world);
// a bunch of code was here
env("FLAGS", "-help")
}
```

the error generated before this commit from the compiler is

```
error[E0765]: unterminated double quote string
 --> bug.rs:4:20
  |
4 |   env("FLAGS", "-help")
  |  ____________________^
5 | | }
  | |__^
```

The compiler is not wrong here. The missing `"` on the line 2 makes `"world);\n// a bunch of code was here\nenv("` a valid string literal, so the quote that remains without a pair is really the one on the line 4. The problem is that the user has no way to know it, and in a real file the two lines can be very far away from each other, in the issue the compiler was pointing at the line 208 while the mistake was on the line 180.

So this commit is keeping track of the first string literal that contains an unescaped newline, and when the lexer finds an unterminated string it points at it as a possible cause. A `\` at the end of the line is a line continuation written on purpose, so these literals are skipped and we do not blame them.

So the new error emitted by the compiler is

```
error[E0765]: unterminated double quote string
 --> bug.rs:4:20
  |
4 |   env("FLAGS", "-help")
  |  ____________________^
5 | | }
  | |__^
  |
note: this string literal spans multiple lines; a missing closing `"` here could be the cause
 --> bug.rs:2:7
  |
2 |   hello("world);
  |  _______^
3 | | // a bunch of code was here
4 | | env("FLAGS", "-help")
  | |_____^
```

The heuristic is on the first literal with an unescaped newline, so in a file that already has a legit multi line string before the typo the note points to that one instead. This is why it is a `note` and not a suggestion, it is only to give a place where to start looking. Happy to move it to the nearest one before the error if you prefer.

Tests added `unterminated-string-multiline-note` for the case of the issue and `unterminated-string-line-continuation` to be sure that a `\` at the end of the line is not reported.

## Dislaimer

AI helped me speed up test reproduction and analyse where in the compiler it's best to add this change. However, the changes are authored by me inside the Rust compiler. I am using AI to optimise my time because I am an old contributor in the compiler, but I do not find a lot of time these days to contribute, so AI is helping me to cut some time and go back to contributing because there are a few things that I would like to improve

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>
