### PR TITLE
Cache const-eval local layouts per instance

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -6,6 +6,7 @@ use rustc_abi::{Align, HasDataLayout, Size, TargetDataLayout};
 use rustc_data_structures::Limit;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::DefId;
+use rustc_index::IndexVec;
 use rustc_middle::mir::interpret::{ErrorHandled, InvalidMetaKind, ReportedErrorInfo};
 use rustc_middle::query::TyCtxtAt;
 use rustc_middle::ty::layout::{
@@ -44,6 +45,19 @@ pub struct InterpCx<'tcx, M: Machine<'tcx>> {
 
     /// The query cache is slow so we have our own cache in front of it.
     pub(super) layout_cache: RefCell<FxHashMap<Ty<'tcx>, rustc_abi::Layout<'tcx>>>,
+
+    /// Layouts of MIR locals, keyed by instance and promoted body.
+    ///
+    /// The per-frame `LocalState::layout` cell starts empty on every call, so
+    /// without this we re-instantiate and re-layout the same locals each time a
+    /// monomorphic function is invoked. That dominates const-eval of tables that
+    /// call small helpers (e.g. `f64::from_bits`) thousands of times.
+    pub(super) local_layout_cache: RefCell<
+        FxHashMap<
+            (ty::Instance<'tcx>, Option<mir::Promoted>),
+            IndexVec<mir::Local, Option<TyAndLayout<'tcx>>>,
+        >,
+    >,
 
     /// The virtual memory system.
     pub memory: Memory<'tcx, M>,
@@ -253,6 +267,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             tcx: tcx.at(root_span),
             typing_env,
             layout_cache: RefCell::new(FxHashMap::default()),
+            local_layout_cache: RefCell::new(FxHashMap::default()),
             memory: Memory::new(),
             recursion_limit: tcx.recursion_limit(),
         }

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -384,7 +384,16 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // First push a stack frame so we have access to `instantiate_from_current_frame` and other
         // `self.frame()`-based functions.
         let dead_local = LocalState { value: LocalValue::Dead, layout: Cell::new(None) };
-        let locals = IndexVec::from_elem(dead_local, &body.local_decls);
+        let mut locals = IndexVec::from_elem(dead_local, &body.local_decls);
+        if let Some(cached) =
+            self.local_layout_cache.borrow().get(&(instance, body.source.promoted))
+        {
+            for (local, layout) in cached.iter_enumerated() {
+                if let Some(layout) = *layout {
+                    locals[local].layout.set(Some(layout));
+                }
+            }
+        }
         let pre_frame = Frame {
             body,
             loc: Right(self.tcx.def_span(body.source.def_id())), // Span used for errors caused during preamble.
@@ -624,6 +633,18 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             return interp_ok(layout);
         }
 
+        let key = (frame.instance, frame.body.source.promoted);
+        if let Some(layout) = self
+            .local_layout_cache
+            .borrow()
+            .get(&key)
+            .and_then(|layouts| layouts.get(local).copied())
+            .flatten()
+        {
+            state.layout.set(Some(layout));
+            return interp_ok(layout);
+        }
+
         let layout = from_known_layout(self.tcx, self.typing_env, layout, || {
             let local_ty = frame.body.local_decls[local].ty;
             let local_ty =
@@ -633,6 +654,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
         // Layouts of locals are requested a lot, so we cache them.
         state.layout.set(Some(layout));
+        let n_locals = frame.body.local_decls.len();
+        self.local_layout_cache
+            .borrow_mut()
+            .entry(key)
+            .or_insert_with(|| IndexVec::from_elem_n(None, n_locals))[local] = Some(layout);
         interp_ok(layout)
     }
 }

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -384,7 +384,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // First push a stack frame so we have access to `instantiate_from_current_frame` and other
         // `self.frame()`-based functions.
         let dead_local = LocalState { value: LocalValue::Dead, layout: Cell::new(None) };
-        let mut locals = IndexVec::from_elem(dead_local, &body.local_decls);
+        let locals = IndexVec::from_elem(dead_local, &body.local_decls);
         if let Some(cached) =
             self.local_layout_cache.borrow().get(&(instance, body.source.promoted))
         {

--- a/tests/ui/consts/const-eval/instance-local-layout-cache.rs
+++ b/tests/ui/consts/const-eval/instance-local-layout-cache.rs
@@ -1,0 +1,45 @@
+//@ check-pass
+
+// Repeated calls to the same monomorphic `const fn` must keep using the same
+// local layouts. This would fail at compile time if the instance cache mixed
+// layouts across instances (e.g. `ident::<u64>` vs `ident::<bool>`).
+
+const fn bump(x: u64) -> u64 {
+    x.wrapping_add(1)
+}
+
+const fn ident<T: Copy>(x: T) -> T {
+    x
+}
+
+const fn bits(v: u64) -> f64 {
+    f64::from_bits(v)
+}
+
+const TABLE: [u64; 32] = {
+    let mut t = [0u64; 32];
+    let mut i = 0;
+    while i < 32 {
+        t[i] = bump(ident(i as u64));
+        i += 1;
+    }
+    t
+};
+
+const FLOATS: [f64; 8] = {
+    let mut t = [0.0; 8];
+    let mut i = 0;
+    while i < 8 {
+        t[i] = bits(i as u64);
+        i += 1;
+    }
+    t
+};
+
+const _: () = assert!(TABLE[0] == 1);
+const _: () = assert!(TABLE[31] == 32);
+const _: () = assert!(FLOATS[0].to_bits() == 0);
+const _: () = assert!(ident(true) == true);
+const _: () = assert!(ident(3u8) == 3);
+
+fn main() {}


### PR DESCRIPTION
Repeated calls to the same monomorphic `const fn` currently re-compute the layout of every local on each invocation: `LocalState::layout` is a per-frame cell and starts empty when the frame is pushed.

This adds a per-interpreter cache keyed by instance and optional promoted index. The first call fills it; later calls prefill the frame cells and skip instantiate + `layout_of`.

This is the remaining miss after the per-interpreter type layout cache (rust-lang/rust#157275). Large `const` tables that call small helpers (`f64::from_bits`, outlined math) currently hit `layout_of_local` once per call instead of once per instance — see rust-lang/rust#157010 (`image`, `moxcms`/`pxfm`).

Local same-commit stage1 measurements (`--edition=2024 --crate-type=bin --emit=metadata`, median of 3 after warmup):

| workload | before | after |
|---|---:|---:|
| outlined `update_sum` table, N=2^16 | 0.424s | 0.412s |
| outlined `update_sum` table, N=2^18 | 1.604s | 1.548s |
| `f64::from_bits` helper × 3 × 2^17 | 4.739s | 4.426s |

The leftover outlined-vs-inlined gap is interpreter call overhead, not layout. The cache removes the redundant `layout_of_local` work described in rust-lang/rust#157010.

Not stacked on rust-lang/rust#161477. Different subsystem (CTFE layouts, not next-solver fulfillment).

r? RalfJung