### PR TITLE
[EXPERIMENT] Check if isolating `Matrix::unspecialize` dodges regressions

### DIFF
--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -147,6 +147,18 @@ impl<T: Idx> DenseBitSet<T> {
     /// Insert `elem`. Returns whether the set has changed.
     #[inline]
     pub fn insert(&mut self, elem: T) -> bool {
+        assert!(elem.index() < self.domain_size);
+        let (word_index, mask) = word_index_and_mask(elem);
+        let word_ref = &mut self.words[word_index];
+        let word = *word_ref;
+        let new_word = word | mask;
+        *word_ref = new_word;
+        new_word != word
+    }
+
+    /// Insert `elem`. Returns whether the set has changed.
+    #[inline]
+    pub fn insert2(&mut self, elem: T) -> bool {
         assert!(
             elem.index() < self.domain_size,
             "inserting element at index {} but domain size is {}",

--- a/compiler/rustc_pattern_analysis/src/usefulness.rs
+++ b/compiler/rustc_pattern_analysis/src/usefulness.rs
@@ -1327,7 +1327,7 @@ impl<'p, Cx: PatCx> Matrix<'p, Cx> {
                 let parent_intersection = specialized.rows[child_intersection].parent_row;
                 // Note: self-intersection can happen with or-patterns.
                 if parent_intersection != parent_row_id {
-                    parent_row.intersects_at_least.insert(parent_intersection);
+                    parent_row.intersects_at_least.insert2(parent_intersection);
                 }
             }
         }


### PR DESCRIPTION
We know from https://github.com/rust-lang/rust/pull/161496 that `DenseBitSet::insert` is extremely sensitive to seemingly-irrelevant changes.

This is a perf experiment to see whether isolating `Matrix::unspecialize` from those changes avoids the regression.