### PR TITLE
make `Complex` ABI-compatible on sparc64 and powerpc64

### DIFF
--- a/compiler/rustc_abi/src/layout/ty.rs
+++ b/compiler/rustc_abi/src/layout/ty.rs
@@ -7,7 +7,7 @@ use rustc_macros::StableHash;
 
 use crate::layout::{FieldIdx, VariantIdx};
 use crate::{
-    AbiAlign, Align, BackendRepr, FieldsShape, Float, HasDataLayout, LayoutData, Niche,
+    AbiAlign, Align, BackendRepr, FieldsShape, Float, HasDataLayout, LayoutData, Niche, Numeric,
     PointeeInfo, Primitive, Size, Variants,
 };
 
@@ -229,12 +229,12 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
     }
 
     /// Returns `true` if this type needs to match the ABI of the C `_Complex` type. See
-    /// [`TyAndLayout::complex_number_primitive`] for details.
+    /// [`TyAndLayout::complex_number`] for details.
     pub fn is_complex_number<C>(self, cx: &C) -> bool
     where
         Ty: TyAbiInterface<'a, C> + Copy,
     {
-        self.complex_number_primitive(cx).is_some()
+        self.complex_number(cx).is_some()
     }
 
     pub fn is_scalable_vector<C>(self) -> bool
@@ -302,9 +302,11 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
     }
 
     /// If this type should match the ABI of the C `_Complex` type, returns the primitive that is
-    /// used for its parts. This only returns `Some(T)` for `core::num::Complex<T>` where `T` is
+    /// used for its components.
+    ///
+    /// This function only returns `Some(T)` for `core::num::Complex<T>` where `T` is
     /// either a float or an integer. `repr(transparent)` wrapper types are automatically handled.
