### PR TITLE
Apply missing transmute annotations lint

### DIFF
--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -59,7 +59,7 @@ impl Layout {
     pub const fn from_size_align(size: usize, align: usize) -> Result<Self, LayoutError> {
         if Layout::is_size_align_valid(size, align) {
             // SAFETY: Layout::is_size_align_valid checks the preconditions for this call.
-            unsafe { Ok(Layout { size, align: mem::transmute(align) }) }
+            unsafe { Ok(Layout { size, align: mem::transmute::<usize, mem::alignment::Alignment>(align) }) }
         } else {
             Err(LayoutError)
         }
@@ -140,7 +140,7 @@ impl Layout {
             ) => Layout::is_size_align_valid(size, align)
         );
         // SAFETY: the caller is required to uphold the preconditions.
-        unsafe { Layout { size, align: mem::transmute(align) } }
+        unsafe { Layout { size, align: mem::transmute::<usize, mem::alignment::Alignment>(align) } }
     }
 
     /// Creates a layout, bypassing all checks.

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -59,7 +59,7 @@ impl Layout {
     pub const fn from_size_align(size: usize, align: usize) -> Result<Self, LayoutError> {
         if Layout::is_size_align_valid(size, align) {
             // SAFETY: Layout::is_size_align_valid checks the preconditions for this call.
-            unsafe { Ok(Layout { size, align: mem::transmute::<usize, mem::alignment::Alignment>(align) }) }
+            unsafe { Ok(Layout { size, align: mem::transmute::<usize, Alignment>(align) }) }
         } else {
             Err(LayoutError)
         }
@@ -140,7 +140,7 @@ impl Layout {
             ) => Layout::is_size_align_valid(size, align)
         );
         // SAFETY: the caller is required to uphold the preconditions.
-        unsafe { Layout { size, align: mem::transmute::<usize, mem::alignment::Alignment>(align) } }
+        unsafe { Layout { size, align: mem::transmute::<usize, Alignment>(align) } }
     }
 
     /// Creates a layout, bypassing all checks.

--- a/library/core/src/array/equality.rs
+++ b/library/core/src/array/equality.rs
@@ -154,7 +154,7 @@ const impl<T: [const] BytewiseEq<U>, U, const N: usize> SpecArrayEq<U, N> for T 
         // SAFETY: Arrays are compared element-wise, and don't add any padding
         // between elements, so when the elements are `BytewiseEq`, we can
         // compare the entire array at once.
-        unsafe { crate::intrinsics::raw_eq(a, crate::mem::transmute(b)) }
+        unsafe { crate::intrinsics::raw_eq(a, crate::mem::transmute::<&[U; N], &[T; N]>(b)) }
     }
     fn spec_ne(a: &[T; N], b: &[U; N]) -> bool {
         !Self::spec_eq(a, b)

--- a/library/core/src/char/convert.rs
+++ b/library/core/src/char/convert.rs
@@ -294,7 +294,7 @@ const fn char_try_from_u32(i: u32) -> Result<char, CharTryFromError> {
         Err(CharTryFromError(()))
     } else {
         // SAFETY: checked that it's a legal unicode value
-        Ok(unsafe { transmute(i) })
+        Ok(unsafe { transmute::<u32, char>(i) })
     }
 }
 

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -731,7 +731,12 @@ impl<'a> Arguments<'a> {
         args: &'a [rt::Argument<'a>; M],
     ) -> Arguments<'a> {
         // SAFETY: Responsibility of the caller.
-        unsafe { Arguments { template: mem::transmute::<&[u8; N], NonNull<u8>>(template), args: mem::transmute::<&[rt::Argument<'_>; M], NonNull<rt::Argument<'_>>>(args) } }
+        unsafe {
+            Arguments {
+                template: mem::transmute::<&[u8; N], NonNull<u8>>(template),
+                args: mem::transmute::<&[rt::Argument<'_>; M], NonNull<rt::Argument<'_>>>(args),
+            }
+        }
     }
 
     // Same as `from_str`, but not const.

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -731,7 +731,7 @@ impl<'a> Arguments<'a> {
         args: &'a [rt::Argument<'a>; M],
     ) -> Arguments<'a> {
         // SAFETY: Responsibility of the caller.
-        unsafe { Arguments { template: mem::transmute(template), args: mem::transmute(args) } }
+        unsafe { Arguments { template: mem::transmute::<&[u8; N], ptr::non_null::NonNull<u8>>(template), args: mem::transmute::<&[fmt::rt::Argument<'_>; M], ptr::non_null::NonNull<fmt::rt::Argument<'_>>>(args) } }
     }
 
     // Same as `from_str`, but not const.
@@ -816,8 +816,8 @@ impl<'a> Arguments<'a> {
         // SAFETY: This is the "static str" representation of fmt::Arguments; see above.
         unsafe {
             Arguments {
-                template: mem::transmute(s.as_ptr()),
-                args: mem::transmute(s.len() << 1 | 1),
+                template: mem::transmute::<*const u8, ptr::non_null::NonNull<u8>>(s.as_ptr()),
+                args: mem::transmute::<usize, ptr::non_null::NonNull<fmt::rt::Argument<'_>>>(s.len() << 1 | 1),
             }
         }
     }

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -731,7 +731,7 @@ impl<'a> Arguments<'a> {
         args: &'a [rt::Argument<'a>; M],
     ) -> Arguments<'a> {
         // SAFETY: Responsibility of the caller.
