### PR TITLE
More EC2 instance usage

### DIFF
--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -84,20 +84,34 @@ label_prefix = "ec2"
 region = "us-east-2"
 images = {
     "x86_64ami" = "latest-gha-runner-ami"
+    "arm64ami" = "latest-gha-runner-ami-arm64"
 }
 jit_runner = "organization"
-# Prices per hour of on-demand compute in us-east-2 (as of Aug 2026)
-# See rough assessment of build speed for dist-x86_64-quick in https://github.com/rust-lang/simpleinfra/issues/1132
-# m8a.2x     8 vCPU, 32 GB   $0.48688/hr
-# c8a.4x    16 vCPU, 32 GB   $0.86216/hr
-# c8a.8x    32 vCPU, 64 GB   $1.72432/hr
-# c8a.12x   48 vCPU, 96 GB   $2.58648/hr
-# CodeBuild 36 vCPU          $4.78799/hr
 allowed_instances = [
+    # AMD Zen 5 (x86_64) instances, a subset of these is used in production.
+    # Prices per hour of on-demand compute in us-east-2 (as of Aug 2026)
+    # See rough assessment of build speed for dist-x86_64-quick in https://github.com/rust-lang/simpleinfra/issues/1132
+    # m8a.2x     8 vCPU, 32 GB   $0.48688/hr
+    # c8a.4x    16 vCPU, 32 GB   $0.86216/hr
+    # c8a.8x    32 vCPU, 64 GB   $1.72432/hr
+    # c8a.12x   48 vCPU, 96 GB   $2.58648/hr
+    # CodeBuild 36 vCPU          $4.78799/hr
     "m8a.2xlarge",
     "c8a.4xlarge",
     "c8a.8xlarge",
     "c8a.12xlarge",
+
+    # Graviton 4 (aarch64) instances, currently just for experimentation
+    "m8g.2xlarge",
+    "c8g.4xlarge",
+    "c8g.8xlarge",
+    "c8g.12xlarge",
+
+    # Graviton 5 (aarch64) instances, currently just for experimentation
+    "m9g.2xlarge",
+    "c9g.4xlarge",
+    "c9g.8xlarge",
+    "c9g.12xlarge",
 ]
 
 # Enable unrolling of rollup member PRs after rollup merge

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -15,18 +15,6 @@ runners:
     free_disk: true
     <<: *base-job
 
-  - &job-linux-4c-largedisk
-    os: ubuntu-24.04-4core-16gb
-    <<: *base-job
-
-  - &job-linux-8c
-    os: ubuntu-24.04-8core-32gb
-    <<: *base-job
-
-  - &job-linux-16c
-    os: ubuntu-24.04-16core-64gb
-    <<: *base-job
-
   - &job-macos-15
     os: macos-15 # macOS 15 Arm64
     <<: *base-job
@@ -65,14 +53,12 @@ runners:
     os: codebuild-ubuntu-22-36c-$github.run_id-$github.run_attempt
     <<: *base-job
 
-  - &job-linux-8c-codebuild
-    free_disk: true
-    codebuild: true
-    os: codebuild-ubuntu-22-8c-$github.run_id-$github.run_attempt
+  - &job-linux-x86-32c-ec2
+    os: ec2-x86_64ami-c8a.8xlarge-x64-linux-$github.run_id-$github.run_attempt
     <<: *base-job
 
-  - &job-linux-32c-ec2
-    os: ec2-x86_64ami-c8a.8xlarge-x64-linux-$github.run_id-$github.run_attempt
+  - &job-linux-x86-8c-ec2
+    os: ec2-x86_64ami-m8a.2xlarge-x64-linux-$github.run_id-$github.run_attempt
     <<: *base-job
 
 envs:
@@ -179,7 +165,7 @@ pr:
 # These jobs automatically inherit envs.try, to avoid repeating
 # it in each job definition.
 try:
-  - <<: [*job-dist-x86_64-linux, *job-linux-32c-ec2]
+  - <<: [*job-dist-x86_64-linux, *job-linux-x86-32c-ec2]
     name: dist-x86_64-linux-quick
 
 # Jobs that only run when explicitly invoked in one of the following ways:
@@ -203,7 +189,7 @@ optional:
       DIST_TRY_BUILD: 1
   # We repeat the try job here so that it can be explicitly executed using `@bors try jobs`, to test
   # full x64 Linux dist try builds on EC2.
-  - <<: [*job-dist-x86_64-linux, *job-linux-32c-ec2]
+  - <<: [*job-dist-x86_64-linux, *job-linux-x86-32c-ec2]
     name: dist-x86_64-linux-quick
 
 # Main CI jobs that have to be green to merge a commit into the default branch.
@@ -312,14 +298,14 @@ auto:
   - name: dist-x86_64-illumos
     <<: *job-linux-4c
 
-  - <<: [*job-dist-x86_64-linux, *job-linux-32c-ec2]
+  - <<: [*job-dist-x86_64-linux, *job-linux-x86-32c-ec2]
 
   - name: dist-x86_64-linux-alt
     env:
       IMAGE: dist-x86_64-linux
       CODEGEN_BACKENDS: llvm,cranelift
       DOCKER_SCRIPT: dist-alt.sh
-    <<: *job-linux-8c
+    <<: *job-linux-x86-8c-ec2
 
   - name: dist-x86_64-musl
     env:


### PR DESCRIPTION
This extends our usage of EC2 to dist-x86_64-linux-alt builders (1h23m with m8a.2xlarge, https://github.com/rust-lang/rust/actions/runs/32137297331/job/95711706485).

This is moving from GHA credits to EC2 credits, so we should confirm we want that, but in dollar terms this is cheaper: at 1h55m (last auto build) on [GHA $1.32/hr](https://docs.github.com/en/billing/reference/actions-runner-pricing) = $2.53/run, vs. 1h23m on EC2 at $0.48688/hr = $0.67/run.

My primary goal is to try to free up GHA credits so we can move Windows and/or macOS jobs to large runners, since I suspect us trying to host those ourselves is going to be more painful.

As a drive-by change this also adds support for EC2 aarch64 machines to the bors config (but not CI config). My suspicion is that if/when we have aarch64 perf we may want faster aarch64 try builds, and in any case dist-aarch64-linux is one of our slower runners -- at 2h24m -- so it may benefit from getting a faster machine. I don't know yet how EC2 will compare but extending the bors config is cheap so I'd rather just do that now to enable easier testing.

I also deleted some of the old unused runner templates, I don't see much point in keeping dead ones around.

r? Kobzol

