### PR TITLE
Replace check_attr_crate_level with check_target for #[doc]

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -156,7 +156,7 @@ impl DocParser {
                 }
 
                 cx.check_target(
-                    &sym::no_crate_inject.to_string(),
+                    sym::no_crate_inject.as_str(),
                     &AllowedTargets::AllowList(&[Allow(Target::Crate)]),
                 );
 
@@ -542,10 +542,7 @@ impl DocParser {
                     return;
                 };
 
-                cx.check_target(
-                    &s.to_string(),
-                    &AllowedTargets::AllowList(&[Allow(Target::Crate)]),
-                );
+                cx.check_target(s.as_str(), &AllowedTargets::AllowList(&[Allow(Target::Crate)]));
 
                 // FIXME: It's errorring when the attribute is passed multiple times on the command
                 // line.

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -14,8 +14,8 @@ use super::prelude::{ALL_TARGETS, AllowedTargets};
 use super::{AcceptMapping, AttributeParser, template};
 use crate::context::{AcceptContext, FinalizeContext};
 use crate::diagnostics::{
-    AttrCrateLevelOnly, DocAliasBadChar, DocAliasDuplicated, DocAliasEmpty, DocAliasMalformed,
-    DocAliasStartEnd, DocAttrNotCrateLevel, DocAttributeNotAttribute, DocAutoCfgExpectsHideOrShow,
+    DocAliasBadChar, DocAliasDuplicated, DocAliasEmpty, DocAliasMalformed, DocAliasStartEnd,
+    DocAttrNotCrateLevel, DocAttributeNotAttribute, DocAutoCfgExpectsHideOrShow,
     DocAutoCfgHideShowExpectsList, DocAutoCfgHideShowNoIdentBeforeValues,
     DocAutoCfgHideShowUnexpectedItem, DocAutoCfgHideShowUnexpectedItemAfterValues,
     DocAutoCfgHideShowValuesMix, DocAutoCfgWrongLiteral, DocKeywordNotKeyword, DocTestLiteral,
@@ -26,6 +26,7 @@ use crate::diagnostics::{
 use crate::parser::{
     ArgParser, MetaItemListParser, MetaItemOrLitParser, MetaItemParser, OwnedPathParser,
 };
+use crate::target_checking::Policy::Allow;
 
 fn check_keyword(cx: &mut AcceptContext<'_, '_>, keyword: Symbol, span: Span) -> bool {
     // FIXME: Once rustdoc can handle URL conflicts on case insensitive file systems, we
@@ -58,15 +59,6 @@ fn check_attr_not_crate_level(
 ) -> bool {
     if cx.shared.target == Target::Crate {
         cx.emit_err(DocAttrNotCrateLevel { span, attr_name });
-        return false;
-    }
-    true
-}
-
-/// Checks that an attribute is used at the crate level. Returns `true` if valid.
-fn check_attr_crate_level(cx: &mut AcceptContext<'_, '_>, span: Span) -> bool {
-    if cx.shared.target != Target::Crate {
-        cx.emit_lint(INVALID_DOC_ATTRIBUTES, AttrCrateLevelOnly, span);
         return false;
     }
     true
@@ -163,9 +155,10 @@ impl DocParser {
                     return;
                 }
 
-                if !check_attr_crate_level(cx, path.span()) {
-                    return;
-                }
+                cx.check_target(
+                    &sym::no_crate_inject.to_string(),
+                    &AllowedTargets::AllowList(&[Allow(Target::Crate)]),
+                );
 
                 self.attribute.no_crate_inject = Some(path.span())
             }
@@ -530,9 +523,10 @@ impl DocParser {
                     return;
                 }
                 let span = path.span();
-                if !check_attr_crate_level(cx, span) {
-                    return;
-                }
+                cx.check_target(
+                    concat!("(", stringify!($ident), ")"),
+                    &AllowedTargets::AllowList(&[Allow(Target::Crate)]),
+                );
                 self.attribute.$ident = Some(span);
             }};
         }
@@ -548,9 +542,10 @@ impl DocParser {
                     return;
                 };
 