-        unsafe { Arguments { template: mem::transmute::<&[u8; N], ptr::non_null::NonNull<u8>>(template), args: mem::transmute::<&[fmt::rt::Argument<'_>; M], ptr::non_null::NonNull<fmt::rt::Argument<'_>>>(args) } }
+        unsafe { Arguments { template: mem::transmute::<&[u8; N], NonNull<u8>>(template), args: mem::transmute::<&[rt::Argument<'_>; M], NonNull<rt::Argument<'_>>>(args) } }
     }
 
     // Same as `from_str`, but not const.
@@ -816,8 +816,8 @@ impl<'a> Arguments<'a> {
         // SAFETY: This is the "static str" representation of fmt::Arguments; see above.
         unsafe {
             Arguments {
-                template: mem::transmute::<*const u8, ptr::non_null::NonNull<u8>>(s.as_ptr()),
-                args: mem::transmute::<usize, ptr::non_null::NonNull<fmt::rt::Argument<'_>>>(s.len() << 1 | 1),
+                template: mem::transmute::<*const u8, NonNull<u8>>(s.as_ptr()),
+                args: mem::transmute::<usize, NonNull<rt::Argument<'_>>>(s.len() << 1 | 1),
             }
         }
     }

--- a/library/core/src/fmt/rt.rs
+++ b/library/core/src/fmt/rt.rs
@@ -68,8 +68,14 @@ macro_rules! argument_new {
                 #[cfg(not(any(sanitize = "cfi", sanitize = "kcfi")))]
                 formatter: {
                     let f: fn(&$t, &mut Formatter<'_>) -> Result = $f;
+                    #[expect(
+                        clippy::missing_transmute_annotations,
+                        reason = "inside macro, types are unknown or too complex"
+                    )]
                     // SAFETY: This is only called with `value`, which has the right type.
-                    unsafe { core::mem::transmute(f) }
+                    unsafe {
+                        core::mem::transmute(f)
+                    }
                 },
                 #[cfg(any(sanitize = "cfi", sanitize = "kcfi"))]
                 formatter: |ptr: NonNull<()>, fmt: &mut Formatter<'_>| {

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3130,7 +3130,10 @@ pub fn type_id<T: ?Sized>() -> crate::any::TypeId;
 pub const fn type_id_eq(a: crate::any::TypeId, b: crate::any::TypeId) -> bool {
     // SAFETY: we know `TypeId` is 16 bytes of initialized data.
     // This is runtime-only code so we do not have to worry about provenance.
-    unsafe { crate::mem::transmute::<crate::any::TypeId, u128>(a) == crate::mem::transmute::<crate::any::TypeId, u128>(b) }
+    unsafe {
+        crate::mem::transmute::<crate::any::TypeId, u128>(a)
+            == crate::mem::transmute::<crate::any::TypeId, u128>(b)
+    }
 }
 
 /// Returns whether the type represented by this `TypeId` is a signed integer.

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3130,7 +3130,7 @@ pub fn type_id<T: ?Sized>() -> crate::any::TypeId;
 pub const fn type_id_eq(a: crate::any::TypeId, b: crate::any::TypeId) -> bool {
     // SAFETY: we know `TypeId` is 16 bytes of initialized data.
     // This is runtime-only code so we do not have to worry about provenance.
-    unsafe { crate::mem::transmute::<any::TypeId, u128>(a) == crate::mem::transmute::<any::TypeId, u128>(b) }
+    unsafe { crate::mem::transmute::<crate::any::TypeId, u128>(a) == crate::mem::transmute::<crate::any::TypeId, u128>(b) }
 }
 
 /// Returns whether the type represented by this `TypeId` is a signed integer.

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3130,7 +3130,7 @@ pub fn type_id<T: ?Sized>() -> crate::any::TypeId;
 pub const fn type_id_eq(a: crate::any::TypeId, b: crate::any::TypeId) -> bool {
     // SAFETY: we know `TypeId` is 16 bytes of initialized data.
     // This is runtime-only code so we do not have to worry about provenance.
-    unsafe { crate::mem::transmute::<_, u128>(a) == crate::mem::transmute::<_, u128>(b) }
+    unsafe { crate::mem::transmute::<any::TypeId, u128>(a) == crate::mem::transmute::<any::TypeId, u128>(b) }
 }
 
 /// Returns whether the type represented by this `TypeId` is a signed integer.

--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -1388,7 +1388,7 @@ impl Ipv6Addr {
         Ipv6Addr {
             // All elements in `addr16` are big endian.
             // SAFETY: `[u16; 8]` is always safe to transmute to `[u8; 16]`.
-            octets: unsafe { transmute::<_, [u8; 16]>(addr16) },
+            octets: unsafe { transmute::<[u16; 8], [u8; 16]>(addr16) },
         }
     }
 
@@ -1525,7 +1525,7 @@ impl Ipv6Addr {
     pub const fn segments(&self) -> [u16; 8] {
         // All elements in `self.octets` must be big endian.
         // SAFETY: `[u8; 16]` is always safe to transmute to `[u16; 8]`.
-        let [a, b, c, d, e, f, g, h] = unsafe { transmute::<_, [u16; 8]>(self.octets) };
+        let [a, b, c, d, e, f, g, h] = unsafe { transmute::<[u8; 16], [u16; 8]>(self.octets) };
         // We want native endian u16
         [
             u16::from_be(a),

--- a/library/core/src/num/niche_types.rs
+++ b/library/core/src/num/niche_types.rs
@@ -24,7 +24,7 @@ macro_rules! define_valid_range_type {
                 #[allow(non_contiguous_range_endpoints)]
                 if let $pat = val {
                     // SAFETY: just checked that the value matches the pattern
-                    Some(unsafe { $name(crate::mem::transmute(val)) })
+                    Some(unsafe { $name(crate::mem::transmute::<$int, pattern_type!($int is $pat)>(val)) })
                 } else {
                     None
                 }

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -318,7 +318,7 @@ impl<'a> ContextBuilder<'a> {
     #[unstable(feature = "local_waker", issue = "118959")]
     pub const fn from_waker(waker: &'a Waker) -> Self {
         // SAFETY: LocalWaker is just Waker without thread safety
-        let local_waker = unsafe { transmute::<&task::wake::Waker, &task::wake::LocalWaker>(waker) };
+        let local_waker = unsafe { transmute::<&Waker, &LocalWaker>(waker) };
         Self {
             waker,
             local_waker,

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -318,7 +318,7 @@ impl<'a> ContextBuilder<'a> {
     #[unstable(feature = "local_waker", issue = "118959")]
     pub const fn from_waker(waker: &'a Waker) -> Self {
         // SAFETY: LocalWaker is just Waker without thread safety
-        let local_waker = unsafe { transmute(waker) };
+        let local_waker = unsafe { transmute::<&task::wake::Waker, &task::wake::LocalWaker>(waker) };
         Self {
             waker,
             local_waker,

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -360,7 +360,11 @@ pub fn set_alloc_error_hook(hook: fn(Layout)) {
 #[unstable(feature = "alloc_error_hook", issue = "51245")]
 pub fn take_alloc_error_hook() -> fn(Layout) {
     let hook = HOOK.swap(ptr::null_mut(), Ordering::Acquire);
-    if hook.is_null() { default_alloc_error_hook } else { unsafe { mem::transmute::<*mut (), fn(core::alloc::Layout)>(hook) } }
+    if hook.is_null() {
+        default_alloc_error_hook
+    } else {
+        unsafe { mem::transmute::<*mut (), fn(core::alloc::Layout)>(hook) }
+    }
 }
 
 #[optimize(size)]
@@ -435,8 +439,11 @@ fn default_alloc_error_hook(layout: Layout) {
 pub fn rust_oom(layout: Layout) -> ! {
     crate::sys::backtrace::__rust_end_short_backtrace(|| {
         let hook = HOOK.load(Ordering::Acquire);
-        let hook: fn(Layout) =
-            if hook.is_null() { default_alloc_error_hook } else { unsafe { mem::transmute::<*mut (), fn(core::alloc::Layout)>(hook) } };
+        let hook: fn(Layout) = if hook.is_null() {
+            default_alloc_error_hook
+        } else {
+            unsafe { mem::transmute::<*mut (), fn(core::alloc::Layout)>(hook) }
+        };
         hook(layout);
         crate::process::abort()
     })

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -360,7 +360,7 @@ pub fn set_alloc_error_hook(hook: fn(Layout)) {
 #[unstable(feature = "alloc_error_hook", issue = "51245")]
 pub fn take_alloc_error_hook() -> fn(Layout) {
     let hook = HOOK.swap(ptr::null_mut(), Ordering::Acquire);
-    if hook.is_null() { default_alloc_error_hook } else { unsafe { mem::transmute(hook) } }
+    if hook.is_null() { default_alloc_error_hook } else { unsafe { mem::transmute::<*mut (), fn(core::alloc::Layout)>(hook) } }
 }
 
 #[optimize(size)]
@@ -436,7 +436,7 @@ pub fn rust_oom(layout: Layout) -> ! {
     crate::sys::backtrace::__rust_end_short_backtrace(|| {
         let hook = HOOK.load(Ordering::Acquire);
         let hook: fn(Layout) =
-            if hook.is_null() { default_alloc_error_hook } else { unsafe { mem::transmute(hook) } };
+            if hook.is_null() { default_alloc_error_hook } else { unsafe { mem::transmute::<*mut (), fn(core::alloc::Layout)>(hook) } };
         hook(layout);
         crate::process::abort()
     })

--- a/library/std/src/sys/thread_local/key/unix.rs
+++ b/library/std/src/sys/thread_local/key/unix.rs
@@ -25,7 +25,16 @@ pub type Key = libc::pthread_key_t;
 #[inline]
 pub fn create(dtor: Option<unsafe extern "C" fn(*mut u8)>) -> Key {
     let mut key = 0;
-    if unsafe { libc::pthread_key_create(&mut key, mem::transmute::<core::option::Option<unsafe extern "C" fn(*mut u8)>, core::option::Option<unsafe extern "C" fn(*mut libc::c_void)>>(dtor)) } != 0 {
+    if unsafe {
+        libc::pthread_key_create(
+            &mut key,
+            mem::transmute::<
+                core::option::Option<unsafe extern "C" fn(*mut u8)>,
+                core::option::Option<unsafe extern "C" fn(*mut libc::c_void)>,
+            >(dtor),
+        )
+    } != 0
+    {
         rtabort!("out of TLS keys");
     }
     key

--- a/library/std/src/sys/thread_local/key/unix.rs
+++ b/library/std/src/sys/thread_local/key/unix.rs
@@ -25,7 +25,7 @@ pub type Key = libc::pthread_key_t;
 #[inline]
 pub fn create(dtor: Option<unsafe extern "C" fn(*mut u8)>) -> Key {
     let mut key = 0;
-    if unsafe { libc::pthread_key_create(&mut key, mem::transmute(dtor)) } != 0 {
+    if unsafe { libc::pthread_key_create(&mut key, mem::transmute::<core::option::Option<unsafe extern "C" fn(*mut u8)>, core::option::Option<unsafe extern "C" fn(*mut libc::c_void)>>(dtor)) } != 0 {
         rtabort!("out of TLS keys");
     }
     key

--- a/library/stdarch/crates/core_arch/src/x86/avx.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx.rs
@@ -565,7 +565,7 @@ pub const fn _mm256_blend_ps<const IMM8: i32>(a: __m256, b: __m256) -> __m256 {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm256_blendv_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
     unsafe {
-        let mask: i64x4 = simd_lt(transmute::<core_arch::x86::__m256d, core_arch::simd::Simd<i64, 4>>(c), i64x4::ZERO);
+        let mask: i64x4 = simd_lt(transmute::<__m256d, i64x4>(c), i64x4::ZERO);
         transmute(simd_select(mask, b.as_f64x4(), a.as_f64x4()))
     }
 }
@@ -581,7 +581,7 @@ pub const fn _mm256_blendv_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm256_blendv_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
     unsafe {
-        let mask: i32x8 = simd_lt(transmute::<core_arch::x86::__m256, core_arch::simd::Simd<i32, 8>>(c), i32x8::ZERO);
+        let mask: i32x8 = simd_lt(transmute::<__m256, i32x8>(c), i32x8::ZERO);
         transmute(simd_select(mask, b.as_f32x8(), a.as_f32x8()))
     }
 }
@@ -2195,7 +2195,7 @@ pub fn _mm256_testnzc_pd(a: __m256d, b: __m256d) -> i32 {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_testz_pd(a: __m128d, b: __m128d) -> i32 {
     unsafe {
-        let r: i64x2 = simd_lt(transmute::<core_arch::x86::__m128d, core_arch::simd::Simd<i64, 2>>(_mm_and_pd(a, b)), i64x2::ZERO);
+        let r: i64x2 = simd_lt(transmute::<__m128d, i64x2>(_mm_and_pd(a, b)), i64x2::ZERO);
         (0i64 == simd_reduce_or(r)) as i32
     }
 }
@@ -2216,7 +2216,7 @@ pub const fn _mm_testz_pd(a: __m128d, b: __m128d) -> i32 {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_testc_pd(a: __m128d, b: __m128d) -> i32 {
     unsafe {
-        let r: i64x2 = simd_lt(transmute::<core_arch::x86::__m128d, core_arch::simd::Simd<i64, 2>>(_mm_andnot_pd(a, b)), i64x2::ZERO);
+        let r: i64x2 = simd_lt(transmute::<__m128d, i64x2>(_mm_andnot_pd(a, b)), i64x2::ZERO);
         (0i64 == simd_reduce_or(r)) as i32
     }
 }
@@ -2307,7 +2307,7 @@ pub fn _mm256_testnzc_ps(a: __m256, b: __m256) -> i32 {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_testz_ps(a: __m128, b: __m128) -> i32 {
     unsafe {
-        let r: i32x4 = simd_lt(transmute::<core_arch::x86::__m128, core_arch::simd::Simd<i32, 4>>(_mm_and_ps(a, b)), i32x4::ZERO);
+        let r: i32x4 = simd_lt(transmute::<__m128, i32x4>(_mm_and_ps(a, b)), i32x4::ZERO);
         (0i32 == simd_reduce_or(r)) as i32
     }
 }
@@ -2328,7 +2328,7 @@ pub const fn _mm_testz_ps(a: __m128, b: __m128) -> i32 {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_testc_ps(a: __m128, b: __m128) -> i32 {
     unsafe {
-        let r: i32x4 = simd_lt(transmute::<core_arch::x86::__m128, core_arch::simd::Simd<i32, 4>>(_mm_andnot_ps(a, b)), i32x4::ZERO);
+        let r: i32x4 = simd_lt(transmute::<__m128, i32x4>(_mm_andnot_ps(a, b)), i32x4::ZERO);
         (0i32 == simd_reduce_or(r)) as i32
     }
 }
@@ -2365,7 +2365,7 @@ pub const fn _mm256_movemask_pd(a: __m256d) -> i32 {
     // Propagate the highest bit to the rest, because simd_bitmask
     // requires all-1 or all-0.
     unsafe {
-        let mask: i64x4 = simd_lt(transmute::<core_arch::x86::__m256d, core_arch::simd::Simd<i64, 4>>(a), i64x4::ZERO);
+        let mask: i64x4 = simd_lt(transmute::<__m256d, i64x4>(a), i64x4::ZERO);
         simd_bitmask::<i64x4, u8>(mask) as i32
     }
 }
@@ -2384,7 +2384,7 @@ pub const fn _mm256_movemask_ps(a: __m256) -> i32 {
     // Propagate the highest bit to the rest, because simd_bitmask
     // requires all-1 or all-0.
     unsafe {
-        let mask: i32x8 = simd_lt(transmute::<core_arch::x86::__m256, core_arch::simd::Simd<i32, 8>>(a), i32x8::ZERO);
+        let mask: i32x8 = simd_lt(transmute::<__m256, i32x8>(a), i32x8::ZERO);
         simd_bitmask::<i32x8, u8>(mask) as i32
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/avx.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx.rs
@@ -565,7 +565,7 @@ pub const fn _mm256_blend_ps<const IMM8: i32>(a: __m256, b: __m256) -> __m256 {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm256_blendv_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
     unsafe {
-        let mask: i64x4 = simd_lt(transmute::<_, i64x4>(c), i64x4::ZERO);
+        let mask: i64x4 = simd_lt(transmute::<core_arch::x86::__m256d, core_arch::simd::Simd<i64, 4>>(c), i64x4::ZERO);
         transmute(simd_select(mask, b.as_f64x4(), a.as_f64x4()))
     }
 }
@@ -581,7 +581,7 @@ pub const fn _mm256_blendv_pd(a: __m256d, b: __m256d, c: __m256d) -> __m256d {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm256_blendv_ps(a: __m256, b: __m256, c: __m256) -> __m256 {
     unsafe {
-        let mask: i32x8 = simd_lt(transmute::<_, i32x8>(c), i32x8::ZERO);
+        let mask: i32x8 = simd_lt(transmute::<core_arch::x86::__m256, core_arch::simd::Simd<i32, 8>>(c), i32x8::ZERO);
         transmute(simd_select(mask, b.as_f32x8(), a.as_f32x8()))
     }
 }
@@ -2195,7 +2195,7 @@ pub fn _mm256_testnzc_pd(a: __m256d, b: __m256d) -> i32 {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_testz_pd(a: __m128d, b: __m128d) -> i32 {
     unsafe {
-        let r: i64x2 = simd_lt(transmute(_mm_and_pd(a, b)), i64x2::ZERO);
+        let r: i64x2 = simd_lt(transmute::<core_arch::x86::__m128d, core_arch::simd::Simd<i64, 2>>(_mm_and_pd(a, b)), i64x2::ZERO);
         (0i64 == simd_reduce_or(r)) as i32
     }
 }
@@ -2216,7 +2216,7 @@ pub const fn _mm_testz_pd(a: __m128d, b: __m128d) -> i32 {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_testc_pd(a: __m128d, b: __m128d) -> i32 {
     unsafe {
-        let r: i64x2 = simd_lt(transmute(_mm_andnot_pd(a, b)), i64x2::ZERO);
+        let r: i64x2 = simd_lt(transmute::<core_arch::x86::__m128d, core_arch::simd::Simd<i64, 2>>(_mm_andnot_pd(a, b)), i64x2::ZERO);
         (0i64 == simd_reduce_or(r)) as i32
     }
 }
@@ -2307,7 +2307,7 @@ pub fn _mm256_testnzc_ps(a: __m256, b: __m256) -> i32 {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_testz_ps(a: __m128, b: __m128) -> i32 {
     unsafe {
-        let r: i32x4 = simd_lt(transmute(_mm_and_ps(a, b)), i32x4::ZERO);
+        let r: i32x4 = simd_lt(transmute::<core_arch::x86::__m128, core_arch::simd::Simd<i32, 4>>(_mm_and_ps(a, b)), i32x4::ZERO);
         (0i32 == simd_reduce_or(r)) as i32
     }
 }
@@ -2328,7 +2328,7 @@ pub const fn _mm_testz_ps(a: __m128, b: __m128) -> i32 {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_testc_ps(a: __m128, b: __m128) -> i32 {
     unsafe {
-        let r: i32x4 = simd_lt(transmute(_mm_andnot_ps(a, b)), i32x4::ZERO);
+        let r: i32x4 = simd_lt(transmute::<core_arch::x86::__m128, core_arch::simd::Simd<i32, 4>>(_mm_andnot_ps(a, b)), i32x4::ZERO);
         (0i32 == simd_reduce_or(r)) as i32
     }
 }
@@ -2365,7 +2365,7 @@ pub const fn _mm256_movemask_pd(a: __m256d) -> i32 {
     // Propagate the highest bit to the rest, because simd_bitmask
     // requires all-1 or all-0.
     unsafe {
-        let mask: i64x4 = simd_lt(transmute(a), i64x4::ZERO);
+        let mask: i64x4 = simd_lt(transmute::<core_arch::x86::__m256d, core_arch::simd::Simd<i64, 4>>(a), i64x4::ZERO);
         simd_bitmask::<i64x4, u8>(mask) as i32
     }
 }
@@ -2384,7 +2384,7 @@ pub const fn _mm256_movemask_ps(a: __m256) -> i32 {
     // Propagate the highest bit to the rest, because simd_bitmask
     // requires all-1 or all-0.
     unsafe {
-        let mask: i32x8 = simd_lt(transmute(a), i32x8::ZERO);
+        let mask: i32x8 = simd_lt(transmute::<core_arch::x86::__m256, core_arch::simd::Simd<i32, 8>>(a), i32x8::ZERO);
         simd_bitmask::<i32x8, u8>(mask) as i32
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/avx2.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx2.rs
@@ -2738,7 +2738,7 @@ pub const fn _mm256_slli_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
         if IMM8 >= 16 {
             _mm256_setzero_si256()
         } else {
-            transmute(simd_shl(a.as_u16x16(), u16x16::splat(IMM8 as u16)))
+            transmute::<core_arch::simd::Simd<u16, 16>, core_arch::x86::__m256i>(simd_shl(a.as_u16x16(), u16x16::splat(IMM8 as u16)))
         }
     }
 }
@@ -2759,7 +2759,7 @@ pub const fn _mm256_slli_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
         if IMM8 >= 32 {
             _mm256_setzero_si256()
         } else {
-            transmute(simd_shl(a.as_u32x8(), u32x8::splat(IMM8 as u32)))
+            transmute::<core_arch::simd::Simd<u32, 8>, core_arch::x86::__m256i>(simd_shl(a.as_u32x8(), u32x8::splat(IMM8 as u32)))
         }
     }
 }
@@ -2780,7 +2780,7 @@ pub const fn _mm256_slli_epi64<const IMM8: i32>(a: __m256i) -> __m256i {
         if IMM8 >= 64 {
             _mm256_setzero_si256()
         } else {
-            transmute(simd_shl(a.as_u64x4(), u64x4::splat(IMM8 as u64)))
+            transmute::<core_arch::simd::Simd<u64, 4>, core_arch::x86::__m256i>(simd_shl(a.as_u64x4(), u64x4::splat(IMM8 as u64)))
         }
     }
 }
@@ -3005,7 +3005,7 @@ pub const fn _mm_srav_epi32(a: __m128i, count: __m128i) -> __m128i {
     unsafe {
         let count = count.as_u32x4();
         let no_overflow: u32x4 = simd_lt(count, u32x4::splat(u32::BITS));
-        let count = simd_select(no_overflow, transmute(count), i32x4::splat(31));
+        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u32, 4>, core_arch::simd::Simd<i32, 4>>(count), i32x4::splat(31));
         simd_shr(a.as_i32x4(), count).as_m128i()
     }
 }
@@ -3023,7 +3023,7 @@ pub const fn _mm256_srav_epi32(a: __m256i, count: __m256i) -> __m256i {
     unsafe {
         let count = count.as_u32x8();
         let no_overflow: u32x8 = simd_lt(count, u32x8::splat(u32::BITS));
-        let count = simd_select(no_overflow, transmute(count), i32x8::splat(31));
+        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u32, 8>, core_arch::simd::Simd<i32, 8>>(count), i32x8::splat(31));
         simd_shr(a.as_i32x8(), count).as_m256i()
     }
 }
@@ -3157,7 +3157,7 @@ pub const fn _mm256_srli_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
         if IMM8 >= 16 {
             _mm256_setzero_si256()
         } else {
-            transmute(simd_shr(a.as_u16x16(), u16x16::splat(IMM8 as u16)))
+            transmute::<core_arch::simd::Simd<u16, 16>, core_arch::x86::__m256i>(simd_shr(a.as_u16x16(), u16x16::splat(IMM8 as u16)))
         }
     }
 }
@@ -3178,7 +3178,7 @@ pub const fn _mm256_srli_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
         if IMM8 >= 32 {
             _mm256_setzero_si256()
         } else {
-            transmute(simd_shr(a.as_u32x8(), u32x8::splat(IMM8 as u32)))
+            transmute::<core_arch::simd::Simd<u32, 8>, core_arch::x86::__m256i>(simd_shr(a.as_u32x8(), u32x8::splat(IMM8 as u32)))
         }
     }
 }
@@ -3199,7 +3199,7 @@ pub const fn _mm256_srli_epi64<const IMM8: i32>(a: __m256i) -> __m256i {
         if IMM8 >= 64 {
             _mm256_setzero_si256()
         } else {
-            transmute(simd_shr(a.as_u64x4(), u64x4::splat(IMM8 as u64)))
+            transmute::<core_arch::simd::Simd<u64, 4>, core_arch::x86::__m256i>(simd_shr(a.as_u64x4(), u64x4::splat(IMM8 as u64)))
         }
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/avx2.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx2.rs
@@ -2738,7 +2738,7 @@ pub const fn _mm256_slli_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
         if IMM8 >= 16 {
             _mm256_setzero_si256()
         } else {
-            transmute::<core_arch::simd::Simd<u16, 16>, core_arch::x86::__m256i>(simd_shl(a.as_u16x16(), u16x16::splat(IMM8 as u16)))
+            transmute::<u16x16, __m256i>(simd_shl(a.as_u16x16(), u16x16::splat(IMM8 as u16)))
         }
     }
 }
@@ -2759,7 +2759,7 @@ pub const fn _mm256_slli_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
         if IMM8 >= 32 {
             _mm256_setzero_si256()
         } else {
-            transmute::<core_arch::simd::Simd<u32, 8>, core_arch::x86::__m256i>(simd_shl(a.as_u32x8(), u32x8::splat(IMM8 as u32)))
+            transmute::<u32x8, __m256i>(simd_shl(a.as_u32x8(), u32x8::splat(IMM8 as u32)))
         }
     }
 }
@@ -2780,7 +2780,7 @@ pub const fn _mm256_slli_epi64<const IMM8: i32>(a: __m256i) -> __m256i {
         if IMM8 >= 64 {
             _mm256_setzero_si256()
         } else {
-            transmute::<core_arch::simd::Simd<u64, 4>, core_arch::x86::__m256i>(simd_shl(a.as_u64x4(), u64x4::splat(IMM8 as u64)))
+            transmute::<u64x4, __m256i>(simd_shl(a.as_u64x4(), u64x4::splat(IMM8 as u64)))
         }
     }
 }
@@ -3005,7 +3005,7 @@ pub const fn _mm_srav_epi32(a: __m128i, count: __m128i) -> __m128i {
     unsafe {
         let count = count.as_u32x4();
         let no_overflow: u32x4 = simd_lt(count, u32x4::splat(u32::BITS));
-        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u32, 4>, core_arch::simd::Simd<i32, 4>>(count), i32x4::splat(31));
+        let count = simd_select(no_overflow, transmute::<u32x4, i32x4>(count), i32x4::splat(31));
         simd_shr(a.as_i32x4(), count).as_m128i()
     }
 }
@@ -3023,7 +3023,7 @@ pub const fn _mm256_srav_epi32(a: __m256i, count: __m256i) -> __m256i {
     unsafe {
         let count = count.as_u32x8();
         let no_overflow: u32x8 = simd_lt(count, u32x8::splat(u32::BITS));
-        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u32, 8>, core_arch::simd::Simd<i32, 8>>(count), i32x8::splat(31));
+        let count = simd_select(no_overflow, transmute::<u32x8, i32x8>(count), i32x8::splat(31));
         simd_shr(a.as_i32x8(), count).as_m256i()
     }
 }
@@ -3157,7 +3157,7 @@ pub const fn _mm256_srli_epi16<const IMM8: i32>(a: __m256i) -> __m256i {
         if IMM8 >= 16 {
             _mm256_setzero_si256()
         } else {
-            transmute::<core_arch::simd::Simd<u16, 16>, core_arch::x86::__m256i>(simd_shr(a.as_u16x16(), u16x16::splat(IMM8 as u16)))
+            transmute::<u16x16, __m256i>(simd_shr(a.as_u16x16(), u16x16::splat(IMM8 as u16)))
         }
     }
 }
@@ -3178,7 +3178,7 @@ pub const fn _mm256_srli_epi32<const IMM8: i32>(a: __m256i) -> __m256i {
         if IMM8 >= 32 {
             _mm256_setzero_si256()
         } else {
-            transmute::<core_arch::simd::Simd<u32, 8>, core_arch::x86::__m256i>(simd_shr(a.as_u32x8(), u32x8::splat(IMM8 as u32)))
+            transmute::<u32x8, __m256i>(simd_shr(a.as_u32x8(), u32x8::splat(IMM8 as u32)))
         }
     }
 }
@@ -3199,7 +3199,7 @@ pub const fn _mm256_srli_epi64<const IMM8: i32>(a: __m256i) -> __m256i {
         if IMM8 >= 64 {
             _mm256_setzero_si256()
         } else {
-            transmute::<core_arch::simd::Simd<u64, 4>, core_arch::x86::__m256i>(simd_shr(a.as_u64x4(), u64x4::splat(IMM8 as u64)))
+            transmute::<u64x4, __m256i>(simd_shr(a.as_u64x4(), u64x4::splat(IMM8 as u64)))
         }
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/avx512bf16.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx512bf16.rs
@@ -385,7 +385,7 @@ pub fn _mm512_maskz_dpbf16_ps(k: __mmask16, src: __m512, a: __m512bh, b: __m512b
 #[target_feature(enable = "avx512bf16,avx512f")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _mm512_cvtpbh_ps(a: __m256bh) -> __m512 {
-    unsafe { _mm512_castsi512_ps(_mm512_slli_epi32::<16>(_mm512_cvtepi16_epi32(transmute(a)))) }
+    unsafe { _mm512_castsi512_ps(_mm512_slli_epi32::<16>(_mm512_cvtepi16_epi32(transmute::<core_arch::x86::__m256bh, core_arch::x86::__m256i>(a)))) }
 }
 
 /// Converts packed BF16 (16-bit) floating-point elements in a to packed single-precision (32-bit)
@@ -426,7 +426,7 @@ pub fn _mm512_maskz_cvtpbh_ps(k: __mmask16, a: __m256bh) -> __m512 {
 #[target_feature(enable = "avx512bf16,avx512vl")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _mm256_cvtpbh_ps(a: __m128bh) -> __m256 {
-    unsafe { _mm256_castsi256_ps(_mm256_slli_epi32::<16>(_mm256_cvtepi16_epi32(transmute(a)))) }
+    unsafe { _mm256_castsi256_ps(_mm256_slli_epi32::<16>(_mm256_cvtepi16_epi32(transmute::<core_arch::x86::__m128bh, core_arch::x86::__m128i>(a)))) }
 }
 
 /// Converts packed BF16 (16-bit) floating-point elements in a to packed single-precision (32-bit)
@@ -467,7 +467,7 @@ pub fn _mm256_maskz_cvtpbh_ps(k: __mmask8, a: __m128bh) -> __m256 {
 #[target_feature(enable = "avx512bf16,avx512vl")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _mm_cvtpbh_ps(a: __m128bh) -> __m128 {
-    unsafe { _mm_castsi128_ps(_mm_slli_epi32::<16>(_mm_cvtepi16_epi32(transmute(a)))) }
+    unsafe { _mm_castsi128_ps(_mm_slli_epi32::<16>(_mm_cvtepi16_epi32(transmute::<core_arch::x86::__m128bh, core_arch::x86::__m128i>(a)))) }
 }
 
 /// Converts packed BF16 (16-bit) floating-point elements in a to single-precision (32-bit) floating-point

--- a/library/stdarch/crates/core_arch/src/x86/avx512bf16.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx512bf16.rs
@@ -385,8 +385,9 @@ pub fn _mm512_maskz_dpbf16_ps(k: __mmask16, src: __m512, a: __m512bh, b: __m512b
 #[target_feature(enable = "avx512bf16,avx512f")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _mm512_cvtpbh_ps(a: __m256bh) -> __m512 {
-    unsafe { _mm512_castsi512_ps(_mm512_slli_epi32::<16>(_mm512_cvtepi16_epi32(transmute::<core_arch::x86::__m256bh, core_arch::x86::__m256i>(a)))) }
+    unsafe { _mm512_castsi512_ps(_mm512_slli_epi32::<16>(_mm512_cvtepi16_epi32(transmute::<__m256bh, __m256i>(a)))) }
 }
+
 
 /// Converts packed BF16 (16-bit) floating-point elements in a to packed single-precision (32-bit)
 /// floating-point elements, and store the results in dst using writemask k (elements are copied
@@ -426,7 +427,7 @@ pub fn _mm512_maskz_cvtpbh_ps(k: __mmask16, a: __m256bh) -> __m512 {
 #[target_feature(enable = "avx512bf16,avx512vl")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _mm256_cvtpbh_ps(a: __m128bh) -> __m256 {
-    unsafe { _mm256_castsi256_ps(_mm256_slli_epi32::<16>(_mm256_cvtepi16_epi32(transmute::<core_arch::x86::__m128bh, core_arch::x86::__m128i>(a)))) }
+    unsafe { _mm256_castsi256_ps(_mm256_slli_epi32::<16>(_mm256_cvtepi16_epi32(transmute::<__m128bh, __m128i>(a)))) }
 }
 
 /// Converts packed BF16 (16-bit) floating-point elements in a to packed single-precision (32-bit)
@@ -467,7 +468,7 @@ pub fn _mm256_maskz_cvtpbh_ps(k: __mmask8, a: __m128bh) -> __m256 {
 #[target_feature(enable = "avx512bf16,avx512vl")]
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 pub fn _mm_cvtpbh_ps(a: __m128bh) -> __m128 {
-    unsafe { _mm_castsi128_ps(_mm_slli_epi32::<16>(_mm_cvtepi16_epi32(transmute::<core_arch::x86::__m128bh, core_arch::x86::__m128i>(a)))) }
+    unsafe { _mm_castsi128_ps(_mm_slli_epi32::<16>(_mm_cvtepi16_epi32(transmute::<__m128bh, __m128i>(a)))) }
 }
 
 /// Converts packed BF16 (16-bit) floating-point elements in a to single-precision (32-bit) floating-point

--- a/library/stdarch/crates/core_arch/src/x86/avx512bw.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx512bw.rs
@@ -3348,7 +3348,7 @@ pub const fn _mm_mask_cmple_epu16_mask(k1: __mmask8, a: __m128i, b: __m128i) -> 
     _mm_mask_cmp_epu16_mask::<_MM_CMPINT_LE>(k1, a, b)
 }
 
-/// Compare packed unsigned 8-bit integers in a and b for less-than-or-equal, and store the results in mask vector k.   
+/// Compare packed unsigned 8-bit integers in a and b for less-than-or-equal, and store the results in mask vector k.
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_cmple_epu8_mask&expand=1007)
 #[inline]
@@ -3372,7 +3372,7 @@ pub const fn _mm512_mask_cmple_epu8_mask(k1: __mmask64, a: __m512i, b: __m512i) 
     _mm512_mask_cmp_epu8_mask::<_MM_CMPINT_LE>(k1, a, b)
 }
 
-/// Compare packed unsigned 8-bit integers in a and b for less-than-or-equal, and store the results in mask vector k.   
+/// Compare packed unsigned 8-bit integers in a and b for less-than-or-equal, and store the results in mask vector k.
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_cmple_epu8_mask&expand=1005)
 #[inline]
@@ -3396,7 +3396,7 @@ pub const fn _mm256_mask_cmple_epu8_mask(k1: __mmask32, a: __m256i, b: __m256i) 
     _mm256_mask_cmp_epu8_mask::<_MM_CMPINT_LE>(k1, a, b)
 }
 
-/// Compare packed unsigned 8-bit integers in a and b for less-than-or-equal, and store the results in mask vector k.   
+/// Compare packed unsigned 8-bit integers in a and b for less-than-or-equal, and store the results in mask vector k.
 ///
 /// [Intel's documentation](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmple_epu8_mask&expand=1003)
 #[inline]
@@ -7220,7 +7220,7 @@ pub const fn _mm512_slli_epi16<const IMM8: u32>(a: __m512i) -> __m512i {
         if IMM8 >= 16 {
             _mm512_setzero_si512()
         } else {
-            transmute(simd_shl(a.as_u16x32(), u16x32::splat(IMM8 as u16)))
+            transmute::<core_arch::simd::Simd<u16, 32>, core_arch::x86::__m512i>(simd_shl(a.as_u16x32(), u16x32::splat(IMM8 as u16)))
         }
     }
 }
@@ -7266,7 +7266,7 @@ pub const fn _mm512_maskz_slli_epi16<const IMM8: u32>(k: __mmask32, a: __m512i) 
             _mm512_setzero_si512()
         } else {
             let shf = simd_shl(a.as_u16x32(), u16x32::splat(IMM8 as u16));
-            transmute(simd_select_bitmask(k, shf, u16x32::ZERO))
+            transmute::<core_arch::simd::Simd<u16, 32>, core_arch::x86::__m512i>(simd_select_bitmask(k, shf, u16x32::ZERO))
         }
     }
 }
@@ -7312,7 +7312,7 @@ pub const fn _mm256_maskz_slli_epi16<const IMM8: u32>(k: __mmask16, a: __m256i) 
             _mm256_setzero_si256()
         } else {
             let shf = simd_shl(a.as_u16x16(), u16x16::splat(IMM8 as u16));
-            transmute(simd_select_bitmask(k, shf, u16x16::ZERO))
+            transmute::<core_arch::simd::Simd<u16, 16>, core_arch::x86::__m256i>(simd_select_bitmask(k, shf, u16x16::ZERO))
         }
     }
 }
@@ -7358,7 +7358,7 @@ pub const fn _mm_maskz_slli_epi16<const IMM8: u32>(k: __mmask8, a: __m128i) -> _
             _mm_setzero_si128()
         } else {
             let shf = simd_shl(a.as_u16x8(), u16x8::splat(IMM8 as u16));
-            transmute(simd_select_bitmask(k, shf, u16x8::ZERO))
+            transmute::<core_arch::simd::Simd<u16, 8>, core_arch::x86::__m128i>(simd_select_bitmask(k, shf, u16x8::ZERO))
         }
     }
 }
