### PR TITLE
Constify MapWhile

### DIFF
--- a/library/core/src/iter/adapters/array_chunks.rs
+++ b/library/core/src/iter/adapters/array_chunks.rs
@@ -1,6 +1,7 @@
 use crate::array;
 use crate::iter::adapters::SourceIter;
 use crate::iter::{FusedIterator, InPlaceIterable, TrustedFused, TrustedRandomAccessNoCoerce};
+use crate::marker::Destruct;
 use crate::num::NonZero;
 use crate::ops::{ControlFlow, NeverShortCircuit, Try};
 

--- a/library/core/src/iter/adapters/map_while.rs
+++ b/library/core/src/iter/adapters/map_while.rs
@@ -1,6 +1,7 @@
 use crate::fmt;
 use crate::iter::InPlaceIterable;
 use crate::iter::adapters::SourceIter;
+use crate::marker::Destruct;
 use crate::num::NonZero;
 use crate::ops::{ControlFlow, Try};
 

--- a/library/core/src/iter/adapters/map_while.rs
+++ b/library/core/src/iter/adapters/map_while.rs
@@ -34,9 +34,10 @@ impl<I: fmt::Debug, P> fmt::Debug for MapWhile<I, P> {
 }
 
 #[stable(feature = "iter_map_while", since = "1.57.0")]
-impl<B, I: Iterator, P> Iterator for MapWhile<I, P>
+#[rustc_const_unstable(feature = "const_iter", issue = "92476")]
+const impl<B, I: [const] Iterator, P> Iterator for MapWhile<I, P>
 where
-    P: FnMut(I::Item) -> Option<B>,
+    P: [const] FnMut(I::Item) -> Option<B>,
 {
     type Item = B;
 
@@ -56,18 +57,18 @@ where
     fn try_fold<Acc, Fold, R>(&mut self, init: Acc, mut fold: Fold) -> R
     where
         Self: Sized,
-        Fold: FnMut(Acc, Self::Item) -> R,
-        R: Try<Output = Acc>,
+        Fold: [const] FnMut(Acc, Self::Item) -> R + [const] Destruct,
+        R: [const] Try<Output = Acc>,
     {
         let Self { iter, predicate } = self;
-        iter.try_fold(init, |acc, x| match predicate(x) {
+        iter.try_fold(init, const |acc, x| match predicate(x) {
             Some(item) => ControlFlow::from_try(fold(acc, item)),
             None => ControlFlow::Break(try { acc }),
         })
         .into_try()
     }
 
-    impl_fold_via_try_fold! { fold -> try_fold }
+    impl_fold_via_try_fold! { const fold -> try_fold }
 }
 
 #[unstable(issue = "none", feature = "inplace_iteration")]

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -1,4 +1,5 @@
 use crate::iter::InPlaceIterable;
+use crate::marker::Destruct;
 use crate::num::NonZero;
 use crate::ops::{ChangeOutputType, ControlFlow, FromResidual, Residual, Try};
 

--- a/library/core/src/iter/adapters/scan.rs
+++ b/library/core/src/iter/adapters/scan.rs
@@ -1,6 +1,7 @@
 use crate::fmt;
 use crate::iter::InPlaceIterable;
 use crate::iter::adapters::SourceIter;
+use crate::marker::Destruct;
 use crate::num::NonZero;
 use crate::ops::{ControlFlow, Try};
 

--- a/library/core/src/iter/adapters/skip.rs
+++ b/library/core/src/iter/adapters/skip.rs
@@ -5,6 +5,7 @@ use crate::iter::{
     FusedIterator, InPlaceIterable, TrustedFused, TrustedLen, TrustedRandomAccess,
     TrustedRandomAccessNoCoerce,
 };
+use crate::marker::Destruct;
 use crate::num::NonZero;
 use crate::ops::{ControlFlow, Try};
 

--- a/library/core/src/iter/adapters/take_while.rs
+++ b/library/core/src/iter/adapters/take_while.rs
@@ -1,6 +1,7 @@
 use crate::fmt;
 use crate::iter::adapters::SourceIter;
 use crate::iter::{FusedIterator, InPlaceIterable, TrustedFused};
+use crate::marker::Destruct;
 use crate::num::NonZero;
 use crate::ops::{ControlFlow, Try};
 

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -357,30 +357,27 @@
 
 // This needs to be up here in order to be usable in the child modules
 macro_rules! impl_fold_via_try_fold {
-    (fold -> try_fold) => {
-        impl_fold_via_try_fold! { @internal fold -> try_fold }
-    };
-    (rfold -> try_rfold) => {
-        impl_fold_via_try_fold! { @internal rfold -> try_rfold }
-    };
-    (spec_fold -> spec_try_fold) => {
-        impl_fold_via_try_fold! { @internal spec_fold -> spec_try_fold }
-    };
-    (spec_rfold -> spec_try_rfold) => {
-        impl_fold_via_try_fold! { @internal spec_rfold -> spec_try_rfold }
-    };
-    (@internal $fold:ident -> $try_fold:ident) => {
-        #[inline]
-        fn $fold<AAA, FFF>(mut self, init: AAA, fold: FFF) -> AAA
-        where
-            FFF: FnMut(AAA, Self::Item) -> AAA,
-        {
-            use crate::ops::NeverShortCircuit;
+      (const $fold:ident -> $try_fold:ident) => {
+          impl_fold_via_try_fold!(@internal [[const]] $fold -> $try_fold);
+      };
+      ($fold:ident -> $try_fold:ident) => {
+          impl_fold_via_try_fold!(@internal [] $fold -> $try_fold);
+      };
 
-            self.$try_fold(init, NeverShortCircuit::wrap_mut_2(fold)).0
-        }
-    };
-}
+      (@internal [$($constness:tt)*] $fold:ident -> $try_fold:ident) => {
+          #[inline]
+          fn $fold<AAA, FFF>(mut self, init: AAA, fold: FFF) -> AAA
+          where
+              Self: $($constness)* Destruct,
+              FFF: $($constness)* FnMut(AAA, Self::Item) -> AAA
+                  + $($constness)* Destruct,
+          {
+              use crate::ops::NeverShortCircuit;
+
+              self.$try_fold(init, NeverShortCircuit::wrap_mut_2(fold)).0
+          }
+      };
+  }
 
 #[unstable(feature = "iter_array_chunks", issue = "100450")]
 pub use self::adapters::ArrayChunks;

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -2,6 +2,7 @@ use super::{
     FusedIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce, TrustedStep,
 };
 use crate::ascii::Char as AsciiChar;
+use crate::marker::Destruct;
 use crate::mem;
 use crate::net::{Ipv4Addr, Ipv6Addr};
 use crate::num::NonZero;


### PR DESCRIPTION
This is part of an attempt to fully constify `Iterator`. Specifically, I'm extracting the changes from the [local branch](https://github.com/Randl/rust/tree/iter_const_poc) that contains more or less minimal Iterator constification. While MapWhile itself is not very important, it is a good way to make sure `impl_fold_via_try_fold` works properly with const.