### PR TITLE
Fix rmeta-link metadata not being read on AIX

### DIFF
--- a/compiler/rustc_codegen_gcc/src/back/lto.rs
+++ b/compiler/rustc_codegen_gcc/src/back/lto.rs
@@ -45,7 +45,11 @@ struct LtoData {
     tmp_path: TempDir,
 }
 
-fn prepare_lto(each_linked_rlib_for_lto: &[PathBuf], dcx: DiagCtxtHandle<'_>) -> LtoData {
+fn prepare_lto(
+    each_linked_rlib_for_lto: &[PathBuf],
+    dcx: DiagCtxtHandle<'_>,
+    is_like_aix: bool,
+) -> LtoData {
     let tmp_path = match tempdir() {
         Ok(tmp_path) => tmp_path,
         Err(error) => {
@@ -64,7 +68,7 @@ fn prepare_lto(each_linked_rlib_for_lto: &[PathBuf], dcx: DiagCtxtHandle<'_>) ->
         let archive_data = unsafe {
             Mmap::map(File::open(path).expect("couldn't open rlib")).expect("couldn't map rlib")
         };
-        let metadata_link = rmeta_link::read_from_data(&archive_data, path).unwrap();
+        let metadata_link = rmeta_link::read_from_data(&archive_data, path, is_like_aix).unwrap();
         let archive = ArchiveFile::parse(&*archive_data).expect("wanted an rlib");
         let obj_files = archive
             .members()
@@ -110,7 +114,7 @@ pub(crate) fn run_fat(
 ) -> CompiledModule {
     let dcx = DiagCtxt::new(Box::new(shared_emitter.clone()));
     let dcx = dcx.handle();
-    let lto_data = prepare_lto(each_linked_rlib_for_lto, dcx);
+    let lto_data = prepare_lto(each_linked_rlib_for_lto, dcx, cgcx.target_is_like_aix);
     /*let symbols_below_threshold =
     lto_data.symbols_below_threshold.iter().map(|c| c.as_ptr()).collect::<Vec<_>>();*/
     fat_lto(

--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -97,7 +97,8 @@ fn prepare_lto(
                 .expect("couldn't map rlib")
         };
         let archive = ArchiveFile::parse(&*archive_data).expect("wanted an rlib");
-        let metadata_link = rmeta_link::read(&archive, &archive_data, &path).unwrap();
+        let metadata_link =
+            rmeta_link::read(&archive, &archive_data, &path, cgcx.target_is_like_aix).unwrap();
         let obj_files = archive
             .members()
             .filter_map(|child| {

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -491,7 +491,12 @@ impl<'a> ArchiveBuilder for ArArchiveBuilder<'a> {
         };
         let metadata_link = match &mut ar_kind {
             AddArchiveKind::Rlib(cache, _) => cache.get_or_insert_with(&archive_path, || {
-                rmeta_link::read(&archive, &archive_map, &archive_path)
+                rmeta_link::read(
+                    &archive,
+                    &archive_map,
+                    &archive_path,
+                    self.sess.target.is_like_aix,
+                )
             }),
             AddArchiveKind::Other => None,
         };

--- a/compiler/rustc_codegen_ssa/src/back/rmeta_link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/rmeta_link.rs
@@ -47,14 +47,28 @@ impl RmetaLink {
     }
 }
 
+/// Decodes the `lib.rmeta-link` member.
+fn decode_member(rlib_path: &Path, member_data: &[u8], is_like_aix: bool) -> Option<RmetaLink> {
+    let section_data = if is_like_aix {
+        get_metadata_xcoff(rlib_path, member_data).ok()?
+    } else {
+        search_for_section(rlib_path, member_data, SECTION).ok()?
+    };
+    RmetaLink::decode(section_data)
+}
+
 /// Reads the link-time metadata from an already-parsed archive.
-pub fn read(archive: &ArchiveFile<'_>, archive_data: &[u8], rlib_path: &Path) -> Option<RmetaLink> {
+pub fn read(
+    archive: &ArchiveFile<'_>,
+    archive_data: &[u8],
+    rlib_path: &Path,
+    is_like_aix: bool,
+) -> Option<RmetaLink> {
     for entry in archive.members() {
         let entry = entry.ok()?;
         if entry.name() == FILENAME.as_bytes() {
             let data = entry.data(archive_data).ok()?;
-            let section_data = search_for_section(rlib_path, data, SECTION).ok()?;
-            return RmetaLink::decode(section_data);
+            return decode_member(rlib_path, data, is_like_aix);
         }
     }
     None
@@ -63,9 +77,13 @@ pub fn read(archive: &ArchiveFile<'_>, archive_data: &[u8], rlib_path: &Path) ->
 /// Like [`read`], but parses the archive from raw bytes.
 ///
 /// Use this when the caller's `ArchiveFile` comes from a different version of the `object` crate.
-pub fn read_from_data(archive_data: &[u8], rlib_path: &Path) -> Option<RmetaLink> {
+pub fn read_from_data(
+    archive_data: &[u8],
+    rlib_path: &Path,
+    is_like_aix: bool,
+) -> Option<RmetaLink> {
     let archive = ArchiveFile::parse(archive_data).ok()?;
-    read(&archive, archive_data, rlib_path)
+    read(&archive, archive_data, rlib_path, is_like_aix)
 }
 
 #[derive(Default)]
@@ -91,7 +109,7 @@ impl RmetaLinkCache {
         if !crate_may_have_bundled_libs(native_libs) {
             return Vec::new();
         }
-        self.get_or_insert_with(rlib_path, || read_from_path(target, rlib_path))
+        self.get_or_insert_with(rlib_path, || read_from_path(rlib_path, target.is_like_aix))
             .map(|rl| {
                 rl.native_lib_filenames.iter().map(|f| f.as_deref().map(Symbol::intern)).collect()
             })
@@ -105,7 +123,7 @@ fn crate_may_have_bundled_libs(libs: &[NativeLib]) -> bool {
 }
 
 // FIXME: this is mostly a copy-paste of `DefaultMetadataLoader::get_rlib_metadata`.
-fn read_from_path(target: &Target, path: &Path) -> Option<RmetaLink> {
+fn read_from_path(path: &Path, is_like_aix: bool) -> Option<RmetaLink> {
     let Ok(file) = File::open(path) else {
         debug!("failed to open rlib for rmeta-link: {}", path.display());
         return None;
@@ -115,18 +133,5 @@ fn read_from_path(target: &Target, path: &Path) -> Option<RmetaLink> {
         return None;
     };
 
-    if target.is_like_aix {
-        let archive = ArchiveFile::parse(&*mmap).ok()?;
-        for entry in archive.members() {
-            let entry = entry.ok()?;
-            if entry.name() == FILENAME.as_bytes() {
-                let member_data = entry.data(&*mmap).ok()?;
-                let section_data = get_metadata_xcoff(path, member_data).ok()?;
-                return RmetaLink::decode(section_data);
-            }
-        }
-        return None;
-    }
-
-    read_from_data(&mmap, path)
+    read_from_data(&mmap, path, is_like_aix)
 }


### PR DESCRIPTION
on XCOFF file format the payload goes to `.info` and the writer knows this from the file format 
on the other hand `rmeta_link::read` has no target so it always looks at the named section  which on AIX returns nothing and returns `None`

This PR is the fix so that it checks the format just like the writer does

Note that there is no AIX in CI so I couldn't test it and don't have access to a machine so was not tested locally either 