@@ -7624,7 +7624,7 @@ pub const fn _mm512_srli_epi16<const IMM8: u32>(a: __m512i) -> __m512i {
         if IMM8 >= 16 {
             _mm512_setzero_si512()
         } else {
-            transmute(simd_shr(a.as_u16x32(), u16x32::splat(IMM8 as u16)))
+            transmute::<core_arch::simd::Simd<u16, 32>, core_arch::x86::__m512i>(simd_shr(a.as_u16x32(), u16x32::splat(IMM8 as u16)))
         }
     }
 }
@@ -7671,7 +7671,7 @@ pub const fn _mm512_maskz_srli_epi16<const IMM8: i32>(k: __mmask32, a: __m512i) 
             _mm512_setzero_si512()
         } else {
             let shf = simd_shr(a.as_u16x32(), u16x32::splat(IMM8 as u16));
-            transmute(simd_select_bitmask(k, shf, u16x32::ZERO))
+            transmute::<core_arch::simd::Simd<u16, 32>, core_arch::x86::__m512i>(simd_select_bitmask(k, shf, u16x32::ZERO))
         }
     }
 }
@@ -8140,7 +8140,7 @@ pub const fn _mm512_srav_epi16(a: __m512i, count: __m512i) -> __m512i {
     unsafe {
         let count = count.as_u16x32();
         let no_overflow: u16x32 = simd_lt(count, u16x32::splat(u16::BITS as u16));
-        let count = simd_select(no_overflow, transmute(count), i16x32::splat(15));
+        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u16, 32>, core_arch::simd::Simd<i16, 32>>(count), i16x32::splat(15));
         simd_shr(a.as_i16x32(), count).as_m512i()
     }
 }
@@ -8192,7 +8192,7 @@ pub const fn _mm256_srav_epi16(a: __m256i, count: __m256i) -> __m256i {
     unsafe {
         let count = count.as_u16x16();
         let no_overflow: u16x16 = simd_lt(count, u16x16::splat(u16::BITS as u16));
-        let count = simd_select(no_overflow, transmute(count), i16x16::splat(15));
+        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u16, 16>, core_arch::simd::Simd<i16, 16>>(count), i16x16::splat(15));
         simd_shr(a.as_i16x16(), count).as_m256i()
     }
 }
@@ -8244,7 +8244,7 @@ pub const fn _mm_srav_epi16(a: __m128i, count: __m128i) -> __m128i {
     unsafe {
         let count = count.as_u16x8();
         let no_overflow: u16x8 = simd_lt(count, u16x8::splat(u16::BITS as u16));
-        let count = simd_select(no_overflow, transmute(count), i16x8::splat(15));
+        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u16, 8>, core_arch::simd::Simd<i16, 8>>(count), i16x8::splat(15));
         simd_shr(a.as_i16x8(), count).as_m128i()
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/avx512bw.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx512bw.rs
@@ -7220,7 +7220,7 @@ pub const fn _mm512_slli_epi16<const IMM8: u32>(a: __m512i) -> __m512i {
         if IMM8 >= 16 {
             _mm512_setzero_si512()
         } else {
-            transmute::<core_arch::simd::Simd<u16, 32>, core_arch::x86::__m512i>(simd_shl(a.as_u16x32(), u16x32::splat(IMM8 as u16)))
+            transmute::<u16x32, __m512i>(simd_shl(a.as_u16x32(), u16x32::splat(IMM8 as u16)))
         }
     }
 }
@@ -7266,7 +7266,7 @@ pub const fn _mm512_maskz_slli_epi16<const IMM8: u32>(k: __mmask32, a: __m512i) 
             _mm512_setzero_si512()
         } else {
             let shf = simd_shl(a.as_u16x32(), u16x32::splat(IMM8 as u16));
-            transmute::<core_arch::simd::Simd<u16, 32>, core_arch::x86::__m512i>(simd_select_bitmask(k, shf, u16x32::ZERO))
+            transmute::<u16x32, __m512i>(simd_select_bitmask(k, shf, u16x32::ZERO))
         }
     }
 }
@@ -7312,7 +7312,7 @@ pub const fn _mm256_maskz_slli_epi16<const IMM8: u32>(k: __mmask16, a: __m256i) 
             _mm256_setzero_si256()
         } else {
             let shf = simd_shl(a.as_u16x16(), u16x16::splat(IMM8 as u16));
-            transmute::<core_arch::simd::Simd<u16, 16>, core_arch::x86::__m256i>(simd_select_bitmask(k, shf, u16x16::ZERO))
+            transmute::<u16x16, __m256i>(simd_select_bitmask(k, shf, u16x16::ZERO))
         }
     }
 }
@@ -7358,7 +7358,7 @@ pub const fn _mm_maskz_slli_epi16<const IMM8: u32>(k: __mmask8, a: __m128i) -> _
             _mm_setzero_si128()
         } else {
             let shf = simd_shl(a.as_u16x8(), u16x8::splat(IMM8 as u16));
-            transmute::<core_arch::simd::Simd<u16, 8>, core_arch::x86::__m128i>(simd_select_bitmask(k, shf, u16x8::ZERO))
+            transmute::<u16x8, __m128i>(simd_select_bitmask(k, shf, u16x8::ZERO))
         }
     }
 }
@@ -7624,7 +7624,7 @@ pub const fn _mm512_srli_epi16<const IMM8: u32>(a: __m512i) -> __m512i {
         if IMM8 >= 16 {
             _mm512_setzero_si512()
         } else {
-            transmute::<core_arch::simd::Simd<u16, 32>, core_arch::x86::__m512i>(simd_shr(a.as_u16x32(), u16x32::splat(IMM8 as u16)))
+            transmute::<u16x32, __m512i>(simd_shr(a.as_u16x32(), u16x32::splat(IMM8 as u16)))
         }
     }
 }
@@ -7671,7 +7671,7 @@ pub const fn _mm512_maskz_srli_epi16<const IMM8: i32>(k: __mmask32, a: __m512i) 
             _mm512_setzero_si512()
         } else {
             let shf = simd_shr(a.as_u16x32(), u16x32::splat(IMM8 as u16));
-            transmute::<core_arch::simd::Simd<u16, 32>, core_arch::x86::__m512i>(simd_select_bitmask(k, shf, u16x32::ZERO))
+            transmute::<u16x32, __m512i>(simd_select_bitmask(k, shf, u16x32::ZERO))
         }
     }
 }
@@ -8140,7 +8140,7 @@ pub const fn _mm512_srav_epi16(a: __m512i, count: __m512i) -> __m512i {
     unsafe {
         let count = count.as_u16x32();
         let no_overflow: u16x32 = simd_lt(count, u16x32::splat(u16::BITS as u16));
-        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u16, 32>, core_arch::simd::Simd<i16, 32>>(count), i16x32::splat(15));
+        let count = simd_select(no_overflow, transmute::<u16x32, i16x32>(count), i16x32::splat(15));
         simd_shr(a.as_i16x32(), count).as_m512i()
     }
 }
@@ -8192,7 +8192,7 @@ pub const fn _mm256_srav_epi16(a: __m256i, count: __m256i) -> __m256i {
     unsafe {
         let count = count.as_u16x16();
         let no_overflow: u16x16 = simd_lt(count, u16x16::splat(u16::BITS as u16));
-        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u16, 16>, core_arch::simd::Simd<i16, 16>>(count), i16x16::splat(15));
+        let count = simd_select(no_overflow, transmute::<u16x16, i16x16>(count), i16x16::splat(15));
         simd_shr(a.as_i16x16(), count).as_m256i()
     }
 }
