### PR TITLE
also trigger overflow FCW when going from overflow -> error

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -359,12 +359,11 @@ fn maybe_evaluate_root_goal_with_higher_recursion_limit<D, I>(
             EvalCtxt::enter_root(delegate, delegate.cx().recursion_limit() * 2, span, |ecx| {
                 ecx.evaluate_goal_no_fast_paths(GoalSource::Misc, goal)
             });
-        if let Ok(goal_evaluation) = &rerun_result
-            && !goal_evaluation.certainty.is_overflow()
-        {
-            Ok(rerun_result)
-        } else {
+
+        if rerun_result.as_ref().is_ok_and(|evaluation| evaluation.certainty.is_overflow()) {
             Err(())
+        } else {
+            Ok(rerun_result)
         }
     });
     if let Ok(rerun_result) = rerun_result {
@@ -408,12 +407,11 @@ fn maybe_evaluate_root_goal_for_proof_tree_with_higher_recursion_limit<D, I>(
             span,
             delegate.cx().recursion_limit() * 2,
         );
-        if let Ok(response) = &new_goal_evaluation.result
-            && !response.value.certainty.is_overflow()
-        {
-            Ok((new_result, new_goal_evaluation))
-        } else {
+
+        if new_goal_evaluation.result.is_ok_and(|response| response.value.certainty.is_overflow()) {
             Err(())
+        } else {
+            Ok((new_result, new_goal_evaluation))
         }
     });
     if let Ok(rerun_result) = rerun_result {

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -282,10 +282,7 @@ where
         goal: Goal<Self::Interner, <Self::Interner as Interner>::Predicate>,
     ) -> bool {
         self.probe(|| {
-            EvalCtxt::enter_root(self, self.cx().recursion_limit(), I::Span::dummy(), |ecx| {
-                ecx.evaluate_goal(GoalSource::Misc, goal, None)
-            })
-            .is_ok_and(|r| match r.certainty {
+            self.evaluate_root_goal(goal, I::Span::dummy(), None).is_ok_and(|r| match r.certainty {
                 Certainty::Yes => true,
                 Certainty::Maybe(MaybeInfo {
                     cause: _,

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -544,8 +544,9 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                     pred_str(goal.predicate),
                 ));
                 for p in visitor.predicates.into_iter().skip(1) {
-                    diag.note(format!("which requires {}", pred_str(p)));
+                    diag.note(format!("which requires `{}`", pred_str(p)));
                 }
+                diag.note("and so on...");
                 diag.help(
                     "consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved",
                 );

--- a/tests/ui/traits/next-solver/overflow-discards-constraints.stderr
+++ b/tests/ui/traits/next-solver/overflow-discards-constraints.stderr
@@ -4,11 +4,12 @@ warning: overflow evaluating the requirement `(): Trait<i32>`
 LL |     foo(); // register a `(): Trait<?t>` obligation
    |     ^^^^^
    |
-   = note: which requires W1<i32>: Trait<i32>
-   = note: which requires W2<i32>: Trait<i32>
-   = note: which requires W3<i32>: Trait<i32>
-   = note: which requires W4<i32>: Trait<i32>
-   = note: which requires W5<i32>: Trait<i32>
+   = note: which requires `W1<i32>: Trait<i32>`
+   = note: which requires `W2<i32>: Trait<i32>`
+   = note: which requires `W3<i32>: Trait<i32>`
+   = note: which requires `W4<i32>: Trait<i32>`
+   = note: which requires `W5<i32>: Trait<i32>`
+   = note: and so on...
    = help: consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
    = help: or consider increasing the recursion limit by adding a `#![recursion_limit = "12"]` attribute to your crate (`overflow_discards_constraints`)
    = note: this lint is attached to the whole crate and can't be disabled on a per-function basis

--- a/tests/ui/traits/next-solver/overflow/fcw-on-auto-trait.next.stderr
+++ b/tests/ui/traits/next-solver/overflow/fcw-on-auto-trait.next.stderr
@@ -4,13 +4,14 @@ warning: overflow evaluating the requirement `Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>: 
 LL |     require_sync::<Foo<Foo<Foo<Foo<Foo<Foo<()>>>>>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: which requires Option<Foo<Foo<Foo<Foo<Foo<()>>>>>>: Sync
-   = note: which requires Foo<Foo<Foo<Foo<Foo<()>>>>>: Sync
-   = note: which requires Option<Foo<Foo<Foo<Foo<()>>>>>: Sync
-   = note: which requires Foo<Foo<Foo<Foo<()>>>>: Sync
-   = note: which requires Option<Foo<Foo<Foo<()>>>>: Sync
-   = note: which requires Foo<Foo<Foo<()>>>: Sync
-   = note: which requires Option<Foo<Foo<()>>>: Sync
+   = note: which requires `Option<Foo<Foo<Foo<Foo<Foo<()>>>>>>: Sync`
+   = note: which requires `Foo<Foo<Foo<Foo<Foo<()>>>>>: Sync`
+   = note: which requires `Option<Foo<Foo<Foo<Foo<()>>>>>: Sync`
+   = note: which requires `Foo<Foo<Foo<Foo<()>>>>: Sync`
+   = note: which requires `Option<Foo<Foo<Foo<()>>>>: Sync`
+   = note: which requires `Foo<Foo<Foo<()>>>: Sync`
+   = note: which requires `Option<Foo<Foo<()>>>: Sync`
+   = note: and so on...
    = help: consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
    = help: or consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_on_auto_trait`)
    = note: this lint is attached to the whole crate and can't be disabled on a per-function basis

--- a/tests/ui/traits/next-solver/overflow/fcw-on-normalization.next.stderr
+++ b/tests/ui/traits/next-solver/overflow/fcw-on-normalization.next.stderr
@@ -4,8 +4,9 @@ warning: overflow evaluating the requirement `<W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>> 
 LL |     let b: <W<W<W<W<W<W<W<W<W<W<()>>>>>>>>>> as HasAssoc>::Assoc = loop {};
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: which requires <W<W<W<W<W<W<W<W<W<()>>>>>>>>> as HasAssoc>::Assoc == ()
-   = note: which requires <W<W<W<W<W<W<W<W<()>>>>>>>> as HasAssoc>::Assoc == ()
+   = note: which requires `<W<W<W<W<W<W<W<W<W<()>>>>>>>>> as HasAssoc>::Assoc == ()`
+   = note: which requires `<W<W<W<W<W<W<W<W<()>>>>>>>> as HasAssoc>::Assoc == ()`
+   = note: and so on...
    = help: consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
    = help: or consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_on_normalization`)
    = note: this lint is attached to the whole crate and can't be disabled on a per-function basis

--- a/tests/ui/traits/next-solver/overflow/fcw-overflow-to-ambig-with-constraints.next.stderr
+++ b/tests/ui/traits/next-solver/overflow/fcw-overflow-to-ambig-with-constraints.next.stderr
@@ -4,13 +4,14 @@ warning: overflow evaluating the requirement `u32: Constrain<u32, _, W<W<W<(), W
 LL |     fun_times();
    |     ^^^^^^^^^^^
    |
-   = note: which requires W<W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, _>>, _>: Count
-   = note: which requires W<W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, _>>, _>: Count
-   = note: which requires W<W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, _>>, _>: Count
-   = note: which requires W<W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, _>>, _>: Count
-   = note: which requires W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, W<_, _>>>: Count
-   = note: which requires W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, W<_, _>>>: Count
-   = note: which requires W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, W<(), _>>>: Count
+   = note: which requires `W<W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, _>>, _>: Count`
+   = note: which requires `W<W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, _>>, _>: Count`
+   = note: which requires `W<W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, _>>, _>: Count`
+   = note: which requires `W<W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, _>>, _>: Count`
+   = note: which requires `W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, W<_, _>>>: Count`
+   = note: which requires `W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, W<_, _>>>: Count`
+   = note: which requires `W<W<(), W<(), W<(), W<(), ()>>>>, W<W<(), W<(), W<(), W<(), ()>>>>, W<(), _>>>: Count`
+   = note: and so on...
    = help: consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
    = help: or consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_overflow_to_ambig_with_constraints`)
    = note: this lint is attached to the whole crate and can't be disabled on a per-function basis

--- a/tests/ui/traits/next-solver/overflow/fcw-overflow-to-error.next.stderr
+++ b/tests/ui/traits/next-solver/overflow/fcw-overflow-to-error.next.stderr
@@ -1,0 +1,19 @@
+warning: overflow evaluating the requirement `W<W<W<W<W<()>>>>>: Overflow`
+  --> $DIR/fcw-overflow-to-error.rs:34:23
+   |
+LL |     W(W(W(W(W(()))))).foo();
+   |                       ^^^
+   |
+   = note: which requires `W<W<W<W<W<()>>>>>: Trait`
+   = note: which requires `Indir<W<W<W<W<()>>>>>: Trait`
+   = note: which requires `W<W<W<W<()>>>>: Trait`
+   = note: and so on...
+   = help: consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = help: or consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`fcw_overflow_to_error`)
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+   = note: `#[warn(recursion_depth_exceeding_limit)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/next-solver/overflow/fcw-overflow-to-error.rs
+++ b/tests/ui/traits/next-solver/overflow/fcw-overflow-to-error.rs
@@ -1,0 +1,37 @@
+//@ revisions: old next
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+#![recursion_limit = "8"]
+
+// Regression test for the <https://github.com/bevyengine/bevy/issues/25511>.
+//
+// We previously didn't apply the future compat warning if overflow was hiding
+// an error. We need to do so to avoid ambiguity in method selection.
+
+struct W<T>(T);
+struct Indir<T>(T);
+
+trait Trait {}
+impl<T> Trait for W<T>
+where
+    Indir<T>: Trait
+{}
+impl<T: Trait> Trait for Indir<T> {}
+
+trait Overflow {
+    fn foo(&self) {}
+}
+impl<T: Trait> Overflow for T {}
+
+trait Accepted {
+    fn foo(&self) {}
+}
+impl<T> Accepted for T {}
+
+fn main() {
+    W(W(W(()))).foo();
+    W(W(W(W(W(()))))).foo();
+    //[next]~^ WARN: overflow evaluating the requirement `W<W<W<W<W<()>>>>>: Overflow`
+    //[next]~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+}


### PR DESCRIPTION
based on rust-lang/rust#161341. This changes the FCW to also trigger if doubling the recursion limit changes things to an error.

Fixes https://github.com/bevyengine/bevy/issues/25511

I am also changing `fn root_goal_may_hold_opaque_types_jank` to just use `evaluate_root_goal`. That isn't necessary for the example itself but we previously didn't do the FCW in there, which feels subtle and brittle. THis should just generally be more consistent

r? adwinwhite (or anyone else really)