### PR TITLE
Rollup of 18 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -743,3 +743,4 @@ Zack Corr <zack@z0w0.me> <zackcorr95@gmail.com>
 Zack Slayton <zack.slayton@gmail.com>
 Zbigniew Siciarz <zbigniew@siciarz.net> Zbigniew Siciarz <antyqjon@gmail.com>
 y21 <30553356+y21@users.noreply.github.com>
+朝倉水希 <mizuk1@mzk1.dev> <asakuramizu111@gmail.com>

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -478,14 +478,9 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
         let errci = ErrorConstraintInfo { fr, outlived_fr, category, span };
 
         let mut diag = match (category, fr_is_local, outlived_fr_is_local) {
-            (ConstraintCategory::SolverRegionConstraint(span), _, _) => {
-                let mut d = self.dcx().struct_span_err(
-                    span,
-                    "unsatisfied lifetime constraint from -Zassumptions-on-binders :3",
-                );
-                d.note("meoow :c");
-                d
-            }
+            (ConstraintCategory::SolverRegionConstraint(span), _, _) => self
+                .dcx()
+                .struct_span_err(span, "higher-ranked lifetime bound could not be satisfied"),
             (ConstraintCategory::Return(kind), true, false)
                 if self.regioncx.is_closure_fn_mut(fr) =>
             {

--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -153,7 +153,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
             GenericArgKind::Lifetime(r1) => {
                 let r1_vid = self.to_region_vid(r1);
                 let r2_vid = self.to_region_vid(r2);
-                self.add_outlives(r1_vid, r2_vid, constraint_category);
+                self.add_outlives(r1_vid, r2_vid, constraint_category, self.span);
             }
 
             GenericArgKind::Type(mut t1) => {
@@ -221,6 +221,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
         sup: ty::RegionVid,
         sub: ty::RegionVid,
         category: ConstraintCategory<'tcx>,
+        span: Span,
     ) {
         let category = match self.category {
             ConstraintCategory::Boring | ConstraintCategory::BoringNoLocation => category,
@@ -229,7 +230,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
         self.constraints.outlives_constraints.push(OutlivesConstraint {
             locations: self.locations,
             category,
-            span: self.span,
+            span,
             sub,
             sup,
             variance_info: ty::VarianceDiagInfo::default(),
@@ -246,14 +247,14 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
 impl<'a, 'b, 'tcx> TypeOutlivesDelegate<'tcx> for &'a mut ConstraintConversion<'b, 'tcx> {
     fn push_sub_region_constraint(
         &mut self,
-        _origin: SubregionOrigin<'tcx>,
+        origin: SubregionOrigin<'tcx>,
         a: ty::Region<'tcx>,
         b: ty::Region<'tcx>,
         constraint_category: ConstraintCategory<'tcx>,
     ) {
         let b = self.to_region_vid(b);
         let a = self.to_region_vid(a);
-        self.add_outlives(b, a, constraint_category);
+        self.add_outlives(b, a, constraint_category, origin.span());
     }
 
     fn push_verify(

--- a/compiler/rustc_borrowck/src/type_check/liveness/local_use_map.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/local_use_map.rs
@@ -1,4 +1,5 @@
 use rustc_index::IndexVec;
+use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::visit::{PlaceContext, Visitor};
 use rustc_middle::mir::{Body, Local, Location};
 use rustc_mir_dataflow::points::{DenseLocationMap, PointIndex};
@@ -97,9 +98,11 @@ impl LocalUseMap {
             return local_use_map;
         }
 
-        let mut locals_with_use_data: IndexVec<Local, bool> =
-            IndexVec::from_elem(false, &body.local_decls);
-        live_locals.iter().for_each(|&local| locals_with_use_data[local] = true);
+        let mut locals_with_use_data: DenseBitSet<Local> =
+            DenseBitSet::new_empty(body.local_decls.len());
+        live_locals.iter().for_each(|&local| {
+            locals_with_use_data.insert(local);
+        });
 
         LocalUseMapBuild { local_use_map: &mut local_use_map, location_map, locals_with_use_data }
             .visit_body(body);
@@ -134,12 +137,12 @@ struct LocalUseMapBuild<'me> {
     // obtained the same information from `live_locals` but we want to
     // avoid repeatedly calling `Vec::contains()` (see `LocalUseMap` for
     // the rationale on the time-memory trade-off we're favoring here).
-    locals_with_use_data: IndexVec<Local, bool>,
+    locals_with_use_data: DenseBitSet<Local>,
 }
 
 impl Visitor<'_> for LocalUseMapBuild<'_> {
     fn visit_local(&mut self, local: Local, context: PlaceContext, location: Location) {
-        if self.locals_with_use_data[local]
+        if self.locals_with_use_data.contains(local)
             && let Some(def_use) = def_use::categorize(context)
         {
             let first_appearance = match def_use {

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -188,7 +188,6 @@ pub(crate) fn type_check<'tcx>(
             &mut converter,
             typeck.known_type_outlives_obligations,
             universal_region_relations.outlives.clone(),
-            infcx.tcx.def_span(infcx.root_def_id),
         );
     }
 

--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -434,8 +434,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     parse_atomic_ordering(fail_ordering),
                     weak,
                 );
-                let val = bx.from_immediate(val);
-                let success = bx.from_immediate(success);
 
                 let mut builder = OperandRefBuilder::new(result_layout);
                 builder.insert_imm(FieldIdx::from_u32(0), val);

--- a/compiler/rustc_const_eval/src/const_eval/type_info.rs
+++ b/compiler/rustc_const_eval/src/const_eval/type_info.rs
@@ -61,7 +61,6 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
         // Fill all fields of the `TypeInfo` struct.
         for (idx, field) in ty_struct.fields.iter_enumerated() {
             let field_dest = self.project_field(dest, idx)?;
-            let ptr_bit_width = || self.tcx.data_layout.pointer_size().bits();
             match field.name {
                 sym::kind => {
                     let variant_index = match ty.kind() {
@@ -115,33 +114,19 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
                                 self.project_downcast_named(&field_dest, sym::Char)?;
                             variant
                         }
-                        ty::Int(int_ty) => {
-                            let (variant, variant_place) =
+                        ty::Int(_) => {
+                            let (variant, _variant_place) =
                                 self.project_downcast_named(&field_dest, sym::Int)?;
-                            let place = self.project_field(&variant_place, FieldIdx::ZERO)?;
-                            self.write_int_type_info(
-                                place,
-                                int_ty.bit_width().unwrap_or_else(/* isize */ ptr_bit_width),
-                                true,
-                            )?;
                             variant
                         }
-                        ty::Uint(uint_ty) => {
-                            let (variant, variant_place) =
+                        ty::Uint(_) => {
+                            let (variant, _variant_place) =
                                 self.project_downcast_named(&field_dest, sym::Int)?;
-                            let place = self.project_field(&variant_place, FieldIdx::ZERO)?;
-                            self.write_int_type_info(
-                                place,
-                                uint_ty.bit_width().unwrap_or_else(/* usize */ ptr_bit_width),
-                                false,
-                            )?;
                             variant
                         }
-                        ty::Float(float_ty) => {
-                            let (variant, variant_place) =
+                        ty::Float(_) => {
+                            let (variant, _variant_place) =
                                 self.project_downcast_named(&field_dest, sym::Float)?;
-                            let place = self.project_field(&variant_place, FieldIdx::ZERO)?;
-                            self.write_float_type_info(place, float_ty.bit_width())?;
                             variant
                         }
                         ty::Str => {
@@ -313,48 +298,6 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
             }
         }
 
-        interp_ok(())
-    }
-
-    fn write_int_type_info(
-        &mut self,
-        place: impl Writeable<'tcx, CtfeProvenance>,
-        bit_width: u64,
-        signed: bool,
-    ) -> InterpResult<'tcx> {
-        for (field_idx, field) in
-            place.layout().ty.ty_adt_def().unwrap().non_enum_variant().fields.iter_enumerated()
-        {
-            let field_place = self.project_field(&place, field_idx)?;
-            match field.name {
-                sym::bits => self.write_scalar(
-                    Scalar::from_u32(bit_width.try_into().expect("bit_width overflowed")),
-                    &field_place,
-                )?,
-                sym::signed => self.write_scalar(Scalar::from_bool(signed), &field_place)?,
-                other => span_bug!(self.tcx.def_span(field.did), "unimplemented field {other}"),
-            }
-        }
-        interp_ok(())
-    }
-
-    fn write_float_type_info(
-        &mut self,
-        place: impl Writeable<'tcx, CtfeProvenance>,
-        bit_width: u64,
-    ) -> InterpResult<'tcx> {
-        for (field_idx, field) in
-            place.layout().ty.ty_adt_def().unwrap().non_enum_variant().fields.iter_enumerated()
-        {
-            let field_place = self.project_field(&place, field_idx)?;
-            match field.name {
-                sym::bits => self.write_scalar(
-                    Scalar::from_u32(bit_width.try_into().expect("bit_width overflowed")),
-                    &field_place,
-                )?,
-                other => span_bug!(self.tcx.def_span(field.did), "unimplemented field {other}"),
-            }
-        }
         interp_ok(())
     }
 

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -13,6 +13,7 @@ use tracing::instrument;
 
 use super::{HirPlaceholderCollector, ItemCtxt, bad_placeholder};
 use crate::check::wfcheck::check_static_item;
+use crate::diagnostics::ParamInTyOfConstParam;
 use crate::hir_ty_lowering::HirTyLowerer;
 
 mod opaque;
@@ -235,8 +236,19 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
         }
 
         Node::GenericParam(param) => match &param.kind {
-            GenericParamKind::Type { default: Some(ty), .. }
-            | GenericParamKind::Const { ty, .. } => icx.lower_ty(ty),
+            GenericParamKind::Type { default: Some(ty), .. } => icx.lower_ty(ty),
+            GenericParamKind::Const { ty, .. } => {
+                let lowered_ty = icx.lower_ty(ty);
+                if !tcx.features().generic_const_parameter_types() && lowered_ty.has_param() {
+                    let guar = tcx
+                        .dcx()
+                        .create_err(ParamInTyOfConstParam { span: ty.span, ty: lowered_ty })
+                        .emit();
+                    Ty::new_error(tcx, guar)
+                } else {
+                    lowered_ty
+                }
+            }
             x => bug!("unexpected non-type Node::GenericParam: {:?}", x),
         },
 

--- a/compiler/rustc_hir_analysis/src/diagnostics.rs
+++ b/compiler/rustc_hir_analysis/src/diagnostics.rs
@@ -2030,3 +2030,12 @@ pub(crate) struct OnlyStructsCanBeViewedAdt<'tcx> {
     pub article: &'static str,
     pub kind: &'static str,
 }
+
+#[derive(Diagnostic)]
+#[diag("the type of const parameters must not depend on other generic parameters", code = E0770)]
+pub(crate) struct ParamInTyOfConstParam<'tcx> {
+    #[primary_span]
+    #[label("the type `{$ty}` must not depend on other generic parameter")]
+    pub(crate) span: Span,
+    pub(crate) ty: Ty<'tcx>,
+}

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -64,12 +64,13 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
     fn get_solver_region_constraint(
         &self,
     ) -> rustc_type_ir::region_constraint::RegionConstraint<TyCtxt<'tcx>> {
-        self.inner.borrow().solver_region_constraint_storage.get_constraint()
+        self.inner.borrow().solver_region_constraint_storage.get_unspanned_constraint()
     }
 
     fn overwrite_solver_region_constraint(
         &self,
         constraint: rustc_type_ir::region_constraint::RegionConstraint<TyCtxt<'tcx>>,
+        span: Span,
     ) {
         let mut inner = self.inner.borrow_mut();
         use rustc_data_structures::undo_log::UndoLogs;
@@ -77,7 +78,7 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         use crate::infer::UndoLog;
         let old_constraint = inner.solver_region_constraint_storage.get_constraint();
         inner.undo_log.push(UndoLog::OverwriteSolverRegionConstraint { old_constraint });
-        inner.solver_region_constraint_storage.overwrite_solver_region_constraint(constraint);
+        inner.solver_region_constraint_storage.overwrite(constraint, span);
     }
 
     fn universe_of_ty(&self, vid: ty::TyVid) -> Option<ty::UniverseIndex> {
@@ -331,6 +332,7 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
     fn register_solver_region_constraint(
         &self,
         c: rustc_type_ir::region_constraint::RegionConstraint<TyCtxt<'tcx>>,
+        span: Span,
     ) {
         let mut inner = self.inner.borrow_mut();
         use rustc_data_structures::undo_log::UndoLogs;
@@ -338,7 +340,7 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         use crate::infer::UndoLog;
         let previous_was_and = inner.solver_region_constraint_storage.is_and();
         inner.undo_log.push(UndoLog::PushSolverRegionConstraint { previous_was_and });
-        inner.solver_region_constraint_storage.push(c);
+        inner.solver_region_constraint_storage.push(c, span);
     }
 
     fn register_ty_outlives(&self, ty: Ty<'tcx>, r: ty::Region<'tcx>, span: Span) {

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -61,8 +61,12 @@ pub mod region_constraints;
 pub mod relate;
 pub mod resolve;
 pub(crate) mod snapshot;
+mod solver_region_constraints;
 mod type_variable;
 mod unify_key;
+
+pub(crate) use solver_region_constraints::SolverRegionConstraint;
+use solver_region_constraints::SolverRegionConstraintStorage;
 
 /// `InferOk<'tcx, ()>` is used a lot. It may seem like a useless wrapper
 /// around `PredicateObligations<'tcx>`, but it has one important property:
@@ -1806,62 +1810,6 @@ impl<'tcx> InferCtxt<'tcx> {
             hir::Node::Expr(e) => e.span,
             _ => DUMMY_SP,
         }
-    }
-}
-
-type SolverRegionConstraint<'tcx> =
-    rustc_type_ir::region_constraint::RegionConstraint<TyCtxt<'tcx>>;
-
-#[derive(Clone, Debug)]
-struct SolverRegionConstraintStorage<'tcx>(SolverRegionConstraint<'tcx>);
-
-impl<'tcx> SolverRegionConstraintStorage<'tcx> {
-    fn new() -> Self {
-        SolverRegionConstraintStorage(SolverRegionConstraint::And(Box::new([])))
-    }
-
-    fn get_constraint(&self) -> SolverRegionConstraint<'tcx> {
-        self.0.clone()
-    }
-
-    fn is_and(&self) -> bool {
-        self.0.is_and()
-    }
-
-    fn pop(&mut self, previous_was_and: bool) -> Option<SolverRegionConstraint<'tcx>> {
-        match &mut self.0 {
-            SolverRegionConstraint::And(and) => {
-                let mut and = core::mem::take(and).into_iter().collect::<Vec<_>>();
-                let popped = and.pop()?;
-                if previous_was_and {
-                    self.0 = SolverRegionConstraint::And(and.into_boxed_slice());
-                } else {
-                    assert_eq!(and.len(), 1);
-                    self.0 = and.pop().unwrap();
-                }
-                Some(popped)
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    #[instrument(level = "debug")]
-    fn push(&mut self, constraint: SolverRegionConstraint<'tcx>) {
-        match core::mem::replace(&mut self.0, SolverRegionConstraint::new_true()) {
-            SolverRegionConstraint::And(and) => {
-                let and =
-                    and.into_iter().chain([constraint]).collect::<Vec<_>>().into_boxed_slice();
-                self.0 = SolverRegionConstraint::And(and);
-            }
-            previous => {
-                self.0 = SolverRegionConstraint::And(Box::new([previous, constraint]));
-            }
-        }
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn overwrite_solver_region_constraint(&mut self, constraint: SolverRegionConstraint<'tcx>) {
-        self.0 = constraint;
     }
 }
 

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -248,20 +248,19 @@ impl<'tcx> InferCtxt<'tcx> {
 
         let constraint = self.inner.borrow().solver_region_constraint_storage.get_constraint();
         debug!(?constraint);
-        let constraint = constraint.map_atomic_constraints(&mut |constraint| {
+        let constraint =
             rustc_type_ir::region_constraint::destructure_type_outlives_constraints_in_root(
                 self,
                 constraint,
                 &assumptions,
-            )
-        });
+            );
         debug!(?constraint);
-        let constraint = constraint.evaluate();
+        let constraint = rustc_type_ir::region_constraint::evaluate_solver_constraint(&constraint);
         debug!(?constraint);
 
         let mut constraints = vec![constraint];
         while let Some(c) = constraints.pop() {
-            use crate::infer::SolverRegionConstraint::*;
+            use rustc_type_ir::region_constraint::RegionConstraint::*;
 
             match c {
                 Ambiguity(span) => {

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -215,13 +215,12 @@ impl<'tcx> InferCtxt<'tcx> {
     pub fn destructure_solver_region_constraints_for_regionck(
         &self,
         outlives_env: &OutlivesEnvironment<'tcx>,
-        span: Span,
     ) {
         let assumptions = rustc_type_ir::region_constraint::Assumptions::new(
             outlives_env.known_type_outlives().into_iter().cloned().collect(),
             outlives_env.free_region_map().relation.clone(),
         );
-        self.destructure_solver_region_constraints(assumptions, self, span);
+        self.destructure_solver_region_constraints(assumptions, self);
     }
 
     pub fn destructure_solver_region_constraints_for_borrowck(
@@ -230,13 +229,12 @@ impl<'tcx> InferCtxt<'tcx> {
         conversion: impl TypeOutlivesDelegate<'tcx>,
         known_type_outlives: &[PolyTypeOutlivesClause<'tcx>],
         region_outlives: TransitiveRelation<RegionVid>,
-        span: Span,
     ) {
         let assumptions = rustc_type_ir::region_constraint::Assumptions::new(
             known_type_outlives.into_iter().cloned().collect(),
             region_outlives.maybe_map(|r| Some(Region::new_var(self.tcx, r))).unwrap(),
         );
-        self.destructure_solver_region_constraints(assumptions, conversion, span);
+        self.destructure_solver_region_constraints(assumptions, conversion);
     }
 
     #[instrument(level = "debug", skip(self, conversion))]
@@ -244,41 +242,42 @@ impl<'tcx> InferCtxt<'tcx> {
         &self,
         assumptions: rustc_type_ir::region_constraint::Assumptions<TyCtxt<'tcx>>,
         mut conversion: impl TypeOutlivesDelegate<'tcx>,
-        span: Span,
     ) {
         assert!(self.tcx.assumptions_on_binders());
         assert!(self.next_trait_solver());
 
-        let origin = SubregionOrigin::SolverRegionConstraint(span);
-        let category = origin.to_constraint_category();
-
         let constraint = self.inner.borrow().solver_region_constraint_storage.get_constraint();
         debug!(?constraint);
-        let constraint =
+        let constraint = constraint.map_atomic_constraints(&mut |constraint| {
             rustc_type_ir::region_constraint::destructure_type_outlives_constraints_in_root(
                 self,
                 constraint,
                 &assumptions,
-            );
+            )
+        });
         debug!(?constraint);
-        let constraint = rustc_type_ir::region_constraint::evaluate_solver_constraint(&constraint);
+        let constraint = constraint.evaluate();
         debug!(?constraint);
 
         let mut constraints = vec![constraint];
         while let Some(c) = constraints.pop() {
-            use rustc_type_ir::region_constraint::RegionConstraint::*;
+            use crate::infer::SolverRegionConstraint::*;
 
             match c {
-                Ambiguity => {
-                    self.dcx().err("unable to satisfy constraints involving placeholders due to unknown implied bounds");
+                Ambiguity(span) => {
+                    self.dcx()
+                        .struct_span_err(
+                            span,
+                            "unable to satisfy constraints involving placeholders due to unknown implied bounds",
+                        )
+                        .emit();
                 }
-                RegionOutlives(a, b) => {
+                RegionOutlives(a, b, span) => {
+                    let origin = SubregionOrigin::SolverRegionConstraint(span);
+                    let category = origin.to_constraint_category();
                     conversion.push_sub_region_constraint(
-                        origin.clone(),
-                        // we flip these because regionck is silly :>
-                        b,
-                        a,
-                        category,
+                        origin, // we flip these because regionck is silly :>
+                        b, a, category,
                     );
                 }
                 // FIXME(-Zassumptions-on-binders): actually implement OR as an  OR
@@ -306,7 +305,7 @@ impl<'tcx> InferCtxt<'tcx> {
         assert!(!self.in_snapshot(), "cannot process registered region obligations in a snapshot");
 
         if self.tcx.assumptions_on_binders() {
-            self.destructure_solver_region_constraints_for_regionck(outlives_env, span);
+            self.destructure_solver_region_constraints_for_regionck(outlives_env);
         }
 
         // Must loop since the process of normalizing may itself register region obligations.

--- a/compiler/rustc_infer/src/infer/snapshot/undo_log.rs
+++ b/compiler/rustc_infer/src/infer/snapshot/undo_log.rs
@@ -88,8 +88,7 @@ impl<'tcx> Rollback<UndoLog<'tcx>> for InferCtxtInner<'tcx> {
                 );
             }
             UndoLog::OverwriteSolverRegionConstraint { old_constraint } => {
-                self.solver_region_constraint_storage
-                    .overwrite_solver_region_constraint(old_constraint);
+                self.solver_region_constraint_storage.overwrite_spanned(old_constraint);
             }
             UndoLog::PushTypeOutlivesConstraint => {
                 let popped = self.region_obligations.pop();

--- a/compiler/rustc_infer/src/infer/solver_region_constraints.rs
+++ b/compiler/rustc_infer/src/infer/solver_region_constraints.rs
@@ -1,135 +1,11 @@
-use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
-use rustc_type_ir::region_constraint::RegionConstraint as UnspannedRegionConstraint;
+use rustc_type_ir::region_constraint::{
+    RegionConstraint as UnspannedRegionConstraint, SpannedRegionConstraint,
+};
 use tracing::instrument;
 
-/// A solver region constraint together with the span that caused each atomic constraint.
-///
-/// Solver query responses use [`UnspannedRegionConstraint`] so that source locations do not
-/// participate in candidate equality or caching. Spans are attached when those responses are
-/// applied to an inference context.
-#[derive(Clone, Debug)]
-pub(crate) enum SolverRegionConstraint<'tcx> {
-    Ambiguity(Span),
-    RegionOutlives(ty::Region<'tcx>, ty::Region<'tcx>, Span),
-    AliasTyOutlivesViaEnv(ty::Binder<'tcx, (ty::AliasTy<'tcx>, ty::Region<'tcx>)>, Span),
-    PlaceholderTyOutlives(Ty<'tcx>, ty::Region<'tcx>, Span),
-    And(Box<[SolverRegionConstraint<'tcx>]>),
-    Or(Box<[SolverRegionConstraint<'tcx>]>),
-}
-
-impl<'tcx> SolverRegionConstraint<'tcx> {
-    fn with_span(
-        constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>,
-        span: Span,
-    ) -> SolverRegionConstraint<'tcx> {
-        use rustc_type_ir::region_constraint::RegionConstraint::*;
-
-        match constraint {
-            Ambiguity => Self::Ambiguity(span),
-            RegionOutlives(a, b) => Self::RegionOutlives(a, b, span),
-            AliasTyOutlivesViaEnv(outlives) => Self::AliasTyOutlivesViaEnv(outlives, span),
-            PlaceholderTyOutlives(ty, region) => Self::PlaceholderTyOutlives(ty, region, span),
-            And(constraints) => {
-                Self::And(constraints.into_iter().map(|c| Self::with_span(c, span)).collect())
-            }
-            Or(constraints) => {
-                Self::Or(constraints.into_iter().map(|c| Self::with_span(c, span)).collect())
-            }
-        }
-    }
-
-    fn without_spans(&self) -> UnspannedRegionConstraint<TyCtxt<'tcx>> {
-        use rustc_type_ir::region_constraint::RegionConstraint::*;
-
-        match self {
-            Self::Ambiguity(_) => Ambiguity,
-            Self::RegionOutlives(a, b, _) => RegionOutlives(*a, *b),
-            Self::AliasTyOutlivesViaEnv(outlives, _) => AliasTyOutlivesViaEnv(*outlives),
-            Self::PlaceholderTyOutlives(ty, region, _) => PlaceholderTyOutlives(*ty, *region),
-            Self::And(constraints) => And(constraints.iter().map(Self::without_spans).collect()),
-            Self::Or(constraints) => Or(constraints.iter().map(Self::without_spans).collect()),
-        }
-    }
-
-    pub(crate) fn map_atomic_constraints(
-        self,
-        f: &mut impl FnMut(
-            UnspannedRegionConstraint<TyCtxt<'tcx>>,
-        ) -> UnspannedRegionConstraint<TyCtxt<'tcx>>,
-    ) -> SolverRegionConstraint<'tcx> {
-        let (constraint, span) = match self {
-            Self::Ambiguity(span) => (UnspannedRegionConstraint::Ambiguity, span),
-            Self::RegionOutlives(a, b, span) => {
-                (UnspannedRegionConstraint::RegionOutlives(a, b), span)
-            }
-            Self::AliasTyOutlivesViaEnv(outlives, span) => {
-                (UnspannedRegionConstraint::AliasTyOutlivesViaEnv(outlives), span)
-            }
-            Self::PlaceholderTyOutlives(ty, region, span) => {
-                (UnspannedRegionConstraint::PlaceholderTyOutlives(ty, region), span)
-            }
-            Self::And(constraints) => {
-                return Self::And(
-                    constraints.into_iter().map(|c| c.map_atomic_constraints(f)).collect(),
-                );
-            }
-            Self::Or(constraints) => {
-                return Self::Or(
-                    constraints.into_iter().map(|c| c.map_atomic_constraints(f)).collect(),
-                );
-            }
-        };
-
-        Self::with_span(f(constraint), span)
-    }
-
-    pub(crate) fn evaluate(self) -> SolverRegionConstraint<'tcx> {
-        match self {
-            Self::And(constraints) => {
-                let mut evaluated = Vec::new();
-                let mut ambiguity = None;
-                for constraint in constraints {
-                    let constraint = constraint.evaluate();
-                    if constraint.is_false() {
-                        return Self::Or(Box::new([]));
-                    } else if let Self::Ambiguity(span) = constraint {
-                        ambiguity.get_or_insert(span);
-                    } else if !constraint.is_true() {
-                        evaluated.push(constraint);
-                    }
-                }
-
-                ambiguity.map_or_else(|| Self::And(evaluated.into_boxed_slice()), Self::Ambiguity)
-            }
-            Self::Or(constraints) => {
-                let mut evaluated = Vec::new();
-                let mut ambiguity = None;
-                for constraint in constraints {
-                    let constraint = constraint.evaluate();
-                    if constraint.is_true() {
-                        return Self::And(Box::new([]));
-                    } else if let Self::Ambiguity(span) = constraint {
-                        ambiguity.get_or_insert(span);
-                    } else if !constraint.is_false() {
-                        evaluated.push(constraint);
-                    }
-                }
-
-                ambiguity.map_or_else(|| Self::Or(evaluated.into_boxed_slice()), Self::Ambiguity)
-            }
-            constraint => constraint,
-        }
-    }
-
-    fn is_true(&self) -> bool {
-        matches!(self, Self::And(constraints) if constraints.is_empty())
-    }
-
-    fn is_false(&self) -> bool {
-        matches!(self, Self::Or(constraints) if constraints.is_empty())
-    }
-}
+pub(crate) type SolverRegionConstraint<'tcx> = SpannedRegionConstraint<TyCtxt<'tcx>>;
 
 #[derive(Clone, Debug)]
 pub(crate) struct SolverRegionConstraintStorage<'tcx>(SolverRegionConstraint<'tcx>);
@@ -144,11 +20,11 @@ impl<'tcx> SolverRegionConstraintStorage<'tcx> {
     }
 
     pub(crate) fn get_unspanned_constraint(&self) -> UnspannedRegionConstraint<TyCtxt<'tcx>> {
-        self.0.without_spans()
+        self.0.clone().without_spans()
     }
 
     pub(crate) fn is_and(&self) -> bool {
-        matches!(self.0, SolverRegionConstraint::And(_))
+        self.0.is_and()
     }
 
     pub(crate) fn pop(&mut self, previous_was_and: bool) -> Option<SolverRegionConstraint<'tcx>> {
@@ -170,8 +46,8 @@ impl<'tcx> SolverRegionConstraintStorage<'tcx> {
 
     #[instrument(level = "debug")]
     pub(crate) fn push(&mut self, constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>, span: Span) {
-        let constraint = SolverRegionConstraint::with_span(constraint, span);
-        match core::mem::replace(&mut self.0, SolverRegionConstraint::And(Box::new([]))) {
+        let constraint = constraint.with_span(span);
+        match core::mem::replace(&mut self.0, SolverRegionConstraint::new_true()) {
             SolverRegionConstraint::And(and) => {
                 let and =
                     and.into_iter().chain([constraint]).collect::<Vec<_>>().into_boxed_slice();
@@ -189,7 +65,7 @@ impl<'tcx> SolverRegionConstraintStorage<'tcx> {
         constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>,
         span: Span,
     ) {
-        self.overwrite_spanned(SolverRegionConstraint::with_span(constraint, span));
+        self.overwrite_spanned(constraint.with_span(span));
     }
 
     pub(crate) fn overwrite_spanned(&mut self, constraint: SolverRegionConstraint<'tcx>) {

--- a/compiler/rustc_infer/src/infer/solver_region_constraints.rs
+++ b/compiler/rustc_infer/src/infer/solver_region_constraints.rs
@@ -1,0 +1,201 @@
+use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_span::Span;
+use rustc_type_ir::region_constraint::RegionConstraint as UnspannedRegionConstraint;
+use tracing::instrument;
+
+/// A solver region constraint together with the span that caused each atomic constraint.
+///
+/// Solver query responses use [`UnspannedRegionConstraint`] so that source locations do not
+/// participate in candidate equality or caching. Spans are attached when those responses are
+/// applied to an inference context.
+#[derive(Clone, Debug)]
+pub(crate) enum SolverRegionConstraint<'tcx> {
+    Ambiguity(Span),
+    RegionOutlives(ty::Region<'tcx>, ty::Region<'tcx>, Span),
+    AliasTyOutlivesViaEnv(ty::Binder<'tcx, (ty::AliasTy<'tcx>, ty::Region<'tcx>)>, Span),
+    PlaceholderTyOutlives(Ty<'tcx>, ty::Region<'tcx>, Span),
+    And(Box<[SolverRegionConstraint<'tcx>]>),
+    Or(Box<[SolverRegionConstraint<'tcx>]>),
+}
+
+impl<'tcx> SolverRegionConstraint<'tcx> {
+    fn with_span(
+        constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>,
+        span: Span,
+    ) -> SolverRegionConstraint<'tcx> {
+        use rustc_type_ir::region_constraint::RegionConstraint::*;
+
+        match constraint {
+            Ambiguity => Self::Ambiguity(span),
+            RegionOutlives(a, b) => Self::RegionOutlives(a, b, span),
+            AliasTyOutlivesViaEnv(outlives) => Self::AliasTyOutlivesViaEnv(outlives, span),
+            PlaceholderTyOutlives(ty, region) => Self::PlaceholderTyOutlives(ty, region, span),
+            And(constraints) => {
+                Self::And(constraints.into_iter().map(|c| Self::with_span(c, span)).collect())
+            }
+            Or(constraints) => {
+                Self::Or(constraints.into_iter().map(|c| Self::with_span(c, span)).collect())
+            }
+        }
+    }
+
+    fn without_spans(&self) -> UnspannedRegionConstraint<TyCtxt<'tcx>> {
+        use rustc_type_ir::region_constraint::RegionConstraint::*;
+
+        match self {
+            Self::Ambiguity(_) => Ambiguity,
+            Self::RegionOutlives(a, b, _) => RegionOutlives(*a, *b),
+            Self::AliasTyOutlivesViaEnv(outlives, _) => AliasTyOutlivesViaEnv(*outlives),
+            Self::PlaceholderTyOutlives(ty, region, _) => PlaceholderTyOutlives(*ty, *region),
+            Self::And(constraints) => And(constraints.iter().map(Self::without_spans).collect()),
+            Self::Or(constraints) => Or(constraints.iter().map(Self::without_spans).collect()),
+        }
+    }
+
+    pub(crate) fn map_atomic_constraints(
+        self,
+        f: &mut impl FnMut(
+            UnspannedRegionConstraint<TyCtxt<'tcx>>,
+        ) -> UnspannedRegionConstraint<TyCtxt<'tcx>>,
+    ) -> SolverRegionConstraint<'tcx> {
+        let (constraint, span) = match self {
+            Self::Ambiguity(span) => (UnspannedRegionConstraint::Ambiguity, span),
+            Self::RegionOutlives(a, b, span) => {
+                (UnspannedRegionConstraint::RegionOutlives(a, b), span)
+            }
+            Self::AliasTyOutlivesViaEnv(outlives, span) => {
+                (UnspannedRegionConstraint::AliasTyOutlivesViaEnv(outlives), span)
+            }
+            Self::PlaceholderTyOutlives(ty, region, span) => {
+                (UnspannedRegionConstraint::PlaceholderTyOutlives(ty, region), span)
+            }
+            Self::And(constraints) => {
+                return Self::And(
+                    constraints.into_iter().map(|c| c.map_atomic_constraints(f)).collect(),
+                );
+            }
+            Self::Or(constraints) => {
+                return Self::Or(
+                    constraints.into_iter().map(|c| c.map_atomic_constraints(f)).collect(),
+                );
+            }
+        };
+
+        Self::with_span(f(constraint), span)
+    }
+
+    pub(crate) fn evaluate(self) -> SolverRegionConstraint<'tcx> {
+        match self {
+            Self::And(constraints) => {
+                let mut evaluated = Vec::new();
+                let mut ambiguity = None;
+                for constraint in constraints {
+                    let constraint = constraint.evaluate();
+                    if constraint.is_false() {
+                        return Self::Or(Box::new([]));
+                    } else if let Self::Ambiguity(span) = constraint {
+                        ambiguity.get_or_insert(span);
+                    } else if !constraint.is_true() {
+                        evaluated.push(constraint);
+                    }
+                }
+
+                ambiguity.map_or_else(|| Self::And(evaluated.into_boxed_slice()), Self::Ambiguity)
+            }
+            Self::Or(constraints) => {
+                let mut evaluated = Vec::new();
+                let mut ambiguity = None;
+                for constraint in constraints {
+                    let constraint = constraint.evaluate();
+                    if constraint.is_true() {
+                        return Self::And(Box::new([]));
+                    } else if let Self::Ambiguity(span) = constraint {
+                        ambiguity.get_or_insert(span);
+                    } else if !constraint.is_false() {
+                        evaluated.push(constraint);
+                    }
+                }
+
+                ambiguity.map_or_else(|| Self::Or(evaluated.into_boxed_slice()), Self::Ambiguity)
+            }
+            constraint => constraint,
+        }
+    }
+
+    fn is_true(&self) -> bool {
+        matches!(self, Self::And(constraints) if constraints.is_empty())
+    }
+
+    fn is_false(&self) -> bool {
+        matches!(self, Self::Or(constraints) if constraints.is_empty())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SolverRegionConstraintStorage<'tcx>(SolverRegionConstraint<'tcx>);
+
+impl<'tcx> SolverRegionConstraintStorage<'tcx> {
+    pub(crate) fn new() -> Self {
+        Self(SolverRegionConstraint::And(Box::new([])))
+    }
+
+    pub(crate) fn get_constraint(&self) -> SolverRegionConstraint<'tcx> {
+        self.0.clone()
+    }
+
+    pub(crate) fn get_unspanned_constraint(&self) -> UnspannedRegionConstraint<TyCtxt<'tcx>> {
+        self.0.without_spans()
+    }
+
+    pub(crate) fn is_and(&self) -> bool {
+        matches!(self.0, SolverRegionConstraint::And(_))
+    }
+
+    pub(crate) fn pop(&mut self, previous_was_and: bool) -> Option<SolverRegionConstraint<'tcx>> {
+        match &mut self.0 {
+            SolverRegionConstraint::And(and) => {
+                let mut and = core::mem::take(and).into_vec();
+                let popped = and.pop()?;
+                if previous_was_and {
+                    self.0 = SolverRegionConstraint::And(and.into_boxed_slice());
+                } else {
+                    assert_eq!(and.len(), 1);
+                    self.0 = and.pop().unwrap();
+                }
+                Some(popped)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[instrument(level = "debug")]
+    pub(crate) fn push(&mut self, constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>, span: Span) {
+        let constraint = SolverRegionConstraint::with_span(constraint, span);
+        match core::mem::replace(&mut self.0, SolverRegionConstraint::And(Box::new([]))) {
+            SolverRegionConstraint::And(and) => {
+                let and =
+                    and.into_iter().chain([constraint]).collect::<Vec<_>>().into_boxed_slice();
+                self.0 = SolverRegionConstraint::And(and);
+            }
+            previous => {
+                self.0 = SolverRegionConstraint::And(Box::new([previous, constraint]));
+            }
+        }
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    pub(crate) fn overwrite(
+        &mut self,
+        constraint: UnspannedRegionConstraint<TyCtxt<'tcx>>,
+        span: Span,
+    ) {
+        self.overwrite_spanned(SolverRegionConstraint::with_span(constraint, span));
+    }
+
+    pub(crate) fn overwrite_spanned(&mut self, constraint: SolverRegionConstraint<'tcx>) {
+        self.0 = constraint;
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/compiler/rustc_infer/src/infer/solver_region_constraints/tests.rs
+++ b/compiler/rustc_infer/src/infer/solver_region_constraints/tests.rs
@@ -1,0 +1,57 @@
+use rustc_span::{BytePos, DUMMY_SP, Span};
+use rustc_type_ir::region_constraint::evaluate_solver_constraint;
+
+use super::SolverRegionConstraint;
+
+fn and(constraints: Vec<SolverRegionConstraint<'static>>) -> SolverRegionConstraint<'static> {
+    SolverRegionConstraint::And(constraints.into_boxed_slice())
+}
+
+fn or(constraints: Vec<SolverRegionConstraint<'static>>) -> SolverRegionConstraint<'static> {
+    SolverRegionConstraint::Or(constraints.into_boxed_slice())
+}
+
+fn ambiguity() -> SolverRegionConstraint<'static> {
+    SolverRegionConstraint::Ambiguity(DUMMY_SP)
+}
+
+#[test]
+fn evaluation_matches_type_ir() {
+    let constraints = [
+        ambiguity(),
+        and(vec![]),
+        or(vec![]),
+        and(vec![and(vec![]), ambiguity()]),
+        and(vec![ambiguity(), or(vec![])]),
+        or(vec![or(vec![]), ambiguity()]),
+        or(vec![ambiguity(), and(vec![])]),
+        and(vec![or(vec![or(vec![]), ambiguity()]), or(vec![ambiguity(), and(vec![])])]),
+    ];
+
+    for constraint in constraints {
+        let expected = evaluate_solver_constraint(&constraint.without_spans());
+        let actual = constraint.evaluate().without_spans();
+        assert_eq!(actual, expected);
+    }
+}
+
+#[test]
+fn evaluation_preserves_first_ambiguity_span() {
+    let first = Span::with_root_ctxt(BytePos(1), BytePos(2));
+    let second = Span::with_root_ctxt(BytePos(3), BytePos(4));
+
+    for constraint in [
+        and(vec![
+            SolverRegionConstraint::Ambiguity(first),
+            SolverRegionConstraint::Ambiguity(second),
+        ]),
+        or(vec![
+            SolverRegionConstraint::Ambiguity(first),
+            SolverRegionConstraint::Ambiguity(second),
+        ]),
+    ] {
+        assert!(
+            matches!(constraint.evaluate(), SolverRegionConstraint::Ambiguity(span) if span == first)
+        );
+    }
+}

--- a/compiler/rustc_infer/src/infer/solver_region_constraints/tests.rs
+++ b/compiler/rustc_infer/src/infer/solver_region_constraints/tests.rs
@@ -16,7 +16,7 @@ fn ambiguity() -> SolverRegionConstraint<'static> {
 }
 
 #[test]
-fn evaluation_matches_type_ir() {
+fn evaluation_is_span_agnostic() {
     let constraints = [
         ambiguity(),
         and(vec![]),
@@ -29,8 +29,8 @@ fn evaluation_matches_type_ir() {
     ];
 
     for constraint in constraints {
-        let expected = evaluate_solver_constraint(&constraint.without_spans());
-        let actual = constraint.evaluate().without_spans();
+        let expected = evaluate_solver_constraint(&constraint.clone().without_spans());
+        let actual = evaluate_solver_constraint(&constraint).without_spans();
         assert_eq!(actual, expected);
     }
 }
@@ -50,8 +50,9 @@ fn evaluation_preserves_first_ambiguity_span() {
             SolverRegionConstraint::Ambiguity(second),
         ]),
     ] {
-        assert!(
-            matches!(constraint.evaluate(), SolverRegionConstraint::Ambiguity(span) if span == first)
-        );
+        assert!(matches!(
+            evaluate_solver_constraint(&constraint),
+            SolverRegionConstraint::Ambiguity(span) if span == first
+        ));
     }
 }

--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -134,7 +134,7 @@ where
             span,
         ),
         ExternalRegionConstraints::NextGen(r) => {
-            delegate.register_solver_region_constraint(r.clone())
+            delegate.register_solver_region_constraint(r.clone(), span)
         }
     };
     register_new_opaque_types(delegate, opaque_types, span);

--- a/compiler/rustc_next_trait_solver/src/delegate.rs
+++ b/compiler/rustc_next_trait_solver/src/delegate.rs
@@ -7,6 +7,22 @@ use rustc_type_ir::solve::{
 };
 use rustc_type_ir::{self as ty, CanonicalizerState, InferCtxtLike, Interner, TypeFoldable};
 
+/// `SolverDelegate` is one of the two traits in the `rustc_type_ir` shared abstraction layer
+/// between rustc and rust-analyzer abstracting over the [InferCtxt][inferctxt-doc], which had to be
+/// split due to coherence reasons:
+/// - `SolverDelegate` contains the parts depending on trait-solving logic, to provide functionality
+///   in `rustc_trait_selection`, and is implemented by a [simple wrapper over
+///   `InferCtxt`][inferctxt-wrapper-doc] there,
+/// - [InferCtxtLike] contains the other parts, and is implemented [directly on
+///   `InferCtxt`][inferctxtlike-impl-doc].
+///
+/// More information can also be found in the dedicated chapter in the dev-guide, in [this
+/// section][dev-guide].
+///
+/// [inferctxt-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxt.html
+/// [inferctxt-wrapper-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_trait_selection/solve/delegate/struct.SolverDelegate.html
+/// [inferctxtlike-impl-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxt.html#impl-InferCtxtLike-for-InferCtxt%3C'tcx%3E
+/// [dev-guide]: https://rustc-dev-guide.rust-lang.org/solve/sharing-crates-with-rust-analyzer.html#trait-inferctxtlike-and-trait-solverdelegate
 pub trait SolverDelegate: Deref<Target = Self::Infcx> + Sized {
     type Infcx: InferCtxtLike<Interner = Self::Interner>;
     type Interner: Interner;

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1329,7 +1329,7 @@ where
     }
 
     pub(super) fn register_solver_region_constraint(&self, c: RegionConstraint<I>) {
-        self.delegate.register_solver_region_constraint(c);
+        self.delegate.register_solver_region_constraint(c, self.origin_span);
     }
 
     pub(super) fn register_ty_outlives(&self, ty: I::Ty, lt: Region<I>) {

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
@@ -177,13 +177,13 @@ where
     fn destructure_component(&mut self, c: &Component<I>, r: Region<I>) -> RegionConstraint<I> {
         use Component::*;
         match c {
-            Region(c_r) => RegionConstraint::RegionOutlives(*c_r, r),
+            Region(c_r) => RegionConstraint::RegionOutlives(*c_r, r, ()),
             Placeholder(p) => {
-                RegionConstraint::PlaceholderTyOutlives(Ty::new_placeholder(self.cx(), *p), r)
+                RegionConstraint::PlaceholderTyOutlives(Ty::new_placeholder(self.cx(), *p), r, ())
             }
             // The alias is either rigid or ambiguous in which case we'll return with ambiguity.
             Alias(_, alias) => self.destructure_alias_outlives(*alias, r),
-            UnresolvedInferenceVariable(_) => RegionConstraint::Ambiguity,
+            UnresolvedInferenceVariable(_) => RegionConstraint::Ambiguity(()),
             Param(_) => panic!("Params should have been canonicalized to placeholders"),
             EscapingAlias(components) => self.destructure_components(components, r),
         }
@@ -204,11 +204,11 @@ where
     ) -> RegionConstraint<I> {
         let item_bounds =
             rustc_type_ir::outlives::declared_bounds_from_definition(self.cx(), alias)
-                .map(|bound| RegionConstraint::RegionOutlives(bound, r));
+                .map(|bound| RegionConstraint::RegionOutlives(bound, r, ()));
         let item_bound_outlives = RegionConstraint::Or(item_bounds.collect());
 
         let where_clause_outlives =
-            RegionConstraint::AliasTyOutlivesViaEnv(Binder::dummy((alias, r)));
+            RegionConstraint::AliasTyOutlivesViaEnv(Binder::dummy((alias, r)), ());
 
         let mut components = Default::default();
         rustc_type_ir::outlives::compute_alias_components_recursive(

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
@@ -139,7 +139,7 @@ where
             });
         let constraint = evaluate_solver_constraint(&constraint.canonical_form());
 
-        self.delegate.overwrite_solver_region_constraint(constraint.clone());
+        self.delegate.overwrite_solver_region_constraint(constraint.clone(), self.origin_span);
 
         if constraint.is_false() {
             Err(NoSolution)

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -120,7 +120,7 @@ where
 
         if self.cx().assumptions_on_binders() {
             let constraint =
-                rustc_type_ir::region_constraint::RegionConstraint::RegionOutlives(a, b);
+                rustc_type_ir::region_constraint::RegionConstraint::RegionOutlives(a, b, ());
             self.register_solver_region_constraint(constraint);
         } else {
             self.register_region_outlives(a, b, VisibleForLeakCheck::Yes);

--- a/compiler/rustc_resolve/src/diagnostics/impls.rs
+++ b/compiler/rustc_resolve/src/diagnostics/impls.rs
@@ -1283,6 +1283,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ResolutionError::ParamInTyOfConstParam { name } => {
                 self.dcx().create_err(diagnostics::ParamInTyOfConstParam { span, name })
             }
+            ResolutionError::SelfInConstParam => {
+                self.dcx().create_err(diagnostics::SelfInConstGenericTy {
+                    span,
+                    enable_feature: self.tcx().sess.is_nightly_build(),
+                })
+            }
             ResolutionError::ParamInNonTrivialAnonConst { is_gca, name, param_kind: is_type } => {
                 self.dcx().create_err(diagnostics::ParamInNonTrivialAnonConst {
                     span,
@@ -1306,9 +1312,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 ForwardGenericParamBanReason::Default => {
                     self.dcx().create_err(diagnostics::SelfInGenericParamDefault { span })
                 }
-                ForwardGenericParamBanReason::ConstParamTy => {
-                    self.dcx().create_err(diagnostics::SelfInConstGenericTy { span })
-                }
+                ForwardGenericParamBanReason::ConstParamTy => self
+                    .dcx()
+                    .create_err(diagnostics::SelfInConstGenericTy { span, enable_feature: false }),
             },
             ResolutionError::UnreachableLabel { name, definition_span, suggestion } => {
                 let ((sub_suggestion_label, sub_suggestion), sub_unreachable_label) =

--- a/compiler/rustc_resolve/src/diagnostics/impls.rs
+++ b/compiler/rustc_resolve/src/diagnostics/impls.rs
@@ -1928,9 +1928,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ident,
             is_expected,
         );
-        if !self.add_typo_suggestion(err, suggestion, ident.span) {
-            self.detect_derive_attribute(err, ident, parent_scope, sugg_span);
-        }
+        self.add_typo_suggestion(err, suggestion, ident.span);
+        self.detect_derive_attribute(err, ident, parent_scope, sugg_span);
 
         let import_suggestions =
             self.lookup_import_candidates(ident, Namespace::MacroNS, parent_scope, is_expected);
@@ -2211,11 +2210,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         err: &mut Diag<'_>,
         suggestion: Option<TypoSuggestion>,
         span: Span,
-    ) -> bool {
+    ) {
         let suggestion = match suggestion {
-            None => return false,
+            None => return,
             // We shouldn't suggest underscore.
-            Some(suggestion) if suggestion.candidate == kw::Underscore => return false,
+            Some(suggestion) if suggestion.candidate == kw::Underscore => return,
             Some(suggestion) => suggestion,
         };
 
@@ -2241,7 +2240,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 //    |
                 // LL | const Y: X = Y("ö");
                 //    |              ^
-                return false;
+                return;
             }
             let span = self.tcx.sess.source_map().guess_head_span(def_span);
             let candidate_descr = suggestion.res.descr();
@@ -2271,7 +2270,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 "the leading underscore in `{candidate}` marks it as unused, consider renaming it to `{snippet}`"
             );
             if !did_label_def_span {
-                err.span_label(span, format!("`{candidate}` defined here"));
+                err.span_note(span, format!("`{candidate}` defined here"));
             }
             (span, msg, snippet)
         } else {
@@ -2288,7 +2287,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             (span, msg, suggestion.candidate.to_ident_string())
         };
         err.span_suggestion_verbose(span, msg, sugg, Applicability::MaybeIncorrect);
-        true
     }
 
     fn decl_description(&self, b: Decl<'_>, ident: Ident, scope: Scope<'_>) -> String {

--- a/compiler/rustc_resolve/src/diagnostics/mod.rs
+++ b/compiler/rustc_resolve/src/diagnostics/mod.rs
@@ -386,6 +386,10 @@ pub(crate) struct SelfInGenericParamDefault {
 pub(crate) struct SelfInConstGenericTy {
     #[primary_span]
     pub(crate) span: Span,
+    #[help(
+        "add `#![feature(min_adt_const_params)]` to the crate attributes to enable `Self` as a const parameter type"
+    )]
+    pub(crate) enable_feature: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_resolve/src/diagnostics/mod.rs
+++ b/compiler/rustc_resolve/src/diagnostics/mod.rs
@@ -1219,14 +1219,14 @@ pub(crate) struct CannotFindBuiltinMacroWithName {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum DefinedHere {
-    #[label("similarly named {$candidate_descr} `{$candidate}` defined here")]
+    #[note("similarly named {$candidate_descr} `{$candidate}` defined here")]
     SimilarlyNamed {
         #[primary_span]
         span: Span,
         candidate_descr: &'static str,
         candidate: Symbol,
     },
-    #[label("{$candidate_descr} `{$candidate}` defined here")]
+    #[note("{$candidate_descr} `{$candidate}` defined here")]
     SingleItem {
         #[primary_span]
         span: Span,

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1593,18 +1593,28 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         }
 
                         RibKind::ConstParamTy => {
-                            if !self.features.generic_const_parameter_types() {
+                            let adt_enabled = self.features.min_adt_const_params()
+                                || self.features.adt_const_params();
+                            let is_self = matches!(res, Res::SelfTyAlias { .. });
+                            // We check whether Self depends on generics parameters in `fn type_of`
+                            if self.features.generic_const_parameter_types()
+                                || (adt_enabled && is_self)
+                            {
+                                continue;
+                            } else {
                                 if let Some(span) = finalize {
-                                    self.report_error(
-                                        span,
-                                        ResolutionError::ParamInTyOfConstParam {
-                                            name: rib_ident.name,
-                                        },
-                                    );
+                                    if matches!(res, Res::SelfTyAlias { .. }) {
+                                        self.report_error(span, ResolutionError::SelfInConstParam);
+                                    } else {
+                                        self.report_error(
+                                            span,
+                                            ResolutionError::ParamInTyOfConstParam {
+                                                name: rib_ident.name,
+                                            },
+                                        );
+                                    }
                                 }
                                 return Res::Err;
-                            } else {
-                                continue;
                             }
                         }
 

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1319,30 +1319,29 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
 
         let typo_sugg =
             self.lookup_typo_candidate(path, following_seg, source.namespace(), is_expected);
-        let mut fallback = false;
+        let mut fallback = true;
         let typo_sugg = typo_sugg
             .to_opt_suggestion()
             .filter(|sugg| !suggested_candidates.contains(sugg.candidate.as_str()));
-        if !self.r.add_typo_suggestion(err, typo_sugg, ident_span) {
-            fallback = true;
-            match self.diag_metadata.current_let_binding {
-                Some((pat_sp, Some(ty_sp), None))
-                    if ty_sp.contains(base_error.span) && base_error.could_be_expr =>
-                {
-                    err.span_suggestion_verbose(
-                        pat_sp.between(ty_sp),
-                        "use `=` if you meant to assign",
-                        " = ",
-                        Applicability::MaybeIncorrect,
-                    );
-                }
-                _ => {}
-            }
+        self.r.add_typo_suggestion(err, typo_sugg, ident_span);
 
-            // If the trait has a single item (which wasn't matched by the algorithm), suggest it
-            let suggestion = self.get_single_associated_item(path, &source, is_expected);
-            self.r.add_typo_suggestion(err, suggestion, ident_span);
+        match self.diag_metadata.current_let_binding {
+            Some((pat_sp, Some(ty_sp), None))
+                if ty_sp.contains(base_error.span) && base_error.could_be_expr =>
+            {
+                err.span_suggestion_verbose(
+                    pat_sp.between(ty_sp),
+                    "use `=` if you meant to assign",
+                    " = ",
+                    Applicability::MaybeIncorrect,
+                );
+            }
+            _ => {}
         }
+
+        // If the trait has a single item (which wasn't matched by the algorithm), suggest it
+        let suggestion = self.get_single_associated_item(path, &source, is_expected);
+        self.r.add_typo_suggestion(err, suggestion, ident_span);
 
         if self.let_binding_suggestion(err, ident_span) {
             fallback = false;

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -297,6 +297,8 @@ enum ResolutionError<'ra> {
     // problematic to use *forward declared* parameters when the feature is enabled.
     /// ERROR E0770: the type of const parameters must not depend on other generic parameters.
     ParamInTyOfConstParam { name: Symbol },
+    /// cannot use self in const param
+    SelfInConstParam,
     /// generic parameters must not be used inside const evaluations.
     ///
     /// This error is only emitted when using `min_const_generics`.

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2358,7 +2358,7 @@ options! {
     dual_proc_macros: bool = (false, parse_bool, [TRACKED],
         "load proc macros for both target and host, but only link to the target (default: no)"),
     dump_dep_graph: bool = (false, parse_bool, [UNTRACKED],
-        "dump the dependency graph to $RUST_DEP_GRAPH (default: /tmp/dep_graph.gv) \
+        "dump the dependency graph to `$RUST_DEP_GRAPH` as both a text file and a GraphViz dot file (default: ./dep_graph.{dot, txt}) \
         (default: no)"),
     dump_mir: Option<String> = (None, parse_opt_string, [UNTRACKED],
         "dump MIR state to file.

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -297,7 +297,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             SubregionOrigin::SolverRegionConstraint(span) => {
                 RegionOriginNote::Plain {
                     span,
-                    msg: msg!("this diagnostic is currently WIP while -Zassumptions-on-binders is incomplete"),
+                    msg: msg!("...so that a higher-ranked lifetime bound can be satisfied"),
                 }
                 .add_to_diag(err);
             }
@@ -569,14 +569,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     notes: instantiated.into_iter().chain(must_outlive).collect(),
                 })
             }
-            SubregionOrigin::SolverRegionConstraint(span) => {
-                let mut d = self.dcx().struct_span_err(
-                    span,
-                    "unsatisfied lifetime constraint from -Zassumptions-on-binders :3",
-                );
-                d.note("meoow :c");
-                d
-            }
+            SubregionOrigin::SolverRegionConstraint(span) => self
+                .dcx()
+                .struct_span_err(span, "higher-ranked lifetime bound could not be satisfied"),
         };
         if sub.is_error() || sup.is_error() {
             err.downgrade_to_delayed_bug();

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -419,6 +419,13 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             FulfillmentErrorCode::Project(ref e) => {
                 self.report_projection_error(&error.obligation, e)
             }
+            FulfillmentErrorCode::Outlives => self
+                .dcx()
+                .struct_span_err(
+                    error.obligation.cause.span,
+                    "higher-ranked lifetime bound could not be satisfied",
+                )
+                .emit(),
             FulfillmentErrorCode::Ambiguity { overflow: None } => {
                 self.maybe_report_ambiguity(&error.obligation, related)
             }

--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -66,6 +66,9 @@ pub(super) fn fulfillment_error_for_no_solution<'tcx>(
             let expected_found = ExpectedFound::new(b, a);
             FulfillmentErrorCode::Subtype(expected_found, TypeError::Sorts(expected_found))
         }
+        ty::PredicateKind::Clause(
+            ty::ClauseKind::RegionOutlives(_) | ty::ClauseKind::TypeOutlives(_),
+        ) if infcx.tcx.assumptions_on_binders() => FulfillmentErrorCode::Outlives,
         ty::PredicateKind::Clause(_)
         | ty::PredicateKind::DynCompatible(_)
         | ty::PredicateKind::Ambiguous => {

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -1066,6 +1066,7 @@ impl<'tcx> FromSolverError<'tcx, OldSolverError<'tcx>> for ScrubbedTraitError<'t
         match error.0.error {
             FulfillmentErrorCode::Select(_)
             | FulfillmentErrorCode::Project(_)
+            | FulfillmentErrorCode::Outlives
             | FulfillmentErrorCode::Subtype(_, _)
             | FulfillmentErrorCode::ConstEquate(_, _) => ScrubbedTraitError::TrueError,
             FulfillmentErrorCode::Ambiguity { overflow: _ } => ScrubbedTraitError::Ambiguity,

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -98,6 +98,7 @@ impl<'tcx> FulfillmentError<'tcx> {
         match self.code {
             FulfillmentErrorCode::Select(_)
             | FulfillmentErrorCode::Project(_)
+            | FulfillmentErrorCode::Outlives
             | FulfillmentErrorCode::Subtype(_, _)
             | FulfillmentErrorCode::ConstEquate(_, _) => true,
             FulfillmentErrorCode::Cycle(_) | FulfillmentErrorCode::Ambiguity { overflow: _ } => {
@@ -114,6 +115,8 @@ pub enum FulfillmentErrorCode<'tcx> {
     Cycle(PredicateObligations<'tcx>),
     Select(SelectionError<'tcx>),
     Project(MismatchedProjectionTypes<'tcx>),
+    /// An outlives constraint emitted for `-Zassumptions-on-binders` was unsatisfiable.
+    Outlives,
     Subtype(ExpectedFound<Ty<'tcx>>, TypeError<'tcx>), // always comes from a SubtypePredicate
     ConstEquate(ExpectedFound<ty::Const<'tcx>>, TypeError<'tcx>),
     Ambiguity {
@@ -129,6 +132,7 @@ impl<'tcx> Debug for FulfillmentErrorCode<'tcx> {
         match *self {
             FulfillmentErrorCode::Select(ref e) => write!(f, "{e:?}"),
             FulfillmentErrorCode::Project(ref e) => write!(f, "{e:?}"),
+            FulfillmentErrorCode::Outlives => write!(f, "CodeOutlivesError"),
             FulfillmentErrorCode::Subtype(ref a, ref b) => {
                 write!(f, "CodeSubtypeError({a:?}, {b:?})")
             }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -709,6 +709,11 @@ fn project<'cx, 'tcx>(
     if let ty::Dynamic(data, ..) = self_ty.kind() {
         if let Some(def_id) = data.principal_def_id() {
             let tcx = selcx.tcx();
+            // Delaying a bug is fine here:
+            // - In case of a dymmy span, we are in a canonical query.
+            // - `CheckAssociatedTypeBounds` means that the trait object is part of the trait's item bounds
+            //   or the impl's associated type; both are checked at their own definition
+            //   where the error is already reported with a better span.
             if !tcx.is_dyn_compatible(def_id) {
                 let span = obligation.cause.span;
                 let guar = if span.is_dummy()

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -27,6 +27,7 @@ use super::{
     SelectionError, specialization_graph, translate_args, util,
 };
 use crate::diagnostics::InherentProjectionNormalizationOverflow;
+use crate::error_reporting::traits::report_dyn_incompatibility;
 use crate::infer::{BoundRegionConversionTime, InferOk};
 use crate::traits::normalize::{normalize_with_depth, normalize_with_depth_to};
 use crate::traits::query::evaluate_obligation::InferCtxtExt as _;
@@ -702,6 +703,35 @@ fn project<'cx, 'tcx>(
         )));
     }
 
+    // `<dyn Trait>::Name` is only valid when `Trait` is dyn-compatible.
+    // If it isn't, create an error at the projection site and return a tainted error term.
+    let self_ty = selcx.infcx.shallow_resolve(obligation.predicate.self_ty());
+    if let ty::Dynamic(data, ..) = self_ty.kind() {
+        if let Some(def_id) = data.principal_def_id() {
+            let tcx = selcx.tcx();
+            if !tcx.is_dyn_compatible(def_id) {
+                let span = obligation.cause.span;
+                let guar = if !span.is_dummy() {
+                    let violations = tcx.dyn_compatibility_violations(def_id);
+                    report_dyn_incompatibility(tcx, span, None, def_id, &violations).emit()
+                } else {
+                    tcx.dcx().span_delayed_bug(
+                        span,
+                        format!(
+                            "projection from non-dyn-compatible trait `{}`",
+                            tcx.def_path_str(def_id)
+                        ),
+                    )
+                };
+                return Ok(Projected::Progress(Progress::error_for_term(
+                    tcx,
+                    obligation.predicate,
+                    guar,
+                )));
+            }
+        }
+    }
+
     let mut candidates = ProjectionCandidateSet::None;
 
     // Make sure that the following procedures are kept in order. ParamEnv
@@ -852,7 +882,7 @@ fn assemble_candidates_from_object_ty<'cx, 'tcx>(
         return;
     }
 
-    let env_clauses = data
+    let env_predicates = data
         .projection_bounds()
         .filter(|bound| bound.item_def_id() == obligation.predicate.expect_projection_def_id())
         .map(|p| p.with_self_ty(tcx, object_ty).upcast(tcx));
@@ -862,7 +892,7 @@ fn assemble_candidates_from_object_ty<'cx, 'tcx>(
         obligation,
         candidate_set,
         ProjectionCandidate::Object,
-        env_clauses,
+        env_predicates,
         false,
     );
 }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -711,10 +711,11 @@ fn project<'cx, 'tcx>(
             let tcx = selcx.tcx();
             if !tcx.is_dyn_compatible(def_id) {
                 let span = obligation.cause.span;
-                let guar = if !span.is_dummy() {
-                    let violations = tcx.dyn_compatibility_violations(def_id);
-                    report_dyn_incompatibility(tcx, span, None, def_id, &violations).emit()
-                } else {
+                let guar = if span.is_dummy()
+                    || matches!(
+                        obligation.cause.code(),
+                        ObligationCauseCode::CheckAssociatedTypeBounds { .. }
+                    ) {
                     tcx.dcx().span_delayed_bug(
                         span,
                         format!(
@@ -722,6 +723,9 @@ fn project<'cx, 'tcx>(
                             tcx.def_path_str(def_id)
                         ),
                     )
+                } else {
+                    let violations = tcx.dyn_compatibility_violations(def_id);
+                    report_dyn_incompatibility(tcx, span, None, def_id, &violations).emit()
                 };
                 return Ok(Projected::Progress(Progress::error_for_term(
                     tcx,

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -846,6 +846,12 @@ fn assemble_candidates_from_object_ty<'cx, 'tcx>(
         }
         _ => return,
     };
+
+    // Projecting `dyn Trait` is only valid when `Trait` is dyn-compatible.
+    if data.principal_def_id().is_some_and(|def_id| !tcx.is_dyn_compatible(def_id)) {
+        return;
+    }
+
     let env_clauses = data
         .projection_bounds()
         .filter(|bound| bound.item_def_id() == obligation.predicate.expect_projection_def_id())

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
@@ -146,6 +146,24 @@ where
         root_def_id: LocalDefId,
         span: Span,
     ) -> Result<TypeOpOutput<'tcx, Self>, ErrorGuaranteed> {
+        // Canonical type-op queries drop NextGen solver region constraints when
+        // building `QueryResponse`. Evaluate locally so `-Zassumptions-on-binders`
+        // can attach those constraints to this `InferCtxt` and report them from
+        // borrowck instead of silently succeeding.
+        if infcx.tcx.assumptions_on_binders() {
+            if !infcx.disable_trait_solver_fast_paths()
+                && let Some(output) = Q::try_fast_path(infcx.tcx, &self)
+            {
+                return Ok(TypeOpOutput { output, constraints: None, error_info: None });
+            }
+
+            let (output, _) =
+                scrape_region_constraints(infcx, root_def_id, "fully_perform", span, |ocx| {
+                    Q::perform_locally_with_next_solver(ocx, self, span)
+                })?;
+            return Ok(output);
+        }
+
         let mut error_info = None;
         let mut region_constraints = QueryRegionConstraints::default();
 

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
@@ -146,24 +146,6 @@ where
         root_def_id: LocalDefId,
         span: Span,
     ) -> Result<TypeOpOutput<'tcx, Self>, ErrorGuaranteed> {
-        // Canonical type-op queries drop NextGen solver region constraints when
-        // building `QueryResponse`. Evaluate locally so `-Zassumptions-on-binders`
-        // can attach those constraints to this `InferCtxt` and report them from
-        // borrowck instead of silently succeeding.
-        if infcx.tcx.assumptions_on_binders() {
-            if !infcx.disable_trait_solver_fast_paths()
-                && let Some(output) = Q::try_fast_path(infcx.tcx, &self)
-            {
-                return Ok(TypeOpOutput { output, constraints: None, error_info: None });
-            }
-
-            let (output, _) =
-                scrape_region_constraints(infcx, root_def_id, "fully_perform", span, |ocx| {
-                    Q::perform_locally_with_next_solver(ocx, self, span)
-                })?;
-            return Ok(output);
-        }
-
         let mut error_info = None;
         let mut region_constraints = QueryRegionConstraints::default();
 

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -399,6 +399,7 @@ pub trait InferCtxtLike: Sized {
     fn overwrite_solver_region_constraint(
         &self,
         constraint: crate::region_constraint::RegionConstraint<Self::Interner>,
+        span: <Self::Interner as Interner>::Span,
     );
 
     fn universe_of_ty(&self, ty: ty::TyVid) -> Option<ty::UniverseIndex>;
@@ -520,6 +521,7 @@ pub trait InferCtxtLike: Sized {
     fn register_solver_region_constraint(
         &self,
         c: crate::region_constraint::RegionConstraint<Self::Interner>,
+        span: <Self::Interner as Interner>::Span,
     );
 
     fn register_ty_outlives(

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -362,6 +362,22 @@ impl<I: Interner> From<TypingMode<I, CantBeErased>> for TypingMode<I, MayBeErase
     }
 }
 
+/// `InferCtxtLike` is one of the two traits abstracting over the [InferCtxt][inferctxt-doc], which
+/// had to be split due to coherence reasons:
+/// - `InferCtxtLike`] contains the parts that have to live in `rustc_infer`, and thus aren't only
+///   about trait-solving. It is implemented [directly on `InferCtxt`][inferctxtlike-impl-doc],
+/// - [SolverDelegate][solverdelegate-doc] contains the parts depending on trait-solving logic, to
+///   provide functionality in `rustc_trait_selection`, and is implemented by a [simple wrapper over
+///   `InferCtxt`][inferctxt-wrapper-doc] there.
+///
+/// More information can also be found in the dedicated chapter in the dev-guide, in [this
+/// section][dev-guide].
+///
+/// [inferctxt-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxt.html
+/// [inferctxtlike-impl-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxt.html#impl-InferCtxtLike-for-InferCtxt%3C'tcx%3E
+/// [solverdelegate-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_next_trait_solver/delegate/trait.SolverDelegate.html
+/// [inferctxt-wrapper-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_trait_selection/solve/delegate/struct.SolverDelegate.html
+/// [dev-guide]: https://rustc-dev-guide.rust-lang.org/solve/sharing-crates-with-rust-analyzer.html#trait-inferctxtlike-and-trait-solverdelegate
 #[cfg_attr(feature = "nightly", rustc_diagnostic_item = "type_ir_infer_ctxt_like")]
 pub trait InferCtxtLike: Sized {
     type Interner: Interner;

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -24,6 +24,26 @@ use crate::{
     TraitRef, search_graph,
 };
 
+/// The central trait in the shared abstraction layer, specifying all implementation-specific
+/// details for rustc and rust-analyzer.
+///
+/// Among its essential responsibilities:
+/// - it specifies the concrete types used by each implementation via its associated types; these
+///   form the backbone of how each compiler frontend instantiates the shared IR.
+/// - it provides the context required by the solver (e.g., querying lang items, enumerating all
+///   blanket impls for a trait)
+/// - it implements [IrPrint] for formatting and tracing.
+///
+/// In rustc, it is [implemented by TyCtxt][interner-impl-doc]. In rust-analyzer, the implementing
+/// type is named [DbInterner][dbinterner-code] (as it performs most interning through the salsa
+/// database).
+///
+/// More information can also be found in the dedicated chapter in the dev-guide, in [this
+/// section][dev-guide].
+///
+/// [interner-impl-doc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.TyCtxt.html#impl-Interner-for-TyCtxt%3C'tcx%3E
+/// [dbinterner-code]: https://github.com/rust-lang/rust-analyzer/blob/a50c1ccc9cf3dab1afdc857a965a9992fbad7a53/crates/hir-ty/src/next_solver/interner.rs#L272
+/// [dev-guide]: https://rustc-dev-guide.rust-lang.org/solve/sharing-crates-with-rust-analyzer.html#trait-interner
 #[cfg_attr(feature = "nightly", rustc_diagnostic_item = "type_ir_interner")]
 pub trait Interner:
     Sized

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -1,3 +1,24 @@
+//! This crate is an abstraction layer, shared between rustc and rust-analyzer, to help with the
+//! overlapping responsibilities (like type inference and trait solving), reduce duplication, and
+//! maintain consistent behavior between the two implementations.
+//!
+//! It defines fundamental interfaces for types, predicates, and the context required by the next
+//! trait solver.
+//!
+//! Both rustc and rust-analyzer immplement these traits for their own concrete implementations, and
+//! `rustc_next_trait_solver` is written to be generic over these abstractions.
+//!
+//! In addition to these interfaces, it also contains components built on top of the abstraction
+//! layer, for example elaboration logic, and the search graph machinery used by the solver, as well
+//! as items that do not need compiler-specific implementations.
+//!
+//! Note that rust-analyzer is built with a stable compiler, while rustc uses unstable features, so
+//! this crate and some of its dependencies need to separate unstable code under the `nightly`
+//! feature.
+//!
+//! There are more details available in a [dedicated dev-guide
+//! chapter](https://rustc-dev-guide.rust-lang.org/solve/sharing-crates-with-rust-analyzer.html).
+
 #![cfg_attr(feature = "nightly", rustc_diagnostic_item = "type_ir")]
 // tidy-alphabetical-start
 #![allow(rustc::direct_use_of_rustc_type_ir)]

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -91,11 +91,11 @@ impl<I: Interner> Assumptions<I> {
     }
 }
 
-#[derive_where(Clone, Hash, PartialEq, Debug; I: Interner)]
+#[derive_where(Clone, Hash, PartialEq, Debug; I: Interner, S)]
 #[derive(GenericTypeVisitable)]
-pub enum RegionConstraint<I: Interner> {
-    Ambiguity,
-    RegionOutlives(Region<I>, Region<I>),
+pub enum RegionConstraint<I: Interner, S = ()> {
+    Ambiguity(S),
+    RegionOutlives(Region<I>, Region<I>, S),
     /// Requirement that a (potentially higher ranked) alias outlives some (potentially higher ranked)
     /// region due to an assumption in the environment. This cannot be satisfied via component outlives
     /// or item bounds.
@@ -105,7 +105,7 @@ pub enum RegionConstraint<I: Interner> {
     ///
     /// We eagerly destructure alias outlives requirements into region outlives requirements corresponding to
     /// component outlives & item bound outlives rules, leaving only param env candidates.
-    AliasTyOutlivesViaEnv(Binder<I, (AliasTy<I>, Region<I>)>),
+    AliasTyOutlivesViaEnv(Binder<I, (AliasTy<I>, Region<I>)>, S),
     /// This is an `I::Ty` for two reasons:
     /// 1. We need the type visitable impl to be able to `visit_ty` on this so canonicalization
     ///    knows about the placeholder
@@ -115,11 +115,18 @@ pub enum RegionConstraint<I: Interner> {
     ///
     /// We cannot eagerly look at assumptions as we are usually working with an incomplete set of assumptions
     /// and there may wind up being assumptions we can use to prove this when we're in a smaller universe.
-    PlaceholderTyOutlives(I::Ty, Region<I>),
+    PlaceholderTyOutlives(I::Ty, Region<I>, S),
 
-    And(Box<[RegionConstraint<I>]>),
-    Or(Box<[RegionConstraint<I>]>),
+    And(Box<[RegionConstraint<I, S>]>),
+    Or(Box<[RegionConstraint<I, S>]>),
 }
+
+/// A solver region constraint together with the span that caused each atomic constraint.
+///
+/// Solver query responses use [`RegionConstraint`] so source locations do not participate in
+/// candidate equality or caching. Spans are attached when responses are applied to an inference
+/// context.
+pub type SpannedRegionConstraint<I> = RegionConstraint<I, <I as Interner>::Span>;
 
 // This is not a derived impl because a perfect derive leads to inductive
 // cycle causing the trait to never actually be implemented.
@@ -141,15 +148,15 @@ where
 
         std::mem::discriminant(self).stable_hash(hcx, hasher);
         match self {
-            Ambiguity => (),
-            RegionOutlives(a, b) => {
+            Ambiguity(_) => (),
+            RegionOutlives(a, b, _) => {
                 a.stable_hash(hcx, hasher);
                 b.stable_hash(hcx, hasher);
             }
-            AliasTyOutlivesViaEnv(outlives) => {
+            AliasTyOutlivesViaEnv(outlives, _) => {
                 outlives.stable_hash(hcx, hasher);
             }
-            PlaceholderTyOutlives(a, b) => {
+            PlaceholderTyOutlives(a, b, _) => {
                 a.stable_hash(hcx, hasher);
                 b.stable_hash(hcx, hasher);
             }
@@ -167,15 +174,19 @@ where
     }
 }
 
-impl<I: Interner> TypeFoldable<I> for RegionConstraint<I> {
+impl<I: Interner, S: Clone + std::fmt::Debug> TypeFoldable<I> for RegionConstraint<I, S> {
     fn try_fold_with<F: FallibleTypeFolder<I>>(self, f: &mut F) -> Result<Self, F::Error> {
         use RegionConstraint::*;
         Ok(match self {
-            Ambiguity => self,
-            RegionOutlives(a, b) => RegionOutlives(a.try_fold_with(f)?, b.try_fold_with(f)?),
-            AliasTyOutlivesViaEnv(outlives) => AliasTyOutlivesViaEnv(outlives.try_fold_with(f)?),
-            PlaceholderTyOutlives(a, b) => {
-                PlaceholderTyOutlives(a.try_fold_with(f)?, b.try_fold_with(f)?)
+            Ambiguity(_) => self,
+            RegionOutlives(a, b, span) => {
+                RegionOutlives(a.try_fold_with(f)?, b.try_fold_with(f)?, span)
+            }
+            AliasTyOutlivesViaEnv(outlives, span) => {
+                AliasTyOutlivesViaEnv(outlives.try_fold_with(f)?, span)
+            }
+            PlaceholderTyOutlives(a, b, span) => {
+                PlaceholderTyOutlives(a.try_fold_with(f)?, b.try_fold_with(f)?, span)
             }
             And(and) => {
                 let mut new_and = Vec::new();
@@ -197,10 +208,14 @@ impl<I: Interner> TypeFoldable<I> for RegionConstraint<I> {
     fn fold_with<F: TypeFolder<I>>(self, f: &mut F) -> Self {
         use RegionConstraint::*;
         match self {
-            Ambiguity => self,
-            RegionOutlives(a, b) => RegionOutlives(a.fold_with(f), b.fold_with(f)),
-            AliasTyOutlivesViaEnv(outlives) => AliasTyOutlivesViaEnv(outlives.fold_with(f)),
-            PlaceholderTyOutlives(a, b) => PlaceholderTyOutlives(a.fold_with(f), b.fold_with(f)),
+            Ambiguity(_) => self,
+            RegionOutlives(a, b, span) => RegionOutlives(a.fold_with(f), b.fold_with(f), span),
+            AliasTyOutlivesViaEnv(outlives, span) => {
+                AliasTyOutlivesViaEnv(outlives.fold_with(f), span)
+            }
+            PlaceholderTyOutlives(a, b, span) => {
+                PlaceholderTyOutlives(a.fold_with(f), b.fold_with(f), span)
+            }
             And(and) => {
                 let mut new_and = Vec::new();
                 for a in and {
@@ -219,20 +234,20 @@ impl<I: Interner> TypeFoldable<I> for RegionConstraint<I> {
     }
 }
 
-impl<I: Interner> TypeVisitable<I> for RegionConstraint<I> {
+impl<I: Interner, S: std::fmt::Debug> TypeVisitable<I> for RegionConstraint<I, S> {
     fn visit_with<F: TypeVisitor<I>>(&self, f: &mut F) -> F::Result {
         use RegionConstraint::*;
 
         match self {
-            Ambiguity => (),
-            RegionOutlives(a, b) => {
+            Ambiguity(_) => (),
+            RegionOutlives(a, b, _) => {
                 try_visit!(a.visit_with(f));
                 try_visit!(b.visit_with(f));
             }
-            AliasTyOutlivesViaEnv(outlives) => {
+            AliasTyOutlivesViaEnv(outlives, _) => {
                 try_visit!(outlives.visit_with(f));
             }
-            PlaceholderTyOutlives(a, b) => {
+            PlaceholderTyOutlives(a, b, _) => {
                 try_visit!(a.visit_with(f));
                 try_visit!(b.visit_with(f));
             }
@@ -248,13 +263,38 @@ impl<I: Interner> TypeVisitable<I> for RegionConstraint<I> {
     }
 }
 
-impl<I: Interner> Default for RegionConstraint<I> {
+impl<I: Interner, S> RegionConstraint<I, S> {
+    fn map_spans<T>(self, f: &mut impl FnMut(S) -> T) -> RegionConstraint<I, T> {
+        use RegionConstraint::*;
+
+        match self {
+            Ambiguity(span) => Ambiguity(f(span)),
+            RegionOutlives(a, b, span) => RegionOutlives(a, b, f(span)),
+            AliasTyOutlivesViaEnv(outlives, span) => AliasTyOutlivesViaEnv(outlives, f(span)),
+            PlaceholderTyOutlives(ty, region, span) => PlaceholderTyOutlives(ty, region, f(span)),
+            And(constraints) => And(constraints.into_iter().map(|c| c.map_spans(f)).collect()),
+            Or(constraints) => Or(constraints.into_iter().map(|c| c.map_spans(f)).collect()),
+        }
+    }
+
+    pub fn without_spans(self) -> RegionConstraint<I> {
+        self.map_spans(&mut |_| ())
+    }
+}
+
+impl<I: Interner> RegionConstraint<I> {
+    pub fn with_span<S: Clone>(self, span: S) -> RegionConstraint<I, S> {
+        self.map_spans(&mut |_| span.clone())
+    }
+}
+
+impl<I: Interner, S: Clone + std::fmt::Debug> Default for RegionConstraint<I, S> {
     fn default() -> Self {
         Self::new_true()
     }
 }
 
-impl<I: Interner> RegionConstraint<I> {
+impl<I: Interner, S: Clone + std::fmt::Debug> RegionConstraint<I, S> {
     pub fn new_true() -> Self {
         RegionConstraint::And(Box::new([]))
     }
@@ -281,14 +321,14 @@ impl<I: Interner> RegionConstraint<I> {
         matches!(self, Self::Or(_))
     }
 
-    pub fn unwrap_or(self) -> Box<[RegionConstraint<I>]> {
+    pub fn unwrap_or(self) -> Box<[RegionConstraint<I, S>]> {
         match self {
             Self::Or(ors) => ors,
             _ => panic!("`unwrap_or` on non-Or: {self:?}"),
         }
     }
 
-    pub fn unwrap_and(self) -> Box<[RegionConstraint<I>]> {
+    pub fn unwrap_and(self) -> Box<[RegionConstraint<I, S>]> {
         match self {
             Self::And(ands) => ands,
             _ => panic!("`unwrap_and` on non-And: {self:?}"),
@@ -300,10 +340,10 @@ impl<I: Interner> RegionConstraint<I> {
     }
 
     pub fn is_ambig(&self) -> bool {
-        matches!(self, Self::Ambiguity)
+        matches!(self, Self::Ambiguity(_))
     }
 
-    pub fn and(self, other: RegionConstraint<I>) -> RegionConstraint<I> {
+    pub fn and(self, other: RegionConstraint<I, S>) -> RegionConstraint<I, S> {
         use RegionConstraint::*;
 
         match (self, other) {
@@ -325,9 +365,9 @@ impl<I: Interner> RegionConstraint<I> {
     pub fn canonical_form(self) -> Self {
         use RegionConstraint::*;
 
-        fn permutations<I: Interner>(
-            ors: &[Vec<RegionConstraint<I>>],
-        ) -> Vec<Vec<RegionConstraint<I>>> {
+        fn permutations<I: Interner, S: Clone>(
+            ors: &[Vec<RegionConstraint<I, S>>],
+        ) -> Vec<Vec<RegionConstraint<I, S>>> {
             match ors {
                 [] => vec![vec![]],
                 [or1] => {
@@ -405,7 +445,7 @@ impl<I: Interner> RegionConstraint<I> {
     fn is_leaf_constraint(&self) -> bool {
         use RegionConstraint::*;
         match self {
-            Ambiguity
+            Ambiguity(_)
             | RegionOutlives(..)
             | AliasTyOutlivesViaEnv(..)
             | PlaceholderTyOutlives(..) => true,
@@ -504,10 +544,10 @@ fn compute_new_region_constraints<Infcx: InferCtxtLike<Interner = I>, I: Interne
     for c in constraints {
         match c {
             And(..) | Or(..) => unreachable!(),
-            Ambiguity | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
+            Ambiguity(_) | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
                 new_constraints.push(c.clone())
             }
-            RegionOutlives(r1, r2) => {
+            RegionOutlives(r1, r2, _) => {
                 regions.insert(r1);
                 regions.insert(r2);
                 region_flows_builder.add(r2, r1);
@@ -531,7 +571,7 @@ fn compute_new_region_constraints<Infcx: InferCtxtLike<Interner = I>, I: Interne
             };
 
             if is_placeholder_like(*r) && is_placeholder_like(*ub) {
-                new_constraints.push(RegionOutlives(*ub, *r));
+                new_constraints.push(RegionOutlives(*ub, *r, ()));
             }
         }
     }
@@ -541,57 +581,56 @@ fn compute_new_region_constraints<Infcx: InferCtxtLike<Interner = I>, I: Interne
 
 /// Evaluate ANDs and ORs to true/false/ambiguous based on whether their arguments are true/false/ambiguous
 #[instrument(level = "debug", ret)]
-pub fn evaluate_solver_constraint<I: Interner>(
-    constraint: &RegionConstraint<I>,
-) -> RegionConstraint<I> {
+pub fn evaluate_solver_constraint<I: Interner, S: Clone + std::fmt::Debug>(
+    constraint: &RegionConstraint<I, S>,
+) -> RegionConstraint<I, S> {
     use RegionConstraint::*;
     match constraint {
-        Ambiguity | RegionOutlives(..) | AliasTyOutlivesViaEnv(..) | PlaceholderTyOutlives(..) => {
-            constraint.clone()
-        }
+        Ambiguity(_)
+        | RegionOutlives(..)
+        | AliasTyOutlivesViaEnv(..)
+        | PlaceholderTyOutlives(..) => constraint.clone(),
         And(and) => {
             let mut and_constraints = Vec::new();
-            let mut is_ambiguous_constraint = false;
+            let mut ambiguity = None;
             for c in and.iter() {
                 let evaluated_constraint = evaluate_solver_constraint(c);
                 if evaluated_constraint.is_true() {
                     // - do nothing
                 } else if evaluated_constraint.is_false() {
                     return RegionConstraint::new_false();
-                } else if evaluated_constraint.is_ambig() {
-                    is_ambiguous_constraint = true;
+                } else if let Ambiguity(span) = evaluated_constraint {
+                    ambiguity.get_or_insert(span);
                 } else {
                     and_constraints.push(evaluated_constraint);
                 }
             }
 
-            if is_ambiguous_constraint {
-                RegionConstraint::Ambiguity
-            } else {
-                RegionConstraint::And(and_constraints.into_boxed_slice())
-            }
+            ambiguity.map_or_else(
+                || RegionConstraint::And(and_constraints.into_boxed_slice()),
+                RegionConstraint::Ambiguity,
+            )
         }
         Or(or) => {
             let mut or_constraints = Vec::new();
-            let mut is_ambiguous_constraint = false;
+            let mut ambiguity = None;
             for c in or.iter() {
                 let evaluated_constraint = evaluate_solver_constraint(c);
                 if evaluated_constraint.is_false() {
                     // do nothing
                 } else if evaluated_constraint.is_true() {
                     return RegionConstraint::new_true();
-                } else if evaluated_constraint.is_ambig() {
-                    is_ambiguous_constraint = true;
+                } else if let Ambiguity(span) = evaluated_constraint {
+                    ambiguity.get_or_insert(span);
                 } else {
                     or_constraints.push(evaluated_constraint);
                 }
             }
 
-            if is_ambiguous_constraint {
-                RegionConstraint::Ambiguity
-            } else {
-                RegionConstraint::Or(or_constraints.into_boxed_slice())
-            }
+            ambiguity.map_or_else(
+                || RegionConstraint::Or(or_constraints.into_boxed_slice()),
+                RegionConstraint::Ambiguity,
+            )
         }
     }
 }
@@ -637,11 +676,11 @@ fn pull_region_outlives_constraints_out_of_universe<
 
     use RegionConstraint::*;
     match constraint {
-        Ambiguity | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
+        Ambiguity(_) | PlaceholderTyOutlives(..) | AliasTyOutlivesViaEnv(..) => {
             assert!(max_universe(infcx, constraint.clone()) < u);
             constraint
         }
-        RegionOutlives(region_1, region_2) => {
+        RegionOutlives(region_1, region_2, ()) => {
             let region_1_u = max_universe(infcx, region_1);
             let region_2_u = max_universe(infcx, region_2);
 
@@ -651,7 +690,7 @@ fn pull_region_outlives_constraints_out_of_universe<
 
             let assumptions = match assumptions {
                 Some(assumptions) => assumptions,
-                None => return RegionConstraint::Ambiguity,
+                None => return RegionConstraint::Ambiguity(()),
             };
 
             let mut candidates = vec![];
@@ -667,7 +706,7 @@ fn pull_region_outlives_constraints_out_of_universe<
                     // As long as any region outlived by `region_1` outlives any region region which
                     // `region_2` outlives, we know that `region_1: region_2` holds. In other words,
                     // there exists some set of 4 regions for which `'r1: 'i1` `'i1: 'i2` `'i2: 'r2`
-                    candidates.push(RegionOutlives(ub, lb));
+                    candidates.push(RegionOutlives(ub, lb, ()));
                 }
             }
 
@@ -690,23 +729,25 @@ fn pull_region_outlives_constraints_out_of_universe<
 pub fn destructure_type_outlives_constraints_in_root<
     Infcx: InferCtxtLike<Interner = I>,
     I: Interner,
+    S: Clone + std::fmt::Debug,
 >(
     infcx: &Infcx,
-    constraint: RegionConstraint<I>,
+    constraint: RegionConstraint<I, S>,
     assumptions: &Assumptions<I>,
-) -> RegionConstraint<I> {
+) -> RegionConstraint<I, S> {
     use RegionConstraint::*;
 
     match constraint {
-        Ambiguity | RegionOutlives(..) => constraint,
-        PlaceholderTyOutlives(ty, r) => {
+        Ambiguity(_) | RegionOutlives(..) => constraint,
+        PlaceholderTyOutlives(ty, r, span) => {
             Or(regions_outlived_by_placeholder(ty, assumptions, infcx.cx())
-                .map(move |assumption_r| RegionOutlives(assumption_r, r))
+                .map(move |assumption_r| RegionOutlives(assumption_r, r, span.clone()))
                 .collect::<Vec<_>>()
                 .into_boxed_slice())
         }
-        AliasTyOutlivesViaEnv(bound_outlives) => {
+        AliasTyOutlivesViaEnv(bound_outlives, span) => {
             alias_outlives_candidates_from_assumptions(infcx, bound_outlives, assumptions)
+                .with_span(span)
         }
         And(constraints) => And(constraints
             .into_iter()
@@ -752,8 +793,8 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
 
     use RegionConstraint::*;
     match constraint {
-        Ambiguity | RegionOutlives(..) => constraint,
-        PlaceholderTyOutlives(ty, region) => {
+        Ambiguity(_) | RegionOutlives(..) => constraint,
+        PlaceholderTyOutlives(ty, region, ()) => {
             let ty_u = max_universe(infcx, ty);
             let region_u = max_universe(infcx, region);
 
@@ -763,7 +804,7 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
 
             let assumptions = match assumptions {
                 Some(assumptions) => assumptions,
-                None => return Ambiguity,
+                None => return Ambiguity(()),
             };
 
             let mut candidates = vec![];
@@ -772,7 +813,7 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
             // smaller universe
             candidates.extend(
                 regions_outlived_by_placeholder(ty, assumptions, infcx.cx())
-                    .map(move |assumption_r| RegionOutlives(assumption_r, region)),
+                    .map(move |assumption_r| RegionOutlives(assumption_r, region, ())),
             );
 
             // We can express `!T: 'region` as `!T: 'r` where `'r: 'region`. This is only necessary
@@ -782,13 +823,13 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
                 candidates.extend(
                     regions_outliving::<I>(region, assumptions, infcx.cx())
                         .filter(|r| max_universe(infcx, *r) < u)
-                        .map(|r| PlaceholderTyOutlives(ty, r)),
+                        .map(|r| PlaceholderTyOutlives(ty, r, ())),
                 );
             }
 
             Or(candidates.into_boxed_slice())
         }
-        AliasTyOutlivesViaEnv(bound_outlives) => {
+        AliasTyOutlivesViaEnv(bound_outlives, ()) => {
             let mut candidates = Vec::new();
 
             // given there can be higher ranked assumptions, e.g. `for<'a> <T as Trait<'a>>::Assoc: 'c`, that
@@ -824,21 +865,21 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
                     escaping_outlives,
                     I::BoundVarKinds::from_vars(infcx.cx(), bound_vars),
                 );
-                let candidate = RegionConstraint::AliasTyOutlivesViaEnv(bound_outlives);
+                let candidate = RegionConstraint::AliasTyOutlivesViaEnv(bound_outlives, ());
                 if max_universe(infcx, candidate.clone()) < u {
                     candidates.push(candidate);
                 } else {
                     // `PlaceholderReplacer` only folds regions. A non-lifetime binder can leave
                     // a placeholder type in `u`, so this type-outlives constraint cannot be
                     // handled by the region-outlives-only eager placeholder machinery.
-                    candidates.push(Ambiguity);
+                    candidates.push(Ambiguity(()));
                 }
             }
 
             let assumptions = match assumptions {
                 Some(assumptions) => assumptions,
                 None => {
-                    candidates.push(Ambiguity);
+                    candidates.push(Ambiguity(()));
                     return Or(candidates.into_boxed_slice());
                 }
             };
@@ -881,11 +922,11 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
                     .filter(|r2| max_universe(infcx, *r2) < u)
                 {
                     let candidate =
-                        AliasTyOutlivesViaEnv(bound_alias.map_bound(|alias| (alias, r2)));
+                        AliasTyOutlivesViaEnv(bound_alias.map_bound(|alias| (alias, r2)), ());
                     if max_universe(infcx, candidate.clone()) < u {
                         candidates.push(candidate);
                     } else {
-                        candidates.push(Ambiguity);
+                        candidates.push(Ambiguity(()));
                     }
                 }
             }
@@ -894,7 +935,7 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
             // let's be conservative and not let alias outlives' cause NoSolution
             // in coherence
             match infcx.typing_mode_raw() {
-                TypingMode::Coherence => candidates.push(RegionConstraint::Ambiguity),
+                TypingMode::Coherence => candidates.push(RegionConstraint::Ambiguity(())),
                 TypingMode::Typeck { .. }
                 | TypingMode::ErasedNotCoherence { .. }
                 | TypingMode::PostTypeckUntilBorrowck { .. }
@@ -1032,7 +1073,7 @@ fn alias_outlives_candidates_from_assumptions<Infcx: InferCtxtLike<Interner = I>
 
             let mut relation = HigherRankedAliasMatcher {
                 infcx,
-                region_constraints: vec![RegionConstraint::RegionOutlives(r2, r)],
+                region_constraints: vec![RegionConstraint::RegionOutlives(r2, r, ())],
             };
 
             // FIXME(#155345): Both sides should be rigid in the future.
@@ -1103,8 +1144,8 @@ impl<'a, Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeRelation<I>
 
     fn regions(&mut self, a: Region<I>, b: Region<I>) -> RelateResult<I, Region<I>> {
         if a != b {
-            self.region_constraints.push(RegionConstraint::RegionOutlives(a, b));
-            self.region_constraints.push(RegionConstraint::RegionOutlives(b, a));
+            self.region_constraints.push(RegionConstraint::RegionOutlives(a, b, ()));
+            self.region_constraints.push(RegionConstraint::RegionOutlives(b, a, ()));
         }
         Ok(a)
     }

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -121,7 +121,7 @@ pub enum RegionConstraint<I: Interner, S = ()> {
     Or(Box<[RegionConstraint<I, S>]>),
 }
 
-/// A solver region constraint together with the span that caused each atomic constraint.
+/// A solver region constraint together with the span that caused each leaf constraint.
 ///
 /// Solver query responses use [`RegionConstraint`] so source locations do not participate in
 /// candidate equality or caching. Spans are attached when responses are applied to an inference

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -255,6 +255,7 @@ pub mod fmt;
 pub mod intrinsics;
 #[unstable(feature = "alloc_io", issue = "154046")]
 pub mod io;
+pub mod panicking;
 #[cfg(not(no_rc))]
 pub mod rc;
 pub mod slice;

--- a/library/alloc/src/panicking.rs
+++ b/library/alloc/src/panicking.rs
@@ -1,0 +1,29 @@
+#![doc(hidden)]
+#![unstable(feature = "std_internals", issue = "none")]
+
+use core::any::Any;
+use core::fmt::Display;
+
+use crate::boxed::Box;
+
+/// An internal trait used by std to pass data from std to `panic_unwind` and
+/// other panic runtimes. Not intended to be stabilized any time soon, do not
+/// use.
+pub unsafe trait PanicPayload: Display {
+    /// Take full ownership of the contents.
+    ///
+    /// After this method got called, only some dummy default value is left in `self`.
+    /// Calling this method twice, or calling `get` after calling this method, is an error.
+    ///
+    /// The argument is borrowed because the panic runtime (`__rust_start_panic`) only
+    /// gets a borrowed `dyn PanicPayload`.
+    fn take_box(&mut self) -> Box<dyn Any + Send>;
+
+    /// Just borrow the contents.
+    fn get(&mut self) -> &(dyn Any + Send);
+
+    /// Tries to borrow the contents as `&str`, if possible without doing any allocations.
+    fn as_str(&mut self) -> Option<&str> {
+        None
+    }
+}

--- a/library/alloc/src/panicking.rs
+++ b/library/alloc/src/panicking.rs
@@ -9,7 +9,7 @@ use crate::boxed::Box;
 /// An internal trait used by std to pass data from std to `panic_unwind` and
 /// other panic runtimes. Not intended to be stabilized any time soon, do not
 /// use.
-pub unsafe trait PanicPayload: Display {
+pub trait PanicPayload: Display {
     /// Take full ownership of the contents.
     ///
     /// After this method got called, only some dummy default value is left in `self`.

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1606,6 +1606,46 @@ impl<T: ?Sized> Rc<T> {
     pub unsafe fn decrement_strong_count(ptr: *const T) {
         unsafe { Self::decrement_strong_count_in(ptr, Global) }
     }
+
+    /// Gets the number of strong (`Rc`) pointers to the allocation behind the given raw pointer.
+    ///
+    /// This method does not consume or drop the `Rc` behind this pointer.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must point to (and have valid metadata for) the value inside a live `Rc`
+    /// allocation, such as a pointer returned by [`Rc::into_raw`],
+    /// [`Rc::into_raw_with_allocator`], or [`Rc::as_ptr`].
+    /// `T` must have the same alignment as that value.
+    /// The associated `Rc` instance must be valid (i.e. the strong count must be at
+    /// least 1) for the duration of this method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(arc_raw_get_strong)]
+    /// use std::rc::Rc;
+    ///
+    /// let five = Rc::new(5);
+    /// let _also_five = Rc::clone(&five);
+    /// let ptr = Rc::into_raw(five);
+    ///
+    /// unsafe {
+    ///     assert_eq!(2, Rc::strong_count_from_raw(ptr));
+    ///
+    ///     // Convert back to an `Rc` to avoid leaking memory.
+    ///     let five = Rc::from_raw(ptr);
+    ///     assert_eq!(2, Rc::strong_count(&five));
+    /// }
+    /// ```
+    #[inline]
+    #[unstable(feature = "arc_raw_get_strong", issue = "157021")]
+    pub unsafe fn strong_count_from_raw(ptr: *const T) -> usize {
+        let offset = unsafe { data_offset(ptr) };
+        // Reverse the offset to find the original RcInner.
+        let rc_ptr = unsafe { ptr.byte_sub(offset) as *mut RcInner<T> };
+        unsafe { (*rc_ptr).strong.get() }
+    }
 }
 
 impl<T: ?Sized, A: Allocator> Rc<T, A> {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1771,6 +1771,54 @@ impl<T: ?Sized> Arc<T> {
     pub unsafe fn decrement_strong_count(ptr: *const T) {
         unsafe { Arc::decrement_strong_count_in(ptr, Global) }
     }
+
+    /// Gets the number of strong (`Arc`) pointers to the allocation behind the given raw
+    /// pointer.
+    ///
+    /// This method does not consume or drop the `Arc` behind this pointer.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must point to (and have valid metadata for) the value inside a live `Arc`
+    /// allocation, such as a pointer returned by [`Arc::into_raw`],
+    /// [`Arc::into_raw_with_allocator`], or [`Arc::as_ptr`].
+    /// `T` must have the same alignment as that value.
+    /// The associated `Arc` instance must be valid (i.e. the strong count must be at
+    /// least 1) for the duration of this method.
+    ///
+    /// Using this method correctly also requires extra care: another thread can change the
+    /// strong count at any time, including between calling this method and acting on the
+    /// result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(arc_raw_get_strong)]
+    /// use std::sync::Arc;
+    ///
+    /// let five = Arc::new(5);
+    /// let _also_five = Arc::clone(&five);
+    /// let ptr = Arc::into_raw(five);
+    ///
+    /// unsafe {
+    ///     // This assertion is deterministic because we haven't shared
+    ///     // the `Arc` between threads.
+    ///     assert_eq!(2, Arc::strong_count_from_raw(ptr));
+    ///
+    ///     // Convert back to an `Arc` to avoid leaking memory.
+    ///     let five = Arc::from_raw(ptr);
+    ///     assert_eq!(2, Arc::strong_count(&five));
+    /// }
+    /// ```
+    #[inline]
+    #[must_use]
+    #[unstable(feature = "arc_raw_get_strong", issue = "157021")]
+    pub unsafe fn strong_count_from_raw(ptr: *const T) -> usize {
+        let offset = unsafe { data_offset(ptr) };
+        // Reverse the offset to find the original ArcInner.
+        let arc_ptr = unsafe { ptr.byte_sub(offset) as *mut ArcInner<T> };
+        unsafe { (*arc_ptr).strong.load(Relaxed) }
+    }
 }
 
 impl<T: ?Sized, A: Allocator> Arc<T, A> {

--- a/library/alloc/src/wtf8/mod.rs
+++ b/library/alloc/src/wtf8/mod.rs
@@ -31,7 +31,7 @@ use crate::string::String;
 use crate::sync::Arc;
 use crate::vec::Vec;
 
-/// An owned, growable string of well-formed WTF-8 data.
+/// An owned, growable string of [well-formed WTF-8](https://wtf-8.codeberg.page/#well-formed) data.
 ///
 /// Similar to `String`, but can additionally contain surrogate code points
 /// if they’re not in a surrogate pair.
@@ -104,8 +104,9 @@ impl Wtf8Buf {
 
     /// Creates a WTF-8 string from a WTF-8 byte vec.
     ///
-    /// Since the byte vec is not checked for valid WTF-8, this function is
-    /// marked unsafe.
+    /// # Safety
+    ///
+    /// `value` must contain [well-formed WTF-8](https://wtf-8.codeberg.page/#well-formed).
     #[inline]
     pub unsafe fn from_bytes_unchecked(value: Vec<u8>) -> Wtf8Buf {
         Wtf8Buf { bytes: value, is_known_utf8: false }
@@ -147,12 +148,15 @@ impl Wtf8Buf {
                 Ok(ch) => string.push_char(ch),
                 Err(surrogate) => {
                     let surrogate = surrogate.unpaired_surrogate();
-                    // Surrogates are known to be in the code point range.
+                    // SAFETY: Surrogates are known to be in the code point range.
                     let code_point = unsafe { CodePoint::from_u32_unchecked(surrogate as u32) };
                     // The string will now contain an unpaired surrogate.
                     string.is_known_utf8 = false;
-                    // Skip the WTF-8 concatenation check,
-                    // surrogate pairs are already decoded by decode_utf16
+                    // SAFETY: `decode_utf16` reports only unpaired surrogates here,
+                    // so this code point cannot form a surrogate pair with the
+                    // preceding and succeeding contents. The existing buffer is
+                    // well-formed WTF-8, and appending this encoded surrogate
+                    // preserves that invariant.
                     unsafe {
                         string.push_code_point_unchecked(code_point);
                     }
@@ -165,6 +169,14 @@ impl Wtf8Buf {
     /// Appends the given `char` to the end of this string.
     /// This does **not** include the WTF-8 concatenation check or `is_known_utf8` check.
     /// Copied from String::push.
+    ///
+    /// # Safety
+    ///
+    /// `self` must contain [well-formed WTF-8](https://wtf-8.codeberg.page/#well-formed),
+    /// and appending `code_point` must preserve that invariant. In particular,
+    /// `code_point` must not be a trailing surrogate if `self` ends with a leading surrogate.
+    ///
+    /// If `self.is_known_utf8` is true, `code_point` must not be a surrogate.
     unsafe fn push_code_point_unchecked(&mut self, code_point: CodePoint) {
         let mut bytes = [0; char::MAX_LEN_UTF8];
         let bytes = encode_utf8_raw(code_point.to_u32(), &mut bytes);
@@ -173,14 +185,13 @@ impl Wtf8Buf {
 
     #[inline]
     pub fn as_slice(&self) -> &Wtf8 {
+        // SAFETY: `self` maintains `bytes` as well-formed WTF-8.
         unsafe { Wtf8::from_bytes_unchecked(&self.bytes) }
     }
 
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut Wtf8 {
-        // Safety: `Wtf8` doesn't expose any way to mutate the bytes that would
-        // cause them to change from well-formed UTF-8 to ill-formed UTF-8,
-        // which would break the assumptions of the `is_known_utf8` field.
+        // SAFETY: `self` maintains `bytes` as well-formed WTF-8.
         unsafe { Wtf8::from_mut_bytes_unchecked(&mut self.bytes) }
     }
 
@@ -262,6 +273,7 @@ impl Wtf8Buf {
 
     #[inline]
     pub fn leak<'a>(self) -> &'a mut Wtf8 {
+        // SAFETY: `self` maintains `bytes` as well-formed WTF-8.
         unsafe { Wtf8::from_mut_bytes_unchecked(self.bytes.leak()) }
     }
 
@@ -336,7 +348,7 @@ impl Wtf8Buf {
             self.is_known_utf8 = false;
         }
 
-        // No newly paired surrogates at the boundary.
+        // SAFETY: We have checked that no newly paired surrogates at the boundary.
         unsafe { self.push_code_point_unchecked(code_point) }
     }
 
@@ -371,6 +383,7 @@ impl Wtf8Buf {
     /// the original WTF-8 string is returned instead.
     pub fn into_string(self) -> Result<String, Wtf8Buf> {
         if self.is_known_utf8 || self.next_surrogate(0).is_none() {
+            // SAFETY: We have checked that `self.bytes` contains valid UTF-8.
             Ok(unsafe { String::from_utf8_unchecked(self.bytes) })
         } else {
             Err(self)
@@ -392,18 +405,23 @@ impl Wtf8Buf {
                 self.bytes[surrogate_pos..pos].copy_from_slice("\u{FFFD}".as_bytes());
             }
         }
+        // SAFETY: Now `self.bytes` contains valid UTF-8.
         unsafe { String::from_utf8_unchecked(self.bytes) }
     }
 
     /// Converts this `Wtf8Buf` into a boxed `Wtf8`.
     #[inline]
     pub fn into_box(self) -> Box<Wtf8> {
-        // SAFETY: relies on `Wtf8` being `repr(transparent)`.
+        // SAFETY: `Wtf8` is a transparent wrapper around `[u8]`, and
+        // `self.bytes.into_boxed_slice()` returns a `Box<[u8]>`.
+        // Therefore, transmuting `Box<[u8]>` to `Box<Wtf8>` is safe.
         unsafe { mem::transmute(self.bytes.into_boxed_slice()) }
     }
 
     /// Converts a `Box<Wtf8>` into a `Wtf8Buf`.
     pub fn from_box(boxed: Box<Wtf8>) -> Wtf8Buf {
+        // SAFETY: `Wtf8` is a transparent wrapper around `[u8]`, and `boxed` is
+        // a `Box<Wtf8>`. Therefore, transmuting `Box<Wtf8>` to `Box<[u8]>` is safe.
         let bytes: Box<[u8]> = unsafe { mem::transmute(boxed) };
         Wtf8Buf { bytes: bytes.into_vec(), is_known_utf8: false }
     }
@@ -411,6 +429,13 @@ impl Wtf8Buf {
     /// Provides plumbing to core `Vec::extend_from_slice`.
     /// More well behaving alternative to allowing outer types
     /// full mutable access to the core `Vec`.
+    ///
+    /// # Safety
+    ///
+    /// `self` and `other` must contain [well-formed WTF-8](https://wtf-8.codeberg.page/#well-formed),
+    /// and appending `other` to `self` must preserve that invariant.
+    /// In particular, `self` must not end with a leading surrogate,
+    /// or `other` must not start with a trailing surrogate.
     #[inline]
     pub unsafe fn extend_from_slice_unchecked(&mut self, other: &[u8]) {
         self.bytes.extend_from_slice(other);
@@ -468,6 +493,8 @@ pub(super) fn to_owned(slice: &Wtf8) -> Wtf8Buf {
 /// This only copies the data if necessary (if it contains any surrogate).
 pub(super) fn to_string_lossy(slice: &Wtf8) -> Cow<'_, str> {
     let Some((surrogate_pos, _)) = slice.next_surrogate(0) else {
+        // SAFETY: `next_surrogate` found no surrogate, so the well-formed WTF-8
+        // bytes are valid UTF-8.
         return Cow::Borrowed(unsafe { str::from_utf8_unchecked(slice.as_bytes()) });
     };
     let wtf8_bytes = slice.as_bytes();
@@ -484,6 +511,8 @@ pub(super) fn to_string_lossy(slice: &Wtf8) -> Cow<'_, str> {
             }
             None => {
                 utf8_bytes.extend_from_slice(&wtf8_bytes[pos..]);
+                // SAFETY: Every surrogate was replaced with `"\u{FFFD}"`,
+                // and the remaining bytes are valid UTF-8, so `utf8_bytes` is valid UTF-8.
                 return Cow::Owned(unsafe { String::from_utf8_unchecked(utf8_bytes) });
             }
         }
@@ -516,12 +545,16 @@ impl Wtf8 {
     #[rustc_allow_incoherent_impl]
     pub fn into_box(&self) -> Box<Wtf8> {
         let boxed: Box<[u8]> = self.as_bytes().into();
+        // SAFETY: `Wtf8` is a transparent wrapper around `[u8]`, and `boxed` is
+        // a `Box<[u8]>`. Therefore, transmuting `Box<[u8]>` to `Box<Wtf8>` is safe.
         unsafe { mem::transmute(boxed) }
     }
 
     #[rustc_allow_incoherent_impl]
     pub fn empty_box() -> Box<Wtf8> {
         let boxed: Box<[u8]> = Default::default();
+        // SAFETY: `Wtf8` is a transparent wrapper around `[u8]`, and `boxed` is
+        // an empty `Box<[u8]>`. Therefore, transmuting it to `Box<Wtf8>` is safe.
         unsafe { mem::transmute(boxed) }
     }
 
@@ -529,12 +562,14 @@ impl Wtf8 {
     #[rustc_allow_incoherent_impl]
     pub fn into_arc(&self) -> Arc<Wtf8> {
         let arc: Arc<[u8]> = Arc::from(self.as_bytes());
+        // SAFETY: `Wtf8` is a transparent wrapper around `[u8]`.
         unsafe { Arc::from_raw(Arc::into_raw(arc) as *const Wtf8) }
     }
 
     #[rustc_allow_incoherent_impl]
     pub fn into_rc(&self) -> Rc<Wtf8> {
         let rc: Rc<[u8]> = Rc::from(self.as_bytes());
+        // SAFETY: `Wtf8` is a transparent wrapper around `[u8]`.
         unsafe { Rc::from_raw(Rc::into_raw(rc) as *const Wtf8) }
     }
 
@@ -554,6 +589,7 @@ impl Wtf8 {
 #[inline]
 fn decode_surrogate_pair(lead: u16, trail: u16) -> char {
     let code_point = 0x10000 + ((((lead - 0xD800) as u32) << 10) | (trail - 0xDC00) as u32);
+    // SAFETY: The computed `code_point` is in 0x10000..=0x10FFFF and is not a surrogate.
     unsafe { char::from_u32_unchecked(code_point) }
 }
 

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -41,6 +41,8 @@ use crate::marker::PointeeSized;
 
 mod num;
 
+#[unstable(feature = "float_conversions", issue = "159913")]
+pub use num::FloatToFloat;
 #[unstable(feature = "convert_float_to_int", issue = "67057")]
 pub use num::FloatToInt;
 #[unstable(feature = "integer_casts", issue = "157388")]

--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -7,6 +7,14 @@ pub impl(self) trait FloatToInt<Int>: Sized {
     #[unstable(feature = "convert_float_to_int", issue = "67057")]
     #[doc(hidden)]
     unsafe fn to_int_unchecked(self) -> Int;
+
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[doc(hidden)]
+    fn to_int_saturating(self) -> Int;
+
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[doc(hidden)]
+    fn to_int_checked(self) -> Option<Int>;
 }
 
 macro_rules! impl_float_to_int {
@@ -19,6 +27,24 @@ macro_rules! impl_float_to_int {
                     // SAFETY: the safety contract must be upheld by the caller.
                     unsafe { crate::intrinsics::float_to_int_unchecked(self) }
                 }
+                #[inline]
+                fn to_int_saturating(self) -> $Int {
+                    // `as` already saturates and maps `NaN` to zero.
+                    self as $Int
+                }
+                #[inline]
+                fn to_int_checked(self) -> Option<$Int> {
+                    // `as` truncates toward zero and these bounds are exact for
+                    // that: `MAX + 1` rounds up to the first out-of-range value,
+                    // and the `- MIN` offset keeps the low comparison exact even
+                    // when `MIN - 1` is not representable. `NaN` and infinities
+                    // fail both comparisons.
+                    if self - (<$Int>::MIN as $Float) > -1.0 && self < <$Int>::MAX as $Float + 1.0 {
+                        Some(self as $Int)
+                    } else {
+                        None
+                    }
+                }
             }
         )+
     }
@@ -28,6 +54,34 @@ impl_float_to_int!(f16 => u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i12
 impl_float_to_int!(f32 => u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
 impl_float_to_int!(f64 => u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
 impl_float_to_int!(f128 => u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
+
+/// Supporting trait for the inherent `cast` method converting between float types.
+/// Typically doesn’t need to be used directly.
+#[unstable(feature = "float_conversions", issue = "159913")]
+pub impl(self) trait FloatToFloat<Flt>: Sized {
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[doc(hidden)]
+    fn cast(self) -> Flt;
+}
+
+macro_rules! impl_float_to_float {
+    ($Float:ty => $($Flt:ty),+) => {
+        $(
+            #[unstable(feature = "float_conversions", issue = "159913")]
+            impl FloatToFloat<$Flt> for $Float {
+                #[inline]
+                fn cast(self) -> $Flt {
+                    self as $Flt
+                }
+            }
+        )+
+    }
+}
+
+impl_float_to_float!(f16 => f16, f32, f64, f128);
+impl_float_to_float!(f32 => f16, f32, f64, f128);
+impl_float_to_float!(f64 => f16, f32, f64, f128);
+impl_float_to_float!(f128 => f16, f32, f64, f128);
 
 /// Implement `From<bool>` for integers
 macro_rules! impl_from_bool {

--- a/library/core/src/mem/type_info.rs
+++ b/library/core/src/mem/type_info.rs
@@ -90,9 +90,9 @@ pub enum TypeKind {
     /// Unions.
     Union,
     /// Primitive boolean type.
-    Bool(Bool),
+    Bool,
     /// Primitive character type.
-    Char(Char),
+    Char,
     /// Primitive signed and unsigned integer type.
     Int,
     /// Primitive floating-point type.
@@ -197,22 +197,6 @@ pub struct GenericType {
 pub struct Const {
     /// The const's type.
     pub ty: TypeId,
-}
-
-/// Compile-time type information about `bool`.
-#[derive(Debug)]
-#[non_exhaustive]
-#[unstable(feature = "type_info", issue = "146922")]
-pub struct Bool {
-    // No additional information to provide for now.
-}
-
-/// Compile-time type information about `char`.
-#[derive(Debug)]
-#[non_exhaustive]
-#[unstable(feature = "type_info", issue = "146922")]
-pub struct Char {
-    // No additional information to provide for now.
 }
 
 /// Compile-time type information about string slice types.

--- a/library/core/src/mem/type_info.rs
+++ b/library/core/src/mem/type_info.rs
@@ -94,9 +94,9 @@ pub enum TypeKind {
     /// Primitive character type.
     Char(Char),
     /// Primitive signed and unsigned integer type.
-    Int(Int),
+    Int,
     /// Primitive floating-point type.
-    Float(Float),
+    Float,
     /// String slice type.
     Str(Str),
     /// References.
@@ -213,26 +213,6 @@ pub struct Bool {
 #[unstable(feature = "type_info", issue = "146922")]
 pub struct Char {
     // No additional information to provide for now.
-}
-
-/// Compile-time type information about signed and unsigned integer types.
-#[derive(Debug)]
-#[non_exhaustive]
-#[unstable(feature = "type_info", issue = "146922")]
-pub struct Int {
-    /// The bit width of the signed integer type.
-    pub bits: u32,
-    /// Whether the integer type is signed.
-    pub signed: bool,
-}
-
-/// Compile-time type information about floating-point types.
-#[derive(Debug)]
-#[non_exhaustive]
-#[unstable(feature = "type_info", issue = "146922")]
-pub struct Float {
-    /// The bit width of the floating-point type.
-    pub bits: u32,
 }
 
 /// Compile-time type information about string slice types.

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -11,7 +11,7 @@
 
 #![unstable(feature = "f128", issue = "116909")]
 
-use crate::convert::FloatToInt;
+use crate::convert::{FloatToFloat, FloatToInt};
 use crate::num::FpCategory;
 use crate::panic::const_assert;
 use crate::{intrinsics, mem};
@@ -1026,6 +1026,100 @@ impl f128 {
         // SAFETY: the caller must uphold the safety contract for
         // `FloatToInt::to_int_unchecked`.
         unsafe { FloatToInt::<Int>::to_int_unchecked(self) }
+    }
+
+    /// Converts to the target float type, rounding as defined in IEEE 754.
+    ///
+    /// This is equivalent to `self as Flt`. Narrowing to a smaller type can
+    /// produce an infinity.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f128)]
+    /// # #[cfg(target_has_reliable_f128)] {
+    ///
+    /// let x = 1.5_f128;
+    /// assert_eq!(x.cast::<f64>(), 1.5_f64);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn cast<Flt>(self) -> Flt
+    where
+        Self: FloatToFloat<Flt>,
+    {
+        FloatToFloat::<Flt>::cast(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, saturating
+    /// at the type's boundaries and mapping `NaN` to zero.
+    ///
+    /// This is equivalent to `self as Int`.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f128)]
+    /// # #[cfg(target_has_reliable_f128)] {
+    ///
+    /// assert_eq!(4.6_f128.to_int_saturating::<u8>(), 4);
+    /// assert_eq!(f128::NAN.to_int_saturating::<u8>(), 0);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_saturating<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_saturating(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, returning
+    /// `None` if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f128)]
+    /// # #[cfg(target_has_reliable_f128)] {
+    ///
+    /// assert_eq!(4.6_f128.to_int_checked::<u8>(), Some(4));
+    /// assert_eq!(f128::NAN.to_int_checked::<u8>(), None);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_checked<Int>(self) -> Option<Int>
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_checked(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type.
+    ///
+    /// This is equivalent to `self.to_int_checked().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f128)]
+    /// # #[cfg(target_has_reliable_f128)] {
+    ///
+    /// assert_eq!(4.6_f128.to_int_strict::<u8>(), 4);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    #[track_caller]
+    pub fn to_int_strict<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        self.to_int_checked::<Int>()
+            .expect("the value cannot be represented in the target integer type")
     }
 
     /// Raw transmutation to `u128`.

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -11,7 +11,7 @@
 
 #![unstable(feature = "f16", issue = "116909")]
 
-use crate::convert::FloatToInt;
+use crate::convert::{FloatToFloat, FloatToInt};
 use crate::num::FpCategory;
 #[cfg(not(test))]
 use crate::num::imp::libm;
@@ -1022,6 +1022,100 @@ impl f16 {
         // SAFETY: the caller must uphold the safety contract for
         // `FloatToInt::to_int_unchecked`.
         unsafe { FloatToInt::<Int>::to_int_unchecked(self) }
+    }
+
+    /// Converts to the target float type, rounding as defined in IEEE 754.
+    ///
+    /// This is equivalent to `self as Flt`. Narrowing to a smaller type can
+    /// produce an infinity.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f16)]
+    /// # #[cfg(target_has_reliable_f16)] {
+    ///
+    /// let x = 1.5_f16;
+    /// assert_eq!(x.cast::<f32>(), 1.5_f32);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn cast<Flt>(self) -> Flt
+    where
+        Self: FloatToFloat<Flt>,
+    {
+        FloatToFloat::<Flt>::cast(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, saturating
+    /// at the type's boundaries and mapping `NaN` to zero.
+    ///
+    /// This is equivalent to `self as Int`.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f16)]
+    /// # #[cfg(target_has_reliable_f16)] {
+    ///
+    /// assert_eq!(4.6_f16.to_int_saturating::<u8>(), 4);
+    /// assert_eq!(f16::NAN.to_int_saturating::<u8>(), 0);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_saturating<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_saturating(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, returning
+    /// `None` if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f16)]
+    /// # #[cfg(target_has_reliable_f16)] {
+    ///
+    /// assert_eq!(4.6_f16.to_int_checked::<u8>(), Some(4));
+    /// assert_eq!(f16::NAN.to_int_checked::<u8>(), None);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_checked<Int>(self) -> Option<Int>
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_checked(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type.
+    ///
+    /// This is equivalent to `self.to_int_checked().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions, f16)]
+    /// # #[cfg(target_has_reliable_f16)] {
+    ///
+    /// assert_eq!(4.6_f16.to_int_strict::<u8>(), 4);
+    /// # }
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    #[track_caller]
+    pub fn to_int_strict<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        self.to_int_checked::<Int>()
+            .expect("the value cannot be represented in the target integer type")
     }
 
     /// Raw transmutation to `u16`.

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -11,7 +11,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use crate::convert::FloatToInt;
+use crate::convert::{FloatToFloat, FloatToInt};
 use crate::num::FpCategory;
 use crate::panic::const_assert;
 use crate::{cfg_select, intrinsics, mem};
@@ -1219,6 +1219,99 @@ impl f32 {
         // SAFETY: the caller must uphold the safety contract for
         // `FloatToInt::to_int_unchecked`.
         unsafe { FloatToInt::<Int>::to_int_unchecked(self) }
+    }
+
+    /// Converts to the target float type, rounding as defined in IEEE 754.
+    ///
+    /// This is equivalent to `self as Flt`. Narrowing to a smaller type can
+    /// produce an infinity.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// let x = 1.5_f32;
+    /// assert_eq!(x.cast::<f64>(), 1.5_f64);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[inline]
+    pub fn cast<Flt>(self) -> Flt
+    where
+        Self: FloatToFloat<Flt>,
+    {
+        FloatToFloat::<Flt>::cast(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, saturating
+    /// at the type's boundaries and mapping `NaN` to zero.
+    ///
+    /// This is equivalent to `self as Int`.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f32.to_int_saturating::<u8>(), 255);
+    /// assert_eq!(300.0_f32.to_int_saturating::<u8>(), 255);
+    /// assert_eq!((-1.0_f32).to_int_saturating::<u8>(), 0);
+    /// assert_eq!(f32::NAN.to_int_saturating::<u8>(), 0);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[inline]
+    pub fn to_int_saturating<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_saturating(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, returning
+    /// `None` if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f32.to_int_checked::<u8>(), Some(255));
+    /// assert_eq!(256.0_f32.to_int_checked::<u8>(), None);
+    /// assert_eq!(f32::NAN.to_int_checked::<u8>(), None);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[inline]
+    pub fn to_int_checked<Int>(self) -> Option<Int>
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_checked(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type.
+    ///
+    /// This is equivalent to `self.to_int_checked().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f32.to_int_strict::<u8>(), 255);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[inline]
+    #[track_caller]
+    pub fn to_int_strict<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        self.to_int_checked::<Int>()
+            .expect("the value cannot be represented in the target integer type")
     }
 
     /// Raw transmutation to `u32`.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -11,7 +11,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use crate::convert::FloatToInt;
+use crate::convert::{FloatToFloat, FloatToInt};
 use crate::num::FpCategory;
 use crate::panic::const_assert;
 use crate::{intrinsics, mem};
@@ -1202,6 +1202,95 @@ impl f64 {
         // SAFETY: the caller must uphold the safety contract for
         // `FloatToInt::to_int_unchecked`.
         unsafe { FloatToInt::<Int>::to_int_unchecked(self) }
+    }
+
+    /// Converts to the target float type, rounding as defined in IEEE 754.
+    ///
+    /// This is equivalent to `self as Flt`. Narrowing to a smaller type can
+    /// produce an infinity.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// let x = 1.5_f64;
+    /// assert_eq!(x.cast::<f32>(), 1.5_f32);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn cast<Flt>(self) -> Flt
+    where
+        Self: FloatToFloat<Flt>,
+    {
+        FloatToFloat::<Flt>::cast(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, saturating
+    /// at the type's boundaries and mapping `NaN` to zero.
+    ///
+    /// This is equivalent to `self as Int`.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f64.to_int_saturating::<u8>(), 255);
+    /// assert_eq!(300.0_f64.to_int_saturating::<u8>(), 255);
+    /// assert_eq!((-1.0_f64).to_int_saturating::<u8>(), 0);
+    /// assert_eq!(f64::NAN.to_int_saturating::<u8>(), 0);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_saturating<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_saturating(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type, returning
+    /// `None` if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f64.to_int_checked::<u8>(), Some(255));
+    /// assert_eq!(256.0_f64.to_int_checked::<u8>(), None);
+    /// assert_eq!(f64::NAN.to_int_checked::<u8>(), None);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    pub fn to_int_checked<Int>(self) -> Option<Int>
+    where
+        Self: FloatToInt<Int>,
+    {
+        FloatToInt::<Int>::to_int_checked(self)
+    }
+
+    /// Rounds toward zero and converts to any primitive integer type.
+    ///
+    /// This is equivalent to `self.to_int_checked().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is `NaN`, infinite, or does not fit in the target type.
+    ///
+    /// ```
+    /// #![feature(float_conversions)]
+    ///
+    /// assert_eq!(255.5_f64.to_int_strict::<u8>(), 255);
+    /// ```
+    #[unstable(feature = "float_conversions", issue = "159913")]
+    #[must_use = "this returns the result of the operation, without modifying the original"]
+    #[inline]
+    #[track_caller]
+    pub fn to_int_strict<Int>(self) -> Int
+    where
+        Self: FloatToInt<Int>,
+    {
+        self.to_int_checked::<Int>()
+            .expect("the value cannot be represented in the target integer type")
     }
 
     /// Raw transmutation to `u64`.

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -14,7 +14,6 @@ pub use self::panic_info::PanicInfo;
 pub use self::panic_info::PanicMessage;
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 pub use self::unwind_safe::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
-use crate::any::Any;
 
 #[doc(hidden)]
 #[unstable(feature = "edition_panic", issue = "none", reason = "use panic!() instead")]
@@ -118,31 +117,6 @@ pub macro unreachable_2021 {
 #[rustc_nounwind]
 pub fn abort_on_unwind<F: FnOnce() -> R, R>(f: F) -> R {
     f()
-}
-
-/// An internal trait used by std to pass data from std to `panic_unwind` and
-/// other panic runtimes. Not intended to be stabilized any time soon, do not
-/// use.
-#[unstable(feature = "std_internals", issue = "none")]
-#[doc(hidden)]
-pub unsafe trait PanicPayload: crate::fmt::Display {
-    /// Take full ownership of the contents.
-    /// The return type is actually `Box<dyn Any + Send>`, but we cannot use `Box` in core.
-    ///
-    /// After this method got called, only some dummy default value is left in `self`.
-    /// Calling this method twice, or calling `get` after calling this method, is an error.
-    ///
-    /// The argument is borrowed because the panic runtime (`__rust_start_panic`) only
-    /// gets a borrowed `dyn PanicPayload`.
-    fn take_box(&mut self) -> *mut (dyn Any + Send);
-
-    /// Just borrow the contents.
-    fn get(&mut self) -> &(dyn Any + Send);
-
-    /// Tries to borrow the contents as `&str`, if possible without doing any allocations.
-    fn as_str(&mut self) -> Option<&str> {
-        None
-    }
 }
 
 /// Helper macro for panicking in a `const fn`.

--- a/library/core/src/wtf8.rs
+++ b/library/core/src/wtf8.rs
@@ -1,11 +1,11 @@
-//! Implementation of [the WTF-8 encoding](https://simonsapin.github.io/wtf-8/).
+//! Implementation of [the WTF-8 encoding](https://wtf-8.codeberg.page/).
 //!
 //! This library uses Rust’s type system to maintain
-//! [well-formedness](https://simonsapin.github.io/wtf-8/#well-formed),
+//! [well-formedness](https://wtf-8.codeberg.page/#well-formed),
 //! like the `String` and `&str` types do for UTF-8.
 //!
 //! Since [WTF-8 must not be used
-//! for interchange](https://simonsapin.github.io/wtf-8/#intended-audience),
+//! for interchange](https://wtf-8.codeberg.page/#intended-audience),
 //! this library deliberately does not provide access to the underlying bytes
 //! of WTF-8 strings,
 //! nor can it decode WTF-8 from arbitrary bytes.

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -54,6 +54,7 @@
 #![feature(extern_types)]
 #![feature(f16)]
 #![feature(f128)]
+#![feature(float_conversions)]
 #![feature(float_exact_integer_constants)]
 #![feature(float_gamma)]
 #![feature(float_minimum_maximum)]

--- a/library/coretests/tests/mem/type_info.rs
+++ b/library/coretests/tests/mem/type_info.rs
@@ -223,12 +223,12 @@ fn test_primitives() {
     use TypeKind::*;
 
     const {
-        let Type { kind: Bool(_ty), .. } = (const { Type::of::<bool>() }) else { panic!() };
+        let Type { kind: Bool, .. } = (const { Type::of::<bool>() }) else { panic!() };
         let ty_id = TypeId::of::<bool>();
         assert!(ty_id.size() == Some(size_of::<bool>()));
         assert!(ty_id.variants() == 1);
 
-        let Type { kind: Char(_ty), .. } = (const { Type::of::<char>() }) else { panic!() };
+        let Type { kind: Char, .. } = (const { Type::of::<char>() }) else { panic!() };
         let ty_id = TypeId::of::<char>();
         assert!(ty_id.size() == Some(size_of::<char>()));
         assert!(ty_id.variants() == 1);

--- a/library/coretests/tests/mem/type_info.rs
+++ b/library/coretests/tests/mem/type_info.rs
@@ -233,36 +233,31 @@ fn test_primitives() {
         assert!(ty_id.size() == Some(size_of::<char>()));
         assert!(ty_id.variants() == 1);
 
-        let Type { kind: Int(ty), .. } = (const { Type::of::<i32>() }) else { panic!() };
-        assert!(ty.bits == 32);
-        assert!(ty.signed);
+        let Type { kind: Int, .. } = (const { Type::of::<i32>() }) else { panic!() };
         let ty_id = TypeId::of::<i32>();
+        assert!(ty_id.is_signed());
         assert!(ty_id.size() == Some(size_of::<i32>()));
         assert!(ty_id.variants() == 1);
 
-        let Type { kind: Int(ty), .. } = (const { Type::of::<isize>() }) else { panic!() };
-        assert!(ty.bits as usize == size_of::<isize>() * 8);
-        assert!(ty.signed);
+        let Type { kind: Int, .. } = (const { Type::of::<isize>() }) else { panic!() };
         let ty_id = TypeId::of::<isize>();
+        assert!(ty_id.is_signed());
         assert!(ty_id.size() == Some(size_of::<isize>()));
         assert!(ty_id.variants() == 1);
 
-        let Type { kind: Int(ty), .. } = (const { Type::of::<u32>() }) else { panic!() };
-        assert!(ty.bits == 32);
-        assert!(!ty.signed);
+        let Type { kind: Int, .. } = (const { Type::of::<u32>() }) else { panic!() };
         let ty_id = TypeId::of::<u32>();
+        assert!(!ty_id.is_signed());
         assert!(ty_id.size() == Some(size_of::<u32>()));
         assert!(ty_id.variants() == 1);
 
-        let Type { kind: Int(ty), .. } = (const { Type::of::<usize>() }) else { panic!() };
-        assert!(ty.bits as usize == size_of::<usize>() * 8);
-        assert!(!ty.signed);
+        let Type { kind: Int, .. } = (const { Type::of::<usize>() }) else { panic!() };
         let ty_id = TypeId::of::<usize>();
+        assert!(!ty_id.is_signed());
         assert!(ty_id.size() == Some(size_of::<usize>()));
         assert!(ty_id.variants() == 1);
 
-        let Type { kind: Float(ty), .. } = (const { Type::of::<f32>() }) else { panic!() };
-        assert!(ty.bits == 32);
+        let Type { kind: Float, .. } = (const { Type::of::<f32>() }) else { panic!() };
         let ty_id = TypeId::of::<f32>();
         assert!(ty_id.size() == Some(size_of::<f32>()));
         assert!(ty_id.variants() == 1);

--- a/library/coretests/tests/num/float_conversions.rs
+++ b/library/coretests/tests/num/float_conversions.rs
@@ -1,0 +1,117 @@
+// Tests for the `float_conversions` methods (ACP rust-lang/libs-team#810):
+// `cast`, `to_int_saturating`, `to_int_checked`, and `to_int_strict`.
+
+#[test]
+fn cast_widen_narrow() {
+    assert_eq!(1.5_f32.cast::<f64>(), 1.5_f64);
+    assert_eq!(0.5_f64.cast::<f32>(), 0.5_f32);
+    // Narrowing a value out of the target range produces an infinity.
+    assert_eq!(1e300_f64.cast::<f32>(), f32::INFINITY);
+    assert_eq!((-1e300_f64).cast::<f32>(), f32::NEG_INFINITY);
+    // Same-type cast is the identity.
+    assert_eq!(3.25_f64.cast::<f64>(), 3.25_f64);
+    // Narrowing rounds to the nearest representable value.
+    assert_eq!(0.1_f64.cast::<f32>(), 0.1_f32);
+}
+
+#[test]
+fn saturating_basics() {
+    assert_eq!(255.9_f32.to_int_saturating::<u8>(), 255);
+    assert_eq!(300.0_f32.to_int_saturating::<u8>(), 255);
+    assert_eq!((-1.0_f32).to_int_saturating::<u8>(), 0);
+    assert_eq!(f32::NAN.to_int_saturating::<u8>(), 0);
+    assert_eq!(f32::INFINITY.to_int_saturating::<u8>(), 255);
+    assert_eq!(f32::NEG_INFINITY.to_int_saturating::<i8>(), i8::MIN);
+    assert_eq!(f64::NAN.to_int_saturating::<i32>(), 0);
+    // Large finite values saturate at the target boundary.
+    assert_eq!(1e18_f64.to_int_saturating::<i32>(), i32::MAX);
+    assert_eq!((-1e18_f64).to_int_saturating::<i32>(), i32::MIN);
+}
+
+#[test]
+fn checked_truncates_then_bounds() {
+    // Truncation toward zero happens before the bounds check.
+    assert_eq!(255.5_f64.to_int_checked::<u8>(), Some(255));
+    assert_eq!(255.9_f64.to_int_checked::<u8>(), Some(255));
+    assert_eq!(256.0_f64.to_int_checked::<u8>(), None);
+    // A negative fraction truncates toward zero and fits.
+    assert_eq!((-0.5_f64).to_int_checked::<u8>(), Some(0));
+    assert_eq!((-1.0_f64).to_int_checked::<u8>(), None);
+    // Non-finite is always None.
+    assert_eq!(f64::NAN.to_int_checked::<u8>(), None);
+    assert_eq!(f64::INFINITY.to_int_checked::<u8>(), None);
+    assert_eq!(f64::NEG_INFINITY.to_int_checked::<i32>(), None);
+}
+
+#[test]
+fn checked_signed_boundaries() {
+    assert_eq!((-128.0_f64).to_int_checked::<i8>(), Some(-128));
+    assert_eq!((-128.9_f64).to_int_checked::<i8>(), Some(-128));
+    assert_eq!((-129.0_f64).to_int_checked::<i8>(), None);
+    assert_eq!(127.0_f64.to_int_checked::<i8>(), Some(127));
+    assert_eq!(127.9_f64.to_int_checked::<i8>(), Some(127));
+    assert_eq!(128.0_f64.to_int_checked::<i8>(), None);
+}
+
+#[test]
+fn checked_exact_power_of_two_bounds() {
+    // i32::MIN is exactly representable and must be accepted.
+    assert_eq!((i32::MIN as f64).to_int_checked::<i32>(), Some(i32::MIN));
+    // 2^31 as f32 is exact and one past i32::MAX, so it is rejected...
+    assert_eq!((2147483648.0_f32).to_int_checked::<i32>(), None);
+    // ...while the largest f32 below 2^31 is accepted.
+    assert_eq!((2147483520.0_f32).to_int_checked::<i32>(), Some(2147483520));
+}
+
+#[test]
+fn strict_matches_checked() {
+    assert_eq!(255.5_f64.to_int_strict::<u8>(), 255);
+    assert_eq!((-128.0_f64).to_int_strict::<i8>(), -128);
+}
+
+#[test]
+#[should_panic]
+fn strict_panics_on_nan() {
+    let _ = f64::NAN.to_int_strict::<u8>();
+}
+
+#[test]
+#[should_panic]
+fn strict_panics_on_overflow() {
+    let _ = 256.0_f64.to_int_strict::<u8>();
+}
+
+#[cfg(target_has_reliable_f16)]
+#[test]
+fn f16_into_wide_int_accepts_all_finite() {
+    // Every finite f16 fits in i128, so the bounds are +/-inf and accept all
+    // finite values; only non-finite is rejected.
+    assert_eq!(f16::MAX.to_int_checked::<i128>(), Some(f16::MAX as i128));
+    assert_eq!((-f16::MAX).to_int_checked::<i128>(), Some(-f16::MAX as i128));
+    assert_eq!(f16::INFINITY.to_int_checked::<u128>(), None);
+    assert_eq!(f16::NAN.to_int_checked::<u128>(), None);
+    assert_eq!(4.6_f16.to_int_saturating::<u8>(), 4);
+    assert_eq!(1.5_f16.cast::<f32>(), 1.5_f32);
+}
+
+// Truncation-then-check must not depend on a libm `trunc`, which is unreliable
+// for f16/f128 on some targets. These exercise the fractional checked path.
+#[cfg(target_has_reliable_f16)]
+#[test]
+fn f16_checked_fractional() {
+    assert_eq!(4.6_f16.to_int_checked::<u8>(), Some(4));
+    assert_eq!(255.5_f16.to_int_checked::<u8>(), Some(255));
+    assert_eq!(256.0_f16.to_int_checked::<u8>(), None);
+    assert_eq!((-0.5_f16).to_int_checked::<u8>(), Some(0));
+    assert_eq!(4.6_f16.to_int_strict::<u8>(), 4);
+}
+
+#[cfg(target_has_reliable_f128)]
+#[test]
+fn f128_checked_fractional() {
+    assert_eq!(4.6_f128.to_int_checked::<u8>(), Some(4));
+    assert_eq!(255.5_f128.to_int_checked::<u8>(), Some(255));
+    assert_eq!(256.0_f128.to_int_checked::<u8>(), None);
+    assert_eq!((-0.5_f128).to_int_checked::<u8>(), Some(0));
+    assert_eq!(4.6_f128.to_int_strict::<u8>(), 4);
+}

--- a/library/coretests/tests/num/mod.rs
+++ b/library/coretests/tests/num/mod.rs
@@ -26,6 +26,7 @@ mod carryless_mul;
 mod cast;
 mod const_from;
 mod dec2flt;
+mod float_conversions;
 mod float_ieee754_flt2dec_dec2flt;
 mod float_iter_sum_identity;
 mod floats;

--- a/library/panic_abort/Cargo.toml
+++ b/library/panic_abort/Cargo.toml
@@ -12,10 +12,8 @@ bench = false
 doc = false
 
 [dependencies]
+alloc = { path = "../alloc" }
 core = { path = "../rustc-std-workspace-core", package = "rustc-std-workspace-core" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 libc = { version = "0.2", default-features = false }
-
-[target.'cfg(any(target_os = "android", target_os = "zkvm"))'.dependencies]
-alloc = { path = "../alloc" }

--- a/library/panic_abort/src/android.rs
+++ b/library/panic_abort/src/android.rs
@@ -1,6 +1,6 @@
+use alloc::panicking::PanicPayload;
 use alloc::string::String;
 use core::mem::transmute;
-use core::panic::PanicPayload;
 use core::ptr::copy_nonoverlapping;
 
 const ANDROID_SET_ABORT_MESSAGE: &[u8] = b"android_set_abort_message\0";

--- a/library/panic_abort/src/android.rs
+++ b/library/panic_abort/src/android.rs
@@ -15,7 +15,7 @@ type SetAbortMessageType = unsafe extern "C" fn(*const libc::c_char) -> ();
 //
 // Weakly resolve the symbol for android_set_abort_message. This function is only available
 // for API >= 21.
-pub(crate) unsafe fn android_set_abort_message(payload: &mut dyn PanicPayload) {
+pub(crate) fn android_set_abort_message(payload: &mut dyn PanicPayload) {
     let func_addr = unsafe {
         libc::dlsym(libc::RTLD_DEFAULT, ANDROID_SET_ABORT_MESSAGE.as_ptr() as *const libc::c_char)
             as usize

--- a/library/panic_abort/src/lib.rs
+++ b/library/panic_abort/src/lib.rs
@@ -30,16 +30,12 @@ pub unsafe fn __rust_panic_cleanup(_: *mut u8) -> Box<dyn Any + Send + 'static> 
 
 // "Leak" the payload and shim to the relevant abort on the platform in question.
 #[rustc_std_internal_symbol]
-pub unsafe fn __rust_start_panic(_payload: &mut dyn PanicPayload) -> u32 {
+pub fn __rust_start_panic(_payload: &mut dyn PanicPayload) -> u32 {
     // Android has the ability to attach a message as part of the abort.
     #[cfg(target_os = "android")]
-    unsafe {
-        android::android_set_abort_message(_payload);
-    }
+    android::android_set_abort_message(_payload);
     #[cfg(target_os = "zkvm")]
-    unsafe {
-        zkvm::zkvm_set_abort_message(_payload);
-    }
+    zkvm::zkvm_set_abort_message(_payload);
 
     unsafe extern "Rust" {
         // This is defined in std::rt.

--- a/library/panic_abort/src/lib.rs
+++ b/library/panic_abort/src/lib.rs
@@ -19,11 +19,12 @@ mod android;
 #[cfg(target_os = "zkvm")]
 mod zkvm;
 
+use alloc::boxed::Box;
+use alloc::panicking::PanicPayload;
 use core::any::Any;
-use core::panic::PanicPayload;
 
 #[rustc_std_internal_symbol]
-pub unsafe fn __rust_panic_cleanup(_: *mut u8) -> *mut (dyn Any + Send + 'static) {
+pub unsafe fn __rust_panic_cleanup(_: *mut u8) -> Box<dyn Any + Send + 'static> {
     unreachable!()
 }
 

--- a/library/panic_abort/src/lib.rs
+++ b/library/panic_abort/src/lib.rs
@@ -23,8 +23,7 @@ use core::any::Any;
 use core::panic::PanicPayload;
 
 #[rustc_std_internal_symbol]
-#[allow(improper_ctypes_definitions)]
-pub unsafe extern "C" fn __rust_panic_cleanup(_: *mut u8) -> *mut (dyn Any + Send + 'static) {
+pub unsafe fn __rust_panic_cleanup(_: *mut u8) -> *mut (dyn Any + Send + 'static) {
     unreachable!()
 }
 

--- a/library/panic_abort/src/zkvm.rs
+++ b/library/panic_abort/src/zkvm.rs
@@ -3,7 +3,7 @@ use alloc::string::String;
 
 // Forward the abort message to zkVM's sys_panic. This is implemented by RISC Zero's
 // platform crate which exposes system calls specifically for the zkVM.
-pub(crate) unsafe fn zkvm_set_abort_message(payload: &mut dyn PanicPayload) {
+pub(crate) fn zkvm_set_abort_message(payload: &mut dyn PanicPayload) {
     let payload = payload.get();
     let msg = match payload.downcast_ref::<&'static str>() {
         Some(msg) => msg.as_bytes(),

--- a/library/panic_abort/src/zkvm.rs
+++ b/library/panic_abort/src/zkvm.rs
@@ -1,5 +1,5 @@
+use alloc::panicking::PanicPayload;
 use alloc::string::String;
-use core::panic::PanicPayload;
 
 // Forward the abort message to zkVM's sys_panic. This is implemented by RISC Zero's
 // platform crate which exposes system calls specifically for the zkVM.

--- a/library/panic_unwind/src/dummy.rs
+++ b/library/panic_unwind/src/dummy.rs
@@ -3,6 +3,7 @@
 //! Stubs that simply abort for targets that don't support unwinding otherwise.
 
 use alloc::boxed::Box;
+use alloc::panicking::PanicPayload;
 use core::any::Any;
 
 unsafe extern "Rust" {
@@ -15,6 +16,6 @@ pub(crate) unsafe fn cleanup(_ptr: *mut u8) -> Box<dyn Any + Send> {
     __rust_abort()
 }
 
-pub(crate) unsafe fn panic(_data: Box<dyn Any + Send>) -> u32 {
+pub(crate) fn panic(_data: &mut dyn PanicPayload) -> u32 {
     __rust_abort()
 }

--- a/library/panic_unwind/src/gcc.rs
+++ b/library/panic_unwind/src/gcc.rs
@@ -76,10 +76,8 @@ pub(crate) fn panic(data: &mut dyn PanicPayload) -> u32 {
         _unwind_code: uw::_Unwind_Reason_Code,
         exception: *mut uw::_Unwind_Exception,
     ) {
-        unsafe {
-            let _: Box<Exception> = Box::from_raw(exception as *mut Exception);
-            super::__rust_drop_panic();
-        }
+        let _: Box<Exception> = unsafe { Box::from_raw(exception as *mut Exception) };
+        super::__rust_drop_panic();
     }
 }
 

--- a/library/panic_unwind/src/gcc.rs
+++ b/library/panic_unwind/src/gcc.rs
@@ -37,6 +37,7 @@
 //! and the last personality routine transfers control to the catch block.
 
 use alloc::boxed::Box;
+use alloc::panicking::PanicPayload;
 use core::any::Any;
 use core::ptr;
 
@@ -58,7 +59,7 @@ struct Exception {
     cause: Box<dyn Any + Send>,
 }
 
-pub(crate) unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
+pub(crate) fn panic(data: &mut dyn PanicPayload) -> u32 {
     let exception = Box::new(Exception {
         _uwe: uw::_Unwind_Exception {
             exception_class: RUST_EXCEPTION_CLASS,
@@ -66,7 +67,7 @@ pub(crate) unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
             private: [core::ptr::null(); _],
         },
         canary: &CANARY,
-        cause: data,
+        cause: data.take_box(),
     });
     let exception_param = Box::into_raw(exception) as *mut uw::_Unwind_Exception;
     return unsafe { uw::_Unwind_RaiseException(exception_param) as u32 };

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -80,8 +80,7 @@ unsafe extern "C" {
 }
 
 #[rustc_std_internal_symbol]
-#[allow(improper_ctypes_definitions)]
-pub unsafe extern "C" fn __rust_panic_cleanup(payload: *mut u8) -> *mut (dyn Any + Send + 'static) {
+pub unsafe fn __rust_panic_cleanup(payload: *mut u8) -> *mut (dyn Any + Send + 'static) {
     unsafe { Box::into_raw(imp::cleanup(payload)) }
 }
 

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -88,6 +88,5 @@ pub unsafe fn __rust_panic_cleanup(payload: *mut u8) -> Box<dyn Any + Send + 'st
 // implementation.
 #[rustc_std_internal_symbol]
 pub fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32 {
-    let payload = payload.take_box();
-    unsafe { imp::panic(payload) }
+    imp::panic(payload)
 }

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -28,8 +28,8 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 use alloc::boxed::Box;
+use alloc::panicking::PanicPayload;
 use core::any::Any;
-use core::panic::PanicPayload;
 
 cfg_select! {
     any(
@@ -80,17 +80,14 @@ unsafe extern "C" {
 }
 
 #[rustc_std_internal_symbol]
-pub unsafe fn __rust_panic_cleanup(payload: *mut u8) -> *mut (dyn Any + Send + 'static) {
-    unsafe { Box::into_raw(imp::cleanup(payload)) }
+pub unsafe fn __rust_panic_cleanup(payload: *mut u8) -> Box<dyn Any + Send + 'static> {
+    unsafe { imp::cleanup(payload) }
 }
 
 // Entry point for raising an exception, just delegates to the platform-specific
 // implementation.
 #[rustc_std_internal_symbol]
 pub unsafe fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32 {
-    unsafe {
-        let payload = Box::from_raw(payload.take_box());
-
-        imp::panic(payload)
-    }
+    let payload = payload.take_box();
+    unsafe { imp::panic(payload) }
 }

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -87,7 +87,7 @@ pub unsafe fn __rust_panic_cleanup(payload: *mut u8) -> Box<dyn Any + Send + 'st
 // Entry point for raising an exception, just delegates to the platform-specific
 // implementation.
 #[rustc_std_internal_symbol]
-pub unsafe fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32 {
+pub fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32 {
     let payload = payload.take_box();
     unsafe { imp::panic(payload) }
 }

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -68,15 +68,15 @@ cfg_select! {
     }
 }
 
-unsafe extern "C" {
+unsafe extern "Rust" {
     /// Handler in std called when a panic object is dropped outside of
     /// `catch_unwind`.
     #[rustc_std_internal_symbol]
-    fn __rust_drop_panic() -> !;
+    safe fn __rust_drop_panic() -> !;
 
     /// Handler in std called when a foreign exception is caught.
     #[rustc_std_internal_symbol]
-    fn __rust_foreign_exception() -> !;
+    safe fn __rust_foreign_exception() -> !;
 }
 
 #[rustc_std_internal_symbol]

--- a/library/panic_unwind/src/miri.rs
+++ b/library/panic_unwind/src/miri.rs
@@ -1,6 +1,7 @@
 //! Unwinding panics for Miri.
 
 use alloc::boxed::Box;
+use alloc::panicking::PanicPayload;
 use core::any::Any;
 
 // The type of the payload that the Miri engine propagates through unwinding for us.
@@ -12,10 +13,10 @@ unsafe extern "Rust" {
     fn miri_start_unwind(payload: *mut u8) -> !;
 }
 
-pub(crate) unsafe fn panic(payload: Box<dyn Any + Send>) -> u32 {
+pub(crate) fn panic(payload: &mut dyn PanicPayload) -> u32 {
     // The payload we pass to `miri_start_unwind` will be exactly the argument we get
     // in `cleanup` below. So we just box it up once, to get something pointer-sized.
-    let payload_box: Payload = Box::new(payload);
+    let payload_box: Payload = Box::new(payload.take_box());
     unsafe { miri_start_unwind(Box::into_raw(payload_box) as *mut u8) }
 }
 

--- a/library/panic_unwind/src/seh.rs
+++ b/library/panic_unwind/src/seh.rs
@@ -371,13 +371,13 @@ unsafe fn throw_exception(data: Option<Box<dyn Any + Send>>) -> ! {
 }
 
 pub(crate) unsafe fn cleanup(payload: *mut u8) -> Box<dyn Any + Send> {
+    // A null payload here means that we got here from the catch (...) of
+    // __rust_try. This happens when a non-Rust foreign exception is caught.
+    if payload.is_null() {
+        super::__rust_foreign_exception();
+    }
+    let exception = payload as *mut Exception;
     unsafe {
-        // A null payload here means that we got here from the catch (...) of
-        // __rust_try. This happens when a non-Rust foreign exception is caught.
-        if payload.is_null() {
-            super::__rust_foreign_exception();
-        }
-        let exception = payload as *mut Exception;
         let canary = (&raw const (*exception).canary).read();
         if !core::ptr::eq(canary, &raw const TYPE_DESCRIPTOR) {
             // A foreign Rust exception.

--- a/library/panic_unwind/src/seh.rs
+++ b/library/panic_unwind/src/seh.rs
@@ -47,6 +47,7 @@
 #![allow(nonstandard_style)]
 
 use alloc::boxed::Box;
+use alloc::panicking::PanicPayload;
 use core::any::Any;
 use core::ffi::{c_int, c_uint, c_void};
 use core::mem::ManuallyDrop;
@@ -298,8 +299,8 @@ cfg_select! {
    }
 }
 
-pub(crate) unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
-    unsafe { throw_exception(Some(data)) }
+pub(crate) fn panic(data: &mut dyn PanicPayload) -> u32 {
+    unsafe { throw_exception(Some(data.take_box())) }
 }
 
 unsafe fn throw_exception(data: Option<Box<dyn Any + Send>>) -> ! {

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -69,7 +69,7 @@ unsafe extern "Rust" {
 /// with our panic count.
 #[cfg(not(test))]
 #[rustc_std_internal_symbol]
-extern "C" fn __rust_drop_panic() -> ! {
+fn __rust_drop_panic() -> ! {
     rtabort!("Rust panics must be rethrown");
 }
 
@@ -77,7 +77,7 @@ extern "C" fn __rust_drop_panic() -> ! {
 /// object which does not correspond to a Rust panic.
 #[cfg(not(test))]
 #[rustc_std_internal_symbol]
-extern "C" fn __rust_foreign_exception() -> ! {
+fn __rust_foreign_exception() -> ! {
     rtabort!("Rust cannot catch foreign exceptions");
 }
 

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -53,13 +53,10 @@ pub static EMPTY_PANIC: fn(&'static str) -> ! =
 //
 // One day this may look a little less ad-hoc with the compiler helping out to
 // hook up these functions, but it is not this day!
-#[allow(improper_ctypes)]
-unsafe extern "C" {
+unsafe extern "Rust" {
     #[rustc_std_internal_symbol]
     fn __rust_panic_cleanup(payload: *mut u8) -> *mut (dyn Any + Send + 'static);
-}
 
-unsafe extern "Rust" {
     /// `PanicPayload` lazily performs allocation only when needed (this avoids
     /// allocations when using the "abort" panic runtime).
     #[rustc_std_internal_symbol]

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -9,7 +9,8 @@
 
 #![deny(unsafe_op_in_unsafe_fn)]
 
-use core::panic::{Location, PanicPayload};
+use alloc::panicking::PanicPayload;
+use core::panic::Location;
 
 // make sure to use the stderr output configured
 // by libtest in the real copy of std
@@ -55,7 +56,7 @@ pub static EMPTY_PANIC: fn(&'static str) -> ! =
 // hook up these functions, but it is not this day!
 unsafe extern "Rust" {
     #[rustc_std_internal_symbol]
-    fn __rust_panic_cleanup(payload: *mut u8) -> *mut (dyn Any + Send + 'static);
+    fn __rust_panic_cleanup(payload: *mut u8) -> Box<dyn Any + Send + 'static>;
 
     /// `PanicPayload` lazily performs allocation only when needed (this avoids
     /// allocations when using the "abort" panic runtime).
@@ -556,7 +557,7 @@ pub unsafe fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any +
         // the panic handler `__rust_panic_cleanup`. As such we can only
         // assume it returns the correct thing for `Box::from_raw` to work
         // without undefined behavior.
-        let obj = unsafe { Box::from_raw(__rust_panic_cleanup(payload)) };
+        let obj = unsafe { __rust_panic_cleanup(payload) };
         panic_count::decrease();
         obj
     }
@@ -626,12 +627,12 @@ pub fn panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
     }
 
     unsafe impl PanicPayload for FormatStringPayload<'_> {
-        fn take_box(&mut self) -> *mut (dyn Any + Send) {
+        fn take_box(&mut self) -> Box<dyn Any + Send> {
             // We do two allocations here, unfortunately. But (a) they're required with the current
             // scheme, and (b) we don't handle panic + OOM properly anyway (see comment in
             // begin_panic below).
             let contents = mem::take(self.fill());
-            Box::into_raw(Box::new(contents))
+            Box::new(contents)
         }
 
         fn get(&mut self) -> &(dyn Any + Send) {
@@ -652,8 +653,8 @@ pub fn panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
     struct StaticStrPayload(&'static str);
 
     unsafe impl PanicPayload for StaticStrPayload {
-        fn take_box(&mut self) -> *mut (dyn Any + Send) {
-            Box::into_raw(Box::new(self.0))
+        fn take_box(&mut self) -> Box<dyn Any + Send> {
+            Box::new(self.0)
         }
 
         fn get(&mut self) -> &(dyn Any + Send) {
@@ -714,17 +715,16 @@ pub const fn begin_panic<M: Any + Send>(msg: M) -> ! {
     }
 
     unsafe impl<A: Send + 'static> PanicPayload for Payload<A> {
-        fn take_box(&mut self) -> *mut (dyn Any + Send) {
+        fn take_box(&mut self) -> Box<dyn Any + Send> {
             // Note that this should be the only allocation performed in this code path. Currently
             // this means that panic!() on OOM will invoke this code path, but then again we're not
             // really ready for panic on OOM anyway. If we do start doing this, then we should
             // propagate this allocation to be performed in the parent of this thread instead of the
             // thread that's panicking.
-            let data = match self.inner.take() {
+            match self.inner.take() {
                 Some(a) => Box::new(a) as Box<dyn Any + Send>,
                 None => process::abort(),
-            };
-            Box::into_raw(data)
+            }
         }
 
         fn get(&mut self) -> &(dyn Any + Send) {
@@ -857,8 +857,8 @@ pub fn resume_unwind(payload: Box<dyn Any + Send>) -> ! {
     struct RewrapBox(Box<dyn Any + Send>);
 
     unsafe impl PanicPayload for RewrapBox {
-        fn take_box(&mut self) -> *mut (dyn Any + Send) {
-            Box::into_raw(mem::replace(&mut self.0, Box::new(())))
+        fn take_box(&mut self) -> Box<dyn Any + Send> {
+            mem::replace(&mut self.0, Box::new(()))
         }
 
         fn get(&mut self) -> &(dyn Any + Send) {

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -61,7 +61,7 @@ unsafe extern "Rust" {
     /// `PanicPayload` lazily performs allocation only when needed (this avoids
     /// allocations when using the "abort" panic runtime).
     #[rustc_std_internal_symbol]
-    fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32;
+    safe fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32;
 }
 
 /// This function is called by the panic runtime if FFI code catches a Rust
@@ -626,7 +626,7 @@ pub fn panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
         }
     }
 
-    unsafe impl PanicPayload for FormatStringPayload<'_> {
+    impl PanicPayload for FormatStringPayload<'_> {
         fn take_box(&mut self) -> Box<dyn Any + Send> {
             // We do two allocations here, unfortunately. But (a) they're required with the current
             // scheme, and (b) we don't handle panic + OOM properly anyway (see comment in
@@ -652,7 +652,7 @@ pub fn panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
 
     struct StaticStrPayload(&'static str);
 
-    unsafe impl PanicPayload for StaticStrPayload {
+    impl PanicPayload for StaticStrPayload {
         fn take_box(&mut self) -> Box<dyn Any + Send> {
             Box::new(self.0)
         }
@@ -714,7 +714,7 @@ pub const fn begin_panic<M: Any + Send>(msg: M) -> ! {
         inner: Option<A>,
     }
 
-    unsafe impl<A: Send + 'static> PanicPayload for Payload<A> {
+    impl<A: Send + 'static> PanicPayload for Payload<A> {
         fn take_box(&mut self) -> Box<dyn Any + Send> {
             // Note that this should be the only allocation performed in this code path. Currently
             // this means that panic!() on OOM will invoke this code path, but then again we're not
@@ -856,7 +856,7 @@ pub fn resume_unwind(payload: Box<dyn Any + Send>) -> ! {
 
     struct RewrapBox(Box<dyn Any + Send>);
 
-    unsafe impl PanicPayload for RewrapBox {
+    impl PanicPayload for RewrapBox {
         fn take_box(&mut self) -> Box<dyn Any + Send> {
             mem::replace(&mut self.0, Box::new(()))
         }
@@ -881,7 +881,7 @@ pub fn resume_unwind(payload: Box<dyn Any + Send>) -> ! {
 #[cfg_attr(not(test), rustc_std_internal_symbol)]
 #[cfg(not(panic = "immediate-abort"))]
 fn rust_panic(msg: &mut dyn PanicPayload) -> ! {
-    let code = unsafe { __rust_start_panic(msg) };
+    let code = __rust_start_panic(msg);
     rtabort!("failed to initiate panic, error {code}")
 }
 

--- a/library/std/src/sync/once.rs
+++ b/library/std/src/sync/once.rs
@@ -347,6 +347,16 @@ impl fmt::Debug for Once {
     }
 }
 
+#[stable(feature = "once_default", since = "CURRENT_RUSTC_VERSION")]
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+const impl Default for Once {
+    /// Creates a new `Once` value, same as [`Once::new`].
+    #[inline]
+    fn default() -> Once {
+        Once::new()
+    }
+}
+
 impl OnceState {
     /// Returns `true` if the associated [`Once`] was poisoned prior to the
     /// invocation of the closure passed to [`Once::call_once_force()`].

--- a/library/std/src/sys/thread_local/guard/windows.rs
+++ b/library/std/src/sys/thread_local/guard/windows.rs
@@ -176,6 +176,12 @@ pub fn enable() {
             }
         };
 
+        // We must not set the key if we are in a fiber, since deleting that fiber from a thread
+        // will cause the destructors to run before thread exit.
+        if is_thread_a_fiber() {
+            return;
+        }
+
         // Setting the key's value to non-zero will cause the dtor callback to be called when the thread exits.
         unsafe { set(key, ptr::without_provenance(1)) };
     }

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -98,17 +98,16 @@ use crate::fmt;
 ///    run on the thread that causes the process to exit. This is because the
 ///    other threads may be forcibly terminated.
 ///
-///    If a thread is [converted into a fiber], destructors will not be run unless
-///    the fiber is [converted back into a thread] before the underlying thread exits.
+///    TLS destructors may be leaked if a thread exits while [converted into a fiber],
+///    or if Rust TLS destructor support is first needed while running in a fiber.
 ///
 ///    If a process loads a Rust `cdylib`, it must not cause the Rust TLS destructor support
-//     to be initialized for the first time during process shutdown.
+///    to be initialized for the first time during process shutdown.
 ///
 ///    When dynamically unloading a Rust `cdylib`, pending TLS destructors may run
-//     during the unload or may be leaked.
+///    during the unload or may be leaked.
 ///
 /// [converted into a fiber]: https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-convertthreadtofiber
-/// [converted back into a thread]: https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-convertfibertothread
 /// [loader lock]: https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-best-practices
 /// [`with`]: LocalKey::with
 #[cfg_attr(not(test), rustc_diagnostic_item = "LocalKey")]

--- a/library/std/tests/thread_local/tests.rs
+++ b/library/std/tests/thread_local/tests.rs
@@ -416,9 +416,17 @@ fn fiber_does_not_trigger_dtor() {
     unsafe extern "system" {
         fn ConvertFiberToThread() -> i32;
         fn ConvertThreadToFiber(lpParameter: *const c_void) -> *mut c_void;
+        fn CreateFiber(
+            dwStackSize: usize,
+            lpStartAddress: unsafe extern "system" fn(*mut c_void),
+            lpParameter: *mut c_void,
+        ) -> *mut c_void;
+        fn DeleteFiber(lpFiber: *mut c_void);
+        fn SwitchToFiber(lpFiber: *mut c_void);
     }
 
     thread_local!(static FOO: UnsafeCell<Option<NotifyOnDrop>> = UnsafeCell::new(None));
+
     let signal = Signal::default();
 
     let signal2 = signal.clone();
@@ -438,13 +446,49 @@ fn fiber_does_not_trigger_dtor() {
     // As long as we stop using fibers before thread teardown, everything works as expected.
     let signal2 = signal.clone();
     let t = thread::spawn(move || unsafe {
-        let mut signal = Some(signal2);
-        let _ = ConvertThreadToFiber(ptr::null());
-        FOO.with(|f| {
-            *f.get() = Some(NotifyOnDrop(signal.take().unwrap()));
-        });
-        let _ = ConvertFiberToThread();
+        struct FiberData {
+            main: *mut c_void,
+            signal: Signal,
+        }
+
+        unsafe extern "system" fn fiber_start(data: *mut c_void) {
+            let data = unsafe { &mut *data.cast::<FiberData>() };
+
+            // Set the value while this fiber is current.
+            // This must NOT arm the FLS cleanup guard for the fiber.
+            FOO.with(|f| unsafe {
+                *f.get() = Some(NotifyOnDrop(data.signal.clone()));
+            });
+
+            unsafe {
+                SwitchToFiber(data.main);
+            }
+        }
+
+        let main = ConvertThreadToFiber(ptr::null());
+        assert!(!main.is_null());
+
+        let mut data = FiberData { main, signal: signal2.clone() };
+        let foo = CreateFiber(0, fiber_start, ptr::from_mut(&mut data).cast());
+        assert!(!foo.is_null());
+
+        // Run `foo`, which sets FOO while `foo` is the current fiber,
+        // then switches back to main.
+        SwitchToFiber(foo);
+
+        // Convert main back to a thread before deleting `foo`.
+        assert_ne!(ConvertFiberToThread(), 0);
+
+        // Deleting `foo` must not trigger dtors like a thread teardown.
+        DeleteFiber(foo);
+        assert!(!signal2.is_set());
+
+        // Arm the guard now from the normal thread.
+        // `FOO`'s destructor is already registered, so it will run when the thread exits.
+        thread_local!(static BAR: UnsafeCell<Option<NotifyOnDrop>> = UnsafeCell::new(None));
+        BAR.with(|_| {});
     });
+
     signal.wait();
     assert!(signal.is_set());
     t.join().unwrap();

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2277,6 +2277,8 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
         // running compiler in stage 2 when plugins run.
         let query_compiler;
         let (stage, stage_id) = if suite == "ui-fulldeps" && test_compiler.stage == 1 {
+            builder.info("Warning: running ui-fulldeps tests in stage 1 might cause failures");
+
             // Even when using the stage 0 compiler, we also need to provide the stage 1 compiler
             // so that compiletest can query it for target information.
             query_compiler = Some(test_compiler);

--- a/src/bootstrap/src/core/session.rs
+++ b/src/bootstrap/src/core/session.rs
@@ -1606,7 +1606,11 @@ impl Build {
                 metadata = t!(fs::metadata(&src), format!("target = {}", src.display()));
             } else {
                 let link = t!(fs::read_link(src));
-                t!(self.symlink_file(link, dst));
+                if t!(link.metadata()).is_dir() {
+                    t!(symlink_dir(&self.config, &link, dst));
+                } else {
+                    t!(self.symlink_file(link, dst));
+                }
                 return;
             }
         }

--- a/src/doc/rustc-dev-guide/src/solve/sharing-crates-with-rust-analyzer.md
+++ b/src/doc/rustc-dev-guide/src/solve/sharing-crates-with-rust-analyzer.md
@@ -29,7 +29,7 @@ Since these crates are not published on `crates.io` as part of the compiler's no
 process, rust-analyzer maintains its own publishing pipeline.
 It uses the [rustc-auto-publish script][rustc-auto-publish] to publish these crates to `crates.io`
 with the prefix `ra-ap-rustc_*`
-(for example: https://crates.io/crates/ra-ap-rustc_next_trait_solver).
+(for example: <https://crates.io/crates/ra-ap-rustc_next_trait_solver>).
 rust-analyzer then depends on these re-published crates in its own build.
 
 For trait solving specifically, the primary shared crates are `rustc_type_ir` and

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-inline.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-inline.stderr
@@ -541,6 +541,11 @@ help: a built-in attribute with a similar name exists
 LL - #[lint("this is an example message", code = E0123)]
 LL + #[link("this is an example message", code = E0123)]
    |
+help: the derive macros `Lift` and `Lift_Generic` accept the similarly named `lift` attribute
+   |
+LL - #[lint("this is an example message", code = E0123)]
+LL + #[lift("this is an example message", code = E0123)]
+   |
 
 error: cannot find attribute `multipart_suggestion` in this scope
   --> $DIR/diagnostic-derive-inline.rs:565:3

--- a/tests/ui/argument-suggestions/disjoint-spans-issue-151607.stderr
+++ b/tests/ui/argument-suggestions/disjoint-spans-issue-151607.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find type `E` in this scope
   --> $DIR/disjoint-spans-issue-151607.rs:8:24
    |
-LL | struct B;
-   | --------- similarly named struct `B` defined here
-...
 LL | fn foo(g: F, y: F, e: &E) {
-   |                        ^
+   |                        ^ not found in this scope
    |
+note: similarly named struct `B` defined here
+  --> $DIR/disjoint-spans-issue-151607.rs:5:1
+   |
+LL | struct B;
+   | ^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - fn foo(g: F, y: F, e: &E) {
@@ -21,7 +23,7 @@ error[E0425]: cannot find value `E` in this scope
   --> $DIR/disjoint-spans-issue-151607.rs:10:18
    |
 LL |     foo(B, g, D, E, F, G)
-   |                  ^
+   |                  ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -43,7 +45,7 @@ error[E0425]: cannot find value `G` in this scope
   --> $DIR/disjoint-spans-issue-151607.rs:10:24
    |
 LL |     foo(B, g, D, E, F, G)
-   |                        ^
+   |                        ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/argument-suggestions/issue-109831.stderr
+++ b/tests/ui/argument-suggestions/issue-109831.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find type `C` in this scope
   --> $DIR/issue-109831.rs:4:24
    |
-LL | struct A;
-   | --------- similarly named struct `A` defined here
-...
 LL | fn f(b1: B, b2: B, a2: C) {}
-   |                        ^
+   |                        ^ not found in this scope
    |
+note: similarly named struct `A` defined here
+  --> $DIR/issue-109831.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - fn f(b1: B, b2: B, a2: C) {}
@@ -20,12 +22,14 @@ LL | fn f<C>(b1: B, b2: B, a2: C) {}
 error[E0425]: cannot find value `C` in this scope
   --> $DIR/issue-109831.rs:7:16
    |
-LL | struct A;
-   | --------- similarly named unit struct `A` defined here
-...
 LL |     f(A, A, B, C);
-   |                ^
+   |                ^ not found in this scope
    |
+note: similarly named unit struct `A` defined here
+  --> $DIR/issue-109831.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^
 help: a unit struct with a similar name exists
    |
 LL -     f(A, A, B, C);

--- a/tests/ui/associated-item/issue-87638.stderr
+++ b/tests/ui/associated-item/issue-87638.stderr
@@ -1,12 +1,14 @@
 error[E0576]: cannot find associated type `Output` in trait `Trait`
   --> $DIR/issue-87638.rs:17:26
    |
-LL |     type Target;
-   |     ------------ associated type `Target` defined here
-...
 LL |     let _: <S as Trait>::Output;
    |                          ^^^^^^ not found in `Trait`
    |
+note: associated type `Target` defined here
+  --> $DIR/issue-87638.rs:6:5
+   |
+LL |     type Target;
+   |     ^^^^^^^^^^^^
 help: maybe you meant this associated type
    |
 LL -     let _: <S as Trait>::Output;
@@ -16,12 +18,14 @@ LL +     let _: <S as Trait>::Target;
 error[E0576]: cannot find method or associated constant `BAR` in trait `Trait`
   --> $DIR/issue-87638.rs:20:27
    |
-LL |     const FOO: usize;
-   |     ----------------- associated constant `FOO` defined here
-...
 LL |     let _ = <S as Trait>::BAR;
    |                           ^^^ not found in `Trait`
    |
+note: associated constant `FOO` defined here
+  --> $DIR/issue-87638.rs:4:5
+   |
+LL |     const FOO: usize;
+   |     ^^^^^^^^^^^^^^^^^
 help: maybe you meant this associated constant
    |
 LL -     let _ = <S as Trait>::BAR;

--- a/tests/ui/associated-types/issue-19883.stderr
+++ b/tests/ui/associated-types/issue-19883.stderr
@@ -1,12 +1,14 @@
 error[E0576]: cannot find associated type `Dst` in trait `From`
   --> $DIR/issue-19883.rs:9:30
    |
-LL |     type Output;
-   |     ------------ associated type `Output` defined here
-...
 LL |         <Dst as From<Self>>::Dst
    |                              ^^^ not found in `From`
    |
+note: associated type `Output` defined here
+  --> $DIR/issue-19883.rs:2:5
+   |
+LL |     type Output;
+   |     ^^^^^^^^^^^^
 help: maybe you meant this associated type
    |
 LL -         <Dst as From<Self>>::Dst

--- a/tests/ui/associated-types/issue-22037.stderr
+++ b/tests/ui/associated-types/issue-22037.stderr
@@ -1,11 +1,14 @@
 error[E0576]: cannot find associated type `X` in trait `A`
   --> $DIR/issue-22037.rs:3:33
    |
-LL |     type Output;
-   |     ------------ associated type `Output` defined here
 LL |     fn a(&self) -> <Self as A>::X;
    |                                 ^ not found in `A`
    |
+note: associated type `Output` defined here
+  --> $DIR/issue-22037.rs:2:5
+   |
+LL |     type Output;
+   |     ^^^^^^^^^^^^
 help: maybe you meant this associated type
    |
 LL -     fn a(&self) -> <Self as A>::X;

--- a/tests/ui/assumptions_on_binders/alias_outlives.rs
+++ b/tests/ui/assumptions_on_binders/alias_outlives.rs
@@ -23,11 +23,22 @@ where
 }
 
 fn borrowck_env_fail<'a, T: AliasHaver>()
-// FIXME: ^ this should raise an ERROR: unsatisfied lifetime constraint from -Zassumptions-on-binders
 where
     <T as AliasHaver>::Assoc: 'a,
 {
     let _: ReqTrait<T::Assoc>;
+    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
+}
+
+fn borrowck_multiple_origins_fail<'a, 'b, T: AliasHaver, U: AliasHaver>()
+where
+    <T as AliasHaver>::Assoc: 'a,
+    <U as AliasHaver>::Assoc: 'b,
+{
+    let _: ReqTrait<T::Assoc>;
+    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
+    let _: ReqTrait<U::Assoc>;
+    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
 }
 
 const REGIONCK_ENV_PASS<'a, T: AliasHaver>: ReqTrait<T::Assoc> = todo!()
@@ -35,7 +46,7 @@ where
     <T as AliasHaver>::Assoc: 'static;
 
 const REGIONCK_ENV_FAIL<'a, T: AliasHaver>: ReqTrait<T::Assoc> = todo!()
-//~^ ERROR: unsatisfied lifetime constraint from -Zassumptions-on-binders
+//~^ ERROR: higher-ranked lifetime bound could not be satisfied
 where
     <T as AliasHaver>::Assoc: 'a;
 

--- a/tests/ui/assumptions_on_binders/alias_outlives.rs
+++ b/tests/ui/assumptions_on_binders/alias_outlives.rs
@@ -23,22 +23,11 @@ where
 }
 
 fn borrowck_env_fail<'a, T: AliasHaver>()
+// FIXME: ^ this should raise an ERROR: unsatisfied lifetime constraint from -Zassumptions-on-binders
 where
     <T as AliasHaver>::Assoc: 'a,
 {
     let _: ReqTrait<T::Assoc>;
-    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
-}
-
-fn borrowck_multiple_origins_fail<'a, 'b, T: AliasHaver, U: AliasHaver>()
-where
-    <T as AliasHaver>::Assoc: 'a,
-    <U as AliasHaver>::Assoc: 'b,
-{
-    let _: ReqTrait<T::Assoc>;
-    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
-    let _: ReqTrait<U::Assoc>;
-    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
 }
 
 const REGIONCK_ENV_PASS<'a, T: AliasHaver>: ReqTrait<T::Assoc> = todo!()

--- a/tests/ui/assumptions_on_binders/alias_outlives.stderr
+++ b/tests/ui/assumptions_on_binders/alias_outlives.stderr
@@ -1,26 +1,8 @@
 error: higher-ranked lifetime bound could not be satisfied
-  --> $DIR/alias_outlives.rs:48:45
+  --> $DIR/alias_outlives.rs:37:45
    |
 LL | const REGIONCK_ENV_FAIL<'a, T: AliasHaver>: ReqTrait<T::Assoc> = todo!()
    |                                             ^^^^^^^^^^^^^^^^^^
 
-error: higher-ranked lifetime bound could not be satisfied
-  --> $DIR/alias_outlives.rs:29:12
-   |
-LL |     let _: ReqTrait<T::Assoc>;
-   |            ^^^^^^^^^^^^^^^^^^
-
-error: higher-ranked lifetime bound could not be satisfied
-  --> $DIR/alias_outlives.rs:38:12
-   |
-LL |     let _: ReqTrait<T::Assoc>;
-   |            ^^^^^^^^^^^^^^^^^^
-
-error: higher-ranked lifetime bound could not be satisfied
-  --> $DIR/alias_outlives.rs:40:12
-   |
-LL |     let _: ReqTrait<U::Assoc>;
-   |            ^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 4 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/assumptions_on_binders/alias_outlives.stderr
+++ b/tests/ui/assumptions_on_binders/alias_outlives.stderr
@@ -1,10 +1,25 @@
-error: unsatisfied lifetime constraint from -Zassumptions-on-binders :3
-  --> $DIR/alias_outlives.rs:37:1
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/alias_outlives.rs:48:45
    |
 LL | const REGIONCK_ENV_FAIL<'a, T: AliasHaver>: ReqTrait<T::Assoc> = todo!()
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                             ^^^^^^^^^^^^^^^^^^
+
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/alias_outlives.rs:29:12
    |
-   = note: meoow :c
+LL |     let _: ReqTrait<T::Assoc>;
+   |            ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/alias_outlives.rs:38:12
+   |
+LL |     let _: ReqTrait<T::Assoc>;
+   |            ^^^^^^^^^^^^^^^^^^
 
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/alias_outlives.rs:40:12
+   |
+LL |     let _: ReqTrait<U::Assoc>;
+   |            ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors

--- a/tests/ui/assumptions_on_binders/alias_outlives.stderr
+++ b/tests/ui/assumptions_on_binders/alias_outlives.stderr
@@ -23,3 +23,4 @@ LL |     let _: ReqTrait<U::Assoc>;
    |            ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
+

--- a/tests/ui/assumptions_on_binders/higher-ranked-outlives-issue-157732.rs
+++ b/tests/ui/assumptions_on_binders/higher-ranked-outlives-issue-157732.rs
@@ -1,0 +1,12 @@
+//@ compile-flags: -Zassumptions-on-binders -Znext-solver=globally
+
+fn foo<'a>(_a: &'a u32)
+where
+    for<'b> &'b (): 'a,
+{
+}
+
+fn main() {
+    foo(&10);
+    //~^ ERROR: higher-ranked lifetime bound could not be satisfied
+}

--- a/tests/ui/assumptions_on_binders/higher-ranked-outlives-issue-157732.stderr
+++ b/tests/ui/assumptions_on_binders/higher-ranked-outlives-issue-157732.stderr
@@ -1,0 +1,8 @@
+error: higher-ranked lifetime bound could not be satisfied
+  --> $DIR/higher-ranked-outlives-issue-157732.rs:10:5
+   |
+LL |     foo(&10);
+   |     ^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/attributes/align-on-fields-143987.stderr
+++ b/tests/ui/attributes/align-on-fields-143987.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find type `usize8` in this scope
   --> $DIR/align-on-fields-143987.rs:17:8
    |
 LL |     x: usize8,
-   |        ^^^^^^
+   |        ^^^^^^ not found in this scope
    |
 help: a builtin type with a similar name exists
    |

--- a/tests/ui/c-variadic/issue-86053-1.stderr
+++ b/tests/ui/c-variadic/issue-86053-1.stderr
@@ -58,11 +58,10 @@ error[E0425]: cannot find type `F` in this scope
   --> $DIR/issue-86053-1.rs:10:54
    |
 LL |     self , _: ... ,   self ,   self , _: ... ) where F : FnOnce ( & 'a & 'b usize ) {
-   |                                                      ^
+   |                                                      ^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL |     self , _: ... ,   self ,   self , _: ... ) where Fn : FnOnce ( & 'a & 'b usize ) {

--- a/tests/ui/closures/issue-78720.stderr
+++ b/tests/ui/closures/issue-78720.stderr
@@ -8,11 +8,10 @@ error[E0425]: cannot find type `F` in this scope
   --> $DIR/issue-78720.rs:14:12
    |
 LL |     _func: F,
-   |            ^
+   |            ^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL |     _func: Fn,

--- a/tests/ui/closures/issue-90871.stderr
+++ b/tests/ui/closures/issue-90871.stderr
@@ -2,11 +2,10 @@ error[E0425]: cannot find type `n` in this scope
   --> $DIR/issue-90871.rs:4:22
    |
 LL |     type_ascribe!(2, n([u8; || 1]))
-   |                      ^
+   |                      ^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL |     type_ascribe!(2, Fn([u8; || 1]))

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
@@ -7,11 +7,14 @@ LL |     f1: extern "cmse-nonsecure-call" fn<U: Copy>(U, u32, u32, u32) -> u64,
 error[E0425]: cannot find type `U` in this scope
   --> $DIR/generics.rs:15:50
    |
-LL | struct Test<T: Copy> {
-   |             - similarly named type parameter `T` defined here
 LL |     f1: extern "cmse-nonsecure-call" fn<U: Copy>(U, u32, u32, u32) -> u64,
-   |                                                  ^
+   |                                                  ^ not found in this scope
    |
+note: similarly named type parameter `T` defined here
+  --> $DIR/generics.rs:14:13
+   |
+LL | struct Test<T: Copy> {
+   |             ^
 help: a type parameter with a similar name exists
    |
 LL -     f1: extern "cmse-nonsecure-call" fn<U: Copy>(U, u32, u32, u32) -> u64,

--- a/tests/ui/compiletest-self-test/ui-testing-optout.stderr
+++ b/tests/ui/compiletest-self-test/ui-testing-optout.stderr
@@ -7,12 +7,14 @@ error[E0425]: cannot find type `B` in this scope
 error[E0425]: cannot find type `D` in this scope
  --> $DIR/ui-testing-optout.rs:7:10
   |
-4 | type A = B;
-  | ----------- similarly named type alias `A` defined here
-...
 7 | type C = D;
-  |          ^
+  |          ^ not found in this scope
   |
+note: similarly named type alias `A` defined here
+ --> $DIR/ui-testing-optout.rs:4:1
+  |
+4 | type A = B;
+  | ^^^^^^^^^^^
 help: a type alias with a similar name exists
   |
 7 - type C = D;
@@ -22,12 +24,14 @@ help: a type alias with a similar name exists
 error[E0425]: cannot find type `F` in this scope
   --> $DIR/ui-testing-optout.rs:92:10
    |
- 4 | type A = B;
-   | ----------- similarly named type alias `A` defined here
-...
 92 | type E = F;
-   |          ^
+   |          ^ not found in this scope
    |
+note: similarly named type alias `A` defined here
+  --> $DIR/ui-testing-optout.rs:4:1
+   |
+ 4 | type A = B;
+   | ^^^^^^^^^^^
 help: a type alias with a similar name exists
    |
 92 - type E = F;

--- a/tests/ui/const-generics/allow-self-in-const-generics.rs
+++ b/tests/ui/const-generics/allow-self-in-const-generics.rs
@@ -1,0 +1,36 @@
+// Allow Self in const generics when Self doesn't depends on generics(#149203)
+#![feature(min_adt_const_params)]
+
+//1
+trait MyTrait {
+    fn foo<const N: i32>();
+}
+
+impl MyTrait for i32 {
+    fn foo<const N: Self>() {}
+}
+
+//2
+impl<T> Wrap<T> {
+    fn f<const N: Self>() {}
+    //~^ ERROR the type of const parameters must not depend on other generic parameters
+
+}
+struct Wrap<T>(T);
+
+//3
+type Foo<const N: usize> = Bar;
+
+#[derive(Eq, PartialEq, core::marker::ConstParamTy)]
+struct Bar;
+
+trait Trait<const N: usize> {
+    fn bar<const C: Bar>();
+}
+
+impl<const N: usize> Trait<N> for Foo<N> {
+    fn bar<const C: Self>() {}
+    // FIXME: currently the compiler let this pass
+    // https://github.com/rust-lang/rust/pull/157949#discussion_r3544858218
+}
+fn main(){}

--- a/tests/ui/const-generics/allow-self-in-const-generics.stderr
+++ b/tests/ui/const-generics/allow-self-in-const-generics.stderr
@@ -1,0 +1,9 @@
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/allow-self-in-const-generics.rs:15:19
+   |
+LL |     fn f<const N: Self>() {}
+   |                   ^^^^ the type `Wrap<T>` must not depend on other generic parameter
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0770`.

--- a/tests/ui/const-generics/ban-self-when-feature-not-enabled.rs
+++ b/tests/ui/const-generics/ban-self-when-feature-not-enabled.rs
@@ -1,0 +1,13 @@
+// Ban Self in const generics when min_adt_const_params and adt_const_params are not enabled
+// #149203
+trait MyTrait {
+    fn foo<const N: i32>();
+}
+
+impl MyTrait for i32 {
+    fn foo<const N: Self>() {}
+    //~^ ERROR cannot use `Self` in const parameter type
+    //~| ERROR associated function `foo` has an incompatible generic parameter for trait `MyTrait`
+}
+
+fn main(){}

--- a/tests/ui/const-generics/ban-self-when-feature-not-enabled.stderr
+++ b/tests/ui/const-generics/ban-self-when-feature-not-enabled.stderr
@@ -1,0 +1,24 @@
+error: cannot use `Self` in const parameter type
+  --> $DIR/ban-self-when-feature-not-enabled.rs:8:21
+   |
+LL |     fn foo<const N: Self>() {}
+   |                     ^^^^
+   |
+   = help: add `#![feature(min_adt_const_params)]` to the crate attributes to enable `Self` as a const parameter type
+
+error[E0053]: associated function `foo` has an incompatible generic parameter for trait `MyTrait`
+  --> $DIR/ban-self-when-feature-not-enabled.rs:8:12
+   |
+LL | trait MyTrait {
+   |       -------
+LL |     fn foo<const N: i32>();
+   |            ------------ expected const parameter of type `i32`
+...
+LL | impl MyTrait for i32 {
+   | --------------------
+LL |     fn foo<const N: Self>() {}
+   |            ^^^^^^^^^^^^^ found const parameter of type `{type error}`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0053`.

--- a/tests/ui/const-generics/generic_const_exprs/error_in_ty.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/error_in_ty.stderr
@@ -2,10 +2,13 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/error_in_ty.rs:6:31
    |
 LL | pub struct A<const z: [usize; x]> {}
-   |                    -          ^
-   |                    |
-   |                    similarly named const parameter `z` defined here
+   |                               ^ not found in this scope
    |
+note: similarly named const parameter `z` defined here
+  --> $DIR/error_in_ty.rs:6:20
+   |
+LL | pub struct A<const z: [usize; x]> {}
+   |                    ^
 help: a const parameter with a similar name exists
    |
 LL - pub struct A<const z: [usize; x]> {}

--- a/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
@@ -2,11 +2,10 @@ error[E0425]: cannot find type `F` in this scope
   --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:11:17
    |
 LL |          let f: F = async { 1 };
-   |                 ^
+   |                 ^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL |          let f: Fn = async { 1 };

--- a/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
@@ -19,12 +19,14 @@ LL |     const v0: [[usize; v4]; v4] = v6(v8);
 error[E0425]: cannot find type `v18` in this scope
   --> $DIR/unevaluated-const-ice-119731.rs:23:31
    |
-LL |     pub type v11 = [[usize; v4]; v4];
-   |     --------------------------------- similarly named type alias `v11` defined here
-...
 LL |         pub const fn v21() -> v18 {}
-   |                               ^^^
+   |                               ^^^ not found in this scope
    |
+note: similarly named type alias `v11` defined here
+  --> $DIR/unevaluated-const-ice-119731.rs:9:5
+   |
+LL |     pub type v11 = [[usize; v4]; v4];
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a type alias with a similar name exists
    |
 LL -         pub const fn v21() -> v18 {}
@@ -34,12 +36,14 @@ LL +         pub const fn v21() -> v11 {}
 error[E0425]: cannot find type `v18` in this scope
   --> $DIR/unevaluated-const-ice-119731.rs:35:31
    |
-LL |     pub type v11 = [[usize; v4]; v4];
-   |     --------------------------------- similarly named type alias `v11` defined here
-...
 LL |         pub const fn v21() -> v18 {
-   |                               ^^^
+   |                               ^^^ not found in this scope
    |
+note: similarly named type alias `v11` defined here
+  --> $DIR/unevaluated-const-ice-119731.rs:9:5
+   |
+LL |     pub type v11 = [[usize; v4]; v4];
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a type alias with a similar name exists
    |
 LL -         pub const fn v21() -> v18 {
@@ -49,12 +53,14 @@ LL +         pub const fn v21() -> v11 {
 error[E0422]: cannot find struct, variant or union type `v18` in this scope
   --> $DIR/unevaluated-const-ice-119731.rs:37:13
    |
-LL |     pub type v11 = [[usize; v4]; v4];
-   |     --------------------------------- similarly named type alias `v11` defined here
-...
 LL |             v18 { _p: () }
-   |             ^^^
+   |             ^^^ not found in this scope
    |
+note: similarly named type alias `v11` defined here
+  --> $DIR/unevaluated-const-ice-119731.rs:9:5
+   |
+LL |     pub type v11 = [[usize; v4]; v4];
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a type alias with a similar name exists
    |
 LL -             v18 { _p: () }

--- a/tests/ui/const-generics/mgca/adt_expr_erroneuous_inits.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_erroneuous_inits.stderr
@@ -1,12 +1,14 @@
 error[E0422]: cannot find struct, variant or union type `Fooo` in this scope
   --> $DIR/adt_expr_erroneuous_inits.rs:20:17
    |
-LL | struct Foo<T> { field: T }
-   | ------------- similarly named struct `Foo` defined here
-...
 LL |     accepts::<{ Fooo::<u8> { field: const { 1 } }}>();
-   |                 ^^^^
+   |                 ^^^^ not found in this scope
    |
+note: similarly named struct `Foo` defined here
+  --> $DIR/adt_expr_erroneuous_inits.rs:9:1
+   |
+LL | struct Foo<T> { field: T }
+   | ^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL -     accepts::<{ Fooo::<u8> { field: const { 1 } }}>();

--- a/tests/ui/const-generics/mgca/projection-error.stderr
+++ b/tests/ui/const-generics/mgca/projection-error.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find type `T` in this scope
   --> $DIR/projection-error.rs:12:17
    |
-LL | pub trait Tr<A> {
-   | --------------- similarly named trait `Tr` defined here
-...
 LL | fn mk_array(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
-   |                 ^
+   |                 ^ not found in this scope
    |
+note: similarly named trait `Tr` defined here
+  --> $DIR/projection-error.rs:8:1
+   |
+LL | pub trait Tr<A> {
+   | ^^^^^^^^^^^^^^^
 help: a trait with a similar name exists
    |
 LL | fn mk_array(_x: Tr) -> [(); <T as Tr<bool>>::SIZE] {}
@@ -19,12 +21,14 @@ LL | fn mk_array<T>(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
 error[E0425]: cannot find type `T` in this scope
   --> $DIR/projection-error.rs:12:29
    |
-LL | pub trait Tr<A> {
-   | --------------- similarly named trait `Tr` defined here
-...
 LL | fn mk_array(_x: T) -> [(); <T as Tr<bool>>::SIZE] {}
-   |                             ^
+   |                             ^ not found in this scope
    |
+note: similarly named trait `Tr` defined here
+  --> $DIR/projection-error.rs:8:1
+   |
+LL | pub trait Tr<A> {
+   | ^^^^^^^^^^^^^^^
 help: a trait with a similar name exists
    |
 LL | fn mk_array(_x: T) -> [(); <Tr as Tr<bool>>::SIZE] {}

--- a/tests/ui/const-generics/mgca/unused_speculative_def_id.stderr
+++ b/tests/ui/const-generics/mgca/unused_speculative_def_id.stderr
@@ -2,11 +2,10 @@ error[E0425]: cannot find value `ERR` in this scope
   --> $DIR/unused_speculative_def_id.rs:20:16
    |
 LL |     field: A<{ ERR::<const { 1 }> }>,
-   |                ^^^
+   |                ^^^ not found in this scope
    |
+note: similarly named tuple variant `Err` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named tuple variant `Err` defined here
 help: a tuple variant with a similar name exists
    |
 LL -     field: A<{ ERR::<const { 1 }> }>,

--- a/tests/ui/const-generics/parent_generics_of_nested_in_default.stderr
+++ b/tests/ui/const-generics/parent_generics_of_nested_in_default.stderr
@@ -8,10 +8,13 @@ error[E0425]: cannot find value `B` in this scope
   --> $DIR/parent_generics_of_nested_in_default.rs:1:30
    |
 LL | impl<const A: i32 = { || [0; B] }> Tr {}
-   |            -                 ^
-   |            |
-   |            similarly named const parameter `A` defined here
+   |                              ^ not found in this scope
    |
+note: similarly named const parameter `A` defined here
+  --> $DIR/parent_generics_of_nested_in_default.rs:1:12
+   |
+LL | impl<const A: i32 = { || [0; B] }> Tr {}
+   |            ^
 help: a const parameter with a similar name exists
    |
 LL - impl<const A: i32 = { || [0; B] }> Tr {}

--- a/tests/ui/consts/const-eval/ice-unhandled-type-122191.stderr
+++ b/tests/ui/consts/const-eval/ice-unhandled-type-122191.stderr
@@ -22,11 +22,13 @@ error[E0425]: cannot find function `value` in this scope
   --> $DIR/ice-unhandled-type-122191.rs:9:5
    |
 LL |     value()
-   |     ^^^^^
-...
-LL | const VALUE: Foo = foo();
-   | ------------------------- similarly named constant `VALUE` defined here
+   |     ^^^^^ not found in this scope
    |
+note: similarly named constant `VALUE` defined here
+  --> $DIR/ice-unhandled-type-122191.rs:13:1
+   |
+LL | const VALUE: Foo = foo();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists
    |
 LL -     value()

--- a/tests/ui/consts/const-pattern-rewrite-error-32086.stderr
+++ b/tests/ui/consts/const-pattern-rewrite-error-32086.stderr
@@ -1,12 +1,14 @@
 error[E0532]: expected tuple struct or tuple variant, found constant `C`
   --> $DIR/const-pattern-rewrite-error-32086.rs:6:9
    |
-LL | struct S(u8);
-   | ------------- similarly named tuple struct `S` defined here
-...
 LL |     let C(a) = S(11);
-   |         ^
+   |         ^ not a tuple struct or tuple variant
    |
+note: similarly named tuple struct `S` defined here
+  --> $DIR/const-pattern-rewrite-error-32086.rs:2:1
+   |
+LL | struct S(u8);
+   | ^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL -     let C(a) = S(11);
@@ -16,12 +18,14 @@ LL +     let S(a) = S(11);
 error[E0532]: expected tuple struct or tuple variant, found constant `C`
   --> $DIR/const-pattern-rewrite-error-32086.rs:7:9
    |
-LL | struct S(u8);
-   | ------------- similarly named tuple struct `S` defined here
-...
 LL |     let C(..) = S(11);
-   |         ^
+   |         ^ not a tuple struct or tuple variant
    |
+note: similarly named tuple struct `S` defined here
+  --> $DIR/const-pattern-rewrite-error-32086.rs:2:1
+   |
+LL | struct S(u8);
+   | ^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL -     let C(..) = S(11);

--- a/tests/ui/consts/ice-bad-input-type-for-cast-83056.stderr
+++ b/tests/ui/consts/ice-bad-input-type-for-cast-83056.stderr
@@ -1,11 +1,14 @@
 error[E0425]: cannot find type `T` in this scope
   --> $DIR/ice-bad-input-type-for-cast-83056.rs:5:11
    |
-LL | struct S([bool; f as usize]);
-   | ----------------------------- similarly named struct `S` defined here
 LL | fn f() -> T {}
-   |           ^
+   |           ^ not found in this scope
    |
+note: similarly named struct `S` defined here
+  --> $DIR/ice-bad-input-type-for-cast-83056.rs:4:1
+   |
+LL | struct S([bool; f as usize]);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - fn f() -> T {}

--- a/tests/ui/consts/ice-extra-args-fn-abi-issue-127423.stderr
+++ b/tests/ui/consts/ice-extra-args-fn-abi-issue-127423.stderr
@@ -25,7 +25,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/ice-extra-args-fn-abi-issue-127423.rs:8:11
    |
 LL |     Qux + y
-   |           ^
+   |           ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/delegation/bad-resolve.stderr
+++ b/tests/ui/delegation/bad-resolve.stderr
@@ -51,12 +51,14 @@ LL |     reuse <F as Trait>::Type;
 error[E0576]: cannot find method or associated constant `baz` in trait `Trait`
   --> $DIR/bad-resolve.rs:29:25
    |
-LL |     fn bar() {}
-   |     -------- similarly named associated function `bar` defined here
-...
 LL |     reuse <F as Trait>::baz;
-   |                         ^^^
+   |                         ^^^ not found in `Trait`
    |
+note: similarly named associated function `bar` defined here
+  --> $DIR/bad-resolve.rs:6:5
+   |
+LL |     fn bar() {}
+   |     ^^^^^^^^
 help: an associated function with a similar name exists
    |
 LL -     reuse <F as Trait>::baz;
@@ -72,12 +74,14 @@ LL |     reuse foo { &self.0 }
 error[E0425]: cannot find function `foo2` in trait `Trait`
   --> $DIR/bad-resolve.rs:37:18
    |
-LL |     fn foo(&self, x: i32) -> i32 { x }
-   |     ---------------------------- similarly named associated function `foo` defined here
-...
 LL |     reuse Trait::foo2 { self.0 }
-   |                  ^^^^
+   |                  ^^^^ not found in `Trait`
    |
+note: similarly named associated function `foo` defined here
+  --> $DIR/bad-resolve.rs:7:5
+   |
+LL |     fn foo(&self, x: i32) -> i32 { x }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: an associated function with a similar name exists
    |
 LL -     reuse Trait::foo2 { self.0 }

--- a/tests/ui/derives/deriving-meta-unknown-trait.stderr
+++ b/tests/ui/derives/deriving-meta-unknown-trait.stderr
@@ -4,9 +4,8 @@ error: cannot find derive macro `Eqr` in this scope
 LL | #[derive(Eqr)]
    |          ^^^
    |
+note: similarly named derive macro `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named derive macro `Eq` defined here
 help: a derive macro with a similar name exists
    |
 LL - #[derive(Eqr)]
@@ -19,10 +18,8 @@ error: cannot find derive macro `Eqr` in this scope
 LL | #[derive(Eqr)]
    |          ^^^
    |
+note: similarly named derive macro `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named derive macro `Eq` defined here
-   |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: a derive macro with a similar name exists
    |

--- a/tests/ui/diagnostic_namespace/on_unknown/late_res.rs
+++ b/tests/ui/diagnostic_namespace/on_unknown/late_res.rs
@@ -12,16 +12,40 @@ fn stuff(x: u32) {
     match x {
         empty::blah => {}
         //~^ ERROR it works `empty` `blah` [E0531]
+        //~| NOTE cannot find unit struct, unit variant or constant `blah` in module `empty`
+        //~| NOTE label it works
+        //~| NOTE note it works
         _ => {}
     }
 
     println!("{}", empty::blah);
     //~^ ERROR it works `empty` `blah` [E0425]
+    //~| NOTE cannot find value `blah` in module `empty`
+    //~| NOTE label it works
+    //~| NOTE note it works
 
     let x = [
         empty::blah,
         //~^ ERROR it works `empty` `blah` [E0425]
+        //~| NOTE cannot find value `blah` in module `empty`
+        //~| NOTE label it works
+        //~| NOTE note it works
         empty::blah2,
         //~^ ERROR it works `empty` `blah2` [E0425]
+        //~| NOTE cannot find value `blah2` in module `empty`
+        //~| NOTE label it works
+        //~| NOTE note it works
     ];
 }
+
+#[diagnostic::on_unknown(message = "message", label = "label", note = "note")]
+mod x {
+    const WHAT: u32 = 1;
+    //~^ NOTE similarly named constant `WHAT` defined here
+
+}
+const X: u32 = x::WAHT;
+//~^ ERROR message
+//~| NOTE note
+//~| NOTE label
+//~| NOTE cannot find value `WAHT` in module `x`

--- a/tests/ui/diagnostic_namespace/on_unknown/late_res.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/late_res.stderr
@@ -8,7 +8,7 @@ LL |         empty::blah => {}
    = note: note it works
 
 error[E0425]: it works `empty` `blah`
-  --> $DIR/late_res.rs:18:27
+  --> $DIR/late_res.rs:21:27
    |
 LL |     println!("{}", empty::blah);
    |                           ^^^^ label it works
@@ -17,7 +17,7 @@ LL |     println!("{}", empty::blah);
    = note: note it works
 
 error[E0425]: it works `empty` `blah`
-  --> $DIR/late_res.rs:22:16
+  --> $DIR/late_res.rs:28:16
    |
 LL |         empty::blah,
    |                ^^^^ label it works
@@ -26,7 +26,7 @@ LL |         empty::blah,
    = note: note it works
 
 error[E0425]: it works `empty` `blah2`
-  --> $DIR/late_res.rs:24:16
+  --> $DIR/late_res.rs:33:16
    |
 LL |         empty::blah2,
    |                ^^^^^ label it works
@@ -34,7 +34,26 @@ LL |         empty::blah2,
    = note: cannot find value `blah2` in module `empty`
    = note: note it works
 
-error: aborting due to 4 previous errors
+error[E0425]: message
+  --> $DIR/late_res.rs:47:19
+   |
+LL | const X: u32 = x::WAHT;
+   |                   ^^^^ label
+   |
+   = note: cannot find value `WAHT` in module `x`
+   = note: note
+note: similarly named constant `WHAT` defined here
+  --> $DIR/late_res.rs:43:5
+   |
+LL |     const WHAT: u32 = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^
+help: a constant with a similar name exists
+   |
+LL - const X: u32 = x::WAHT;
+LL + const X: u32 = x::WHAT;
+   |
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0425, E0531.
 For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/did_you_mean/println-typo.stderr
+++ b/tests/ui/did_you_mean/println-typo.stderr
@@ -4,9 +4,8 @@ error: cannot find macro `prinltn` in this scope
 LL |     prinltn!();
    |     ^^^^^^^
    |
+note: similarly named macro `println` defined here
   --> $SRC_DIR/std/src/macros.rs:LL:COL
-   |
-   = note: similarly named macro `println` defined here
 help: a macro with a similar name exists
    |
 LL -     prinltn!();

--- a/tests/ui/did_you_mean/typo-suggestion-improvement-46332.stderr
+++ b/tests/ui/did_you_mean/typo-suggestion-improvement-46332.stderr
@@ -1,12 +1,14 @@
 error[E0422]: cannot find struct, variant or union type `TyUInt` in this scope
   --> $DIR/typo-suggestion-improvement-46332.rs:10:5
    |
-LL | struct TyUint {}
-   | ------------- similarly named struct `TyUint` defined here
-...
 LL |     TyUInt {};
-   |     ^^^^^^
+   |     ^^^^^^ not found in this scope
    |
+note: similarly named struct `TyUint` defined here
+  --> $DIR/typo-suggestion-improvement-46332.rs:5:1
+   |
+LL | struct TyUint {}
+   | ^^^^^^^^^^^^^
 help: a struct with a similar name exists (notice the capitalization)
    |
 LL -     TyUInt {};

--- a/tests/ui/error-codes/E0423.stderr
+++ b/tests/ui/error-codes/E0423.stderr
@@ -46,11 +46,13 @@ LL |     struct Foo { a: bool };
 LL |
 LL |     let f = Foo();
    |             ^^^^^
-...
-LL | fn foo() {
-   | -------- similarly named function `foo` defined here
    |
    = note: a struct named `Foo` exists in another namespace
+note: similarly named function `foo` defined here
+  --> $DIR/E0423.rs:19:1
+   |
+LL | fn foo() {
+   | ^^^^^^^^
 help: use struct literal syntax instead
    |
 LL -     let f = Foo();

--- a/tests/ui/expr/if/bad-if-let-suggestion.stderr
+++ b/tests/ui/expr/if/bad-if-let-suggestion.stderr
@@ -17,12 +17,14 @@ LL |     if let x = 1 && i == 2 {}
 error[E0425]: cannot find value `i` in this scope
   --> $DIR/bad-if-let-suggestion.rs:7:9
    |
-LL | fn a() {
-   | ------ similarly named function `a` defined here
-...
 LL |     if (i + j) = i {}
-   |         ^
+   |         ^ not found in this scope
    |
+note: similarly named function `a` defined here
+  --> $DIR/bad-if-let-suggestion.rs:1:1
+   |
+LL | fn a() {
+   | ^^^^^^
 help: a function with a similar name exists
    |
 LL -     if (i + j) = i {}
@@ -32,12 +34,14 @@ LL +     if (a + j) = i {}
 error[E0425]: cannot find value `j` in this scope
   --> $DIR/bad-if-let-suggestion.rs:7:13
    |
-LL | fn a() {
-   | ------ similarly named function `a` defined here
-...
 LL |     if (i + j) = i {}
-   |             ^
+   |             ^ not found in this scope
    |
+note: similarly named function `a` defined here
+  --> $DIR/bad-if-let-suggestion.rs:1:1
+   |
+LL | fn a() {
+   | ^^^^^^
 help: a function with a similar name exists
    |
 LL -     if (i + j) = i {}
@@ -47,12 +51,14 @@ LL +     if (i + a) = i {}
 error[E0425]: cannot find value `i` in this scope
   --> $DIR/bad-if-let-suggestion.rs:7:18
    |
-LL | fn a() {
-   | ------ similarly named function `a` defined here
-...
 LL |     if (i + j) = i {}
-   |                  ^
+   |                  ^ not found in this scope
    |
+note: similarly named function `a` defined here
+  --> $DIR/bad-if-let-suggestion.rs:1:1
+   |
+LL | fn a() {
+   | ^^^^^^
 help: a function with a similar name exists
    |
 LL -     if (i + j) = i {}
@@ -62,12 +68,14 @@ LL +     if (i + j) = a {}
 error[E0425]: cannot find value `x` in this scope
   --> $DIR/bad-if-let-suggestion.rs:14:8
    |
-LL | fn a() {
-   | ------ similarly named function `a` defined here
-...
 LL |     if x[0] = 1 {}
-   |        ^
+   |        ^ not found in this scope
    |
+note: similarly named function `a` defined here
+  --> $DIR/bad-if-let-suggestion.rs:1:1
+   |
+LL | fn a() {
+   | ^^^^^^
 help: a function with a similar name exists
    |
 LL -     if x[0] = 1 {}

--- a/tests/ui/fmt/format-args-capture-issue-102057.stderr
+++ b/tests/ui/fmt/format-args-capture-issue-102057.stderr
@@ -14,7 +14,7 @@ error[E0425]: cannot find value `b` in this scope
   --> $DIR/format-args-capture-issue-102057.rs:9:22
    |
 LL |     format!("\x7Ba} {b}");
-   |                      ^
+   |                      ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -26,7 +26,7 @@ error[E0425]: cannot find value `b` in this scope
   --> $DIR/format-args-capture-issue-102057.rs:11:25
    |
 LL |     format!("\x7Ba\x7D {b}");
-   |                         ^
+   |                         ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -38,7 +38,7 @@ error[E0425]: cannot find value `b` in this scope
   --> $DIR/format-args-capture-issue-102057.rs:13:25
    |
 LL |     format!("\x7Ba} \x7Bb}");
-   |                         ^
+   |                         ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -50,7 +50,7 @@ error[E0425]: cannot find value `b` in this scope
   --> $DIR/format-args-capture-issue-102057.rs:15:28
    |
 LL |     format!("\x7Ba\x7D \x7Bb}");
-   |                            ^
+   |                            ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -62,7 +62,7 @@ error[E0425]: cannot find value `b` in this scope
   --> $DIR/format-args-capture-issue-102057.rs:17:28
    |
 LL |     format!("\x7Ba\x7D \x7Bb\x7D");
-   |                            ^
+   |                            ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/fmt/format-args-capture-issue-94010.stderr
+++ b/tests/ui/fmt/format-args-capture-issue-94010.stderr
@@ -1,11 +1,14 @@
 error[E0425]: cannot find value `foo` in this scope
   --> $DIR/format-args-capture-issue-94010.rs:3:16
    |
-LL |     const FOO: i32 = 123;
-   |     --------------------- similarly named constant `FOO` defined here
 LL |     println!("{foo:X}");
-   |                ^^^
+   |                ^^^ not found in this scope
    |
+note: similarly named constant `FOO` defined here
+  --> $DIR/format-args-capture-issue-94010.rs:2:5
+   |
+LL |     const FOO: i32 = 123;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists (notice the capitalization)
    |
 LL -     println!("{foo:X}");
@@ -15,12 +18,14 @@ LL +     println!("{FOO:X}");
 error[E0425]: cannot find value `foo` in this scope
   --> $DIR/format-args-capture-issue-94010.rs:5:18
    |
-LL |     const FOO: i32 = 123;
-   |     --------------------- similarly named constant `FOO` defined here
-...
 LL |     println!("{:.foo$}", 0);
-   |                  ^^^
+   |                  ^^^ not found in this scope
    |
+note: similarly named constant `FOO` defined here
+  --> $DIR/format-args-capture-issue-94010.rs:2:5
+   |
+LL |     const FOO: i32 = 123;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists (notice the capitalization)
    |
 LL -     println!("{:.foo$}", 0);

--- a/tests/ui/fn/fn-ptr-pattern.stderr
+++ b/tests/ui/fn/fn-ptr-pattern.stderr
@@ -198,11 +198,13 @@ error[E0425]: cannot find type `NoThing` in this scope
   --> $DIR/fn-ptr-pattern.rs:19:32
    |
 LL |     pat4: fn(NoThing { a, b }: NoThing),
-   |                                ^^^^^^^
-...
-LL | struct Thing { a: bool, b: bool }
-   | ------------ similarly named struct `Thing` defined here
+   |                                ^^^^^^^ not found in this scope
    |
+note: similarly named struct `Thing` defined here
+  --> $DIR/fn-ptr-pattern.rs:75:1
+   |
+LL | struct Thing { a: bool, b: bool }
+   | ^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL -     pat4: fn(NoThing { a, b }: NoThing),

--- a/tests/ui/hygiene/globs.stderr
+++ b/tests/ui/hygiene/globs.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find function `f` in this scope
   --> $DIR/globs.rs:23:9
    |
-LL |     pub fn g() {}
-   |     ---------- similarly named function `g` defined here
-...
 LL |         f();
-   |         ^
+   |         ^ not found in this scope
    |
+note: similarly named function `g` defined here
+  --> $DIR/globs.rs:9:5
+   |
+LL |     pub fn g() {}
+   |     ^^^^^^^^^^
 help: a function with a similar name exists
    |
 LL -         f();
@@ -20,11 +22,8 @@ LL + use foo::f;
 error[E0425]: cannot find function `g` in this scope
   --> $DIR/globs.rs:16:5
    |
-LL |       pub fn f() {}
-   |       ---------- similarly named function `f` defined here
-...
 LL |       g();
-   |       ^
+   |       ^ not found in this scope
 ...
 LL | /     m! {
 LL | |         use bar::*;
@@ -33,6 +32,11 @@ LL | |         f();
 LL | |     }
    | |_____- in this macro invocation
    |
+note: similarly named function `f` defined here
+  --> $DIR/globs.rs:5:5
+   |
+LL |     pub fn f() {}
+   |     ^^^^^^^^^^
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a function with a similar name exists
    |

--- a/tests/ui/hygiene/rustc-macro-transparency.stderr
+++ b/tests/ui/hygiene/rustc-macro-transparency.stderr
@@ -7,13 +7,19 @@ LL |     Opaque;
 error[E0423]: cannot find value `semiopaque` in this scope
   --> $DIR/rustc-macro-transparency.rs:29:5
    |
-LL |     struct SemiOpaque;
-   |     ------------------ similarly named unit struct `SemiOpaque` defined here
-...
 LL |     semiopaque;
    |     ^^^^^^^^^^ not found in this scope
    |
    = note: a macro named `semiopaque` exists in another namespace
+note: similarly named unit struct `SemiOpaque` defined here
+  --> $DIR/rustc-macro-transparency.rs:10:5
+   |
+LL |     struct SemiOpaque;
+   |     ^^^^^^^^^^^^^^^^^^
+...
+LL |     semiopaque!();
+   |     ------------- in this macro invocation
+   = note: this error originates in the macro `semiopaque` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a unit struct with a similar name exists (notice the capitalization)
    |
 LL -     semiopaque;

--- a/tests/ui/impl-restriction/restriction_resolution_errors.stderr
+++ b/tests/ui/impl-restriction/restriction_resolution_errors.stderr
@@ -47,12 +47,14 @@ LL |         pub impl(in super::G) trait L2 {}
 error[E0577]: expected module, found enum `crate::a::E`
   --> $DIR/restriction_resolution_errors.rs:51:13
    |
-LL |     pub mod b {
-   |     --------- similarly named module `b` defined here
-...
 LL | pub impl(in crate::a::E) trait T14 {}
-   |             ^^^^^^^^^^^
+   |             ^^^^^^^^^^^ not a module
    |
+note: similarly named module `b` defined here
+  --> $DIR/restriction_resolution_errors.rs:9:5
+   |
+LL |     pub mod b {
+   |     ^^^^^^^^^
 help: a module with a similar name exists
    |
 LL - pub impl(in crate::a::E) trait T14 {}
@@ -62,12 +64,14 @@ LL + pub impl(in crate::a::b) trait T14 {}
 error[E0577]: expected module, found enum `crate::I`
   --> $DIR/restriction_resolution_errors.rs:63:13
    |
-LL | pub mod a {
-   | --------- similarly named module `a` defined here
-...
 LL | pub impl(in crate::I) trait L5 {}
-   |             ^^^^^^^^
+   |             ^^^^^^^^ not a module
    |
+note: similarly named module `a` defined here
+  --> $DIR/restriction_resolution_errors.rs:6:1
+   |
+LL | pub mod a {
+   | ^^^^^^^^^
 help: a module with a similar name exists
    |
 LL - pub impl(in crate::I) trait L5 {}

--- a/tests/ui/imports/glob-resolve1.stderr
+++ b/tests/ui/imports/glob-resolve1.stderr
@@ -72,12 +72,14 @@ LL + use other::import;
 error[E0425]: cannot find type `A` in this scope
   --> $DIR/glob-resolve1.rs:33:11
    |
-LL |     pub enum B {
-   |     ---------- similarly named enum `B` defined here
-...
 LL |     foo::<A>();
-   |           ^
+   |           ^ not found in this scope
    |
+note: similarly named enum `B` defined here
+  --> $DIR/glob-resolve1.rs:15:5
+   |
+LL |     pub enum B {
+   |     ^^^^^^^^^^
 note: enum `bar::A` exists but is inaccessible
   --> $DIR/glob-resolve1.rs:12:5
    |
@@ -92,12 +94,14 @@ LL +     foo::<B>();
 error[E0425]: cannot find type `C` in this scope
   --> $DIR/glob-resolve1.rs:34:11
    |
-LL |     pub enum B {
-   |     ---------- similarly named enum `B` defined here
-...
 LL |     foo::<C>();
-   |           ^
+   |           ^ not found in this scope
    |
+note: similarly named enum `B` defined here
+  --> $DIR/glob-resolve1.rs:15:5
+   |
+LL |     pub enum B {
+   |     ^^^^^^^^^^
 note: struct `bar::C` exists but is inaccessible
   --> $DIR/glob-resolve1.rs:19:5
    |
@@ -112,12 +116,14 @@ LL +     foo::<B>();
 error[E0425]: cannot find type `D` in this scope
   --> $DIR/glob-resolve1.rs:35:11
    |
-LL |     pub enum B {
-   |     ---------- similarly named enum `B` defined here
-...
 LL |     foo::<D>();
-   |           ^
+   |           ^ not found in this scope
    |
+note: similarly named enum `B` defined here
+  --> $DIR/glob-resolve1.rs:15:5
+   |
+LL |     pub enum B {
+   |     ^^^^^^^^^^
 note: type alias `bar::D` exists but is inaccessible
   --> $DIR/glob-resolve1.rs:21:5
    |

--- a/tests/ui/lint/recommend-literal.rs
+++ b/tests/ui/lint/recommend-literal.rs
@@ -1,5 +1,3 @@
-//~vv HELP consider importing this struct
-
 type Real = double;
 //~^ ERROR cannot find type `double` in this scope
 //~| HELP perhaps you intended to use this type
@@ -16,6 +14,7 @@ fn main() {
     //~^ ERROR: cannot find type `Bool` in this scope [E0425]
     //~| HELP a builtin type with a similar name exists
     //~| HELP perhaps you intended to use this type
+    //~| HELP: there is an enum variant `std::mem::type_info::TypeKind::Bool`; try using the variant's enum
 }
 
 fn z(a: boolean) {

--- a/tests/ui/lint/recommend-literal.stderr
+++ b/tests/ui/lint/recommend-literal.stderr
@@ -29,7 +29,7 @@ error[E0425]: cannot find type `Bool` in this scope
   --> $DIR/recommend-literal.rs:15:13
    |
 LL |     let v2: Bool = true;
-   |             ^^^^
+   |             ^^^^ not found in this scope
    |
 help: a builtin type with a similar name exists
    |

--- a/tests/ui/lint/recommend-literal.stderr
+++ b/tests/ui/lint/recommend-literal.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find type `double` in this scope
-  --> $DIR/recommend-literal.rs:3:13
+  --> $DIR/recommend-literal.rs:1:13
    |
 LL | type Real = double;
    |             ^^^^^^
@@ -8,7 +8,7 @@ LL | type Real = double;
    |             help: perhaps you intended to use this type: `f64`
 
 error[E0425]: cannot find type `long` in this scope
-  --> $DIR/recommend-literal.rs:9:12
+  --> $DIR/recommend-literal.rs:7:12
    |
 LL |     let y: long = 74802374902374923;
    |            ^^^^
@@ -17,7 +17,7 @@ LL |     let y: long = 74802374902374923;
    |            help: perhaps you intended to use this type: `i64`
 
 error[E0425]: cannot find type `Boolean` in this scope
-  --> $DIR/recommend-literal.rs:12:13
+  --> $DIR/recommend-literal.rs:10:13
    |
 LL |     let v1: Boolean = true;
    |             ^^^^^^^
@@ -26,10 +26,15 @@ LL |     let v1: Boolean = true;
    |             help: perhaps you intended to use this type: `bool`
 
 error[E0425]: cannot find type `Bool` in this scope
-  --> $DIR/recommend-literal.rs:15:13
+  --> $DIR/recommend-literal.rs:13:13
    |
 LL |     let v2: Bool = true;
    |             ^^^^
+   |
+help: there is an enum variant `std::mem::type_info::TypeKind::Bool`; try using the variant's enum
+   |
+LL -     let v2: Bool = true;
+LL +     let v2: std::mem::type_info::TypeKind = true;
    |
 help: a builtin type with a similar name exists
    |
@@ -41,13 +46,9 @@ help: perhaps you intended to use this type
 LL -     let v2: Bool = true;
 LL +     let v2: bool = true;
    |
-help: consider importing this struct
-   |
-LL + use std::mem::type_info::Bool;
-   |
 
 error[E0425]: cannot find type `boolean` in this scope
-  --> $DIR/recommend-literal.rs:21:9
+  --> $DIR/recommend-literal.rs:20:9
    |
 LL | fn z(a: boolean) {
    |         ^^^^^^^
@@ -56,7 +57,7 @@ LL | fn z(a: boolean) {
    |         help: perhaps you intended to use this type: `bool`
 
 error[E0425]: cannot find type `byte` in this scope
-  --> $DIR/recommend-literal.rs:26:11
+  --> $DIR/recommend-literal.rs:25:11
    |
 LL | fn a() -> byte {
    |           ^^^^
@@ -65,7 +66,7 @@ LL | fn a() -> byte {
    |           help: perhaps you intended to use this type: `u8`
 
 error[E0425]: cannot find type `float` in this scope
-  --> $DIR/recommend-literal.rs:33:12
+  --> $DIR/recommend-literal.rs:32:12
    |
 LL |     width: float,
    |            ^^^^^
@@ -74,7 +75,7 @@ LL |     width: float,
    |            help: perhaps you intended to use this type: `f32`
 
 error[E0425]: cannot find type `int` in this scope
-  --> $DIR/recommend-literal.rs:36:19
+  --> $DIR/recommend-literal.rs:35:19
    |
 LL |     depth: Option<int>,
    |                   ^^^ not found in this scope
@@ -90,7 +91,7 @@ LL | struct Data<int> {
    |            +++++
 
 error[E0425]: cannot find type `short` in this scope
-  --> $DIR/recommend-literal.rs:42:16
+  --> $DIR/recommend-literal.rs:41:16
    |
 LL | impl Stuff for short {}
    |                ^^^^^

--- a/tests/ui/macros/expand-full-no-resolution.stderr
+++ b/tests/ui/macros/expand-full-no-resolution.stderr
@@ -1,12 +1,18 @@
 error: cannot find macro `a` in this scope
   --> $DIR/expand-full-no-resolution.rs:18:18
    |
-LL |         macro_rules! _a {
-   |         --------------- similarly named macro `_a` defined here
-...
 LL |     format_args!(a!());
    |                  ^
    |
+note: similarly named macro `_a` defined here
+  --> $DIR/expand-full-no-resolution.rs:7:9
+   |
+LL |         macro_rules! _a {
+   |         ^^^^^^^^^^^^^^^
+...
+LL | wrap!();
+   | ------- in this macro invocation
+   = note: this error originates in the macro `wrap` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: the leading underscore in `_a` marks it as unused, consider renaming it to `a`
    |
 LL -         macro_rules! _a {
@@ -16,12 +22,18 @@ LL +         macro_rules! a {
 error: cannot find macro `a` in this scope
   --> $DIR/expand-full-no-resolution.rs:19:10
    |
-LL |         macro_rules! _a {
-   |         --------------- similarly named macro `_a` defined here
-...
 LL |     env!(a!());
    |          ^
    |
+note: similarly named macro `_a` defined here
+  --> $DIR/expand-full-no-resolution.rs:7:9
+   |
+LL |         macro_rules! _a {
+   |         ^^^^^^^^^^^^^^^
+...
+LL | wrap!();
+   | ------- in this macro invocation
+   = note: this error originates in the macro `wrap` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: the leading underscore in `_a` marks it as unused, consider renaming it to `a`
    |
 LL -         macro_rules! _a {

--- a/tests/ui/macros/macro-context.stderr
+++ b/tests/ui/macros/macro-context.stderr
@@ -46,7 +46,7 @@ error[E0425]: cannot find type `i` in this scope
   --> $DIR/macro-context.rs:3:13
    |
 LL |     () => ( i ; typeof );
-   |             ^
+   |             ^ not found in this scope
 ...
 LL |     let a: m!();
    |            ---- in this macro invocation

--- a/tests/ui/macros/macro-name-typo.stderr
+++ b/tests/ui/macros/macro-name-typo.stderr
@@ -4,9 +4,8 @@ error: cannot find macro `printlx` in this scope
 LL |     printlx!("oh noes!");
    |     ^^^^^^^
    |
+note: similarly named macro `println` defined here
   --> $SRC_DIR/std/src/macros.rs:LL:COL
-   |
-   = note: similarly named macro `println` defined here
 help: a macro with a similar name exists
    |
 LL -     printlx!("oh noes!");

--- a/tests/ui/macros/macro-path-prelude-fail-3.stderr
+++ b/tests/ui/macros/macro-path-prelude-fail-3.stderr
@@ -4,10 +4,8 @@ error: cannot find macro `inline` in this scope
 LL |     inline!();
    |     ^^^^^^
    |
+note: similarly named macro `line` defined here
   --> $SRC_DIR/core/src/macros/mod.rs:LL:COL
-   |
-   = note: similarly named macro `line` defined here
-   |
    = note: `inline` is in scope, but it is an attribute: `#[inline]`
 help: a macro with a similar name exists
    |

--- a/tests/ui/macros/macro-use-wrong-name.stderr
+++ b/tests/ui/macros/macro-use-wrong-name.stderr
@@ -4,11 +4,11 @@ error: cannot find macro `macro_two` in this scope
 LL |     macro_two!();
    |     ^^^^^^^^^
    |
-  ::: $DIR/auxiliary/two_macros.rs:2:1
+note: similarly named macro `macro_one` defined here
+  --> $DIR/auxiliary/two_macros.rs:2:1
    |
 LL | macro_rules! macro_one { () => ("one") }
-   | ---------------------- similarly named macro `macro_one` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^
 help: a macro with a similar name exists
    |
 LL -     macro_two!();

--- a/tests/ui/macros/macro_undefined.stderr
+++ b/tests/ui/macros/macro_undefined.stderr
@@ -1,12 +1,14 @@
 error: cannot find macro `k` in this scope
   --> $DIR/macro_undefined.rs:11:5
    |
-LL |     macro_rules! kl {
-   |     --------------- similarly named macro `kl` defined here
-...
 LL |     k!();
    |     ^
    |
+note: similarly named macro `kl` defined here
+  --> $DIR/macro_undefined.rs:5:5
+   |
+LL |     macro_rules! kl {
+   |     ^^^^^^^^^^^^^^^
 help: a macro with a similar name exists
    |
 LL |     kl!();

--- a/tests/ui/missing/missing-items/missing-const-parameter.stderr
+++ b/tests/ui/missing/missing-items/missing-const-parameter.stderr
@@ -46,10 +46,13 @@ error[E0425]: cannot find value `C` in this scope
   --> $DIR/missing-const-parameter.rs:19:37
    |
 LL | struct Image<const R: usize>([[u32; C]; R]);
-   |                    -                ^
-   |                    |
-   |                    similarly named const parameter `R` defined here
+   |                                     ^ not found in this scope
    |
+note: similarly named const parameter `R` defined here
+  --> $DIR/missing-const-parameter.rs:19:20
+   |
+LL | struct Image<const R: usize>([[u32; C]; R]);
+   |                    ^
 help: a const parameter with a similar name exists
    |
 LL - struct Image<const R: usize>([[u32; C]; R]);

--- a/tests/ui/missing/missing-items/missing-type-parameter2.stderr
+++ b/tests/ui/missing/missing-items/missing-type-parameter2.stderr
@@ -29,12 +29,14 @@ LL | impl<T, const A: u8 = 2, const N: u8> X<N> {}
 error[E0425]: cannot find type `T` in this scope
   --> $DIR/missing-type-parameter2.rs:11:20
    |
-LL | struct X<const N: u8>();
-   | ------------------------ similarly named struct `X` defined here
-...
 LL | fn foo(_: T) where T: Send {}
-   |                    ^
+   |                    ^ not found in this scope
    |
+note: similarly named struct `X` defined here
+  --> $DIR/missing-type-parameter2.rs:1:1
+   |
+LL | struct X<const N: u8>();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - fn foo(_: T) where T: Send {}
@@ -48,12 +50,14 @@ LL | fn foo<T>(_: T) where T: Send {}
 error[E0425]: cannot find type `T` in this scope
   --> $DIR/missing-type-parameter2.rs:11:11
    |
-LL | struct X<const N: u8>();
-   | ------------------------ similarly named struct `X` defined here
-...
 LL | fn foo(_: T) where T: Send {}
-   |           ^
+   |           ^ not found in this scope
    |
+note: similarly named struct `X` defined here
+  --> $DIR/missing-type-parameter2.rs:1:1
+   |
+LL | struct X<const N: u8>();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - fn foo(_: T) where T: Send {}
@@ -67,12 +71,14 @@ LL | fn foo<T>(_: T) where T: Send {}
 error[E0425]: cannot find type `A` in this scope
   --> $DIR/missing-type-parameter2.rs:15:24
    |
-LL | struct X<const N: u8>();
-   | ------------------------ similarly named struct `X` defined here
-...
 LL | fn bar<const N: u8>(_: A) {}
-   |                        ^
+   |                        ^ not found in this scope
    |
+note: similarly named struct `X` defined here
+  --> $DIR/missing-type-parameter2.rs:1:1
+   |
+LL | struct X<const N: u8>();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - fn bar<const N: u8>(_: A) {}

--- a/tests/ui/missing/undeclared-generic-parameter.stderr
+++ b/tests/ui/missing/undeclared-generic-parameter.stderr
@@ -1,11 +1,14 @@
 error[E0425]: cannot find type `B` in this scope
   --> $DIR/undeclared-generic-parameter.rs:2:8
    |
-LL | struct A;
-   | --------- similarly named struct `A` defined here
 LL | impl A<B> {}
-   |        ^
+   |        ^ not found in this scope
    |
+note: similarly named struct `A` defined here
+  --> $DIR/undeclared-generic-parameter.rs:1:1
+   |
+LL | struct A;
+   | ^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL - impl A<B> {}

--- a/tests/ui/mut-restriction/restriction-resolution-errors.stderr
+++ b/tests/ui/mut-restriction/restriction-resolution-errors.stderr
@@ -41,12 +41,14 @@ LL |             pub mut(in super::E) i6: i32,
 error[E0577]: expected module, found enum `crate::a::E`
   --> $DIR/restriction-resolution-errors.rs:33:16
    |
-LL |     pub mod b {
-   |     --------- similarly named module `b` defined here
-...
 LL |         mut(in crate::a::E) e2: i32,
-   |                ^^^^^^^^^^^
+   |                ^^^^^^^^^^^ not a module
    |
+note: similarly named module `b` defined here
+  --> $DIR/restriction-resolution-errors.rs:7:5
+   |
+LL |     pub mod b {
+   |     ^^^^^^^^^
 help: a module with a similar name exists
    |
 LL -         mut(in crate::a::E) e2: i32,

--- a/tests/ui/namespace/namespace-mix.stderr
+++ b/tests/ui/namespace/namespace-mix.stderr
@@ -1,13 +1,15 @@
 error[E0423]: cannot find value `S` in module `m1`
   --> $DIR/namespace-mix.rs:35:15
    |
-LL |     pub struct TS();
-   |     ---------------- similarly named tuple struct `TS` defined here
-...
 LL |     check(m1::S);
-   |               ^
+   |               ^ not found in `m1`
    |
    = note: a type alias named `m1::S` exists in another namespace
+note: similarly named tuple struct `TS` defined here
+  --> $DIR/namespace-mix.rs:9:5
+   |
+LL |     pub struct TS();
+   |     ^^^^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL |     check(m1::TS);
@@ -28,14 +30,14 @@ error[E0423]: cannot find value `S` in module `xm1`
   --> $DIR/namespace-mix.rs:41:16
    |
 LL |     check(xm1::S);
-   |                ^
-   |
-  ::: $DIR/auxiliary/namespace-mix.rs:5:5
-   |
-LL |     pub struct TS();
-   |     ------------- similarly named tuple struct `TS` defined here
+   |                ^ not found in `xm1`
    |
    = note: a type alias named `xm1::S` exists in another namespace
+note: similarly named tuple struct `TS` defined here
+  --> $DIR/auxiliary/namespace-mix.rs:5:5
+   |
+LL |     pub struct TS();
+   |     ^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL |     check(xm1::TS);
@@ -55,13 +57,15 @@ LL +     check(S);
 error[E0423]: cannot find value `V` in module `m7`
   --> $DIR/namespace-mix.rs:101:15
    |
-LL |         TV(),
-   |         ---- similarly named tuple variant `TV` defined here
-...
 LL |     check(m7::V);
-   |               ^
+   |               ^ not found in `m7`
    |
    = note: a type alias named `m7::V` exists in another namespace
+note: similarly named tuple variant `TV` defined here
+  --> $DIR/namespace-mix.rs:13:9
+   |
+LL |         TV(),
+   |         ^^^^
 help: a tuple variant with a similar name exists
    |
 LL |     check(m7::TV);
@@ -82,14 +86,14 @@ error[E0423]: cannot find value `V` in module `xm7`
   --> $DIR/namespace-mix.rs:107:16
    |
 LL |     check(xm7::V);
-   |                ^
-   |
-  ::: $DIR/auxiliary/namespace-mix.rs:9:9
-   |
-LL |         TV(),
-   |         -- similarly named tuple variant `TV` defined here
+   |                ^ not found in `xm7`
    |
    = note: a type alias named `xm7::V` exists in another namespace
+note: similarly named tuple variant `TV` defined here
+  --> $DIR/auxiliary/namespace-mix.rs:9:9
+   |
+LL |         TV(),
+   |         ^^
 help: a tuple variant with a similar name exists
    |
 LL |     check(xm7::TV);

--- a/tests/ui/parser/emoji-identifiers.stderr
+++ b/tests/ui/parser/emoji-identifiers.stderr
@@ -87,12 +87,14 @@ LL |     👀::full_of_✨()
 error[E0425]: cannot find function `i_like_to_😄_a_lot` in this scope
   --> $DIR/emoji-identifiers.rs:13:13
    |
-LL | fn i_like_to_😅_a_lot() -> 👀 {
-   | ----------------------------- similarly named function `i_like_to_😅_a_lot` defined here
-...
 LL |     let _ = i_like_to_😄_a_lot() ➖ 4;
-   |             ^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^ not found in this scope
    |
+note: similarly named function `i_like_to_😅_a_lot` defined here
+  --> $DIR/emoji-identifiers.rs:8:1
+   |
+LL | fn i_like_to_😅_a_lot() -> 👀 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a function with a similar name exists
    |
 LL -     let _ = i_like_to_😄_a_lot() ➖ 4;

--- a/tests/ui/parser/kw-in-trait-bounds.stderr
+++ b/tests/ui/parser/kw-in-trait-bounds.stderr
@@ -94,11 +94,13 @@ error[E0405]: cannot find trait `r#struct` in this scope
   --> $DIR/kw-in-trait-bounds.rs:16:10
    |
 LL | fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
-   |          ^^^^^^
-...
-LL | trait Struct {}
-   | ------------ similarly named trait `Struct` defined here
+   |          ^^^^^^ not found in this scope
    |
+note: similarly named trait `Struct` defined here
+  --> $DIR/kw-in-trait-bounds.rs:37:1
+   |
+LL | trait Struct {}
+   | ^^^^^^^^^^^^
 help: a trait with a similar name exists (notice the capitalization)
    |
 LL - fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
@@ -109,11 +111,13 @@ error[E0405]: cannot find trait `r#struct` in this scope
   --> $DIR/kw-in-trait-bounds.rs:30:8
    |
 LL |     B: struct,
-   |        ^^^^^^
-...
-LL | trait Struct {}
-   | ------------ similarly named trait `Struct` defined here
+   |        ^^^^^^ not found in this scope
    |
+note: similarly named trait `Struct` defined here
+  --> $DIR/kw-in-trait-bounds.rs:37:1
+   |
+LL | trait Struct {}
+   | ^^^^^^^^^^^^
 help: a trait with a similar name exists (notice the capitalization)
    |
 LL -     B: struct,
@@ -124,11 +128,13 @@ error[E0405]: cannot find trait `r#struct` in this scope
   --> $DIR/kw-in-trait-bounds.rs:16:29
    |
 LL | fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
-   |                             ^^^^^^
-...
-LL | trait Struct {}
-   | ------------ similarly named trait `Struct` defined here
+   |                             ^^^^^^ not found in this scope
    |
+note: similarly named trait `Struct` defined here
+  --> $DIR/kw-in-trait-bounds.rs:37:1
+   |
+LL | trait Struct {}
+   | ^^^^^^^^^^^^
 help: a trait with a similar name exists (notice the capitalization)
    |
 LL - fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
@@ -139,11 +145,13 @@ error[E0405]: cannot find trait `r#struct` in this scope
   --> $DIR/kw-in-trait-bounds.rs:16:45
    |
 LL | fn _g<A: struct, B>(_: impl struct, _: &dyn struct)
-   |                                             ^^^^^^
-...
-LL | trait Struct {}
-   | ------------ similarly named trait `Struct` defined here
+   |                                             ^^^^^^ not found in this scope
    |
+note: similarly named trait `Struct` defined here
+  --> $DIR/kw-in-trait-bounds.rs:37:1
+   |
+LL | trait Struct {}
+   | ^^^^^^^^^^^^
 help: a trait with a similar name exists (notice the capitalization)
    |
 LL - fn _g<A: struct, B>(_: impl struct, _: &dyn struct)

--- a/tests/ui/parser/recover/raw-no-const-mut.stderr
+++ b/tests/ui/parser/recover/raw-no-const-mut.stderr
@@ -71,12 +71,14 @@ LL |     x = &raw mut 1;
 error[E0425]: cannot find function `f` in this scope
   --> $DIR/raw-no-const-mut.rs:17:5
    |
-LL | fn a() {
-   | ------ similarly named function `a` defined here
-...
 LL |     f(&raw 2);
-   |     ^
+   |     ^ not found in this scope
    |
+note: similarly named function `a` defined here
+  --> $DIR/raw-no-const-mut.rs:1:1
+   |
+LL | fn a() {
+   | ^^^^^^
 help: a function with a similar name exists
    |
 LL -     f(&raw 2);

--- a/tests/ui/pattern/constructor-type-mismatch.stderr
+++ b/tests/ui/pattern/constructor-type-mismatch.stderr
@@ -3,12 +3,15 @@ error[E0532]: expected unit struct, unit variant or constant, found tuple varian
    |
 LL |     Bar(i32),
    |     -------- `Foo::Bar` defined here
-LL |     Baz
-   |     --- similarly named unit variant `Baz` defined here
 ...
 LL |         Foo::Bar => {}
    |         ^^^^^^^^
    |
+note: similarly named unit variant `Baz` defined here
+  --> $DIR/constructor-type-mismatch.rs:4:5
+   |
+LL |     Baz
+   |     ^^^
 help: use the tuple variant pattern syntax instead
    |
 LL |         Foo::Bar(_) => {}

--- a/tests/ui/pattern/pat-tuple-field-count-cross.stderr
+++ b/tests/ui/pattern/pat-tuple-field-count-cross.stderr
@@ -20,9 +20,12 @@ LL |         Z0() => {}
    |
 LL | pub struct Z0;
    | ------------- `Z0` defined here
-LL | pub struct Z1();
-   | ------------- similarly named tuple struct `Z1` defined here
    |
+note: similarly named tuple struct `Z1` defined here
+  --> $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:2:1
+   |
+LL | pub struct Z1();
+   | ^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Z0() => {}
@@ -44,9 +47,12 @@ LL |         Z0(x) => {}
    |
 LL | pub struct Z0;
    | ------------- `Z0` defined here
-LL | pub struct Z1();
-   | ------------- similarly named tuple struct `Z1` defined here
    |
+note: similarly named tuple struct `Z1` defined here
+  --> $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:2:1
+   |
+LL | pub struct Z1();
+   | ^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Z0(x) => {}
@@ -67,10 +73,13 @@ LL |         E1::Z0() => {}
   ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:15
    |
 LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
-   |               --  -- similarly named tuple variant `Z1` defined here
-   |               |
-   |               `E1::Z0` defined here
+   |               -- `E1::Z0` defined here
    |
+note: similarly named tuple variant `Z1` defined here
+  --> $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:19
+   |
+LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
+   |                   ^^
 help: use this syntax instead
    |
 LL -         E1::Z0() => {}
@@ -91,10 +100,13 @@ LL |         E1::Z0(x) => {}
   ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:15
    |
 LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
-   |               --  -- similarly named tuple variant `Z1` defined here
-   |               |
-   |               `E1::Z0` defined here
+   |               -- `E1::Z0` defined here
    |
+note: similarly named tuple variant `Z1` defined here
+  --> $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:19
+   |
+LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
+   |                   ^^
 help: use this syntax instead
    |
 LL -         E1::Z0(x) => {}
@@ -115,10 +127,13 @@ LL |         E1::Z1 => {}
   ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:19
    |
 LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
-   |               --  -- `E1::Z1` defined here
-   |               |
-   |               similarly named unit variant `Z0` defined here
+   |                   -- `E1::Z1` defined here
    |
+note: similarly named unit variant `Z0` defined here
+  --> $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:11:15
+   |
+LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
+   |               ^^
 help: use the tuple variant pattern syntax instead
    |
 LL |         E1::Z1() => {}

--- a/tests/ui/pattern/pat-tuple-overfield.stderr
+++ b/tests/ui/pattern/pat-tuple-overfield.stderr
@@ -15,12 +15,15 @@ error[E0532]: expected tuple struct or tuple variant, found unit struct `Z0`
    |
 LL | struct Z0;
    | ---------- `Z0` defined here
-LL | struct Z1();
-   | ------------ similarly named tuple struct `Z1` defined here
 ...
 LL |         Z0() => {}
    |         ^^^^
    |
+note: similarly named tuple struct `Z1` defined here
+  --> $DIR/pat-tuple-overfield.rs:11:1
+   |
+LL | struct Z1();
+   | ^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Z0() => {}
@@ -37,12 +40,15 @@ error[E0532]: expected tuple struct or tuple variant, found unit struct `Z0`
    |
 LL | struct Z0;
    | ---------- `Z0` defined here
-LL | struct Z1();
-   | ------------ similarly named tuple struct `Z1` defined here
 ...
 LL |         Z0(_) => {}
    |         ^^^^^
    |
+note: similarly named tuple struct `Z1` defined here
+  --> $DIR/pat-tuple-overfield.rs:11:1
+   |
+LL | struct Z1();
+   | ^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Z0(_) => {}
@@ -59,12 +65,15 @@ error[E0532]: expected tuple struct or tuple variant, found unit struct `Z0`
    |
 LL | struct Z0;
    | ---------- `Z0` defined here
-LL | struct Z1();
-   | ------------ similarly named tuple struct `Z1` defined here
 ...
 LL |         Z0(_, _) => {}
    |         ^^^^^^^^
    |
+note: similarly named tuple struct `Z1` defined here
+  --> $DIR/pat-tuple-overfield.rs:11:1
+   |
+LL | struct Z1();
+   | ^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Z0(_, _) => {}
@@ -81,12 +90,15 @@ error[E0532]: expected tuple struct or tuple variant, found unit variant `E1::Z0
    |
 LL |     Z0,
    |     -- `E1::Z0` defined here
-LL |     Z1(),
-   |     ---- similarly named tuple variant `Z1` defined here
 ...
 LL |         E1::Z0() => {}
    |         ^^^^^^^^
    |
+note: similarly named tuple variant `Z1` defined here
+  --> $DIR/pat-tuple-overfield.rs:14:5
+   |
+LL |     Z1(),
+   |     ^^^^
 help: use this syntax instead
    |
 LL -         E1::Z0() => {}
@@ -103,12 +115,15 @@ error[E0532]: expected tuple struct or tuple variant, found unit variant `E1::Z0
    |
 LL |     Z0,
    |     -- `E1::Z0` defined here
-LL |     Z1(),
-   |     ---- similarly named tuple variant `Z1` defined here
 ...
 LL |         E1::Z0(_) => {}
    |         ^^^^^^^^^
    |
+note: similarly named tuple variant `Z1` defined here
+  --> $DIR/pat-tuple-overfield.rs:14:5
+   |
+LL |     Z1(),
+   |     ^^^^
 help: use this syntax instead
    |
 LL -         E1::Z0(_) => {}
@@ -125,12 +140,15 @@ error[E0532]: expected tuple struct or tuple variant, found unit variant `E1::Z0
    |
 LL |     Z0,
    |     -- `E1::Z0` defined here
-LL |     Z1(),
-   |     ---- similarly named tuple variant `Z1` defined here
 ...
 LL |         E1::Z0(_, _) => {}
    |         ^^^^^^^^^^^^
    |
+note: similarly named tuple variant `Z1` defined here
+  --> $DIR/pat-tuple-overfield.rs:14:5
+   |
+LL |     Z1(),
+   |     ^^^^
 help: use this syntax instead
    |
 LL -         E1::Z0(_, _) => {}
@@ -145,14 +163,17 @@ LL +         E1::Z1(_, _) => {}
 error[E0532]: expected unit struct, unit variant or constant, found tuple variant `E1::Z1`
   --> $DIR/pat-tuple-overfield.rs:69:9
    |
-LL |     Z0,
-   |     -- similarly named unit variant `Z0` defined here
 LL |     Z1(),
    |     ---- `E1::Z1` defined here
 ...
 LL |         E1::Z1 => {}
    |         ^^^^^^
    |
+note: similarly named unit variant `Z0` defined here
+  --> $DIR/pat-tuple-overfield.rs:13:5
+   |
+LL |     Z0,
+   |     ^^
 help: use the tuple variant pattern syntax instead
    |
 LL |         E1::Z1() => {}

--- a/tests/ui/pattern/pattern-error-continue.stderr
+++ b/tests/ui/pattern/pattern-error-continue.stderr
@@ -1,15 +1,17 @@
 error[E0532]: expected tuple struct or tuple variant, found unit variant `A::D`
   --> $DIR/pattern-error-continue.rs:20:9
    |
-LL |     B(isize, isize),
-   |     --------------- similarly named tuple variant `B` defined here
-LL |     C(isize, isize, isize),
 LL |     D
    |     - `A::D` defined here
 ...
 LL |         A::D(_) => (),
    |         ^^^^^^^
    |
+note: similarly named tuple variant `B` defined here
+  --> $DIR/pattern-error-continue.rs:6:5
+   |
+LL |     B(isize, isize),
+   |     ^^^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         A::D(_) => (),

--- a/tests/ui/pattern/rfc-3637-guard-patterns/name-resolution.stderr
+++ b/tests/ui/pattern/rfc-3637-guard-patterns/name-resolution.stderr
@@ -38,7 +38,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:11:34
    |
 LL | fn bad_fn_item_1(x: bool, ((y if x) | y): bool) {}
-   |                                  ^
+   |                                  ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -50,7 +50,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:13:25
    |
 LL | fn bad_fn_item_2(((x if y) | x): bool, y: bool) {}
-   |                         ^
+   |                         ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -62,7 +62,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:21:18
    |
 LL |         (x, y if x) => x && y,
-   |                  ^
+   |                  ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -74,7 +74,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:23:15
    |
 LL |         (x if y, y) => x && y,
-   |               ^
+   |               ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -86,7 +86,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:30:20
    |
 LL |         (x @ (y if x),) => x && y,
-   |                    ^
+   |                    ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -98,7 +98,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:38:20
    |
 LL |         ((Ok(x) if y) | (Err(y) if x),) => x && y,
-   |                    ^
+   |                    ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -110,7 +110,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:38:36
    |
 LL |         ((Ok(x) if y) | (Err(y) if x),) => x && y,
-   |                                    ^
+   |                                    ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -128,7 +128,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:47:22
    |
 LL |     if let ((x, y if x) | (x if y, y)) = (true, true) { x && y; }
-   |                      ^
+   |                      ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -140,7 +140,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:47:33
    |
 LL |     if let ((x, y if x) | (x if y, y)) = (true, true) { x && y; }
-   |                                 ^
+   |                                 ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -152,7 +152,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:50:25
    |
 LL |     while let ((x, y if x) | (x if y, y)) = (true, true) { x && y; }
-   |                         ^
+   |                         ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -164,7 +164,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:50:36
    |
 LL |     while let ((x, y if x) | (x if y, y)) = (true, true) { x && y; }
-   |                                    ^
+   |                                    ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -176,7 +176,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:53:19
    |
 LL |     for ((x, y if x) | (x if y, y)) in [(true, true)] { x && y; }
-   |                   ^
+   |                   ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -188,7 +188,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:53:30
    |
 LL |     for ((x, y if x) | (x if y, y)) in [(true, true)] { x && y; }
-   |                              ^
+   |                              ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -200,7 +200,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/name-resolution.rs:58:13
    |
 LL |     (|(x if y), (y if x)| x && y)(true, true);
-   |             ^
+   |             ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -212,7 +212,7 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/name-resolution.rs:58:23
    |
 LL |     (|(x if y), (y if x)| x && y)(true, true);
-   |                       ^
+   |                       ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/pattern/struct-pattern-with-missing-fields-resolve-error.rs
+++ b/tests/ui/pattern/struct-pattern-with-missing-fields-resolve-error.rs
@@ -25,6 +25,9 @@ fn main() {
 
     let x = Foo::Bar { a: 1 };
     if let Foo::Bar { .. } = x { //~ NOTE this pattern
-        println!("{a}"); //~ ERROR cannot find value `a` in this scope
+        println!("{a}");
+        //~^ ERROR cannot find value `a` in this scope
+        //~| NOTE not found in this scope
+
     }
 }

--- a/tests/ui/pattern/struct-pattern-with-missing-fields-resolve-error.stderr
+++ b/tests/ui/pattern/struct-pattern-with-missing-fields-resolve-error.stderr
@@ -20,7 +20,7 @@ error[E0425]: cannot find value `a` in this scope
 LL |     if let Foo::Bar { .. } = x {
    |            --------------- this pattern doesn't include `a`, which is available in `Bar`
 LL |         println!("{a}");
-   |                    ^
+   |                    ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/privacy/privacy-ns1.stderr
+++ b/tests/ui/privacy/privacy-ns1.stderr
@@ -1,13 +1,15 @@
 error[E0423]: cannot find function, tuple struct or tuple variant `Bar` in this scope
   --> $DIR/privacy-ns1.rs:21:5
    |
-LL |     pub struct Baz;
-   |     --------------- similarly named unit struct `Baz` defined here
-...
 LL |     Bar();
-   |     ^^^
+   |     ^^^ not found in this scope
    |
    = note: a trait named `Bar` exists in another namespace
+note: similarly named unit struct `Baz` defined here
+  --> $DIR/privacy-ns1.rs:13:5
+   |
+LL |     pub struct Baz;
+   |     ^^^^^^^^^^^^^^^
 note: these functions exist but are inaccessible
   --> $DIR/privacy-ns1.rs:15:5
    |
@@ -29,12 +31,14 @@ LL + use foo2::Bar;
 error[E0425]: cannot find function, tuple struct or tuple variant `Bar` in this scope
   --> $DIR/privacy-ns1.rs:52:5
    |
-LL |     pub struct Baz;
-   |     --------------- similarly named unit struct `Baz` defined here
-...
 LL |     Bar();
-   |     ^^^
+   |     ^^^ not found in this scope
    |
+note: similarly named unit struct `Baz` defined here
+  --> $DIR/privacy-ns1.rs:44:5
+   |
+LL |     pub struct Baz;
+   |     ^^^^^^^^^^^^^^^
 note: these functions exist but are inaccessible
   --> $DIR/privacy-ns1.rs:15:5
    |
@@ -56,12 +60,14 @@ LL + use foo2::Bar;
 error[E0425]: cannot find type `Bar` in this scope
   --> $DIR/privacy-ns1.rs:53:17
    |
-LL |     pub struct Baz;
-   |     --------------- similarly named struct `Baz` defined here
-...
 LL |     let _x: Box<Bar>;
-   |                 ^^^
+   |                 ^^^ not found in this scope
    |
+note: similarly named struct `Baz` defined here
+  --> $DIR/privacy-ns1.rs:44:5
+   |
+LL |     pub struct Baz;
+   |     ^^^^^^^^^^^^^^^
 note: these traits exist but are inaccessible
   --> $DIR/privacy-ns1.rs:26:5
    |

--- a/tests/ui/privacy/privacy-ns2.stderr
+++ b/tests/ui/privacy/privacy-ns2.stderr
@@ -21,13 +21,15 @@ LL + use foo2::Bar;
 error[E0423]: cannot find function, tuple struct or tuple variant `Bar` in this scope
   --> $DIR/privacy-ns2.rs:27:5
    |
-LL |     pub struct Baz;
-   |     --------------- similarly named unit struct `Baz` defined here
-...
 LL |     Bar();
-   |     ^^^
+   |     ^^^ not found in this scope
    |
    = note: a trait named `Bar` exists in another namespace
+note: similarly named unit struct `Baz` defined here
+  --> $DIR/privacy-ns2.rs:13:5
+   |
+LL |     pub struct Baz;
+   |     ^^^^^^^^^^^^^^^
 note: these functions exist but are inaccessible
   --> $DIR/privacy-ns2.rs:15:5
    |

--- a/tests/ui/privacy/sysroot-private.default.stderr
+++ b/tests/ui/privacy/sysroot-private.default.stderr
@@ -1,17 +1,20 @@
 error[E0405]: cannot find trait `Equivalent` in this scope
-  --> $DIR/sysroot-private.rs:27:18
+  --> $DIR/sysroot-private.rs:29:18
    |
 LL | trait Trait2<K>: Equivalent<K> {}
    |                  ^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `K` in this scope
-  --> $DIR/sysroot-private.rs:32:35
+  --> $DIR/sysroot-private.rs:34:35
    |
 LL | fn trait_member<T>(val: &T, key: &K) -> bool {
-   |                 -                 ^
-   |                 |
-   |                 similarly named type parameter `T` defined here
+   |                                   ^ not found in this scope
    |
+note: similarly named type parameter `T` defined here
+  --> $DIR/sysroot-private.rs:34:17
+   |
+LL | fn trait_member<T>(val: &T, key: &K) -> bool {
+   |                 ^
 help: a type parameter with a similar name exists
    |
 LL - fn trait_member<T>(val: &T, key: &K) -> bool {
@@ -29,7 +32,7 @@ LL | type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
    |                               ^^^^^^^^^^^^^^^ help: `Trait` has the following associated type: `Bar`
 
 error[E0425]: cannot find function `memchr2` in this scope
-  --> $DIR/sysroot-private.rs:40:5
+  --> $DIR/sysroot-private.rs:47:5
    |
 LL |     memchr2(b'a', b'b', buf)
    |     ^^^^^^^ not found in this scope

--- a/tests/ui/privacy/sysroot-private.rs
+++ b/tests/ui/privacy/sysroot-private.rs
@@ -21,6 +21,8 @@ trait Trait { type Bar; }
 // present in diagnostics (it is a dependency of the compiler).
 type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
 //~^ ERROR associated type `ExpressionStack` not found
+//[default]~| HELP `Trait` has the following associated type
+//[default]~| SUGGESTION Bar
 //[rustc_private_enabled]~| NOTE there is an associated type `ExpressionStack` in the trait `gimli::read::op::EvaluationStorage`
 
 // Attempt to get a suggestion for `hashbrown::Equivalent`
@@ -31,6 +33,11 @@ trait Trait2<K>: Equivalent<K> {}
 // Attempt to get a suggestion for `hashbrown::Equivalent::equivalent`
 fn trait_member<T>(val: &T, key: &K) -> bool {
     //~^ ERROR cannot find type `K`
+    //~| NOTE not found in this scope
+    //~| SUGGESTION K
+    //~| SUGGESTION T
+    //~| HELP you might be missing a type parameter
+    //~| HELP a type parameter with a similar name exists
     //~| NOTE similarly named
     val.equivalent(key)
 }
@@ -40,4 +47,5 @@ fn free_function(buf: &[u8]) -> Option<usize> {
     memchr2(b'a', b'b', buf)
     //~^ ERROR cannot find function
     //~| NOTE not found
+
 }

--- a/tests/ui/privacy/sysroot-private.rustc_private_enabled.stderr
+++ b/tests/ui/privacy/sysroot-private.rustc_private_enabled.stderr
@@ -1,17 +1,20 @@
 error[E0405]: cannot find trait `Equivalent` in this scope
-  --> $DIR/sysroot-private.rs:27:18
+  --> $DIR/sysroot-private.rs:29:18
    |
 LL | trait Trait2<K>: Equivalent<K> {}
    |                  ^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `K` in this scope
-  --> $DIR/sysroot-private.rs:32:35
+  --> $DIR/sysroot-private.rs:34:35
    |
 LL | fn trait_member<T>(val: &T, key: &K) -> bool {
-   |                 -                 ^
-   |                 |
-   |                 similarly named type parameter `T` defined here
+   |                                   ^ not found in this scope
    |
+note: similarly named type parameter `T` defined here
+  --> $DIR/sysroot-private.rs:34:17
+   |
+LL | fn trait_member<T>(val: &T, key: &K) -> bool {
+   |                 ^
 help: a type parameter with a similar name exists
    |
 LL - fn trait_member<T>(val: &T, key: &K) -> bool {
@@ -29,7 +32,7 @@ LL | type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
    |                               ^^^^^^^^^^^^^^^ there is an associated type `ExpressionStack` in the trait `gimli::read::op::EvaluationStorage`
 
 error[E0425]: cannot find function `memchr2` in this scope
-  --> $DIR/sysroot-private.rs:40:5
+  --> $DIR/sysroot-private.rs:47:5
    |
 LL |     memchr2(b'a', b'b', buf)
    |     ^^^^^^^ not found in this scope

--- a/tests/ui/proc-macro/gen-macro-rules-hygiene.stderr
+++ b/tests/ui/proc-macro/gen-macro-rules-hygiene.stderr
@@ -13,7 +13,7 @@ error[E0425]: cannot find value `local_use` in this scope
   --> $DIR/gen-macro-rules-hygiene.rs:13:1
    |
 LL | gen_macro_rules!();
-   | ^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^ not found in this scope
 ...
 LL |         generated!();
    |         ------------ in this macro invocation
@@ -34,7 +34,7 @@ error[E0425]: cannot find value `local_def` in this scope
   --> $DIR/gen-macro-rules-hygiene.rs:22:9
    |
 LL |         local_def;
-   |         ^^^^^^^^^
+   |         ^^^^^^^^^ not found in this scope
    |
 help: an identifier with the same name is defined here, but is not accessible due to macro hygiene
   --> $DIR/gen-macro-rules-hygiene.rs:13:1

--- a/tests/ui/proc-macro/lints_in_proc_macros.stderr
+++ b/tests/ui/proc-macro/lints_in_proc_macros.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `foobar2` in this scope
   --> $DIR/lints_in_proc_macros.rs:10:5
    |
 LL |     bang_proc_macro2!();
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
    = note: this error originates in the macro `bang_proc_macro2` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a local variable with a similar name exists

--- a/tests/ui/proc-macro/mixed-site-span.stderr
+++ b/tests/ui/proc-macro/mixed-site-span.stderr
@@ -714,7 +714,7 @@ error[E0425]: cannot find value `local_use` in this scope
   --> $DIR/mixed-site-span.rs:23:9
    |
 LL |         proc_macro_rules!();
-   |         ^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
 help: an identifier with the same name exists, but is not accessible due to macro hygiene
   --> $DIR/mixed-site-span.rs:22:13
@@ -732,7 +732,7 @@ error[E0425]: cannot find value `local_def` in this scope
   --> $DIR/mixed-site-span.rs:28:9
    |
 LL |         local_def;
-   |         ^^^^^^^^^
+   |         ^^^^^^^^^ not found in this scope
    |
 help: an identifier with the same name is defined here, but is not accessible due to macro hygiene
   --> $DIR/mixed-site-span.rs:23:9

--- a/tests/ui/proc-macro/parent-source-spans.stderr
+++ b/tests/ui/proc-macro/parent-source-spans.stderr
@@ -140,15 +140,13 @@ error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:30:5
    |
 LL |     parent_source_spans!($($tokens)*);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
 ...
 LL |     one!("hello", "world");
    |     ---------------------- in this macro invocation
    |
+note: similarly named tuple variant `Ok` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named tuple variant `Ok` defined here
-   |
    = note: this error originates in the macro `parent_source_spans` which comes from the expansion of the macro `one` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a tuple variant with a similar name exists
    |
@@ -160,15 +158,13 @@ error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:30:5
    |
 LL |     parent_source_spans!($($tokens)*);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
 ...
 LL |     two!("yay", "rust");
    |     ------------------- in this macro invocation
    |
+note: similarly named tuple variant `Ok` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named tuple variant `Ok` defined here
-   |
    = note: this error originates in the macro `parent_source_spans` which comes from the expansion of the macro `two` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a tuple variant with a similar name exists
    |
@@ -180,15 +176,13 @@ error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:30:5
    |
 LL |     parent_source_spans!($($tokens)*);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
 ...
 LL |     three!("hip", "hop");
    |     -------------------- in this macro invocation
    |
+note: similarly named tuple variant `Ok` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named tuple variant `Ok` defined here
-   |
    = note: this error originates in the macro `parent_source_spans` which comes from the expansion of the macro `three` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a tuple variant with a similar name exists
    |

--- a/tests/ui/proc-macro/resolve-error.stderr
+++ b/tests/ui/proc-macro/resolve-error.stderr
@@ -4,11 +4,11 @@ error: cannot find macro `bang_proc_macrp` in this scope
 LL |     bang_proc_macrp!();
    |     ^^^^^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/test-macros.rs:10:1
+note: similarly named macro `bang_proc_macro` defined here
+  --> $DIR/auxiliary/test-macros.rs:10:1
    |
 LL | pub fn empty(_: TokenStream) -> TokenStream {
-   | ------------------------------------------- similarly named macro `bang_proc_macro` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a macro with a similar name exists
    |
 LL -     bang_proc_macrp!();
@@ -24,12 +24,14 @@ LL |     Dlona!();
 error: cannot find macro `attr_proc_macra` in this scope
   --> $DIR/resolve-error.rs:54:5
    |
-LL | macro_rules! attr_proc_mac {
-   | -------------------------- similarly named macro `attr_proc_mac` defined here
-...
 LL |     attr_proc_macra!();
    |     ^^^^^^^^^^^^^^^
    |
+note: similarly named macro `attr_proc_mac` defined here
+  --> $DIR/resolve-error.rs:18:1
+   |
+LL | macro_rules! attr_proc_mac {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a macro with a similar name exists
    |
 LL -     attr_proc_macra!();
@@ -39,12 +41,14 @@ LL +     attr_proc_mac!();
 error: cannot find macro `FooWithLongNama` in this scope
   --> $DIR/resolve-error.rs:51:5
    |
-LL | macro_rules! FooWithLongNam {
-   | --------------------------- similarly named macro `FooWithLongNam` defined here
-...
 LL |     FooWithLongNama!();
    |     ^^^^^^^^^^^^^^^
    |
+note: similarly named macro `FooWithLongNam` defined here
+  --> $DIR/resolve-error.rs:14:1
+   |
+LL | macro_rules! FooWithLongNam {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a macro with a similar name exists
    |
 LL -     FooWithLongNama!();
@@ -71,11 +75,11 @@ error: cannot find derive macro `Dlona` in this scope
 LL | #[derive(Dlona)]
    |          ^^^^^
    |
-  ::: $DIR/auxiliary/derive-clona.rs:6:1
+note: similarly named derive macro `Clona` defined here
+  --> $DIR/auxiliary/derive-clona.rs:6:1
    |
 LL | pub fn derive_clonea(input: TokenStream) -> TokenStream {
-   | ------------------------------------------------------- similarly named derive macro `Clona` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a derive macro with a similar name exists
    |
 LL - #[derive(Dlona)]
@@ -88,11 +92,11 @@ error: cannot find derive macro `Dlona` in this scope
 LL | #[derive(Dlona)]
    |          ^^^^^
    |
-  ::: $DIR/auxiliary/derive-clona.rs:6:1
+note: similarly named derive macro `Clona` defined here
+  --> $DIR/auxiliary/derive-clona.rs:6:1
    |
 LL | pub fn derive_clonea(input: TokenStream) -> TokenStream {
-   | ------------------------------------------------------- similarly named derive macro `Clona` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: a derive macro with a similar name exists
    |
@@ -106,9 +110,8 @@ error: cannot find derive macro `Dlone` in this scope
 LL | #[derive(Dlone)]
    |          ^^^^^
    |
+note: similarly named derive macro `Clone` defined here
   --> $SRC_DIR/core/src/clone.rs:LL:COL
-   |
-   = note: similarly named derive macro `Clone` defined here
 help: a derive macro with a similar name exists
    |
 LL - #[derive(Dlone)]
@@ -121,10 +124,8 @@ error: cannot find derive macro `Dlone` in this scope
 LL | #[derive(Dlone)]
    |          ^^^^^
    |
+note: similarly named derive macro `Clone` defined here
   --> $SRC_DIR/core/src/clone.rs:LL:COL
-   |
-   = note: similarly named derive macro `Clone` defined here
-   |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: a derive macro with a similar name exists
    |
@@ -144,11 +145,11 @@ error: cannot find attribute `attr_proc_macra` in this scope
 LL | #[attr_proc_macra]
    |   ^^^^^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/test-macros.rs:15:1
+note: similarly named attribute macro `attr_proc_macro` defined here
+  --> $DIR/auxiliary/test-macros.rs:15:1
    |
 LL | pub fn empty_attr(_: TokenStream, _: TokenStream) -> TokenStream {
-   | ---------------------------------------------------------------- similarly named attribute macro `attr_proc_macro` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: an attribute macro with a similar name exists
    |
 LL - #[attr_proc_macra]
@@ -161,11 +162,11 @@ error: cannot find derive macro `FooWithLongNan` in this scope
 LL | #[derive(FooWithLongNan)]
    |          ^^^^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/derive-foo.rs:6:1
+note: similarly named derive macro `FooWithLongName` defined here
+  --> $DIR/auxiliary/derive-foo.rs:6:1
    |
 LL | pub fn derive_foo(input: TokenStream) -> TokenStream {
-   | ---------------------------------------------------- similarly named derive macro `FooWithLongName` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a derive macro with a similar name exists
    |
 LL - #[derive(FooWithLongNan)]
@@ -178,11 +179,11 @@ error: cannot find derive macro `FooWithLongNan` in this scope
 LL | #[derive(FooWithLongNan)]
    |          ^^^^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/derive-foo.rs:6:1
+note: similarly named derive macro `FooWithLongName` defined here
+  --> $DIR/auxiliary/derive-foo.rs:6:1
    |
 LL | pub fn derive_foo(input: TokenStream) -> TokenStream {
-   | ---------------------------------------------------- similarly named derive macro `FooWithLongName` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: a derive macro with a similar name exists
    |

--- a/tests/ui/regions/outlives-with-missing.stderr
+++ b/tests/ui/regions/outlives-with-missing.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find type `T` in this scope
   --> $DIR/outlives-with-missing.rs:10:9
    |
-LL | impl<H: HandlerFamily> HandlerWrapper<H> {
-   |      - similarly named type parameter `H` defined here
-...
 LL |         T: Send + Sync + 'static,
-   |         ^
+   |         ^ not found in this scope
    |
+note: similarly named type parameter `H` defined here
+  --> $DIR/outlives-with-missing.rs:7:6
+   |
+LL | impl<H: HandlerFamily> HandlerWrapper<H> {
+   |      ^
 help: a type parameter with a similar name exists
    |
 LL -         T: Send + Sync + 'static,

--- a/tests/ui/resolve/builtin-attribute-not-value.stderr
+++ b/tests/ui/resolve/builtin-attribute-not-value.stderr
@@ -10,7 +10,7 @@ error[E0423]: cannot find value `path` in this scope
   --> $DIR/builtin-attribute-not-value.rs:13:5
    |
 LL |     path;
-   |     ^^^^
+   |     ^^^^ not found in this scope
    |
    = note: a built-in attribute named `path` exists in another namespace
 help: a local variable with a similar name exists

--- a/tests/ui/resolve/empty-struct-braces-expr.stderr
+++ b/tests/ui/resolve/empty-struct-braces-expr.stderr
@@ -7,12 +7,12 @@ LL | struct Empty1 {}
 LL |     let e1 = Empty1;
    |              ^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:2:1
+   = note: a struct named `Empty1` exists in another namespace
+note: similarly named unit struct `XEmpty2` defined here
+  --> $DIR/auxiliary/empty-struct.rs:2:1
    |
 LL | pub struct XEmpty2;
-   | ------------------ similarly named unit struct `XEmpty2` defined here
-   |
-   = note: a struct named `Empty1` exists in another namespace
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct literal syntax instead
    |
 LL |     let e1 = Empty1 {};
@@ -33,10 +33,13 @@ LL |     let xe1 = XEmpty1;
    |
 LL | pub struct XEmpty1 {}
    | ------------------ `XEmpty1` defined here
-LL | pub struct XEmpty2;
-   | ------------------ similarly named unit struct `XEmpty2` defined here
    |
    = note: a struct named `XEmpty1` exists in another namespace
+note: similarly named unit struct `XEmpty2` defined here
+  --> $DIR/auxiliary/empty-struct.rs:2:1
+   |
+LL | pub struct XEmpty2;
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct literal syntax instead
    |
 LL |     let xe1 = XEmpty1 {};
@@ -56,12 +59,12 @@ LL | struct Empty1 {}
 LL |     let e1 = Empty1();
    |              ^^^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:2:1
+   = note: a struct named `Empty1` exists in another namespace
+note: similarly named unit struct `XEmpty2` defined here
+  --> $DIR/auxiliary/empty-struct.rs:2:1
    |
 LL | pub struct XEmpty2;
-   | ------------------ similarly named unit struct `XEmpty2` defined here
-   |
-   = note: a struct named `Empty1` exists in another namespace
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct literal syntax instead
    |
 LL -     let e1 = Empty1();
@@ -106,10 +109,13 @@ LL |     let xe1 = XEmpty1();
    |
 LL | pub struct XEmpty1 {}
    | ------------------ `XEmpty1` defined here
-LL | pub struct XEmpty2;
-   | ------------------ similarly named unit struct `XEmpty2` defined here
    |
    = note: a struct named `XEmpty1` exists in another namespace
+note: similarly named unit struct `XEmpty2` defined here
+  --> $DIR/auxiliary/empty-struct.rs:2:1
+   |
+LL | pub struct XEmpty2;
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct literal syntax instead
    |
 LL -     let xe1 = XEmpty1();

--- a/tests/ui/resolve/empty-struct-braces-pat-2.stderr
+++ b/tests/ui/resolve/empty-struct-braces-pat-2.stderr
@@ -7,12 +7,12 @@ LL | struct Empty1 {}
 LL |         Empty1() => ()
    |         ^^^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:3:1
+   = note: a struct named `Empty1` exists in another namespace
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
    |
 LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
-   |
-   = note: a struct named `Empty1` exists in another namespace
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct pattern syntax instead
    |
 LL -         Empty1() => ()
@@ -34,11 +34,13 @@ LL |         XEmpty1() => ()
    |
 LL | pub struct XEmpty1 {}
    | ------------------ `XEmpty1` defined here
-LL | pub struct XEmpty2;
-LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
    |
    = note: a struct named `XEmpty1` exists in another namespace
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
+   |
+LL | pub struct XEmpty6();
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct pattern syntax instead
    |
 LL -         XEmpty1() => ()
@@ -59,12 +61,12 @@ LL | struct Empty1 {}
 LL |         Empty1(..) => ()
    |         ^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:3:1
+   = note: a struct named `Empty1` exists in another namespace
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
    |
 LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
-   |
-   = note: a struct named `Empty1` exists in another namespace
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct pattern syntax instead
    |
 LL -         Empty1(..) => ()
@@ -86,11 +88,13 @@ LL |         XEmpty1(..) => ()
    |
 LL | pub struct XEmpty1 {}
    | ------------------ `XEmpty1` defined here
-LL | pub struct XEmpty2;
-LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
    |
    = note: a struct named `XEmpty1` exists in another namespace
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
+   |
+LL | pub struct XEmpty6();
+   | ^^^^^^^^^^^^^^^^^^
 help: use struct pattern syntax instead
    |
 LL -         XEmpty1(..) => ()

--- a/tests/ui/resolve/empty-struct-tuple-pat.stderr
+++ b/tests/ui/resolve/empty-struct-tuple-pat.stderr
@@ -37,13 +37,16 @@ error[E0532]: expected unit struct, unit variant or constant, found tuple varian
 LL |         XE::XEmpty5 => (),
    |         ^^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:7:5
+  ::: $DIR/auxiliary/empty-struct.rs:8:5
    |
-LL |     XEmpty4,
-   |     ------- similarly named unit variant `XEmpty4` defined here
 LL |     XEmpty5(),
    |     ------- `XE::XEmpty5` defined here
    |
+note: similarly named unit variant `XEmpty4` defined here
+  --> $DIR/auxiliary/empty-struct.rs:7:5
+   |
+LL |     XEmpty4,
+   |     ^^^^^^^
 help: use the tuple variant pattern syntax instead
    |
 LL |         XE::XEmpty5() => (),

--- a/tests/ui/resolve/empty-struct-unit-pat.stderr
+++ b/tests/ui/resolve/empty-struct-unit-pat.stderr
@@ -7,11 +7,11 @@ LL | struct Empty2;
 LL |         Empty2() => ()
    |         ^^^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:3:1
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
    |
 LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Empty2() => ()
@@ -33,9 +33,12 @@ LL |         XEmpty2() => ()
    |
 LL | pub struct XEmpty2;
    | ------------------ `XEmpty2` defined here
-LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
    |
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
+   |
+LL | pub struct XEmpty6();
+   | ^^^^^^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         XEmpty2() => ()
@@ -56,11 +59,11 @@ LL | struct Empty2;
 LL |         Empty2(..) => ()
    |         ^^^^^^^^^^
    |
-  ::: $DIR/auxiliary/empty-struct.rs:3:1
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
    |
 LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
-   |
+   | ^^^^^^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         Empty2(..) => ()
@@ -82,9 +85,12 @@ LL |         XEmpty2(..) => ()
    |
 LL | pub struct XEmpty2;
    | ------------------ `XEmpty2` defined here
-LL | pub struct XEmpty6();
-   | ------------------ similarly named tuple struct `XEmpty6` defined here
    |
+note: similarly named tuple struct `XEmpty6` defined here
+  --> $DIR/auxiliary/empty-struct.rs:3:1
+   |
+LL | pub struct XEmpty6();
+   | ^^^^^^^^^^^^^^^^^^
 help: use this syntax instead
    |
 LL -         XEmpty2(..) => ()
@@ -115,9 +121,12 @@ LL |         XE::XEmpty4() => (),
    |
 LL |     XEmpty4,
    |     ------- `XE::XEmpty4` defined here
-LL |     XEmpty5(),
-   |     ------- similarly named tuple variant `XEmpty5` defined here
    |
+note: similarly named tuple variant `XEmpty5` defined here
+  --> $DIR/auxiliary/empty-struct.rs:8:5
+   |
+LL |     XEmpty5(),
+   |     ^^^^^^^
 help: use this syntax instead
    |
 LL -         XE::XEmpty4() => (),
@@ -148,9 +157,12 @@ LL |         XE::XEmpty4(..) => (),
    |
 LL |     XEmpty4,
    |     ------- `XE::XEmpty4` defined here
-LL |     XEmpty5(),
-   |     ------- similarly named tuple variant `XEmpty5` defined here
    |
+note: similarly named tuple variant `XEmpty5` defined here
+  --> $DIR/auxiliary/empty-struct.rs:8:5
+   |
+LL |     XEmpty5(),
+   |     ^^^^^^^
 help: use this syntax instead
    |
 LL -         XE::XEmpty4(..) => (),

--- a/tests/ui/resolve/issue-10200.stderr
+++ b/tests/ui/resolve/issue-10200.stderr
@@ -1,13 +1,15 @@
 error[E0532]: expected a pattern, found a function call
   --> $DIR/issue-10200.rs:6:9
    |
-LL | struct Foo(bool);
-   | ----------------- similarly named tuple struct `Foo` defined here
-...
 LL |         foo(x)
-   |         ^^^
+   |         ^^^ not a tuple struct or tuple variant
    |
    = note: function calls are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
+note: similarly named tuple struct `Foo` defined here
+  --> $DIR/issue-10200.rs:1:1
+   |
+LL | struct Foo(bool);
+   | ^^^^^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists (notice the capitalization)
    |
 LL -         foo(x)

--- a/tests/ui/resolve/issue-5035.stderr
+++ b/tests/ui/resolve/issue-5035.stderr
@@ -9,12 +9,14 @@ LL | use crate::ImportError;
 error[E0404]: expected trait, found type alias `K`
   --> $DIR/issue-5035.rs:5:6
    |
-LL | trait I {}
-   | ------- similarly named trait `I` defined here
-LL | type K = dyn I;
 LL | impl K for isize {}
    |      ^ type aliases cannot be used as traits
    |
+note: similarly named trait `I` defined here
+  --> $DIR/issue-5035.rs:3:1
+   |
+LL | trait I {}
+   | ^^^^^^^
 help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
    |
 LL - type K = dyn I;

--- a/tests/ui/resolve/levenshtein.stderr
+++ b/tests/ui/resolve/levenshtein.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find type `esize` in this scope
   --> $DIR/levenshtein.rs:5:11
    |
 LL | fn foo(c: esize) {} // Misspelled primitive type name.
-   |           ^^^^^
+   |           ^^^^^ not found in this scope
    |
 help: a builtin type with a similar name exists
    |
@@ -13,12 +13,14 @@ LL + fn foo(c: isize) {} // Misspelled primitive type name.
 error[E0425]: cannot find type `Baz` in this scope
   --> $DIR/levenshtein.rs:10:10
    |
-LL | enum Bar { }
-   | -------- similarly named enum `Bar` defined here
-LL |
 LL | type A = Baz; // Misspelled type name.
-   |          ^^^
+   |          ^^^ not found in this scope
    |
+note: similarly named enum `Bar` defined here
+  --> $DIR/levenshtein.rs:8:1
+   |
+LL | enum Bar { }
+   | ^^^^^^^^
 help: an enum with a similar name exists
    |
 LL - type A = Baz; // Misspelled type name.
@@ -29,11 +31,10 @@ error[E0425]: cannot find type `Opiton` in this scope
   --> $DIR/levenshtein.rs:12:10
    |
 LL | type B = Opiton<u8>; // Misspelled type name from the prelude.
-   |          ^^^^^^
+   |          ^^^^^^ not found in this scope
    |
+note: similarly named enum `Option` defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
-   |
-   = note: similarly named enum `Option` defined here
 help: an enum with a similar name exists
    |
 LL - type B = Opiton<u8>; // Misspelled type name from the prelude.
@@ -49,12 +50,14 @@ LL |     type A = Baz; // No suggestion here, Bar is not visible
 error[E0425]: cannot find value `MAXITEM` in this scope
   --> $DIR/levenshtein.rs:24:20
    |
-LL | const MAX_ITEM: usize = 10;
-   | --------------------------- similarly named constant `MAX_ITEM` defined here
-...
 LL |     let v = [0u32; MAXITEM]; // Misspelled constant name.
-   |                    ^^^^^^^
+   |                    ^^^^^^^ not found in this scope
    |
+note: similarly named constant `MAX_ITEM` defined here
+  --> $DIR/levenshtein.rs:1:1
+   |
+LL | const MAX_ITEM: usize = 10;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists
    |
 LL |     let v = [0u32; MAX_ITEM]; // Misspelled constant name.
@@ -63,12 +66,14 @@ LL |     let v = [0u32; MAX_ITEM]; // Misspelled constant name.
 error[E0425]: cannot find type `first` in module `m`
   --> $DIR/levenshtein.rs:28:15
    |
-LL |     pub struct First;
-   |     ----------------- similarly named struct `First` defined here
-...
 LL |     let b: m::first = m::second; // Misspelled item in module.
-   |               ^^^^^
+   |               ^^^^^ not found in `m`
    |
+note: similarly named struct `First` defined here
+  --> $DIR/levenshtein.rs:19:5
+   |
+LL |     pub struct First;
+   |     ^^^^^^^^^^^^^^^^^
 help: a struct with a similar name exists (notice the capitalization)
    |
 LL -     let b: m::first = m::second; // Misspelled item in module.
@@ -78,12 +83,14 @@ LL +     let b: m::First = m::second; // Misspelled item in module.
 error[E0425]: cannot find value `second` in module `m`
   --> $DIR/levenshtein.rs:28:26
    |
-LL |     pub struct Second;
-   |     ------------------ similarly named unit struct `Second` defined here
-...
 LL |     let b: m::first = m::second; // Misspelled item in module.
-   |                          ^^^^^^
+   |                          ^^^^^^ not found in `m`
    |
+note: similarly named unit struct `Second` defined here
+  --> $DIR/levenshtein.rs:20:5
+   |
+LL |     pub struct Second;
+   |     ^^^^^^^^^^^^^^^^^^
 help: a unit struct with a similar name exists (notice the capitalization)
    |
 LL -     let b: m::first = m::second; // Misspelled item in module.
@@ -93,12 +100,14 @@ LL +     let b: m::first = m::Second; // Misspelled item in module.
 error[E0425]: cannot find function `foobar` in this scope
   --> $DIR/levenshtein.rs:26:5
    |
-LL | fn foo_bar() {}
-   | ------------ similarly named function `foo_bar` defined here
-...
 LL |     foobar(); // Misspelled function name.
-   |     ^^^^^^
+   |     ^^^^^^ not found in this scope
    |
+note: similarly named function `foo_bar` defined here
+  --> $DIR/levenshtein.rs:3:1
+   |
+LL | fn foo_bar() {}
+   | ^^^^^^^^^^^^
 help: a function with a similar name exists
    |
 LL |     foo_bar(); // Misspelled function name.

--- a/tests/ui/resolve/privacy-enum-ctor.stderr
+++ b/tests/ui/resolve/privacy-enum-ctor.stderr
@@ -59,9 +59,6 @@ LL +         (m::Z::Fn(/* fields */));
 error[E0423]: cannot find value `E` in module `m`
   --> $DIR/privacy-enum-ctor.rs:42:19
    |
-LL |     fn f() {
-   |     ------ similarly named function `f` defined here
-...
 LL |     let _: E = m::E;
    |                   ^
    |
@@ -77,6 +74,11 @@ LL | |         },
 LL | |         Unit,
 LL | |     }
    | |_____^
+note: similarly named function `f` defined here
+  --> $DIR/privacy-enum-ctor.rs:23:5
+   |
+LL |     fn f() {
+   |     ^^^^^^
 help: you might have meant to use the following enum variant
    |
 LL -     let _: E = m::E;
@@ -149,12 +151,14 @@ LL + use std::f64::consts::E;
 error[E0425]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:58:12
    |
-LL |     pub enum E {
-   |     ---------- similarly named enum `E` defined here
-...
 LL |     let _: Z = m::n::Z;
-   |            ^
+   |            ^ not found in this scope
    |
+note: similarly named enum `E` defined here
+  --> $DIR/privacy-enum-ctor.rs:3:5
+   |
+LL |     pub enum E {
+   |     ^^^^^^^^^^
 note: enum `m::Z` exists but is inaccessible
   --> $DIR/privacy-enum-ctor.rs:12:9
    |
@@ -198,12 +202,14 @@ LL +     let _: Z = (m::Z::Fn(/* fields */));
 error[E0425]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:62:12
    |
-LL |     pub enum E {
-   |     ---------- similarly named enum `E` defined here
-...
 LL |     let _: Z = m::n::Z::Fn;
-   |            ^
+   |            ^ not found in this scope
    |
+note: similarly named enum `E` defined here
+  --> $DIR/privacy-enum-ctor.rs:3:5
+   |
+LL |     pub enum E {
+   |     ^^^^^^^^^^
 note: enum `m::Z` exists but is inaccessible
   --> $DIR/privacy-enum-ctor.rs:12:9
    |
@@ -218,12 +224,14 @@ LL +     let _: E = m::n::Z::Fn;
 error[E0425]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:65:12
    |
-LL |     pub enum E {
-   |     ---------- similarly named enum `E` defined here
-...
 LL |     let _: Z = m::n::Z::Struct;
-   |            ^
+   |            ^ not found in this scope
    |
+note: similarly named enum `E` defined here
+  --> $DIR/privacy-enum-ctor.rs:3:5
+   |
+LL |     pub enum E {
+   |     ^^^^^^^^^^
 note: enum `m::Z` exists but is inaccessible
   --> $DIR/privacy-enum-ctor.rs:12:9
    |
@@ -238,12 +246,14 @@ LL +     let _: E = m::n::Z::Struct;
 error[E0425]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:69:12
    |
-LL |     pub enum E {
-   |     ---------- similarly named enum `E` defined here
-...
 LL |     let _: Z = m::n::Z::Unit {};
-   |            ^
+   |            ^ not found in this scope
    |
+note: similarly named enum `E` defined here
+  --> $DIR/privacy-enum-ctor.rs:3:5
+   |
+LL |     pub enum E {
+   |     ^^^^^^^^^^
 note: enum `m::Z` exists but is inaccessible
   --> $DIR/privacy-enum-ctor.rs:12:9
    |

--- a/tests/ui/resolve/privacy-struct-ctor.stderr
+++ b/tests/ui/resolve/privacy-struct-ctor.stderr
@@ -1,13 +1,15 @@
 error[E0423]: cannot find value `Z` in this scope
   --> $DIR/privacy-struct-ctor.rs:21:9
    |
-LL |     pub struct S(u8);
-   |     ----------------- similarly named tuple struct `S` defined here
-...
 LL |         Z;
    |         ^ constructor is not visible here due to private fields
    |
    = note: a struct named `Z` exists in another namespace
+note: similarly named tuple struct `S` defined here
+  --> $DIR/privacy-struct-ctor.rs:7:5
+   |
+LL |     pub struct S(u8);
+   |     ^^^^^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL -         Z;

--- a/tests/ui/resolve/suggestions/suggest-path-instead-of-mod-dot-item.stderr
+++ b/tests/ui/resolve/suggestions/suggest-path-instead-of-mod-dot-item.stderr
@@ -40,13 +40,15 @@ LL +     a::b.J
 error[E0423]: cannot find value `b` in module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:35:8
    |
-LL |     pub const I: i32 = 1;
-   |     --------------------- similarly named constant `I` defined here
-...
 LL |     a::b.J
    |        ^
    |
    = note: a module named `a::b` exists in another namespace
+note: similarly named constant `I` defined here
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:5:5
+   |
+LL |     pub const I: i32 = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: use the path separator to refer to an item
    |
 LL -     a::b.J
@@ -74,13 +76,15 @@ LL +     a::b.f();
 error[E0423]: cannot find value `b` in module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:46:15
    |
-LL |     pub const I: i32 = 1;
-   |     --------------------- similarly named constant `I` defined here
-...
 LL |     v.push(a::b);
-   |               ^
+   |               ^ not found in `a`
    |
    = note: a module named `a::b` exists in another namespace
+note: similarly named constant `I` defined here
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:5:5
+   |
+LL |     pub const I: i32 = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists
    |
 LL -     v.push(a::b);
@@ -90,13 +94,15 @@ LL +     v.push(a::I);
 error[E0423]: cannot find value `b` in module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:52:8
    |
-LL |     pub const I: i32 = 1;
-   |     --------------------- similarly named constant `I` defined here
-...
 LL |     a::b.f()
    |        ^
    |
    = note: a module named `a::b` exists in another namespace
+note: similarly named constant `I` defined here
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:5:5
+   |
+LL |     pub const I: i32 = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: use the path separator to refer to an item
    |
 LL -     a::b.f()
@@ -111,13 +117,15 @@ LL +     a::I.f()
 error[E0423]: cannot find value `b` in module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:59:8
    |
-LL |     pub const I: i32 = 1;
-   |     --------------------- similarly named constant `I` defined here
-...
 LL |     a::b
-   |        ^
+   |        ^ not found in `a`
    |
    = note: a module named `a::b` exists in another namespace
+note: similarly named constant `I` defined here
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:5:5
+   |
+LL |     pub const I: i32 = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists
    |
 LL -     a::b
@@ -127,13 +135,15 @@ LL +     a::I
 error[E0423]: cannot find function `b` in module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:65:8
    |
-LL |     pub const I: i32 = 1;
-   |     --------------------- similarly named constant `I` defined here
-...
 LL |     a::b()
-   |        ^
+   |        ^ not found in `a`
    |
    = note: a module named `a::b` exists in another namespace
+note: similarly named constant `I` defined here
+  --> $DIR/suggest-path-instead-of-mod-dot-item.rs:5:5
+   |
+LL |     pub const I: i32 = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists
    |
 LL -     a::b()

--- a/tests/ui/resolve/tuple-struct-alias.stderr
+++ b/tests/ui/resolve/tuple-struct-alias.stderr
@@ -1,13 +1,15 @@
 error[E0532]: cannot find tuple struct or tuple variant `A` in this scope
   --> $DIR/tuple-struct-alias.rs:7:9
    |
-LL | struct S(u8, u16);
-   | ------------------ similarly named tuple struct `S` defined here
-...
 LL |         A(..) => {}
-   |         ^
+   |         ^ not found in this scope
    |
    = note: a type alias named `A` exists in another namespace
+note: similarly named tuple struct `S` defined here
+  --> $DIR/tuple-struct-alias.rs:1:1
+   |
+LL | struct S(u8, u16);
+   | ^^^^^^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL -         A(..) => {}
@@ -17,13 +19,15 @@ LL +         S(..) => {}
 error[E0423]: cannot find function, tuple struct or tuple variant `A` in this scope
   --> $DIR/tuple-struct-alias.rs:5:13
    |
-LL | struct S(u8, u16);
-   | ------------------ similarly named tuple struct `S` defined here
-...
 LL |     let s = A(0, 1);
    |             ^
    |
    = note: a type alias named `A` exists in another namespace
+note: similarly named tuple struct `S` defined here
+  --> $DIR/tuple-struct-alias.rs:1:1
+   |
+LL | struct S(u8, u16);
+   | ^^^^^^^^^^^^^^^^^^
 help: a tuple struct with a similar name exists
    |
 LL -     let s = A(0, 1);

--- a/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
+++ b/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
@@ -49,10 +49,12 @@ error[E0425]: cannot find value `bah` in this scope
    |
 LL |         bah;
    |         ^^^
-...
-LL | fn ba() {}
-   | ------- similarly named function `ba` defined here
    |
+note: similarly named function `ba` defined here
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:42:1
+   |
+LL | fn ba() {}
+   | ^^^^^^^
 help: you might have meant to refer to the associated function
    |
 LL |         Self::bah;
@@ -68,10 +70,12 @@ error[E0425]: cannot find value `BAR` in this scope
    |
 LL |         BAR;
    |         ^^^
-...
-LL | const BARR: u32 = 3;
-   | -------------------- similarly named constant `BARR` defined here
    |
+note: similarly named constant `BARR` defined here
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:43:1
+   |
+LL | const BARR: u32 = 3;
+   | ^^^^^^^^^^^^^^^^^^^^
 help: you might have meant to use the associated `const`
    |
 LL |         Self::BAR;
@@ -86,10 +90,12 @@ error[E0425]: cannot find type `Baz` in this scope
    |
 LL |         let foo: Baz = "".to_string();
    |                  ^^^
-...
-LL | type Bar = String;
-   | ------------------ similarly named type alias `Bar` defined here
    |
+note: similarly named type alias `Bar` defined here
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:44:1
+   |
+LL | type Bar = String;
+   | ^^^^^^^^^^^^^^^^^^
 help: you might have meant to use the associated type
    |
 LL |         let foo: Self::Baz = "".to_string();
@@ -105,10 +111,12 @@ error[E0425]: cannot find function `baz` in this scope
    |
 LL |         baz();
    |         ^^^
-...
-LL | fn ba() {}
-   | ------- similarly named function `ba` defined here
    |
+note: similarly named function `ba` defined here
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:42:1
+   |
+LL | fn ba() {}
+   | ^^^^^^^
 help: you might have meant to call the method
    |
 LL |         self.baz();

--- a/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.rs
+++ b/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.rs
@@ -12,7 +12,7 @@ trait Foo: Deref<Target = W> {
 fn test(x: &dyn Foo) {
     //~^ ERROR the trait `Foo` is not dyn compatible
     x.method();
-    //~^ ERROR the trait `Foo` is not dyn compatible
+    //~^ ERROR no method named `method` found for reference `&dyn Foo`
 }
 
 fn main() {}

--- a/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.rs
+++ b/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.rs
@@ -12,7 +12,6 @@ trait Foo: Deref<Target = W> {
 fn test(x: &dyn Foo) {
     //~^ ERROR the trait `Foo` is not dyn compatible
     x.method();
-    //~^ ERROR no method named `method` found for reference `&dyn Foo`
 }
 
 fn main() {}

--- a/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
+++ b/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
@@ -25,25 +25,16 @@ LL |     fn method(self: &W) {}
    = note: type of `self` must be `Self` or a type that dereferences to it
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
-error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:14:5
+error[E0599]: no method named `method` found for reference `&dyn Foo` in the current scope
+  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:14:7
    |
 LL |     fn method(self: &W) {}
-   |                     -- help: consider changing method `method`'s `self` parameter to be `&self`: `&Self`
+   |                     -- the method might not be found because of this arbitrary self type
 ...
 LL |     x.method();
-   |     ^^^^^^^^^^ `Foo` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:8:21
-   |
-LL | trait Foo: Deref<Target = W> {
-   |       --- this trait is not dyn compatible...
-LL |     fn method(self: &W) {}
-   |                     ^^ ...because method `method`'s `self` parameter cannot be dispatched on
+   |       ^^^^^^ method not found in `&dyn Foo`
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0038, E0307.
+Some errors have detailed explanations: E0038, E0307, E0599.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
+++ b/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
@@ -25,16 +25,7 @@ LL |     fn method(self: &W) {}
    = note: type of `self` must be `Self` or a type that dereferences to it
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
-error[E0599]: no method named `method` found for reference `&dyn Foo` in the current scope
-  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:14:7
-   |
-LL |     fn method(self: &W) {}
-   |                     -- the method might not be found because of this arbitrary self type
-...
-LL |     x.method();
-   |       ^^^^^^ method not found in `&dyn Foo`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0038, E0307, E0599.
+Some errors have detailed explanations: E0038, E0307.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/span/suggestion-raw-68962.stderr
+++ b/tests/ui/span/suggestion-raw-68962.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `fina` in this scope
   --> $DIR/suggestion-raw-68962.rs:7:5
    |
 LL |     fina;
-   |     ^^^^
+   |     ^^^^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -13,12 +13,14 @@ LL +     r#final;
 error[E0425]: cannot find function `f` in this scope
   --> $DIR/suggestion-raw-68962.rs:10:5
    |
-LL | fn r#fn() {}
-   | --------- similarly named function `r#fn` defined here
-...
 LL |     f();
-   |     ^
+   |     ^ not found in this scope
    |
+note: similarly named function `r#fn` defined here
+  --> $DIR/suggestion-raw-68962.rs:1:1
+   |
+LL | fn r#fn() {}
+   | ^^^^^^^^^
 help: a function with a similar name exists
    |
 LL -     f();

--- a/tests/ui/span/typo-suggestion.stderr
+++ b/tests/ui/span/typo-suggestion.stderr
@@ -8,7 +8,7 @@ error[E0425]: cannot find value `fob` in this scope
   --> $DIR/typo-suggestion.rs:8:26
    |
 LL |     println!("Hello {}", fob);
-   |                          ^^^
+   |                          ^^^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/stability-attribute/issue-109177.stderr
+++ b/tests/ui/stability-attribute/issue-109177.stderr
@@ -2,13 +2,13 @@ error[E0425]: cannot find function `foo1` in crate `similar_unstable_method`
   --> $DIR/issue-109177.rs:7:30
    |
 LL |     similar_unstable_method::foo1();
-   |                              ^^^^
+   |                              ^^^^ not found in `similar_unstable_method`
    |
-  ::: $DIR/auxiliary/similar-unstable-method.rs:5:1
+note: similarly named function `foo` defined here
+  --> $DIR/auxiliary/similar-unstable-method.rs:5:1
    |
 LL | pub fn foo() {}
-   | ------------ similarly named function `foo` defined here
-   |
+   | ^^^^^^^^^^^^
 help: a function with a similar name exists
    |
 LL -     similar_unstable_method::foo1();

--- a/tests/ui/structs/struct-fields-shorthand-unresolved.stderr
+++ b/tests/ui/structs/struct-fields-shorthand-unresolved.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/struct-fields-shorthand-unresolved.rs:10:9
    |
 LL |         y
-   |         ^
+   |         ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/suggestions/attribute-typos.stderr
+++ b/tests/ui/suggestions/attribute-typos.stderr
@@ -33,9 +33,8 @@ error: cannot find attribute `tests` in this scope
 LL | #[tests]
    |   ^^^^^
    |
+note: similarly named attribute macro `test` defined here
   --> $SRC_DIR/core/src/macros/mod.rs:LL:COL
-   |
-   = note: similarly named attribute macro `test` defined here
 help: an attribute macro with a similar name exists
    |
 LL - #[tests]

--- a/tests/ui/suggestions/case-difference-suggestions.stderr
+++ b/tests/ui/suggestions/case-difference-suggestions.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `Hello` in this scope
   --> $DIR/case-difference-suggestions.rs:5:20
    |
 LL |     println!("{}", Hello);
-   |                    ^^^^^
+   |                    ^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -14,7 +14,7 @@ error[E0425]: cannot find value `myvariable` in this scope
   --> $DIR/case-difference-suggestions.rs:9:20
    |
 LL |     println!("{}", myvariable);
-   |                    ^^^^^^^^^^
+   |                    ^^^^^^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the capitalization)
    |
@@ -26,7 +26,7 @@ error[E0425]: cannot find value `User_Name` in this scope
   --> $DIR/case-difference-suggestions.rs:13:20
    |
 LL |     println!("{}", User_Name);
-   |                    ^^^^^^^^^
+   |                    ^^^^^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -38,7 +38,7 @@ error[E0425]: cannot find value `foo` in this scope
   --> $DIR/case-difference-suggestions.rs:17:20
    |
 LL |     println!("{}", foo);
-   |                    ^^^
+   |                    ^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the capitalization)
    |
@@ -50,7 +50,7 @@ error[E0425]: cannot find value `FFOO` in this scope
   --> $DIR/case-difference-suggestions.rs:22:20
    |
 LL |     println!("{}", FFOO);
-   |                    ^^^^
+   |                    ^^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -62,7 +62,7 @@ error[E0425]: cannot find value `list` in this scope
   --> $DIR/case-difference-suggestions.rs:25:20
    |
 LL |     println!("{}", list);
-   |                    ^^^^
+   |                    ^^^^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -74,7 +74,7 @@ error[E0425]: cannot find value `SS` in this scope
   --> $DIR/case-difference-suggestions.rs:28:20
    |
 LL |     println!("{}", SS);
-   |                    ^^
+   |                    ^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -86,7 +86,7 @@ error[E0425]: cannot find value `a55` in this scope
   --> $DIR/case-difference-suggestions.rs:31:20
    |
 LL |     println!("{}", a55);
-   |                    ^^^
+   |                    ^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -98,7 +98,7 @@ error[E0425]: cannot find value `BB` in this scope
   --> $DIR/case-difference-suggestions.rs:34:20
    |
 LL |     println!("{}", BB);
-   |                    ^^
+   |                    ^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -110,7 +110,7 @@ error[E0425]: cannot find value `gg` in this scope
   --> $DIR/case-difference-suggestions.rs:37:20
    |
 LL |     println!("{}", gg);
-   |                    ^^
+   |                    ^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -122,7 +122,7 @@ error[E0425]: cannot find value `old` in this scope
   --> $DIR/case-difference-suggestions.rs:40:20
    |
 LL |     println!("{}", old);
-   |                    ^^^
+   |                    ^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -134,7 +134,7 @@ error[E0425]: cannot find value `newl` in this scope
   --> $DIR/case-difference-suggestions.rs:43:20
    |
 LL |     println!("{}", newl);
-   |                    ^^^^
+   |                    ^^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -146,7 +146,7 @@ error[E0425]: cannot find value `app1e` in this scope
   --> $DIR/case-difference-suggestions.rs:46:20
    |
 LL |     println!("{}", app1e);
-   |                    ^^^^^
+   |                    ^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the digit/letter confusion)
    |
@@ -158,7 +158,7 @@ error[E0425]: cannot find value `A` in this scope
   --> $DIR/case-difference-suggestions.rs:49:20
    |
 LL |     println!("{}", A);
-   |                    ^
+   |                    ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |
@@ -170,7 +170,7 @@ error[E0425]: cannot find value `world1U` in this scope
   --> $DIR/case-difference-suggestions.rs:52:20
    |
 LL |     println!("{}", world1U);
-   |                    ^^^^^^^
+   |                    ^^^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the capitalization and digit/letter confusion)
    |
@@ -182,7 +182,7 @@ error[E0425]: cannot find value `myv4r1able` in this scope
   --> $DIR/case-difference-suggestions.rs:55:20
    |
 LL |     println!("{}", myv4r1able);
-   |                    ^^^^^^^^^^
+   |                    ^^^^^^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists (notice the capitalization and digit/letter confusion)
    |

--- a/tests/ui/suggestions/do-not-attempt-to-add-suggestions-with-no-changes.stderr
+++ b/tests/ui/suggestions/do-not-attempt-to-add-suggestions-with-no-changes.stderr
@@ -2,11 +2,10 @@ error[E0573]: expected type, found module `result`
   --> $DIR/do-not-attempt-to-add-suggestions-with-no-changes.rs:3:6
    |
 LL | impl result {
-   |      ^^^^^^
+   |      ^^^^^^ not a type
    |
+note: similarly named enum `Result` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named enum `Result` defined here
 help: an enum with a similar name exists
    |
 LL - impl result {

--- a/tests/ui/suggestions/issue-66968-suggest-sorted-words.stderr
+++ b/tests/ui/suggestions/issue-66968-suggest-sorted-words.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `a_variable_longer_name` in this scope
   --> $DIR/issue-66968-suggest-sorted-words.rs:3:20
    |
 LL |     println!("{}", a_variable_longer_name);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
@@ -63,17 +63,24 @@ LL |     let x: bar;
 error[E0573]: cannot find type `x` in this scope
   --> $DIR/let-binding-init-expr-as-ty.rs:40:12
    |
-LL | struct K(S::new(()));
-   | --------------------- similarly named struct `K` defined here
-...
 LL |     let x: x;
-   |            ^
+   |            ^ not found in this scope
    |
    = note: a local variable named `x` exists in another namespace
+note: similarly named struct `K` defined here
+  --> $DIR/let-binding-init-expr-as-ty.rs:18:1
+   |
+LL | struct K(S::new(()));
+   | ^^^^^^^^^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL -     let x: x;
 LL +     let x: K;
+   |
+help: use `=` if you meant to assign
+   |
+LL -     let x: x;
+LL +     let x = x;
    |
 
 error[E0658]: return type notation is experimental

--- a/tests/ui/suggestions/silenced-binding-typo.stderr
+++ b/tests/ui/suggestions/silenced-binding-typo.stderr
@@ -1,11 +1,14 @@
 error[E0425]: cannot find value `x` in this scope
   --> $DIR/silenced-binding-typo.rs:4:14
    |
-LL |     let _x = 42;
-   |         -- `_x` defined here
 LL |     let _y = x;
-   |              ^
+   |              ^ not found in this scope
    |
+note: `_x` defined here
+  --> $DIR/silenced-binding-typo.rs:3:9
+   |
+LL |     let _x = 42;
+   |         ^^
 help: the leading underscore in `_x` marks it as unused, consider renaming it to `x`
    |
 LL -     let _x = 42;

--- a/tests/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
+++ b/tests/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
@@ -4,9 +4,8 @@ error[E0404]: expected trait, found struct `String`
 LL | struct Foo<T> where T: Bar, <T as Bar>::Baz: String {
    |                                              ^^^^^^ not a trait
    |
+note: similarly named trait `ToString` defined here
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
-   |
-   = note: similarly named trait `ToString` defined here
 help: constrain the associated type to `String`
    |
 LL - struct Foo<T> where T: Bar, <T as Bar>::Baz: String {
@@ -23,9 +22,8 @@ error[E0404]: expected trait, found struct `String`
 LL | struct Qux<'a, T> where T: Bar, <&'a T as Bar>::Baz: String {
    |                                                      ^^^^^^ not a trait
    |
+note: similarly named trait `ToString` defined here
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
-   |
-   = note: similarly named trait `ToString` defined here
 help: constrain the associated type to `String`
    |
 LL - struct Qux<'a, T> where T: Bar, <&'a T as Bar>::Baz: String {
@@ -42,9 +40,8 @@ error[E0404]: expected trait, found struct `String`
 LL | fn foo<T: Bar>(_: T) where <T as Bar>::Baz: String {
    |                                             ^^^^^^ not a trait
    |
+note: similarly named trait `ToString` defined here
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
-   |
-   = note: similarly named trait `ToString` defined here
 help: constrain the associated type to `String`
    |
 LL - fn foo<T: Bar>(_: T) where <T as Bar>::Baz: String {
@@ -61,9 +58,8 @@ error[E0404]: expected trait, found struct `String`
 LL | fn qux<'a, T: Bar>(_: &'a T) where <&'a T as Bar>::Baz: String {
    |                                                         ^^^^^^ not a trait
    |
+note: similarly named trait `ToString` defined here
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
-   |
-   = note: similarly named trait `ToString` defined here
 help: constrain the associated type to `String`
    |
 LL - fn qux<'a, T: Bar>(_: &'a T) where <&'a T as Bar>::Baz: String {
@@ -84,11 +80,10 @@ error[E0404]: expected trait, found struct `String`
   --> $DIR/assoc_type_bound_with_struct.rs:19:51
    |
 LL | fn issue_95327() where <u8 as Unresolved>::Assoc: String {}
-   |                                                   ^^^^^^
+   |                                                   ^^^^^^ not a trait
    |
+note: similarly named trait `ToString` defined here
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
-   |
-   = note: similarly named trait `ToString` defined here
 help: a trait with a similar name exists
    |
 LL | fn issue_95327() where <u8 as Unresolved>::Assoc: ToString {}

--- a/tests/ui/traits/bound/not-on-struct.stderr
+++ b/tests/ui/traits/bound/not-on-struct.stderr
@@ -147,8 +147,6 @@ LL + fn f<'a,T,E>(iter: Iterator<Item=Result<T,E>>) {
 error[E0404]: expected trait, found struct `Traitor`
   --> $DIR/not-on-struct.rs:36:11
    |
-LL | trait Trait {}
-   | ----------- similarly named trait `Trait` defined here
 LL | fn g() -> Traitor + 'static {
    |           ^^^^^^^ not a trait
    |
@@ -159,6 +157,11 @@ LL | fn g() -> Traitor + 'static {
    |           -------   ^^^^^^^ ...because of this bound
    |           |
    |           expected this type to be a trait...
+note: similarly named trait `Trait` defined here
+  --> $DIR/not-on-struct.rs:35:1
+   |
+LL | trait Trait {}
+   | ^^^^^^^^^^^
 help: if you meant to use a type and not a trait here, remove the bounds
    |
 LL - fn g() -> Traitor + 'static {

--- a/tests/ui/traits/const-traits/ice-120503-async-const-method.stderr
+++ b/tests/ui/traits/const-traits/ice-120503-async-const-method.stderr
@@ -44,11 +44,13 @@ error[E0425]: cannot find function `main8` in this scope
   --> $DIR/ice-120503-async-const-method.rs:11:9
    |
 LL |         main8().await;
-   |         ^^^^^
-...
-LL | fn main() {}
-   | --------- similarly named function `main` defined here
+   |         ^^^^^ not found in this scope
    |
+note: similarly named function `main` defined here
+  --> $DIR/ice-120503-async-const-method.rs:16:1
+   |
+LL | fn main() {}
+   | ^^^^^^^^^
 help: a function with a similar name exists
    |
 LL -         main8().await;

--- a/tests/ui/traits/const-traits/mismatched_generic_args.stderr
+++ b/tests/ui/traits/const-traits/mismatched_generic_args.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find value `y` in this scope
   --> $DIR/mismatched_generic_args.rs:19:9
    |
-LL | pub fn add<const U: Dimension>(x: Quantity<f32, U>) -> Quantity<f32, U> {
-   |                  - similarly named const parameter `U` defined here
-LL |
 LL |     x + y
-   |         ^
+   |         ^ not found in this scope
    |
+note: similarly named const parameter `U` defined here
+  --> $DIR/mismatched_generic_args.rs:17:18
+   |
+LL | pub fn add<const U: Dimension>(x: Quantity<f32, U>) -> Quantity<f32, U> {
+   |                  ^
 help: a const parameter with a similar name exists
    |
 LL -     x + y

--- a/tests/ui/traits/ice-with-dyn-pointee-errors.rs
+++ b/tests/ui/traits/ice-with-dyn-pointee-errors.rs
@@ -8,7 +8,8 @@ fn unknown_sized_object_ptr_in(_: &(impl Pointee<Metadata = ()> + ?Sized)) {}
 fn raw_pointer_in(x: &dyn Pointee<Metadata = ()>) {
     //~^ ERROR the trait `Pointee` is not dyn compatible
     unknown_sized_object_ptr_in(x)
-    //~^ ERROR the trait `Pointee` is not dyn compatible
+    //~^ ERROR type mismatch resolving `<dyn Pointee<Metadata = ()> as Pointee>::Metadata == ()`
+    //~| ERROR the trait `Pointee` is not dyn compatible
 }
 
 fn main() {

--- a/tests/ui/traits/ice-with-dyn-pointee-errors.rs
+++ b/tests/ui/traits/ice-with-dyn-pointee-errors.rs
@@ -8,7 +8,7 @@ fn unknown_sized_object_ptr_in(_: &(impl Pointee<Metadata = ()> + ?Sized)) {}
 fn raw_pointer_in(x: &dyn Pointee<Metadata = ()>) {
     //~^ ERROR the trait `Pointee` is not dyn compatible
     unknown_sized_object_ptr_in(x)
-    //~^ ERROR type mismatch resolving `<dyn Pointee<Metadata = ()> as Pointee>::Metadata == ()`
+    //~^ ERROR the trait `Pointee` is not dyn compatible
     //~| ERROR the trait `Pointee` is not dyn compatible
 }
 

--- a/tests/ui/traits/ice-with-dyn-pointee-errors.stderr
+++ b/tests/ui/traits/ice-with-dyn-pointee-errors.stderr
@@ -10,6 +10,22 @@ note: for a trait to be dyn compatible it needs to allow building a vtable
    |
    = note: the trait is not dyn compatible because it opted out of dyn-compatibility
 
+error[E0271]: type mismatch resolving `<dyn Pointee<Metadata = ()> as Pointee>::Metadata == ()`
+  --> $DIR/ice-with-dyn-pointee-errors.rs:10:33
+   |
+LL |     unknown_sized_object_ptr_in(x)
+   |     --------------------------- ^ expected `()`, found `DynMetadata<dyn Pointee<Metadata = ()>>`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = note: expected unit type `()`
+                 found struct `DynMetadata<dyn Pointee<Metadata = ()>>`
+note: required by a bound in `unknown_sized_object_ptr_in`
+  --> $DIR/ice-with-dyn-pointee-errors.rs:6:50
+   |
+LL | fn unknown_sized_object_ptr_in(_: &(impl Pointee<Metadata = ()> + ?Sized)) {}
+   |                                                  ^^^^^^^^^^^^^ required by this bound in `unknown_sized_object_ptr_in`
+
 error[E0038]: the trait `Pointee` is not dyn compatible
   --> $DIR/ice-with-dyn-pointee-errors.rs:10:5
    |
@@ -23,7 +39,7 @@ note: for a trait to be dyn compatible it needs to allow building a vtable
    = note: the trait is not dyn compatible because it opted out of dyn-compatibility
 
 error[E0038]: the trait `Pointee` is not dyn compatible
-  --> $DIR/ice-with-dyn-pointee-errors.rs:15:20
+  --> $DIR/ice-with-dyn-pointee-errors.rs:16:20
    |
 LL |     raw_pointer_in(&42)
    |                    ^^^ `Pointee` is not dyn compatible
@@ -34,6 +50,7 @@ note: for a trait to be dyn compatible it needs to allow building a vtable
    |
    = note: the trait is not dyn compatible because it opted out of dyn-compatibility
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0038`.
+Some errors have detailed explanations: E0038, E0271.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/traits/ice-with-dyn-pointee-errors.stderr
+++ b/tests/ui/traits/ice-with-dyn-pointee-errors.stderr
@@ -10,21 +10,17 @@ note: for a trait to be dyn compatible it needs to allow building a vtable
    |
    = note: the trait is not dyn compatible because it opted out of dyn-compatibility
 
-error[E0271]: type mismatch resolving `<dyn Pointee<Metadata = ()> as Pointee>::Metadata == ()`
-  --> $DIR/ice-with-dyn-pointee-errors.rs:10:33
+error[E0038]: the trait `Pointee` is not dyn compatible
+  --> $DIR/ice-with-dyn-pointee-errors.rs:10:5
    |
 LL |     unknown_sized_object_ptr_in(x)
-   |     --------------------------- ^ expected `()`, found `DynMetadata<dyn Pointee<Metadata = ()>>`
-   |     |
-   |     required by a bound introduced by this call
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Pointee` is not dyn compatible
    |
-   = note: expected unit type `()`
-                 found struct `DynMetadata<dyn Pointee<Metadata = ()>>`
-note: required by a bound in `unknown_sized_object_ptr_in`
-  --> $DIR/ice-with-dyn-pointee-errors.rs:6:50
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
    |
-LL | fn unknown_sized_object_ptr_in(_: &(impl Pointee<Metadata = ()> + ?Sized)) {}
-   |                                                  ^^^^^^^^^^^^^ required by this bound in `unknown_sized_object_ptr_in`
+   = note: the trait is not dyn compatible because it opted out of dyn-compatibility
 
 error[E0038]: the trait `Pointee` is not dyn compatible
   --> $DIR/ice-with-dyn-pointee-errors.rs:10:5
@@ -52,5 +48,4 @@ note: for a trait to be dyn compatible it needs to allow building a vtable
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0038, E0271.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/traits/impl-for-module.stderr
+++ b/tests/ui/traits/impl-for-module.stderr
@@ -1,12 +1,14 @@
 error[E0573]: expected type, found module `a`
   --> $DIR/impl-for-module.rs:7:12
    |
-LL | trait A {
-   | ------- similarly named trait `A` defined here
-...
 LL | impl A for a {
-   |            ^
+   |            ^ not a type
    |
+note: similarly named trait `A` defined here
+  --> $DIR/impl-for-module.rs:4:1
+   |
+LL | trait A {
+   | ^^^^^^^
 help: a trait with a similar name exists
    |
 LL - impl A for a {

--- a/tests/ui/traits/issue-50480.stderr
+++ b/tests/ui/traits/issue-50480.stderr
@@ -41,10 +41,13 @@ error[E0425]: cannot find type `N` in this scope
   --> $DIR/issue-50480.rs:12:18
    |
 LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
-   |            -     ^
-   |            |
-   |            similarly named type parameter `T` defined here
+   |                  ^ not found in this scope
    |
+note: similarly named type parameter `T` defined here
+  --> $DIR/issue-50480.rs:12:12
+   |
+LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
+   |            ^
 help: a type parameter with a similar name exists
    |
 LL - struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);

--- a/tests/ui/traits/issue-78372.stderr
+++ b/tests/ui/traits/issue-78372.stderr
@@ -13,10 +13,13 @@ error[E0425]: cannot find type `U` in this scope
   --> $DIR/issue-78372.rs:3:31
    |
 LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}
-   |      -                        ^
-   |      |
-   |      similarly named type parameter `T` defined here
+   |                               ^ not found in this scope
    |
+note: similarly named type parameter `T` defined here
+  --> $DIR/issue-78372.rs:3:6
+   |
+LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}
+   |      ^
 help: a type parameter with a similar name exists
    |
 LL - impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}

--- a/tests/ui/traits/late-bound-type-method-probe.stderr
+++ b/tests/ui/traits/late-bound-type-method-probe.stderr
@@ -2,11 +2,10 @@ error[E0425]: cannot find type `F` in this scope
   --> $DIR/late-bound-type-method-probe.rs:8:26
    |
 LL |     fn t<Tail>(&self, _: F) {}
-   |                          ^
+   |                          ^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL |     fn t<Tail>(&self, _: Fn) {}

--- a/tests/ui/traits/object/dyn-proj-non-dyn-compat.rs
+++ b/tests/ui/traits/object/dyn-proj-non-dyn-compat.rs
@@ -1,0 +1,20 @@
+// Check that we are not producing long error messages
+
+trait Trait {
+    type Output;
+    fn process<T>(&mut self, input: T) -> T;
+}
+
+struct MyImpl;
+
+impl Trait for MyImpl {
+    type Output = &'static str;
+    fn process<T>(&mut self, input: T) -> T { input }
+}
+
+fn make() -> impl Trait<Output = <dyn Trait<Output = &'static str> as Trait>::Output> {
+    //~^ ERROR the trait `Trait` is not dyn compatible
+    MyImpl
+}
+
+fn main() {}

--- a/tests/ui/traits/object/dyn-proj-non-dyn-compat.stderr
+++ b/tests/ui/traits/object/dyn-proj-non-dyn-compat.stderr
@@ -1,0 +1,21 @@
+error[E0038]: the trait `Trait` is not dyn compatible
+  --> $DIR/dyn-proj-non-dyn-compat.rs:15:14
+   |
+LL | fn make() -> impl Trait<Output = <dyn Trait<Output = &'static str> as Trait>::Output> {
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Trait` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/dyn-proj-non-dyn-compat.rs:5:8
+   |
+LL | trait Trait {
+   |       ----- this trait is not dyn compatible...
+LL |     type Output;
+LL |     fn process<T>(&mut self, input: T) -> T;
+   |        ^^^^^^^ ...because method `process` has generic type parameters
+   = help: consider moving `process` to another trait
+   = help: only type `MyImpl` implements `Trait`; consider using it directly instead.
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/traits/object/dyn-type-param-bound-not-checked.rs
+++ b/tests/ui/traits/object/dyn-type-param-bound-not-checked.rs
@@ -1,0 +1,13 @@
+//@ check-pass
+// Protection against a naive fix for #152607
+
+//@ revisions: current next
+
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+trait Trait<T: Sized> {}
+
+fn foo(_: &dyn Trait<[u32]>) {}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/type-error-drop-elaboration.stderr
+++ b/tests/ui/type-alias-impl-trait/type-error-drop-elaboration.stderr
@@ -2,11 +2,13 @@ error[E0425]: cannot find function `value` in this scope
   --> $DIR/type-error-drop-elaboration.rs:12:5
    |
 LL |     value()
-   |     ^^^^^
-...
-LL | const VALUE: Foo = foo();
-   | ------------------------- similarly named constant `VALUE` defined here
+   |     ^^^^^ not found in this scope
    |
+note: similarly named constant `VALUE` defined here
+  --> $DIR/type-error-drop-elaboration.rs:16:1
+   |
+LL | const VALUE: Foo = foo();
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 help: a constant with a similar name exists
    |
 LL -     value()

--- a/tests/ui/type/issue-7607-1.stderr
+++ b/tests/ui/type/issue-7607-1.stderr
@@ -2,11 +2,10 @@ error[E0425]: cannot find type `Fo` in this scope
   --> $DIR/issue-7607-1.rs:5:6
    |
 LL | impl Fo {
-   |      ^^
+   |      ^^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL - impl Fo {

--- a/tests/ui/typeck/issue-114423-ice-regression-in-suggestion.stderr
+++ b/tests/ui/typeck/issue-114423-ice-regression-in-suggestion.stderr
@@ -14,7 +14,7 @@ error[E0425]: cannot find value `g` in this scope
   --> $DIR/issue-114423-ice-regression-in-suggestion.rs:11:22
    |
 LL |     let _ = RGB { r, g, b };
-   |                      ^
+   |                      ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/typeck/issue-83693.stderr
+++ b/tests/ui/typeck/issue-83693.stderr
@@ -2,11 +2,10 @@ error[E0425]: cannot find type `F` in this scope
   --> $DIR/issue-83693.rs:6:6
    |
 LL | impl F {
-   |      ^
+   |      ^ not found in this scope
    |
+note: similarly named trait `Fn` defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-   |
-   = note: similarly named trait `Fn` defined here
 help: a trait with a similar name exists
    |
 LL | impl Fn {

--- a/tests/ui/typeck/issue-88844.rs
+++ b/tests/ui/typeck/issue-88844.rs
@@ -5,6 +5,7 @@ struct Struct { value: i32 }
 
 impl Stuct {
 //~^ ERROR: cannot find type `Stuct` in this scope [E0425]
+//~| NOTE not found in this scope
 //~| HELP: a struct with a similar name exists
     fn new() -> Self {
         Self { value: 42 }

--- a/tests/ui/typeck/issue-88844.stderr
+++ b/tests/ui/typeck/issue-88844.stderr
@@ -1,12 +1,14 @@
 error[E0425]: cannot find type `Stuct` in this scope
   --> $DIR/issue-88844.rs:6:6
    |
-LL | struct Struct { value: i32 }
-   | ------------- similarly named struct `Struct` defined here
-...
 LL | impl Stuct {
-   |      ^^^^^
+   |      ^^^^^ not found in this scope
    |
+note: similarly named struct `Struct` defined here
+  --> $DIR/issue-88844.rs:3:1
+   |
+LL | struct Struct { value: i32 }
+   | ^^^^^^^^^^^^^
 help: a struct with a similar name exists
    |
 LL | impl Struct {

--- a/tests/ui/ufcs/ufcs-partially-resolved.stderr
+++ b/tests/ui/ufcs/ufcs-partially-resolved.stderr
@@ -1,13 +1,25 @@
 error[E0576]: cannot find associated type `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:19:24
    |
-LL |     type Y = u16;
-   |     ------------- similarly named associated type `Y` defined here
-...
 LL |     let _: <u8 as Tr>::N;
-   |                        ^
+   |                        ^ not found in `Tr`
    |
+note: similarly named associated type `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:4:5
+   |
+LL |     type Y = u16;
+   |     ^^^^^^^^^^^^^
+note: associated type `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:4:5
+   |
+LL |     type Y = u16;
+   |     ^^^^^^^^^^^^^
 help: an associated type with a similar name exists
+   |
+LL -     let _: <u8 as Tr>::N;
+LL +     let _: <u8 as Tr>::Y;
+   |
+help: maybe you meant this associated type
    |
 LL -     let _: <u8 as Tr>::N;
 LL +     let _: <u8 as Tr>::Y;
@@ -17,11 +29,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:20:19
    |
 LL |     let _: <u8 as E>::N;
-   |                   ^
+   |                   ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     let _: <u8 as Eq>::N;
@@ -42,13 +53,25 @@ LL + trait A = u32;
 error[E0576]: cannot find method or associated constant `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:22:17
    |
-LL |     fn Y() {}
-   |     ------ similarly named associated function `Y` defined here
-...
 LL |     <u8 as Tr>::N;
-   |                 ^
+   |                 ^ not found in `Tr`
    |
+note: similarly named associated function `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:5:5
+   |
+LL |     fn Y() {}
+   |     ^^^^^^
+note: associated function `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:5:5
+   |
+LL |     fn Y() {}
+   |     ^^^^^^
 help: an associated function with a similar name exists
+   |
+LL -     <u8 as Tr>::N;
+LL +     <u8 as Tr>::Y;
+   |
+help: maybe you meant this associated function
    |
 LL -     <u8 as Tr>::N;
 LL +     <u8 as Tr>::Y;
@@ -58,11 +81,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:23:12
    |
 LL |     <u8 as E>::N;
-   |            ^
+   |            ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     <u8 as Eq>::N;
@@ -84,11 +106,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:26:19
    |
 LL |     let _: <u8 as E>::Y;
-   |                   ^
+   |                   ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     let _: <u8 as Eq>::Y;
@@ -98,11 +119,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:28:12
    |
 LL |     <u8 as E>::Y;
-   |            ^
+   |            ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     <u8 as Eq>::Y;
@@ -111,13 +131,25 @@ LL |     <u8 as Eq>::Y;
 error[E0576]: cannot find associated type `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:30:24
    |
-LL |     type Y = u16;
-   |     ------------- similarly named associated type `Y` defined here
-...
 LL |     let _: <u8 as Tr>::N::NN;
-   |                        ^
+   |                        ^ not found in `Tr`
    |
+note: similarly named associated type `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:4:5
+   |
+LL |     type Y = u16;
+   |     ^^^^^^^^^^^^^
+note: associated type `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:4:5
+   |
+LL |     type Y = u16;
+   |     ^^^^^^^^^^^^^
 help: an associated type with a similar name exists
+   |
+LL -     let _: <u8 as Tr>::N::NN;
+LL +     let _: <u8 as Tr>::Y::NN;
+   |
+help: maybe you meant this associated type
    |
 LL -     let _: <u8 as Tr>::N::NN;
 LL +     let _: <u8 as Tr>::Y::NN;
@@ -127,11 +159,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:31:19
    |
 LL |     let _: <u8 as E>::N::NN;
-   |                   ^
+   |                   ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     let _: <u8 as Eq>::N::NN;
@@ -152,13 +183,25 @@ LL + trait A = u32;
 error[E0576]: cannot find associated type `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:33:17
    |
-LL |     type Y = u16;
-   |     ------------- similarly named associated type `Y` defined here
-...
 LL |     <u8 as Tr>::N::NN;
-   |                 ^
+   |                 ^ not found in `Tr`
    |
+note: similarly named associated type `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:4:5
+   |
+LL |     type Y = u16;
+   |     ^^^^^^^^^^^^^
+note: associated type `Y` defined here
+  --> $DIR/ufcs-partially-resolved.rs:4:5
+   |
+LL |     type Y = u16;
+   |     ^^^^^^^^^^^^^
 help: an associated type with a similar name exists
+   |
+LL -     <u8 as Tr>::N::NN;
+LL +     <u8 as Tr>::Y::NN;
+   |
+help: maybe you meant this associated type
    |
 LL -     <u8 as Tr>::N::NN;
 LL +     <u8 as Tr>::Y::NN;
@@ -168,11 +211,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:34:12
    |
 LL |     <u8 as E>::N::NN;
-   |            ^
+   |            ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     <u8 as Eq>::N::NN;
@@ -194,11 +236,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:37:19
    |
 LL |     let _: <u8 as E>::Y::NN;
-   |                   ^
+   |                   ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     let _: <u8 as Eq>::Y::NN;
@@ -208,11 +249,10 @@ error[E0404]: expected trait, found enum `E`
   --> $DIR/ufcs-partially-resolved.rs:39:12
    |
 LL |     <u8 as E>::Y::NN;
-   |            ^
+   |            ^ not a trait
    |
+note: similarly named trait `Eq` defined here
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   |
-   = note: similarly named trait `Eq` defined here
 help: a trait with a similar name exists
    |
 LL |     <u8 as Eq>::Y::NN;
@@ -281,14 +321,26 @@ LL |     <u8 as E::Y>::NN;
 error[E0575]: cannot find associated type `Z` in trait `Dr`
   --> $DIR/ufcs-partially-resolved.rs:52:24
    |
-LL |     type X = u16;
-   |     ------------- similarly named associated type `X` defined here
-...
 LL |     let _: <u8 as Dr>::Z;
-   |                        ^
+   |                        ^ not found in `Dr`
    |
    = note: an associated function named `Dr::Z` exists in another namespace
+note: similarly named associated type `X` defined here
+  --> $DIR/ufcs-partially-resolved.rs:10:5
+   |
+LL |     type X = u16;
+   |     ^^^^^^^^^^^^^
+note: associated type `X` defined here
+  --> $DIR/ufcs-partially-resolved.rs:10:5
+   |
+LL |     type X = u16;
+   |     ^^^^^^^^^^^^^
 help: an associated type with a similar name exists
+   |
+LL -     let _: <u8 as Dr>::Z;
+LL +     let _: <u8 as Dr>::X;
+   |
+help: maybe you meant this associated type
    |
 LL -     let _: <u8 as Dr>::Z;
 LL +     let _: <u8 as Dr>::X;
@@ -297,14 +349,26 @@ LL +     let _: <u8 as Dr>::X;
 error[E0575]: cannot find method or associated constant `X` in trait `Dr`
   --> $DIR/ufcs-partially-resolved.rs:53:17
    |
-LL |     fn Z() {}
-   |     ------ similarly named associated function `Z` defined here
-...
 LL |     <u8 as Dr>::X;
-   |                 ^
+   |                 ^ not found in `Dr`
    |
    = note: an associated type named `Dr::X` exists in another namespace
+note: similarly named associated function `Z` defined here
+  --> $DIR/ufcs-partially-resolved.rs:11:5
+   |
+LL |     fn Z() {}
+   |     ^^^^^^
+note: associated function `Z` defined here
+  --> $DIR/ufcs-partially-resolved.rs:11:5
+   |
+LL |     fn Z() {}
+   |     ^^^^^^
 help: an associated function with a similar name exists
+   |
+LL -     <u8 as Dr>::X;
+LL +     <u8 as Dr>::Z;
+   |
+help: maybe you meant this associated function
    |
 LL -     <u8 as Dr>::X;
 LL +     <u8 as Dr>::Z;
@@ -313,14 +377,26 @@ LL +     <u8 as Dr>::Z;
 error[E0575]: cannot find associated type `Z` in trait `Dr`
   --> $DIR/ufcs-partially-resolved.rs:54:24
    |
-LL |     type X = u16;
-   |     ------------- similarly named associated type `X` defined here
-...
 LL |     let _: <u8 as Dr>::Z::N;
-   |                        ^
+   |                        ^ not found in `Dr`
    |
    = note: an associated function named `Dr::Z` exists in another namespace
+note: similarly named associated type `X` defined here
+  --> $DIR/ufcs-partially-resolved.rs:10:5
+   |
+LL |     type X = u16;
+   |     ^^^^^^^^^^^^^
+note: associated type `X` defined here
+  --> $DIR/ufcs-partially-resolved.rs:10:5
+   |
+LL |     type X = u16;
+   |     ^^^^^^^^^^^^^
 help: an associated type with a similar name exists
+   |
+LL -     let _: <u8 as Dr>::Z::N;
+LL +     let _: <u8 as Dr>::X::N;
+   |
+help: maybe you meant this associated type
    |
 LL -     let _: <u8 as Dr>::Z::N;
 LL +     let _: <u8 as Dr>::X::N;

--- a/tests/ui/unboxed-closures/unboxed-closures-type-mismatch-closure-from-another-scope.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-type-mismatch-closure-from-another-scope.stderr
@@ -8,7 +8,7 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/unboxed-closures-type-mismatch-closure-from-another-scope.rs:9:26
    |
 LL |         closure(&mut p, &y);
-   |                          ^
+   |                          ^ not found in this scope
    |
 help: a local variable with a similar name exists
    |

--- a/tests/ui/variants/variant-result-noresult-used-as-type.stderr
+++ b/tests/ui/variants/variant-result-noresult-used-as-type.stderr
@@ -2,11 +2,10 @@ error[E0573]: expected type, found variant `NoResult`
   --> $DIR/variant-result-noresult-used-as-type.rs:16:17
    |
 LL |     fn new() -> NoResult<MyEnum, String> {
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ not a type
    |
+note: similarly named enum `Result` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named enum `Result` defined here
 help: try using the variant's enum
    |
 LL -     fn new() -> NoResult<MyEnum, String> {
@@ -56,11 +55,10 @@ error[E0573]: expected type, found variant `NoResult`
   --> $DIR/variant-result-noresult-used-as-type.rs:37:15
    |
 LL | fn newer() -> NoResult<foo::MyEnum, String> {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a type
    |
+note: similarly named enum `Result` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-   |
-   = note: similarly named enum `Result` defined here
 help: try using the variant's enum
    |
 LL - fn newer() -> NoResult<foo::MyEnum, String> {


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#154992 (Error on projection of dyn noncompat type in old trait solver)
 - rust-lang/rust#157949 (Allow self in const generics)
 - rust-lang/rust#158588 (trait_selection: fix assumptions-on-binders diagnostics)
 - rust-lang/rust#159954 (core: implement float conversion methods)
 - rust-lang/rust#160136 (Add `Default` implementation for `std::sync::Once`)
 - rust-lang/rust#160835 (resolver diagnostics: don't swallow labels and point out  similar items as a note, not a label)
 - rust-lang/rust#161048 (Improve the ABI between the panic runtime and libstd)
 - rust-lang/rust#161292 (Add safety comments in alloc::Wtf8)
 - rust-lang/rust#161444 (Add some `rustc_type_ir` comments)
 - rust-lang/rust#161465 (Remove leftover immediate creation)
 - rust-lang/rust#152433 (Use `symlink_dir` to create junctions on Windows instead of trying to use symbolic links in `copy_link_internal`)
 - rust-lang/rust#159098 (Add Arc/Rc::strong_count_from_raw)
 - rust-lang/rust#159282 (Update documentation for `-Zdump-dep-graph`)
 - rust-lang/rust#161401 (Remove fields from TypeKind: Bool, Char, Float and Int)
 - rust-lang/rust#161451 (Avoid arming the Windows TLS destructor guard in fibers)
 - rust-lang/rust#161463 (Add myself to mailmap)
 - rust-lang/rust#161476 (Use bitset for locals_with_use_data)
 - rust-lang/rust#161483 (Warn about running ui-fulldeps tests in stage 1)

Failed merges:

 - rust-lang/rust#161443 (add internal DSL for testing binders)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=154992,157949,158588,159954,160136,160835,161048,161292,161443,161444,161465,152433,159098,159282,161401,161451,161463,161476,161483)
<!-- homu-ignore:end -->

