### PR TITLE
Add wcslen builtin

### DIFF
--- a/library/compiler-builtins/builtins-test/tests/mem.rs
+++ b/library/compiler-builtins/builtins-test/tests/mem.rs
@@ -1,5 +1,5 @@
 extern crate compiler_builtins;
-use compiler_builtins::mem::{memcmp, memcpy, memmove, memset};
+use compiler_builtins::mem::{memcmp, memcpy, memmove, memset, wcslen};
 
 const WORD_SIZE: usize = core::mem::size_of::<usize>();
 
@@ -283,4 +283,13 @@ fn memset_backward_aligned() {
         core::ptr::write_bytes(reference.0.as_mut_ptr().add(3 + WORD_SIZE), 0xCC, 17);
         assert_eq!(arr.0, reference.0);
     }
+}
+
+#[test]
+fn wide_string_length() {
+    let s = [0];
+    assert_eq!(unsafe { wcslen(s.as_ptr()) }, 0);
+
+    let s = [97, 98, 99, 0];
+    assert_eq!(unsafe { wcslen(s.as_ptr()) }, 3);
 }

--- a/library/compiler-builtins/compiler-builtins/src/mem/mod.rs
+++ b/library/compiler-builtins/compiler-builtins/src/mem/mod.rs
@@ -9,6 +9,13 @@
 #[cfg_attr(all(feature = "arch", target_arch = "x86_64"), path = "x86_64.rs")]
 mod impls;
 
+#[cfg(any(windows, target_os = "uefi"))]
+#[expect(non_camel_case_types)]
+type wchar_t = u16;
+#[cfg(not(any(windows, target_os = "uefi")))]
+#[expect(non_camel_case_types)]
+type wchar_t = i32;
+
 intrinsics! {
     #[mem_builtin]
     #[allow(suspicious_runtime_symbol_definitions)]
@@ -53,5 +60,16 @@ intrinsics! {
     #[mem_builtin]
     pub unsafe extern "C" fn strlen(s: *const core::ffi::c_char) -> usize {
         impls::c_string_length(s)
+    }
+
+    #[mem_builtin]
+    pub unsafe extern "C" fn wcslen(s: *const crate::mem::wchar_t) -> usize {
+        let mut s = s;
+        let mut n = 0;
+        while *s != 0 {
+            n += 1;
+            s = s.wrapping_add(1);
+        }
+        n
     }
 }


### PR DESCRIPTION
In LLVM 23, calls to `wcslen` are sometimes generated by a loop optimization pass: https://github.com/llvm/llvm-project/pull/132572. This causes some Rust targets (including but not limited to the UEFI targets) to fail with a linker error if a loop is transformed into a `wcslen` call. Provide a simple implementation of `wcslen` in compiler-builtins to fix this.

Fixes https://github.com/rust-lang/rust/issues/160827