### PR TITLE
Put back `tests/rustdoc-gui/search-result-display.goml`

### DIFF
--- a/tests/rustdoc-gui/search-about-this-result.goml
+++ b/tests/rustdoc-gui/search-about-this-result.goml
@@ -1,13 +1,15 @@
 // Check the "About this Result" popover.
 // Try a complex result.
+
+include: "utils.goml"
+
 go-to: "file://" + |DOC_PATH| + "/lib2/index.html?search=scroll_traits::Iterator<T>,(T->bool)->(Extend<T>,Extend<T>)"
 
 // These two commands are used to be sure the search will be run.
 focus: ".search-input"
 press-key: "Enter"
 
-wait-for: "#search-tabs"
-wait-for-false: "#search-tabs .count.loading"
+call-function: ("wait-for-search-results", {})
 assert-count: ("#search-tabs button", 1)
 assert-count: (".search-results > a", 1)
 
@@ -32,8 +34,7 @@ go-to: "file://" + |DOC_PATH| + "/lib2/index.html?search=F->lib2::WhereWhitespac
 focus: ".search-input"
 press-key: "Enter"
 
-wait-for: "#search-tabs"
-wait-for-false: "#search-tabs .count.loading"
+call-function: ("wait-for-search-results", {})
 assert-text: ("//div[@class='type-signature']", "F -> WhereWhitespace<T>")
 assert-count: ("#search-tabs button", 1)
 assert-count: (".search-results > a", 1)

