### PR TITLE
rename `T-libs-api` to `T-libs` in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/library_tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/library_tracking_issue.md
@@ -2,7 +2,7 @@
 name: Library Tracking Issue
 about: A tracking issue for an unstable library feature.
 title: Tracking Issue for XXX
-labels: C-tracking-issue, T-libs-api, S-tracking-unimplemented
+labels: C-tracking-issue, T-libs, S-tracking-unimplemented
 ---
 <!--
 Thank you for creating a tracking issue!

--- a/.github/ISSUE_TEMPLATE/tracking_issue_future.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue_future.md
@@ -10,7 +10,7 @@ are for lints that implement a future-incompatible warning.
 
 Remember to add team labels to the tracking issue.
 For something that affects the language, this would be `T-lang`, and for libs
-it would be `T-libs-api`.
+it would be `T-libs`.
 Also check for any `A-` labels to add.
 -->
 


### PR DESCRIPTION
Since they were merged with https://github.com/rust-lang/rfcs/pull/3984.