### PR TITLE
Add `str::is_char_boundary` ASCII successor optimization hint

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -393,7 +393,20 @@ impl str {
             // code on higher opt-levels. See PR #84751 for more details.
             index == self.len()
         } else {
-            self.as_bytes()[index].is_utf8_char_boundary()
+            let is_char_boundary = self.as_bytes()[index].is_utf8_char_boundary();
+
+            // SAFETY: `self` is valid UTF-8. If `!is_char_boundary` then the byte at `index` is a
+            // continuation byte. Therefore, by definition, the preceding byte must be the first
+            // byte of a multi-byte sequence or another continuation byte. In either case, the
+            // preceding byte is not in the ASCII range.
+            //
+            // This hint enables the optimizer to elide runtime char boundary checks when the byte
+            // at `index` is the successor to a known ASCII character.
+            //
+            // Note: `0 < index < self.len()` so `index - 1` is in bounds.
+            unsafe { assert_unchecked(is_char_boundary || !self.as_bytes()[index - 1].is_ascii()) };
+
+            is_char_boundary
         }
     }
 

--- a/tests/codegen-llvm/str-split-at-ascii-boundary.rs
+++ b/tests/codegen-llvm/str-split-at-ascii-boundary.rs
@@ -1,0 +1,66 @@
+//@ compile-flags: -Copt-level=3
+#![crate_type = "lib"]
+
+// Make sure no char boundary checks are emitted when slicing or splitting after
+// a byte known to be an ASCII character.
+
+// CHECK-LABEL: @slice_after_ascii
+#[no_mangle]
+pub fn slice_after_ascii(s: &str) -> (&str, &str) {
+    // CHECK-NOT: panic
+    // CHECK-NOT: slice_error_fail
+    let mut mid = s.len();
+    let v = s.as_bytes();
+    for index in 0..v.len() {
+        if v[index] == b'\n' {
+            mid = index + 1;
+            break;
+        }
+    }
+    (&s[..mid], &s[mid..])
+}
+
+// CHECK-LABEL: @try_slice_after_ascii
+#[no_mangle]
+pub fn try_slice_after_ascii(s: &str) -> Option<(&str, &str)> {
+    // CHECK-NOT: panic
+    // CHECK-NOT: slice_error_fail
+    let v = s.as_bytes();
+    for index in 0..v.len() {
+        if v[index] == b'\n' {
+            let mid = index + 1;
+            return Some((&s[..mid], &s[mid..]));
+        }
+    }
+    None
+}
+
+// CHECK-LABEL: @split_after_ascii
+#[no_mangle]
+pub fn split_after_ascii(s: &str) -> (&str, &str) {
+    // CHECK-NOT: panic
+    // CHECK-NOT: slice_error_fail
+    let mut mid = s.len();
+    let v = s.as_bytes();
+    for index in 0..v.len() {
+        if v[index] == b'\n' {
+            mid = index + 1;
+            break;
+        }
+    }
+    s.split_at(mid)
+}
+
+// CHECK-LABEL: @try_split_after_ascii
+#[no_mangle]
+pub fn try_split_after_ascii(s: &str) -> Option<(&str, &str)> {
+    // CHECK-NOT: panic
+    // CHECK-NOT: slice_error_fail
+    let v = s.as_bytes();
+    for index in 0..v.len() {
+        if v[index] == b'\n' {
+            return Some(s.split_at(index + 1));
+        }
+    }
+    None
+}


### PR DESCRIPTION
Indexing and splitting `&str` after an ASCII character is a common pattern in parsing or tokenizing a string.

Today, if the index or split occurs *after* the ASCII character (e.g., a line feed or a double quote), the operation incurs a runtime character boundary check, which adversely affects runtime performance and increases binary size.

This commit enables the optimizer to eliminate that runtime check by adding a hint about a continuation byte's predecessor.

<!-- homu-ignore:start -->
<!--
LLM disclosure: I used an LLM to review the hand-written commit and PR before submitting. The LLM suggested adding additional test cases and shared some editorial feedback, which I also implemented by hand.
-->
<!-- homu-ignore:end -->
