### PR TITLE
Add no-value `DropGuard::new(|| ...)`

### DIFF
--- a/library/alloc/src/io/read.rs
+++ b/library/alloc/src/io/read.rs
@@ -814,7 +814,7 @@ where
     let len_original = buf.len();
     // SAFETY: invalid UTF-8 discarded before return or unwind
     let buf_vec = unsafe { buf.as_mut_vec() };
-    let mut g = DropGuard::new((len_original, buf_vec), |(len, buf)| unsafe {
+    let mut g = DropGuard::with((len_original, buf_vec), |(len, buf)| unsafe {
         buf.set_len(len);
     });
     let ret = f(g.1);

--- a/library/core/src/mem/drop_guard.rs
+++ b/library/core/src/mem/drop_guard.rs
@@ -19,7 +19,7 @@ use crate::ops::{Deref, DerefMut};
 ///     // Create a new guard around a string that will
 ///     // print its value when dropped.
 ///     let s = String::from("Chashu likes tuna");
-///     let mut s = DropGuard::new(s, |s| println!("{s}"));
+///     let mut s = DropGuard::with(s, |s| println!("{s}"));
 ///
 ///     // Modify the string contained in the guard.
 ///     s.push_str("!!!");
@@ -39,11 +39,56 @@ where
     f: ManuallyDrop<F>,
 }
 
+impl DropGuard<(), UnitFn> {
+    /// Create a new instance of `DropGuard` with only a closure, no value.
+    ///
+    /// `DropGuard::new(|| ...)` is equivalent to `DropGuard::with((), |()| ...)`.
+    ///
+    /// # Example
+    ///
+    /// Enabling and then disabling a Unix terminal's [raw mode] within some
+    /// block of code is a good use for `DropGuard`. Whether the block ends
+    /// through successful completion, an unwinding panic, or early
+    /// `return`/`break`/`continue`/`?`, the raw mode guard will ensure the
+    /// disabling takes place.
+    ///
+    /// [raw mode]: https://man7.org/linux/man-pages/man3/termios.3.html#:~:text=Raw%20mode
+    ///
+    /// ```
+    /// #![feature(drop_guard)]
+    ///
+    /// use std::mem::DropGuard;
+    /// #
+    /// # struct Terminal;
+    /// # impl Terminal {
+    /// #     fn enable_raw_mode(&self) {}
+    /// #     fn disable_raw_mode(&self) {}
+    /// # }
+    /// # let terminal = Terminal;
+    ///
+    /// {
+    ///     terminal.enable_raw_mode();
+    ///     let _raw_mode_guard = DropGuard::new(|| terminal.disable_raw_mode());
+    ///
+    ///     // Write to terminal in raw mode. Upon end of this scope, raw mode ends.
+    /// }
+    /// ```
+    #[unstable(feature = "drop_guard", issue = "144426")]
+    #[must_use]
+    pub const fn new(f: impl FnOnce()) -> DropGuard<(), impl FnOnce(())> {
+        DropGuard::with((), |()| f())
+    }
+}
+
 impl<T, F> DropGuard<T, F>
 where
     F: FnOnce(T),
 {
-    /// Create a new instance of `DropGuard`.
+    /// Create a new instance of `DropGuard` holding a value of type `T`.
+    ///
+    /// The value (`inner`) is provided to the closure that runs during drop,
+    /// but also remains accessible to the surrounding code through the guard's
+    /// `Deref`/`DerefMut`.
     ///
     /// # Example
     ///
@@ -54,11 +99,11 @@ where
     /// use std::mem::DropGuard;
     ///
     /// let value = String::from("Chashu likes tuna");
-    /// let guard = DropGuard::new(value, |s| println!("{s}"));
+    /// let guard = DropGuard::with(value, |s| println!("{s}"));
     /// ```
     #[unstable(feature = "drop_guard", issue = "144426")]
     #[must_use]
-    pub const fn new(inner: T, f: F) -> Self {
+    pub const fn with(inner: T, f: F) -> Self {
         Self { inner: ManuallyDrop::new(inner), f: ManuallyDrop::new(f) }
     }
 
@@ -78,7 +123,7 @@ where
     /// use std::mem::DropGuard;
     ///
     /// let value = String::from("Nori likes chicken");
-    /// let guard = DropGuard::new(value, |s| println!("{s}"));
+    /// let guard = DropGuard::with(value, |s| println!("{s}"));
     /// assert_eq!(DropGuard::dismiss(guard), "Nori likes chicken");
     /// ```
     #[unstable(feature = "drop_guard", issue = "144426")]
@@ -156,5 +201,23 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
+    }
+}
+
+/// A private placeholder that prevents using turbofish in the `DropGuard::new`
+/// call (`DropGuard::<(), ???>::new(...)`) with anything other than `_` as the
+/// second type parameter.
+///
+/// Not publicly nameable outside libcore and not on track for stabilization.
+#[unstable(feature = "drop_guard_unit_fn", issue = "none")]
+#[allow(missing_debug_implementations)]
+pub enum UnitFn {}
+
+#[unstable(feature = "drop_guard_unit_fn", issue = "none")]
+impl FnOnce<((),)> for UnitFn {
+    type Output = ();
+
+    extern "rust-call" fn call_once(self, _args: ((),)) -> Self::Output {
+        match self {}
     }
 }

--- a/library/coretests/tests/mem.rs
+++ b/library/coretests/tests/mem.rs
@@ -778,9 +778,9 @@ fn const_maybe_uninit_zeroed() {
 #[test]
 fn drop_guards_only_dropped_by_closure_when_run() {
     let value_drops = Cell::new(0);
-    let value = DropGuard::new((), |()| value_drops.set(1 + value_drops.get()));
+    let value = DropGuard::new(|| value_drops.set(1 + value_drops.get()));
     let closure_drops = Cell::new(0);
-    let guard = DropGuard::new(value, |_| closure_drops.set(1 + closure_drops.get()));
+    let guard = DropGuard::with(value, |_| closure_drops.set(1 + closure_drops.get()));
     assert_eq!(value_drops.get(), 0);
     assert_eq!(closure_drops.get(), 0);
     drop(guard);
@@ -791,8 +791,8 @@ fn drop_guards_only_dropped_by_closure_when_run() {
 #[test]
 fn drop_guard_into_inner() {
     let dropped = Cell::new(false);
-    let value = DropGuard::new(42, |_| dropped.set(true));
-    let guard = DropGuard::new(value, |_| dropped.set(true));
+    let value = DropGuard::with(42, |_| dropped.set(true));
+    let guard = DropGuard::with(value, |_| dropped.set(true));
     let inner = DropGuard::dismiss(guard);
     assert_eq!(dropped.get(), false);
     assert_eq!(*inner, 42);
@@ -803,10 +803,10 @@ fn drop_guard_into_inner() {
 fn drop_guard_always_drops_value_if_closure_drop_unwinds() {
     // Create a value with a destructor, which we will validate ran successfully.
     let mut value_was_dropped = false;
-    let value_with_tracked_destruction = DropGuard::new((), |_| value_was_dropped = true);
+    let value_with_tracked_destruction = DropGuard::new(|| value_was_dropped = true);
 
     // Create a closure that will begin unwinding when dropped.
-    let drop_bomb = DropGuard::new((), |_| panic!());
+    let drop_bomb = DropGuard::new(|| panic!());
     let closure_that_panics_on_drop = move |_| {
         let _drop_bomb = drop_bomb;
     };
@@ -814,7 +814,7 @@ fn drop_guard_always_drops_value_if_closure_drop_unwinds() {
     // This will run the closure, which will panic when dropped. This should
     // run the destructor of the value we passed, which we validate.
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let guard = DropGuard::new(value_with_tracked_destruction, closure_that_panics_on_drop);
+        let guard = DropGuard::with(value_with_tracked_destruction, closure_that_panics_on_drop);
         DropGuard::dismiss(guard);
     }));
     assert!(value_was_dropped);

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -52,7 +52,7 @@ impl Thread {
         let data = init;
         let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = mem::MaybeUninit::uninit();
         assert_eq!(libc::pthread_attr_init(attr.as_mut_ptr()), 0);
-        let mut attr = DropGuard::new(&mut attr, |attr| {
+        let mut attr = DropGuard::with(&mut attr, |attr| {
             assert_eq!(libc::pthread_attr_destroy(attr.as_mut_ptr()), 0)
         });
 


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/144426

According to https://github.com/rust-lang/rust/issues/144426#issuecomment-3579420458, in some projects `DropGuard<(), ...>` is the common case.