@@ -8244,7 +8244,7 @@ pub const fn _mm_srav_epi16(a: __m128i, count: __m128i) -> __m128i {
     unsafe {
         let count = count.as_u16x8();
         let no_overflow: u16x8 = simd_lt(count, u16x8::splat(u16::BITS as u16));
-        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u16, 8>, core_arch::simd::Simd<i16, 8>>(count), i16x8::splat(15));
+        let count = simd_select(no_overflow, transmute::<u16x8, i16x8>(count), i16x8::splat(15));
         simd_shr(a.as_i16x8(), count).as_m128i()
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/avx512dq.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx512dq.rs
@@ -82,7 +82,7 @@ pub const fn _mm256_maskz_and_pd(k: __mmask8, a: __m256d, b: __m256d) -> __m256d
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_and_pd(a: __m512d, b: __m512d) -> __m512d {
-    unsafe { transmute(simd_and(transmute::<_, u64x8>(a), transmute::<_, u64x8>(b))) }
+    unsafe { transmute(simd_and(transmute::<core_arch::x86::__m512d, core_arch::simd::Simd<u64, 8>>(a), transmute::<core_arch::x86::__m512d, core_arch::simd::Simd<u64, 8>>(b))) }
 }
 
 /// Compute the bitwise AND of packed double-precision (64-bit) floating point numbers in a and b
@@ -196,8 +196,8 @@ pub const fn _mm256_maskz_and_ps(k: __mmask8, a: __m256, b: __m256) -> __m256 {
 pub const fn _mm512_and_ps(a: __m512, b: __m512) -> __m512 {
     unsafe {
         transmute(simd_and(
-            transmute::<_, u32x16>(a),
-            transmute::<_, u32x16>(b),
+            transmute::<core_arch::x86::__m512, core_arch::simd::Simd<u32, 16>>(a),
+            transmute::<core_arch::x86::__m512, core_arch::simd::Simd<u32, 16>>(b),
         ))
     }
 }
@@ -315,7 +315,7 @@ pub const fn _mm256_maskz_andnot_pd(k: __mmask8, a: __m256d, b: __m256d) -> __m2
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_andnot_pd(a: __m512d, b: __m512d) -> __m512d {
-    unsafe { _mm512_and_pd(_mm512_xor_pd(a, transmute(_mm512_set1_epi64(-1))), b) }
+    unsafe { _mm512_and_pd(_mm512_xor_pd(a, transmute::<core_arch::x86::__m512i, core_arch::x86::__m512d>(_mm512_set1_epi64(-1))), b) }
 }
 
 /// Compute the bitwise NOT of packed double-precision (64-bit) floating point numbers in a and then
@@ -430,7 +430,7 @@ pub const fn _mm256_maskz_andnot_ps(k: __mmask8, a: __m256, b: __m256) -> __m256
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_andnot_ps(a: __m512, b: __m512) -> __m512 {
-    unsafe { _mm512_and_ps(_mm512_xor_ps(a, transmute(_mm512_set1_epi32(-1))), b) }
+    unsafe { _mm512_and_ps(_mm512_xor_ps(a, transmute::<core_arch::x86::__m512i, core_arch::x86::__m512>(_mm512_set1_epi32(-1))), b) }
 }
 
 /// Compute the bitwise NOT of packed single-precision (32-bit) floating point numbers in a and then
@@ -545,7 +545,7 @@ pub const fn _mm256_maskz_or_pd(k: __mmask8, a: __m256d, b: __m256d) -> __m256d 
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_or_pd(a: __m512d, b: __m512d) -> __m512d {
-    unsafe { transmute(simd_or(transmute::<_, u64x8>(a), transmute::<_, u64x8>(b))) }
+    unsafe { transmute(simd_or(transmute::<core_arch::x86::__m512d, core_arch::simd::Simd<u64, 8>>(a), transmute::<core_arch::x86::__m512d, core_arch::simd::Simd<u64, 8>>(b))) }
 }
 
 /// Compute the bitwise OR of packed double-precision (64-bit) floating point numbers in a and b and
@@ -659,8 +659,8 @@ pub const fn _mm256_maskz_or_ps(k: __mmask8, a: __m256, b: __m256) -> __m256 {
 pub const fn _mm512_or_ps(a: __m512, b: __m512) -> __m512 {
     unsafe {
         transmute(simd_or(
-            transmute::<_, u32x16>(a),
-            transmute::<_, u32x16>(b),
+            transmute::<core_arch::x86::__m512, core_arch::simd::Simd<u32, 16>>(a),
+            transmute::<core_arch::x86::__m512, core_arch::simd::Simd<u32, 16>>(b),
         ))
     }
 }
@@ -776,7 +776,7 @@ pub const fn _mm256_maskz_xor_pd(k: __mmask8, a: __m256d, b: __m256d) -> __m256d
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_xor_pd(a: __m512d, b: __m512d) -> __m512d {
-    unsafe { transmute(simd_xor(transmute::<_, u64x8>(a), transmute::<_, u64x8>(b))) }
+    unsafe { transmute(simd_xor(transmute::<core_arch::x86::__m512d, core_arch::simd::Simd<u64, 8>>(a), transmute::<core_arch::x86::__m512d, core_arch::simd::Simd<u64, 8>>(b))) }
 }
 
 /// Compute the bitwise XOR of packed double-precision (64-bit) floating point numbers in a and b and
@@ -890,8 +890,8 @@ pub const fn _mm256_maskz_xor_ps(k: __mmask8, a: __m256, b: __m256) -> __m256 {
 pub const fn _mm512_xor_ps(a: __m512, b: __m512) -> __m512 {
     unsafe {
         transmute(simd_xor(
-            transmute::<_, u32x16>(a),
-            transmute::<_, u32x16>(b),
+            transmute::<core_arch::x86::__m512, core_arch::simd::Simd<u32, 16>>(a),
+            transmute::<core_arch::x86::__m512, core_arch::simd::Simd<u32, 16>>(b),
         ))
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/avx512dq.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx512dq.rs
@@ -82,7 +82,7 @@ pub const fn _mm256_maskz_and_pd(k: __mmask8, a: __m256d, b: __m256d) -> __m256d
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_and_pd(a: __m512d, b: __m512d) -> __m512d {
-    unsafe { transmute(simd_and(transmute::<core_arch::x86::__m512d, core_arch::simd::Simd<u64, 8>>(a), transmute::<core_arch::x86::__m512d, core_arch::simd::Simd<u64, 8>>(b))) }
+    unsafe { transmute(simd_and(transmute::<__m512d, u64x8>(a), transmute::<__m512d, u64x8>(b))) }
 }
 
 /// Compute the bitwise AND of packed double-precision (64-bit) floating point numbers in a and b
@@ -196,8 +196,8 @@ pub const fn _mm256_maskz_and_ps(k: __mmask8, a: __m256, b: __m256) -> __m256 {
 pub const fn _mm512_and_ps(a: __m512, b: __m512) -> __m512 {
     unsafe {
         transmute(simd_and(
-            transmute::<core_arch::x86::__m512, core_arch::simd::Simd<u32, 16>>(a),
-            transmute::<core_arch::x86::__m512, core_arch::simd::Simd<u32, 16>>(b),
+            transmute::<__m512, u32x16>(a),
+            transmute::<__m512, u32x16>(b),
         ))
     }
 }
@@ -315,7 +315,7 @@ pub const fn _mm256_maskz_andnot_pd(k: __mmask8, a: __m256d, b: __m256d) -> __m2
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_andnot_pd(a: __m512d, b: __m512d) -> __m512d {
-    unsafe { _mm512_and_pd(_mm512_xor_pd(a, transmute::<core_arch::x86::__m512i, core_arch::x86::__m512d>(_mm512_set1_epi64(-1))), b) }
+    unsafe { _mm512_and_pd(_mm512_xor_pd(a, transmute::<__m512i, __m512d>(_mm512_set1_epi64(-1))), b) }
 }
 
 /// Compute the bitwise NOT of packed double-precision (64-bit) floating point numbers in a and then
@@ -430,7 +430,7 @@ pub const fn _mm256_maskz_andnot_ps(k: __mmask8, a: __m256, b: __m256) -> __m256
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_andnot_ps(a: __m512, b: __m512) -> __m512 {
-    unsafe { _mm512_and_ps(_mm512_xor_ps(a, transmute::<core_arch::x86::__m512i, core_arch::x86::__m512>(_mm512_set1_epi32(-1))), b) }
+    unsafe { _mm512_and_ps(_mm512_xor_ps(a, transmute::<__m512i, __m512>(_mm512_set1_epi32(-1))), b) }
 }
 
 /// Compute the bitwise NOT of packed single-precision (32-bit) floating point numbers in a and then
@@ -545,7 +545,7 @@ pub const fn _mm256_maskz_or_pd(k: __mmask8, a: __m256d, b: __m256d) -> __m256d 
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_or_pd(a: __m512d, b: __m512d) -> __m512d {
-    unsafe { transmute(simd_or(transmute::<core_arch::x86::__m512d, core_arch::simd::Simd<u64, 8>>(a), transmute::<core_arch::x86::__m512d, core_arch::simd::Simd<u64, 8>>(b))) }
+    unsafe { transmute(simd_or(transmute::<__m512d, u64x8>(a), transmute::<__m512d, u64x8>(b))) }
 }
 
 /// Compute the bitwise OR of packed double-precision (64-bit) floating point numbers in a and b and
@@ -659,8 +659,8 @@ pub const fn _mm256_maskz_or_ps(k: __mmask8, a: __m256, b: __m256) -> __m256 {
 pub const fn _mm512_or_ps(a: __m512, b: __m512) -> __m512 {
     unsafe {
         transmute(simd_or(
-            transmute::<core_arch::x86::__m512, core_arch::simd::Simd<u32, 16>>(a),
-            transmute::<core_arch::x86::__m512, core_arch::simd::Simd<u32, 16>>(b),
+            transmute::<__m512, u32x16>(a),
+            transmute::<__m512, u32x16>(b),
         ))
     }
 }
@@ -776,7 +776,7 @@ pub const fn _mm256_maskz_xor_pd(k: __mmask8, a: __m256d, b: __m256d) -> __m256d
 #[stable(feature = "stdarch_x86_avx512", since = "1.89")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_xor_pd(a: __m512d, b: __m512d) -> __m512d {
-    unsafe { transmute(simd_xor(transmute::<core_arch::x86::__m512d, core_arch::simd::Simd<u64, 8>>(a), transmute::<core_arch::x86::__m512d, core_arch::simd::Simd<u64, 8>>(b))) }
+    unsafe { transmute(simd_xor(transmute::<__m512d, u64x8>(a), transmute::<__m512d, u64x8>(b))) }
 }
 
 /// Compute the bitwise XOR of packed double-precision (64-bit) floating point numbers in a and b and
@@ -890,8 +890,8 @@ pub const fn _mm256_maskz_xor_ps(k: __mmask8, a: __m256, b: __m256) -> __m256 {
 pub const fn _mm512_xor_ps(a: __m512, b: __m512) -> __m512 {
     unsafe {
         transmute(simd_xor(
-            transmute::<core_arch::x86::__m512, core_arch::simd::Simd<u32, 16>>(a),
-            transmute::<core_arch::x86::__m512, core_arch::simd::Simd<u32, 16>>(b),
+            transmute::<__m512, u32x16>(a),
+            transmute::<__m512, u32x16>(b),
         ))
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/avx512f.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx512f.rs
@@ -20028,7 +20028,7 @@ pub const fn _mm512_slli_epi32<const IMM8: u32>(a: __m512i) -> __m512i {
         if IMM8 >= 32 {
             _mm512_setzero_si512()
         } else {
-            transmute::<core_arch::simd::Simd<u32, 16>, core_arch::x86::__m512i>(simd_shl(a.as_u32x16(), u32x16::splat(IMM8)))
+            transmute::<u32x16, __m512i>(simd_shl(a.as_u32x16(), u32x16::splat(IMM8)))
         }
     }
 }
@@ -20074,7 +20074,7 @@ pub const fn _mm512_maskz_slli_epi32<const IMM8: u32>(k: __mmask16, a: __m512i) 
             _mm512_setzero_si512()
         } else {
             let shf = simd_shl(a.as_u32x16(), u32x16::splat(IMM8));
-            transmute::<core_arch::simd::Simd<u32, 16>, core_arch::x86::__m512i>(simd_select_bitmask(k, shf, u32x16::ZERO))
+            transmute::<u32x16, __m512i>(simd_select_bitmask(k, shf, u32x16::ZERO))
         }
     }
 }
@@ -20120,7 +20120,7 @@ pub const fn _mm256_maskz_slli_epi32<const IMM8: u32>(k: __mmask8, a: __m256i) -
             _mm256_setzero_si256()
         } else {
             let r = simd_shl(a.as_u32x8(), u32x8::splat(IMM8));
-            transmute::<core_arch::simd::Simd<u32, 8>, core_arch::x86::__m256i>(simd_select_bitmask(k, r, u32x8::ZERO))
+            transmute::<u32x8, __m256i>(simd_select_bitmask(k, r, u32x8::ZERO))
         }
     }
 }
@@ -20166,7 +20166,7 @@ pub const fn _mm_maskz_slli_epi32<const IMM8: u32>(k: __mmask8, a: __m128i) -> _
             _mm_setzero_si128()
         } else {
             let r = simd_shl(a.as_u32x4(), u32x4::splat(IMM8));
-            transmute::<core_arch::simd::Simd<u32, 4>, core_arch::x86::__m128i>(simd_select_bitmask(k, r, u32x4::ZERO))
+            transmute::<u32x4, __m128i>(simd_select_bitmask(k, r, u32x4::ZERO))
         }
     }
 }
@@ -20186,7 +20186,7 @@ pub const fn _mm512_srli_epi32<const IMM8: u32>(a: __m512i) -> __m512i {
         if IMM8 >= 32 {
             _mm512_setzero_si512()
         } else {
-            transmute::<core_arch::simd::Simd<u32, 16>, core_arch::x86::__m512i>(simd_shr(a.as_u32x16(), u32x16::splat(IMM8)))
+            transmute::<u32x16, __m512i>(simd_shr(a.as_u32x16(), u32x16::splat(IMM8)))
         }
     }
 }
@@ -20232,7 +20232,7 @@ pub const fn _mm512_maskz_srli_epi32<const IMM8: u32>(k: __mmask16, a: __m512i) 
             _mm512_setzero_si512()
         } else {
             let shf = simd_shr(a.as_u32x16(), u32x16::splat(IMM8));
-            transmute::<core_arch::simd::Simd<u32, 16>, core_arch::x86::__m512i>(simd_select_bitmask(k, shf, u32x16::ZERO))
+            transmute::<u32x16, __m512i>(simd_select_bitmask(k, shf, u32x16::ZERO))
         }
     }
 }
@@ -20278,7 +20278,7 @@ pub const fn _mm256_maskz_srli_epi32<const IMM8: u32>(k: __mmask8, a: __m256i) -
             _mm256_setzero_si256()
         } else {
             let r = simd_shr(a.as_u32x8(), u32x8::splat(IMM8));
-            transmute::<core_arch::simd::Simd<u32, 8>, core_arch::x86::__m256i>(simd_select_bitmask(k, r, u32x8::ZERO))
+            transmute::<u32x8, __m256i>(simd_select_bitmask(k, r, u32x8::ZERO))
         }
     }
 }
@@ -20324,7 +20324,7 @@ pub const fn _mm_maskz_srli_epi32<const IMM8: u32>(k: __mmask8, a: __m128i) -> _
             _mm_setzero_si128()
         } else {
             let r = simd_shr(a.as_u32x4(), u32x4::splat(IMM8));
-            transmute::<core_arch::simd::Simd<u32, 4>, core_arch::x86::__m128i>(simd_select_bitmask(k, r, u32x4::ZERO))
+            transmute::<u32x4, __m128i>(simd_select_bitmask(k, r, u32x4::ZERO))
         }
     }
 }
@@ -20344,7 +20344,7 @@ pub const fn _mm512_slli_epi64<const IMM8: u32>(a: __m512i) -> __m512i {
         if IMM8 >= 64 {
             _mm512_setzero_si512()
         } else {
-            transmute::<core_arch::simd::Simd<u64, 8>, core_arch::x86::__m512i>(simd_shl(a.as_u64x8(), u64x8::splat(IMM8 as u64)))
+            transmute::<u64x8, __m512i>(simd_shl(a.as_u64x8(), u64x8::splat(IMM8 as u64)))
         }
     }
 }
@@ -20390,7 +20390,7 @@ pub const fn _mm512_maskz_slli_epi64<const IMM8: u32>(k: __mmask8, a: __m512i) -
             _mm512_setzero_si512()
         } else {
             let shf = simd_shl(a.as_u64x8(), u64x8::splat(IMM8 as u64));
-            transmute::<core_arch::simd::Simd<u64, 8>, core_arch::x86::__m512i>(simd_select_bitmask(k, shf, u64x8::ZERO))
+            transmute::<u64x8, __m512i>(simd_select_bitmask(k, shf, u64x8::ZERO))
         }
     }
 }
@@ -20436,7 +20436,7 @@ pub const fn _mm256_maskz_slli_epi64<const IMM8: u32>(k: __mmask8, a: __m256i) -
             _mm256_setzero_si256()
         } else {
             let r = simd_shl(a.as_u64x4(), u64x4::splat(IMM8 as u64));
-            transmute::<core_arch::simd::Simd<u64, 4>, core_arch::x86::__m256i>(simd_select_bitmask(k, r, u64x4::ZERO))
+            transmute::<u64x4, __m256i>(simd_select_bitmask(k, r, u64x4::ZERO))
         }
     }
 }
@@ -20482,7 +20482,7 @@ pub const fn _mm_maskz_slli_epi64<const IMM8: u32>(k: __mmask8, a: __m128i) -> _
             _mm_setzero_si128()
         } else {
             let r = simd_shl(a.as_u64x2(), u64x2::splat(IMM8 as u64));
-            transmute::<core_arch::simd::Simd<u64, 2>, core_arch::x86::__m128i>(simd_select_bitmask(k, r, u64x2::ZERO))
+            transmute::<u64x2, __m128i>(simd_select_bitmask(k, r, u64x2::ZERO))
         }
     }
 }
@@ -20502,7 +20502,7 @@ pub const fn _mm512_srli_epi64<const IMM8: u32>(a: __m512i) -> __m512i {
         if IMM8 >= 64 {
             _mm512_setzero_si512()
         } else {
-            transmute::<core_arch::simd::Simd<u64, 8>, core_arch::x86::__m512i>(simd_shr(a.as_u64x8(), u64x8::splat(IMM8 as u64)))
+            transmute::<u64x8, __m512i>(simd_shr(a.as_u64x8(), u64x8::splat(IMM8 as u64)))
         }
     }
 }
@@ -20548,7 +20548,7 @@ pub const fn _mm512_maskz_srli_epi64<const IMM8: u32>(k: __mmask8, a: __m512i) -
             _mm512_setzero_si512()
         } else {
             let shf = simd_shr(a.as_u64x8(), u64x8::splat(IMM8 as u64));
-            transmute::<core_arch::simd::Simd<u64, 8>, core_arch::x86::__m512i>(simd_select_bitmask(k, shf, u64x8::ZERO))
+            transmute::<u64x8, __m512i>(simd_select_bitmask(k, shf, u64x8::ZERO))
         }
     }
 }
@@ -20594,7 +20594,7 @@ pub const fn _mm256_maskz_srli_epi64<const IMM8: u32>(k: __mmask8, a: __m256i) -
             _mm256_setzero_si256()
         } else {
             let r = simd_shr(a.as_u64x4(), u64x4::splat(IMM8 as u64));
-            transmute::<core_arch::simd::Simd<u64, 4>, core_arch::x86::__m256i>(simd_select_bitmask(k, r, u64x4::ZERO))
+            transmute::<u64x4, __m256i>(simd_select_bitmask(k, r, u64x4::ZERO))
         }
     }
 }