-    pub fn complex_number_primitive<C>(&self, cx: &C) -> Option<Primitive>
+    pub fn complex_number<C>(&self, cx: &C) -> Option<Numeric>
     where
         Ty: TyAbiInterface<'a, C> + Copy,
     {
@@ -313,35 +315,35 @@ impl<'a, Ty> TyAndLayout<'a, Ty> {
             return None;
         }
 
-        let part = complex.field(cx, 0).peel_transparent_wrappers(cx);
+        let component = complex.field(cx, 0).peel_transparent_wrappers(cx);
 
-        if let BackendRepr::Scalar(scalar) = part.backend_repr {
-            // Only Complex<{ float }> and Complex<{ integer }> have special layout.
-            let primitive = scalar.primitive();
-            match primitive {
-                // Explicitly spell out all the float types so that any new ones have to be added to
-                // one of the match branches.
-                Primitive::Int(..)
-                | Primitive::Float(Float::F16 | Float::F32 | Float::F64 | Float::F128) => {
-                    Some(primitive)
-                }
-                Primitive::Pointer(..) => None,
+        let BackendRepr::Scalar(scalar) = component.backend_repr else {
+            return None;
+        };
+
+        // Only Complex<{ float }> and Complex<{ integer }> have special layout.
+        //
+        // Explicitly spell out all the float types so that any new ones have to be added to
+        // one of the match branches.
+        let primitive = scalar.primitive();
+        match primitive {
+            Primitive::Int(integer, is_signed) => Some(Numeric::Int(integer, is_signed)),
+            Primitive::Float(float @ (Float::F16 | Float::F32 | Float::F64 | Float::F128)) => {
+                Some(Numeric::Float(float))
             }
-        } else {
-            None
+            Primitive::Pointer(..) => None,
         }
     }
 
-    /// Returns `Some` if this type has the ABI of the C `_Complex` type with float parts. See
-    /// [`TyAndLayout::complex_number_primitive`] for details.
+    /// Returns `Some` if this type has the ABI of the C `_Complex` type with float components.
+    /// See [`TyAndLayout::complex_number`] for details.
     pub fn complex_float<C>(&self, cx: &C) -> Option<Float>
     where
         Ty: TyAbiInterface<'a, C> + Copy,
     {
-        if let Some(Primitive::Float(float)) = self.complex_number_primitive(cx) {
-            Some(float)
-        } else {
-            None
+        match self.complex_number(cx) {
+            Some(Numeric::Float(float)) => Some(float),
+            _ => None,
         }
     }
 

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1451,6 +1451,31 @@ impl Float {
     }
 }
 
+/// Numeric primitives.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "nightly", derive(StableHash))]
+pub enum Numeric {
+    /// The `bool` is the signedness of the `Integer` type.
+    Int(Integer, bool),
+    Float(Float),
+}
+
+impl Numeric {
+    pub fn size(self) -> Size {
+        match self {
+            Numeric::Int(integer, _) => integer.size(),
+            Numeric::Float(float) => float.size(),
+        }
+    }
+
+    pub fn reg_kind(self) -> RegKind {
+        match self {
+            Numeric::Int(_, _) => RegKind::Integer,
+            Numeric::Float(_) => RegKind::Float,
+        }
+    }
+}
+
 /// Fundamental unit of memory access and layout.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "nightly", derive(StableHash))]

--- a/compiler/rustc_target/src/callconv/powerpc64.rs
+++ b/compiler/rustc_target/src/callconv/powerpc64.rs
@@ -2,9 +2,9 @@
 // Alignment of 128 bit types is not currently handled, this will
 // need to be fixed when PowerPC vector support is added.
 
-use rustc_abi::{HasDataLayout, TyAbiInterface};
+use rustc_abi::{HasDataLayout, Integer, Numeric, TyAbiInterface};
 
-use crate::callconv::{Align, ArgAbi, FnAbi, Reg, RegKind, Uniform};
+use crate::callconv::{Align, ArgAbi, CastTarget, FnAbi, Reg, RegKind, Uniform};
 use crate::spec::{HasTargetSpec, LlvmAbi, Os};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -58,6 +58,17 @@ where
     }
     if !arg.layout.is_aggregate() {
         arg.extend_integer_width_to(64);
+        return;
+    }
+    if let Some(component) = arg.layout.complex_number(cx) {
+        if let Numeric::Int(Integer::I16, _) = component {
+            // FIXME: use `PassMode::Cast` here. In LLVM 23 doing so would hit
+            // https://github.com/llvm/llvm-project/issues/218676.
+            return;
+        }
+
+        let reg = Reg { kind: component.reg_kind(), size: component.size() };
+        arg.cast_to(CastTarget::pair(reg, reg));
         return;
     }
 

--- a/compiler/rustc_target/src/callconv/sparc64.rs
+++ b/compiler/rustc_target/src/callconv/sparc64.rs
@@ -1,7 +1,7 @@
 use arrayvec::ArrayVec;
 use rustc_abi::{
-    Align, BackendRepr, FieldsShape, Float, HasDataLayout, Primitive, Reg, Size, TyAbiInterface,
-    TyAndLayout, Variants,
+    Align, BackendRepr, FieldsShape, Float, HasDataLayout, Integer, Numeric, Primitive, Reg,
+    RegKind, Size, TyAbiInterface, TyAndLayout, Variants,
 };
 
 use crate::callconv::{ArgAbi, ArgAttribute, CastTarget, FnAbi, Uniform};
@@ -142,6 +142,12 @@ fn classify_arg<'a, Ty, C>(
     }
 
     *total_double_word_count = start_double_word_count + double_word_count;
+
+    // Compatible with GCC and Clang 24.
+    if let Some(Numeric::Int(Integer::I8 | Integer::I16, _)) = arg.layout.complex_number(cx) {
+        arg.cast_to(Reg { kind: RegKind::Integer, size: total });
+        return;
+    }
 
     const ARGUMENT_REGISTERS: usize = 8;
 

--- a/tests/codegen-llvm/complex-abi.rs
+++ b/tests/codegen-llvm/complex-abi.rs
@@ -61,7 +61,15 @@
 //@ [CSKY] compile-flags: --target csky-unknown-linux-gnuabiv2
 //@ [CSKY] needs-llvm-components: csky
 
+//@ revisions: SPARC64
+//@ [SPARC64] compile-flags: --target sparc64-unknown-linux-gnu
+//@ [SPARC64] needs-llvm-components: sparc
+
 // FIXME: the below revisions are deliberately disabled for now.
