### PR TITLE
Don't treat slashes as path seps after drive letters in verbatim paths

### DIFF
--- a/library/std/src/sys/path/windows/tests.rs
+++ b/library/std/src/sys/path/windows/tests.rs
@@ -83,6 +83,9 @@ fn verbatim() {
     // Make sure opening a drive will work.
     check("Z:", "Z:");
 
+    // Verbatim drive paths begin with `LETTER:\`. `/` is just a regular character here
+    check(r"\\?\C:/path\somewhere", r"\\?\C:/path\somewhere");
+
     // A path that contains null is not a valid path.
     assert!(maybe_verbatim(Path::new("\0")).is_err());
 }
@@ -93,9 +96,23 @@ fn parse_prefix(path: &str) -> Option<Prefix<'_>> {
 
 #[test]
 fn test_parse_prefix_verbatim() {
-    let prefix = Some(Prefix::VerbatimDisk(b'C'));
-    assert_eq!(prefix, parse_prefix(r"\\?\C:/windows/system32/notepad.exe"));
-    assert_eq!(prefix, parse_prefix(r"\\?\C:\windows\system32\notepad.exe"));
+    assert_eq!(
+        parse_prefix(r"\\?\C:\windows\system32\notepad.exe"),
+        Some(Prefix::VerbatimDisk(b'C')),
+    );
+}
+
+#[test]
+fn test_verbatim_disk_issue_161651() {
+    use crate::path::Path;
+
+    // This is not a `VerbatimDisk` path, because `/` is not a separator in verbatim paths!
+    assert_eq!(
+        parse_prefix(r"\\?\C:/windows\system32"),
+        Some(Prefix::Verbatim(OsStr::new("C:/windows"))),
+    );
+
+    assert_ne!(Path::new(r"\\?\C:/foo"), Path::new(r"\\?\C:\foo"));
 }
 
 #[test]

--- a/library/std/src/sys/path/windows_prefix.rs
+++ b/library/std/src/sys/path/windows_prefix.rs
@@ -142,7 +142,7 @@ fn parse_drive(path: &OsStr) -> Option<u8> {
 // Parses a drive prefix exactly, e.g. "C:"
 fn parse_drive_exact(path: &OsStr) -> Option<u8> {
     // only parse two bytes: the drive letter and the drive separator
-    if path.as_encoded_bytes().get(2).map(|&x| is_sep_byte(x)).unwrap_or(true) {
+    if path.as_encoded_bytes().get(2).map(|&x| is_verbatim_sep(x)).unwrap_or(true) {
         parse_drive(path)
     } else {
         None

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -989,14 +989,14 @@ pub fn test_decompositions_windows() {
     );
 
     t!("\\\\?\\C:/foo/bar",
-    iter: ["\\\\?\\C:", "\\", "foo/bar"],
+    iter: ["\\\\?\\C:/foo/bar"],
     has_root: true,
     is_absolute: true,
-    parent: Some("\\\\?\\C:/"),
-    file_name: Some("foo/bar"),
-    file_stem: Some("foo/bar"),
+    parent: None,
+    file_name: None,
+    file_stem: None,
     extension: None,
-    file_prefix: Some("foo/bar")
+    file_prefix: None
     );
 
     t!("\\\\.\\foo\\bar",


### PR DESCRIPTION
Treat slashes as just a regular character in `\\?\C:/path\somewhere`. This mirrors how slashes are treated afterwards, e.g. in `\\?\C:\path/somewhere`, which has a component `path/somewhere`, rather than `path`, `somewhere`. 

Likewise, drive letters followed by `/` do not denote a `VerbatimDisk`, but an arbitrary `Verbatim` path: The prefix of `\\?\C:/path\somewhere` is `\\?\C:/path`.

Fixes rust-lang/rust#161651