@@ -20640,7 +20640,7 @@ pub const fn _mm_maskz_srli_epi64<const IMM8: u32>(k: __mmask8, a: __m128i) -> _
             _mm_setzero_si128()
         } else {
             let r = simd_shr(a.as_u64x2(), u64x2::splat(IMM8 as u64));
-            transmute::<core_arch::simd::Simd<u64, 2>, core_arch::x86::__m128i>(simd_select_bitmask(k, r, u64x2::ZERO))
+            transmute::<u64x2, __m128i>(simd_select_bitmask(k, r, u64x2::ZERO))
         }
     }
 }
@@ -21537,7 +21537,7 @@ pub const fn _mm512_srav_epi32(a: __m512i, count: __m512i) -> __m512i {
     unsafe {
         let count = count.as_u32x16();
         let no_overflow: u32x16 = simd_lt(count, u32x16::splat(u32::BITS));
-        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u32, 16>, core_arch::simd::Simd<i32, 16>>(count), i32x16::splat(31));
+        let count = simd_select(no_overflow, transmute::<u32x16, i32x16>(count), i32x16::splat(31));
         simd_shr(a.as_i32x16(), count).as_m512i()
     }
 }
@@ -21654,7 +21654,7 @@ pub const fn _mm512_srav_epi64(a: __m512i, count: __m512i) -> __m512i {
     unsafe {
         let count = count.as_u64x8();
         let no_overflow: u64x8 = simd_lt(count, u64x8::splat(u64::BITS as u64));
-        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u64, 8>, core_arch::simd::Simd<i64, 8>>(count), i64x8::splat(63));
+        let count = simd_select(no_overflow, transmute::<u64x8, i64x8>(count), i64x8::splat(63));
         simd_shr(a.as_i64x8(), count).as_m512i()
     }
 }
@@ -21706,7 +21706,7 @@ pub const fn _mm256_srav_epi64(a: __m256i, count: __m256i) -> __m256i {
     unsafe {
         let count = count.as_u64x4();
         let no_overflow: u64x4 = simd_lt(count, u64x4::splat(u64::BITS as u64));
-        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u64, 4>, core_arch::simd::Simd<i64, 4>>(count), i64x4::splat(63));
+        let count = simd_select(no_overflow, transmute::<u64x4, i64x4>(count), i64x4::splat(63));
         simd_shr(a.as_i64x4(), count).as_m256i()
     }
 }
@@ -21758,7 +21758,7 @@ pub const fn _mm_srav_epi64(a: __m128i, count: __m128i) -> __m128i {
     unsafe {
         let count = count.as_u64x2();
         let no_overflow: u64x2 = simd_lt(count, u64x2::splat(u64::BITS as u64));
-        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u64, 2>, core_arch::simd::Simd<i64, 2>>(count), i64x2::splat(63));
+        let count = simd_select(no_overflow, transmute::<u64x2, i64x2>(count), i64x2::splat(63));
         simd_shr(a.as_i64x2(), count).as_m128i()
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/avx512f.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx512f.rs
@@ -20028,7 +20028,7 @@ pub const fn _mm512_slli_epi32<const IMM8: u32>(a: __m512i) -> __m512i {
         if IMM8 >= 32 {
             _mm512_setzero_si512()
         } else {
-            transmute(simd_shl(a.as_u32x16(), u32x16::splat(IMM8)))
+            transmute::<core_arch::simd::Simd<u32, 16>, core_arch::x86::__m512i>(simd_shl(a.as_u32x16(), u32x16::splat(IMM8)))
         }
     }
 }
@@ -20074,7 +20074,7 @@ pub const fn _mm512_maskz_slli_epi32<const IMM8: u32>(k: __mmask16, a: __m512i) 
             _mm512_setzero_si512()
         } else {
             let shf = simd_shl(a.as_u32x16(), u32x16::splat(IMM8));
-            transmute(simd_select_bitmask(k, shf, u32x16::ZERO))
+            transmute::<core_arch::simd::Simd<u32, 16>, core_arch::x86::__m512i>(simd_select_bitmask(k, shf, u32x16::ZERO))
         }
     }
 }
@@ -20120,7 +20120,7 @@ pub const fn _mm256_maskz_slli_epi32<const IMM8: u32>(k: __mmask8, a: __m256i) -
             _mm256_setzero_si256()
         } else {
             let r = simd_shl(a.as_u32x8(), u32x8::splat(IMM8));
-            transmute(simd_select_bitmask(k, r, u32x8::ZERO))
+            transmute::<core_arch::simd::Simd<u32, 8>, core_arch::x86::__m256i>(simd_select_bitmask(k, r, u32x8::ZERO))
         }
     }
 }
@@ -20166,7 +20166,7 @@ pub const fn _mm_maskz_slli_epi32<const IMM8: u32>(k: __mmask8, a: __m128i) -> _
             _mm_setzero_si128()
         } else {
             let r = simd_shl(a.as_u32x4(), u32x4::splat(IMM8));
-            transmute(simd_select_bitmask(k, r, u32x4::ZERO))
+            transmute::<core_arch::simd::Simd<u32, 4>, core_arch::x86::__m128i>(simd_select_bitmask(k, r, u32x4::ZERO))
         }
     }
 }
@@ -20186,7 +20186,7 @@ pub const fn _mm512_srli_epi32<const IMM8: u32>(a: __m512i) -> __m512i {
         if IMM8 >= 32 {
             _mm512_setzero_si512()
         } else {
-            transmute(simd_shr(a.as_u32x16(), u32x16::splat(IMM8)))
+            transmute::<core_arch::simd::Simd<u32, 16>, core_arch::x86::__m512i>(simd_shr(a.as_u32x16(), u32x16::splat(IMM8)))
         }
     }
 }
@@ -20232,7 +20232,7 @@ pub const fn _mm512_maskz_srli_epi32<const IMM8: u32>(k: __mmask16, a: __m512i) 
             _mm512_setzero_si512()
         } else {
             let shf = simd_shr(a.as_u32x16(), u32x16::splat(IMM8));
-            transmute(simd_select_bitmask(k, shf, u32x16::ZERO))
+            transmute::<core_arch::simd::Simd<u32, 16>, core_arch::x86::__m512i>(simd_select_bitmask(k, shf, u32x16::ZERO))
         }
     }
 }
@@ -20278,7 +20278,7 @@ pub const fn _mm256_maskz_srli_epi32<const IMM8: u32>(k: __mmask8, a: __m256i) -
             _mm256_setzero_si256()
         } else {
             let r = simd_shr(a.as_u32x8(), u32x8::splat(IMM8));
-            transmute(simd_select_bitmask(k, r, u32x8::ZERO))
+            transmute::<core_arch::simd::Simd<u32, 8>, core_arch::x86::__m256i>(simd_select_bitmask(k, r, u32x8::ZERO))
         }
     }
 }
@@ -20324,7 +20324,7 @@ pub const fn _mm_maskz_srli_epi32<const IMM8: u32>(k: __mmask8, a: __m128i) -> _
             _mm_setzero_si128()
         } else {
             let r = simd_shr(a.as_u32x4(), u32x4::splat(IMM8));
-            transmute(simd_select_bitmask(k, r, u32x4::ZERO))
+            transmute::<core_arch::simd::Simd<u32, 4>, core_arch::x86::__m128i>(simd_select_bitmask(k, r, u32x4::ZERO))
         }
     }
 }
@@ -20344,7 +20344,7 @@ pub const fn _mm512_slli_epi64<const IMM8: u32>(a: __m512i) -> __m512i {
         if IMM8 >= 64 {
             _mm512_setzero_si512()
         } else {
-            transmute(simd_shl(a.as_u64x8(), u64x8::splat(IMM8 as u64)))
+            transmute::<core_arch::simd::Simd<u64, 8>, core_arch::x86::__m512i>(simd_shl(a.as_u64x8(), u64x8::splat(IMM8 as u64)))
         }
     }
 }
@@ -20390,7 +20390,7 @@ pub const fn _mm512_maskz_slli_epi64<const IMM8: u32>(k: __mmask8, a: __m512i) -
             _mm512_setzero_si512()
         } else {
             let shf = simd_shl(a.as_u64x8(), u64x8::splat(IMM8 as u64));
-            transmute(simd_select_bitmask(k, shf, u64x8::ZERO))
+            transmute::<core_arch::simd::Simd<u64, 8>, core_arch::x86::__m512i>(simd_select_bitmask(k, shf, u64x8::ZERO))
         }
     }
 }
@@ -20436,7 +20436,7 @@ pub const fn _mm256_maskz_slli_epi64<const IMM8: u32>(k: __mmask8, a: __m256i) -
             _mm256_setzero_si256()
         } else {
             let r = simd_shl(a.as_u64x4(), u64x4::splat(IMM8 as u64));
-            transmute(simd_select_bitmask(k, r, u64x4::ZERO))
+            transmute::<core_arch::simd::Simd<u64, 4>, core_arch::x86::__m256i>(simd_select_bitmask(k, r, u64x4::ZERO))
         }
     }
 }
@@ -20482,7 +20482,7 @@ pub const fn _mm_maskz_slli_epi64<const IMM8: u32>(k: __mmask8, a: __m128i) -> _
             _mm_setzero_si128()
         } else {
             let r = simd_shl(a.as_u64x2(), u64x2::splat(IMM8 as u64));
-            transmute(simd_select_bitmask(k, r, u64x2::ZERO))
+            transmute::<core_arch::simd::Simd<u64, 2>, core_arch::x86::__m128i>(simd_select_bitmask(k, r, u64x2::ZERO))
         }
     }
 }
@@ -20502,7 +20502,7 @@ pub const fn _mm512_srli_epi64<const IMM8: u32>(a: __m512i) -> __m512i {
         if IMM8 >= 64 {
             _mm512_setzero_si512()
         } else {
-            transmute(simd_shr(a.as_u64x8(), u64x8::splat(IMM8 as u64)))
+            transmute::<core_arch::simd::Simd<u64, 8>, core_arch::x86::__m512i>(simd_shr(a.as_u64x8(), u64x8::splat(IMM8 as u64)))
         }
     }
 }
@@ -20548,7 +20548,7 @@ pub const fn _mm512_maskz_srli_epi64<const IMM8: u32>(k: __mmask8, a: __m512i) -
             _mm512_setzero_si512()
         } else {
             let shf = simd_shr(a.as_u64x8(), u64x8::splat(IMM8 as u64));
-            transmute(simd_select_bitmask(k, shf, u64x8::ZERO))
+            transmute::<core_arch::simd::Simd<u64, 8>, core_arch::x86::__m512i>(simd_select_bitmask(k, shf, u64x8::ZERO))
         }
     }
 }
@@ -20594,7 +20594,7 @@ pub const fn _mm256_maskz_srli_epi64<const IMM8: u32>(k: __mmask8, a: __m256i) -
             _mm256_setzero_si256()
         } else {
             let r = simd_shr(a.as_u64x4(), u64x4::splat(IMM8 as u64));
-            transmute(simd_select_bitmask(k, r, u64x4::ZERO))
+            transmute::<core_arch::simd::Simd<u64, 4>, core_arch::x86::__m256i>(simd_select_bitmask(k, r, u64x4::ZERO))
         }
     }
 }
@@ -20640,7 +20640,7 @@ pub const fn _mm_maskz_srli_epi64<const IMM8: u32>(k: __mmask8, a: __m128i) -> _
             _mm_setzero_si128()
         } else {
             let r = simd_shr(a.as_u64x2(), u64x2::splat(IMM8 as u64));
-            transmute(simd_select_bitmask(k, r, u64x2::ZERO))
+            transmute::<core_arch::simd::Simd<u64, 2>, core_arch::x86::__m128i>(simd_select_bitmask(k, r, u64x2::ZERO))
         }
     }
 }
@@ -21537,7 +21537,7 @@ pub const fn _mm512_srav_epi32(a: __m512i, count: __m512i) -> __m512i {
     unsafe {
         let count = count.as_u32x16();
         let no_overflow: u32x16 = simd_lt(count, u32x16::splat(u32::BITS));
-        let count = simd_select(no_overflow, transmute(count), i32x16::splat(31));
+        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u32, 16>, core_arch::simd::Simd<i32, 16>>(count), i32x16::splat(31));
         simd_shr(a.as_i32x16(), count).as_m512i()
     }
 }
@@ -21654,7 +21654,7 @@ pub const fn _mm512_srav_epi64(a: __m512i, count: __m512i) -> __m512i {
     unsafe {
         let count = count.as_u64x8();
         let no_overflow: u64x8 = simd_lt(count, u64x8::splat(u64::BITS as u64));
-        let count = simd_select(no_overflow, transmute(count), i64x8::splat(63));
+        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u64, 8>, core_arch::simd::Simd<i64, 8>>(count), i64x8::splat(63));
         simd_shr(a.as_i64x8(), count).as_m512i()
     }
 }
@@ -21706,7 +21706,7 @@ pub const fn _mm256_srav_epi64(a: __m256i, count: __m256i) -> __m256i {
     unsafe {
         let count = count.as_u64x4();
         let no_overflow: u64x4 = simd_lt(count, u64x4::splat(u64::BITS as u64));
-        let count = simd_select(no_overflow, transmute(count), i64x4::splat(63));
+        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u64, 4>, core_arch::simd::Simd<i64, 4>>(count), i64x4::splat(63));
         simd_shr(a.as_i64x4(), count).as_m256i()
     }
 }
@@ -21758,7 +21758,7 @@ pub const fn _mm_srav_epi64(a: __m128i, count: __m128i) -> __m128i {
     unsafe {
         let count = count.as_u64x2();
         let no_overflow: u64x2 = simd_lt(count, u64x2::splat(u64::BITS as u64));
-        let count = simd_select(no_overflow, transmute(count), i64x2::splat(63));
+        let count = simd_select(no_overflow, transmute::<core_arch::simd::Simd<u64, 2>, core_arch::simd::Simd<i64, 2>>(count), i64x2::splat(63));
         simd_shr(a.as_i64x2(), count).as_m128i()
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/avx512fp16.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx512fp16.rs
@@ -2708,7 +2708,7 @@ pub fn _mm_mul_pch(a: __m128h, b: __m128h) -> __m128h {
 #[cfg_attr(test, assert_instr(vfmulcph))]
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 pub fn _mm_mask_mul_pch(src: __m128h, k: __mmask8, a: __m128h, b: __m128h) -> __m128h {
-    unsafe { transmute(vfmulcph_128(transmute(a), transmute(b), transmute(src), k)) }
+    unsafe { transmute(vfmulcph_128(transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(src), k)) }
 }
 
 /// Multiply packed complex numbers in a and b, and store the results in dst using zeromask k (the element
@@ -2747,7 +2747,7 @@ pub fn _mm256_mul_pch(a: __m256h, b: __m256h) -> __m256h {
 #[cfg_attr(test, assert_instr(vfmulcph))]
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 pub fn _mm256_mask_mul_pch(src: __m256h, k: __mmask8, a: __m256h, b: __m256h) -> __m256h {
-    unsafe { transmute(vfmulcph_256(transmute(a), transmute(b), transmute(src), k)) }
+    unsafe { transmute(vfmulcph_256(transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a), transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(b), transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(src), k)) }
 }
 
 /// Multiply packed complex numbers in a and b, and store the results in dst using zeromask k (the element
@@ -2852,9 +2852,9 @@ pub fn _mm512_mask_mul_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfmulcph_512(
-            transmute(a),
-            transmute(b),
-            transmute(src),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(b),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(src),
             k,
             ROUNDING,
         ))
@@ -2982,9 +2982,9 @@ pub fn _mm_mask_mul_round_sch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfmulcsh(
-            transmute(a),
-            transmute(b),
-            transmute(src),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(src),
             k,
             ROUNDING,
         ))
@@ -3350,7 +3350,7 @@ pub fn _mm_cmul_pch(a: __m128h, b: __m128h) -> __m128h {
 #[cfg_attr(test, assert_instr(vfcmulcph))]
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 pub fn _mm_mask_cmul_pch(src: __m128h, k: __mmask8, a: __m128h, b: __m128h) -> __m128h {
-    unsafe { transmute(vfcmulcph_128(transmute(a), transmute(b), transmute(src), k)) }
+    unsafe { transmute(vfcmulcph_128(transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(src), k)) }
 }
 
 /// Multiply packed complex numbers in a by the complex conjugates of packed complex numbers in b, and
@@ -3392,7 +3392,7 @@ pub fn _mm256_cmul_pch(a: __m256h, b: __m256h) -> __m256h {
 #[cfg_attr(test, assert_instr(vfcmulcph))]
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 pub fn _mm256_mask_cmul_pch(src: __m256h, k: __mmask8, a: __m256h, b: __m256h) -> __m256h {
-    unsafe { transmute(vfcmulcph_256(transmute(a), transmute(b), transmute(src), k)) }
+    unsafe { transmute(vfcmulcph_256(transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a), transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(b), transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(src), k)) }
 }
 
 /// Multiply packed complex numbers in a by the complex conjugates of packed complex numbers in b, and
@@ -3503,9 +3503,9 @@ pub fn _mm512_mask_cmul_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfcmulcph_512(
-            transmute(a),
-            transmute(b),
-            transmute(src),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(b),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(src),
             k,
             ROUNDING,
         ))
@@ -3632,9 +3632,9 @@ pub fn _mm_mask_cmul_round_sch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfcmulcsh(
-            transmute(a),
-            transmute(b),
-            transmute(src),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(src),
             k,
             ROUNDING,
         ))
