### PR TITLE
re-bless `pretty-std` on windows

### DIFF
--- a/tests/debuginfo/pretty-std/lldb_input/windows_gnu.json
+++ b/tests/debuginfo/pretty-std/lldb_input/windows_gnu.json
@@ -91,7 +91,7 @@
    "some": {
     "type": "core::option::Option<i16>",
     "pretty_print": "Some(8)",
-    "synthetic": "lldb_lookup.synthetic_lookup",
+    "synthetic": "lldb_lookup.ClangEncodedEnumProvider",
     "summary": "lldb_lookup.ClangEncodedEnumSummaryProvider",
     "children": [
      {
@@ -104,13 +104,12 @@
    "none": {
     "type": "core::option::Option<i64>",
     "pretty_print": "None",
-    "synthetic": "lldb_lookup.synthetic_lookup",
+    "synthetic": "lldb_lookup.ClangEncodedEnumProvider",
     "summary": "lldb_lookup.ClangEncodedEnumSummaryProvider"
    },
    "os_string": {
     "type": "std::ffi::os_str::OsString",
     "pretty_print": "\"IAMA OS string \ud83d\ude03\"",
-    "synthetic": "lldb_lookup.synthetic_lookup",
     "summary": "lldb_lookup.StdOsStringSummaryProvider",
     "children": [
      {

--- a/tests/debuginfo/pretty-std/lldb_input/windows_msvc.json
+++ b/tests/debuginfo/pretty-std/lldb_input/windows_msvc.json
@@ -114,7 +114,6 @@
    "os_string": {
     "type": "std::ffi::os_str::OsString",
     "pretty_print": "\"IAMA OS string \ud83d\ude03\"",
-    "synthetic": "lldb_lookup.synthetic_lookup",
     "summary": "lldb_lookup.StdOsStringSummaryProvider",
     "children": [
      {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Corrects a small error from https://github.com/rust-lang/rust/pull/160331. I forgot CI doesn't run lldb on windows, so it didn't catch that these hadn't been updated.

At the very least though, this lets us see, in isolation, what a typical diff will look like for the json data.

r? @Kobzol @jieyouxu 