+
+//  revisions: SPARC
+// [SPARC] compile-flags: --target sparc-unknown-linux-gnu
+// [SPARC] needs-llvm-components: sparc
 
 // revisions: POWERPC POWERPC64LE POWERPC64 AIX
 // [POWERPC] compile-flags: --target powerpc-unknown-linux-gnu
@@ -143,7 +151,7 @@ pub extern "C" fn cplx_f32(x: Complex<f32>) -> Complex<f32> {
     // RISCV32:        define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
     // RISCV64:        define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
     // S390X:          define{{.*}} void @cplx_f32(ptr {{.*}} sret([8 x i8]) {{.*}}, ptr {{.*}})
-    // SPARC64:        define{{.*}} {{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
+    // SPARC64:        define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
     // SPARC:          define{{.*}} { float, float } @cplx_f32(ptr {{.*}} byval({ float, float }) {{.*}})
     // WASM32:         define{{.*}} void @cplx_f32(ptr {{.*}} sret([8 x i8]) {{.*}}, ptr {{.*}})
     // WASM64:         define{{.*}} void @cplx_f32(ptr {{.*}} sret([8 x i8]) {{.*}}, ptr {{.*}})
@@ -177,7 +185,7 @@ pub extern "C" fn cplx_f64(x: Complex<f64>) -> Complex<f64> {
     // RISCV32:        define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
     // RISCV64:        define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
     // S390X:          define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
-    // SPARC64:        define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
+    // SPARC64:        define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
     // SPARC:          define{{.*}} { double, double } @cplx_f64(ptr {{.*}} byval({ double, double }) {{.*}})
     // WASM32:         define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // WASM64:         define{{.*}} void @cplx_f64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
@@ -225,7 +233,7 @@ pub extern "C" fn cplx_i8(x: Complex<i8>) -> Complex<i8> {
     // RISCV32:        define{{.*}} i32 @cplx_i8(i32{{.*}})
     // RISCV64:        define{{.*}} i64 @cplx_i8(i64{{.*}})
     // S390X:          define{{.*}} void @cplx_i8(ptr {{.*}} sret([2 x i8]) {{.*}}, ptr {{.*}})
-    // SPARC64:        define{{.*}} {{.*}} i64 @cplx_i8(i64{{.*}})
+    // SPARC64:        define{{.*}} i16 @cplx_i8(i16{{.*}})
     // SPARC:          define{{.*}} { i8, i8 } @cplx_i8(ptr {{.*}} byval({ i8, i8 }) {{.*}})
     // WASM32:         define{{.*}} void @cplx_i8(ptr {{.*}} sret([2 x i8]) {{.*}}, ptr {{.*}})
     // WASM64:         define{{.*}} void @cplx_i8(ptr {{.*}} sret([2 x i8]) {{.*}}, ptr {{.*}})
@@ -259,7 +267,7 @@ pub extern "C" fn cplx_i16(x: Complex<i16>) -> Complex<i16> {
     // RISCV32:        define{{.*}} i32 @cplx_i16(i32 {{.*}})
     // RISCV64:        define{{.*}} i64 @cplx_i16(i64{{.*}})
     // S390X:          define{{.*}} void @cplx_i16(ptr {{.*}} sret([4 x i8]) {{.*}}, ptr {{.*}})
-    // SPARC64:        define{{.*}} {{.*}} i64 @cplx_i16(i64{{.*}})
+    // SPARC64:        define{{.*}} i32 @cplx_i16(i32{{.*}})
     // SPARC:          define{{.*}} { i16, i16 } @cplx_i16(ptr {{.*}} byval({ i16, i16 }) {{.*}})
     // WASM32:         define{{.*}} void @cplx_i16(ptr {{.*}} sret([4 x i8]) {{.*}}, ptr {{.*}})
     // WASM64:         define{{.*}} void @cplx_i16(ptr {{.*}} sret([4 x i8]) {{.*}}, ptr {{.*}})
@@ -327,7 +335,7 @@ pub extern "C" fn cplx_i64(x: Complex<i64>) -> Complex<i64> {
     // RISCV32:        define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // RISCV64:        define{{.*}} [2 x i64] @cplx_i64([2 x i64] {{.*}})
     // S390X:          define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
-    // SPARC64:        define{{.*}} { i64, i64 } @cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // SPARC64:        define{{.*}} { i64, i64 } @cplx_i64({ i64, i64 } {{.*}})
     // SPARC:          define{{.*}} { i64, i64 } @cplx_i64(ptr {{.*}} byval({ i64, i64 }) {{.*}})
     // WASM32:         define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // WASM64:         define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
@@ -366,7 +374,7 @@ pub extern "C" fn wrapper_cplx_i64(
     // RISCV32:        define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // RISCV64:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
     // S390X:          define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
-    // SPARC64:        define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // SPARC64:        define { i64, i64 } @wrapper_cplx_i64({ i64, i64 } {{.*}})
     // SPARC:          define{{.*}} { i64, i64 } @wrapper_cplx_i64(ptr {{.*}} byval({ i64, i64 }) {{.*}})
     // WASM32:         define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // WASM64:         define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})

--- a/tests/codegen-llvm/complex-abi.rs
+++ b/tests/codegen-llvm/complex-abi.rs
@@ -83,6 +83,10 @@
 // [NVPTX] compile-flags: --target nvptx64-nvidia-cuda
 // [NVPTX] needs-llvm-components: nvptx
 
+// revisions: AMDGPU
+// [AMDGPU] compile-flags: --target amdgcn-amd-amdhsa -Ctarget-cpu=gfx900
+// [AMDGPU] needs-llvm-components: amdgpu
+
 // revisions: BPF
 // [BPF] compile-flags: --target bpfel-unknown-none
 // [BPF] needs-llvm-components: bpf

--- a/tests/codegen-llvm/complex-abi.rs
+++ b/tests/codegen-llvm/complex-abi.rs
@@ -65,21 +65,23 @@
 //@ [SPARC64] compile-flags: --target sparc64-unknown-linux-gnu
 //@ [SPARC64] needs-llvm-components: sparc
 
+//@ revisions: POWERPC64LE POWERPC64 AIX
+//@ [POWERPC64LE] compile-flags: --target powerpc64le-unknown-linux-gnu
+//@ [POWERPC64LE] needs-llvm-components: powerpc
+//@ [POWERPC64] compile-flags: --target powerpc64-unknown-linux-gnu
+//@ [POWERPC64] needs-llvm-components: powerpc
+//@ [AIX] compile-flags: --target powerpc64-ibm-aix
+//@ [AIX] needs-llvm-components: powerpc
+
 // FIXME: the below revisions are deliberately disabled for now.
 
 //  revisions: SPARC
 // [SPARC] compile-flags: --target sparc-unknown-linux-gnu
 // [SPARC] needs-llvm-components: sparc
 
-// revisions: POWERPC POWERPC64LE POWERPC64 AIX
+// revisions: POWERPC
 // [POWERPC] compile-flags: --target powerpc-unknown-linux-gnu
 // [POWERPC] needs-llvm-components: powerpc
-// [POWERPC64LE] compile-flags: --target powerpc64le-unknown-linux-gnu
-// [POWERPC64LE] needs-llvm-components: powerpc
-// [POWERPC64] compile-flags: --target powerpc64-unknown-linux-gnu
-// [POWERPC64] needs-llvm-components: powerpc
-// [AIX] compile-flags: --target powerpc64-ibm-aix
-// [AIX] needs-llvm-components: powerpc
 
 // revisions: MIPS64EL MIPS
 // [MIPS64EL] compile-flags: --target mips64el-unknown-linux-gnuabi64
@@ -134,7 +136,7 @@ pub extern "C" fn cplx_f32(x: Complex<f32>) -> Complex<f32> {
     // AARCH64:        define{{.*}} [2 x float] @cplx_f32([2 x float] {{.*}})
     // AARCH64_DARWIN: define{{.*}} [2 x float] @cplx_f32([2 x float] {{.*}})
     // AARCH64_MSVC:   define{{.*}} [2 x float] @cplx_f32([2 x float] {{.*}})
-    // AIX:            define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
+    // AIX:            define{{.*}} { float, float } @cplx_f32({ float, float } %0)
     // ARM64EC:        define{{.*}} [2 x float] @cplx_f32([2 x float] {{.*}})
     // ARM:            define{{.*}} [2 x float] @cplx_f32([2 x float] {{.*}})
     // BPF:            define{{.*}} void @cplx_f32(ptr {{.*}} sret({ float, float }) {{.*}}, i64 {{.*}})
@@ -145,8 +147,8 @@ pub extern "C" fn cplx_f32(x: Complex<f32>) -> Complex<f32> {
     // MIPS64EL:       define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
     // MIPS:           define{{.*}} { float, float } @cplx_f32([2 x i32] {{.*}})
     // NVPTX:          define{{.*}} { float, float } @cplx_f32(ptr {{.*}} byval({ float, float }) {{.*}})
-    // POWERPC64:      define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
-    // POWERPC64LE:    define{{.*}} { float, float } @cplx_f32(float {{.*}}, float {{.*}})
+    // POWERPC64:      define{{.*}} { float, float } @cplx_f32({ float, float } %0)
+    // POWERPC64LE:    define{{.*}} { float, float } @cplx_f32({ float, float } %0)
     // POWERPC:        define{{.*}} void @cplx_f32(ptr {{.*}} sret({ float, float }) {{.*}}, ptr {{.*}} byval({ float, float }) {{.*}})
     // RISCV32:        define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
     // RISCV64:        define{{.*}} { float, float } @cplx_f32({ float, float } {{.*}})
@@ -168,7 +170,7 @@ pub extern "C" fn cplx_f64(x: Complex<f64>) -> Complex<f64> {
     // AARCH64:        define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
     // AARCH64_DARWIN: define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
     // AARCH64_MSVC:   define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
-    // AIX:            define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
+    // AIX:            define{{.*}} { double, double } @cplx_f64({ double, double } %0)
     // ARM64EC:        define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
     // ARM:            define{{.*}} [2 x double] @cplx_f64([2 x double] {{.*}})
     // BPF:            define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, [2 x i64] {{.*}})
@@ -179,8 +181,8 @@ pub extern "C" fn cplx_f64(x: Complex<f64>) -> Complex<f64> {
     // MIPS64EL:       define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
     // MIPS:           define{{.*}} { double, double } @cplx_f64(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
     // NVPTX:          define{{.*}} { double, double } @cplx_f64(ptr {{.*}} byval({ double, double }) {{.*}})
-    // POWERPC64:      define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
-    // POWERPC64LE:    define{{.*}} { double, double } @cplx_f64(double {{.*}}, double {{.*}})
+    // POWERPC64:      define{{.*}} { double, double } @cplx_f64({ double, double } %0)
+    // POWERPC64LE:    define{{.*}} { double, double } @cplx_f64({ double, double } %0)
     // POWERPC:        define{{.*}} void @cplx_f64(ptr {{.*}} sret({ double, double }) {{.*}}, ptr {{.*}} byval({ double, double }) {{.*}})
     // RISCV32:        define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
     // RISCV64:        define{{.*}} { double, double } @cplx_f64({ double, double } {{.*}})
@@ -216,7 +218,7 @@ pub extern "C" fn cplx_i8(x: Complex<i8>) -> Complex<i8> {
     // AARCH64:        define{{.*}} i64 @cplx_i8(i64{{.*}})
     // AARCH64_DARWIN: define{{.*}} i64 @cplx_i8(i64{{.*}})
     // AARCH64_MSVC:   define{{.*}} i64 @cplx_i8(i64{{.*}})
-    // AIX:            define{{.*}} { i8, i8 } @cplx_i8(i8 {{.*}}, i8 {{.*}})
+    // AIX:            define{{.*}} { i8, i8 } @cplx_i8({ i8, i8 } %0)
     // ARM64EC:        define{{.*}} i64 @cplx_i8(i64{{.*}})
     // ARM:            define{{.*}} i32 @cplx_i8(i32{{.*}})
     // BPF:            define{{.*}} void @cplx_i8(ptr {{.*}} sret({ i8, i8 }) {{.*}}, i16 {{.*}})
@@ -227,8 +229,8 @@ pub extern "C" fn cplx_i8(x: Complex<i8>) -> Complex<i8> {
     // MIPS64EL:       define{{.*}} { i8, i8 } @cplx_i8(i16 {{.*}})
     // MIPS:           define{{.*}} { i8, i8 } @cplx_i8(i16 {{.*}})
     // NVPTX:          define{{.*}} { i8, i8 } @cplx_i8(ptr {{.*}} byval({ i8, i8 }) {{.*}})
-    // POWERPC64:      define{{.*}} { i8, i8 } @cplx_i8(i8 {{.*}}, i8 {{.*}})
-    // POWERPC64LE:    define{{.*}} { i8, i8 } @cplx_i8(i8 {{.*}}, i8 {{.*}})
+    // POWERPC64:      define{{.*}} { i8, i8 } @cplx_i8({ i8, i8 } %0)
+    // POWERPC64LE:    define{{.*}} { i8, i8 } @cplx_i8({ i8, i8 } %0)
     // POWERPC:        define{{.*}} void @cplx_i8(ptr {{.*}} sret({ i8, i8 }) {{.*}}, ptr {{.*}} byval({ i8, i8 }) {{.*}})
     // RISCV32:        define{{.*}} i32 @cplx_i8(i32{{.*}})
     // RISCV64:        define{{.*}} i64 @cplx_i8(i64{{.*}})
@@ -284,7 +286,7 @@ pub extern "C" fn cplx_i32(x: Complex<i32>) -> Complex<i32> {
     // AARCH64:        define{{.*}} i64 @cplx_i32(i64 {{.*}})
     // AARCH64_DARWIN: define{{.*}} i64 @cplx_i32(i64 {{.*}})
     // AARCH64_MSVC:   define{{.*}} i64 @cplx_i32(i64 {{.*}})
-    // AIX:            define{{.*}} { i32, i32 } @cplx_i32(i32 {{.*}}, i32 {{.*}})
+    // AIX:            define{{.*}} { i32, i32 } @cplx_i32({ i32, i32 } %0)
     // ARM64EC:        define{{.*}} i64 @cplx_i32(i64 {{.*}})
     // ARM:            define{{.*}} void @cplx_i32(ptr {{.*}} sret([8 x i8]) {{.*}}, [2 x i32] {{.*}})
     // BPF:            define{{.*}} void @cplx_i32(ptr {{.*}} sret({ i32, i32 }) {{.*}}, i64 {{.*}})
@@ -295,8 +297,8 @@ pub extern "C" fn cplx_i32(x: Complex<i32>) -> Complex<i32> {
     // MIPS64EL:       define{{.*}} { i32, i32 } @cplx_i32(i64 {{.*}})
     // MIPS:           define{{.*}} { i32, i32 } @cplx_i32(i32 {{.*}}, i32 {{.*}})
     // NVPTX:          define{{.*}} { i32, i32 } @cplx_i32(ptr {{.*}} byval({ i32, i32 }) {{.*}})
-    // POWERPC64:      define{{.*}} { i32, i32 } @cplx_i32(i32 {{.*}}, i32 {{.*}})
-    // POWERPC64LE:    define{{.*}} { i32, i32 } @cplx_i32(i32 {{.*}}, i32 {{.*}})
+    // POWERPC64:      define{{.*}} { i32, i32 } @cplx_i32({ i32, i32 } %0)
+    // POWERPC64LE:    define{{.*}} { i32, i32 } @cplx_i32({ i32, i32 } %0)
     // POWERPC:        define{{.*}} void @cplx_i32(ptr {{.*}} sret({ i32, i32 }) {{.*}}, ptr {{.*}} byval({ i32, i32 }) {{.*}})
     // RISCV32:        define{{.*}} [2 x i32] @cplx_i32([2 x i32] {{.*}})
     // RISCV64:        define{{.*}} i64 @cplx_i32(i64 {{.*}})
@@ -318,7 +320,7 @@ pub extern "C" fn cplx_i64(x: Complex<i64>) -> Complex<i64> {
     // AARCH64:        define{{.*}} [2 x i64] @cplx_i64([2 x i64] {{.*}})
     // AARCH64_DARWIN: define{{.*}} [2 x i64] @cplx_i64([2 x i64] {{.*}})
     // AARCH64_MSVC:   define{{.*}} [2 x i64] @cplx_i64([2 x i64] {{.*}})
-    // AIX:            define{{.*}} { i64, i64 } @cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // AIX:            define{{.*}} { i64, i64 } @cplx_i64({ i64, i64 } %0)
     // ARM64EC:        define{{.*}} [2 x i64] @cplx_i64([2 x i64] {{.*}})
     // ARM:            define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, [2 x i64] {{.*}})
     // BPF:            define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
@@ -329,8 +331,8 @@ pub extern "C" fn cplx_i64(x: Complex<i64>) -> Complex<i64> {
     // MIPS64EL:       define{{.*}} { i64, i64 } @cplx_i64(i64 {{.*}}, i64 {{.*}})
     // MIPS:           define{{.*}} { i64, i64 } @cplx_i64(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
     // NVPTX:          define{{.*}} { i64, i64 } @cplx_i64(ptr {{.*}} byval({ i64, i64 }) {{.*}})
-    // POWERPC64:      define{{.*}} { i64, i64 } @cplx_i64(i64 {{.*}}, i64 {{.*}})
-    // POWERPC64LE:    define{{.*}} { i64, i64 } @cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // POWERPC64:      define{{.*}} { i64, i64 } @cplx_i64({ i64, i64 } %0)
+    // POWERPC64LE:    define{{.*}} { i64, i64 } @cplx_i64({ i64, i64 } %0)
     // POWERPC:        define{{.*}} void @cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
     // RISCV32:        define{{.*}} void @cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // RISCV64:        define{{.*}} [2 x i64] @cplx_i64([2 x i64] {{.*}})
@@ -357,7 +359,7 @@ pub extern "C" fn wrapper_cplx_i64(
     // AARCH64:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
     // AARCH64_DARWIN: define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
     // AARCH64_MSVC:   define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
-    // AIX:            define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // AIX:            define{{.*}} { i64, i64 } @wrapper_cplx_i64({ i64, i64 } %0)
     // ARM64EC:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})
     // ARM:            define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, [2 x i64] {{.*}})
     // BPF:            define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, [2 x i64] {{.*}})
@@ -368,8 +370,8 @@ pub extern "C" fn wrapper_cplx_i64(
     // MIPS64EL:       define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
     // MIPS:           define{{.*}} { i64, i64 } @wrapper_cplx_i64(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
     // NVPTX:          define{{.*}} { i64, i64 } @wrapper_cplx_i64(ptr {{.*}} byval({ i64, i64 }) {{.*}})
-    // POWERPC64:      define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
-    // POWERPC64LE:    define{{.*}} { i64, i64 } @wrapper_cplx_i64(i64 {{.*}}, i64 {{.*}})
+    // POWERPC64:      define{{.*}} { i64, i64 } @wrapper_cplx_i64({ i64, i64 } %0)
+    // POWERPC64LE:    define{{.*}} { i64, i64 } @wrapper_cplx_i64({ i64, i64 } %0)
     // POWERPC:        define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret({ i64, i64 }) {{.*}}, ptr {{.*}} byval({ i64, i64 }) {{.*}})
     // RISCV32:        define{{.*}} void @wrapper_cplx_i64(ptr {{.*}} sret([16 x i8]) {{.*}}, ptr {{.*}})
     // RISCV64:        define{{.*}} [2 x i64] @wrapper_cplx_i64([2 x i64] {{.*}})


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/154023

Make the ABI for `Complex` match C for two slightly more involved targets. 

For Sparc64 the implementation matches GCC and Clang 24 and up. In https://github.com/llvm/llvm-project/pull/215015 a bug with how small complex numbers are passed was fixed.

For powerpc64 we match Clang exactly (and Clang is compatible with GCC for this target). 

cc @beetrees @Gelbpunkt 