### PR TITLE
ensure absolute paths hash differently from relative ones

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3795,7 +3795,26 @@ impl cmp::PartialEq<Path> for String {
 impl Hash for Path {
     fn hash<H: Hasher>(&self, h: &mut H) {
         let bytes = self.as_u8_slice();
-        let (prefix_len, verbatim) = match parse_prefix(&self.inner) {
+        let prefix = parse_prefix(&self.inner);
+
+        // Determine whether the path has a root component, matching what Eq does.
+        //
+        // Eq checks that self.components() == other.components(). The components iterator returns a
+        // RootDir under one of the following two conditions:
+        //
+        // 1. has_physical_root() is true.
+        // 2. There's a prefix `p` present, and `p.has_implicit_root() && !p.is_verbatim()` is true.
+        //
+        // So we check for exactly those conditions here.
+        //
+        // Note that the definition of "is a separator byte" used for is_sep below is slightly
+        // different from what has_physical_root uses: the latter does not account for verbatim
+        // paths. This should likely be fixed in has_physical_root. See
+        // https://github.com/rust-lang/rust/issues/161651.
+        let has_root = has_physical_root(bytes, prefix)
+            || prefix.is_some_and(|p| p.has_implicit_root() && !p.is_verbatim());
+
+        let (prefix_len, verbatim) = match prefix {
             Some(prefix) => {
                 prefix.hash(h);
                 (prefix.len(), prefix.is_verbatim())
@@ -3803,6 +3822,8 @@ impl Hash for Path {
             None => (0, false),
         };
         let bytes = &bytes[prefix_len..];
+
+        h.write_u8(has_root as u8);
 
         let mut component_start = 0;
         // track some extra state to avoid prefix collisions.

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -2183,6 +2183,48 @@ pub fn test_compare() {
     relative_from: Some("foo/bar")
     );
 
+    tc!("/a/b", "a/b",
+    eq: false,
+    starts_with: false,
+    ends_with: true,
+    relative_from: None
+    );
+
+    tc!("/", "",
+    eq: false,
+    starts_with: true,
+    ends_with: true,
+    relative_from: Some("/")
+    );
+
+    tc!("//x", "x",
+    eq: false,
+    starts_with: false,
+    ends_with: true,
+    relative_from: None
+    );
+
+    tc!("/usr/lib", "usr/lib",
+    eq: false,
+    starts_with: false,
+    ends_with: true,
+    relative_from: None
+    );
+
+    tc!("/a/b", "/./a/b",
+    eq: true,
+    starts_with: true,
+    ends_with: true,
+    relative_from: Some("")
+    );
+
+    tc!("/", "//",
+    eq: true,
+    starts_with: true,
+    ends_with: true,
+    relative_from: Some("")
+    );
+
     if cfg!(windows) {
         tc!(r"C:\src\rust\cargo-test\test\Cargo.toml",
         r"c:\src\rust\cargo-test\test",
@@ -2214,6 +2256,51 @@ pub fn test_compare() {
         );
 
         tc!(r"\\?\C:\foo\.\bar.txt", r"\\?\C:\foo\bar.txt",
+        eq: false,
+        starts_with: false,
+        ends_with: false,
+        relative_from: None
+        );
+
+        tc!(r"C:\foo", r"C:foo",
+        eq: false,
+        starts_with: false,
+        ends_with: false,
+        relative_from: None
+        );
+
+        tc!(r"\\?\C:\foo", r"\\?\C:foo",
+        eq: false,
+        starts_with: false,
+        ends_with: false,
+        relative_from: None
+        );
+
+        // The pair (r"\\?\C:/foo", r"\\?\C:\foo") is broken -- eq is true for them but they hash
+        // differently. See https://github.com/rust-lang/rust/issues/161651.
+
+        tc!(r"\foo", "foo",
+        eq: false,
+        starts_with: false,
+        ends_with: true,
+        relative_from: None
+        );
+
+        tc!(r"\\server\share", r"\\server\share\",
+        eq: true,
+        starts_with: true,
+        ends_with: true,
+        relative_from: Some("")
+        );
+
+        tc!(r"\\.\COM42", r"\\.\COM42\",
+        eq: true,
+        starts_with: true,
+        ends_with: true,
+        relative_from: Some("")
+        );
+
+        tc!(r"\\?\UNC\server\share", r"\\?\UNC\server\share\",
         eq: false,
         starts_with: false,
         ends_with: false,


### PR DESCRIPTION
Previously, paths like `"usr/lib"` would hash the same as `"/usr/lib"`, even though they are unequal. This is not a `Hash`/`Eq` violation -- hashes for different items are allowed to collide -- but can be improved, similar to rust-lang/rust#127297.

Along the way I found a bug: rust-lang/rust#161651. That bug isn't fixed here, though I've documented it in the comments.

(LLM disclosure: Fable helped me analyze the collision while working on a different project, and reviewed the final code. I typed and wrote all of it myself -- was a fun exercise.)