### PR TITLE
prevent next-solver ICE when evaluating ill-formed associated consts

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1410,9 +1410,30 @@ where
         &mut self,
         param_env: I::ParamEnv,
         alias_const: ty::AliasConst<I>,
+        ensure_wf_before_eval: bool,
     ) -> Result<Option<I::Const>, NoSolutionOrRerunNonErased> {
         if self.typing_mode().is_erased_not_coherence() {
             match self.opaque_accesses.rerun_always(RerunReason::EvaluateConst)? {}
+        }
+
+        if ensure_wf_before_eval && !self.typing_mode().is_coherence() {
+            let cx = self.cx();
+
+            let wf_goal = Goal::new(
+                cx,
+                param_env,
+                ty::ClauseKind::WellFormed(
+                    I::Const::new_alias(cx, ty::IsRigid::Yes, alias_const).into(),
+                ),
+            );
+
+            self.add_goal(GoalSource::AliasWellFormed, wf_goal)?;
+
+            let wf_certainty = self.try_evaluate_added_goals()?;
+
+            if matches!(wf_certainty, Certainty::Maybe(_)) {
+                return Ok(None);
+            }
         }
 
         self.delegate.evaluate_const(param_env, alias_const, |ty| {
@@ -1427,7 +1448,7 @@ where
         expected_term: I::Term,
         alias_const: ty::AliasConst<I>,
     ) -> QueryResultOrRerunNonErased<I> {
-        match self.evaluate_const(param_env, alias_const)? {
+        match self.evaluate_const(param_env, alias_const, true)? {
             Some(evaluated) => {
                 self.eq(param_env, expected_term, evaluated.into())?;
                 self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -224,7 +224,7 @@ where
 
                 // FIXME(generic_const_exprs): Implement handling for generic
                 // const expressions here.
-                if let Some(_normalized) = self.evaluate_const(param_env, alias_const)? {
+                if let Some(_normalized) = self.evaluate_const(param_env, alias_const, false)? {
                     self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
                 } else {
                     self.evaluate_added_goals_and_make_canonical_response(Certainty::AMBIGUOUS)

--- a/tests/ui/traits/next-solver/associated-const-wf-before-ctfe-161510.rs
+++ b/tests/ui/traits/next-solver/associated-const-wf-before-ctfe-161510.rs
@@ -1,0 +1,21 @@
+//@ compile-flags: -Znext-solver=globally
+
+#![feature(generic_const_items)]
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+
+trait Owner {
+    type const K<const N: u16>: u16;
+}
+
+impl Owner for () {
+    type const K<const N: u32>: u32 = N;
+    //~^ ERROR associated constant `K` has an incompatible generic parameter for trait `Owner`
+}
+
+fn take1(_: impl Owner<K<9> = 0>) {}
+
+fn main() {
+    take1(());
+    //~^ ERROR type mismatch resolving `<() as Owner>::K<9> == 0`
+}

--- a/tests/ui/traits/next-solver/associated-const-wf-before-ctfe-161510.stderr
+++ b/tests/ui/traits/next-solver/associated-const-wf-before-ctfe-161510.stderr
@@ -1,0 +1,33 @@
+error[E0053]: associated constant `K` has an incompatible generic parameter for trait `Owner`
+  --> $DIR/associated-const-wf-before-ctfe-161510.rs:12:18
+   |
+LL | trait Owner {
+   |       -----
+LL |     type const K<const N: u16>: u16;
+   |                  ------------ expected const parameter of type `u16`
+...
+LL | impl Owner for () {
+   | -----------------
+LL |     type const K<const N: u32>: u32 = N;
+   |                  ^^^^^^^^^^^^ found const parameter of type `u32`
+
+error[E0271]: type mismatch resolving `<() as Owner>::K<9> == 0`
+  --> $DIR/associated-const-wf-before-ctfe-161510.rs:19:11
+   |
+LL |     take1(());
+   |     ----- ^^ expected `0`, found `9`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = note: expected constant `0`
+              found constant `9`
+note: required by a bound in `take1`
+  --> $DIR/associated-const-wf-before-ctfe-161510.rs:16:24
+   |
+LL | fn take1(_: impl Owner<K<9> = 0>) {}
+   |                        ^^^^^^^^ required by this bound in `take1`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0053, E0271.
+For more information about an error, try `rustc --explain E0053`.


### PR DESCRIPTION
fixes rust-lang/rust#161510
const projections can currently reach const-eval before the impl item has been proven well-formed which allowed this case to ICE in CTFE after evaluating a u32 const where the trait expected a u16
we can check that the projection is well-formed before evaluating it and the existing WF error is reported instead skipping the check during coherence to avoid changing existing generic-const overlap