### PR TITLE
Revert binutils installation

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
@@ -16,23 +16,7 @@ python3 ../x.py build --set rust.debug=true opt-dist
 # Use GCC for building GCC components, as it seems to behave badly when built with Clang
 # Only build GCC on full builds, not try builds
 if [ "${DIST_TRY_BUILD:-0}" == "0" ]; then
-    # We add the binutils binary path to ensure that it uses the 2.47 version of binutils,
-    # which is needed for the `retain` attribute feature.
-    export PATH="/tmp/binutils-install/bin:$PATH"
-
-    CC=/rustroot/bin/cc CXX=/rustroot/bin/c++ \
-        python3 ../x.py dist \
-        gcc-dev \
-        gcc
-
-    gcc_path="./build/$HOSTS/gcc/$HOSTS/install/bin/gcc"
-    if echo 'int x __attribute__((used, retain));' | \
-            "$gcc_path" -S -x c -o - - | grep -i '"a.*R"'; then
-        echo "retain attribute is supported"
-    else
-        echo "retain attribute is not supported"
-        # We display the generated asm just in case...
-        echo 'int x __attribute__((used, retain));' | "$gcc_path" -S -x c -o - -
-        exit 1
-    fi
+    CC=/rustroot/bin/cc CXX=/rustroot/bin/c++ python3 ../x.py dist \
+      gcc-dev \
+      gcc
 fi

--- a/src/ci/docker/scripts/build-gcc.sh
+++ b/src/ci/docker/scripts/build-gcc.sh
@@ -4,30 +4,6 @@ set -eux
 
 source shared.sh
 
-# We have to build our own binutils for the GCC build, because the default CentOS 7 binutils are
-# too old, and they do not support `SHF_GNU_RETAIN`.
-BINUTILS="2.47"
-BINUTILS_ROOT_PATH="$(pwd)/binutils-install"
-BINUTILS_PATH="$BINUTILS_ROOT_PATH/bin"
-curl https://ci-mirrors.rust-lang.org/rustc/gcc/binutils-$BINUTILS.tar.xz | xzcat | tar xf -
-mkdir binutils-build
-mkdir "$BINUTILS_ROOT_PATH"
-cd binutils-build
-
-hide_output ../binutils-$BINUTILS/configure --prefix="$BINUTILS_ROOT_PATH" --disable-werror
-hide_output make -j$(nproc)
-hide_output make install
-
-cd ..
-rm -rf binutils-build binutils-$BINUTILS
-
-if echo '.section .test,"awR",@progbits' | "$BINUTILS_PATH"/as - -o /dev/null 2>/dev/null; then
-    echo "binutils assembler supports SHF_GNU_RETAIN"
-else
-    echo "binutils assembler DOES NOT support SHF_GNU_RETAIN"
-    exit 1
-fi
-
 # Note: in the future when bumping to version 10.1.0, also take care of the sed block below.
 # This version is specified in the Dockerfile
 GCC=$GCC_VERSION

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -240,7 +240,7 @@ trap datecheck EXIT
 
 # Bump this value if you need to invalidate sccache's cache, if some wrong
 # builds go into it
-export SCCACHE_C_CUSTOM_CACHE_BUSTER=1
+export SCCACHE_C_CUSTOM_CACHE_BUSTER=2
 
 # We've had problems in the past of shell scripts leaking fds into the sccache
 # server (#48192) which causes Cargo to erroneously think that a build script


### PR DESCRIPTION
This reverts https://github.com/rust-lang/rust/pull/161243 as that broke the Miri build again.

Can we maybe build the GCC backend on a different builder where it cannot affect anything else? Or in a separate docker container, or so? Apparently, the GCC build system is so arcane that it is nearly impossible to build GCC without side-effects on the rest of the system.

Cc @Kobzol @GuillaumeGomez 