### PR TITLE
hir_typeck: Don't ICE on closures without drop location in closure capture lint

### DIFF
--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -992,6 +992,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) {
         struct MigrationLint<'a, 'tcx> {
             closure_def_id: LocalDefId,
+            closure_drop_location_span: Span,
             this: &'a FnCtxt<'a, 'tcx>,
             body_id: hir::BodyId,
             need_migrations: Vec<NeededMigration>,
@@ -1000,8 +1001,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         impl<'a, 'b, 'tcx> Diagnostic<'a, ()> for MigrationLint<'b, 'tcx> {
             fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, ()> {
-                let Self { closure_def_id, this, body_id, need_migrations, migration_message } =
-                    self;
+                let Self {
+                    closure_def_id,
+                    closure_drop_location_span,
+                    this,
+                    body_id,
+                    need_migrations,
+                    migration_message,
+                } = self;
                 let mut lint = Diag::new(dcx, level, migration_message);
 
                 let (migration_string, migrated_variables_concat) =
@@ -1034,25 +1041,32 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             _ => {}
                         }
 
-                        // Add a label pointing to where a captured variable affected by drop order
-                        // is dropped
+                        // Add a label pointing to where a captured variable affected by drop
+                        // order is dropped.
                         if lint_note.reason.drop_order {
-                            let drop_location_span = drop_location_span(this.tcx, closure_hir_id);
-
+                            let var_name = this.tcx.hir_name(*var_hir_id);
                             match &lint_note.captures_info {
                                 UpvarMigrationInfo::CapturingPrecise {
                                     var_name: captured_name,
                                     ..
                                 } => {
-                                    lint.span_label(drop_location_span, format!("in Rust 2018, `{}` is dropped here, but in Rust 2021, only `{}` will be dropped here as part of the closure",
-                                        this.tcx.hir_name(*var_hir_id),
-                                        captured_name,
-                                    ));
+                                    lint.span_label(
+                                            closure_drop_location_span,
+                                            format!(
+                                                "in Rust 2018, `{var_name}` is dropped here, but in Rust 2021, \
+                                                only `{captured_name}` will be dropped here as part of the closure"
+                                            ),
+                                        );
                                 }
                                 UpvarMigrationInfo::CapturingNothing { use_span: _ } => {
-                                    lint.span_label(drop_location_span, format!("in Rust 2018, `{v}` is dropped here along with the closure, but in Rust 2021 `{v}` is not part of the closure",
-                                        v = this.tcx.hir_name(*var_hir_id),
-                                    ));
+                                    lint.span_label(
+                                            closure_drop_location_span,
+                                            format!(
+                                                "in Rust 2018, `{var_name}` is dropped here along with \
+                                                the closure, but in Rust 2021 `{var_name}` is not part \
+                                                of the closure"
+                                            ),
+                                        );
                                 }
                             }
                         }
@@ -1189,13 +1203,19 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.typeck_results.borrow().closure_min_captures.get(&closure_def_id),
         );
 
-        if !need_migrations.is_empty() {
+        // Without a valid drop location, the closure syntax is invalid, and
+        // emitted lints become nonsensical.
+        if !need_migrations.is_empty()
+            && let Some(drop_location_span) =
+                drop_location_span(self.tcx, self.tcx.local_def_id_to_hir_id(closure_def_id))
+        {
             self.tcx.emit_node_span_lint(
                 RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES,
                 self.tcx.local_def_id_to_hir_id(closure_def_id),
                 self.tcx.def_span(closure_def_id),
                 MigrationLint {
                     this: self,
+                    closure_drop_location_span: drop_location_span,
                     migration_message: reasons.migration_message(),
                     closure_def_id,
                     body_id,
@@ -2056,25 +2076,17 @@ fn apply_capture_kind_on_capture_ty<'tcx>(
 }
 
 /// Returns the Span of where the value with the provided HirId would be dropped
-fn drop_location_span(tcx: TyCtxt<'_>, hir_id: HirId) -> Span {
-    let owner_id = tcx.hir_get_enclosing_scope(hir_id).unwrap();
+fn drop_location_span(tcx: TyCtxt<'_>, hir_id: HirId) -> Option<Span> {
+    let owner_id = tcx.hir_get_enclosing_scope(hir_id)?;
 
-    let owner_node = tcx.hir_node(owner_id);
-    let owner_span = match owner_node {
-        hir::Node::Item(item) => match item.kind {
-            hir::ItemKind::Fn { body: owner_id, .. } => tcx.hir_span(owner_id.hir_id),
-            _ => {
-                bug!("Drop location span error: need to handle more ItemKind '{:?}'", item.kind);
-            }
-        },
-        hir::Node::Block(block) => tcx.hir_span(block.hir_id),
-        hir::Node::TraitItem(item) => tcx.hir_span(item.hir_id()),
-        hir::Node::ImplItem(item) => tcx.hir_span(item.hir_id()),
-        _ => {
-            bug!("Drop location span error: need to handle more Node '{:?}'", owner_node);
-        }
+    let hir_id = match tcx.hir_node(owner_id) {
+        hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn { body, .. }, .. }) => body.hir_id,
+        hir::Node::Block(block) => block.hir_id,
+        hir::Node::TraitItem(item) => item.hir_id(),
+        hir::Node::ImplItem(item) => item.hir_id(),
+        _ => return None,
     };
-    tcx.sess.source_map().end_point(owner_span)
+    Some(tcx.sess.source_map().end_point(tcx.hir_span(hir_id)))
 }
 
 struct InferBorrowKind<'a, 'tcx> {

--- a/tests/crashes/156288.rs
+++ b/tests/crashes/156288.rs
@@ -1,3 +1,0 @@
-//@ known-bug: #156288
-#[warn(rust_2021_incompatible_closure_captures)]
-const _: () = |b| move || b;

--- a/tests/ui/closures/2229_closure_analysis/incompatible-captures-without-drop-location.rs
+++ b/tests/ui/closures/2229_closure_analysis/incompatible-captures-without-drop-location.rs
@@ -1,0 +1,22 @@
+//@ edition:2018
+
+#[warn(rust_2021_incompatible_closure_captures)]
+enum Functions {
+    Square = |b| move || format!("{b}"),
+    //~^ ERROR mismatched types
+}
+
+#[warn(rust_2021_incompatible_closure_captures)]
+static _static: () = |b| move || b;
+//~^ ERROR mismatched types
+
+fn main() {
+    #[warn(rust_2021_incompatible_closure_captures)]
+    const _: () = |b| move || b;
+    //~^ ERROR mismatched types
+
+    #[warn(rust_2021_incompatible_closure_captures)]
+    let _: () = |b| move || b;
+    //~^ ERROR mismatched types
+    //~| WARN changes to closure capture in Rust 2021 will affect drop order
+}

--- a/tests/ui/closures/2229_closure_analysis/incompatible-captures-without-drop-location.stderr
+++ b/tests/ui/closures/2229_closure_analysis/incompatible-captures-without-drop-location.stderr
@@ -1,0 +1,66 @@
+error[E0308]: mismatched types
+  --> $DIR/incompatible-captures-without-drop-location.rs:5:14
+   |
+LL |     Square = |b| move || format!("{b}"),
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `isize`, found closure
+   |
+   = note: expected type `isize`
+           found closure `{closure@$DIR/incompatible-captures-without-drop-location.rs:5:14: 5:17}`
+   = note: enum variant discriminant can only be of a primitive type compatible with the enum's `repr`
+
+error[E0308]: mismatched types
+  --> $DIR/incompatible-captures-without-drop-location.rs:10:22
+   |
+LL | static _static: () = |b| move || b;
+   |                 --   ^^^^^^^^^^^^^ expected `()`, found closure
+   |                 |
+   |                 expected because of the type of the static
+   |
+   = note: expected unit type `()`
+                found closure `{closure@$DIR/incompatible-captures-without-drop-location.rs:10:22: 10:25}`
+
+error[E0308]: mismatched types
+  --> $DIR/incompatible-captures-without-drop-location.rs:19:17
+   |
+LL |     let _: () = |b| move || b;
+   |            --   ^^^^^^^^^^^^^ expected `()`, found closure
+   |            |
+   |            expected due to this
+   |
+   = note: expected unit type `()`
+                found closure `{closure@$DIR/incompatible-captures-without-drop-location.rs:19:17: 19:20}`
+
+warning: changes to closure capture in Rust 2021 will affect drop order
+  --> $DIR/incompatible-captures-without-drop-location.rs:19:21
+   |
+LL |     let _: () = |b| move || b;
+   |                     ^^^^^^^ - in Rust 2018, this causes the closure to capture `b`, but in Rust 2021, it has no effect
+...
+LL | }
+   | - in Rust 2018, `b` is dropped here along with the closure, but in Rust 2021 `b` is not part of the closure
+   |
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/disjoint-capture-in-closures.html>
+note: the lint level is defined here
+  --> $DIR/incompatible-captures-without-drop-location.rs:18:12
+   |
+LL |     #[warn(rust_2021_incompatible_closure_captures)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: add a dummy let to cause `b` to be fully captured
+   |
+LL |     let _: () = |b| move || { let _ = &b; b };
+   |                             +++++++++++++   +
+
+error[E0308]: mismatched types
+  --> $DIR/incompatible-captures-without-drop-location.rs:15:19
+   |
+LL |     const _: () = |b| move || b;
+   |              --   ^^^^^^^^^^^^^ expected `()`, found closure
+   |              |
+   |              expected because of the type of the constant
+   |
+   = note: expected unit type `()`
+                found closure `{closure@$DIR/incompatible-captures-without-drop-location.rs:15:19: 15:22}`
+
+error: aborting due to 4 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161548)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Resolves rust-lang/rust#156288. 

`drop_location_span` assumed that every closure had a valid drop location, which could cause an ICE for closures in unsupported contexts. This changes `drop_location_span` to return `Option<Span>`. If there is no valid drop location, the migration lint is not emitted because its drop-order diagnostic would be misleading. The span is computed before creating `MigrationLint` and stored there so it can be reused for the drop-order labels.