### PR TITLE
Add rustc_deny_explicit_impl to UnsafeUnpin

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -924,6 +924,7 @@ marker_impls! {
 /// This is part of [RFC 3467](https://rust-lang.github.io/rfcs/3467-unsafe-pinned.html), and is
 /// tracked by [#125735](https://github.com/rust-lang/rust/issues/125735).
 #[lang = "unsafe_unpin"]
+#[rustc_deny_explicit_impl]
 #[unstable(feature = "unsafe_unpin", issue = "125735")]
 pub unsafe auto trait UnsafeUnpin {}
 

--- a/tests/ui/feature-gate-unsafe-unpin-impls.rs
+++ b/tests/ui/feature-gate-unsafe-unpin-impls.rs
@@ -1,9 +1,0 @@
-#![feature(unsafe_unpin, negative_impls)]
-use std::marker::UnsafeUnpin;
-
-struct MyType;
-
-unsafe impl UnsafeUnpin for MyType {}
-impl !UnsafeUnpin for MyType {}
-
-fn main() {}

--- a/tests/ui/feature-gate-unsafe-unpin-impls.rs
+++ b/tests/ui/feature-gate-unsafe-unpin-impls.rs
@@ -1,0 +1,9 @@
+#![feature(unsafe_unpin, negative_impls)]
+use std::marker::UnsafeUnpin;
+
+struct MyType;
+
+unsafe impl UnsafeUnpin for MyType {}
+impl !UnsafeUnpin for MyType {}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-unsafe-unpin-impls.rs
+++ b/tests/ui/feature-gates/feature-gate-unsafe-unpin-impls.rs
@@ -1,0 +1,9 @@
+#![feature(unsafe_unpin, negative_impls)]
+use std::marker::UnsafeUnpin;
+
+struct MyType;
+
+unsafe impl UnsafeUnpin for MyType {}
+impl !UnsafeUnpin for MyType {}
+
+fn main() {}


### PR DESCRIPTION
Add rustc_deny_explicit_impl to UnsafeUnpin to fix rust-lang/rust#161630 . Aslo created tests, waiting for ``.stderr``.