### PR TITLE
Add regression test for gce dependency ICE in non-gce crate

### DIFF
--- a/tests/ui/const-generics/generic_const_exprs/auxiliary/dep-with-gce-128525.rs
+++ b/tests/ui/const-generics/generic_const_exprs/auxiliary/dep-with-gce-128525.rs
@@ -1,0 +1,18 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+pub trait LibTrait {
+    const NUM: usize;
+    fn configure(&mut self, cfg: &Config<{ Self::NUM }>);
+}
+
+pub struct Config<const N: usize> {
+    pub config: [u8; N],
+}
+
+pub struct ImplementsTraitOverConstGeneric<const N: usize>;
+
+impl<const N: usize> LibTrait for ImplementsTraitOverConstGeneric<N> {
+    const NUM: usize = N;
+    fn configure(&mut self, _: &Config<{ Self::NUM }>) {}
+}

--- a/tests/ui/const-generics/generic_const_exprs/dependent-crate-no-gce-128525.rs
+++ b/tests/ui/const-generics/generic_const_exprs/dependent-crate-no-gce-128525.rs
@@ -1,0 +1,15 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/128525>.
+// Using a `generic_const_exprs` API from a dependency in a crate that does not
+// enable the feature itself used to ICE ("called `Option::unwrap()` on a `None`
+// value" in `ty/sty.rs`) instead of compiling.
+//@ aux-build: dep-with-gce-128525.rs
+//@ build-pass
+
+extern crate dep_with_gce_128525 as library;
+
+use library::*;
+
+fn main() {
+    let mut inner = ImplementsTraitOverConstGeneric::<4>;
+    inner.configure(&Config { config: [0, 0, 0, 0] });
+}


### PR DESCRIPTION
Closes rust-lang/rust#128525