@@ -4006,7 +4006,7 @@ pub fn _mm_maskz_fcmul_round_sch<const ROUNDING: i32>(
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_abs_ph(v2: __m128h) -> __m128h {
-    unsafe { transmute(_mm_and_si128(transmute(v2), _mm_set1_epi16(i16::MAX))) }
+    unsafe { transmute(_mm_and_si128(transmute::<core_arch::x86::__m128h, core_arch::x86::__m128i>(v2), _mm_set1_epi16(i16::MAX))) }
 }
 
 /// Finds the absolute value of each packed half-precision (16-bit) floating-point element in v2, storing
@@ -4018,7 +4018,7 @@ pub const fn _mm_abs_ph(v2: __m128h) -> __m128h {
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm256_abs_ph(v2: __m256h) -> __m256h {
-    unsafe { transmute(_mm256_and_si256(transmute(v2), _mm256_set1_epi16(i16::MAX))) }
+    unsafe { transmute(_mm256_and_si256(transmute::<core_arch::x86::__m256h, core_arch::x86::__m256i>(v2), _mm256_set1_epi16(i16::MAX))) }
 }
 
 /// Finds the absolute value of each packed half-precision (16-bit) floating-point element in v2, storing
@@ -4030,7 +4030,7 @@ pub const fn _mm256_abs_ph(v2: __m256h) -> __m256h {
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_abs_ph(v2: __m512h) -> __m512h {
-    unsafe { transmute(_mm512_and_si512(transmute(v2), _mm512_set1_epi16(i16::MAX))) }
+    unsafe { transmute(_mm512_and_si512(transmute::<core_arch::x86::__m512h, core_arch::x86::__m512i>(v2), _mm512_set1_epi16(i16::MAX))) }
 }
 
 /// Compute the complex conjugates of complex numbers in a, and store the results in dst. Each complex
@@ -4044,7 +4044,7 @@ pub const fn _mm512_abs_ph(v2: __m512h) -> __m512h {
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_conj_pch(a: __m128h) -> __m128h {
-    unsafe { transmute(_mm_xor_si128(transmute(a), _mm_set1_epi32(i32::MIN))) }
+    unsafe { transmute(_mm_xor_si128(transmute::<core_arch::x86::__m128h, core_arch::x86::__m128i>(a), _mm_set1_epi32(i32::MIN))) }
 }
 
 /// Compute the complex conjugates of complex numbers in a, and store the results in dst using writemask k
@@ -4060,7 +4060,7 @@ pub const fn _mm_conj_pch(a: __m128h) -> __m128h {
 pub const fn _mm_mask_conj_pch(src: __m128h, k: __mmask8, a: __m128h) -> __m128h {
     unsafe {
         let r: __m128 = transmute(_mm_conj_pch(a));
-        transmute(simd_select_bitmask(k, r, transmute(src)))
+        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(src)))
     }
 }
 
@@ -4088,7 +4088,7 @@ pub const fn _mm_maskz_conj_pch(k: __mmask8, a: __m128h) -> __m128h {
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm256_conj_pch(a: __m256h) -> __m256h {
-    unsafe { transmute(_mm256_xor_si256(transmute(a), _mm256_set1_epi32(i32::MIN))) }
+    unsafe { transmute(_mm256_xor_si256(transmute::<core_arch::x86::__m256h, core_arch::x86::__m256i>(a), _mm256_set1_epi32(i32::MIN))) }
 }
 
 /// Compute the complex conjugates of complex numbers in a, and store the results in dst using writemask k
@@ -4104,7 +4104,7 @@ pub const fn _mm256_conj_pch(a: __m256h) -> __m256h {
 pub const fn _mm256_mask_conj_pch(src: __m256h, k: __mmask8, a: __m256h) -> __m256h {
     unsafe {
         let r: __m256 = transmute(_mm256_conj_pch(a));
-        transmute(simd_select_bitmask(k, r, transmute(src)))
+        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(src)))
     }
 }
 
@@ -4132,7 +4132,7 @@ pub const fn _mm256_maskz_conj_pch(k: __mmask8, a: __m256h) -> __m256h {
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_conj_pch(a: __m512h) -> __m512h {
-    unsafe { transmute(_mm512_xor_si512(transmute(a), _mm512_set1_epi32(i32::MIN))) }
+    unsafe { transmute(_mm512_xor_si512(transmute::<core_arch::x86::__m512h, core_arch::x86::__m512i>(a), _mm512_set1_epi32(i32::MIN))) }
 }
 
 /// Compute the complex conjugates of complex numbers in a, and store the results in dst using writemask k
@@ -4148,7 +4148,7 @@ pub const fn _mm512_conj_pch(a: __m512h) -> __m512h {
 pub const fn _mm512_mask_conj_pch(src: __m512h, k: __mmask16, a: __m512h) -> __m512h {
     unsafe {
         let r: __m512 = transmute(_mm512_conj_pch(a));
-        transmute(simd_select_bitmask(k, r, transmute(src)))
+        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(src)))
     }
 }
 
@@ -4192,7 +4192,7 @@ pub fn _mm_fmadd_pch(a: __m128h, b: __m128h, c: __m128h) -> __m128h {
 pub fn _mm_mask_fmadd_pch(a: __m128h, k: __mmask8, b: __m128h, c: __m128h) -> __m128h {
     unsafe {
         let r: __m128 = transmute(_mm_mask3_fmadd_pch(a, b, c, k)); // using `0xff` would have been fine here, but this is what CLang does
-        transmute(simd_select_bitmask(k, r, transmute(a)))
+        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a)))
     }
 }
 
@@ -4209,9 +4209,9 @@ pub fn _mm_mask_fmadd_pch(a: __m128h, k: __mmask8, b: __m128h, c: __m128h) -> __
 pub fn _mm_mask3_fmadd_pch(a: __m128h, b: __m128h, c: __m128h, k: __mmask8) -> __m128h {
     unsafe {
         transmute(vfmaddcph_mask3_128(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
             k,
         ))
     }
@@ -4230,9 +4230,9 @@ pub fn _mm_mask3_fmadd_pch(a: __m128h, b: __m128h, c: __m128h, k: __mmask8) -> _
 pub fn _mm_maskz_fmadd_pch(k: __mmask8, a: __m128h, b: __m128h, c: __m128h) -> __m128h {
     unsafe {
         transmute(vfmaddcph_maskz_128(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
             k,
         ))
     }
@@ -4264,7 +4264,7 @@ pub fn _mm256_fmadd_pch(a: __m256h, b: __m256h, c: __m256h) -> __m256h {
 pub fn _mm256_mask_fmadd_pch(a: __m256h, k: __mmask8, b: __m256h, c: __m256h) -> __m256h {
     unsafe {
         let r: __m256 = transmute(_mm256_mask3_fmadd_pch(a, b, c, k)); // using `0xff` would have been fine here, but this is what CLang does
-        transmute(simd_select_bitmask(k, r, transmute(a)))
+        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a)))
     }
 }
 
@@ -4281,9 +4281,9 @@ pub fn _mm256_mask_fmadd_pch(a: __m256h, k: __mmask8, b: __m256h, c: __m256h) ->
 pub fn _mm256_mask3_fmadd_pch(a: __m256h, b: __m256h, c: __m256h, k: __mmask8) -> __m256h {
     unsafe {
         transmute(vfmaddcph_mask3_256(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a),
+            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(b),
+            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(c),
             k,
         ))
     }
@@ -4302,9 +4302,9 @@ pub fn _mm256_mask3_fmadd_pch(a: __m256h, b: __m256h, c: __m256h, k: __mmask8) -
 pub fn _mm256_maskz_fmadd_pch(k: __mmask8, a: __m256h, b: __m256h, c: __m256h) -> __m256h {
     unsafe {
         transmute(vfmaddcph_maskz_256(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a),
+            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(b),
+            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(c),
             k,
         ))
     }
@@ -4416,7 +4416,7 @@ pub fn _mm512_mask_fmadd_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         let r: __m512 = transmute(_mm512_mask3_fmadd_round_pch::<ROUNDING>(a, b, c, k)); // using `0xffff` would have been fine here, but this is what CLang does
-        transmute(simd_select_bitmask(k, r, transmute(a)))
+        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a)))
     }
 }
 
@@ -4448,9 +4448,9 @@ pub fn _mm512_mask3_fmadd_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfmaddcph_mask3_512(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(b),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(c),
             k,
             ROUNDING,
         ))
@@ -4485,9 +4485,9 @@ pub fn _mm512_maskz_fmadd_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfmaddcph_maskz_512(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(b),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(c),
             k,
             ROUNDING,
         ))
@@ -4575,9 +4575,9 @@ pub fn _mm_fmadd_round_sch<const ROUNDING: i32>(a: __m128h, b: __m128h, c: __m12
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfmaddcsh_mask(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
             0xff,
             ROUNDING,
         ))
@@ -4612,8 +4612,8 @@ pub fn _mm_mask_fmadd_round_sch<const ROUNDING: i32>(
 ) -> __m128h {
     unsafe {
         static_assert_rounding!(ROUNDING);
-        let a = transmute(a);
-        let r = vfmaddcsh_mask(a, transmute(b), transmute(c), k, ROUNDING); // using `0xff` would have been fine here, but this is what CLang does
+        let a = transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a);
+        let r = vfmaddcsh_mask(a, transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c), k, ROUNDING); // using `0xff` would have been fine here, but this is what CLang does
         transmute(_mm_mask_move_ss(a, k, a, r))
     }
 }
@@ -4646,8 +4646,8 @@ pub fn _mm_mask3_fmadd_round_sch<const ROUNDING: i32>(
 ) -> __m128h {
     unsafe {
         static_assert_rounding!(ROUNDING);
-        let c = transmute(c);
-        let r = vfmaddcsh_mask(transmute(a), transmute(b), c, k, ROUNDING);
+        let c = transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c);
+        let r = vfmaddcsh_mask(transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b), c, k, ROUNDING);
         transmute(_mm_move_ss(c, r))
     }
 }
@@ -4681,9 +4681,9 @@ pub fn _mm_maskz_fmadd_round_sch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfmaddcsh_maskz(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
             k,
             ROUNDING,
         ))
@@ -4718,7 +4718,7 @@ pub fn _mm_fcmadd_pch(a: __m128h, b: __m128h, c: __m128h) -> __m128h {
 pub fn _mm_mask_fcmadd_pch(a: __m128h, k: __mmask8, b: __m128h, c: __m128h) -> __m128h {
     unsafe {
         let r: __m128 = transmute(_mm_mask3_fcmadd_pch(a, b, c, k)); // using `0xff` would have been fine here, but this is what CLang does
-        transmute(simd_select_bitmask(k, r, transmute(a)))
+        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a)))
     }
 }
 
@@ -4736,9 +4736,9 @@ pub fn _mm_mask_fcmadd_pch(a: __m128h, k: __mmask8, b: __m128h, c: __m128h) -> _
 pub fn _mm_mask3_fcmadd_pch(a: __m128h, b: __m128h, c: __m128h, k: __mmask8) -> __m128h {
     unsafe {
         transmute(vfcmaddcph_mask3_128(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
             k,
         ))
     }
@@ -4758,9 +4758,9 @@ pub fn _mm_mask3_fcmadd_pch(a: __m128h, b: __m128h, c: __m128h, k: __mmask8) -> 
 pub fn _mm_maskz_fcmadd_pch(k: __mmask8, a: __m128h, b: __m128h, c: __m128h) -> __m128h {
     unsafe {
         transmute(vfcmaddcph_maskz_128(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
             k,
         ))
     }
@@ -4794,7 +4794,7 @@ pub fn _mm256_fcmadd_pch(a: __m256h, b: __m256h, c: __m256h) -> __m256h {
 pub fn _mm256_mask_fcmadd_pch(a: __m256h, k: __mmask8, b: __m256h, c: __m256h) -> __m256h {
     unsafe {
         let r: __m256 = transmute(_mm256_mask3_fcmadd_pch(a, b, c, k)); // using `0xff` would have been fine here, but this is what CLang does
-        transmute(simd_select_bitmask(k, r, transmute(a)))
+        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a)))
     }
 }
 
@@ -4812,9 +4812,9 @@ pub fn _mm256_mask_fcmadd_pch(a: __m256h, k: __mmask8, b: __m256h, c: __m256h) -
 pub fn _mm256_mask3_fcmadd_pch(a: __m256h, b: __m256h, c: __m256h, k: __mmask8) -> __m256h {
     unsafe {
         transmute(vfcmaddcph_mask3_256(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a),
+            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(b),
+            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(c),
             k,
         ))
     }
@@ -4834,9 +4834,9 @@ pub fn _mm256_mask3_fcmadd_pch(a: __m256h, b: __m256h, c: __m256h, k: __mmask8) 
 pub fn _mm256_maskz_fcmadd_pch(k: __mmask8, a: __m256h, b: __m256h, c: __m256h) -> __m256h {
     unsafe {
         transmute(vfcmaddcph_maskz_256(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a),
+            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(b),
+            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(c),
             k,
         ))
     }
@@ -4954,7 +4954,7 @@ pub fn _mm512_mask_fcmadd_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         let r: __m512 = transmute(_mm512_mask3_fcmadd_round_pch::<ROUNDING>(a, b, c, k)); // using `0xffff` would have been fine here, but this is what CLang does
-        transmute(simd_select_bitmask(k, r, transmute(a)))
+        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a)))
     }
 }
 
@@ -4987,9 +4987,9 @@ pub fn _mm512_mask3_fcmadd_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfcmaddcph_mask3_512(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(b),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(c),
             k,
             ROUNDING,
         ))
@@ -5025,9 +5025,9 @@ pub fn _mm512_maskz_fcmadd_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfcmaddcph_maskz_512(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(b),
+            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(c),
             k,
             ROUNDING,
         ))
@@ -5121,9 +5121,9 @@ pub fn _mm_fcmadd_round_sch<const ROUNDING: i32>(a: __m128h, b: __m128h, c: __m1
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfcmaddcsh_mask(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
             0xff,
             ROUNDING,
         ))
@@ -5159,8 +5159,8 @@ pub fn _mm_mask_fcmadd_round_sch<const ROUNDING: i32>(
 ) -> __m128h {
     unsafe {
         static_assert_rounding!(ROUNDING);
-        let a = transmute(a);
-        let r = vfcmaddcsh_mask(a, transmute(b), transmute(c), k, ROUNDING);
+        let a = transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a);
+        let r = vfcmaddcsh_mask(a, transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c), k, ROUNDING);
         transmute(_mm_mask_move_ss(a, k, a, r))
     }
 }
@@ -5194,8 +5194,8 @@ pub fn _mm_mask3_fcmadd_round_sch<const ROUNDING: i32>(
 ) -> __m128h {
     unsafe {
         static_assert_rounding!(ROUNDING);
-        let c = transmute(c);
-        let r = vfcmaddcsh_mask(transmute(a), transmute(b), c, k, ROUNDING);
+        let c = transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c);
+        let r = vfcmaddcsh_mask(transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b), c, k, ROUNDING);
         transmute(_mm_move_ss(c, r))
     }
 }
@@ -5230,9 +5230,9 @@ pub fn _mm_maskz_fcmadd_round_sch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfcmaddcsh_maskz(
-            transmute(a),
-            transmute(b),
-            transmute(c),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
+            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
             k,
             ROUNDING,
         ))

--- a/library/stdarch/crates/core_arch/src/x86/avx512fp16.rs
+++ b/library/stdarch/crates/core_arch/src/x86/avx512fp16.rs
@@ -2708,7 +2708,7 @@ pub fn _mm_mul_pch(a: __m128h, b: __m128h) -> __m128h {
 #[cfg_attr(test, assert_instr(vfmulcph))]
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 pub fn _mm_mask_mul_pch(src: __m128h, k: __mmask8, a: __m128h, b: __m128h) -> __m128h {
-    unsafe { transmute(vfmulcph_128(transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(src), k)) }
+    unsafe { transmute(vfmulcph_128(transmute::<__m128h, __m128>(a), transmute::<__m128h, __m128>(b), transmute::<__m128h, __m128>(src), k)) }
 }
 
 /// Multiply packed complex numbers in a and b, and store the results in dst using zeromask k (the element
@@ -2747,7 +2747,7 @@ pub fn _mm256_mul_pch(a: __m256h, b: __m256h) -> __m256h {
 #[cfg_attr(test, assert_instr(vfmulcph))]
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 pub fn _mm256_mask_mul_pch(src: __m256h, k: __mmask8, a: __m256h, b: __m256h) -> __m256h {
-    unsafe { transmute(vfmulcph_256(transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a), transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(b), transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(src), k)) }
+    unsafe { transmute(vfmulcph_256(transmute::<__m256h, __m256>(a), transmute::<__m256h, __m256>(b), transmute::<__m256h, __m256>(src), k)) }
 }
 
 /// Multiply packed complex numbers in a and b, and store the results in dst using zeromask k (the element
@@ -2852,9 +2852,9 @@ pub fn _mm512_mask_mul_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfmulcph_512(
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a),
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(b),
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(src),
+            transmute::<__m512h, __m512>(a),
+            transmute::<__m512h, __m512>(b),
+            transmute::<__m512h, __m512>(src),
             k,
             ROUNDING,
         ))
@@ -2982,9 +2982,9 @@ pub fn _mm_mask_mul_round_sch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfmulcsh(
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(src),
+            transmute::<__m128h, __m128>(a),
+            transmute::<__m128h, __m128>(b),
+            transmute::<__m128h, __m128>(src),
             k,
             ROUNDING,
         ))