--- a/tests/rustdoc-gui/search-error.goml
+++ b/tests/rustdoc-gui/search-error.goml
@@ -8,7 +8,7 @@ define-function: (
     [theme, error_background],
     block {
         call-function: ("switch-theme", {"theme": |theme|})
-        wait-for-false: "#search-tabs .count.loading"
+        call-function: ("wait-for-search-results", {})
         wait-for: "#search .error code"
         assert-css: ("#search .error code", {"background-color": |error_background|})
     }

--- a/tests/rustdoc-gui/search-filter.goml
+++ b/tests/rustdoc-gui/search-filter.goml
@@ -8,9 +8,7 @@ assert-text: ("#results .externcrate", "test_docs")
 wait-for: "#crate-search"
 // We now want to change the crate filter to "lib2".
 click: "#crate-search option[value='lib2']"
-// Waiting for the search results to appear...
-wait-for: "#search-tabs"
-wait-for-false: "#search-tabs .count.loading"
+call-function: ("wait-for-search-results", {})
 assert-document-property: ({"URL": "&filter-crate="}, CONTAINS)
 // We check that there is no more "test_docs" appearing.
 assert-false: "#results .externcrate"
@@ -30,9 +28,7 @@ assert-property: ("#crate-search", {"value": "lib2"})
 
 // Selecting back "All crates"
 click: "#crate-search option[value='all crates']"
-// Waiting for the search results to appear...
-wait-for: "#search-tabs"
-wait-for-false: "#search-tabs .count.loading"
+call-function: ("wait-for-search-results", {})
 assert-property: ("#crate-search", {"value": "all crates"})
 
 // Checking that the URL parameter is taken into account for crate filtering.

--- a/tests/rustdoc-gui/search-form-elements.goml
+++ b/tests/rustdoc-gui/search-form-elements.goml
@@ -1,8 +1,7 @@
 // This test ensures that the elements in ".search-form" have the expected display.
 include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search=test"
-wait-for: "#search-tabs" // Waiting for the search.js to load.
-wait-for-false: "#search-tabs .count.loading"
+call-function: ("wait-for-search-results", {})
 show-text: true
 
 define-function: (
@@ -120,11 +119,9 @@ call-function: (
 
 // Check that search input correctly decodes form encoding.
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search=a+b"
-wait-for: "#search-tabs" // Waiting for the search.js to load.
-wait-for-false: "#search-tabs .count.loading"
+call-function: ("wait-for-search-results", {})
 assert-property: (".search-input", { "value": "a b" })
 // Check that literal + is not treated as space.
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search=a%2Bb"
-wait-for: "#search-tabs" // Waiting for the search.js to load.
-wait-for-false: "#search-tabs .count.loading"
+call-function: ("wait-for-search-results", {})
 assert-property: (".search-input", { "value": "a+b" })

--- a/tests/rustdoc-gui/search-result-color.goml
+++ b/tests/rustdoc-gui/search-result-color.goml
@@ -13,9 +13,7 @@ define-function: (
     block {
         call-function: ("switch-theme", {"theme": |theme|})
 
-        // Waiting for the search results to appear...
-        wait-for: "#search-tabs"
-        wait-for-false: "#search-tabs .count.loading"
+        call-function: ("wait-for-search-results", {})
         assert-css: (
             "#search-tabs > button > .count",
             {"color": |count_color|},

--- a/tests/rustdoc-gui/search-result-description.goml
+++ b/tests/rustdoc-gui/search-result-description.goml
@@ -1,6 +1,5 @@
 // This test is to ensure that the codeblocks are correctly rendered in the search results.
+include: "utils.goml"
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search=some_more_function"
-// Waiting for the search results to appear...
-wait-for: "#search-tabs"
-wait-for-false: "#search-tabs .count.loading"
+call-function: ("wait-for-search-results", {})
 assert-text: (".search-results .desc code", "format!")

--- a/tests/rustdoc-gui/search-result-display.goml
+++ b/tests/rustdoc-gui/search-result-display.goml
@@ -79,8 +79,7 @@ define-function: (
     [theme, border, filter, hover_border, hover_filter],
     block {
         call-function: ("switch-theme", {"theme": |theme|})
-        wait-for: "#crate-search"
-        wait-for-false: "#search-tabs .count.loading"
+        call-function: ("wait-for-search-results", {})
         assert-css: ("#crate-search", {"border": "1px solid " + |border|})
         assert-css: ("#crate-search-div::after", {"filter": |filter|})
         move-cursor-to: "#crate-search"

--- a/tests/rustdoc-gui/search-result-display.goml
+++ b/tests/rustdoc-gui/search-result-display.goml
@@ -1,0 +1,113 @@
+// ignore-tidy-linelength
+// Checks that the search results have the expected width.
+include: "utils.goml"
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
+set-window-size: (900, 1000)
+call-function: ("perform-search", {"query": "test"})
+// The width is returned by "getComputedStyle" which returns the exact number instead of the
+// CSS rule which is "50%"...
+assert-size: (".search-results div.desc", {"width": 248})
+store-size: (".search-results .result-name .typename", {"width": width})
+set-window-size: (600, 100)
+// As counter-intuitive as it may seem, in this width, the width is "100%", which is why
+// when computed it's larger.
+assert-size: (".search-results div.desc", {"width": 566})
+
+// The result set is all on one line.
+compare-elements-position-near: (
+    ".search-results .result-name .typename",
+    ".search-results .result-name .path",
+    {"y": 2},
+)
+compare-elements-position-near-false: (
+    ".search-results .result-name .typename",
+    ".search-results .result-name .path",
+    {"x": 5},
+)
+// The width of the "typename" isn't fixed anymore in this display mode.
+store-size: (".search-results .result-name .typename", {"width": new_width})
+assert: |new_width| < |width| - 10
+
+store-value: (
+    value,
+    "SuperIncrediblyLongLongLongLongLongLongLongGigaGigaGigaMegaLongLongLongStructName",
+)
+// Check that if the search is too long on mobile, it'll go under the "typename".
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search=" + |value|
+call-function: ("wait-for-search-results", {})
+compare-elements-position-near: (
+    ".search-results .result-name .typename",
+    ".search-results .result-name .path",
+    {"y": 2, "x": 0},
+)
+compare-elements-size-near: (
+    ".search-results .result-name",
+    ".search-results .result-name .path",
+    {"width": 8, "height": 8},
+)
+
+// Check that the crate filter `<select>` is correctly handled when it goes to next line.
+// To do so we need to update the length of one of its `<option>`.
+set-window-size: (900, 900)
+
+// First we check the current width, height and position.
+assert-css: ("#crate-search", {"width": "159px"})
+store-size: (".search-switcher", {
+    "height": search_results_title_height,
+    "width": search_results_title_width,
+})
+assert-css: ("#search", {"width": "640px"})
+
+// Then we update the text of one of the `<option>`.
+set-text: (
+    "#crate-search option",
+    "sdjfaksdjfaksjdbfkadsbfkjsadbfkdsbkfbsadkjfbkdsabfkadsfkjdsafa",
+)
+
+// Then we compare again to confirm the height didn't change.
+assert-size: ("#crate-search", {"width": 185})
+assert-size: (".search-switcher", {
+    "height": |search_results_title_height|,
+})
+assert-css: ("#search", {"width": "640px"})
+assert: |search_results_title_width| <= 640
+
+// Now checking that the crate filter is working as expected too.
+show-text: true
+define-function: (
+    "check-filter",
+    [theme, border, filter, hover_border, hover_filter],
+    block {
+        call-function: ("switch-theme", {"theme": |theme|})
+        wait-for: "#crate-search"
+        wait-for-false: "#search-tabs .count.loading"
+        assert-css: ("#crate-search", {"border": "1px solid " + |border|})
+        assert-css: ("#crate-search-div::after", {"filter": |filter|})
+        move-cursor-to: "#crate-search"
+        assert-css: ("#crate-search", {"border": "1px solid " + |hover_border|})
+        assert-css: ("#crate-search-div::after", {"filter": |hover_filter|})
+        move-cursor-to: ".search-input"
+    },
+)
+
+call-function: ("check-filter", {
+    "theme": "ayu",
+    "border": "#5c6773",
+    "filter": "invert(0.41) sepia(0.12) saturate(4.87) hue-rotate(171deg) brightness(0.94) contrast(0.94)",
+    "hover_border": "#e0e0e0",
+    "hover_filter": "invert(0.98) sepia(0.12) saturate(0.81) hue-rotate(343deg) brightness(1.13) contrast(0.76)",
+})
+call-function: ("check-filter", {
+    "theme": "dark",
+    "border": "#e0e0e0",
+    "filter": "invert(0.94) sepia(0) saturate(7.21) hue-rotate(255deg) brightness(0.9) contrast(0.9)",
+    "hover_border": "#2196f3",
+    "hover_filter": "invert(0.69) sepia(0.6) saturate(66.13) hue-rotate(184deg) brightness(1) contrast(0.91)",
+})
+call-function: ("check-filter", {
+    "theme": "light",
+    "border": "#e0e0e0",
+    "filter": "invert(1) sepia(0) saturate(42.23) hue-rotate(289deg) brightness(1.14) contrast(0.76)",
+    "hover_border": "#717171",
+    "hover_filter": "invert(0.44) sepia(0.18) saturate(0.23) hue-rotate(317deg) brightness(0.96) contrast(0.93)",
+})

--- a/tests/rustdoc-gui/search-result-go-to-first.goml
+++ b/tests/rustdoc-gui/search-result-go-to-first.goml
@@ -3,13 +3,12 @@
 // First, we check that the first page doesn't have the string we're looking for to ensure
 // that the feature is changing page as expected.
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
+include: "utils.goml"
 assert-text-false: (".main-heading h1", "Struct test_docs::FooCopy item path")
 
 // We now check that we land on the search result page if "go_to_first" isn't set.
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search=struct%3AFoo"
-// Waiting for the search results to appear...
-wait-for: "#search-tabs"
-wait-for-false: "#search-tabs .count.loading"
+call-function: ("wait-for-search-results", {})
 assert-text-false: (".main-heading h1", "Struct test_docs::FooCopy item path")
 // Ensure that the search results are displayed, not the "normal" content.
 assert-css: ("#main-content", {"display": "none"})

--- a/tests/rustdoc-gui/search-result-impl-disambiguation.goml
+++ b/tests/rustdoc-gui/search-result-impl-disambiguation.goml
@@ -39,8 +39,7 @@ assert: "section:target"
 // and if it has multiple inherent impl blocks, that the numeric
 // impl block's disambiguator is also acted upon.
 go-to: "file://" + |DOC_PATH| + "/lib2/index.html?search=MultiImplBlockStruct->bool"
-wait-for: "#search-tabs"
-wait-for-false: "#search-tabs .count.loading"
+call-function: ("wait-for-search-results", {})
 assert-count: ("a.result-method", 1)
 assert-attribute: ("a.result-method", {
     "href": "../lib2/another_mod/struct.MultiImplBlockStruct.html#impl-MultiImplBlockStruct/method.second_fn"
@@ -49,8 +48,7 @@ click: "a.result-method"
 wait-for: "details:has(summary > #impl-MultiImplBlockStruct-1) > div section[id='method.second_fn']:target"
 
 go-to: "file://" + |DOC_PATH| + "/lib2/index.html?search=MultiImplBlockStruct->u32"
-wait-for: "#search-tabs"
-wait-for-false: "#search-tabs .count.loading"
+call-function: ("wait-for-search-results", {})
 assert-count: ("a.result-method", 1)
 assert-attribute: ("a.result-method", {
     "href": "../lib2/another_mod/struct.MultiImplBlockStruct.html#impl-MultiImplBlockTrait-for-MultiImplBlockStruct/method.second_fn"

--- a/tests/rustdoc-gui/search-tab.goml
+++ b/tests/rustdoc-gui/search-tab.goml
@@ -15,8 +15,7 @@ define-function: (
         focus: ".search-input"
         press-key: "Enter"
 
-        wait-for: "#search-tabs .count"
-        wait-for-false: "#search-tabs .count.loading"
+        call-function: ("wait-for-search-results", {})
         assert-css: ("#search-tabs > button:not(.selected)", {
             "background-color": |background|,
             "border-bottom": |border_bottom|,

--- a/tests/rustdoc-gui/search-throbber.goml
+++ b/tests/rustdoc-gui/search-throbber.goml
@@ -1,11 +1,11 @@
 // We are intentionally triggering errors for race-free throbber test
 fail-on-request-error: false
 fail-on-js-error: false
+include: "utils.goml"
 
 // First, make sure the throbber goes away when done
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search="
-wait-for: ".search-input"
-wait-for-false: ".search-form.loading"
+call-function: ("wait-for-search-results", {})
 write-into: (".search-input", "test")
 press-key: 'Enter'
 wait-for-false: ".search-form.loading"

--- a/tests/rustdoc-gui/search-title.goml
+++ b/tests/rustdoc-gui/search-title.goml
@@ -12,8 +12,7 @@ assert-document-property: {"title": '"test" Search - Rust'}
 set-property: (".search-input", {"value": "another one"})
 // To be SURE that the search will be run.
 press-key: 'Enter'
-wait-for: "#crate-search"
-wait-for-false: "#search-tabs .count.loading"
+call-function: ("wait-for-search-results", {})
 
 assert-document-property: {"title": '"another one" Search - Rust'}
 

--- a/tests/rustdoc-gui/utils.goml
+++ b/tests/rustdoc-gui/utils.goml
@@ -113,7 +113,16 @@ define-function: (
         focus: ".search-input"
         // We write the actual query.
         write-into: (".search-input", |query|)
+        // We press `Enter` to be sure the query will be run.
         press-key: 'Enter'
+        call-function: ("wait-for-search-results", {})
+    }
+)
+
+define-function: (
+    "wait-for-search-results",
+    [],
+    block {
         // wait for the search to start
         wait-for: "#search-tabs"
         // then wait for it to finish


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/152197.

I updated the test I added back in the first commit to remove some potential flaky issues.

The second commit is just a cleanup to reuse the same function to wait for the search results. Like that we only need to change it in one place if we update this.

r? @Urgau 