### PR TITLE
[experiment] - use DenseBitSetStorage to implement SparseBitMatrix without per-row allocation

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/values.rs
+++ b/compiler/rustc_borrowck/src/region_infer/values.rs
@@ -354,7 +354,7 @@ impl<'tcx, N: Idx> RegionValues<'tcx, N> {
 
     /// Returns just the universal regions that are contained in a given region's value.
     pub(crate) fn universal_regions_outlived_by(&self, r: N) -> impl Iterator<Item = RegionVid> {
-        self.free_regions.row(r).map(|set| set.iter()).into_flat_iter()
+        self.free_regions.row(r).map(|set| set.into_iter()).into_flat_iter()
     }
 
     /// Returns all the elements contained in a given region's value.
@@ -364,7 +364,7 @@ impl<'tcx, N: Idx> RegionValues<'tcx, N> {
     ) -> impl Iterator<Item = ty::PlaceholderRegion<'tcx>> {
         self.placeholders
             .row(r)
-            .map(|set| set.iter())
+            .map(|set| set.into_iter())
             .into_flat_iter()
             .map(move |p| self.placeholder_indices.lookup_placeholder(p))
     }

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -2,10 +2,11 @@ use std::marker::PhantomData;
 use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 use std::rc::Rc;
 use std::{fmt, iter, slice};
-use smallvec::SmallVec;
+
 use Chunk::*;
 #[cfg(feature = "nightly")]
 use rustc_macros::{Decodable_NoContext, Encodable_NoContext};
+use smallvec::SmallVec;
 
 use crate::{Idx, IndexVec};
 
@@ -89,7 +90,7 @@ impl<T, S> DenseBitSet<T, S> {
     }
 }
 
-pub trait DenseBitSetStorage: AsRef<[Word]> + AsMut<[Word]> + DerefMut<Target=[Word]> {}
+pub trait DenseBitSetStorage: AsRef<[Word]> + AsMut<[Word]> + DerefMut<Target = [Word]> {}
 
 impl DenseBitSetStorage for Vec<Word> {}
 impl<const N: usize> DenseBitSetStorage for SmallVec<[Word; N]> {}

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -101,12 +101,14 @@ pub struct ArrayStorage<const N: usize> {
     inner: [Word; N],
 }
 impl<const N: usize> AsRef<[Word]> for ArrayStorage<N> {
+    #[inline]
     fn as_ref(&self) -> &[Word] {
         &self.inner
     }
 }
 
 impl<const N: usize> AsMut<[Word]> for ArrayStorage<N> {
+    #[inline]
     fn as_mut(&mut self) -> &mut [Word] {
         &mut self.inner
     }
@@ -114,12 +116,14 @@ impl<const N: usize> AsMut<[Word]> for ArrayStorage<N> {
 
 impl<const N: usize> Deref for ArrayStorage<N> {
     type Target = [Word];
+    #[inline]
     fn deref(&self) -> &[Word] {
         self.inner.as_ref()
     }
 }
 
 impl<const N: usize> DerefMut for ArrayStorage<N> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner.as_mut()
     }

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -76,9 +76,9 @@ fn inclusive_start_end<T: Idx>(
 ///
 #[cfg_attr(feature = "nightly", derive(Decodable_NoContext, Encodable_NoContext))]
 #[derive(Eq, PartialEq, Hash)]
-pub struct DenseBitSet<T> {
+pub struct DenseBitSet<T, S = Vec<Word>> {
     domain_size: usize,
-    words: Vec<Word>,
+    words: S,
     marker: PhantomData<T>,
 }
 

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 use std::rc::Rc;
 use std::{fmt, iter, slice};
-
+use smallvec::SmallVec;
 use Chunk::*;
 #[cfg(feature = "nightly")]
 use rustc_macros::{Decodable_NoContext, Encodable_NoContext};
@@ -89,6 +89,43 @@ impl<T, S> DenseBitSet<T, S> {
     }
 }
 
+pub trait DenseBitSetStorage: AsRef<[Word]> + AsMut<[Word]> + DerefMut<Target=[Word]> {}
+
+impl DenseBitSetStorage for Vec<Word> {}
+impl<const N: usize> DenseBitSetStorage for SmallVec<[Word; N]> {}
+
+// workaround because arrays don't implement DerefMut
+#[repr(transparent)]
+pub struct ArrayStorage<const N: usize> {
+    inner: [Word; N],
+}
+impl<const N: usize> AsRef<[Word]> for ArrayStorage<N> {
+    fn as_ref(&self) -> &[Word] {
+        &self.inner
+    }
+}
+
+impl<const N: usize> AsMut<[Word]> for ArrayStorage<N> {
+    fn as_mut(&mut self) -> &mut [Word] {
+        &mut self.inner
+    }
+}
+
+impl<const N: usize> Deref for ArrayStorage<N> {
+    type Target = [Word];
+    fn deref(&self) -> &[Word] {
+        self.inner.as_ref()
+    }
+}
+
+impl<const N: usize> DerefMut for ArrayStorage<N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner.as_mut()
+    }
+}
+
+impl<const N: usize> DenseBitSetStorage for ArrayStorage<N> {}
+
 impl<T: Idx> DenseBitSet<T> {
     /// Creates a new, empty bitset with a given `domain_size`.
     #[inline]
@@ -108,7 +145,7 @@ impl<T: Idx> DenseBitSet<T> {
     }
 }
 
