### PR TITLE
Path: use optimized is_empty() method

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/rpath.rs
+++ b/compiler/rustc_codegen_ssa/src/back/rpath.rs
@@ -70,8 +70,8 @@ fn get_rpath_relative_to_output(config: &RPathConfig<'_>, lib: &Path) -> OsStrin
     let output = config.out_filename.parent().unwrap();
 
     // If output or lib is empty, just assume it locates in current path
-    let lib = if lib == Path::new("") { Path::new(".") } else { lib };
-    let output = if output == Path::new("") { Path::new(".") } else { output };
+    let lib = if lib.is_empty() { Path::new(".") } else { lib };
+    let output = if output.is_empty() { Path::new(".") } else { output };
 
     let lib = try_canonicalize(lib).unwrap();
     let output = try_canonicalize(output).unwrap();

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3590,7 +3590,7 @@ impl DirBuilder {
     fn create_dir_all(&self, path: &Path) -> io::Result<()> {
         // if path's parent is None, it is "/" path, which should
         // return Ok immediately
-        if path == Path::new("") || path.parent() == None {
+        if path.is_empty() || path.parent() == None {
             return Ok(());
         }
 
@@ -3601,7 +3601,7 @@ impl DirBuilder {
             // for relative paths like "foo/bar", the parent of
             // "foo" will be "" which there's no need to invoke
             // a mkdir syscall on
-            if ancestor == Path::new("") || ancestor.parent() == None {
+            if ancestor.is_empty() || ancestor.parent() == None {
                 break;
             }
 


### PR DESCRIPTION
A simple change: use the new `Path::is_empty` method, that directly checks if the inner `OsStr` is empty instead of allocating a new `Path` and doing `Path` equality.

