### PR TITLE
Bump cfg_aliases to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,9 +561,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"


### PR DESCRIPTION
Resolves FCW in `nix@0.30.1`'s usage of `cfg_aliases` when building stage1 since https://github.com/rust-lang/rust/pull/159222 reached beta.

Example of FCW: https://github.com/rust-lang/rust/actions/runs/32585824494/job/97061994743?pr=161548#step:28:4792 . If you `./x b` locally, then you should also see this warning, and have a file `build/x86_64-unknown-linux-gnu/stage1-rustc/.future-incompat-report.json` mentioning `nix` and `cfg_aliases`.

cc @Zalathar 

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
