### PR TITLE
Remove `T: Send + Sync` bound from `Arc::downcast`

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2939,7 +2939,7 @@ impl<A: Allocator> Arc<dyn Any + Send + Sync, A> {
     #[stable(feature = "rc_downcast", since = "1.29.0")]
     pub fn downcast<T>(self) -> Result<Arc<T, A>, Self>
     where
-        T: Any + Send + Sync,
+        T: Any,
     {
         if (*self).is::<T>() {
             unsafe {
@@ -2981,7 +2981,7 @@ impl<A: Allocator> Arc<dyn Any + Send + Sync, A> {
     #[unstable(feature = "downcast_unchecked", issue = "90850")]
     pub unsafe fn downcast_unchecked<T>(self) -> Arc<T, A>
     where
-        T: Any + Send + Sync,
+        T: Any,
     {
         unsafe {
             let (ptr, alloc) = Arc::into_inner_with_allocator(self);


### PR DESCRIPTION
[Discussion](https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/Why.20the.20.60T.3A.20Send.20.2B.20Sync.60.20bound.20in.20.60Arc.3A.3Adowncast.60.3F/with/617793925) on zulip

Implements the change described in https://github.com/rust-lang/libs-team/issues/859.
T-libs can pick if they want to skip the ACP or not.

@rustbot label needs-fcp T-libs