### PR TITLE
rustdoc: fix issue preventing "read more" links from generating.

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1595,8 +1595,8 @@ impl MarkdownSummaryLine<'_> {
 
         html::push_html(&mut s, without_paragraphs);
 
-        let has_more_content =
-            matches!(summary.inner.peek(), Some(Event::Start(_))) || summary.skipped_tags > 0;
+        let has_more_content = matches!(summary.inner.peek(), Some(Event::Start(_) | Event::Rule))
+            || summary.skipped_tags > 0;
 
         (s, has_more_content)
     }

--- a/tests/rustdoc-html/trait-read-more-161300.rs
+++ b/tests/rustdoc-html/trait-read-more-161300.rs
@@ -1,0 +1,27 @@
+// regression test for <https://github.com/rust-lang/rust/issues/161300>
+// ensures the "read more" link exists in various circumstances.
+#![crate_name = "foo"]
+
+//@ has 'foo/struct.MyStruct.html'
+pub trait MyTrait {
+    /// First
+    ///
+    /// Next paragraph
+    //@ has - '//a[@href="trait.MyTrait.html#method.first"]' 'Read more'
+    fn first() {}
+
+    /// Second
+    ///
+    /// ---
+    ///
+    /// This method is experimental!
+    ///
+    /// ---
+    ///
+    /// Next paragraph
+    //@ has - '//a[@href="trait.MyTrait.html#method.second"]' 'Read more'
+    fn second() {}
+}
+
+pub struct MyStruct;
+impl MyTrait for MyStruct {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

fixes https://github.com/rust-lang/rust/issues/161300
