### PR TITLE
Print vendor instructions in `x vendor`

### DIFF
--- a/src/bootstrap/src/core/build_steps/vendor.rs
+++ b/src/bootstrap/src/core/build_steps/vendor.rs
@@ -71,13 +71,21 @@ impl CommandLineStep for Vendor {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(Vendor {
+        let vendor = run.builder.ensure(Vendor {
             sync_args: run.builder.config.cmd.vendor_sync_args(),
             versioned_dirs: run.builder.config.cmd.vendor_versioned_dirs(),
             root_dir: run.builder.src.clone(),
             output_dir: None,
             only_library_workspace: false,
         });
+        // Print the config.toml contents, so that the user can manually copy it
+        if !run.builder.config.dry_run() {
+            println!("Put the following config into .cargo/config.toml:\n{}", vendor.config);
+            println!(
+                "Put the following config into library/.cargo/config.toml:\n{}",
+                vendor.config_library
+            );
+        }
     }
 
     /// Executes the vendoring process.


### PR DESCRIPTION
When the user manually runs `x vendor`, we should tell them what to put into their `.cargo/config.toml` file. This regressed some time ago when the Vendor step was refactored in bootstrap, I think.

Before this PR, the part after "this project" was blank:

```
To use vendored sources, add this to your .cargo/config.toml for this project:

[source.crates-io]
replace-with = "vendored-sources"

[source."git+https://github.com/rust-lang/team"]
git = "https://github.com/rust-lang/team"
replace-with = "vendored-sources"

[source.vendored-sources]
directory = "vendor"
```

r? bjorn3