### PR TITLE
Report precondition violation for `<usize as SliceIndex>::get_unchecked` in const-eval

### DIFF
--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -204,7 +204,7 @@ const unsafe impl<T> SliceIndex<[T]> for usize {
     #[track_caller]
     unsafe fn get_unchecked(self, slice: *const [T]) -> *const T {
         assert_unsafe_precondition!(
-            check_language_ub, // okay because of the `assume` below
+            check_library_ub, // Hitting the `assume` provides worse const-eval and Miri diagnostics.
             "slice::get_unchecked requires that the index is within the slice",
             (this: usize = self, len: usize = slice.len()) => this < len
         );

--- a/tests/ui/consts/const-eval/ub-slice-get-unchecked.rs
+++ b/tests/ui/consts/const-eval/ub-slice-get-unchecked.rs
@@ -1,10 +1,24 @@
 #![feature(const_index, const_trait_impl)]
 
-const A: [(); 5] = [(), (), (), (), ()];
+const ZST_ARRAY: [(); 5] = [(), (), (), (), ()];
 
 // Since the indexing is on a ZST, the addresses are all fine,
 // but we should still catch the bad range.
-const B: &[()] = unsafe { A.get_unchecked(3..1) };
+const ZST_RANGE_OOB: &[()] = unsafe { ZST_ARRAY.get_unchecked(3..1) };
 //~^ ERROR: slice::get_unchecked requires that the range is within the slice
+
+const ZST_INDEX_OOB: &() = unsafe { ZST_ARRAY.get_unchecked(9) };
+//~^ ERROR: slice::get_unchecked requires that the index is within the slice
+
+const ARRAY: [i32; 5] = [1, 2, 3, 4, 5];
+
+const INDEX_OOB: &i32 = unsafe { ARRAY.get_unchecked(9) };
+//~^ ERROR: slice::get_unchecked requires that the index is within the slice
+
+const INDEX_OOB_MUT: () = unsafe {
+    let mut array = ARRAY;
+    let _ = array.get_unchecked_mut(9);
+    //~^ ERROR: slice::get_unchecked_mut requires that the index is within the slice
+};
 
 fn main() {}

--- a/tests/ui/consts/const-eval/ub-slice-get-unchecked.stderr
+++ b/tests/ui/consts/const-eval/ub-slice-get-unchecked.stderr
@@ -1,11 +1,35 @@
 error[E0080]: evaluation panicked: unsafe precondition(s) violated: slice::get_unchecked requires that the range is within the slice
               
               This indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety.
-  --> $DIR/ub-slice-get-unchecked.rs:7:27
+  --> $DIR/ub-slice-get-unchecked.rs:7:39
    |
-LL | const B: &[()] = unsafe { A.get_unchecked(3..1) };
-   |                           ^^^^^^^^^^^^^^^^^^^^^ evaluation of `B` failed here
+LL | const ZST_RANGE_OOB: &[()] = unsafe { ZST_ARRAY.get_unchecked(3..1) };
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `ZST_RANGE_OOB` failed here
 
-error: aborting due to 1 previous error
+error[E0080]: evaluation panicked: unsafe precondition(s) violated: slice::get_unchecked requires that the index is within the slice
+              
+              This indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety.
+  --> $DIR/ub-slice-get-unchecked.rs:10:37
+   |
+LL | const ZST_INDEX_OOB: &() = unsafe { ZST_ARRAY.get_unchecked(9) };
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `ZST_INDEX_OOB` failed here
+
+error[E0080]: evaluation panicked: unsafe precondition(s) violated: slice::get_unchecked requires that the index is within the slice
+              
+              This indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety.
+  --> $DIR/ub-slice-get-unchecked.rs:15:34
+   |
+LL | const INDEX_OOB: &i32 = unsafe { ARRAY.get_unchecked(9) };
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INDEX_OOB` failed here
+
+error[E0080]: evaluation panicked: unsafe precondition(s) violated: slice::get_unchecked_mut requires that the index is within the slice
+              
+              This indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety.
+  --> $DIR/ub-slice-get-unchecked.rs:20:13
+   |
+LL |     let _ = array.get_unchecked_mut(9);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INDEX_OOB_MUT` failed here
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
The precondition check was gated on `check_language_ub`, which is disabled in const-eval and Miri, on the grounds that the `assume` below it is language UB that the interpreter will catch anyway. It does catch it, but only as "`assume` called with `false`", which says nothing about what the caller did wrong.

This PR instead gates the check on `check_library_ub`, matching `get_unchecked_mut`, so that the interpreter reports the violated precondition.

Fixes rust-lang/rust#161611

<!-- homu-ignore:start -->
@rustbot label +A-const-eval +A-diagnostics +A-slice +T-libs +requires-nightly
<!-- homu-ignore:end -->