@@ -3350,7 +3350,7 @@ pub fn _mm_cmul_pch(a: __m128h, b: __m128h) -> __m128h {
 #[cfg_attr(test, assert_instr(vfcmulcph))]
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 pub fn _mm_mask_cmul_pch(src: __m128h, k: __mmask8, a: __m128h, b: __m128h) -> __m128h {
-    unsafe { transmute(vfcmulcph_128(transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(src), k)) }
+    unsafe { transmute(vfcmulcph_128(transmute::<__m128h, __m128>(a), transmute::<__m128h, __m128>(b), transmute::<__m128h, __m128>(src), k)) }
 }
 
 /// Multiply packed complex numbers in a by the complex conjugates of packed complex numbers in b, and
@@ -3392,7 +3392,7 @@ pub fn _mm256_cmul_pch(a: __m256h, b: __m256h) -> __m256h {
 #[cfg_attr(test, assert_instr(vfcmulcph))]
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 pub fn _mm256_mask_cmul_pch(src: __m256h, k: __mmask8, a: __m256h, b: __m256h) -> __m256h {
-    unsafe { transmute(vfcmulcph_256(transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a), transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(b), transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(src), k)) }
+    unsafe { transmute(vfcmulcph_256(transmute::<__m256h, __m256>(a), transmute::<__m256h, __m256>(b), transmute::<__m256h, __m256>(src), k)) }
 }
 
 /// Multiply packed complex numbers in a by the complex conjugates of packed complex numbers in b, and
@@ -3503,9 +3503,9 @@ pub fn _mm512_mask_cmul_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfcmulcph_512(
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a),
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(b),
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(src),
+            transmute::<__m512h, __m512>(a),
+            transmute::<__m512h, __m512>(b),
+            transmute::<__m512h, __m512>(src),
             k,
             ROUNDING,
         ))
@@ -3632,9 +3632,9 @@ pub fn _mm_mask_cmul_round_sch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfcmulcsh(
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(src),
+            transmute::<__m128h, __m128>(a),
+            transmute::<__m128h, __m128>(b),
+            transmute::<__m128h, __m128>(src),
             k,
             ROUNDING,
         ))
@@ -4006,7 +4006,7 @@ pub fn _mm_maskz_fcmul_round_sch<const ROUNDING: i32>(
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_abs_ph(v2: __m128h) -> __m128h {
-    unsafe { transmute(_mm_and_si128(transmute::<core_arch::x86::__m128h, core_arch::x86::__m128i>(v2), _mm_set1_epi16(i16::MAX))) }
+    unsafe { transmute(_mm_and_si128(transmute::<__m128h, __m128i>(v2), _mm_set1_epi16(i16::MAX))) }
 }
 
 /// Finds the absolute value of each packed half-precision (16-bit) floating-point element in v2, storing
@@ -4018,7 +4018,7 @@ pub const fn _mm_abs_ph(v2: __m128h) -> __m128h {
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm256_abs_ph(v2: __m256h) -> __m256h {
-    unsafe { transmute(_mm256_and_si256(transmute::<core_arch::x86::__m256h, core_arch::x86::__m256i>(v2), _mm256_set1_epi16(i16::MAX))) }
+    unsafe { transmute(_mm256_and_si256(transmute::<__m256h, __m256i>(v2), _mm256_set1_epi16(i16::MAX))) }
 }
 
 /// Finds the absolute value of each packed half-precision (16-bit) floating-point element in v2, storing
@@ -4030,7 +4030,7 @@ pub const fn _mm256_abs_ph(v2: __m256h) -> __m256h {
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_abs_ph(v2: __m512h) -> __m512h {
-    unsafe { transmute(_mm512_and_si512(transmute::<core_arch::x86::__m512h, core_arch::x86::__m512i>(v2), _mm512_set1_epi16(i16::MAX))) }
+    unsafe { transmute(_mm512_and_si512(transmute::<__m512h, __m512i>(v2), _mm512_set1_epi16(i16::MAX))) }
 }
 
 /// Compute the complex conjugates of complex numbers in a, and store the results in dst. Each complex
@@ -4044,7 +4044,7 @@ pub const fn _mm512_abs_ph(v2: __m512h) -> __m512h {
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_conj_pch(a: __m128h) -> __m128h {
-    unsafe { transmute(_mm_xor_si128(transmute::<core_arch::x86::__m128h, core_arch::x86::__m128i>(a), _mm_set1_epi32(i32::MIN))) }
+    unsafe { transmute(_mm_xor_si128(transmute::<__m128h, __m128i>(a), _mm_set1_epi32(i32::MIN))) }
 }
 
 /// Compute the complex conjugates of complex numbers in a, and store the results in dst using writemask k
@@ -4060,7 +4060,7 @@ pub const fn _mm_conj_pch(a: __m128h) -> __m128h {
 pub const fn _mm_mask_conj_pch(src: __m128h, k: __mmask8, a: __m128h) -> __m128h {
     unsafe {
         let r: __m128 = transmute(_mm_conj_pch(a));
-        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(src)))
+        transmute(simd_select_bitmask(k, r, transmute::<__m128h, __m128>(src)))
     }
 }
 
@@ -4088,7 +4088,7 @@ pub const fn _mm_maskz_conj_pch(k: __mmask8, a: __m128h) -> __m128h {
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm256_conj_pch(a: __m256h) -> __m256h {
-    unsafe { transmute(_mm256_xor_si256(transmute::<core_arch::x86::__m256h, core_arch::x86::__m256i>(a), _mm256_set1_epi32(i32::MIN))) }
+    unsafe { transmute(_mm256_xor_si256(transmute::<__m256h, __m256i>(a), _mm256_set1_epi32(i32::MIN))) }
 }
 
 /// Compute the complex conjugates of complex numbers in a, and store the results in dst using writemask k
@@ -4104,7 +4104,7 @@ pub const fn _mm256_conj_pch(a: __m256h) -> __m256h {
 pub const fn _mm256_mask_conj_pch(src: __m256h, k: __mmask8, a: __m256h) -> __m256h {
     unsafe {
         let r: __m256 = transmute(_mm256_conj_pch(a));
-        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(src)))
+        transmute(simd_select_bitmask(k, r, transmute::<__m256h, __m256>(src)))
     }
 }
 
@@ -4132,7 +4132,7 @@ pub const fn _mm256_maskz_conj_pch(k: __mmask8, a: __m256h) -> __m256h {
 #[stable(feature = "stdarch_x86_avx512fp16", since = "1.94.0")]
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm512_conj_pch(a: __m512h) -> __m512h {
-    unsafe { transmute(_mm512_xor_si512(transmute::<core_arch::x86::__m512h, core_arch::x86::__m512i>(a), _mm512_set1_epi32(i32::MIN))) }
+    unsafe { transmute(_mm512_xor_si512(transmute::<__m512h, __m512i>(a), _mm512_set1_epi32(i32::MIN))) }
 }
 
 /// Compute the complex conjugates of complex numbers in a, and store the results in dst using writemask k
@@ -4148,7 +4148,7 @@ pub const fn _mm512_conj_pch(a: __m512h) -> __m512h {
 pub const fn _mm512_mask_conj_pch(src: __m512h, k: __mmask16, a: __m512h) -> __m512h {
     unsafe {
         let r: __m512 = transmute(_mm512_conj_pch(a));
-        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(src)))
+        transmute(simd_select_bitmask(k, r, transmute::<__m512h, __m512>(src)))
     }
 }
 
@@ -4192,7 +4192,7 @@ pub fn _mm_fmadd_pch(a: __m128h, b: __m128h, c: __m128h) -> __m128h {
 pub fn _mm_mask_fmadd_pch(a: __m128h, k: __mmask8, b: __m128h, c: __m128h) -> __m128h {
     unsafe {
         let r: __m128 = transmute(_mm_mask3_fmadd_pch(a, b, c, k)); // using `0xff` would have been fine here, but this is what CLang does
-        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a)))
+        transmute(simd_select_bitmask(k, r, transmute::<__m128h, __m128>(a)))
     }
 }
 
@@ -4209,9 +4209,9 @@ pub fn _mm_mask_fmadd_pch(a: __m128h, k: __mmask8, b: __m128h, c: __m128h) -> __
 pub fn _mm_mask3_fmadd_pch(a: __m128h, b: __m128h, c: __m128h, k: __mmask8) -> __m128h {
     unsafe {
         transmute(vfmaddcph_mask3_128(
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
+            transmute::<__m128h, __m128>(a),
+            transmute::<__m128h, __m128>(b),
+            transmute::<__m128h, __m128>(c),
             k,
         ))
     }
@@ -4230,9 +4230,9 @@ pub fn _mm_mask3_fmadd_pch(a: __m128h, b: __m128h, c: __m128h, k: __mmask8) -> _
 pub fn _mm_maskz_fmadd_pch(k: __mmask8, a: __m128h, b: __m128h, c: __m128h) -> __m128h {
     unsafe {
         transmute(vfmaddcph_maskz_128(
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
+            transmute::<__m128h, __m128>(a),
+            transmute::<__m128h, __m128>(b),
+            transmute::<__m128h, __m128>(c),
             k,
         ))
     }
@@ -4264,7 +4264,7 @@ pub fn _mm256_fmadd_pch(a: __m256h, b: __m256h, c: __m256h) -> __m256h {
 pub fn _mm256_mask_fmadd_pch(a: __m256h, k: __mmask8, b: __m256h, c: __m256h) -> __m256h {
     unsafe {
         let r: __m256 = transmute(_mm256_mask3_fmadd_pch(a, b, c, k)); // using `0xff` would have been fine here, but this is what CLang does
-        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a)))
+        transmute(simd_select_bitmask(k, r, transmute::<__m256h, __m256>(a)))
     }
 }
 
@@ -4281,9 +4281,9 @@ pub fn _mm256_mask_fmadd_pch(a: __m256h, k: __mmask8, b: __m256h, c: __m256h) ->
 pub fn _mm256_mask3_fmadd_pch(a: __m256h, b: __m256h, c: __m256h, k: __mmask8) -> __m256h {
     unsafe {
         transmute(vfmaddcph_mask3_256(
-            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a),
-            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(b),
-            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(c),
+            transmute::<__m256h, __m256>(a),
+            transmute::<__m256h, __m256>(b),
+            transmute::<__m256h, __m256>(c),
             k,
         ))
     }
@@ -4302,9 +4302,9 @@ pub fn _mm256_mask3_fmadd_pch(a: __m256h, b: __m256h, c: __m256h, k: __mmask8) -
 pub fn _mm256_maskz_fmadd_pch(k: __mmask8, a: __m256h, b: __m256h, c: __m256h) -> __m256h {
     unsafe {
         transmute(vfmaddcph_maskz_256(
-            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a),
-            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(b),
-            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(c),
+            transmute::<__m256h, __m256>(a),
+            transmute::<__m256h, __m256>(b),
+            transmute::<__m256h, __m256>(c),
             k,
         ))
     }
@@ -4416,7 +4416,7 @@ pub fn _mm512_mask_fmadd_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         let r: __m512 = transmute(_mm512_mask3_fmadd_round_pch::<ROUNDING>(a, b, c, k)); // using `0xffff` would have been fine here, but this is what CLang does
-        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a)))
+        transmute(simd_select_bitmask(k, r, transmute::<__m512h, __m512>(a)))
     }
 }
 
@@ -4448,9 +4448,9 @@ pub fn _mm512_mask3_fmadd_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfmaddcph_mask3_512(
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a),
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(b),
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(c),
+            transmute::<__m512h, __m512>(a),
+            transmute::<__m512h, __m512>(b),
+            transmute::<__m512h, __m512>(c),
             k,
             ROUNDING,
         ))
@@ -4485,9 +4485,9 @@ pub fn _mm512_maskz_fmadd_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfmaddcph_maskz_512(
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a),
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(b),
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(c),
+            transmute::<__m512h, __m512>(a),
+            transmute::<__m512h, __m512>(b),
+            transmute::<__m512h, __m512>(c),
             k,
             ROUNDING,
         ))
@@ -4575,9 +4575,9 @@ pub fn _mm_fmadd_round_sch<const ROUNDING: i32>(a: __m128h, b: __m128h, c: __m12
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfmaddcsh_mask(
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
+            transmute::<__m128h, __m128>(a),
+            transmute::<__m128h, __m128>(b),
+            transmute::<__m128h, __m128>(c),
             0xff,
             ROUNDING,
         ))
@@ -4612,8 +4612,8 @@ pub fn _mm_mask_fmadd_round_sch<const ROUNDING: i32>(
 ) -> __m128h {
     unsafe {
         static_assert_rounding!(ROUNDING);
-        let a = transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a);
-        let r = vfmaddcsh_mask(a, transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c), k, ROUNDING); // using `0xff` would have been fine here, but this is what CLang does
+        let a = transmute::<__m128h, __m128>(a);
+        let r = vfmaddcsh_mask(a, transmute::<__m128h, __m128>(b), transmute::<__m128h, __m128>(c), k, ROUNDING); // using `0xff` would have been fine here, but this is what CLang does
         transmute(_mm_mask_move_ss(a, k, a, r))
     }
 }
@@ -4646,8 +4646,8 @@ pub fn _mm_mask3_fmadd_round_sch<const ROUNDING: i32>(
 ) -> __m128h {
     unsafe {
         static_assert_rounding!(ROUNDING);
-        let c = transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c);
-        let r = vfmaddcsh_mask(transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b), c, k, ROUNDING);
+        let c = transmute::<__m128h, __m128>(c);
+        let r = vfmaddcsh_mask(transmute::<__m128h, __m128>(a), transmute::<__m128h, __m128>(b), c, k, ROUNDING);
         transmute(_mm_move_ss(c, r))
     }
 }
@@ -4681,9 +4681,9 @@ pub fn _mm_maskz_fmadd_round_sch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfmaddcsh_maskz(
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
+            transmute::<__m128h, __m128>(a),
+            transmute::<__m128h, __m128>(b),
+            transmute::<__m128h, __m128>(c),
             k,
             ROUNDING,
         ))
@@ -4718,7 +4718,7 @@ pub fn _mm_fcmadd_pch(a: __m128h, b: __m128h, c: __m128h) -> __m128h {
 pub fn _mm_mask_fcmadd_pch(a: __m128h, k: __mmask8, b: __m128h, c: __m128h) -> __m128h {
     unsafe {
         let r: __m128 = transmute(_mm_mask3_fcmadd_pch(a, b, c, k)); // using `0xff` would have been fine here, but this is what CLang does
-        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a)))
+        transmute(simd_select_bitmask(k, r, transmute::<__m128h, __m128>(a)))
     }
 }
 
@@ -4736,9 +4736,9 @@ pub fn _mm_mask_fcmadd_pch(a: __m128h, k: __mmask8, b: __m128h, c: __m128h) -> _
 pub fn _mm_mask3_fcmadd_pch(a: __m128h, b: __m128h, c: __m128h, k: __mmask8) -> __m128h {
     unsafe {
         transmute(vfcmaddcph_mask3_128(
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
+            transmute::<__m128h, __m128>(a),
+            transmute::<__m128h, __m128>(b),
+            transmute::<__m128h, __m128>(c),
             k,
         ))
     }
@@ -4758,9 +4758,9 @@ pub fn _mm_mask3_fcmadd_pch(a: __m128h, b: __m128h, c: __m128h, k: __mmask8) -> 
 pub fn _mm_maskz_fcmadd_pch(k: __mmask8, a: __m128h, b: __m128h, c: __m128h) -> __m128h {
     unsafe {
         transmute(vfcmaddcph_maskz_128(
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
+            transmute::<__m128h, __m128>(a),
+            transmute::<__m128h, __m128>(b),
+            transmute::<__m128h, __m128>(c),
             k,
         ))
     }
@@ -4794,7 +4794,7 @@ pub fn _mm256_fcmadd_pch(a: __m256h, b: __m256h, c: __m256h) -> __m256h {
 pub fn _mm256_mask_fcmadd_pch(a: __m256h, k: __mmask8, b: __m256h, c: __m256h) -> __m256h {
     unsafe {
         let r: __m256 = transmute(_mm256_mask3_fcmadd_pch(a, b, c, k)); // using `0xff` would have been fine here, but this is what CLang does
-        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a)))
+        transmute(simd_select_bitmask(k, r, transmute::<__m256h, __m256>(a)))
     }
 }
 
@@ -4812,9 +4812,9 @@ pub fn _mm256_mask_fcmadd_pch(a: __m256h, k: __mmask8, b: __m256h, c: __m256h) -
 pub fn _mm256_mask3_fcmadd_pch(a: __m256h, b: __m256h, c: __m256h, k: __mmask8) -> __m256h {
     unsafe {
         transmute(vfcmaddcph_mask3_256(
-            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a),
-            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(b),
-            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(c),
+            transmute::<__m256h, __m256>(a),
+            transmute::<__m256h, __m256>(b),
+            transmute::<__m256h, __m256>(c),
             k,
         ))
     }
@@ -4834,9 +4834,9 @@ pub fn _mm256_mask3_fcmadd_pch(a: __m256h, b: __m256h, c: __m256h, k: __mmask8) 
 pub fn _mm256_maskz_fcmadd_pch(k: __mmask8, a: __m256h, b: __m256h, c: __m256h) -> __m256h {
     unsafe {
         transmute(vfcmaddcph_maskz_256(
-            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(a),
-            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(b),
-            transmute::<core_arch::x86::__m256h, core_arch::x86::__m256>(c),
+            transmute::<__m256h, __m256>(a),
+            transmute::<__m256h, __m256>(b),
+            transmute::<__m256h, __m256>(c),
             k,
         ))
     }
@@ -4954,7 +4954,7 @@ pub fn _mm512_mask_fcmadd_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         let r: __m512 = transmute(_mm512_mask3_fcmadd_round_pch::<ROUNDING>(a, b, c, k)); // using `0xffff` would have been fine here, but this is what CLang does
-        transmute(simd_select_bitmask(k, r, transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a)))
+        transmute(simd_select_bitmask(k, r, transmute::<__m512h, __m512>(a)))
     }
 }
 
