### PR TITLE
Stabilize `core::mem::DropGuard`

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -128,7 +128,6 @@
 #![feature(derive_const)]
 #![feature(diagnostic_on_move)]
 #![feature(dispatch_from_dyn)]
-#![feature(drop_guard)]
 #![feature(ergonomic_clones)]
 #![feature(error_generic_member_access)]
 #![feature(exact_size_is_empty)]

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -28,7 +28,6 @@
 #![feature(const_try)]
 #![feature(copied_into_inner)]
 #![feature(core_intrinsics)]
-#![feature(drop_guard)]
 #![feature(exact_size_is_empty)]
 #![feature(extend_one)]
 #![feature(extend_one_unchecked)]

--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -11,7 +11,6 @@ use crate::ops::{Deref, DerefMut};
 ///
 /// ```rust
 /// # #![allow(unused)]
-/// #![feature(drop_guard)]
 ///
 /// use std::mem::DropGuard;
 ///
@@ -28,7 +27,7 @@ use crate::ops::{Deref, DerefMut};
 ///     // "Chashu likes tuna!!!"
 /// }
 /// ```
-#[unstable(feature = "drop_guard", issue = "144426")]
+#[stable(feature = "drop_guard", since = "CURRENT_RUSTC_VERSION")]
 #[doc(alias = "ScopeGuard")]
 #[doc(alias = "defer")]
 pub struct DropGuard<T, F>
@@ -49,14 +48,14 @@ where
     ///
     /// ```rust
     /// # #![allow(unused)]
-    /// #![feature(drop_guard)]
     ///
     /// use std::mem::DropGuard;
     ///
     /// let value = String::from("Chashu likes tuna");
     /// let guard = DropGuard::new(value, |s| println!("{s}"));
     /// ```
-    #[unstable(feature = "drop_guard", issue = "144426")]
+    #[stable(feature = "drop_guard", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_drop_guard", issue = "none")]
     #[must_use]
     pub const fn new(inner: T, f: F) -> Self {
         Self { inner: ManuallyDrop::new(inner), f: ManuallyDrop::new(f) }
@@ -73,7 +72,6 @@ where
     ///
     /// ```rust
     /// # #![allow(unused)]
-    /// #![feature(drop_guard)]
     ///
     /// use std::mem::DropGuard;
     ///
@@ -81,7 +79,7 @@ where
     /// let guard = DropGuard::new(value, |s| println!("{s}"));
     /// assert_eq!(DropGuard::dismiss(guard), "Nori likes chicken");
     /// ```
-    #[unstable(feature = "drop_guard", issue = "144426")]
+    #[stable(feature = "drop_guard", since = "CURRENT_RUSTC_VERSION")]
     #[rustc_const_unstable(feature = "const_drop_guard", issue = "none")]
     #[inline]
     pub const fn dismiss(guard: Self) -> T
@@ -107,7 +105,7 @@ where
     }
 }
 
-#[unstable(feature = "drop_guard", issue = "144426")]
+#[stable(feature = "drop_guard", since = "CURRENT_RUSTC_VERSION")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl<T, F> Deref for DropGuard<T, F>
 where
@@ -120,7 +118,7 @@ where
     }
 }
 
-#[unstable(feature = "drop_guard", issue = "144426")]
+#[stable(feature = "drop_guard", since = "CURRENT_RUSTC_VERSION")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 const impl<T, F> DerefMut for DropGuard<T, F>
 where
@@ -131,7 +129,7 @@ where
     }
 }
 
-#[unstable(feature = "drop_guard", issue = "144426")]
+#[stable(feature = "drop_guard", since = "CURRENT_RUSTC_VERSION")]
 #[rustc_const_unstable(feature = "const_drop_guard", issue = "none")]
 const impl<T, F> Drop for DropGuard<T, F>
 where
@@ -148,7 +146,7 @@ where
     }
 }
 
-#[unstable(feature = "drop_guard", issue = "144426")]
+#[stable(feature = "drop_guard", since = "CURRENT_RUSTC_VERSION")]
 impl<T, F> Debug for DropGuard<T, F>
 where
     T: Debug,

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -59,7 +59,7 @@ mod transmutability;
 pub use transmutability::{Assume, TransmuteFrom};
 
 mod drop_guard;
-#[unstable(feature = "drop_guard", issue = "144426")]
+#[stable(feature = "drop_guard", since = "CURRENT_RUSTC_VERSION")]
 pub use drop_guard::DropGuard;
 
 // This one has to be a re-export (rather than wrapping the underlying intrinsic) so that we can do

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -47,7 +47,6 @@
 #![feature(cstr_display)]
 #![feature(debug_closure_helpers)]
 #![feature(dec2flt)]
-#![feature(drop_guard)]
 #![feature(duration_constants)]
 #![feature(duration_constructors)]
 #![feature(exact_div)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -337,7 +337,6 @@
 #![feature(cstr_display)]
 #![feature(cursor_split)]
 #![feature(derive_const)]
-#![feature(drop_guard)]
 #![feature(duration_constants)]
 #![feature(error_generic_member_access)]
 #![feature(error_iter)]


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/144426. This PR stabilizes `core::mem::DropGuard`, as per the comment in https://github.com/rust-lang/rust/issues/144426#issuecomment-5332324003:

> [nia-e]: We discussed this in today's libs meeting - DropGuard is a good name, and we agreed dismiss is Good Enough & better than the other options. Feel free to send a stabilisation PR & ask us to open FCP there!

Thanks!

r? @nia-e 