-impl<T: Idx, S: DerefMut<Target = [Word]>> DenseBitSet<T, S> {
+impl<T: Idx, S: DenseBitSetStorage> DenseBitSet<T, S> {
     /// Clear all elements.
     #[inline]
     pub fn clear(&mut self) {
@@ -135,7 +172,7 @@ impl<T: Idx, S: DerefMut<Target = [Word]>> DenseBitSet<T, S> {
 
     /// Is `self` is a (non-strict) superset of `other`?
     #[inline]
-    pub fn superset<OS: Deref<Target = [Word]>>(&self, other: &DenseBitSet<T, OS>) -> bool {
+    pub fn superset<OS: DenseBitSetStorage>(&self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         self.words.iter().zip(&*other.words).all(|(a, b)| (a & b) == *b)
     }
@@ -286,7 +323,7 @@ impl<T: Idx, S: DerefMut<Target = [Word]>> DenseBitSet<T, S> {
     }
 
     /// Sets `self = self | !other`.
-    pub fn union_not<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) {
+    pub fn union_not<OS: DenseBitSetStorage>(&mut self, other: &DenseBitSet<T, OS>) {
         assert_eq!(self.domain_size, other.domain_size);
 
         // FIXME(Zalathar): If we were to forcibly _set_ all excess bits before
@@ -301,19 +338,19 @@ impl<T: Idx, S: DerefMut<Target = [Word]>> DenseBitSet<T, S> {
     }
 
     /// Returns true if `self` was modified.
-    pub fn union<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
+    pub fn union<OS: DenseBitSetStorage>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         update_words(&mut self.words, &other.words, |a, b| a | b)
     }
 
     /// Returns true if `self` was modified.
-    pub fn subtract<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
+    pub fn subtract<OS: DenseBitSetStorage>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         update_words(&mut self.words, &other.words, |a, b| a & !b)
     }
 
     /// Returns true if `self` was modified.
-    pub fn intersect<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
+    pub fn intersect<OS: DenseBitSetStorage>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         update_words(&mut *self.words, &other.words, |a, b| a & b)
     }
@@ -340,13 +377,13 @@ impl<T, S: Clone> Clone for DenseBitSet<T, S> {
     }
 }
 
-impl<T: Idx, S: DerefMut<Target = [Word]>> fmt::Debug for DenseBitSet<T, S> {
+impl<T: Idx, S: DenseBitSetStorage> fmt::Debug for DenseBitSet<T, S> {
     fn fmt(&self, w: &mut fmt::Formatter<'_>) -> fmt::Result {
         w.debug_list().entries(self.iter()).finish()
     }
 }
 
-impl<T: Idx, S: DerefMut<Target = [Word]>> ToString for DenseBitSet<T, S> {
+impl<T: Idx, S: DenseBitSetStorage> ToString for DenseBitSet<T, S> {
     fn to_string(&self) -> String {
         let mut result = String::new();
         let mut sep = '[';

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::ops::{Bound, Range, RangeBounds};
+use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 use std::rc::Rc;
 use std::{fmt, iter, slice};
 
@@ -82,7 +82,7 @@ pub struct DenseBitSet<T, S = Vec<Word>> {
     marker: PhantomData<T>,
 }
 
-impl<T> DenseBitSet<T> {
+impl<T, S> DenseBitSet<T, S> {
     /// Gets the domain size.
     pub fn domain_size(&self) -> usize {
         self.domain_size
@@ -108,7 +108,7 @@ impl<T: Idx> DenseBitSet<T> {
     }
 }
 
-impl<T: Idx> DenseBitSet<T> {
+impl<T: Idx, S: DerefMut<Target = [Word]>> DenseBitSet<T, S> {
     /// Clear all elements.
     #[inline]
     pub fn clear(&mut self) {
@@ -135,9 +135,9 @@ impl<T: Idx> DenseBitSet<T> {
 
     /// Is `self` is a (non-strict) superset of `other`?
     #[inline]
-    pub fn superset(&self, other: &DenseBitSet<T>) -> bool {
+    pub fn superset<OS: Deref<Target = [Word]>>(&self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
-        self.words.iter().zip(&other.words).all(|(a, b)| (a & b) == *b)
+        self.words.iter().zip(&*other.words).all(|(a, b)| (a & b) == *b)
     }
 
     /// Is the set empty?
@@ -286,7 +286,7 @@ impl<T: Idx> DenseBitSet<T> {
     }
 
     /// Sets `self = self | !other`.
-    pub fn union_not(&mut self, other: &DenseBitSet<T>) {
+    pub fn union_not<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) {
         assert_eq!(self.domain_size, other.domain_size);
 
         // FIXME(Zalathar): If we were to forcibly _set_ all excess bits before
@@ -301,21 +301,21 @@ impl<T: Idx> DenseBitSet<T> {
     }
 
     /// Returns true if `self` was modified.
-    pub fn union(&mut self, other: &DenseBitSet<T>) -> bool {
+    pub fn union<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         update_words(&mut self.words, &other.words, |a, b| a | b)
     }
 
     /// Returns true if `self` was modified.
-    pub fn subtract(&mut self, other: &DenseBitSet<T>) -> bool {
+    pub fn subtract<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         update_words(&mut self.words, &other.words, |a, b| a & !b)
     }
 
     /// Returns true if `self` was modified.
-    pub fn intersect(&mut self, other: &DenseBitSet<T>) -> bool {
+    pub fn intersect<OS: Deref<Target = [Word]>>(&mut self, other: &DenseBitSet<T, OS>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
-        update_words(&mut self.words, &other.words, |a, b| a & b)
+        update_words(&mut *self.words, &other.words, |a, b| a & b)
     }
 }
 
@@ -325,7 +325,7 @@ impl<T: Idx> From<GrowableBitSet<T>> for DenseBitSet<T> {
     }
 }
 
-impl<T> Clone for DenseBitSet<T> {
+impl<T, S: Clone> Clone for DenseBitSet<T, S> {
     fn clone(&self) -> Self {
         DenseBitSet {
             domain_size: self.domain_size,
@@ -340,13 +340,13 @@ impl<T> Clone for DenseBitSet<T> {
     }
 }
 
-impl<T: Idx> fmt::Debug for DenseBitSet<T> {
+impl<T: Idx, S: DerefMut<Target = [Word]>> fmt::Debug for DenseBitSet<T, S> {
     fn fmt(&self, w: &mut fmt::Formatter<'_>) -> fmt::Result {
         w.debug_list().entries(self.iter()).finish()
     }
 }
 
-impl<T: Idx> ToString for DenseBitSet<T> {
+impl<T: Idx, S: DerefMut<Target = [Word]>> ToString for DenseBitSet<T, S> {
     fn to_string(&self) -> String {
         let mut result = String::new();
         let mut sep = '[';
@@ -355,7 +355,7 @@ impl<T: Idx> ToString for DenseBitSet<T> {
 
         // i tracks how many bits we have printed so far.
         let mut i = 0;
-        for word in &self.words {
+        for word in &*self.words {
             let mut word = *word;
             for _ in 0..WORD_BYTES {
                 // for each byte in `word`:

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -106,7 +106,9 @@ impl<T: Idx> DenseBitSet<T> {
         result.clear_excess_bits();
         result
     }
+}
 
+impl<T: Idx> DenseBitSet<T> {
     /// Clear all elements.
     #[inline]
     pub fn clear(&mut self) {

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -505,6 +505,18 @@ enum Chunk {
 #[cfg(target_pointer_width = "64")]
 crate::static_assert_size!(Chunk, 16);
 
+#[cfg(target_pointer_width = "64")]
+crate::static_assert_size!(MixedBitSet<usize>, 32);
+
+#[cfg(target_pointer_width = "64")]
+crate::static_assert_size!(DenseBitSet<usize>, 32);
+
+#[cfg(target_pointer_width = "64")]
+crate::static_assert_size!(DenseBitSet<usize, usize>, 16);
+
+#[cfg(target_pointer_width = "64")]
+crate::static_assert_size!(DenseBitSet<usize, [Word;2]>, 24);
+
 impl<T> ChunkedBitSet<T> {
     pub fn domain_size(&self) -> usize {
         self.domain_size

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
 use std::rc::Rc;
+use std::slice::GetDisjointMutError::{IndexOutOfBounds, OverlappingIndices};
 use std::{fmt, iter, slice};
 
 use Chunk::*;
@@ -8,7 +9,7 @@ use Chunk::*;
 use rustc_macros::{Decodable_NoContext, Encodable_NoContext};
 use smallvec::SmallVec;
 
-use crate::{Idx, IndexVec};
+use crate::Idx;
 
 #[cfg(test)]
 mod tests;
@@ -90,10 +91,20 @@ impl<T, S> DenseBitSet<T, S> {
     }
 }
 
-pub trait DenseBitSetStorage: AsRef<[Word]> + AsMut<[Word]> + DerefMut<Target = [Word]> {}
+pub trait DenseBitSetStorage: AsRef<[Word]> + Deref<Target = [Word]> {}
+pub trait DenseBitSetStorageMut:
+    DenseBitSetStorage + AsMut<[Word]> + DerefMut<Target = [Word]>
+{
+}
 
 impl DenseBitSetStorage for Vec<Word> {}
+impl DenseBitSetStorageMut for Vec<Word> {}
+impl<'a> DenseBitSetStorage for &'a [Word] {}
+impl<'a> DenseBitSetStorage for &'a mut [Word] {}
+impl<'a> DenseBitSetStorageMut for &'a mut [Word] {}
+
 impl<const N: usize> DenseBitSetStorage for SmallVec<[Word; N]> {}
+impl<const N: usize> DenseBitSetStorageMut for SmallVec<[Word; N]> {}
 
 // workaround because arrays don't implement DerefMut
 #[repr(transparent)]
@@ -130,6 +141,30 @@ impl<const N: usize> DerefMut for ArrayStorage<N> {
 }
 
 impl<const N: usize> DenseBitSetStorage for ArrayStorage<N> {}
+impl<const N: usize> DenseBitSetStorageMut for ArrayStorage<N> {}
+
+impl<'a, T: Idx> DenseBitSet<T, &'a [Word]> {
+    fn from_slice(domain_size: usize, storage: &'a [Word]) -> DenseBitSet<T, &'a [Word]> {
+        // todo assert storage has space?
+        DenseBitSet { domain_size, words: storage, marker: PhantomData }
+    }
+
+    /// Iterates over the indices of set bits in a sorted order.
+    #[inline]
+    pub fn into_iter(self) -> BitIter<'a, T> {
+        BitIter::new(self.words)
+    }
+}
+
+impl<'a, T: Idx> DenseBitSet<T, &'a mut [Word]> {
+    fn from_slice_mut(
+        domain_size: usize,
+        storage: &'a mut [Word],
+    ) -> DenseBitSet<T, &'a mut [Word]> {
+        // todo assert storage has space?
+        DenseBitSet { domain_size, words: storage, marker: PhantomData }
+    }
+}
 
 impl<T: Idx> DenseBitSet<T> {
     /// Creates a new, empty bitset with a given `domain_size`.
@@ -151,17 +186,6 @@ impl<T: Idx> DenseBitSet<T> {
 }
 
 impl<T: Idx, S: DenseBitSetStorage> DenseBitSet<T, S> {
-    /// Clear all elements.
-    #[inline]
-    pub fn clear(&mut self) {
-        self.words.fill(0);
-    }
-
-    /// Clear excess bits in the final word.
-    fn clear_excess_bits(&mut self) {
-        clear_excess_bits_in_final_word(self.domain_size, &mut self.words);
-    }
-
     /// Count the number of set bits in the set.
     pub fn count(&self) -> usize {
         count_ones(&self.words)
@@ -186,6 +210,96 @@ impl<T: Idx, S: DenseBitSetStorage> DenseBitSet<T, S> {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.words.iter().all(|a| *a == 0)
+    }
+
+    /// Checks whether any bit in the given range is a 1.
+    #[inline]
+    pub fn contains_any(&self, elems: impl RangeBounds<T>) -> bool {
+        let Some((start, end)) = inclusive_start_end(elems, self.domain_size) else {
+            return false;
+        };
+        let (start_word_index, start_mask) = word_index_and_mask(start);
+        let (end_word_index, end_mask) = word_index_and_mask(end);
+
+        if start_word_index == end_word_index {
+            self.words[start_word_index] & (end_mask | (end_mask - start_mask)) != 0
+        } else {
+            if self.words[start_word_index] & !(start_mask - 1) != 0 {
+                return true;
+            }
+
+            let remaining = start_word_index + 1..end_word_index;
+            if remaining.start <= remaining.end {
+                self.words[remaining].iter().any(|&w| w != 0)
+                    || self.words[end_word_index] & (end_mask | (end_mask - 1)) != 0
+            } else {
+                false
+            }
+        }
+    }
+
+    /// Iterates over the indices of set bits in a sorted order.
+    #[inline]
+    pub fn iter(&self) -> BitIter<'_, T> {
+        BitIter::new(&self.words)
+    }
+
+    /// Finds the first set bit at or after `elem`, if there is one.
+    pub fn first_set_at_or_after(&self, elem: T) -> Option<T> {
+        assert!(elem.index() < self.domain_size);
+        let (mut word_index, mask) = word_index_and_mask(elem);
+        // Mask out all bits below `elem`.
+        let mut word = self.words[word_index] & !(mask - 1);
+        loop {
+            if word != 0 {
+                return Some(T::new(WORD_BITS * word_index + word.trailing_zeros() as usize));
+            }
+            word_index += 1;
+            word = *self.words.get(word_index)?;
+        }
+    }
+
+    pub fn last_set_in(&self, range: impl RangeBounds<T>) -> Option<T> {
+        let (start, end) = inclusive_start_end(range, self.domain_size)?;
+        let (start_word_index, _) = word_index_and_mask(start);
+        let (end_word_index, end_mask) = word_index_and_mask(end);
+
+        let end_word = self.words[end_word_index] & (end_mask | (end_mask - 1));
+        if end_word != 0 {
+            let pos = max_bit(end_word) + WORD_BITS * end_word_index;
+            if start <= pos {
+                return Some(T::new(pos));
+            }
+        }
+
+        // We exclude end_word_index from the range here, because we don't want
+        // to limit ourselves to *just* the last word: the bits set it in may be
+        // after `end`, so it may not work out.
+        if let Some(offset) =
+            self.words[start_word_index..end_word_index].iter().rposition(|&w| w != 0)
+        {
+            let word_idx = start_word_index + offset;
+            let start_word = self.words[word_idx];
+            let pos = max_bit(start_word) + WORD_BITS * word_idx;
+            if start <= pos {
+                return Some(T::new(pos));
+            }
+        }
+
+        None
+    }
+}
+
+impl<T: Idx, S: DenseBitSetStorageMut> DenseBitSet<T, S> {
+    /// Clear all elements.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.words.fill(0);
+    }
+
+    /// Clear excess bits in the final word.
+    fn clear_excess_bits(&mut self) {
+        clear_excess_bits_in_final_word(self.domain_size, &mut self.words);
     }
 
     /// Insert `elem`. Returns whether the set has changed.
@@ -238,32 +352,6 @@ impl<T: Idx, S: DenseBitSetStorage> DenseBitSet<T, S> {
         self.clear_excess_bits();
     }
 
-    /// Checks whether any bit in the given range is a 1.
-    #[inline]
-    pub fn contains_any(&self, elems: impl RangeBounds<T>) -> bool {
-        let Some((start, end)) = inclusive_start_end(elems, self.domain_size) else {
-            return false;
-        };
-        let (start_word_index, start_mask) = word_index_and_mask(start);
-        let (end_word_index, end_mask) = word_index_and_mask(end);
-
-        if start_word_index == end_word_index {
-            self.words[start_word_index] & (end_mask | (end_mask - start_mask)) != 0
-        } else {
-            if self.words[start_word_index] & !(start_mask - 1) != 0 {
-                return true;
-            }
-
-            let remaining = start_word_index + 1..end_word_index;
-            if remaining.start <= remaining.end {
-                self.words[remaining].iter().any(|&w| w != 0)
-                    || self.words[end_word_index] & (end_mask | (end_mask - 1)) != 0
-            } else {
-                false
-            }
-        }
-    }
-
     /// Returns `true` if the set has changed.
     #[inline]
     pub fn remove(&mut self, elem: T) -> bool {
@@ -274,57 +362,6 @@ impl<T: Idx, S: DenseBitSetStorage> DenseBitSet<T, S> {
         let new_word = word & !mask;
         *word_ref = new_word;
         new_word != word
-    }
-
-    /// Iterates over the indices of set bits in a sorted order.
-    #[inline]
-    pub fn iter(&self) -> BitIter<'_, T> {
-        BitIter::new(&self.words)
-    }
-
-    /// Finds the first set bit at or after `elem`, if there is one.
-    pub fn first_set_at_or_after(&self, elem: T) -> Option<T> {
-        assert!(elem.index() < self.domain_size);
-        let (mut word_index, mask) = word_index_and_mask(elem);
-        // Mask out all bits below `elem`.
-        let mut word = self.words[word_index] & !(mask - 1);
-        loop {
-            if word != 0 {
-                return Some(T::new(WORD_BITS * word_index + word.trailing_zeros() as usize));
-            }
-            word_index += 1;
-            word = *self.words.get(word_index)?;
-        }
-    }
-
-    pub fn last_set_in(&self, range: impl RangeBounds<T>) -> Option<T> {
-        let (start, end) = inclusive_start_end(range, self.domain_size)?;
-        let (start_word_index, _) = word_index_and_mask(start);
-        let (end_word_index, end_mask) = word_index_and_mask(end);
-
-        let end_word = self.words[end_word_index] & (end_mask | (end_mask - 1));
-        if end_word != 0 {
-            let pos = max_bit(end_word) + WORD_BITS * end_word_index;
-            if start <= pos {
-                return Some(T::new(pos));
-            }
-        }
-
-        // We exclude end_word_index from the range here, because we don't want
-        // to limit ourselves to *just* the last word: the bits set it in may be
-        // after `end`, so it may not work out.
-        if let Some(offset) =
-            self.words[start_word_index..end_word_index].iter().rposition(|&w| w != 0)
-        {
-            let word_idx = start_word_index + offset;
-            let start_word = self.words[word_idx];
-            let pos = max_bit(start_word) + WORD_BITS * word_idx;
-            if start <= pos {
-                return Some(T::new(pos));
-            }
-        }
-
-        None
     }
 
     /// Sets `self = self | !other`.
@@ -1568,19 +1605,60 @@ where
     C: Idx,
 {
     num_columns: usize,
-    rows: IndexVec<R, Option<DenseBitSet<C>>>,
+    // rows: IndexVec<R, Option<DenseBitSet<C>>>,
+
+    // flat array of rows (as opposed to a vec of vecs)
+    // every row uses num_words based on num_columns
+    data: Vec<Word>,
+
+    marker: PhantomData<(R, C)>,
 }
 
 impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
     /// Creates a new empty sparse bit matrix with no rows or columns.
     pub fn new(num_columns: usize) -> Self {
-        Self { num_columns, rows: IndexVec::new() }
+        Self { num_columns, data: Vec::new(), marker: PhantomData }
     }
 
-    fn ensure_row(&mut self, row: R) -> &mut DenseBitSet<C> {
+    fn ensure_row(&mut self, row: R) -> DenseBitSet<C, &mut [Word]> {
         // Instantiate any missing rows up to and including row `row` with an empty `DenseBitSet`.
         // Then replace row `row` with a full `DenseBitSet` if necessary.
-        self.rows.get_or_insert_with(row, || DenseBitSet::new_empty(self.num_columns))
+        let row_index = row.index();
+        let desired_num_rows = row_index + 1;
+        let num_words_per_row = num_words(self.num_columns);
+        let desired_len = desired_num_rows * num_words_per_row;
+
+        if self.data.len() < desired_len {
+            self.data.resize(desired_len, 0);
+        }
+
+        let start_index = row_index * num_words_per_row;
+        let end_index = (row_index + 1) * num_words_per_row;
+        let row_storage = &mut self.data[start_index..end_index];
+
+        DenseBitSet::from_slice_mut(self.num_columns, row_storage)
+    }
+
+    pub fn row(&self, row: R) -> Option<DenseBitSet<C, &[Word]>> {
+        let row_index = row.index();
+        let num_words_per_row = num_words(self.num_columns);
+
+        let start_index = row_index * num_words_per_row;
+        let end_index = (row_index + 1) * num_words_per_row;
+        let row_storage = self.data.get(start_index..end_index)?;
+
+        Some(DenseBitSet::from_slice(self.num_columns, row_storage))
+    }
+
+    fn row_mut(&mut self, row: R) -> Option<DenseBitSet<C, &mut [Word]>> {
+        let row_index = row.index();
+        let num_words_per_row = num_words(self.num_columns);
+
+        let start_index = row_index * num_words_per_row;
+        let end_index = (row_index + 1) * num_words_per_row;
+        let row_storage = self.data.get_mut(start_index..end_index)?;
+
+        Some(DenseBitSet::from_slice_mut(self.num_columns, row_storage))
     }
 
     /// Sets the cell at `(row, column)` to true. Put another way, insert
@@ -1597,8 +1675,8 @@ impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
     ///
     /// Returns `true` if this changed the matrix.
     pub fn remove(&mut self, row: R, column: C) -> bool {
-        match self.rows.get_mut(row) {
-            Some(Some(row)) => row.remove(column),
+        match self.row_mut(row) {
+            Some(mut row) => row.remove(column),
             _ => false,
         }
     }
@@ -1606,7 +1684,7 @@ impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
     /// Sets all columns at `row` to false. Has no effect if `row` does
     /// not exist.
     pub fn clear(&mut self, row: R) {
-        if let Some(Some(row)) = self.rows.get_mut(row) {
+        if let Some(mut row) = self.row_mut(row) {
             row.clear();
         }
     }
@@ -1627,16 +1705,32 @@ impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
     /// `write` can reach everything that `read` can (and
     /// potentially more).
     pub fn union_rows(&mut self, read: R, write: R) -> bool {
-        if read == write || self.row(read).is_none() {
+        if read == write || self.num_columns == 0 || self.row(read).is_none() {
             return false;
         }
 
         self.ensure_row(write);
-        if let (Some(read_row), Some(write_row)) = self.rows.pick2_mut(read, write) {
-            write_row.union(read_row)
-        } else {
-            unreachable!()
-        }
+
+        let num_word_per_row = num_words(self.num_columns);
+
+        let read_start = read.index() * num_word_per_row;
+        let write_start = write.index() * num_word_per_row;
+        let (ai, bi) = (
+            read_start..read_start + num_word_per_row,
+            write_start..write_start + num_word_per_row,
+        );
+
+        let (read_row, mut write_row) = match self.data.get_disjoint_mut([ai.clone(), bi.clone()]) {
+            Ok([a, b]) => (
+                DenseBitSet::<R, _>::from_slice_mut(self.num_columns, a),
+                DenseBitSet::<R, _>::from_slice_mut(self.num_columns, b),
+            ),
+            Err(OverlappingIndices) => panic!("Indices {ai:?} and {bi:?} are not disjoint!"),
+            Err(IndexOutOfBounds) => {
+                panic!("Some indices among ({ai:?}, {bi:?}) are out of bounds")
+            }
+        };
+        write_row.union(&read_row)
     }
 
     /// Insert all bits in the given row.
@@ -1645,18 +1739,24 @@ impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
     }
 
     pub fn rows(&self) -> impl Iterator<Item = R> {
-        self.rows.indices()
+        let num_words_per_row = num_words(self.num_columns);
+
+        let len = if num_words_per_row == 0 { 0 } else { self.data.len() / num_words_per_row };
+
+        // fixme copypasta from SliceIndex::indices()
+        let _ = R::new(len);
+        (0..len).map(|n| R::new(n))
     }
 
     /// Iterates through all the columns set to true in a given row of
     /// the matrix.
     pub fn iter(&self, row: R) -> impl Iterator<Item = C> {
-        self.row(row).into_iter().flat_map(|r| r.iter())
+        self.row(row).into_iter().flat_map(|r| r.into_iter())
     }
 
-    pub fn row(&self, row: R) -> Option<&DenseBitSet<C>> {
-        self.rows.get(row)?.as_ref()
-    }
+    // pub fn row(&self, row: R) -> Option<&DenseBitSet<C>> {
+    //     self.rows.get(row)?.as_ref()
+    // }
 }
 
 #[inline]


### PR DESCRIPTION
This is an experiment for the DenseBitSetStorage abstraction.

Based on cachegrind benchmarks, this has some impact, as SparseBitMatrix data usually has very few columns, so the empty row in the original implementation actually takes more memory than the non-empty row would allocate. Storing the data inline should take less memory.

This implementation doesn't make much sense though, because there's BitMatrix that's cleaner and works in pretty similar way.

If we proceed with this, it might make more sense to implement it differently (probably as growable BitMatrix).

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
