### PR TITLE
[Bootstrap] Pass exact CI `llvm-config` executable path

### DIFF
--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -285,7 +285,7 @@ fn try_download_ci_llvm(builder: &Builder<'_>, target: TargetSelection) -> Optio
 
     Some(DownloadedLlvm {
         output: LlvmOutput {
-            host_llvm_config: ci_llvm.join("bin").join("llvm-config"),
+            host_llvm_config: ci_llvm.join("bin").join(exe("llvm-config", builder.host_target)),
             link_shared,
             llvm_root_dir: ci_llvm,
             kind: LlvmKind::DownloadedFromCi,


### PR DESCRIPTION
## Summary

Follow-up fix for rust-lang/rust#160916.

I noticed that against latest `main` we are repeatedly invalidating `rustc_llvm`'s build script after

```
       Fresh ar_archive_writer v0.5.3
       Dirty rustc_llvm v0.0.0 (X:\repos\rust\compiler\rustc_llvm): the file `build\x86_64-pc-windows-msvc\ci-llvm\bin\llvm-config` is missing
   Compiling rustc_llvm v0.0.0 (X:\repos\rust\compiler\rustc_llvm)
       Fresh unicode-security **v0.1.2**
```

This PR passes the *exact* CI LLVM `llvm-config` executable path (including the `.exe` extension on Windows). Otherwise, this will cause `rustc_llvm` build script to consider the `llvm-config` executable missing, causing cargo build cache invalidation.

I tested this locally and this seems to fix the invalidation w/ CI LLVM.

r? Kobzol