### PR TITLE
Set `EF_MIPS_CPIC` on static MIPS targets that use abicalls

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -317,6 +317,13 @@ pub(super) fn elf_e_flags(architecture: Architecture, sess: &Session) -> u32 {
                 // despite that being the entire point of the CPIC ABI extension!
                 // As we are in Rome, we do as the Romans do.
                 e_flags |= elf::EF_MIPS_PIC | elf::EF_MIPS_CPIC;
+            } else if !sess.target.options.features.split(',').any(|f| f == "+noabicalls") {
+                // A static target that nonetheless leaves abicalls enabled, which is the
+                // "static object with dynamic calls" case described above. LLVM sets CPIC
+                // on the objects it emits for such a target, so set it here too: mixing
+                // the two makes the linker warn "linking abicalls code with non-abicalls
+                // code" once per object.
+                e_flags |= elf::EF_MIPS_CPIC;
             }
             if sess.target.options.cpu.contains("r6") {
                 e_flags |= elf::EF_MIPS_NAN2008;

--- a/tests/run-make/mips-cpic-e-flags/foo.rs
+++ b/tests/run-make/mips-cpic-e-flags/foo.rs
@@ -1,0 +1,14 @@
+#![allow(internal_features)]
+#![feature(no_core, lang_items)]
+#![no_core]
+#![no_std]
+
+// This is needed because of #![no_core]:
+#[lang = "pointee_sized"]
+trait PointeeSized {}
+
+#[lang = "meta_sized"]
+trait MetaSized: PointeeSized {}
+
+#[lang = "sized"]
+trait Sized: MetaSized {}

--- a/tests/run-make/mips-cpic-e-flags/rmake.rs
+++ b/tests/run-make/mips-cpic-e-flags/rmake.rs
@@ -1,0 +1,37 @@
+// rustc synthesizes some object files with the `object` crate rather than with LLVM (crate
+// metadata, and the `symbols.o` it hands to the linker), so their MIPS ELF header flags are
+// computed by hand. `EF_MIPS_CPIC` used to be omitted from those whenever the target used the
+// static relocation model, but LLVM sets `EF_MIPS_CPIC` on the objects *it* emits unless the
+// target turns abicalls off. On a static target that leaves abicalls enabled the two disagree,
+// and lld warns "linking abicalls code with non-abicalls code" once per object.
+// See <https://github.com/overdrivenpotato/rust-psp/issues/203>.
+
+//@ needs-llvm-components: mips
+
+use run_make_support::{llvm_ar, llvm_readobj, rustc};
+
+fn check(target: &str, expect_cpic: bool) {
+    rustc().crate_name("foo").target(target).crate_type("rlib").input("foo.rs").run();
+
+    // `lib.rmeta` is the member rustc builds itself; the rest of the archive comes from LLVM
+    // and already carries the right flags, so the archive as a whole cannot be checked.
+    llvm_ar().arg("x").arg("libfoo.rlib").arg("lib.rmeta").run();
+
+    // `llvm_readobj()` defaults to the GNU output style, which spells this flag `cpic`. Ask for
+    // the LLVM style instead, which names it in full.
+    let readobj = llvm_readobj().elf_output_style("LLVM").input("lib.rmeta").file_header().run();
+    if expect_cpic {
+        readobj.assert_stdout_contains("EF_MIPS_CPIC");
+    } else {
+        readobj.assert_stdout_not_contains("EF_MIPS_CPIC");
+    }
+}
+
+fn main() {
+    // Static, but abicalls is left enabled, so LLVM marks its objects CPIC and so must we.
+    check("mipsel-sony-psp", true);
+    check("mipsel-sony-psx", true);
+
+    // Static with `+noabicalls`, so LLVM does not mark its objects CPIC either.
+    check("mipsel-unknown-none", false);
+}


### PR DESCRIPTION
rustc synthesizes some object files with the `object` crate rather than with LLVM — crate metadata, and the `symbols.o` it hands to the linker — so their MIPS ELF header flags are computed by hand in `elf_e_flags`. `EF_MIPS_CPIC` was set only when the relocation model was not `static`.

LLVM keys `EF_MIPS_CPIC` off *abicalls*, not off the relocation model: it sets the flag on every object it emits unless the target selects `+noabicalls`. So a static target that leaves abicalls enabled gets LLVM objects marked CPIC and rustc's own objects not, and lld warns once per object:

```
rust-lld: .../libpsp-....rlib(psp-....rcgu.o): linking abicalls code with non-abicalls code .../symbols.o
```

Measured on `mipsel-sony-psp`: every LLVM object is `0x10001005` (`noreorder|cpic|o32|mips2`) while `symbols.o` and `lib.rmeta` are `0x10001000`. A hello-world picks up **60** such warnings — now visible via the `linker_messages` lint. Reported downstream as overdrivenpotato/rust-psp#203.

This is precisely the "static object with dynamic calls" case the existing comment in this function describes, so the fix sets CPIC (without PIC) for it, matching LLVM.

### Affected targets

Only static MIPS targets whose spec omits `+noabicalls`: `mipsel-sony-psp` and `mipsel-sony-psx`. Targets that are not static are untouched, and `mipsel-unknown-none` (which sets `+noabicalls`) keeps getting no CPIC — the added test pins both directions.

### Verification

I have not built a patched compiler, so I verified the change by reproducing its exact effect: taking rustc's own `symbols.o` from a real build, setting the CPIC bit, and re-running rustc's exact `rust-lld` invocation.

| | before | after |
| --- | --- | --- |
| abicalls warnings (`ci/tests`) | 65 | **0** |

Combined with rust-lang/rust#161484, a `cargo psp` build of `rust-psp`'s test suite goes from 130 linker warnings to 0, and the suite still passes on PPSSPP (47 pass / 0 fail, `FINAL_SUCCESS`).

The new `tests/run-make/mips-cpic-e-flags` checks `lib.rmeta` inside the rlib, which is the member rustc builds itself. I confirmed by hand that it is `0x10001000` today, i.e. the test does fail without the change. Note that the test itself has not been executed (I could not build the compiler locally), so please give the `run_make_support` usage a careful look.
