### PR TITLE
enable next solver in Miri

### DIFF
--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -201,7 +201,4 @@ pub const MIRI_DEFAULT_ARGS: &[&str] = &[
     // Deduplicating diagnostics means we miss events when tracking what happens during an
     // execution. Let's not do that.
     "-Zdeduplicate-diagnostics=no",
-    // FIXME(#160895): the new solver is enabled by default on nightly, but we
-    // don't want to use it in Miri for now. Remove once that's reverted.
-    "-Znext-solver=coherence",
 ];


### PR DESCRIPTION
This was disabled in https://github.com/rust-lang/rust/pull/160619, apparently because some tests failed. But I can't reproduce those test failures locally.

Fixes https://github.com/rust-lang/miri/issues/5269
Landing this here because rustc CI is where this used to break, and also Miri got broken again so we can't do syncs currently.

Cc @Kivooeo r? @lcnr 