### PR TITLE
implement [u8]::split_ascii_whitespace

### DIFF
--- a/library/core/src/internal_macros.rs
+++ b/library/core/src/internal_macros.rs
@@ -72,13 +72,13 @@ macro_rules! forward_ref_op_assign {
 macro_rules! impl_fn_for_zst {
     ($(
         $( #[$attr: meta] )*
-        struct $Name: ident impl$( <$( $lifetime : lifetime ),+> )? Fn =
+        $vis:vis struct $Name: ident impl$( <$( $lifetime : lifetime ),+> )? Fn =
             |$( $arg: ident: $ArgTy: ty ),*| -> $ReturnTy: ty
             $body: block;
     )+) => {
         $(
             $( #[$attr] )*
-            struct $Name;
+            $vis struct $Name;
 
             impl $( <$( $lifetime ),+> )? Fn<($( $ArgTy, )*)> for $Name {
                 #[inline]

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -6,6 +6,12 @@ use crate::fmt::{self, Write};
 #[cfg(not(all(target_arch = "loongarch64", target_feature = "lsx")))]
 use crate::intrinsics::const_eval_select;
 use crate::{ascii, iter, ops};
+#[unstable(feature = "u8_split_ascii_whitespace", issue = "147878")]
+use crate::{
+    iter::{Filter, FusedIterator},
+    slice::Split,
+    str::{BytesIsNotEmpty, IsAsciiWhitespace},
+};
 
 impl [u8] {
     /// Checks if all bytes in this slice are within the ASCII range.
@@ -313,6 +319,140 @@ impl [u8] {
     #[inline]
     pub const fn trim_ascii(&self) -> &[u8] {
         self.trim_ascii_start().trim_ascii_end()
+    }
+
+    /// Splits a byte slice by ASCII whitespace.
+    ///
+    /// The returned iterator yields byte slices that are subslices of the
+    /// original byte slice, separated by any amount of ASCII whitespace.
+    ///
+    /// This uses the same definition as [`u8::is_ascii_whitespace`].
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(u8_split_ascii_whitespace)]
+    ///
+    /// let mut iter = b"A few words".split_ascii_whitespace();
+    ///
+    /// assert_eq!(Some(&b"A"[..]), iter.next());
+    /// assert_eq!(Some(&b"few"[..]), iter.next());
+    /// assert_eq!(Some(&b"words"[..]), iter.next());
+    ///
+    /// assert_eq!(None, iter.next());
+    /// ```
+    ///
+    /// Various kinds of ASCII whitespace are considered
+    /// (see [`u8::is_ascii_whitespace`]):
+    ///
+    /// ```
+    /// #![feature(u8_split_ascii_whitespace)]
+    ///
+    /// let mut iter = b" Mary   had\ta little  \n\t lamb".split_ascii_whitespace();
+    ///
+    /// assert_eq!(Some(&b"Mary"[..]), iter.next());
+    /// assert_eq!(Some(&b"had"[..]), iter.next());
+    /// assert_eq!(Some(&b"a"[..]), iter.next());
+    /// assert_eq!(Some(&b"little"[..]), iter.next());
+    /// assert_eq!(Some(&b"lamb"[..]), iter.next());
+    ///
+    /// assert_eq!(None, iter.next());
+    /// ```
+    ///
+    /// If the byte slice is empty or contains only ASCII whitespace, the iterator
+    /// yields no byte slices:
+    ///
+    /// ```
+    /// #![feature(u8_split_ascii_whitespace)]
+    ///
+    /// assert_eq!(b"".split_ascii_whitespace().next(), None);
+    /// assert_eq!(b"   ".split_ascii_whitespace().next(), None);
+    /// ```
+    #[must_use = "this returns the split byte slice as an iterator, without modifying the original"]
+    #[unstable(feature = "u8_split_ascii_whitespace", issue = "147878")]
+    #[inline]
+    pub fn split_ascii_whitespace(&self) -> SplitAsciiWhitespace<'_> {
+        let inner = self.split(IsAsciiWhitespace).filter(BytesIsNotEmpty);
+        SplitAsciiWhitespace { inner }
+    }
+}
+
+/// An iterator over the non-ASCII-whitespace subslices of a byte slice,
+/// separated by any amount of ASCII whitespace.
+///
+/// This struct is created by the [`split_ascii_whitespace`] method on [`[u8]`][byteslice].
+/// See its documentation for more.
+///
+/// [`split_ascii_whitespace`]: slice::split_ascii_whitespace
+/// [byteslice]: prim@slice
+#[unstable(feature = "u8_split_ascii_whitespace", issue = "147878")]
+#[derive(Clone, Debug)]
+pub struct SplitAsciiWhitespace<'a> {
+    pub(crate) inner: Filter<Split<'a, u8, IsAsciiWhitespace>, BytesIsNotEmpty>,
+}
+
+#[unstable(feature = "u8_split_ascii_whitespace", issue = "147878")]
+impl<'a> Iterator for SplitAsciiWhitespace<'a> {
+    type Item = &'a [u8];
+
+    #[inline]
+    fn next(&mut self) -> Option<&'a [u8]> {
+        self.inner.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+
+    #[inline]
+    fn last(mut self) -> Option<&'a [u8]> {
+        self.next_back()
+    }
+}
+
+#[unstable(feature = "u8_split_ascii_whitespace", issue = "147878")]
+impl<'a> DoubleEndedIterator for SplitAsciiWhitespace<'a> {
+    #[inline]
+    fn next_back(&mut self) -> Option<&'a [u8]> {
+        self.inner.next_back()
+    }
+}
+
+#[unstable(feature = "u8_split_ascii_whitespace", issue = "147878")]
+impl FusedIterator for SplitAsciiWhitespace<'_> {}
+
+impl<'a> SplitAsciiWhitespace<'a> {
+    /// Returns remainder of the split slice.
+    ///
+    /// If the iterator is empty, returns `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(u8_split_ascii_whitespace)]
+    ///
+    /// let mut split = b"Mary had a little lamb".split_ascii_whitespace();
+    /// assert_eq!(split.remainder(), Some(b"Mary had a little lamb".as_slice()));
+    ///
+    /// split.next();
+    /// assert_eq!(split.remainder(), Some(b"had a little lamb".as_slice()));
+    ///
+    /// split.by_ref().for_each(drop);
+    /// assert_eq!(split.remainder(), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    // This is also blocked on: https://github.com/rust-lang/rust/issues/77998
+    #[unstable(feature = "u8_split_ascii_whitespace", issue = "147878")]
+    pub fn remainder(&self) -> Option<&'a [u8]> {
+        if self.inner.iter.finished {
+            return None;
+        }
+
+        Some(self.inner.iter.v)
     }
 }
 

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -45,6 +45,8 @@ mod specialize;
 
 #[stable(feature = "inherent_ascii_escape", since = "1.60.0")]
 pub use ascii::EscapeAscii;
+#[unstable(feature = "u8_split_ascii_whitespace", issue = "147878")]
+pub use ascii::SplitAsciiWhitespace;
 #[unstable(feature = "str_internals", issue = "none")]
 #[doc(hidden)]
 pub use ascii::is_ascii_simple;

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1263,8 +1263,7 @@ impl str {
     #[stable(feature = "split_ascii_whitespace", since = "1.34.0")]
     #[inline]
     pub fn split_ascii_whitespace(&self) -> SplitAsciiWhitespace<'_> {
-        let inner =
-            self.as_bytes().split(IsAsciiWhitespace).filter(BytesIsNotEmpty).map(UnsafeBytesToStr);
+        let inner = self.as_bytes().split_ascii_whitespace().inner.map(UnsafeBytesToStr);
         SplitAsciiWhitespace { inner }
     }
 
@@ -3351,7 +3350,7 @@ impl_fn_for_zst! {
     };
 
     #[derive(Clone)]
-    struct IsAsciiWhitespace impl Fn = |byte: &u8| -> bool {
+    pub(crate) struct IsAsciiWhitespace impl Fn = |byte: &u8| -> bool {
         byte.is_ascii_whitespace()
     };
 
@@ -3361,7 +3360,7 @@ impl_fn_for_zst! {
     };
 
     #[derive(Clone)]
-    struct BytesIsNotEmpty impl<'a, 'b> Fn = |s: &'a &'b [u8]| -> bool {
+    pub(crate) struct BytesIsNotEmpty impl<'a, 'b> Fn = |s: &'a &'b [u8]| -> bool {
         !s.is_empty()
     };
 

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -123,6 +123,7 @@
 #![feature(try_from_int_error_kind)]
 #![feature(try_trait_v2)]
 #![feature(type_info)]
+#![feature(u8_split_ascii_whitespace)]
 #![feature(uint_carryless_mul)]
 #![feature(uint_gather_scatter_bits)]
 #![feature(unicode_internals)]

--- a/library/coretests/tests/slice.rs
+++ b/library/coretests/tests/slice.rs
@@ -2610,3 +2610,30 @@ fn test_shift_right() {
     case([1, 2, 3, 4], [5], [1], [2, 3, 4, 5]);
     case([1, 2, 3, 4, 5], [], [], [1, 2, 3, 4, 5]);
 }
+
+#[test]
+fn test_split_ascii_whitespace_non_ascii() {
+    let bytes = b"\xff \x80 \xc2\xa0";
+
+    assert_eq!(
+        bytes.split_ascii_whitespace().collect::<Vec<_>>(),
+        vec![&b"\xff"[..], &b"\x80"[..], &b"\xc2\xa0"[..]],
+    );
+}
+
+#[test]
+fn test_split_ascii_whitespace_remainder() {
+    let bytes = b"  Mary \t had  ";
+    let mut split = bytes.split_ascii_whitespace();
+
+    assert_eq!(split.remainder(), Some(&bytes[..]));
+
+    assert_eq!(split.next(), Some(&b"Mary"[..]));
+    assert_eq!(split.remainder(), Some(&b"\t had  "[..]));
+
+    assert_eq!(split.next(), Some(&b"had"[..]));
+    assert_eq!(split.remainder(), Some(&b" "[..]));
+
+    assert_eq!(split.next(), None);
+    assert_eq!(split.remainder(), None);
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Had to create a new pr because in the previous one i somehow deleted all the commits with git.
Tracking issue: https://github.com/rust-lang/rust/issues/147878
[u8] is also missing normal split_whitespace, but that seems like an issue for another pr.