### PR TITLE
Discard `.pdr` in the PSP linker script

### DIFF
--- a/compiler/rustc_target/src/spec/targets/mipsel_sony_psp_linker_script.ld
+++ b/compiler/rustc_target/src/spec/targets/mipsel_sony_psp_linker_script.ld
@@ -41,5 +41,5 @@ SECTIONS
   .gcc_except_table : { *(.gcc_except_table .gcc_except_table.*) }
   .bss : { *(.bss .bss.*) }
 
-  /DISCARD/ : { *(.rel.sceStub.text .MIPS.abiflags .reginfo) }
+  /DISCARD/ : { *(.rel.sceStub.text .MIPS.abiflags .reginfo .pdr) }
 }


### PR DESCRIPTION
The `mipsel-sony-psp` target passes `--emit-relocs` and relies on `--gc-sections`. `.pdr` (MIPS procedure-descriptor debug data) is not allocated, so it survives collection, but the relocations kept for it still point at the functions that *were* collected. rust-lld reports every one of those:

```
rust-lld: relocation refers to a discarded section: .text._RNvNtNtCs1mwba6qCgei_4libm4math3log3log
>>> referenced by libm-...-cgu.3.rcgu.o:(.rel.pdr+0xbfa0) in archive .../liblibm-....rlib
```

A hello-world picks up **70** of these. They were always emitted; they only became visible when cargo stopped suppressing linker output, and are now reported by the `linker_messages` lint. Reported downstream as overdrivenpotato/rust-psp#203.

Nothing on the PSP reads `.pdr`, so this discards it alongside the non-loadable sections the script already drops (`.MIPS.abiflags`, `.reginfo`). Discarding `.pdr` also removes `.rel.pdr`, since `--emit-relocs` only emits relocations for sections that survive.

### Verification

Building `rust-psp`'s `ci/tests` suite and running it on PPSSPP:

|                        | before      | after       |
| ---------------------- | ----------- | ----------- |
| discarded-section warnings | 70      | **0**       |
| `EBOOT.PBP` size       | 1,395,948 B | 1,264,396 B (−9.4%) |
| test suite             | 47 pass / 0 fail | 47 pass / 0 fail (`FINAL_SUCCESS`) |

Since the linker script lives in the target spec, I validated the exact change by building against a patched `--print target-spec-json` copy of the target, and cross-checked it by passing an equivalent `/DISCARD/` fragment as an extra `--script` to a normal `cargo psp` build. Both give the same result.

This is the target's own linker script and affects no other target. The remaining warnings in that issue have a separate cause (`EF_MIPS_CPIC`) and are handled in a follow-up PR.
