### PR TITLE
properly deny combining GCE and GCA

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -741,7 +741,7 @@ fn warn_next_solver_and_gce(sess: &Session, features: &Features) {
 }
 
 fn check_features_requiring_new_solver(sess: &Session, features: &Features) {
-    if sess.opts.unstable_opts.next_solver.globally {
+    if sess.opts.unstable_opts.next_solver.globally && !features.generic_const_exprs() {
         return;
     }
 

--- a/tests/ui/const-generics/generic_const_exprs/next-solver-gce-incompatible-issue-158428.rs
+++ b/tests/ui/const-generics/generic_const_exprs/next-solver-gce-incompatible-issue-158428.rs
@@ -1,8 +1,8 @@
-//@ run-pass
 //@ compile-flags: -Znext-solver=globally
 
 #![feature(min_generic_const_args)]
 #![feature(generic_const_args)]
+//~^ ERROR:`generic_const_args` requires -Znext-solver=globally to be enabled
 #![feature(generic_const_exprs)]
 //~^ WARN: `feature(generic_const_exprs)` is not supported with the next-generation trait solver
 //@ normalize-stderr: "(--> ).*/tests/ui/const-generics/generic_const_exprs" -> "$1$$DIR"
@@ -10,7 +10,6 @@
 use std::mem::size_of;
 
 union AsBytes<T> {
-    //~^ WARN: union `AsBytes` is never used
     as_bytes: [u8; { size_of::<T>() }],
 }
 

--- a/tests/ui/const-generics/generic_const_exprs/next-solver-gce-incompatible-issue-158428.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/next-solver-gce-incompatible-issue-158428.stderr
@@ -9,13 +9,13 @@ LL | #![feature(generic_const_exprs)]
    = note: the currently stable trait solver will be used for this crate
    = note: see issues #160895 <https://github.com/rust-lang/rust/issues/160895> for more information
 
-warning: union `AsBytes` is never used
-  --> $DIR/next-solver-gce-incompatible-issue-158428.rs:12:7
+error: `generic_const_args` requires -Znext-solver=globally to be enabled
+  --> $DIR/next-solver-gce-incompatible-issue-158428.rs:4:12
    |
-LL | union AsBytes<T> {
-   |       ^^^^^^^
+LL | #![feature(generic_const_args)]
+   |            ^^^^^^^^^^^^^^^^^^
    |
-   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+   = help: enable all of these features
 
-warning: 2 warnings emitted
+error: aborting due to 1 previous error; 1 warning emitted
 


### PR DESCRIPTION
Previously, enabling `generic_const_exprs` disabled the next solver, but also enabling `generic_const_args` was not rejected even though it required the next solver.

Fixes https://github.com/rust-lang/rust/issues/161523.