-                if !check_attr_crate_level(cx, path.span()) {
-                    return;
-                }
+                cx.check_target(
+                    &s.to_string(),
+                    &AllowedTargets::AllowList(&[Allow(Target::Crate)]),
+                );
 
                 // FIXME: It's errorring when the attribute is passed multiple times on the command
                 // line.

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -157,7 +157,7 @@ impl DocParser {
 
                 cx.check_target(
                     sym::no_crate_inject.as_str(),
-                    &AllowedTargets::AllowList(&[Allow(Target::Crate)]),
+                    &AllowedTargets::AllowListWarnRest(&[Allow(Target::Crate)]),
                 );
 
                 self.attribute.no_crate_inject = Some(path.span())
@@ -525,7 +525,7 @@ impl DocParser {
                 let span = path.span();
                 cx.check_target(
                     concat!("(", stringify!($ident), ")"),
-                    &AllowedTargets::AllowList(&[Allow(Target::Crate)]),
+                    &AllowedTargets::AllowListWarnRest(&[Allow(Target::Crate)]),
                 );
                 self.attribute.$ident = Some(span);
             }};
@@ -542,7 +542,10 @@ impl DocParser {
                     return;
                 };
 
-                cx.check_target(s.as_str(), &AllowedTargets::AllowList(&[Allow(Target::Crate)]));
+                cx.check_target(
+                    s.as_str(),
+                    &AllowedTargets::AllowListWarnRest(&[Allow(Target::Crate)]),
+                );
 
                 // FIXME: It's errorring when the attribute is passed multiple times on the command
                 // line.

--- a/compiler/rustc_attr_parsing/src/diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/diagnostics.rs
@@ -287,13 +287,6 @@ pub(crate) struct DocTestUnknown {
 pub(crate) struct DocTestLiteral;
 
 #[derive(Diagnostic)]
-#[diag("this attribute can only be applied at the crate level")]
-#[note(
-    "read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information"
-)]
-pub(crate) struct AttrCrateLevelOnly;
-
-#[derive(Diagnostic)]
 #[diag("`#[diagnostic::do_not_recommend]` does not expect any arguments")]
 pub(crate) struct DoNotRecommendDoesNotExpectArgs;
 

--- a/compiler/rustc_attr_parsing/src/diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/diagnostics.rs
@@ -287,6 +287,13 @@ pub(crate) struct DocTestUnknown {
 pub(crate) struct DocTestLiteral;
 
 #[derive(Diagnostic)]
+#[diag("this attribute can only be applied at the crate level")]
+#[note(
+    "read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information"
+)]
+pub(crate) struct AttrCrateLevelOnly;
+
+#[derive(Diagnostic)]
 #[diag("`#[diagnostic::do_not_recommend]` does not expect any arguments")]
 pub(crate) struct DoNotRecommendDoesNotExpectArgs;
 

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -6,7 +6,7 @@ use rustc_attr_ir::{AttrItem, Attribute, AttributeKind};
 use rustc_errors::{DiagArgValue, MultiSpan, StashKey};
 use rustc_feature::Features;
 use rustc_lint_defs::builtin::{
-    MISPLACED_DIAGNOSTIC_ATTRIBUTES, UNUSED_ATTRIBUTES, USELESS_DEPRECATED,
+    INVALID_DOC_ATTRIBUTES, MISPLACED_DIAGNOSTIC_ATTRIBUTES, UNUSED_ATTRIBUTES, USELESS_DEPRECATED,
 };
 use rustc_span::{BytePos, FileName, RemapPathScopeComponents, Span, Symbol, sym};
 
@@ -235,6 +235,16 @@ impl<'sess> AttributeParser<'sess> {
                 (true, src.path(RemapPathScopeComponents::DIAGNOSTICS).display().to_string())
             })
             .unwrap_or_default();
