### PR TITLE
fix: bpf abi 128 return

### DIFF
--- a/compiler/rustc_target/src/callconv/bpf.rs
+++ b/compiler/rustc_target/src/callconv/bpf.rs
@@ -1,14 +1,26 @@
 // see https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/BPF/BPFCallingConv.td
-use rustc_abi::TyAbiInterface;
+use rustc_abi::{Reg, TyAbiInterface};
 
-use crate::callconv::{ArgAbi, FnAbi};
+use crate::callconv::{ArgAbi, FnAbi, Uniform};
 
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
-    if ret.layout.is_aggregate() || ret.layout.size.bits() > 64 {
-        ret.make_indirect();
-    } else {
-        ret.extend_integer_width_to(32);
+    if !ret.layout.is_sized() {
+        return;
     }
+
+    let size = ret.layout.size;
+    if size.bits() > 128 {
+        ret.make_indirect();
+        return;
+    }
+
+    if ret.layout.is_aggregate() {
+        // Return small aggregates in up to two 64-bit registers.
+        ret.cast_to(Uniform::new(Reg::i64(), size));
+        return;
+    }
+
+    ret.extend_integer_width_to(32);
 }
 
 fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)

--- a/tests/codegen-llvm/bpf-abi-i128-return.rs
+++ b/tests/codegen-llvm/bpf-abi-i128-return.rs
@@ -1,0 +1,38 @@
+//@ add-minicore
+//@ compile-flags: -C no-prepopulate-passes --target bpfel-unknown-none
+//@ needs-llvm-components: bpf
+
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+
+#[no_mangle]
+fn outer_scalar(a: u64) -> u64 {
+    inner_scalar(a) as u64
+}
+
+// CHECK-LABEL: define {{.*}} i128 @_R{{.*}}inner_scalar(
+// CHECK-SAME:   i64{{[^)]*}}
+// CHECK:        ret i128
+#[inline(never)]
+fn inner_scalar(a: u64) -> i128 {
+    a as i128
+}
+
+struct Aggregate128([u64; 2]);
+
+#[no_mangle]
+fn outer_aggregate(a: u64) -> u64 {
+    let Aggregate128([first, _]) = inner_aggregate(a);
+    first
+}
+
+// CHECK-LABEL: define {{.*}} [2 x i64] @_R{{.*}}inner_aggregate(
+// CHECK-SAME:   i64{{[^)]*}}
+// CHECK:        ret [2 x i64]
+#[inline(never)]
+fn inner_aggregate(a: u64) -> Aggregate128 {
+    Aggregate128([a, 42])
+}


### PR DESCRIPTION
BPF backend changed the calling convention for 128-bit return (both scalars and aggregates) in LLVM 23. This PR updates the calling convention accordingly at Rust side. 

The hard error that this mismatch is causing is when 128 math LLVM intrinsics are lowered to libcalls from Rust `compiler_builtins`; the callee lowers the return value as an indirect return, while the caller expects a direct return through R0 and R2. As a workaround, I had to override the libcall and write assembly to explicitly return the value through registers. 

Notes, I don't think we need to gate the change for LLVM 23, given the code involving 128-bit values doesn't compile with LLVM 22 even with https://github.com/rust-lang/rust/pull/147638, so there is no LLVM 22 behavior to preserve. Hence, only the test is gated on LLVM 23


(I hand wrote the code, test and PR description)