### PR TITLE
Pass LargeDataThreshold to LLVM module IR

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -282,6 +282,13 @@ pub(crate) unsafe fn create_module<'ll>(
         llvm::LLVMRustSetModuleCodeModel(llmod, to_llvm_code_model(sess.code_model()));
     }
 
+    let large_data_threshold = sess.opts.unstable_opts.large_data_threshold.unwrap_or(0);
+    if large_data_threshold != 0 {
+        unsafe {
+            llvm::LLVMRustSetModuleLargeDataThreshold(llmod, large_data_threshold);
+        }
+    }
+
     // If skipping the PLT is enabled, we need to add some module metadata
     // to ensure intrinsic calls don't use it.
     if !sess.needs_plt() {

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -282,8 +282,7 @@ pub(crate) unsafe fn create_module<'ll>(
         llvm::LLVMRustSetModuleCodeModel(llmod, to_llvm_code_model(sess.code_model()));
     }
 
-    let large_data_threshold = sess.opts.unstable_opts.large_data_threshold.unwrap_or(0);
-    if large_data_threshold != 0 {
+    if let Some(large_data_threshold) = sess.opts.unstable_opts.large_data_threshold {
         unsafe {
             llvm::LLVMRustSetModuleLargeDataThreshold(llmod, large_data_threshold);
         }

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2508,6 +2508,7 @@ unsafe extern "C" {
     pub(crate) fn LLVMRustSetModulePICLevel(M: &Module);
     pub(crate) fn LLVMRustSetModulePIELevel(M: &Module);
     pub(crate) fn LLVMRustSetModuleCodeModel(M: &Module, Model: CodeModel);
+    pub(crate) fn LLVMRustSetModuleLargeDataThreshold(M: &Module, Threshold: u64);
     pub(crate) fn LLVMRustBufferPtr(p: &Buffer) -> *const u8;
     pub(crate) fn LLVMRustBufferLen(p: &Buffer) -> usize;
     pub(crate) fn LLVMRustBufferFree(p: &'static mut Buffer);

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -1179,6 +1179,11 @@ extern "C" void LLVMRustSetModuleCodeModel(LLVMModuleRef M,
   unwrap(M)->setCodeModel(*CM);
 }
 
+extern "C" void LLVMRustSetModuleLargeDataThreshold(LLVMModuleRef M,
+                                                    uint64_t Threshold) {
+  unwrap(M)->setLargeDataThreshold(Threshold);
+}
+
 // Here you'll find an implementation of ThinLTO as used by the Rust compiler
 // right now. This ThinLTO support is only enabled on "recent ish" versions of
 // LLVM, and otherwise it's just blanket rejected from other compilers.

--- a/tests/codegen-llvm/large_data_threshold.rs
+++ b/tests/codegen-llvm/large_data_threshold.rs
@@ -1,0 +1,9 @@
+//@ only-x86_64
+//@ revisions: DEFAULT EXPLICIT
+//@[DEFAULT] compile-flags: -C code-model=medium
+//@[EXPLICIT] compile-flags: -C code-model=medium -Z large-data-threshold=1024
+
+#![crate_type = "lib"]
+
+// DEFAULT-NOT: !"Large Data Threshold"
+// EXPLICIT: !{{[0-9]+}} = !{i32 1, !"Large Data Threshold", i64 1024}


### PR DESCRIPTION
Before, LargeDataThreshold was only set via `LLVMRustCreateTargetMachine`. When LTO is enabled, this information is required to be passed into the generated LLVM module IR files since the LTO linker spins up its own TargetMachine and otherwise has no knowledge of the LargeDataThreshold.

Currently, `-Z large-data-threshold` has no affect at all when compiling with LTO.
This commit makes sure that if `-Z large-data-threshold` is passed and not 0, it is preserved and stored into the generated LLVM IR.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
