### PR TITLE
Fix ICE when collapsing associated type with mismatched bound vars

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -1298,6 +1298,12 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             let mut next_round = vec![];
 
             for remaining_trait in remaining_candidates {
+                if child_trait.def_id() == remaining_trait.def_id()
+                    && self.tcx().anonymize_bound_vars(child_trait)
+                        != self.tcx().anonymize_bound_vars(remaining_trait)
+                {
+                    return None;
+                }
                 if supertraits.contains(&remaining_trait.def_id()) {
                     made_progress = true;
                     continue;

--- a/tests/ui/supertrait-shadowing/alpha-equivalent-duplicate-supertrait-binders.rs
+++ b/tests/ui/supertrait-shadowing/alpha-equivalent-duplicate-supertrait-binders.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+// positive test for issue - https://github.com/rust-lang/rust/issues/161547
+#![feature(non_lifetime_binders)]
+#![feature(supertrait_item_shadowing)]
+trait E<'e> {
+    type As;
+}
+
+trait F: for<'a> E<'a> + for<'b> E<'b> {}
+
+struct G<T>
+where
+    T: F<As: E<'static>>,
+{
+    x: T,
+}
+
+fn main() {}

--- a/tests/ui/supertrait-shadowing/ambiguous-duplicate-supertrait-binders.rs
+++ b/tests/ui/supertrait-shadowing/ambiguous-duplicate-supertrait-binders.rs
@@ -1,0 +1,17 @@
+// negative test for issue - https://github.com/rust-lang/rust/issues/161547
+#![feature(non_lifetime_binders)]
+#![feature(supertrait_item_shadowing)]
+trait E<'e> {
+    type As;
+}
+
+trait F: for<F> E + for<'e> E<'e> {} //~ ERROR missing lifetime specifier
+
+struct G<T>
+where
+    T: F<As: E<'static>>, //~ ERROR ambiguous associated type `As` in bounds of `F`
+{
+    X: T,
+}
+
+fn main() {}

--- a/tests/ui/supertrait-shadowing/ambiguous-duplicate-supertrait-binders.stderr
+++ b/tests/ui/supertrait-shadowing/ambiguous-duplicate-supertrait-binders.stderr
@@ -1,0 +1,32 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ambiguous-duplicate-supertrait-binders.rs:8:17
+   |
+LL | trait F: for<F> E + for<'e> E<'e> {}
+   |                 ^ expected named lifetime parameter
+   |
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL | trait F: for<'a, F> E<'a> + for<'e> E<'e> {}
+   |              +++     ++++
+help: consider introducing a named lifetime parameter
+   |
+LL | trait F<'a>: for<F> E<'a> + for<'e> E<'e> {}
+   |        ++++          ++++
+
+error[E0221]: ambiguous associated type `As` in bounds of `F`
+  --> $DIR/ambiguous-duplicate-supertrait-binders.rs:12:10
+   |
+LL |     type As;
+   |     -------
+   |     |
+   |     ambiguous `As` from `for<'e> E<'e>`
+   |     ambiguous `As` from `E<'_>`
+...
+LL |     T: F<As: E<'static>>,
+   |          ^^^^^^^^^^^^^^ ambiguous associated type `As`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0106, E0221.
+For more information about an error, try `rustc --explain E0106`.


### PR DESCRIPTION
the ICE caused by `collapse_candidates_to_subtrait_pick` because it decided whether one trait was a supertrait just basing on the `def_id` and ignoring the generic args.

the fix approach adds an check using `anonymize_bound_vars` before merging... if the check fails we return NONE to sign ambiguity and the existing ambiguity diagnostic (E0221) handles the rest...

added 2 test and 1 .stderr

tested with -> `tests/ui/supertrait-shadowing/alpha-equivalent-duplicate-supertrait-binders.rs` and `tests/ui/supertrait-shadowing/ambiguous-duplicate-supertrait-binders.rs`

Fixes rust-lang/rust#161547