### PR TITLE
Avoid invalid suggestion in case of macro expansion without inferrable generic type

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -519,11 +519,13 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         };
 
         let mut local_visitor = FindInferSourceVisitor::new(self, typeck_results, term, ty);
+        let mut body_from_expansion = false;
         if let Some(body) =
             self.tcx.hir_maybe_body_owned_by(self.tcx.typeck_root_def_id_local(body_def_id))
         {
             let expr = body.value;
             local_visitor.visit_expr(expr);
+            body_from_expansion = body.value.span.from_expansion();
         }
 
         let Some(InferSource { span, kind }) = local_visitor.infer_source else {
@@ -566,6 +568,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             term,
             &arg_data,
             typeck_results,
+            body_from_expansion,
             span,
         );
 
@@ -705,6 +708,7 @@ impl<'tcx> InferSourceKind<'tcx> {
         term: Term<'tcx>,
         arg_data: &'local InferenceDiagnosticsData,
         typeck_results: &TypeckResults<'tcx>,
+        body_from_expansion: bool,
         span: Span,
     ) -> Option<SourceKindSubdiag<'local>>
     where
@@ -799,7 +803,7 @@ impl<'tcx> InferSourceKind<'tcx> {
                     p.into_buffer()
                 };
 
-                let suggestion = if have_turbofish {
+                let suggestion = if have_turbofish || body_from_expansion {
                     None
                 } else if generic_args.len() == 1 && used_fallback {
                     match param.kind {

--- a/tests/ui/inference/need_type_info/auxiliary/derive-attribute-annotation-needed.rs
+++ b/tests/ui/inference/need_type_info/auxiliary/derive-attribute-annotation-needed.rs
@@ -1,0 +1,36 @@
+//@ edition: 2018
+#![feature(proc_macro_quote)]
+use proc_macro::{TokenStream, Ident, TokenTree, quote};
+
+#[proc_macro_derive(Serialize, attributes(serde))]
+pub fn serialize(input: TokenStream) -> TokenStream {
+    assert_eq!(
+        input.to_string(),
+        "pub struct Matrix { #[serde(serialize_with = \"f\")] matrix: (), }"
+    );
+
+    let TokenTree::Group(group) = input.into_iter().last().unwrap() else {
+        panic!("unexpected group");
+    };
+
+    let TokenTree::Group(group) = group.stream().into_iter().nth(1).unwrap() else {
+        panic!("expected group");
+    };
+
+    let TokenTree::Group(group) = group.stream().into_iter().nth(1).unwrap() else {
+        panic!("expected group");
+    };
+
+    let TokenTree::Literal(lit) = group.stream().into_iter().nth(2).unwrap() else {
+        panic!("expected literal");
+    };
+
+    let ident = Ident::new("f", lit.span());
+
+    quote! {
+        fn serialize() {
+            $ident();
+        }
+    }
+    .into()
+}

--- a/tests/ui/inference/need_type_info/derive-attribute-annotation-needed.rs
+++ b/tests/ui/inference/need_type_info/derive-attribute-annotation-needed.rs
@@ -10,7 +10,6 @@ fn f<T>() {}
 pub struct Matrix {
     #[serde(serialize_with = "f")]
     //~^ ERROR type annotations needed
-    //~| HELP consider specifying a concrete type for the type parameter `T`
     matrix: (),
 }
 

--- a/tests/ui/inference/need_type_info/derive-attribute-annotation-needed.rs
+++ b/tests/ui/inference/need_type_info/derive-attribute-annotation-needed.rs
@@ -1,0 +1,21 @@
+//@ proc-macro: derive-attribute-annotation-needed.rs
+//@ edition: 2018
+
+
+use derive_attribute_annotation_needed::Serialize;
+
+fn f<T>() {}
+
+#[derive(Serialize)]
+pub struct Matrix {
+    #[serde(serialize_with = "f")]
+    //~^ ERROR type annotations needed
+    //~| HELP consider specifying a concrete type for the type parameter `T`
+    matrix: (),
+}
+
+fn main() {
+    f();
+    //~^ ERROR type annotations needed
+    //~| HELP consider specifying a concrete type for the type parameter `T`
+}

--- a/tests/ui/inference/need_type_info/derive-attribute-annotation-needed.stderr
+++ b/tests/ui/inference/need_type_info/derive-attribute-annotation-needed.stderr
@@ -3,14 +3,9 @@ error[E0282]: type annotations needed
    |
 LL |     #[serde(serialize_with = "f")]
    |                              ^^^ cannot infer type of the type parameter `T` declared on the function `f`
-   |
-help: consider specifying a concrete type for the type parameter `T`
-   |
-LL |     #[serde(serialize_with = "f"::</* Type */>)]
-   |                                 ++++++++++++++
 
 error[E0282]: type annotations needed
-  --> $DIR/derive-attribute-annotation-needed.rs:18:5
+  --> $DIR/derive-attribute-annotation-needed.rs:17:5
    |
 LL |     f();
    |     ^ cannot infer type of the type parameter `T` declared on the function `f`

--- a/tests/ui/inference/need_type_info/derive-attribute-annotation-needed.stderr
+++ b/tests/ui/inference/need_type_info/derive-attribute-annotation-needed.stderr
@@ -1,0 +1,25 @@
+error[E0282]: type annotations needed
+  --> $DIR/derive-attribute-annotation-needed.rs:11:30
+   |
+LL |     #[serde(serialize_with = "f")]
+   |                              ^^^ cannot infer type of the type parameter `T` declared on the function `f`
+   |
+help: consider specifying a concrete type for the type parameter `T`
+   |
+LL |     #[serde(serialize_with = "f"::</* Type */>)]
+   |                                 ++++++++++++++
+
+error[E0282]: type annotations needed
+  --> $DIR/derive-attribute-annotation-needed.rs:18:5
+   |
+LL |     f();
+   |     ^ cannot infer type of the type parameter `T` declared on the function `f`
+   |
+help: consider specifying a concrete type for the type parameter `T`
+   |
+LL |     f::</* Type */>();
+   |      ++++++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Closes rust-lang/rust#129756 .

The main challenge for me in this PR was figuring out how to pass down the information of the code being generated from expansion. I went for the simplest approach I could think of, but I questioned myself if the boolean should be placed inside the Visitor. I don't have enough information to figure this out, if it's badly placed I'd be happy to fix and learn!

About the test, I split the two commits because we can see the issue being reproduced in the first commit but being fixed on the second. I also added a non-expansion example of the same code to show it won't get altered.

Oh, also I didn't know the best place to place the test. I went for the place with same kind of errors, but I guess `proc-macros` could also be a place.