### PR TITLE
add core/clippy.toml to disable missing_transmute_annotations inside all expanded code

### DIFF
--- a/library/core/clippy.toml
+++ b/library/core/clippy.toml
@@ -1,0 +1,1 @@
+missing-transmute-annotations-in-expansions = false


### PR DESCRIPTION
Depends-On: https://github.com/rust-lang/rust-clippy/pull/17612

If https://github.com/rust-lang/rust-clippy/pull/17612 gets merged, we can disable disable missing_transmute_annotations **inside all expanded code**, not just external macros, in core.
This reduces a lot of clippy noise, notably in `define_valid_range_type` and `argument_new` macro calls, and helps envisioning denying this lint in  ci the future.


<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