@@ -4987,9 +4987,9 @@ pub fn _mm512_mask3_fcmadd_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfcmaddcph_mask3_512(
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a),
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(b),
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(c),
+            transmute::<__m512h, __m512>(a),
+            transmute::<__m512h, __m512>(b),
+            transmute::<__m512h, __m512>(c),
             k,
             ROUNDING,
         ))
@@ -5025,9 +5025,9 @@ pub fn _mm512_maskz_fcmadd_round_pch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfcmaddcph_maskz_512(
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(a),
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(b),
-            transmute::<core_arch::x86::__m512h, core_arch::x86::__m512>(c),
+            transmute::<__m512h, __m512>(a),
+            transmute::<__m512h, __m512>(b),
+            transmute::<__m512h, __m512>(c),
             k,
             ROUNDING,
         ))
@@ -5121,9 +5121,9 @@ pub fn _mm_fcmadd_round_sch<const ROUNDING: i32>(a: __m128h, b: __m128h, c: __m1
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfcmaddcsh_mask(
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
+            transmute::<__m128h, __m128>(a),
+            transmute::<__m128h, __m128>(b),
+            transmute::<__m128h, __m128>(c),
             0xff,
             ROUNDING,
         ))
@@ -5159,8 +5159,8 @@ pub fn _mm_mask_fcmadd_round_sch<const ROUNDING: i32>(
 ) -> __m128h {
     unsafe {
         static_assert_rounding!(ROUNDING);
-        let a = transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a);
-        let r = vfcmaddcsh_mask(a, transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c), k, ROUNDING);
+        let a = transmute::<__m128h, __m128>(a);
+        let r = vfcmaddcsh_mask(a, transmute::<__m128h, __m128>(b), transmute::<__m128h, __m128>(c), k, ROUNDING);
         transmute(_mm_mask_move_ss(a, k, a, r))
     }
 }
@@ -5194,8 +5194,8 @@ pub fn _mm_mask3_fcmadd_round_sch<const ROUNDING: i32>(
 ) -> __m128h {
     unsafe {
         static_assert_rounding!(ROUNDING);
-        let c = transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c);
-        let r = vfcmaddcsh_mask(transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a), transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b), c, k, ROUNDING);
+        let c = transmute::<__m128h, __m128>(c);
+        let r = vfcmaddcsh_mask(transmute::<__m128h, __m128>(a), transmute::<__m128h, __m128>(b), c, k, ROUNDING);
         transmute(_mm_move_ss(c, r))
     }
 }
@@ -5230,9 +5230,9 @@ pub fn _mm_maskz_fcmadd_round_sch<const ROUNDING: i32>(
     unsafe {
         static_assert_rounding!(ROUNDING);
         transmute(vfcmaddcsh_maskz(
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(a),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(b),
-            transmute::<core_arch::x86::__m128h, core_arch::x86::__m128>(c),
+            transmute::<__m128h, __m128>(a),
+            transmute::<__m128h, __m128>(b),
+            transmute::<__m128h, __m128>(c),
             k,
             ROUNDING,
         ))

--- a/library/stdarch/crates/core_arch/src/x86/sse.rs
+++ b/library/stdarch/crates/core_arch/src/x86/sse.rs
@@ -1126,7 +1126,7 @@ pub const fn _mm_movemask_ps(a: __m128) -> i32 {
     // Propagate the highest bit to the rest, because simd_bitmask
     // requires all-1 or all-0.
     unsafe {
-        let mask: i32x4 = simd_lt(transmute::<core_arch::x86::__m128, core_arch::simd::Simd<i32, 4>>(a), i32x4::ZERO);
+        let mask: i32x4 = simd_lt(transmute::<__m128, i32x4>(a), i32x4::ZERO);
         simd_bitmask::<i32x4, u8>(mask) as i32
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/sse.rs
+++ b/library/stdarch/crates/core_arch/src/x86/sse.rs
@@ -1126,7 +1126,7 @@ pub const fn _mm_movemask_ps(a: __m128) -> i32 {
     // Propagate the highest bit to the rest, because simd_bitmask
     // requires all-1 or all-0.
     unsafe {
-        let mask: i32x4 = simd_lt(transmute(a), i32x4::ZERO);
+        let mask: i32x4 = simd_lt(transmute::<core_arch::x86::__m128, core_arch::simd::Simd<i32, 4>>(a), i32x4::ZERO);
         simd_bitmask::<i32x4, u8>(mask) as i32
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/sse2.rs
+++ b/library/stdarch/crates/core_arch/src/x86/sse2.rs
@@ -570,7 +570,7 @@ pub const fn _mm_slli_epi16<const IMM8: i32>(a: __m128i) -> __m128i {
         if IMM8 >= 16 {
             _mm_setzero_si128()
         } else {
-            transmute::<core_arch::simd::Simd<u16, 8>, core_arch::x86::__m128i>(simd_shl(a.as_u16x8(), u16x8::splat(IMM8 as u16)))
+            transmute::<u16x8, __m128i>(simd_shl(a.as_u16x8(), u16x8::splat(IMM8 as u16)))
         }
     }
 }
@@ -602,7 +602,7 @@ pub const fn _mm_slli_epi32<const IMM8: i32>(a: __m128i) -> __m128i {
         if IMM8 >= 32 {
             _mm_setzero_si128()
         } else {
-            transmute::<core_arch::simd::Simd<u32, 4>, core_arch::x86::__m128i>(simd_shl(a.as_u32x4(), u32x4::splat(IMM8 as u32)))
+            transmute::<u32x4, __m128i>(simd_shl(a.as_u32x4(), u32x4::splat(IMM8 as u32)))
         }
     }
 }
@@ -634,7 +634,7 @@ pub const fn _mm_slli_epi64<const IMM8: i32>(a: __m128i) -> __m128i {
         if IMM8 >= 64 {
             _mm_setzero_si128()
         } else {
-            transmute::<core_arch::simd::Simd<u64, 2>, core_arch::x86::__m128i>(simd_shl(a.as_u64x2(), u64x2::splat(IMM8 as u64)))
+            transmute::<u64x2, __m128i>(simd_shl(a.as_u64x2(), u64x2::splat(IMM8 as u64)))
         }
     }
 }
@@ -773,7 +773,7 @@ pub const fn _mm_srli_epi16<const IMM8: i32>(a: __m128i) -> __m128i {
         if IMM8 >= 16 {
             _mm_setzero_si128()
         } else {
-            transmute::<core_arch::simd::Simd<u16, 8>, core_arch::x86::__m128i>(simd_shr(a.as_u16x8(), u16x8::splat(IMM8 as u16)))
+            transmute::<u16x8, __m128i>(simd_shr(a.as_u16x8(), u16x8::splat(IMM8 as u16)))
         }
     }
 }
@@ -806,7 +806,7 @@ pub const fn _mm_srli_epi32<const IMM8: i32>(a: __m128i) -> __m128i {
         if IMM8 >= 32 {
             _mm_setzero_si128()
         } else {
-            transmute::<core_arch::simd::Simd<u32, 4>, core_arch::x86::__m128i>(simd_shr(a.as_u32x4(), u32x4::splat(IMM8 as u32)))
+            transmute::<u32x4, __m128i>(simd_shr(a.as_u32x4(), u32x4::splat(IMM8 as u32)))
         }
     }
 }
@@ -839,7 +839,7 @@ pub const fn _mm_srli_epi64<const IMM8: i32>(a: __m128i) -> __m128i {
         if IMM8 >= 64 {
             _mm_setzero_si128()
         } else {
-            transmute::<core_arch::simd::Simd<u64, 2>, core_arch::x86::__m128i>(simd_shr(a.as_u64x2(), u64x2::splat(IMM8 as u64)))
+            transmute::<u64x2, __m128i>(simd_shr(a.as_u64x2(), u64x2::splat(IMM8 as u64)))
         }
     }
 }
@@ -2659,7 +2659,7 @@ pub const fn _mm_movemask_pd(a: __m128d) -> i32 {
     // Propagate the highest bit to the rest, because simd_bitmask
     // requires all-1 or all-0.
     unsafe {
-        let mask: i64x2 = simd_lt(transmute::<core_arch::x86::__m128d, core_arch::simd::Simd<i64, 2>>(a), i64x2::ZERO);
+        let mask: i64x2 = simd_lt(transmute::<__m128d, i64x2>(a), i64x2::ZERO);
         simd_bitmask::<i64x2, u8>(mask) as i32
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/sse2.rs
+++ b/library/stdarch/crates/core_arch/src/x86/sse2.rs
@@ -570,7 +570,7 @@ pub const fn _mm_slli_epi16<const IMM8: i32>(a: __m128i) -> __m128i {
         if IMM8 >= 16 {
             _mm_setzero_si128()
         } else {
-            transmute(simd_shl(a.as_u16x8(), u16x8::splat(IMM8 as u16)))
+            transmute::<core_arch::simd::Simd<u16, 8>, core_arch::x86::__m128i>(simd_shl(a.as_u16x8(), u16x8::splat(IMM8 as u16)))
         }
     }
 }
@@ -602,7 +602,7 @@ pub const fn _mm_slli_epi32<const IMM8: i32>(a: __m128i) -> __m128i {
         if IMM8 >= 32 {
             _mm_setzero_si128()
         } else {
-            transmute(simd_shl(a.as_u32x4(), u32x4::splat(IMM8 as u32)))
+            transmute::<core_arch::simd::Simd<u32, 4>, core_arch::x86::__m128i>(simd_shl(a.as_u32x4(), u32x4::splat(IMM8 as u32)))
         }
     }
 }
@@ -634,7 +634,7 @@ pub const fn _mm_slli_epi64<const IMM8: i32>(a: __m128i) -> __m128i {
         if IMM8 >= 64 {
             _mm_setzero_si128()
         } else {
-            transmute(simd_shl(a.as_u64x2(), u64x2::splat(IMM8 as u64)))
+            transmute::<core_arch::simd::Simd<u64, 2>, core_arch::x86::__m128i>(simd_shl(a.as_u64x2(), u64x2::splat(IMM8 as u64)))
         }
     }
 }
@@ -773,7 +773,7 @@ pub const fn _mm_srli_epi16<const IMM8: i32>(a: __m128i) -> __m128i {
         if IMM8 >= 16 {
             _mm_setzero_si128()
         } else {
-            transmute(simd_shr(a.as_u16x8(), u16x8::splat(IMM8 as u16)))
+            transmute::<core_arch::simd::Simd<u16, 8>, core_arch::x86::__m128i>(simd_shr(a.as_u16x8(), u16x8::splat(IMM8 as u16)))
         }
     }
 }
@@ -806,7 +806,7 @@ pub const fn _mm_srli_epi32<const IMM8: i32>(a: __m128i) -> __m128i {
         if IMM8 >= 32 {
             _mm_setzero_si128()
         } else {
-            transmute(simd_shr(a.as_u32x4(), u32x4::splat(IMM8 as u32)))
+            transmute::<core_arch::simd::Simd<u32, 4>, core_arch::x86::__m128i>(simd_shr(a.as_u32x4(), u32x4::splat(IMM8 as u32)))
         }
     }
 }
@@ -839,7 +839,7 @@ pub const fn _mm_srli_epi64<const IMM8: i32>(a: __m128i) -> __m128i {
         if IMM8 >= 64 {
             _mm_setzero_si128()
         } else {
-            transmute(simd_shr(a.as_u64x2(), u64x2::splat(IMM8 as u64)))
+            transmute::<core_arch::simd::Simd<u64, 2>, core_arch::x86::__m128i>(simd_shr(a.as_u64x2(), u64x2::splat(IMM8 as u64)))
         }
     }
 }
@@ -2659,7 +2659,7 @@ pub const fn _mm_movemask_pd(a: __m128d) -> i32 {
     // Propagate the highest bit to the rest, because simd_bitmask
     // requires all-1 or all-0.
     unsafe {
-        let mask: i64x2 = simd_lt(transmute(a), i64x2::ZERO);
+        let mask: i64x2 = simd_lt(transmute::<core_arch::x86::__m128d, core_arch::simd::Simd<i64, 2>>(a), i64x2::ZERO);
         simd_bitmask::<i64x2, u8>(mask) as i32
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/sse41.rs
+++ b/library/stdarch/crates/core_arch/src/x86/sse41.rs
@@ -111,7 +111,7 @@ pub const fn _mm_blend_epi16<const IMM8: i32>(a: __m128i, b: __m128i) -> __m128i
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_blendv_pd(a: __m128d, b: __m128d, mask: __m128d) -> __m128d {
     unsafe {
-        let mask: i64x2 = simd_lt(transmute::<core_arch::x86::__m128d, core_arch::simd::Simd<i64, 2>>(mask), i64x2::ZERO);
+        let mask: i64x2 = simd_lt(transmute::<__m128d, i64x2>(mask), i64x2::ZERO);
         transmute(simd_select(mask, b.as_f64x2(), a.as_f64x2()))
     }
 }
@@ -127,7 +127,7 @@ pub const fn _mm_blendv_pd(a: __m128d, b: __m128d, mask: __m128d) -> __m128d {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_blendv_ps(a: __m128, b: __m128, mask: __m128) -> __m128 {
     unsafe {
-        let mask: i32x4 = simd_lt(transmute::<core_arch::x86::__m128, core_arch::simd::Simd<i32, 4>>(mask), i32x4::ZERO);
+        let mask: i32x4 = simd_lt(transmute::<__m128, i32x4>(mask), i32x4::ZERO);
         transmute(simd_select(mask, b.as_f32x4(), a.as_f32x4()))
     }
 }

--- a/library/stdarch/crates/core_arch/src/x86/sse41.rs
+++ b/library/stdarch/crates/core_arch/src/x86/sse41.rs
@@ -111,7 +111,7 @@ pub const fn _mm_blend_epi16<const IMM8: i32>(a: __m128i, b: __m128i) -> __m128i
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_blendv_pd(a: __m128d, b: __m128d, mask: __m128d) -> __m128d {
     unsafe {
-        let mask: i64x2 = simd_lt(transmute::<_, i64x2>(mask), i64x2::ZERO);
+        let mask: i64x2 = simd_lt(transmute::<core_arch::x86::__m128d, core_arch::simd::Simd<i64, 2>>(mask), i64x2::ZERO);
         transmute(simd_select(mask, b.as_f64x2(), a.as_f64x2()))
     }
 }
@@ -127,7 +127,7 @@ pub const fn _mm_blendv_pd(a: __m128d, b: __m128d, mask: __m128d) -> __m128d {
 #[rustc_const_unstable(feature = "stdarch_const_x86", issue = "149298")]
 pub const fn _mm_blendv_ps(a: __m128, b: __m128, mask: __m128) -> __m128 {
     unsafe {
-        let mask: i32x4 = simd_lt(transmute::<_, i32x4>(mask), i32x4::ZERO);
+        let mask: i32x4 = simd_lt(transmute::<core_arch::x86::__m128, core_arch::simd::Simd<i32, 4>>(mask), i32x4::ZERO);
         transmute(simd_select(mask, b.as_f32x4(), a.as_f32x4()))
     }
 }


### PR DESCRIPTION
Best reviewed case by case. Special care should be taken when involving pointers.

The [missing_transmute_annotations](https://rust-lang.github.io/rust-clippy/rust-1.89.0/index.html#missing_transmute_annotations) lint.
The point of the lint is that in order  to ensure that the safety invariant holds, the transmute source and destination should be explicitly fixed. 


Remarks: 
 - _many, many many_ suggested fixes were invalid rust code, as they include paths when they should just use the type in scope.
   I kept the initial suggestion and the fixed suggestion in separate commit so that the issue can be observed easily and the clippy lint can be fixed before even considering enabling it.
 - the lint currently fires inside local expanded code (not in calls to external macros). Having dynamically added src and dest inside a macro is a bit _iffy_ and sometimes impossible, as [#general > Running clippy on the rustc repo @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/Running.20clippy.20on.20the.20rustc.20repo/near/618082529) @scottmcm points out. Perhaps there should be a lint about that :)


Notes:

- For the transmute call in `define_valid_range`, the transmute suggestion was wrong because:
   - we get a different suggestion for every call of the macro
   - `pattern_types!` are strangely formatted. The issue is being worked on in https://github.com/rust-lang/rust-clippy/pull/17613.
      Notably, the proper fix may be to change the display impl for pattern_types (see https://github.com/rust-lang/rust-clippy/pull/17613#issuecomment-5388630368 by @ada4a  

Yet I still propose a fix because this case seems clear cut, it may be an exception to the iffiness rule. 

- The suggestion in https://github.com/rust-lang/rust/compare/main...GTimothy:rust:missing-transmute-annotations#diff-4fbe4e316a3fa623f3edea42a8d3ab2ec54de32c3ec8e46e5d5d58a562a86813 was muted because it was very very complex and inside a macro. 

- `core_arch` suggestions are all of the same nature, and the suggestions are wrong because they:
  - use entire paths for the suggested type
  - do not use type aliases that are much leaner. 
  
- I have no clue how this dark magic works:
  ```rust
  unsafe { mem::transmute::<*mut (), fn(core::alloc::Layout)>(hook) } 
  ```
 
Related: _"Enforce even more library clippy lints in CI"_ by @ChrisDenton: https://github.com/rust-lang/rust/pull/161328