### PR TITLE
Clean up a few `_inner` functions after `ensure_sufficient_stack`

### DIFF
--- a/compiler/rustc_mir_build/src/builder/expr/as_temp.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_temp.rs
@@ -12,21 +12,8 @@ use crate::builder::{BlockAnd, BlockAndExtension, Builder};
 impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// Compile `expr` into a fresh temporary. This is used when building
     /// up rvalues so as to freeze the value that will be consumed.
-    pub(crate) fn as_temp(
-        &mut self,
-        block: BasicBlock,
-        temp_lifetime: TempLifetime,
-        expr_id: ExprId,
-        mutability: Mutability,
-    ) -> BlockAnd<Local> {
-        // this is the only place in mir building that we need to truly need to worry about
-        // infinite recursion. Everything else does recurse, too, but it always gets broken up
-        // at some point by inserting an intermediate temporary
-        self.as_temp_inner(block, temp_lifetime, expr_id, mutability)
-    }
-
     #[instrument(skip(self), level = "debug")]
-    fn as_temp_inner(
+    pub(crate) fn as_temp(
         &mut self,
         mut block: BasicBlock,
         temp_lifetime: TempLifetime,

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -69,6 +69,10 @@ fn parsed_attrs(id: HirId, tcx: TyCtxt<'_>) -> ThinVec<AttributeKind> {
 }
 
 impl<'tcx> ThirBuildCx<'tcx> {
+    pub(crate) fn mirror_exprs(&mut self, exprs: &'tcx [hir::Expr<'tcx>]) -> Box<[ExprId]> {
+        exprs.iter().map(|expr| self.mirror_expr(expr)).collect()
+    }
+
     /// Create a THIR expression for the given HIR expression. This expands all
     /// adjustments and directly adds the type information from the
     /// `typeck_results`. See the [dev-guide] for more details.
@@ -77,16 +81,8 @@ impl<'tcx> ThirBuildCx<'tcx> {
     /// "reversed".)
     ///
     /// [dev-guide]: https://rustc-dev-guide.rust-lang.org/thir.html
-    pub(crate) fn mirror_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) -> ExprId {
-        self.mirror_expr_inner(expr)
-    }
-
-    pub(crate) fn mirror_exprs(&mut self, exprs: &'tcx [hir::Expr<'tcx>]) -> Box<[ExprId]> {
-        exprs.iter().map(|expr| self.mirror_expr_inner(expr)).collect()
-    }
-
     #[instrument(level = "trace", skip(self, hir_expr))]
-    pub(super) fn mirror_expr_inner(&mut self, hir_expr: &'tcx hir::Expr<'tcx>) -> ExprId {
+    pub(crate) fn mirror_expr(&mut self, hir_expr: &'tcx hir::Expr<'tcx>) -> ExprId {
         let expr_scope =
             region::Scope { local_id: hir_expr.hir_id.local_id, data: region::ScopeData::Node };
 

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -112,7 +112,6 @@ impl<'a> Parser<'a> {
             let kind = TyKind::Err(self.dcx().emit_err(InvalidCVariadicType { span }));
             return Ok(self.mk_ty(span, kind));
         }
-        // Make sure deeply nested types don't overflow the stack.
         self.parse_ty_common(
             AllowPlus::Yes,
             AllowCVariadic::No,


### PR DESCRIPTION
After the removal of `ensure_sufficient_stack` in https://github.com/rust-lang/rust/pull/160535, these inner and outer functions no longer need to be separate.

cc @ChrisDenton 