### PR TITLE
std::net: uefi: fix TcpStream::nodelay and reject zero timeouts

### DIFF
--- a/library/std/src/sys/net/connection/uefi/mod.rs
+++ b/library/std/src/sys/net/connection/uefi/mod.rs
@@ -34,16 +34,25 @@ impl TcpStream {
     }
 
     pub fn connect_timeout(addr: &SocketAddr, timeout: Duration) -> io::Result<TcpStream> {
+        if timeout == Duration::ZERO {
+            return Err(io::Error::ZERO_TIMEOUT);
+        }
         let inner = tcp::Tcp::connect(addr, Some(timeout))?;
         Ok(Self::new(inner))
     }
 
     pub fn set_read_timeout(&self, t: Option<Duration>) -> io::Result<()> {
+        if t == Some(Duration::ZERO) {
+            return Err(io::Error::ZERO_TIMEOUT);
+        }
         self.read_timeout.set(t).unwrap();
         Ok(())
     }
 
     pub fn set_write_timeout(&self, t: Option<Duration>) -> io::Result<()> {
+        if t == Some(Duration::ZERO) {
+            return Err(io::Error::ZERO_TIMEOUT);
+        }
         self.write_timeout.set(t).unwrap();
         Ok(())
     }

--- a/library/std/src/sys/net/connection/uefi/tcp.rs
+++ b/library/std/src/sys/net/connection/uefi/tcp.rs
@@ -1,7 +1,6 @@
 use super::tcp4;
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::SocketAddr;
-use crate::ptr::NonNull;
 use crate::sys::pal::{helpers, unsupported};
 use crate::time::Duration;
 
@@ -85,11 +84,8 @@ impl Tcp {
     pub(crate) fn nodelay(&self) -> io::Result<bool> {
         match self {
             Self::V4(client) => {
-                let temp = client.get_mode_data()?;
-                match NonNull::new(temp.control_option) {
-                    Some(x) => unsafe { Ok(x.as_ref().enable_nagle.into()) },
-                    None => unsupported(),
-                }
+                let nagle: bool = client.get_control_option()?.enable_nagle.into();
+                Ok(!nagle)
             }
         }
     }

--- a/library/std/src/sys/net/connection/uefi/tcp4.rs
+++ b/library/std/src/sys/net/connection/uefi/tcp4.rs
@@ -20,6 +20,24 @@ pub(crate) struct Tcp4 {
 
 const DEFAULT_ADDR: efi::Ipv4Address = efi::Ipv4Address { addr: [0u8; 4] };
 
+const DEFAULT_CONTROL_OPTION: tcp4::Option = tcp4::Option {
+    receive_buffer_size: 0,
+    send_buffer_size: 0,
+    max_syn_back_log: 0,
+    connection_timeout: 0,
+    data_retries: 0,
+    fin_timeout: 0,
+    time_wait_timeout: 0,
+    keep_alive_probes: 0,
+    keep_alive_time: 0,
+    keep_alive_interval: 0,
+    enable_nagle: efi::Boolean::FALSE,
+    enable_time_stamp: efi::Boolean::FALSE,
+    enable_window_scaling: efi::Boolean::FALSE,
+    enable_selective_ack: efi::Boolean::FALSE,
+    enable_path_mtu_discovery: efi::Boolean::FALSE,
+};
+
 impl Tcp4 {
     pub(crate) fn new() -> io::Result<Self> {
         let (service_binding, handle) =
@@ -71,22 +89,35 @@ impl Tcp4 {
         if r.is_error() { Err(crate::io::Error::from_raw_os_error(r.as_usize())) } else { Ok(()) }
     }
 
-    pub(crate) fn get_mode_data(&self) -> io::Result<tcp4::ConfigData> {
-        let mut config_data = tcp4::ConfigData::default();
+    fn get_mode_data_into(&self, config_data: &mut tcp4::ConfigData) -> io::Result<()> {
         let protocol = self.protocol.as_ptr();
 
         let r = unsafe {
             ((*protocol).get_mode_data)(
                 protocol,
                 ptr::null_mut(),
-                &mut config_data,
+                config_data,
                 ptr::null_mut(),
                 ptr::null_mut(),
                 ptr::null_mut(),
             )
         };
 
-        if r.is_error() { Err(io::Error::from_raw_os_error(r.as_usize())) } else { Ok(config_data) }
+        if r.is_error() { Err(io::Error::from_raw_os_error(r.as_usize())) } else { Ok(()) }
+    }
+
+    pub(crate) fn get_mode_data(&self) -> io::Result<tcp4::ConfigData> {
+        let mut config_data = tcp4::ConfigData::default();
+        self.get_mode_data_into(&mut config_data)?;
+        Ok(config_data)
+    }
+
+    pub(crate) fn get_control_option(&self) -> io::Result<tcp4::Option> {
+        let mut control_option = DEFAULT_CONTROL_OPTION;
+        let mut config_data =
+            tcp4::ConfigData { control_option: &mut control_option, ..Default::default() };
+        self.get_mode_data_into(&mut config_data)?;
+        Ok(control_option)
     }
 
     pub(crate) fn accept(&self) -> io::Result<Self> {


### PR DESCRIPTION
nodelay() passed a null ControlOption to GetModeData, so it always failed with Unsupported, and it returned the Nagle flag instead of its negation. The timeout setters accepted a zero Duration that every other backend rejects.