### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -1012,15 +1012,14 @@ impl<'a> Parser<'a> {
     ) -> PResult<'a, PatKind> {
         let open_paren = self.token.span;
 
-        // In a `let` binding the pattern can be followed by a type, and unlike a
-        // function parameter it doesn't require one. So a tuple pattern whose
-        // elements carry inline type annotations, e.g. `let (a: bool, b: u8) =
-        // ...`, can be cleanly recovered by suggesting that the element types be
-        // written together as a tuple type after the pattern.
-        let recover_type_ascription =
-            self.may_recover() && matches!(syntax_loc, Some(PatternLocation::LetBinding));
+        // The index, the span of the `:` and the type of every element written
+        // with an inline type annotation, which is invalid syntax. This is kept
+        // out of the element patterns themselves so that the happy path doesn't
+        // have to allocate for it.
+        let mut tys: Vec<(usize, Span, Box<Ty>)> = Vec::new();
+        let mut index = 0;
 
-        let (elems, trailing_comma) = self.parse_paren_comma_seq(|p| {
+        let (fields, trailing_comma) = self.parse_paren_comma_seq(|p| {
             let pat = p.parse_pat_allow_top_guard(
                 None,
                 RecoverComma::No,
@@ -1032,27 +1031,31 @@ impl<'a> Parser<'a> {
             // the existing "maybe write a path separator here" (`a::b`)
             // suggestion, which is the more likely intent when the two are
             // written next to each other.
-            let ascription = if recover_type_ascription && p.token == token::Colon {
-                let colon = p.token.span;
-                if p.look_ahead(1, |next| next.span.lo() > colon.hi()) {
-                    p.bump(); // eat the `:`
-                    Some((colon, p.parse_ty()?))
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-            Ok((pat, ascription))
+            if p.may_recover()
+                && p.token == token::Colon
+                && let colon = p.token.span
+                && p.look_ahead(1, |next| next.span.lo() > colon.hi())
+            {
+                p.bump(); // eat the `:`
+                tys.push((index, colon, p.parse_ty()?));
+            }
+            index += 1;
+            Ok(pat)
         })?;
 
         // If any element carried an inline type annotation then this is the
         // invalid `(a: bool, b: u8)` form; report it and suggest the correct
-        // spelling. Either way, continue on with the type annotations stripped.
-        if elems.iter().any(|(_, ascription)| ascription.is_some()) {
-            self.recover_tuple_pat_type_ascription(open_paren, &elems);
+        // spelling where we can. Either way, continue on with the type
+        // annotations stripped.
+        if !tys.is_empty() {
+            self.recover_tuple_pat_type_ascription(
+                open_paren,
+                &fields,
+                &tys,
+                trailing_comma,
+                syntax_loc,
+            );
         }
-        let fields: ThinVec<Pat> = elems.into_iter().map(|(pat, _)| pat).collect();
 
         // Here, `(pat,)` is a tuple pattern.
         // For backward compatibility, `(..)` is a tuple pattern as well.
@@ -1108,62 +1111,121 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Report a tuple pattern whose elements carry inline type annotations, e.g.
-    /// `let (a: bool, b: u8) = ...;`. This is invalid syntax; the element types
-    /// have to be written together as a tuple type after the pattern, i.e.
-    /// `let (a, b): (bool, u8) = ...;`. `elems` are the parsed element patterns,
-    /// each with the span of its `:` and its type when one was written.
+    /// Report a tuple or parenthesized pattern whose elements carry inline type
+    /// annotations, e.g. `let (a: bool, b: u8) = ...;`. This is invalid syntax;
+    /// the element types have to be written together as a tuple type after the
+    /// pattern, i.e. `let (a, b): (bool, u8) = ...;`. `tys` are the annotations
+    /// that were written, indexed into `fields`.
     fn recover_tuple_pat_type_ascription(
         &self,
         open_paren: Span,
-        elems: &[(Pat, Option<(Span, Box<Ty>)>)],
+        fields: &[Pat],
+        tys: &[(usize, Span, Box<Ty>)],
+        trailing_comma: Trailing,
+        syntax_loc: Option<PatternLocation>,
     ) {
         let close_paren = self.prev_token.span;
 
         // Point at every inline type annotation.
-        let ascriptions: Vec<Span> = elems
-            .iter()
-            .filter_map(|(_, ascription)| ascription.as_ref().map(|(colon, ty)| colon.to(ty.span)))
-            .collect();
+        let ty_spans: Vec<Span> = tys.iter().map(|(_, colon, ty)| colon.to(ty.span)).collect();
+        // `(a: T)` is a parenthesized pattern rather than a one element tuple.
+        let paren_pattern =
+            fields.len() == 1 && matches!(trailing_comma, Trailing::No) && !fields[0].is_rest();
         let mut err = self.dcx().struct_span_err(
-            ascriptions,
-            "the elements of a tuple pattern cannot be given types individually",
+            ty_spans.clone(),
+            if paren_pattern {
+                "a parenthesized pattern cannot be given a type"
+            } else {
+                "the elements of a tuple pattern cannot be given types individually"
+            },
         );
 
-        // Build the `(pats): (tys)` replacement from the source snippets.
-        // Elements without an annotation get an inferred `_` type.
-        let mut pats = Vec::with_capacity(elems.len());
-        let mut tys = Vec::with_capacity(elems.len());
-        let mut have_snippets = true;
-        for (pat, ascription) in elems {
-            match self.span_to_snippet(pat.span) {
-                Ok(pat_snippet) => pats.push(pat_snippet),
-                Err(_) => have_snippets = false,
+        // Only the top level pattern of a `let` binding can be followed by a
+        // type, so that's the only place where we know how the pattern should
+        // have been written instead. Anywhere else (`match` arms, function
+        // parameters, nested patterns) we just recover without a suggestion.
+        if matches!(syntax_loc, Some(PatternLocation::LetBinding)) {
+            if self.token == token::Colon {
+                // The pattern is already followed by a type, as in
+                // `let (a: bool, b): (_, u8) = ...;`. Merging that type with the
+                // inline ones isn't always possible, so just suggest dropping
+                // the inline ones.
+                err.multipart_suggestion(
+                    "remove the inline type annotations",
+                    ty_spans.into_iter().map(|span| (span, String::new())).collect(),
+                    Applicability::MaybeIncorrect,
+                );
+            } else if !fields.iter().any(|pat| pat.is_rest()) {
+                // A rest pattern stands for any number of elements, so we can't
+                // tell how many types the tuple type would have to list.
+                self.suggest_tuple_pat_type(
+                    &mut err,
+                    open_paren,
+                    close_paren,
+                    fields,
+                    tys,
+                    paren_pattern,
+                );
             }
-            match ascription {
-                Some((_, ty)) => match self.span_to_snippet(ty.span) {
-                    Ok(ty_snippet) => tys.push(ty_snippet),
-                    Err(_) => have_snippets = false,
-                },
-                None => tys.push("_".to_string()),
-            }
-        }
-
-        // Only offer the suggestion when we could rebuild it from source. A
-        // single-element tuple needs a trailing comma to stay a tuple.
-        if have_snippets {
-            let trailing = if elems.len() == 1 { "," } else { "" };
-            let suggestion =
-                format!("({}{trailing}): ({}{trailing})", pats.join(", "), tys.join(", "));
-            err.span_suggestion_verbose(
-                open_paren.to(close_paren),
-                "to annotate the types of a tuple's elements, write them as a tuple type after \
-                 the pattern",
-                suggestion,
-                Applicability::MaybeIncorrect,
-            );
         }
         err.emit();
+    }
+
+    /// Suggest rewriting `(a: bool, b: u8)` as `(a, b): (bool, u8)`, moving the
+    /// inline type annotations into a tuple type after the pattern.
+    fn suggest_tuple_pat_type(
+        &self,
+        err: &mut Diag<'a>,
+        open_paren: Span,
+        close_paren: Span,
+        fields: &[Pat],
+        tys: &[(usize, Span, Box<Ty>)],
+        paren_pattern: bool,
+    ) {
+        // Build the replacement from the source snippets. Elements without an
+        // annotation get an inferred `_` type.
+        let mut pat_snippets = Vec::with_capacity(fields.len());
+        let mut ty_snippets = Vec::with_capacity(fields.len());
+        let mut tys = tys.iter().peekable();
+        for (index, pat) in fields.iter().enumerate() {
+            let ty_snippet = match tys.next_if(|(i, ..)| *i == index) {
+                Some((_, _, ty)) => self.span_to_snippet(ty.span),
+                None => Ok("_".to_string()),
+            };
+            let (Ok(pat_snippet), Ok(ty_snippet)) = (self.span_to_snippet(pat.span), ty_snippet)
+            else {
+                // We can't rebuild the pattern from source, so don't suggest anything.
+                return;
+            };
+            pat_snippets.push(pat_snippet);
+            ty_snippets.push(ty_snippet);
+        }
+
+        // The type of a parenthesized pattern isn't a tuple type. A one element
+        // tuple on the other hand keeps its trailing comma on both sides.
+        let (suggestion, msg) = if paren_pattern {
+            (
+                format!("({}): {}", pat_snippets[0], ty_snippets[0]),
+                "write the type after the pattern",
+            )
+        } else {
+            let trailing = if fields.len() == 1 { "," } else { "" };
+            (
+                format!(
+                    "({}{trailing}): ({}{trailing})",
+                    pat_snippets.join(", "),
+                    ty_snippets.join(", ")
+                ),
+                "to annotate the types of a tuple's elements, write them as a tuple type after \
+                 the pattern",
+            )
+        };
+        err.span_suggestion_verbose(
+            open_paren.to(close_paren),
+            msg,
+            suggestion,
+            Applicability::MaybeIncorrect,
+        );
     }
 
     /// Parse a mutable binding with the `mut` token already eaten.

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -8,7 +8,7 @@ use rustc_ast::visit::{self, Visitor};
 use rustc_ast::{
     self as ast, Arm, AttrVec, BindingMode, ByRef, Expr, ExprKind, Guard, LocalKind, MacCall,
     Mutability, Pat, PatField, PatFieldsRest, PatKind, Path, QSelf, RangeEnd, RangeSyntax, Stmt,
-    StmtKind,
+    StmtKind, Ty,
 };
 use rustc_ast_pretty::pprust;
 use rustc_errors::{Applicability, Diag, DiagArgValue, PResult, StashKey};
@@ -16,7 +16,6 @@ use rustc_session::diagnostics::ExprParenthesesNeeded;
 use rustc_span::{BytePos, ErrorGuaranteed, Ident, Span, Spanned, kw, respan, sym};
 use thin_vec::{ThinVec, thin_vec};
 
-use super::diagnostics::SnapshotParser;
 use super::{ForceCollect, Parser, PathStyle, Restrictions, Trailing, UsePreAttrPos};
 use crate::diagnostics::{
     self, AmbiguousRangePattern, AtDotDotInStructPattern, AtInStructPattern,
@@ -1013,31 +1012,47 @@ impl<'a> Parser<'a> {
     ) -> PResult<'a, PatKind> {
         let open_paren = self.token.span;
 
-        // In a `let` binding the pattern can be followed by a type and does not
-        // require one, so a tuple pattern with inline element types such as
-        // `(a: bool, b: u8)` can be cleanly recovered by suggesting the types be
-        // written as a tuple type after the pattern. When that recovery is
-        // possible, snapshot the parser first so that we can retry on failure.
+        // In a `let` binding the pattern can be followed by a type, and unlike a
+        // function parameter it doesn't require one. So a tuple pattern whose
+        // elements carry inline type annotations, e.g. `let (a: bool, b: u8) =
+        // ...`, can be cleanly recovered by suggesting that the element types be
+        // written together as a tuple type after the pattern.
         let recover_type_ascription =
             self.may_recover() && matches!(syntax_loc, Some(PatternLocation::LetBinding));
-        let snapshot = recover_type_ascription.then(|| self.create_snapshot_for_diagnostic());
 
-        let (fields, trailing_comma) = match self.parse_paren_comma_seq(|p| {
-            p.parse_pat_allow_top_guard(
+        let (elems, trailing_comma) = self.parse_paren_comma_seq(|p| {
+            let pat = p.parse_pat_allow_top_guard(
                 None,
                 RecoverComma::No,
                 RecoverColon::No,
                 CommaRecoveryMode::LikelyTuple,
-            )
-        }) {
-            Ok(fields) => fields,
-            Err(err) => match snapshot {
-                Some(snapshot) => {
-                    return self.maybe_recover_tuple_pat_type_ascription(err, snapshot, open_paren);
+            )?;
+            // Recover from an inline `: <ty>` type annotation. We only do this
+            // when there is whitespace after the colon, so that `(a:b)` keeps
+            // the existing "maybe write a path separator here" (`a::b`)
+            // suggestion, which is the more likely intent when the two are
+            // written next to each other.
+            let ascription = if recover_type_ascription && p.token == token::Colon {
+                let colon = p.token.span;
+                if p.look_ahead(1, |next| next.span.lo() > colon.hi()) {
+                    p.bump(); // eat the `:`
+                    Some((colon, p.parse_ty()?))
+                } else {
+                    None
                 }
-                None => return Err(err),
-            },
-        };
+            } else {
+                None
+            };
+            Ok((pat, ascription))
+        })?;
+
+        // If any element carried an inline type annotation then this is the
+        // invalid `(a: bool, b: u8)` form; report it and suggest the correct
+        // spelling. Either way, continue on with the type annotations stripped.
+        if elems.iter().any(|(_, ascription)| ascription.is_some()) {
+            self.recover_tuple_pat_type_ascription(open_paren, &elems);
+        }
+        let fields: ThinVec<Pat> = elems.into_iter().map(|(pat, _)| pat).collect();
 
         // Here, `(pat,)` is a tuple pattern.
         // For backward compatibility, `(..)` is a tuple pattern as well.
@@ -1093,94 +1108,62 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Try to recover from a tuple pattern whose elements carry inline type
-    /// annotations, e.g. `let (a: bool, b: u8) = ...;`. This is invalid syntax;
-    /// the type of each element has to be written together as a tuple type after
-    /// the pattern, i.e. `let (a, b): (bool, u8) = ...;`.
-    ///
-    /// On a successful recovery this emits `err` with a suggestion and returns
-    /// the pattern with the type annotations stripped off so that parsing can
-    /// continue. If the input does not look like this mistake, the original
-    /// error is returned unchanged.
-    fn maybe_recover_tuple_pat_type_ascription(
-        &mut self,
-        mut err: Diag<'a>,
-        snapshot: SnapshotParser<'a>,
+    /// Report a tuple pattern whose elements carry inline type annotations, e.g.
+    /// `let (a: bool, b: u8) = ...;`. This is invalid syntax; the element types
+    /// have to be written together as a tuple type after the pattern, i.e.
+    /// `let (a, b): (bool, u8) = ...;`. `elems` are the parsed element patterns,
+    /// each with the span of its `:` and its type when one was written.
+    fn recover_tuple_pat_type_ascription(
+        &self,
         open_paren: Span,
-    ) -> PResult<'a, PatKind> {
-        self.restore_snapshot(snapshot);
-
-        // Reparse the sequence, this time allowing an optional `: <ty>` after
-        // each element pattern.
-        let seq = self.parse_paren_comma_seq(|p| {
-            let pat = p.parse_pat_allow_top_guard(
-                None,
-                RecoverComma::No,
-                RecoverColon::No,
-                CommaRecoveryMode::LikelyTuple,
-            )?;
-            let ty_span = if p.eat(exp!(Colon)) { Some(p.parse_ty()?.span) } else { None };
-            Ok((pat, ty_span))
-        });
-
-        // Only recover when the reparse succeeds and at least one element had a
-        // type annotation. Otherwise this is some other error, so report the
-        // original one.
-        let (elems, trailing_comma) = match seq {
-            Ok((elems, trailing_comma)) if elems.iter().any(|(_, ty)| ty.is_some()) => {
-                (elems, trailing_comma)
-            }
-            Ok(_) => return Err(err),
-            Err(inner) => {
-                inner.cancel();
-                return Err(err);
-            }
-        };
-
+        elems: &[(Pat, Option<(Span, Box<Ty>)>)],
+    ) {
         let close_paren = self.prev_token.span;
 
-        // Build the suggested `(pats): (tys)` replacement from the source
-        // snippets. Elements without an annotation get an inferred `_` type.
+        // Point at every inline type annotation.
+        let ascriptions: Vec<Span> = elems
+            .iter()
+            .filter_map(|(_, ascription)| ascription.as_ref().map(|(colon, ty)| colon.to(ty.span)))
+            .collect();
+        let mut err = self.dcx().struct_span_err(
+            ascriptions,
+            "the elements of a tuple pattern cannot be given types individually",
+        );
+
+        // Build the `(pats): (tys)` replacement from the source snippets.
+        // Elements without an annotation get an inferred `_` type.
         let mut pats = Vec::with_capacity(elems.len());
         let mut tys = Vec::with_capacity(elems.len());
-        for (pat, ty_span) in &elems {
-            let Ok(pat_snippet) = self.span_to_snippet(pat.span) else {
-                return Err(err);
-            };
-            pats.push(pat_snippet);
-            match ty_span {
-                Some(ty_span) => {
-                    let Ok(ty_snippet) = self.span_to_snippet(*ty_span) else {
-                        return Err(err);
-                    };
-                    tys.push(ty_snippet);
-                }
+        let mut have_snippets = true;
+        for (pat, ascription) in elems {
+            match self.span_to_snippet(pat.span) {
+                Ok(pat_snippet) => pats.push(pat_snippet),
+                Err(_) => have_snippets = false,
+            }
+            match ascription {
+                Some((_, ty)) => match self.span_to_snippet(ty.span) {
+                    Ok(ty_snippet) => tys.push(ty_snippet),
+                    Err(_) => have_snippets = false,
+                },
                 None => tys.push("_".to_string()),
             }
         }
 
-        // A single-element tuple needs a trailing comma to stay a tuple.
-        let trailing = if elems.len() == 1 { "," } else { "" };
-        let suggestion = format!("({}{trailing}): ({}{trailing})", pats.join(", "), tys.join(", "));
-
-        err.span_suggestion_verbose(
-            open_paren.to(close_paren),
-            "to annotate the types of a tuple's elements, write them as a tuple type after the \
-             pattern",
-            suggestion,
-            Applicability::MaybeIncorrect,
-        );
+        // Only offer the suggestion when we could rebuild it from source. A
+        // single-element tuple needs a trailing comma to stay a tuple.
+        if have_snippets {
+            let trailing = if elems.len() == 1 { "," } else { "" };
+            let suggestion =
+                format!("({}{trailing}): ({}{trailing})", pats.join(", "), tys.join(", "));
+            err.span_suggestion_verbose(
+                open_paren.to(close_paren),
+                "to annotate the types of a tuple's elements, write them as a tuple type after \
+                 the pattern",
+                suggestion,
+                Applicability::MaybeIncorrect,
+            );
+        }
         err.emit();
-
-        // Continue parsing with the type annotations stripped off.
-        let fields: ThinVec<Pat> = elems.into_iter().map(|(pat, _)| pat).collect();
-        let paren_pattern =
-            fields.len() == 1 && matches!(trailing_comma, Trailing::No) && !fields[0].is_rest();
-        Ok(if paren_pattern {
-            PatKind::Paren(Box::new(fields.into_iter().next().unwrap()))
-        } else {
-            PatKind::Tuple(fields)
-        })
     }
 
     /// Parse a mutable binding with the `mut` token already eaten.

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -16,6 +16,7 @@ use rustc_session::diagnostics::ExprParenthesesNeeded;
 use rustc_span::{BytePos, ErrorGuaranteed, Ident, Span, Spanned, kw, respan, sym};
 use thin_vec::{ThinVec, thin_vec};
 
+use super::diagnostics::SnapshotParser;
 use super::{ForceCollect, Parser, PathStyle, Restrictions, Trailing, UsePreAttrPos};
 use crate::diagnostics::{
     self, AmbiguousRangePattern, AtDotDotInStructPattern, AtInStructPattern,
@@ -746,7 +747,7 @@ impl<'a> Parser<'a> {
         let pat = if self.check(exp!(And)) || self.token == token::AndAnd {
             self.parse_pat_deref(expected)?
         } else if self.check(exp!(OpenParen)) {
-            self.parse_pat_tuple_or_parens()?
+            self.parse_pat_tuple_or_parens(syntax_loc)?
         } else if self.check(exp!(OpenBracket)) {
             // Parse `[pat, pat,...]` as a slice pattern.
             let (pats, _) =
@@ -1006,17 +1007,37 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a tuple or parenthesis pattern.
-    fn parse_pat_tuple_or_parens(&mut self) -> PResult<'a, PatKind> {
+    fn parse_pat_tuple_or_parens(
+        &mut self,
+        syntax_loc: Option<PatternLocation>,
+    ) -> PResult<'a, PatKind> {
         let open_paren = self.token.span;
 
-        let (fields, trailing_comma) = self.parse_paren_comma_seq(|p| {
+        // In a `let` binding the pattern can be followed by a type and does not
+        // require one, so a tuple pattern with inline element types such as
+        // `(a: bool, b: u8)` can be cleanly recovered by suggesting the types be
+        // written as a tuple type after the pattern. When that recovery is
+        // possible, snapshot the parser first so that we can retry on failure.
+        let recover_type_ascription =
+            self.may_recover() && matches!(syntax_loc, Some(PatternLocation::LetBinding));
+        let snapshot = recover_type_ascription.then(|| self.create_snapshot_for_diagnostic());
+
+        let (fields, trailing_comma) = match self.parse_paren_comma_seq(|p| {
             p.parse_pat_allow_top_guard(
                 None,
                 RecoverComma::No,
                 RecoverColon::No,
                 CommaRecoveryMode::LikelyTuple,
             )
-        })?;
+        }) {
+            Ok(fields) => fields,
+            Err(err) => match snapshot {
+                Some(snapshot) => {
+                    return self.maybe_recover_tuple_pat_type_ascription(err, snapshot, open_paren);
+                }
+                None => return Err(err),
+            },
+        };
 
         // Here, `(pat,)` is a tuple pattern.
         // For backward compatibility, `(..)` is a tuple pattern as well.
@@ -1069,6 +1090,96 @@ impl<'a> Parser<'a> {
         Ok(match self.maybe_recover_trailing_expr(open_paren.to(self.prev_token.span), false) {
             None => pat,
             Some((guar, _)) => PatKind::Err(guar),
+        })
+    }
+
+    /// Try to recover from a tuple pattern whose elements carry inline type
+    /// annotations, e.g. `let (a: bool, b: u8) = ...;`. This is invalid syntax;
+    /// the type of each element has to be written together as a tuple type after
+    /// the pattern, i.e. `let (a, b): (bool, u8) = ...;`.
+    ///
+    /// On a successful recovery this emits `err` with a suggestion and returns
+    /// the pattern with the type annotations stripped off so that parsing can
+    /// continue. If the input does not look like this mistake, the original
+    /// error is returned unchanged.
+    fn maybe_recover_tuple_pat_type_ascription(
+        &mut self,
+        mut err: Diag<'a>,
+        snapshot: SnapshotParser<'a>,
+        open_paren: Span,
+    ) -> PResult<'a, PatKind> {
+        self.restore_snapshot(snapshot);
+
+        // Reparse the sequence, this time allowing an optional `: <ty>` after
+        // each element pattern.
+        let seq = self.parse_paren_comma_seq(|p| {
+            let pat = p.parse_pat_allow_top_guard(
+                None,
+                RecoverComma::No,
+                RecoverColon::No,
+                CommaRecoveryMode::LikelyTuple,
+            )?;
+            let ty_span = if p.eat(exp!(Colon)) { Some(p.parse_ty()?.span) } else { None };
+            Ok((pat, ty_span))
+        });
+
+        // Only recover when the reparse succeeds and at least one element had a
+        // type annotation. Otherwise this is some other error, so report the
+        // original one.
+        let (elems, trailing_comma) = match seq {
+            Ok((elems, trailing_comma)) if elems.iter().any(|(_, ty)| ty.is_some()) => {
+                (elems, trailing_comma)
+            }
+            Ok(_) => return Err(err),
+            Err(inner) => {
+                inner.cancel();
+                return Err(err);
+            }
+        };
+
+        let close_paren = self.prev_token.span;
+
+        // Build the suggested `(pats): (tys)` replacement from the source
+        // snippets. Elements without an annotation get an inferred `_` type.
+        let mut pats = Vec::with_capacity(elems.len());
+        let mut tys = Vec::with_capacity(elems.len());
+        for (pat, ty_span) in &elems {
+            let Ok(pat_snippet) = self.span_to_snippet(pat.span) else {
+                return Err(err);
+            };
+            pats.push(pat_snippet);
+            match ty_span {
+                Some(ty_span) => {
+                    let Ok(ty_snippet) = self.span_to_snippet(*ty_span) else {
+                        return Err(err);
+                    };
+                    tys.push(ty_snippet);
+                }
+                None => tys.push("_".to_string()),
+            }
+        }
+
+        // A single-element tuple needs a trailing comma to stay a tuple.
+        let trailing = if elems.len() == 1 { "," } else { "" };
+        let suggestion = format!("({}{trailing}): ({}{trailing})", pats.join(", "), tys.join(", "));
+
+        err.span_suggestion_verbose(
+            open_paren.to(close_paren),
+            "to annotate the types of a tuple's elements, write them as a tuple type after the \
+             pattern",
+            suggestion,
+            Applicability::MaybeIncorrect,
+        );
+        err.emit();
+
+        // Continue parsing with the type annotations stripped off.
+        let fields: ThinVec<Pat> = elems.into_iter().map(|(pat, _)| pat).collect();
+        let paren_pattern =
+            fields.len() == 1 && matches!(trailing_comma, Trailing::No) && !fields[0].is_rest();
+        Ok(if paren_pattern {
+            PatKind::Paren(Box::new(fields.into_iter().next().unwrap()))
+        } else {
+            PatKind::Tuple(fields)
         })
     }
 

--- a/library/std/src/sys/net/connection/uefi/mod.rs
+++ b/library/std/src/sys/net/connection/uefi/mod.rs
@@ -34,16 +34,25 @@ impl TcpStream {
     }
 
     pub fn connect_timeout(addr: &SocketAddr, timeout: Duration) -> io::Result<TcpStream> {
+        if timeout == Duration::ZERO {
+            return Err(io::Error::ZERO_TIMEOUT);
+        }
         let inner = tcp::Tcp::connect(addr, Some(timeout))?;
         Ok(Self::new(inner))
     }
 
     pub fn set_read_timeout(&self, t: Option<Duration>) -> io::Result<()> {
+        if t == Some(Duration::ZERO) {
+            return Err(io::Error::ZERO_TIMEOUT);
+        }
         self.read_timeout.set(t).unwrap();
         Ok(())
     }
 
     pub fn set_write_timeout(&self, t: Option<Duration>) -> io::Result<()> {
+        if t == Some(Duration::ZERO) {
+            return Err(io::Error::ZERO_TIMEOUT);
+        }
         self.write_timeout.set(t).unwrap();
         Ok(())
     }

--- a/library/std/src/sys/net/connection/uefi/tcp.rs
+++ b/library/std/src/sys/net/connection/uefi/tcp.rs
@@ -1,7 +1,6 @@
 use super::tcp4;
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::SocketAddr;
-use crate::ptr::NonNull;
 use crate::sys::pal::{helpers, unsupported};
 use crate::time::Duration;
 
@@ -85,11 +84,8 @@ impl Tcp {
     pub(crate) fn nodelay(&self) -> io::Result<bool> {
         match self {
             Self::V4(client) => {
-                let temp = client.get_mode_data()?;
-                match NonNull::new(temp.control_option) {
-                    Some(x) => unsafe { Ok(x.as_ref().enable_nagle.into()) },
-                    None => unsupported(),
-                }
+                let nagle: bool = client.get_control_option()?.enable_nagle.into();
+                Ok(!nagle)
             }
         }
     }

--- a/library/std/src/sys/net/connection/uefi/tcp4.rs
+++ b/library/std/src/sys/net/connection/uefi/tcp4.rs
@@ -20,6 +20,24 @@ pub(crate) struct Tcp4 {
 
 const DEFAULT_ADDR: efi::Ipv4Address = efi::Ipv4Address { addr: [0u8; 4] };
 
+const DEFAULT_CONTROL_OPTION: tcp4::Option = tcp4::Option {
+    receive_buffer_size: 0,
+    send_buffer_size: 0,
+    max_syn_back_log: 0,
+    connection_timeout: 0,
+    data_retries: 0,
+    fin_timeout: 0,
+    time_wait_timeout: 0,
+    keep_alive_probes: 0,
+    keep_alive_time: 0,
+    keep_alive_interval: 0,
+    enable_nagle: efi::Boolean::FALSE,
+    enable_time_stamp: efi::Boolean::FALSE,
+    enable_window_scaling: efi::Boolean::FALSE,
+    enable_selective_ack: efi::Boolean::FALSE,
+    enable_path_mtu_discovery: efi::Boolean::FALSE,
+};
+
 impl Tcp4 {
     pub(crate) fn new() -> io::Result<Self> {
         let (service_binding, handle) =
@@ -71,22 +89,35 @@ impl Tcp4 {
         if r.is_error() { Err(crate::io::Error::from_raw_os_error(r.as_usize())) } else { Ok(()) }
     }
 
-    pub(crate) fn get_mode_data(&self) -> io::Result<tcp4::ConfigData> {
-        let mut config_data = tcp4::ConfigData::default();
+    fn get_mode_data_into(&self, config_data: &mut tcp4::ConfigData) -> io::Result<()> {
         let protocol = self.protocol.as_ptr();
 
         let r = unsafe {
             ((*protocol).get_mode_data)(
                 protocol,
                 ptr::null_mut(),
-                &mut config_data,
+                config_data,
                 ptr::null_mut(),
                 ptr::null_mut(),
                 ptr::null_mut(),
             )
         };
 
-        if r.is_error() { Err(io::Error::from_raw_os_error(r.as_usize())) } else { Ok(config_data) }
+        if r.is_error() { Err(io::Error::from_raw_os_error(r.as_usize())) } else { Ok(()) }
+    }
+
+    pub(crate) fn get_mode_data(&self) -> io::Result<tcp4::ConfigData> {
+        let mut config_data = tcp4::ConfigData::default();
+        self.get_mode_data_into(&mut config_data)?;
+        Ok(config_data)
+    }
+
+    pub(crate) fn get_control_option(&self) -> io::Result<tcp4::Option> {
+        let mut control_option = DEFAULT_CONTROL_OPTION;
+        let mut config_data =
+            tcp4::ConfigData { control_option: &mut control_option, ..Default::default() };
+        self.get_mode_data_into(&mut config_data)?;
+        Ok(control_option)
     }
 
     pub(crate) fn accept(&self) -> io::Result<Self> {

--- a/tests/ui/parser/tuple-pattern-type-ascription.rs
+++ b/tests/ui/parser/tuple-pattern-type-ascription.rs
@@ -1,9 +1,13 @@
 // Writing the type of each element inline in a tuple pattern, e.g.
-// `(a: bool, b: u8)`, is not valid syntax. In a `let` binding, where the pattern
-// can be followed by a type, check that we recover and suggest writing the
-// element types together as a tuple type after the pattern.
+// `(a: bool, b: u8)`, is not valid syntax. Check that we recover from it, and
+// that in a `let` binding, where the pattern can be followed by a type, we also
+// suggest writing the element types together as a tuple type after the pattern.
 //
 // Regression test for <https://github.com/rust-lang/rust/issues/149246>.
+
+struct S {
+    f: (bool, u8),
+}
 
 fn main() {
     let (a: bool,) = (true,);
@@ -20,9 +24,46 @@ fn main() {
 
     let _ = (a, b, c, d, e, f);
 
+    // A parenthesized pattern is not a one-element tuple, so its type isn't a
+    // tuple type either.
+    let (g: bool) = true;
+    //~^ ERROR a parenthesized pattern cannot be given a type
+
+    // The pattern is already followed by a type, so we only suggest removing the
+    // inline annotations.
+    let (h: bool, i): (bool, u8) = (true, 1);
+    //~^ ERROR the elements of a tuple pattern cannot be given types individually
+
+    // A rest pattern matches any number of elements, so we don't know how many
+    // types the tuple type would have to list.
+    let (.., j: u8) = (true, 1);
+    //~^ ERROR the elements of a tuple pattern cannot be given types individually
+
+    // Anywhere other than the top level pattern of a `let` binding we recover
+    // but don't suggest anything.
+    match (true, 1) {
+        (k: bool, l: u8) => {}
+        //~^ ERROR the elements of a tuple pattern cannot be given types individually
+    }
+
+    for (n: bool, o: u8) in [(true, 1)] {}
+    //~^ ERROR the elements of a tuple pattern cannot be given types individually
+
+    if let (p: bool, q: u8) = (true, 1) {}
+    //~^ ERROR the elements of a tuple pattern cannot be given types individually
+
+    let [(r: bool,)] = [(true,)];
+    //~^ ERROR the elements of a tuple pattern cannot be given types individually
+
+    let S { f: (s: bool, t: u8) } = S { f: (true, 1) };
+    //~^ ERROR the elements of a tuple pattern cannot be given types individually
+
     // With no whitespace after the colon we keep the existing "maybe write a
     // path separator here" suggestion instead, since `m::C` is the likelier
     // intent.
     let (m:C,) = (0,);
     //~^ ERROR expected one of
 }
+
+fn param((u: bool, v: u8): (bool, u8)) {}
+//~^ ERROR the elements of a tuple pattern cannot be given types individually

--- a/tests/ui/parser/tuple-pattern-type-ascription.rs
+++ b/tests/ui/parser/tuple-pattern-type-ascription.rs
@@ -1,0 +1,22 @@
+// Writing the type of each element inline in a tuple pattern, e.g.
+// `(a: bool, b: u8)`, is not valid syntax. In a `let` binding, where the pattern
+// can be followed by a type, check that we recover and suggest writing the
+// element types together as a tuple type after the pattern.
+//
+// Regression test for <https://github.com/rust-lang/rust/issues/149246>.
+
+fn main() {
+    let (a: bool,) = (true,);
+    //~^ ERROR expected one of
+
+    let (b: bool, c: u8) = (true, 1);
+    //~^ ERROR expected one of
+
+    let (d: bool, e) = (true, 1);
+    //~^ ERROR expected one of
+
+    let (f: Option<u8>,) = (Some(1),);
+    //~^ ERROR expected one of
+
+    let _ = (a, b, c, d, e, f);
+}

--- a/tests/ui/parser/tuple-pattern-type-ascription.rs
+++ b/tests/ui/parser/tuple-pattern-type-ascription.rs
@@ -7,16 +7,22 @@
 
 fn main() {
     let (a: bool,) = (true,);
-    //~^ ERROR expected one of
+    //~^ ERROR the elements of a tuple pattern cannot be given types individually
 
     let (b: bool, c: u8) = (true, 1);
-    //~^ ERROR expected one of
+    //~^ ERROR the elements of a tuple pattern cannot be given types individually
 
     let (d: bool, e) = (true, 1);
-    //~^ ERROR expected one of
+    //~^ ERROR the elements of a tuple pattern cannot be given types individually
 
     let (f: Option<u8>,) = (Some(1),);
-    //~^ ERROR expected one of
+    //~^ ERROR the elements of a tuple pattern cannot be given types individually
 
     let _ = (a, b, c, d, e, f);
+
+    // With no whitespace after the colon we keep the existing "maybe write a
+    // path separator here" suggestion instead, since `m::C` is the likelier
+    // intent.
+    let (m:C,) = (0,);
+    //~^ ERROR expected one of
 }

--- a/tests/ui/parser/tuple-pattern-type-ascription.stderr
+++ b/tests/ui/parser/tuple-pattern-type-ascription.stderr
@@ -1,5 +1,5 @@
 error: the elements of a tuple pattern cannot be given types individually
-  --> $DIR/tuple-pattern-type-ascription.rs:9:11
+  --> $DIR/tuple-pattern-type-ascription.rs:13:11
    |
 LL |     let (a: bool,) = (true,);
    |           ^^^^^^
@@ -11,7 +11,7 @@ LL +     let (a,): (bool,) = (true,);
    |
 
 error: the elements of a tuple pattern cannot be given types individually
-  --> $DIR/tuple-pattern-type-ascription.rs:12:11
+  --> $DIR/tuple-pattern-type-ascription.rs:16:11
    |
 LL |     let (b: bool, c: u8) = (true, 1);
    |           ^^^^^^   ^^^^
@@ -23,7 +23,7 @@ LL +     let (b, c): (bool, u8) = (true, 1);
    |
 
 error: the elements of a tuple pattern cannot be given types individually
-  --> $DIR/tuple-pattern-type-ascription.rs:15:11
+  --> $DIR/tuple-pattern-type-ascription.rs:19:11
    |
 LL |     let (d: bool, e) = (true, 1);
    |           ^^^^^^
@@ -35,7 +35,7 @@ LL +     let (d, e): (bool, _) = (true, 1);
    |
 
 error: the elements of a tuple pattern cannot be given types individually
-  --> $DIR/tuple-pattern-type-ascription.rs:18:11
+  --> $DIR/tuple-pattern-type-ascription.rs:22:11
    |
 LL |     let (f: Option<u8>,) = (Some(1),);
    |           ^^^^^^^^^^^^
@@ -46,8 +46,68 @@ LL -     let (f: Option<u8>,) = (Some(1),);
 LL +     let (f,): (Option<u8>,) = (Some(1),);
    |
 
+error: a parenthesized pattern cannot be given a type
+  --> $DIR/tuple-pattern-type-ascription.rs:29:11
+   |
+LL |     let (g: bool) = true;
+   |           ^^^^^^
+   |
+help: write the type after the pattern
+   |
+LL -     let (g: bool) = true;
+LL +     let (g): bool = true;
+   |
+
+error: the elements of a tuple pattern cannot be given types individually
+  --> $DIR/tuple-pattern-type-ascription.rs:34:11
+   |
+LL |     let (h: bool, i): (bool, u8) = (true, 1);
+   |           ^^^^^^
+   |
+help: remove the inline type annotations
+   |
+LL -     let (h: bool, i): (bool, u8) = (true, 1);
+LL +     let (h, i): (bool, u8) = (true, 1);
+   |
+
+error: the elements of a tuple pattern cannot be given types individually
+  --> $DIR/tuple-pattern-type-ascription.rs:39:15
+   |
+LL |     let (.., j: u8) = (true, 1);
+   |               ^^^^
+
+error: the elements of a tuple pattern cannot be given types individually
+  --> $DIR/tuple-pattern-type-ascription.rs:45:11
+   |
+LL |         (k: bool, l: u8) => {}
+   |           ^^^^^^   ^^^^
+
+error: the elements of a tuple pattern cannot be given types individually
+  --> $DIR/tuple-pattern-type-ascription.rs:49:11
+   |
+LL |     for (n: bool, o: u8) in [(true, 1)] {}
+   |           ^^^^^^   ^^^^
+
+error: the elements of a tuple pattern cannot be given types individually
+  --> $DIR/tuple-pattern-type-ascription.rs:52:14
+   |
+LL |     if let (p: bool, q: u8) = (true, 1) {}
+   |              ^^^^^^   ^^^^
+
+error: the elements of a tuple pattern cannot be given types individually
+  --> $DIR/tuple-pattern-type-ascription.rs:55:12
+   |
+LL |     let [(r: bool,)] = [(true,)];
+   |            ^^^^^^
+
+error: the elements of a tuple pattern cannot be given types individually
+  --> $DIR/tuple-pattern-type-ascription.rs:58:18
+   |
+LL |     let S { f: (s: bool, t: u8) } = S { f: (true, 1) };
+   |                  ^^^^^^   ^^^^
+
 error: expected one of `)`, `,`, `@`, `if`, or `|`, found `:`
-  --> $DIR/tuple-pattern-type-ascription.rs:26:11
+  --> $DIR/tuple-pattern-type-ascription.rs:64:11
    |
 LL |     let (m:C,) = (0,);
    |           ^ expected one of `)`, `,`, `@`, `if`, or `|`
@@ -57,5 +117,11 @@ help: maybe write a path separator here
 LL |     let (m::C,) = (0,);
    |            +
 
-error: aborting due to 5 previous errors
+error: the elements of a tuple pattern cannot be given types individually
+  --> $DIR/tuple-pattern-type-ascription.rs:68:12
+   |
+LL | fn param((u: bool, v: u8): (bool, u8)) {}
+   |            ^^^^^^   ^^^^
+
+error: aborting due to 14 previous errors
 

--- a/tests/ui/parser/tuple-pattern-type-ascription.stderr
+++ b/tests/ui/parser/tuple-pattern-type-ascription.stderr
@@ -1,0 +1,50 @@
+error: expected one of `)`, `,`, `@`, `if`, or `|`, found `:`
+  --> $DIR/tuple-pattern-type-ascription.rs:9:11
+   |
+LL |     let (a: bool,) = (true,);
+   |           ^ expected one of `)`, `,`, `@`, `if`, or `|`
+   |
+help: to annotate the types of a tuple's elements, write them as a tuple type after the pattern
+   |
+LL -     let (a: bool,) = (true,);
+LL +     let (a,): (bool,) = (true,);
+   |
+
+error: expected one of `)`, `,`, `@`, `if`, or `|`, found `:`
+  --> $DIR/tuple-pattern-type-ascription.rs:12:11
+   |
+LL |     let (b: bool, c: u8) = (true, 1);
+   |           ^ expected one of `)`, `,`, `@`, `if`, or `|`
+   |
+help: to annotate the types of a tuple's elements, write them as a tuple type after the pattern
+   |
+LL -     let (b: bool, c: u8) = (true, 1);
+LL +     let (b, c): (bool, u8) = (true, 1);
+   |
+
+error: expected one of `)`, `,`, `@`, `if`, or `|`, found `:`
+  --> $DIR/tuple-pattern-type-ascription.rs:15:11
+   |
+LL |     let (d: bool, e) = (true, 1);
+   |           ^ expected one of `)`, `,`, `@`, `if`, or `|`
+   |
+help: to annotate the types of a tuple's elements, write them as a tuple type after the pattern
+   |
+LL -     let (d: bool, e) = (true, 1);
+LL +     let (d, e): (bool, _) = (true, 1);
+   |
+
+error: expected one of `)`, `,`, `@`, `if`, or `|`, found `:`
+  --> $DIR/tuple-pattern-type-ascription.rs:18:11
+   |
+LL |     let (f: Option<u8>,) = (Some(1),);
+   |           ^ expected one of `)`, `,`, `@`, `if`, or `|`
+   |
+help: to annotate the types of a tuple's elements, write them as a tuple type after the pattern
+   |
+LL -     let (f: Option<u8>,) = (Some(1),);
+LL +     let (f,): (Option<u8>,) = (Some(1),);
+   |
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/parser/tuple-pattern-type-ascription.stderr
+++ b/tests/ui/parser/tuple-pattern-type-ascription.stderr
@@ -1,8 +1,8 @@
-error: expected one of `)`, `,`, `@`, `if`, or `|`, found `:`
+error: the elements of a tuple pattern cannot be given types individually
   --> $DIR/tuple-pattern-type-ascription.rs:9:11
    |
 LL |     let (a: bool,) = (true,);
-   |           ^ expected one of `)`, `,`, `@`, `if`, or `|`
+   |           ^^^^^^
    |
 help: to annotate the types of a tuple's elements, write them as a tuple type after the pattern
    |
@@ -10,11 +10,11 @@ LL -     let (a: bool,) = (true,);
 LL +     let (a,): (bool,) = (true,);
    |
 
-error: expected one of `)`, `,`, `@`, `if`, or `|`, found `:`
+error: the elements of a tuple pattern cannot be given types individually
   --> $DIR/tuple-pattern-type-ascription.rs:12:11
    |
 LL |     let (b: bool, c: u8) = (true, 1);
-   |           ^ expected one of `)`, `,`, `@`, `if`, or `|`
+   |           ^^^^^^   ^^^^
    |
 help: to annotate the types of a tuple's elements, write them as a tuple type after the pattern
    |
@@ -22,11 +22,11 @@ LL -     let (b: bool, c: u8) = (true, 1);
 LL +     let (b, c): (bool, u8) = (true, 1);
    |
 
-error: expected one of `)`, `,`, `@`, `if`, or `|`, found `:`
+error: the elements of a tuple pattern cannot be given types individually
   --> $DIR/tuple-pattern-type-ascription.rs:15:11
    |
 LL |     let (d: bool, e) = (true, 1);
-   |           ^ expected one of `)`, `,`, `@`, `if`, or `|`
+   |           ^^^^^^
    |
 help: to annotate the types of a tuple's elements, write them as a tuple type after the pattern
    |
@@ -34,11 +34,11 @@ LL -     let (d: bool, e) = (true, 1);
 LL +     let (d, e): (bool, _) = (true, 1);
    |
 
-error: expected one of `)`, `,`, `@`, `if`, or `|`, found `:`
+error: the elements of a tuple pattern cannot be given types individually
   --> $DIR/tuple-pattern-type-ascription.rs:18:11
    |
 LL |     let (f: Option<u8>,) = (Some(1),);
-   |           ^ expected one of `)`, `,`, `@`, `if`, or `|`
+   |           ^^^^^^^^^^^^
    |
 help: to annotate the types of a tuple's elements, write them as a tuple type after the pattern
    |
@@ -46,5 +46,16 @@ LL -     let (f: Option<u8>,) = (Some(1),);
 LL +     let (f,): (Option<u8>,) = (Some(1),);
    |
 
-error: aborting due to 4 previous errors
+error: expected one of `)`, `,`, `@`, `if`, or `|`, found `:`
+  --> $DIR/tuple-pattern-type-ascription.rs:26:11
+   |
+LL |     let (m:C,) = (0,);
+   |           ^ expected one of `)`, `,`, `@`, `if`, or `|`
+   |
+help: maybe write a path separator here
+   |
+LL |     let (m::C,) = (0,);
+   |            +
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/pattern/bindings-after-at/nested-type-ascription-syntactically-invalid.rs
+++ b/tests/ui/pattern/bindings-after-at/nested-type-ascription-syntactically-invalid.rs
@@ -22,7 +22,7 @@ fn case_1() {
 #[cfg(false)]
 fn case_2() {
     let a @ (b: u8);
-    //~^ ERROR expected one of `)`
+    //~^ ERROR a parenthesized pattern cannot be given a type
 }
 
 #[cfg(false)]

--- a/tests/ui/pattern/bindings-after-at/nested-type-ascription-syntactically-invalid.stderr
+++ b/tests/ui/pattern/bindings-after-at/nested-type-ascription-syntactically-invalid.stderr
@@ -6,11 +6,11 @@ LL |     let a: u8 @ b = 0;
    |          |
    |          while parsing the type for `a`
 
-error: expected one of `)`, `,`, `@`, `if`, or `|`, found `:`
+error: a parenthesized pattern cannot be given a type
   --> $DIR/nested-type-ascription-syntactically-invalid.rs:24:15
    |
 LL |     let a @ (b: u8);
-   |               ^ expected one of `)`, `,`, `@`, `if`, or `|`
+   |               ^^^^
 
 error: expected one of `!`, `(`, `+`, `::`, `;`, `<`, or `=`, found `@`
   --> $DIR/nested-type-ascription-syntactically-invalid.rs:30:15


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#160279 (Recover from tuple patterns with inline element types)
 - rust-lang/rust#161557 (std::net: uefi: fix TcpStream::nodelay and reject zero timeouts)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=160279,161557)
<!-- homu-ignore:end -->