+
+        if name == "doc" {
+            let diag = crate::diagnostics::AttrCrateLevelOnly;
+            if warn {
+                cx.emit_lint(INVALID_DOC_ATTRIBUTES, diag, attr_span);
+            } else {
+                cx.emit_err(diag);
+            }
+            return;
+        }
 
         let diag = crate::diagnostics::InvalidAttrStyle {
             name,

--- a/tests/ui/attributes/doc-crate-level.rs
+++ b/tests/ui/attributes/doc-crate-level.rs
@@ -1,10 +1,4 @@
 #![feature(rustdoc_internals)]
-#![doc(fake_variadic)]
-//~^ ERROR `#![doc(fake_variadic = "...")]` isn't allowed as a crate-level attribute
-#![doc(alias = "test")]
-//~^ ERROR `#![doc(alias = "...")]` isn't allowed as a crate-level attribute
-#![doc(search_unbox)]
-//~^ ERROR `#![doc(search_unbox = "...")]` isn't allowed as a crate-level attribute
 
 #[doc(rust_logo)]
 //~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
@@ -24,20 +18,4 @@
 //~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
 fn function() {}
 
-#![doc(rust_logo)]
-//~^ ERROR an inner attribute is not permitted in this context
-#![doc(html_favicon_url = "example.org")]
-//~^ ERROR an inner attribute is not permitted in this context
-#![doc(html_logo_url = "example.org")]
-//~^ ERROR an inner attribute is not permitted in this context
-#![doc(html_playground_url = "example.org")]
-//~^ ERROR an inner attribute is not permitted in this context
-#![doc(issue_tracker_base_url = "example.org")]
-//~^ ERROR an inner attribute is not permitted in this context
-#![doc(html_root_url = "example.org")]
-//~^ ERROR an inner attribute is not permitted in this context
-#![doc(html_no_source)]
-//~^ ERROR an inner attribute is not permitted in this context
-#![doc(test(no_crate_inject))]
-//~^ ERROR an inner attribute is not permitted in this context
 fn main() {}

--- a/tests/ui/attributes/doc-crate-level.rs
+++ b/tests/ui/attributes/doc-crate-level.rs
@@ -1,0 +1,43 @@
+#![feature(rustdoc_internals)]
+#![doc(fake_variadic)]
+//~^ ERROR `#![doc(fake_variadic = "...")]` isn't allowed as a crate-level attribute
+#![doc(alias = "test")]
+//~^ ERROR `#![doc(alias = "...")]` isn't allowed as a crate-level attribute
+#![doc(search_unbox)]
+//~^ ERROR `#![doc(search_unbox = "...")]` isn't allowed as a crate-level attribute
+
+#[doc(rust_logo)]
+//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+#[doc(html_favicon_url = "example.org")]
+//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+#[doc(html_logo_url = "example.org")]
+//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+#[doc(html_playground_url = "example.org")]
+//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+#[doc(issue_tracker_base_url = "example.org")]
+//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+#[doc(html_root_url = "example.org")]
+//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+#[doc(html_no_source)]
+//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+#[doc(test(no_crate_inject))]
+//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+fn function() {}
+
+#![doc(rust_logo)]
+//~^ ERROR an inner attribute is not permitted in this context
+#![doc(html_favicon_url = "example.org")]
+//~^ ERROR an inner attribute is not permitted in this context
+#![doc(html_logo_url = "example.org")]
+//~^ ERROR an inner attribute is not permitted in this context
+#![doc(html_playground_url = "example.org")]
+//~^ ERROR an inner attribute is not permitted in this context
+#![doc(issue_tracker_base_url = "example.org")]
+//~^ ERROR an inner attribute is not permitted in this context
+#![doc(html_root_url = "example.org")]
+//~^ ERROR an inner attribute is not permitted in this context
+#![doc(html_no_source)]
+//~^ ERROR an inner attribute is not permitted in this context
+#![doc(test(no_crate_inject))]
+//~^ ERROR an inner attribute is not permitted in this context
+fn main() {}

--- a/tests/ui/attributes/doc-crate-level.rs
+++ b/tests/ui/attributes/doc-crate-level.rs
@@ -1,21 +1,22 @@
+//@check-pass
 #![feature(rustdoc_internals)]
 
 #[doc(rust_logo)]
-//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+//~^ WARN this attribute can only be applied at the crate level
 #[doc(html_favicon_url = "example.org")]
-//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+//~^ WARN this attribute can only be applied at the crate level
 #[doc(html_logo_url = "example.org")]
-//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+//~^ WARN this attribute can only be applied at the crate level
 #[doc(html_playground_url = "example.org")]
-//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+//~^ WARN this attribute can only be applied at the crate level
 #[doc(issue_tracker_base_url = "example.org")]
-//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+//~^ WARN this attribute can only be applied at the crate level
 #[doc(html_root_url = "example.org")]
-//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+//~^ WARN this attribute can only be applied at the crate level
 #[doc(html_no_source)]
-//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+//~^ WARN this attribute can only be applied at the crate level
 #[doc(test(no_crate_inject))]
-//~^ ERROR crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+//~^ WARN this attribute can only be applied at the crate level
 fn function() {}
 
 fn main() {}

--- a/tests/ui/attributes/doc-crate-level.stderr
+++ b/tests/ui/attributes/doc-crate-level.stderr
@@ -1,117 +1,47 @@
-error: an inner attribute is not permitted in this context
-  --> $DIR/doc-crate-level.rs:27:1
-   |
-LL | #![doc(rust_logo)]
-   | ^^^^^^^^^^^^^^^^^^
-...
-LL | fn main() {}
-   | ------------ the inner attribute doesn't annotate this function
-   |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
-
-error: an inner attribute is not permitted in this context
-  --> $DIR/doc-crate-level.rs:29:1
-   |
-LL | #![doc(html_favicon_url = "example.org")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | fn main() {}
-   | ------------ the inner attribute doesn't annotate this function
-   |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
-
-error: an inner attribute is not permitted in this context
-  --> $DIR/doc-crate-level.rs:31:1
-   |
-LL | #![doc(html_logo_url = "example.org")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | fn main() {}
-   | ------------ the inner attribute doesn't annotate this function
-   |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
-
-error: an inner attribute is not permitted in this context
-  --> $DIR/doc-crate-level.rs:33:1
-   |
-LL | #![doc(html_playground_url = "example.org")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | fn main() {}
-   | ------------ the inner attribute doesn't annotate this function
-   |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
-
-error: an inner attribute is not permitted in this context
-  --> $DIR/doc-crate-level.rs:35:1
-   |
-LL | #![doc(issue_tracker_base_url = "example.org")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | fn main() {}
-   | ------------ the inner attribute doesn't annotate this function
-   |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
-
-error: an inner attribute is not permitted in this context
-  --> $DIR/doc-crate-level.rs:37:1
-   |
-LL | #![doc(html_root_url = "example.org")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | fn main() {}
-   | ------------ the inner attribute doesn't annotate this function
-   |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
-
-error: an inner attribute is not permitted in this context
-  --> $DIR/doc-crate-level.rs:39:1
-   |
-LL | #![doc(html_no_source)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | fn main() {}
-   | ------------ the inner attribute doesn't annotate this function
-   |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
-
-error: an inner attribute is not permitted in this context
-  --> $DIR/doc-crate-level.rs:41:1
-   |
-LL | #![doc(test(no_crate_inject))]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | fn main() {}
-   | ------------ the inner attribute doesn't annotate this function
-   |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
-
-error: `#![doc(fake_variadic = "...")]` isn't allowed as a crate-level attribute
-  --> $DIR/doc-crate-level.rs:2:8
-   |
-LL | #![doc(fake_variadic)]
-   |        ^^^^^^^^^^^^^
-
-error: `#![doc(alias = "...")]` isn't allowed as a crate-level attribute
-  --> $DIR/doc-crate-level.rs:4:16
-   |
-LL | #![doc(alias = "test")]
-   |                ^^^^^^
-
-error: `#![doc(search_unbox = "...")]` isn't allowed as a crate-level attribute
-  --> $DIR/doc-crate-level.rs:6:8
-   |
-LL | #![doc(search_unbox)]
-   |        ^^^^^^^^^^^^
-
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
-  --> $DIR/doc-crate-level.rs:9:1
+  --> $DIR/doc-crate-level.rs:3:1
    |
 LL | #[doc(rust_logo)]
    | ^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:25:1
+  --> $DIR/doc-crate-level.rs:19:1
+   |
+LL | fn function() {}
+   | ^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+  --> $DIR/doc-crate-level.rs:5:1
+   |
+LL | #[doc(html_favicon_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/doc-crate-level.rs:19:1
+   |
+LL | fn function() {}
+   | ^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+  --> $DIR/doc-crate-level.rs:7:1
+   |
+LL | #[doc(html_logo_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/doc-crate-level.rs:19:1
+   |
+LL | fn function() {}
+   | ^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+  --> $DIR/doc-crate-level.rs:9:1
+   |
+LL | #[doc(html_playground_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/doc-crate-level.rs:19:1
    |
 LL | fn function() {}
    | ^^^^^^^^^^^^^^^^
@@ -119,11 +49,11 @@ LL | fn function() {}
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
   --> $DIR/doc-crate-level.rs:11:1
    |
-LL | #[doc(html_favicon_url = "example.org")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[doc(issue_tracker_base_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:25:1
+  --> $DIR/doc-crate-level.rs:19:1
    |
 LL | fn function() {}
    | ^^^^^^^^^^^^^^^^
@@ -131,11 +61,11 @@ LL | fn function() {}
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
   --> $DIR/doc-crate-level.rs:13:1
    |
-LL | #[doc(html_logo_url = "example.org")]
+LL | #[doc(html_root_url = "example.org")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:25:1
+  --> $DIR/doc-crate-level.rs:19:1
    |
 LL | fn function() {}
    | ^^^^^^^^^^^^^^^^
@@ -143,11 +73,11 @@ LL | fn function() {}
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
   --> $DIR/doc-crate-level.rs:15:1
    |
-LL | #[doc(html_playground_url = "example.org")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[doc(html_no_source)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:25:1
+  --> $DIR/doc-crate-level.rs:19:1
    |
 LL | fn function() {}
    | ^^^^^^^^^^^^^^^^
@@ -155,50 +85,14 @@ LL | fn function() {}
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
   --> $DIR/doc-crate-level.rs:17:1
    |
-LL | #[doc(issue_tracker_base_url = "example.org")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:25:1
-   |
-LL | fn function() {}
-   | ^^^^^^^^^^^^^^^^
-
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
-  --> $DIR/doc-crate-level.rs:19:1
-   |
-LL | #[doc(html_root_url = "example.org")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:25:1
-   |
-LL | fn function() {}
-   | ^^^^^^^^^^^^^^^^
-
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
-  --> $DIR/doc-crate-level.rs:21:1
-   |
-LL | #[doc(html_no_source)]
-   | ^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:25:1
-   |
-LL | fn function() {}
-   | ^^^^^^^^^^^^^^^^
-
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
-  --> $DIR/doc-crate-level.rs:23:1
-   |
 LL | #[doc(test(no_crate_inject))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:25:1
+  --> $DIR/doc-crate-level.rs:19:1
    |
 LL | fn function() {}
    | ^^^^^^^^^^^^^^^^
 
-error: aborting due to 19 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/attributes/doc-crate-level.stderr
+++ b/tests/ui/attributes/doc-crate-level.stderr
@@ -1,0 +1,204 @@
+error: an inner attribute is not permitted in this context
+  --> $DIR/doc-crate-level.rs:27:1
+   |
+LL | #![doc(rust_logo)]
+   | ^^^^^^^^^^^^^^^^^^
+...
+LL | fn main() {}
+   | ------------ the inner attribute doesn't annotate this function
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+
+error: an inner attribute is not permitted in this context
+  --> $DIR/doc-crate-level.rs:29:1
+   |
+LL | #![doc(html_favicon_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn main() {}
+   | ------------ the inner attribute doesn't annotate this function
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+
+error: an inner attribute is not permitted in this context
+  --> $DIR/doc-crate-level.rs:31:1
+   |
+LL | #![doc(html_logo_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn main() {}
+   | ------------ the inner attribute doesn't annotate this function
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+
+error: an inner attribute is not permitted in this context
+  --> $DIR/doc-crate-level.rs:33:1
+   |
+LL | #![doc(html_playground_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn main() {}
+   | ------------ the inner attribute doesn't annotate this function
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+
+error: an inner attribute is not permitted in this context
+  --> $DIR/doc-crate-level.rs:35:1
+   |
+LL | #![doc(issue_tracker_base_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn main() {}
+   | ------------ the inner attribute doesn't annotate this function
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+
+error: an inner attribute is not permitted in this context
+  --> $DIR/doc-crate-level.rs:37:1
+   |
+LL | #![doc(html_root_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn main() {}
+   | ------------ the inner attribute doesn't annotate this function
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+
+error: an inner attribute is not permitted in this context
+  --> $DIR/doc-crate-level.rs:39:1
+   |
+LL | #![doc(html_no_source)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | fn main() {}
+   | ------------ the inner attribute doesn't annotate this function
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+
+error: an inner attribute is not permitted in this context
+  --> $DIR/doc-crate-level.rs:41:1
+   |
+LL | #![doc(test(no_crate_inject))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | fn main() {}
+   | ------------ the inner attribute doesn't annotate this function
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+
+error: `#![doc(fake_variadic = "...")]` isn't allowed as a crate-level attribute
+  --> $DIR/doc-crate-level.rs:2:8
+   |
+LL | #![doc(fake_variadic)]
+   |        ^^^^^^^^^^^^^
+
+error: `#![doc(alias = "...")]` isn't allowed as a crate-level attribute
+  --> $DIR/doc-crate-level.rs:4:16
+   |
+LL | #![doc(alias = "test")]
+   |                ^^^^^^
+
+error: `#![doc(search_unbox = "...")]` isn't allowed as a crate-level attribute
+  --> $DIR/doc-crate-level.rs:6:8
+   |
+LL | #![doc(search_unbox)]
+   |        ^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+  --> $DIR/doc-crate-level.rs:9:1
+   |
+LL | #[doc(rust_logo)]
+   | ^^^^^^^^^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/doc-crate-level.rs:25:1
+   |
+LL | fn function() {}
+   | ^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+  --> $DIR/doc-crate-level.rs:11:1
+   |
+LL | #[doc(html_favicon_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/doc-crate-level.rs:25:1
+   |
+LL | fn function() {}
+   | ^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+  --> $DIR/doc-crate-level.rs:13:1
+   |
+LL | #[doc(html_logo_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/doc-crate-level.rs:25:1
+   |
+LL | fn function() {}
+   | ^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+  --> $DIR/doc-crate-level.rs:15:1
+   |
+LL | #[doc(html_playground_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/doc-crate-level.rs:25:1
+   |
+LL | fn function() {}
+   | ^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+  --> $DIR/doc-crate-level.rs:17:1
+   |
+LL | #[doc(issue_tracker_base_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/doc-crate-level.rs:25:1
+   |
+LL | fn function() {}
+   | ^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+  --> $DIR/doc-crate-level.rs:19:1
+   |
+LL | #[doc(html_root_url = "example.org")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/doc-crate-level.rs:25:1
+   |
+LL | fn function() {}
+   | ^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+  --> $DIR/doc-crate-level.rs:21:1
+   |
+LL | #[doc(html_no_source)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/doc-crate-level.rs:25:1
+   |
+LL | fn function() {}
+   | ^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
+  --> $DIR/doc-crate-level.rs:23:1
+   |
+LL | #[doc(test(no_crate_inject))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/doc-crate-level.rs:25:1
+   |
+LL | fn function() {}
+   | ^^^^^^^^^^^^^^^^
+
+error: aborting due to 19 previous errors
+

--- a/tests/ui/attributes/doc-crate-level.stderr
+++ b/tests/ui/attributes/doc-crate-level.stderr
@@ -1,98 +1,67 @@
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
-  --> $DIR/doc-crate-level.rs:3:1
+warning: this attribute can only be applied at the crate level
+  --> $DIR/doc-crate-level.rs:4:1
    |
 LL | #[doc(rust_logo)]
    | ^^^^^^^^^^^^^^^^^
    |
-note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:19:1
-   |
-LL | fn function() {}
-   | ^^^^^^^^^^^^^^^^
+   = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
+   = note: `#[warn(invalid_doc_attributes)]` on by default
 
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
-  --> $DIR/doc-crate-level.rs:5:1
+warning: this attribute can only be applied at the crate level
+  --> $DIR/doc-crate-level.rs:6:1
    |
 LL | #[doc(html_favicon_url = "example.org")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:19:1
-   |
-LL | fn function() {}
-   | ^^^^^^^^^^^^^^^^
+   = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
 
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
-  --> $DIR/doc-crate-level.rs:7:1
+warning: this attribute can only be applied at the crate level
+  --> $DIR/doc-crate-level.rs:8:1
    |
 LL | #[doc(html_logo_url = "example.org")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:19:1
-   |
-LL | fn function() {}
-   | ^^^^^^^^^^^^^^^^
+   = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
 
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
-  --> $DIR/doc-crate-level.rs:9:1
+warning: this attribute can only be applied at the crate level
+  --> $DIR/doc-crate-level.rs:10:1
    |
 LL | #[doc(html_playground_url = "example.org")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:19:1
-   |
-LL | fn function() {}
-   | ^^^^^^^^^^^^^^^^
+   = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
 
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
-  --> $DIR/doc-crate-level.rs:11:1
+warning: this attribute can only be applied at the crate level
+  --> $DIR/doc-crate-level.rs:12:1
    |
 LL | #[doc(issue_tracker_base_url = "example.org")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:19:1
-   |
-LL | fn function() {}
-   | ^^^^^^^^^^^^^^^^
+   = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
 
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
-  --> $DIR/doc-crate-level.rs:13:1
+warning: this attribute can only be applied at the crate level
+  --> $DIR/doc-crate-level.rs:14:1
    |
 LL | #[doc(html_root_url = "example.org")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:19:1
-   |
-LL | fn function() {}
-   | ^^^^^^^^^^^^^^^^
+   = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
 
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
-  --> $DIR/doc-crate-level.rs:15:1
+warning: this attribute can only be applied at the crate level
+  --> $DIR/doc-crate-level.rs:16:1
    |
 LL | #[doc(html_no_source)]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:19:1
-   |
-LL | fn function() {}
-   | ^^^^^^^^^^^^^^^^
+   = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
 
-error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![doc]`
-  --> $DIR/doc-crate-level.rs:17:1
+warning: this attribute can only be applied at the crate level
+  --> $DIR/doc-crate-level.rs:18:1
    |
 LL | #[doc(test(no_crate_inject))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/doc-crate-level.rs:19:1
-   |
-LL | fn function() {}
-   | ^^^^^^^^^^^^^^^^
+   = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
 
-error: aborting due to 8 previous errors
+warning: 8 warnings emitted
 

--- a/tests/ui/feature-gates/doc-rust-logo.rs
+++ b/tests/ui/feature-gates/doc-rust-logo.rs
@@ -2,6 +2,4 @@
 //~^ ERROR this subset of the `doc` attribute is meant for internal use only
 //! This is not an official rust crate
 
-#[doc(rust_logo)]
-//~^ WARN this attribute can only be applied at the crate level
 fn main() {}

--- a/tests/ui/feature-gates/doc-rust-logo.stderr
+++ b/tests/ui/feature-gates/doc-rust-logo.stderr
@@ -9,15 +9,6 @@ LL | #![doc(rust_logo)]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: the `#[doc(rust_logo)]` attribute is used for Rust branding
 
-warning: this attribute can only be applied at the crate level
-  --> $DIR/doc-rust-logo.rs:5:7
-   |
-LL | #[doc(rust_logo)]
-   |       ^^^^^^^^^
-   |
-   = note: read <https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html#at-the-crate-level> for more information
-   = note: `#[warn(invalid_doc_attributes)]` on by default
-
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161521)*
<!-- homu-ignore:end -->

A small change as part of the target checking refactor for #[doc] attribute parsing.

r? @JonathanBrouwer 