### PR TITLE
Add llubi to llvm-tools

### DIFF
--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/160100
+Last change is for: https://github.com/rust-lang/rust/pull/161603

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -2188,10 +2188,17 @@ impl CommandLineStep for Assemble {
                     let tool_exe = exe(tool, target_compiler.host);
                     let src_path = llvm_bin_dir.join(&tool_exe);
 
-                    // When using `download-ci-llvm`, some of the tools may not exist, so skip trying to copy them.
-                    if !src_path.exists() && builder.config.llvm_ci_mode.download_from_ci() {
-                        eprintln!("{} does not exist; skipping copy", src_path.display());
-                        continue;
+                    if !src_path.exists() {
+                        // When using `download-ci-llvm`, some of the tools may not exist, so skip trying to copy them.
+                        if builder.config.llvm_ci_mode.download_from_ci() {
+                            eprintln!("{} does not exist; skipping copy", src_path.display());
+                            continue;
+                        }
+                        // On older LLVM versions, llubi isn't in the default tools. Remove this
+                        // code when LLVM 23 is the minimum version.
+                        if *tool == "llubi" {
+                            continue;
+                        }
                     }
 
                     // There is a chance that these tools are being installed from an external LLVM.

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -60,9 +60,10 @@ pub(crate) const LLVM_TOOLS: &[&str] = &[
     "llvm-ar",       // used for creating and modifying archive files
     "llvm-as",       // used to convert LLVM assembly to LLVM bitcode
     "llvm-dis",      // used to disassemble LLVM bitcode
-    "llvm-link",     // Used to link LLVM bitcode
-    "llc",           // used to compile LLVM bytecode
-    "opt",           // used to optimize LLVM bytecode
+    "llvm-link",     // used to link LLVM bitcode
+    "llc",           // used to compile LLVM IR
+    "opt",           // used to optimize LLVM IR
+    "llubi",         // used to execute LLVM while checking for Undefined Behavior
 ];
 
 /// LLD file names for all flavors.


### PR DESCRIPTION
llubi is a tool that should be very useful when investigating problems with LLVM, because like Miri it is supposed to tell you if executing some LLVM IR encounters UB (with usual caveats).

(and also clean up comments on adjacent tools)