### PR TITLE
std: reduce visibility of some internal OsStr related types

### DIFF
--- a/library/std/src/sys/os_str/bytes.rs
+++ b/library/std/src/sys/os_str/bytes.rs
@@ -16,12 +16,12 @@ mod tests;
 
 #[derive(Hash)]
 #[repr(transparent)]
-pub struct Buf {
+pub(crate) struct Buf {
     pub inner: Vec<u8>,
 }
 
 #[repr(transparent)]
-pub struct Slice {
+pub(crate) struct Slice {
     pub inner: [u8],
 }
 

--- a/library/std/src/sys/os_str/mod.rs
+++ b/library/std/src/sys/os_str/mod.rs
@@ -3,14 +3,14 @@
 cfg_select! {
     any(target_os = "windows", target_os = "uefi") => {
         mod wtf8;
-        pub use wtf8::{Buf, Slice};
+        pub(crate) use wtf8::{Buf, Slice};
     }
     any(target_os = "motor") => {
         mod utf8;
-        pub use utf8::{Buf, Slice};
+        pub(crate) use utf8::{Buf, Slice};
     }
     _ => {
         mod bytes;
-        pub use bytes::{Buf, Slice};
+        pub(crate) use bytes::{Buf, Slice};
     }
 }

--- a/library/std/src/sys/os_str/utf8.rs
+++ b/library/std/src/sys/os_str/utf8.rs
@@ -11,12 +11,12 @@ use crate::{fmt, mem};
 
 #[derive(Hash)]
 #[repr(transparent)]
-pub struct Buf {
+pub(crate) struct Buf {
     pub inner: String,
 }
 
 #[repr(transparent)]
-pub struct Slice {
+pub(crate) struct Slice {
     pub inner: str,
 }
 

--- a/library/std/src/sys/os_str/wtf8.rs
+++ b/library/std/src/sys/os_str/wtf8.rs
@@ -13,12 +13,12 @@ use crate::{fmt, mem};
 
 #[derive(Hash)]
 #[repr(transparent)]
-pub struct Buf {
+pub(crate) struct Buf {
     pub inner: Wtf8Buf,
 }
 
 #[repr(transparent)]
-pub struct Slice {
+pub(crate) struct Slice {
     pub inner: Wtf8,
 }
 


### PR DESCRIPTION
The std::sys::os_str::{Buf, Slice} types are only used within the std crate and not actually exported. Whole `sys` module is private. They don't need to be public. This might result in a better generated code, but more importantly it avoids some compile errors down the line.

This commit is extracted from https://github.com/rust-lang/rust/pull/160971