### PR TITLE
Assorted bootstrap config refactors (part 1/N)

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -251,6 +251,7 @@ impl Step for PrepareRustcRmetaSysroot {
 
         // Copy the generated rmeta artifacts to a separate directory
         let dir = builder
+            .config
             .out
             .join(build_compiler.host)
             .join(format!("stage{}-rustc-rmeta-artifacts", build_compiler.stage + 1));
@@ -289,6 +290,7 @@ impl Step for PrepareStdRmetaSysroot {
 
         // Copy the generated rmeta artifacts to a separate directory
         let dir = builder
+            .config
             .out
             .join(self.build_compiler.host)
             .join(format!("stage{}-std-rmeta-artifacts", self.build_compiler.stage));

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -778,7 +778,6 @@ impl Step for StdLink {
 
         let is_downloaded_beta_stage0 = builder
             .sess
-            .config
             .initial_rustc
             .starts_with(builder.out.join(compiler.host).join("stage0/bin"));
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1580,7 +1580,7 @@ impl CommandLineStep for RustdocGUI {
             cmd.arg("--out-dir").arg(out_dir);
         }
 
-        if let Some(initial_cargo) = builder.config.initial_cargo.to_str() {
+        if let Some(initial_cargo) = builder.sess.initial_cargo.to_str() {
             cmd.arg("--initial-cargo").arg(initial_cargo);
         }
 

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1462,11 +1462,10 @@ Alternatively, you can set `build.local-rebuild=true` and use a stage0 compiler 
     /// The used Clippy is (or in the case of stage 0, already was) built using `build_compiler`.
     pub fn cargo_clippy_cmd(&self, build_compiler: Compiler) -> BootstrapCommand {
         if build_compiler.stage == 0 {
-            let cargo_clippy = self
-                .config
-                .initial_cargo_clippy
-                .clone()
-                .unwrap_or_else(|| self.sess.config.download_clippy());
+            let cargo_clippy =
+                self.config.external_cargo_clippy.clone().unwrap_or_else(|| {
+                    self.sess.config.download_clippy(&self.sess.initial_sysroot)
+                });
 
             let mut cmd = command(cargo_clippy);
             cmd.env("CARGO", &self.initial_cargo);

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -243,9 +243,13 @@ pub(crate) struct Config {
 
     pub reproducible_artifacts: Vec<String>,
 
+    /// Build triple for the pre-compiled snapshot compiler.
     pub host_target: TargetSelection,
+    /// Which triples to produce a compiler toolchain for.
     pub hosts: Vec<TargetSelection>,
+    /// Which triples to build libraries (core/alloc/std/test/proc_macro) for.
     pub targets: Vec<TargetSelection>,
+
     pub local_rebuild: bool,
     pub allocator: Option<Allocator>,
     pub control_flow_guard: bool,

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -814,10 +814,10 @@ impl Config {
 
         if !flags_skip_stage0_validation {
             if let Some(rustc) = &build_rustc {
-                check_stage0_version(rustc, "rustc", &src, &exec_ctx);
+                check_external_binary_version(rustc, "rustc", &src, &exec_ctx);
             }
             if let Some(cargo) = &build_cargo {
-                check_stage0_version(cargo, "cargo", &src, &exec_ctx);
+                check_external_binary_version(cargo, "cargo", &src, &exec_ctx);
             }
         }
 
@@ -2250,8 +2250,9 @@ fn postprocess_toml(
     toml.merge(None, &mut Default::default(), override_toml, ReplaceOpt::Override);
 }
 
-/// check rustc/cargo version is same or lower with 1 apart from the building one
-pub fn check_stage0_version(
+/// Check that the version of an externally provided rustc/cargo is either the same or 1 version
+/// older than the in-tree version.
+fn check_external_binary_version(
     program_path: &Path,
     component_name: &'static str,
     src_dir: &Path,
@@ -2261,32 +2262,30 @@ pub fn check_stage0_version(
         return;
     }
 
-    let stage0_output =
-        command(program_path).arg("--version").run_capture_stdout(exec_ctx).stdout();
-    let mut stage0_output = stage0_output.lines().next().unwrap().split(' ');
+    let output = command(program_path).arg("--version").run_capture_stdout(exec_ctx).stdout();
+    let mut output = output.lines().next().unwrap().split(' ');
 
-    let stage0_name = stage0_output.next().unwrap();
-    if stage0_name != component_name {
+    let name = output.next().unwrap();
+    if name != component_name {
         fail(&format!(
-            "Expected to find {component_name} at {} but it claims to be {stage0_name}",
+            "Expected to find {component_name} at {} but it claims to be {name}",
             program_path.display()
         ));
     }
 
-    let stage0_version =
-        semver::Version::parse(stage0_output.next().unwrap().split('-').next().unwrap().trim())
-            .unwrap();
+    let binary_version =
+        semver::Version::parse(output.next().unwrap().split('-').next().unwrap().trim()).unwrap();
     let source_version =
         semver::Version::parse(fs::read_to_string(src_dir.join("src/version")).unwrap().trim())
             .unwrap();
-    if !(source_version == stage0_version
-        || (source_version.major == stage0_version.major
-            && (source_version.minor == stage0_version.minor
-                || source_version.minor == stage0_version.minor + 1)))
+    if !(source_version == binary_version
+        || (source_version.major == binary_version.major
+            && (source_version.minor == binary_version.minor
+                || source_version.minor == binary_version.minor + 1)))
     {
         let prev_version = format!("{}.{}.x", source_version.major, source_version.minor - 1);
         fail(&format!(
-            "Unexpected {component_name} version: {stage0_version}, we should use {prev_version}/{source_version} to build source with {source_version}"
+            "Unexpected {component_name} version: {binary_version}, we should use {prev_version}/{source_version} to build source with {source_version}"
         ));
     }
 }

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -53,7 +53,7 @@ use crate::core::config::{
     GccCiMode, LlvmCiMode, LlvmLibunwind, Merge, ReplaceOpt, RustcLto, SplitDebuginfo,
     StringOrBool, TargetSelection, threads_from_config,
 };
-use crate::core::download::{DownloadContext, download_beta_toolchain, is_download_ci_available};
+use crate::core::download::{DownloadContext, is_download_ci_available};
 use crate::utils::channel::{self, GitInfo};
 use crate::utils::exec::{ExecutionContext, command};
 use crate::utils::helpers::{self, exe, fail, get_host_target, t};
@@ -305,12 +305,13 @@ pub(crate) struct Config {
     pub in_tree_llvm_info: channel::GitInfo,
     pub in_tree_gcc_info: channel::GitInfo,
 
-    // These are either the stage0 downloaded binaries or the locally installed ones.
-    pub initial_cargo: PathBuf,
-    pub initial_rustc: PathBuf,
-    pub initial_rustdoc: PathBuf,
-    pub initial_cargo_clippy: Option<PathBuf>,
-    pub initial_sysroot: PathBuf,
+    /// rustc/cargo/rustdoc/clippy paths specified in the config file
+    /// Access the `initial_` fields from `Session` to use either the externally configured
+    /// or downloaded (stage0) binaries.
+    pub external_cargo: Option<PathBuf>,
+    pub external_rustc: Option<PathBuf>,
+    pub external_rustdoc: Option<PathBuf>,
+    pub external_cargo_clippy: Option<PathBuf>,
 
     /// Externally configured `rustfmt` binary for formatting in-tree source code.
     /// If you want to use rustfmt for formatting, use the `InternalRustfmt` step, instead of
@@ -503,7 +504,6 @@ impl Config {
             gdb: build_gdb,
             lldb: build_lldb,
             nodejs: build_nodejs,
-
             yarn: build_yarn,
             npm: build_npm,
             python: build_python,
@@ -775,7 +775,7 @@ impl Config {
 
         // NOTE: Bootstrap spawns various commands with different working directories.
         // To avoid writing to random places on the file system, `config.out` needs to be an absolute path.
-        let mut out = if !out.is_absolute() {
+        let out = if !out.is_absolute() {
             // `canonicalize` requires the path to already exist. Use our vendored copy of `absolute` instead.
             absolute(&out).expect("can't make empty path absolute")
         } else {
@@ -844,34 +844,6 @@ impl Config {
             bootstrap_cache_path: &build_bootstrap_cache_path,
             ci_env,
         };
-
-        let initial_rustc = build_rustc.unwrap_or_else(|| {
-            download_beta_toolchain(&dwn_ctx, &out);
-            default_stage0_rustc_path(&out)
-        });
-
-        let initial_rustdoc = build_rustdoc
-            .unwrap_or_else(|| initial_rustc.with_file_name(exe("rustdoc", host_target)));
-
-        let initial_sysroot = t!(PathBuf::from_str(
-            command(&initial_rustc)
-                .args(["--print", "sysroot"])
-                .run_in_dry_run()
-                .run_capture_stdout(&exec_ctx)
-                .stdout()
-                .trim()
-        ));
-
-        let initial_cargo = build_cargo.unwrap_or_else(|| {
-            download_beta_toolchain(&dwn_ctx, &out);
-            initial_sysroot.join("bin").join(exe("cargo", host_target))
-        });
-
-        // NOTE: it's important this comes *after* we set `initial_rustc` just above.
-        if exec_ctx.dry_run() {
-            out = out.join("tmp-dry-run");
-            fs::create_dir_all(&out).expect("Failed to create dry-run directory");
-        }
 
         let file_content = t!(fs::read_to_string(src.join("src/ci/channel")));
         let ci_channel = file_content.trim_end();
@@ -1468,6 +1440,10 @@ NOTE: Please add `--stage 2` to your command line, or if you're sure you want to
             explicit_stage_from_cli: flags_stage.is_some(),
             explicit_stage_from_config,
             extended: build_extended.unwrap_or(false),
+            external_cargo: build_cargo,
+            external_cargo_clippy: build_cargo_clippy,
+            external_rustc: build_rustc,
+            external_rustdoc: build_rustdoc,
             external_rustfmt: build_rustfmt,
             free_args: flags_free_args,
             full_bootstrap: build_full_bootstrap.unwrap_or(false),
@@ -1479,11 +1455,6 @@ NOTE: Please add `--stage 2` to your command line, or if you're sure you want to
             in_tree_llvm_info,
             include_default_paths: flags_include_default_paths,
             incremental: flags_incremental || rust_incremental == Some(true),
-            initial_cargo,
-            initial_cargo_clippy: build_cargo_clippy,
-            initial_rustc,
-            initial_rustdoc,
-            initial_sysroot,
             jobs: Some(threads_from_config(flags_jobs.or(build_jobs).unwrap_or(0))),
             json_output: flags_json_output,
             keep_stage: flags_keep_stage,

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -108,16 +108,15 @@ enum DownloadSource {
 
 /// Functions that are only ever called once, but named for clarity and to avoid thousand-line functions.
 impl Config {
-    pub(crate) fn download_clippy(&self) -> PathBuf {
+    pub(crate) fn download_clippy(&self, initial_sysroot: &Path) -> PathBuf {
         self.do_if_verbose(|| println!("downloading stage0 clippy artifacts"));
 
         let date = &self.stage0_metadata.compiler.date;
         let version = &self.stage0_metadata.compiler.version;
         let host = self.host_target;
 
-        let clippy_stamp =
-            BuildStamp::new(&self.initial_sysroot).with_prefix("clippy").add_stamp(date);
-        let cargo_clippy = self.initial_sysroot.join("bin").join(exe("cargo-clippy", host));
+        let clippy_stamp = BuildStamp::new(initial_sysroot).with_prefix("clippy").add_stamp(date);
+        let cargo_clippy = initial_sysroot.join("bin").join(exe("cargo-clippy", host));
         if cargo_clippy.exists() && clippy_stamp.is_up_to_date() {
             return cargo_clippy;
         }

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -201,7 +201,7 @@ than building it.
         .map(|p| cmd_finder.must_have(p))
         .or_else(|| cmd_finder.maybe_have("reuse"));
 
-    let stage0_supported_target_list: HashSet<String> = command(&sess.config.initial_rustc)
+    let stage0_supported_target_list: HashSet<String> = command(&sess.initial_rustc)
         .args(["--print", "target-list"])
         .run_in_dry_run()
         .run_capture_stdout(&sess)

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -314,7 +314,7 @@ than building it.
         }
     }
 
-    for target in &sess.targets {
+    for target in &sess.config.targets {
         sess.config
             .target_config
             .entry(*target)

--- a/src/bootstrap/src/core/session.rs
+++ b/src/bootstrap/src/core/session.rs
@@ -1,6 +1,7 @@
 use std::cell::Cell;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::Display;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::{Instant, SystemTime};
@@ -48,28 +49,10 @@ pub(crate) struct Session {
     pub(crate) version: String,
 
     // Properties derived from the above configuration
-    pub(crate) src: PathBuf,
-    pub(crate) out: PathBuf,
     pub(crate) bootstrap_out: PathBuf,
-    pub(crate) cargo_info: GitInfo,
-    pub(crate) rust_analyzer_info: GitInfo,
-    pub(crate) clippy_info: GitInfo,
-    pub(crate) miri_info: GitInfo,
-    pub(crate) rustfmt_info: GitInfo,
-    pub(crate) enzyme_info: GitInfo,
-    pub(crate) in_tree_llvm_info: GitInfo,
-    pub(crate) in_tree_gcc_info: GitInfo,
-    pub(crate) local_rebuild: bool,
     pub(crate) fail_fast: bool,
     pub(crate) test_target: TestTarget,
     pub(crate) verbosity: usize,
-
-    /// Build triple for the pre-compiled snapshot compiler.
-    pub(crate) host_target: TargetSelection,
-    /// Which triples to produce a compiler toolchain for.
-    pub(crate) hosts: Vec<TargetSelection>,
-    /// Which triples to build libraries (core/alloc/std/test/proc_macro) for.
-    pub(crate) targets: Vec<TargetSelection>,
 
     pub(crate) initial_rustc: PathBuf,
     pub(crate) initial_rustdoc: PathBuf,
@@ -98,6 +81,14 @@ pub(crate) struct Session {
 
     #[cfg(feature = "tracing")]
     pub(crate) step_graph: std::cell::RefCell<crate::utils::step_graph::StepGraph>,
+}
+
+impl Deref for Session {
+    type Target = Config;
+
+    fn deref(&self) -> &Self::Target {
+        &self.config
+    }
 }
 
 /// When building Rust various objects are handled differently.
@@ -268,9 +259,6 @@ impl Session {
     ///
     /// By default all build output will be placed in the current directory.
     pub(crate) fn new(mut config: Config) -> Session {
-        let src = config.src.clone();
-        let out = config.out.clone();
-
         #[cfg(unix)]
         // keep this consistent with the equivalent check in x.py:
         // https://github.com/rust-lang/rust/blob/a8a33cf27166d3eabaffc58ed3799e054af3b0c6/src/bootstrap/bootstrap.py#L796-L797
@@ -287,16 +275,6 @@ impl Session {
         };
         #[cfg(not(unix))]
         let is_sudo = false;
-
-        let rust_info = config.rust_info.clone();
-        let cargo_info = config.cargo_info.clone();
-        let rust_analyzer_info = config.rust_analyzer_info.clone();
-        let clippy_info = config.clippy_info.clone();
-        let miri_info = config.miri_info.clone();
-        let rustfmt_info = config.rustfmt_info.clone();
-        let enzyme_info = config.enzyme_info.clone();
-        let in_tree_llvm_info = config.in_tree_llvm_info.clone();
-        let in_tree_gcc_info = config.in_tree_gcc_info.clone();
 
         let initial_target_libdir = command(&config.initial_rustc)
             .run_in_dry_run()
@@ -331,7 +309,7 @@ impl Session {
                 .to_path_buf()
         };
 
-        let version = std::fs::read_to_string(src.join("src").join("version"))
+        let version = std::fs::read_to_string(config.src.join("src").join("version"))
             .expect("failed to read src/version");
         let version = version.trim();
 
@@ -353,7 +331,7 @@ impl Session {
             )
         }
 
-        if rust_info.is_from_tarball() && config.description.is_none() {
+        if config.rust_info.is_from_tarball() && config.description.is_none() {
             config.description = Some("built from a source tarball".to_owned());
         }
 
@@ -364,29 +342,13 @@ impl Session {
             initial_rustdoc: config.initial_rustdoc.clone(),
             initial_cargo: config.initial_cargo.clone(),
             initial_sysroot: config.initial_sysroot.clone(),
-            local_rebuild: config.local_rebuild,
             fail_fast: config.cmd.fail_fast(),
             test_target: config.cmd.test_target(),
             verbosity: config.exec_ctx.verbosity as usize,
-
-            host_target: config.host_target,
-            hosts: config.hosts.clone(),
-            targets: config.targets.clone(),
-
             config,
             version: version.to_string(),
-            src,
-            out,
             bootstrap_out,
 
-            cargo_info,
-            rust_analyzer_info,
-            clippy_info,
-            miri_info,
-            rustfmt_info,
-            enzyme_info,
-            in_tree_llvm_info,
-            in_tree_gcc_info,
             cc: HashMap::new(),
             cxx: HashMap::new(),
             ar: HashMap::new(),
@@ -419,7 +381,7 @@ impl Session {
             .trim();
         if local_release.split('.').take(2).eq(version.split('.').take(2)) {
             sess.do_if_verbose(|| println!("auto-detected local-rebuild {local_release}"));
-            sess.local_rebuild = true;
+            sess.config.local_rebuild = true;
         }
 
         sess.do_if_verbose(|| println!("finding compilers"));

--- a/src/bootstrap/src/core/session.rs
+++ b/src/bootstrap/src/core/session.rs
@@ -855,17 +855,7 @@ impl Session {
 
     /// Returns the sysroot of the snapshot compiler.
     pub(crate) fn rustc_snapshot_sysroot(&self) -> &Path {
-        static SYSROOT_CACHE: OnceLock<PathBuf> = OnceLock::new();
-        SYSROOT_CACHE.get_or_init(|| {
-            command(&self.initial_rustc)
-                .run_in_dry_run()
-                .args(["--print", "sysroot"])
-                .run_capture_stdout(self)
-                .stdout()
-                .trim()
-                .to_owned()
-                .into()
-        })
+        &self.initial_sysroot
     }
 
     pub(crate) fn info(&self, msg: &str) {

--- a/src/bootstrap/src/core/session.rs
+++ b/src/bootstrap/src/core/session.rs
@@ -3,8 +3,6 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::Display;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
-use std::sync::OnceLock;
 use std::time::{Instant, SystemTime};
 use std::{env, fs, io, str};
 
@@ -295,14 +293,21 @@ impl Session {
             .clone()
             .unwrap_or_else(|| initial_rustc.with_file_name(exe("rustdoc", config.host_target)));
 
-        let initial_sysroot = t!(PathBuf::from_str(
-            command(&initial_rustc)
-                .args(["--print", "sysroot"])
-                .run_in_dry_run()
-                .run_capture_stdout(&config.exec_ctx)
-                .stdout()
-                .trim()
-        ));
+        // Gather both the sysroot and the target libdir to avoid an unnecessary rustc execution
+        // and speed up bootstrap slightly.
+        let rustc_paths = command(&initial_rustc)
+            .args(["--print", "sysroot", "--print", "target-libdir"])
+            .run_in_dry_run()
+            .run_capture_stdout(&config)
+            .stdout();
+        let mut rustc_paths = rustc_paths.lines();
+        let initial_sysroot =
+            rustc_paths.next().map(PathBuf::from).expect("Missing sysroot from initial rustc");
+        let initial_target_libdir = rustc_paths
+            .next()
+            .map(PathBuf::from)
+            .expect("Missing target libdir from initial rustc");
+        assert!(rustc_paths.next().is_none());
 
         let initial_cargo = config.external_cargo.clone().unwrap_or_else(|| {
             download_beta_toolchain(&dwn_ctx, &config.out);
@@ -316,17 +321,9 @@ impl Session {
             fs::create_dir_all(&config.out).expect("Failed to create dry-run directory");
         }
 
-        let initial_target_libdir = command(&initial_rustc)
-            .run_in_dry_run()
-            .args(["--print", "target-libdir"])
-            .run_capture_stdout(&config)
-            .stdout()
-            .trim()
-            .to_owned();
-
-        let initial_target_dir = Path::new(&initial_target_libdir)
+        let initial_target_dir = initial_target_libdir
             .parent()
-            .unwrap_or_else(|| panic!("{initial_target_libdir} has no parent"));
+            .unwrap_or_else(|| panic!("{initial_target_libdir:?} has no parent"));
 
         let initial_lld = initial_target_dir.join("bin").join("rust-lld");
 

--- a/src/bootstrap/src/core/session.rs
+++ b/src/bootstrap/src/core/session.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::Display;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::OnceLock;
 use std::time::{Instant, SystemTime};
 use std::{env, fs, io, str};
@@ -19,6 +20,7 @@ use crate::core::builder::{Builder, Kind};
 use crate::core::compiler::Compiler;
 use crate::core::config::flags::{self, Subcommand};
 use crate::core::config::{BootstrapOverrideLld, Config, DryRun, LlvmLibunwind, TargetSelection};
+use crate::core::download::{DownloadContext, download_beta_toolchain};
 use crate::core::metadata::Crate;
 #[cfg(feature = "tracing")]
 use crate::trace_io;
@@ -276,7 +278,45 @@ impl Session {
         #[cfg(not(unix))]
         let is_sudo = false;
 
-        let initial_target_libdir = command(&config.initial_rustc)
+        let dwn_ctx = DownloadContext::from(&config);
+
+        let initial_rustc = config.external_rustc.clone().unwrap_or_else(|| {
+            download_beta_toolchain(&dwn_ctx, &config.out);
+            config
+                .out
+                .join(config.host_target)
+                .join("stage0")
+                .join("bin")
+                .join(exe("rustc", config.host_target))
+        });
+
+        let initial_rustdoc = config
+            .external_rustdoc
+            .clone()
+            .unwrap_or_else(|| initial_rustc.with_file_name(exe("rustdoc", config.host_target)));
+
+        let initial_sysroot = t!(PathBuf::from_str(
+            command(&initial_rustc)
+                .args(["--print", "sysroot"])
+                .run_in_dry_run()
+                .run_capture_stdout(&config.exec_ctx)
+                .stdout()
+                .trim()
+        ));
+
+        let initial_cargo = config.external_cargo.clone().unwrap_or_else(|| {
+            download_beta_toolchain(&dwn_ctx, &config.out);
+            initial_sysroot.join("bin").join(exe("cargo", config.host_target))
+        });
+
+        // NOTE: it's important this comes *after* we potentially download the binaries above,
+        // in order to not redownload them into a temporary directory.
+        if config.exec_ctx.dry_run() {
+            config.out = config.out.join("tmp-dry-run");
+            fs::create_dir_all(&config.out).expect("Failed to create dry-run directory");
+        }
+
+        let initial_target_libdir = command(&initial_rustc)
             .run_in_dry_run()
             .args(["--print", "target-libdir"])
             .run_capture_stdout(&config)
@@ -299,7 +339,7 @@ impl Session {
             });
 
             ancestor
-                .strip_prefix(&config.initial_sysroot)
+                .strip_prefix(&initial_sysroot)
                 .unwrap_or_else(|_| {
                     panic!(
                         "Couldn’t resolve the initial relative libdir from {}",
@@ -338,10 +378,10 @@ impl Session {
         let mut sess = Session {
             initial_lld,
             initial_relative_libdir,
-            initial_rustc: config.initial_rustc.clone(),
-            initial_rustdoc: config.initial_rustdoc.clone(),
-            initial_cargo: config.initial_cargo.clone(),
-            initial_sysroot: config.initial_sysroot.clone(),
+            initial_rustc,
+            initial_rustdoc,
+            initial_cargo,
+            initial_sysroot,
             fail_fast: config.cmd.fail_fast(),
             test_target: config.cmd.test_target(),
             verbosity: config.exec_ctx.verbosity as usize,

--- a/src/bootstrap/src/utils/cc_detect/tests.rs
+++ b/src/bootstrap/src/utils/cc_detect/tests.rs
@@ -151,8 +151,8 @@ fn test_find() {
     let mut sess = Session::new(config);
     let target1 = TargetSelection::from_user("x86_64-unknown-linux-gnu");
     let target2 = TargetSelection::from_user("x86_64-unknown-openbsd");
-    sess.targets.push(target1.clone());
-    sess.hosts.push(target2.clone());
+    sess.config.targets.push(target1.clone());
+    sess.config.hosts.push(target2.clone());
     fill_compilers(&mut sess);
     for t in sess.hosts.iter().chain(sess.targets.iter()).chain(iter::once(&sess.host_target)) {
         assert!(sess.cc.contains_key(t), "CC not set for target {}", t.triple);


### PR DESCRIPTION
Related to my current LLVM refactoring in bootstrap, and some of it was unblocked by it.

The goal is to remove as much command execution and I/O (mainly network I/O) from config parsing, and turn the "impure derived computation" part to `Session` instead. Eventually this will require restructuring `download-ci-rustc`.

As a side note, combining `--print sysroot` and `--print target-libdir`, plus one other cleanup, made cache-primed `./x build compiler` ~40ms faster for me locally.

The first commit removed duplicated fields between `Session` and `Config`. It cheats a bit, I implemented `Deref` to get from `Session` to `Config`, to avoid having to update 100+ use sites across bootstrap. But I think it's fine, because it is read only, and adding `.config` everywhere doesn't really add much.

CC @Zalathar

r? jieyouxu