### PR TITLE
pattern_type: make print format match the current syntax

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -756,9 +756,9 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
             ty::Uint(t) => write!(self, "{}", t.name_str())?,
             ty::Float(t) => write!(self, "{}", t.name_str())?,
             ty::Pat(ty, pat) => {
-                write!(self, "(")?;
+                write!(self, "pattern_type!(")?;
                 ty.print(self)?;
-                write!(self, ") is {pat:?}")?;
+                write!(self, " is {pat:?})")?;
             }
             ty::RawPtr(ty, mutbl) => {
                 write!(self, "*{} ", mutbl.ptr_str())?;

--- a/src/tools/miri/tests/fail/validity/nonzero.stderr
+++ b/src/tools/miri/tests/fail/validity/nonzero.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value of type (u32) is 1..: encountered 0, but expected something greater or equal to 1
+error: Undefined Behavior: constructing invalid value of type pattern_type!(u32 is 1..): encountered 0, but expected something greater or equal to 1
   --> tests/fail/validity/nonzero.rs:LL:CC
    |
 LL |     let _x = Some(unsafe { NonZero(std::mem::transmute(0_u32)) });

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
@@ -37,11 +37,11 @@
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} is !null }};
           _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} is !null }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
-          _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }};
+          _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
-          _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
-          _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
+          _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -37,11 +37,11 @@
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} is !null }};
           _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} is !null }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
-          _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }};
+          _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
-          _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
-          _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
+          _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind: bb2];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
@@ -37,11 +37,11 @@
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} is !null }};
           _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} is !null }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
-          _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }};
+          _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
-          _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
-          _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
+          _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -37,11 +37,11 @@
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} is !null }};
           _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} is !null }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
-          _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }};
+          _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
-          _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
-          _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
+          _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind: bb2];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
@@ -40,13 +40,13 @@
 +         _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} is !null }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
 -         _3 = move _4 as std::ptr::Unique<[bool]> (PointerCoercion(Unsize, Implicit));
-+         _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }};
++         _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
 -         _2 = Box::<[bool]>(copy _3, const std::alloc::Global);
-+         _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
++         _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
-+         _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
++         _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
@@ -40,13 +40,13 @@
 +         _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} is !null }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
 -         _3 = move _4 as std::ptr::Unique<[bool]> (PointerCoercion(Unsize, Implicit));
-+         _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }};
++         _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
 -         _2 = Box::<[bool]>(copy _3, const std::alloc::Global);
-+         _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
++         _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
-+         _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
++         _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind: bb2];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
@@ -40,13 +40,13 @@
 +         _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} is !null }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
 -         _3 = move _4 as std::ptr::Unique<[bool]> (PointerCoercion(Unsize, Implicit));
-+         _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }};
++         _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
 -         _2 = Box::<[bool]>(copy _3, const std::alloc::Global);
-+         _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
++         _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
-+         _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
++         _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
@@ -40,13 +40,13 @@
 +         _4 = const std::ptr::Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} is !null }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
 -         _3 = move _4 as std::ptr::Unique<[bool]> (PointerCoercion(Unsize, Implicit));
-+         _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }};
++         _3 = const std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
 -         _2 = Box::<[bool]>(copy _3, const std::alloc::Global);
-+         _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
++         _2 = const Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
-+         _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: (*const [bool]) is !null }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
++         _1 = const A {{ foo: Box::<[bool]>(std::ptr::Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: pattern_type!(*const [bool] is !null) }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind: bb2];

--- a/tests/mir-opt/dataflow-const-prop/enum.mutate_discriminant.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.mutate_discriminant.DataflowConstProp.32bit.diff
@@ -4,15 +4,15 @@
   fn mutate_discriminant() -> u8 {
       let mut _0: u8;
       let mut _1: std::option::Option<NonZeroUsize>;
-      let mut _2: (usize) is 1..;
+      let mut _2: pattern_type!(usize is 1..);
       let mut _3: isize;
   
       bb0: {
           discriminant(_1) = 1;
--         _2 = const 0_usize as (usize) is 1.. (Transmute);
--         (((_1 as variant#1).0: NonZeroUsize).0: (usize) is 1..=usize::MAX) = copy _2;
-+         _2 = const {transmute(0x00000000): (usize) is 1..};
-+         (((_1 as variant#1).0: NonZeroUsize).0: (usize) is 1..=usize::MAX) = const {transmute(0x00000000): (usize) is 1..=usize::MAX};
+-         _2 = const 0_usize as pattern_type!(usize is 1..) (Transmute);
+-         (((_1 as variant#1).0: NonZeroUsize).0: pattern_type!(usize is 1..=usize::MAX)) = copy _2;
++         _2 = const {transmute(0x00000000): pattern_type!(usize is 1..)};
++         (((_1 as variant#1).0: NonZeroUsize).0: pattern_type!(usize is 1..=usize::MAX)) = const {transmute(0x00000000): pattern_type!(usize is 1..=usize::MAX)};
           _3 = discriminant(_1);
           switchInt(copy _3) -> [0: bb1, otherwise: bb2];
       }

--- a/tests/mir-opt/dataflow-const-prop/enum.mutate_discriminant.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.mutate_discriminant.DataflowConstProp.64bit.diff
@@ -4,15 +4,15 @@
   fn mutate_discriminant() -> u8 {
       let mut _0: u8;
       let mut _1: std::option::Option<NonZeroUsize>;
-      let mut _2: (usize) is 1..;
+      let mut _2: pattern_type!(usize is 1..);
       let mut _3: isize;
   
       bb0: {
           discriminant(_1) = 1;
--         _2 = const 0_usize as (usize) is 1.. (Transmute);
--         (((_1 as variant#1).0: NonZeroUsize).0: (usize) is 1..=usize::MAX) = copy _2;
-+         _2 = const {transmute(0x0000000000000000): (usize) is 1..};
-+         (((_1 as variant#1).0: NonZeroUsize).0: (usize) is 1..=usize::MAX) = const {transmute(0x0000000000000000): (usize) is 1..=usize::MAX};
+-         _2 = const 0_usize as pattern_type!(usize is 1..) (Transmute);
+-         (((_1 as variant#1).0: NonZeroUsize).0: pattern_type!(usize is 1..=usize::MAX)) = copy _2;
++         _2 = const {transmute(0x0000000000000000): pattern_type!(usize is 1..)};
++         (((_1 as variant#1).0: NonZeroUsize).0: pattern_type!(usize is 1..=usize::MAX)) = const {transmute(0x0000000000000000): pattern_type!(usize is 1..=usize::MAX)};
           _3 = discriminant(_1);
           switchInt(copy _3) -> [0: bb1, otherwise: bb2];
       }

--- a/tests/mir-opt/elaborate_box_deref_in_debuginfo.pointee.ElaborateBoxDerefs.diff
+++ b/tests/mir-opt/elaborate_box_deref_in_debuginfo.pointee.ElaborateBoxDerefs.diff
@@ -3,7 +3,7 @@
   
   fn pointee(_1: Box<i32>) -> () {
 -     debug foo => (*_1);
-+     debug foo => (*((((_1.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: (*const i32) is !null).0: *const i32));
++     debug foo => (*((((_1.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: pattern_type!(*const i32 is !null)).0: *const i32));
       let mut _0: ();
   
       bb0: {

--- a/tests/mir-opt/gvn.aggregate_struct_then_transmute.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.aggregate_struct_then_transmute.GVN.panic-abort.diff
@@ -6,7 +6,7 @@
       debug thin => _2;
       let mut _0: ();
       let _3: MyId;
-      let mut _4: (u16) is 0..=55554;
+      let mut _4: pattern_type!(u16 is 0..=55554);
       let mut _5: u16;
       let _6: ();
       let mut _7: u16;
@@ -24,7 +24,7 @@
       let _22: ();
       let mut _23: u32;
       let mut _24: std::option::Option<u16>;
-      let mut _26: (u16) is 0..=55554;
+      let mut _26: pattern_type!(u16 is 0..=55554);
       let mut _27: u16;
       let _28: ();
       let mut _29: i16;
@@ -98,8 +98,8 @@
 +         nop;
           StorageLive(_5);
           _5 = copy _1;
--         _4 = move _5 as (u16) is 0..=55554 (Transmute);
-+         _4 = copy _1 as (u16) is 0..=55554 (Transmute);
+-         _4 = move _5 as pattern_type!(u16 is 0..=55554) (Transmute);
++         _4 = copy _1 as pattern_type!(u16 is 0..=55554) (Transmute);
           StorageDead(_5);
 -         _3 = MyId(move _4);
 -         StorageDead(_4);
@@ -188,7 +188,7 @@
           StorageLive(_26);
           StorageLive(_27);
           _27 = copy _1;
--         _26 = move _27 as (u16) is 0..=55554 (Transmute);
+-         _26 = move _27 as pattern_type!(u16 is 0..=55554) (Transmute);
 +         _26 = copy _4;
           StorageDead(_27);
 -         _25 = MyId(move _26);

--- a/tests/mir-opt/gvn.aggregate_struct_then_transmute.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.aggregate_struct_then_transmute.GVN.panic-unwind.diff
@@ -6,7 +6,7 @@
       debug thin => _2;
       let mut _0: ();
       let _3: MyId;
-      let mut _4: (u16) is 0..=55554;
+      let mut _4: pattern_type!(u16 is 0..=55554);
       let mut _5: u16;
       let _6: ();
       let mut _7: u16;
@@ -24,7 +24,7 @@
       let _22: ();
       let mut _23: u32;
       let mut _24: std::option::Option<u16>;
-      let mut _26: (u16) is 0..=55554;
+      let mut _26: pattern_type!(u16 is 0..=55554);
       let mut _27: u16;
       let _28: ();
       let mut _29: i16;
@@ -98,8 +98,8 @@
 +         nop;
           StorageLive(_5);
           _5 = copy _1;
--         _4 = move _5 as (u16) is 0..=55554 (Transmute);
-+         _4 = copy _1 as (u16) is 0..=55554 (Transmute);
+-         _4 = move _5 as pattern_type!(u16 is 0..=55554) (Transmute);
++         _4 = copy _1 as pattern_type!(u16 is 0..=55554) (Transmute);
           StorageDead(_5);
 -         _3 = MyId(move _4);
 -         StorageDead(_4);
@@ -188,7 +188,7 @@
           StorageLive(_26);
           StorageLive(_27);
           _27 = copy _1;
--         _26 = move _27 as (u16) is 0..=55554 (Transmute);
+-         _26 = move _27 as pattern_type!(u16 is 0..=55554) (Transmute);
 +         _26 = copy _4;
           StorageDead(_27);
 -         _25 = MyId(move _26);

--- a/tests/mir-opt/gvn.rs
+++ b/tests/mir-opt/gvn.rs
@@ -949,7 +949,7 @@ fn cast_pointer_eq(p1: *mut u8, p2: *mut u32, p3: *mut u32, p4: *mut [u32]) {
 
 // CHECK: fn aggregate_struct_then_transmute
 unsafe fn aggregate_struct_then_transmute(id: u16, thin: *const u8) {
-    // CHECK: [[PAT:_[0-9]+]] = copy _1 as (u16) is 0..=55554 (Transmute);
+    // CHECK: [[PAT:_[0-9]+]] = copy _1 as pattern_type!(u16 is 0..=55554) (Transmute);
     // CHECK: [[TEMP:_[0-9]+]] = copy [[PAT]] as u16 (Transmute);
     // CHECK: opaque::<u16>(move [[TEMP]])
     let a = MyId(std::intrinsics::transmute(id));

--- a/tests/mir-opt/jump_threading.mutate_discriminant.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.mutate_discriminant.JumpThreading.panic-abort.diff
@@ -4,13 +4,13 @@
   fn mutate_discriminant() -> u8 {
       let mut _0: u8;
       let mut _1: std::option::Option<NonZeroUsize>;
-      let mut _2: (usize) is 1..;
+      let mut _2: pattern_type!(usize is 1..);
       let mut _3: isize;
   
       bb0: {
           discriminant(_1) = 1;
-          _2 = const 0_usize as (usize) is 1.. (Transmute);
-          (((_1 as variant#1).0: NonZeroUsize).0: (usize) is 1..=usize::MAX) = copy _2;
+          _2 = const 0_usize as pattern_type!(usize is 1..) (Transmute);
+          (((_1 as variant#1).0: NonZeroUsize).0: pattern_type!(usize is 1..=usize::MAX)) = copy _2;
           _3 = discriminant(_1);
           switchInt(copy _3) -> [0: bb1, otherwise: bb2];
       }

--- a/tests/mir-opt/jump_threading.mutate_discriminant.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.mutate_discriminant.JumpThreading.panic-unwind.diff
@@ -4,13 +4,13 @@
   fn mutate_discriminant() -> u8 {
       let mut _0: u8;
       let mut _1: std::option::Option<NonZeroUsize>;
-      let mut _2: (usize) is 1..;
+      let mut _2: pattern_type!(usize is 1..);
       let mut _3: isize;
   
       bb0: {
           discriminant(_1) = 1;
-          _2 = const 0_usize as (usize) is 1.. (Transmute);
-          (((_1 as variant#1).0: NonZeroUsize).0: (usize) is 1..=usize::MAX) = copy _2;
+          _2 = const 0_usize as pattern_type!(usize is 1..) (Transmute);
+          (((_1 as variant#1).0: NonZeroUsize).0: pattern_type!(usize is 1..=usize::MAX)) = copy _2;
           _3 = discriminant(_1);
           switchInt(copy _3) -> [0: bb1, otherwise: bb2];
       }

--- a/tests/mir-opt/pattern_types.main.runtime-optimized.after.mir
+++ b/tests/mir-opt/pattern_types.main.runtime-optimized.after.mir
@@ -5,7 +5,7 @@ fn main() -> () {
     scope 1 {
         debug x => const 2_u32 is 1..;
         scope 2 {
-            debug y => const {transmute(0x00000000): (u32) is 1..};
+            debug y => const {transmute(0x00000000): pattern_type!(u32 is 1..)};
         }
     }
 

--- a/tests/mir-opt/pattern_types.rs
+++ b/tests/mir-opt/pattern_types.rs
@@ -7,6 +7,6 @@ use std::pat::pattern_type;
 fn main() {
     // CHECK: debug x => const 2_u32 is 1..
     let x: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(2) };
-    // CHECK: debug y => const {transmute(0x00000000): (u32) is 1..}
+    // CHECK: debug y => const {transmute(0x00000000): pattern_type!(u32 is 1..)}
     let y: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(0) };
 }

--- a/tests/ui/lint/clashing-extern-fn.stderr
+++ b/tests/ui/lint/clashing-extern-fn.stderr
@@ -17,7 +17,7 @@ LL |             fn hidden_niche_unsafe_cell() -> Option<UnsafeCell<NonZero<usiz
    = help: consider adding a `#[repr(C)]`, `#[repr(transparent)]`, or integer `#[repr(...)]` attribute to this enum
    = note: enum has no representation hint
 
-warning: `extern` block uses type `Option<(usize) is 0..>`, which is not FFI-safe
+warning: `extern` block uses type `Option<pattern_type!(usize is 0..)>`, which is not FFI-safe
   --> $DIR/clashing-extern-fn.rs:502:54
    |
 LL |             fn pt_non_zero_usize_opt_full_range() -> Option<pattern_type!(usize is 0..)>;
@@ -276,7 +276,7 @@ LL |             fn pt_non_null_ptr() -> pattern_type!(usize is 1..);
 LL |             fn pt_non_null_ptr() -> *const ();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
    |
-   = note: expected `unsafe extern "C" fn() -> (usize) is 1..=`
+   = note: expected `unsafe extern "C" fn() -> pattern_type!(usize is 1..=)`
               found `unsafe extern "C" fn() -> *const ()`
 
 warning: 24 warnings emitted

--- a/tests/ui/type/pattern_types/derives.rs
+++ b/tests/ui/type/pattern_types/derives.rs
@@ -9,7 +9,7 @@ use std::pat::pattern_type;
 #[derive(Clone, Copy, PartialEq)]
 #[repr(transparent)]
 struct Nanoseconds(NanoI32);
-//~^ ERROR: binary operation `==` cannot be applied to type `(i32) is 0..=999999999`
+//~^ ERROR: binary operation `==` cannot be applied to type `pattern_type!(i32 is 0..=999999999)`
 
 type NanoI32 = crate::pattern_type!(i32 is 0..=999_999_999);
 

--- a/tests/ui/type/pattern_types/derives.stderr
+++ b/tests/ui/type/pattern_types/derives.stderr
@@ -1,4 +1,4 @@
-error[E0369]: binary operation `==` cannot be applied to type `(i32) is 0..=999999999`
+error[E0369]: binary operation `==` cannot be applied to type `pattern_type!(i32 is 0..=999999999)`
   --> $DIR/derives.rs:11:20
    |
 LL | #[derive(Clone, Copy, PartialEq)]

--- a/tests/ui/type/pattern_types/derives_fail.rs
+++ b/tests/ui/type/pattern_types/derives_fail.rs
@@ -9,11 +9,11 @@ use std::pat::pattern_type;
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Ord, PartialOrd, Hash, Default)]
 #[repr(transparent)]
 struct Nanoseconds(NanoI32);
-//~^ ERROR: the trait bound `(i32) is 0..=999999999: Eq` is not satisfied
-//~| ERROR: `(i32) is 0..=999999999` doesn't implement `Debug`
-//~| ERROR: the trait bound `(i32) is 0..=999999999: Ord` is not satisfied
-//~| ERROR: the trait bound `(i32) is 0..=999999999: Hash` is not satisfied
-//~| ERROR: the trait bound `(i32) is 0..=999999999: Default` is not satisfied
+//~^ ERROR: the trait bound `pattern_type!(i32 is 0..=999999999): Eq` is not satisfied
+//~| ERROR: `pattern_type!(i32 is 0..=999999999)` doesn't implement `Debug`
+//~| ERROR: the trait bound `pattern_type!(i32 is 0..=999999999): Ord` is not satisfied
+//~| ERROR: the trait bound `pattern_type!(i32 is 0..=999999999): Hash` is not satisfied
+//~| ERROR: the trait bound `pattern_type!(i32 is 0..=999999999): Default` is not satisfied
 //~| ERROR: `==` cannot be applied
 
 type NanoI32 = crate::pattern_type!(i32 is 0..=999_999_999);

--- a/tests/ui/type/pattern_types/derives_fail.stderr
+++ b/tests/ui/type/pattern_types/derives_fail.stderr
@@ -1,4 +1,4 @@
-error[E0369]: binary operation `==` cannot be applied to type `(i32) is 0..=999999999`
+error[E0369]: binary operation `==` cannot be applied to type `pattern_type!(i32 is 0..=999999999)`
   --> $DIR/derives_fail.rs:11:20
    |
 LL | #[derive(Clone, Copy, PartialEq, Eq, Debug, Ord, PartialOrd, Hash, Default)]
@@ -7,53 +7,53 @@ LL | #[repr(transparent)]
 LL | struct Nanoseconds(NanoI32);
    |                    ^^^^^^^
 
-error[E0277]: the trait bound `(i32) is 0..=999999999: Eq` is not satisfied
+error[E0277]: the trait bound `pattern_type!(i32 is 0..=999999999): Eq` is not satisfied
   --> $DIR/derives_fail.rs:11:20
    |
 LL | #[derive(Clone, Copy, PartialEq, Eq, Debug, Ord, PartialOrd, Hash, Default)]
    |                                  -- in this derive macro expansion
 LL | #[repr(transparent)]
 LL | struct Nanoseconds(NanoI32);
-   |                    ^^^^^^^ the trait `Eq` is not implemented for `(i32) is 0..=999999999`
+   |                    ^^^^^^^ the trait `Eq` is not implemented for `pattern_type!(i32 is 0..=999999999)`
    |
 note: required by a bound in `std::cmp::AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
 
-error[E0277]: `(i32) is 0..=999999999` doesn't implement `Debug`
+error[E0277]: `pattern_type!(i32 is 0..=999999999)` doesn't implement `Debug`
   --> $DIR/derives_fail.rs:11:20
    |
 LL | #[derive(Clone, Copy, PartialEq, Eq, Debug, Ord, PartialOrd, Hash, Default)]
    |                                      ----- in this derive macro expansion
 LL | #[repr(transparent)]
 LL | struct Nanoseconds(NanoI32);
-   |                    ^^^^^^^ the trait `Debug` is not implemented for `(i32) is 0..=999999999`
+   |                    ^^^^^^^ the trait `Debug` is not implemented for `pattern_type!(i32 is 0..=999999999)`
 
-error[E0277]: the trait bound `(i32) is 0..=999999999: Ord` is not satisfied
+error[E0277]: the trait bound `pattern_type!(i32 is 0..=999999999): Ord` is not satisfied
   --> $DIR/derives_fail.rs:11:20
    |
 LL | #[derive(Clone, Copy, PartialEq, Eq, Debug, Ord, PartialOrd, Hash, Default)]
    |                                             --- in this derive macro expansion
 LL | #[repr(transparent)]
 LL | struct Nanoseconds(NanoI32);
-   |                    ^^^^^^^ the trait `Ord` is not implemented for `(i32) is 0..=999999999`
+   |                    ^^^^^^^ the trait `Ord` is not implemented for `pattern_type!(i32 is 0..=999999999)`
 
-error[E0277]: the trait bound `(i32) is 0..=999999999: Hash` is not satisfied
+error[E0277]: the trait bound `pattern_type!(i32 is 0..=999999999): Hash` is not satisfied
   --> $DIR/derives_fail.rs:11:20
    |
 LL | #[derive(Clone, Copy, PartialEq, Eq, Debug, Ord, PartialOrd, Hash, Default)]
    |                                                              ---- in this derive macro expansion
 LL | #[repr(transparent)]
 LL | struct Nanoseconds(NanoI32);
-   |                    ^^^^^^^ the trait `Hash` is not implemented for `(i32) is 0..=999999999`
+   |                    ^^^^^^^ the trait `Hash` is not implemented for `pattern_type!(i32 is 0..=999999999)`
 
-error[E0277]: the trait bound `(i32) is 0..=999999999: Default` is not satisfied
+error[E0277]: the trait bound `pattern_type!(i32 is 0..=999999999): Default` is not satisfied
   --> $DIR/derives_fail.rs:11:20
    |
 LL | #[derive(Clone, Copy, PartialEq, Eq, Debug, Ord, PartialOrd, Hash, Default)]
    |                                                                    ------- in this derive macro expansion
 LL | #[repr(transparent)]
 LL | struct Nanoseconds(NanoI32);
-   |                    ^^^^^^^ the trait `Default` is not implemented for `(i32) is 0..=999999999`
+   |                    ^^^^^^^ the trait `Default` is not implemented for `pattern_type!(i32 is 0..=999999999)`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/type/pattern_types/literals.rs
+++ b/tests/ui/type/pattern_types/literals.rs
@@ -20,12 +20,12 @@ fn in_range() -> pattern_type!(u32 is 1..) {
 
 fn negative_lit_on_unsigned_ty() -> pattern_type!(u32 is 1..) {
     -3
-    //~^ ERROR: cannot apply unary operator `-` to type `(u32) is 1..`
+    //~^ ERROR: cannot apply unary operator `-` to type `pattern_type!(u32 is 1..)`
 }
 
 fn negative_lit_in_range() -> pattern_type!(i8 is -5..5) {
     -2
-    //~^ ERROR: cannot apply unary operator `-` to type `(i8) is -5..=4`
+    //~^ ERROR: cannot apply unary operator `-` to type `pattern_type!(i8 is -5..=4)`
 }
 
 fn positive_lit_in_range_of_signed() -> pattern_type!(i8 is -5..5) {

--- a/tests/ui/type/pattern_types/literals.stderr
+++ b/tests/ui/type/pattern_types/literals.stderr
@@ -32,20 +32,20 @@ error[E0308]: mismatched types
   --> $DIR/literals.rs:9:5
    |
 LL | fn out_of_range() -> pattern_type!(u32 is 1..) {
-   |                      ------------------------- expected `(u32) is 1..` because of return type
+   |                      ------------------------- expected `pattern_type!(u32 is 1..)` because of return type
 LL |     0
-   |     ^ expected `(u32) is 1..`, found integer
+   |     ^ expected `pattern_type!(u32 is 1..)`, found integer
    |
-   = note: expected pattern type `(u32) is 1..`
+   = note: expected pattern type `pattern_type!(u32 is 1..)`
                       found type `{integer}`
 
-error[E0600]: cannot apply unary operator `-` to type `(u32) is 1..`
+error[E0600]: cannot apply unary operator `-` to type `pattern_type!(u32 is 1..)`
   --> $DIR/literals.rs:22:5
    |
 LL |     -3
    |     ^^ cannot apply unary operator `-`
 
-error[E0600]: cannot apply unary operator `-` to type `(i8) is -5..=4`
+error[E0600]: cannot apply unary operator `-` to type `pattern_type!(i8 is -5..=4)`
   --> $DIR/literals.rs:27:5
    |
 LL |     -2
@@ -55,77 +55,77 @@ error[E0308]: mismatched types
   --> $DIR/literals.rs:36:5
    |
 LL | fn negative_lit_at_range_start() -> pattern_type!(i8 is -5..5) {
-   |                                     -------------------------- expected `(i8) is -5..=4` because of return type
+   |                                     -------------------------- expected `pattern_type!(i8 is -5..=4)` because of return type
 LL |     -5
-   |     ^^ expected `(i8) is -5..=4`, found integer
+   |     ^^ expected `pattern_type!(i8 is -5..=4)`, found integer
    |
-   = note: expected pattern type `(i8) is -5..=4`
+   = note: expected pattern type `pattern_type!(i8 is -5..=4)`
                       found type `{integer}`
 
 error[E0308]: mismatched types
   --> $DIR/literals.rs:45:5
    |
 LL | fn lit_one_beyond_range_end() -> pattern_type!(i8 is -5..5) {
-   |                                  -------------------------- expected `(i8) is -5..=4` because of return type
+   |                                  -------------------------- expected `pattern_type!(i8 is -5..=4)` because of return type
 LL |     5
-   |     ^ expected `(i8) is -5..=4`, found integer
+   |     ^ expected `pattern_type!(i8 is -5..=4)`, found integer
    |
-   = note: expected pattern type `(i8) is -5..=4`
+   = note: expected pattern type `pattern_type!(i8 is -5..=4)`
                       found type `{integer}`
 
 error[E0308]: mismatched types
   --> $DIR/literals.rs:50:5
    |
 LL | fn wrong_lit_kind() -> pattern_type!(u32 is 1..) {
-   |                        ------------------------- expected `(u32) is 1..` because of return type
+   |                        ------------------------- expected `pattern_type!(u32 is 1..)` because of return type
 LL |     '3'
-   |     ^^^ expected `(u32) is 1..`, found `char`
+   |     ^^^ expected `pattern_type!(u32 is 1..)`, found `char`
    |
-   = note: expected pattern type `(u32) is 1..`
+   = note: expected pattern type `pattern_type!(u32 is 1..)`
                       found type `char`
 
 error[E0308]: mismatched types
   --> $DIR/literals.rs:55:5
    |
 LL | fn char_lit_in_range() -> pattern_type!(char is 'a'..'z') {
-   |                           ------------------------------- expected `(char) is 'a'..='y'` because of return type
+   |                           ------------------------------- expected `pattern_type!(char is 'a'..='y')` because of return type
 LL |     'b'
-   |     ^^^ expected `(char) is 'a'..='y'`, found `char`
+   |     ^^^ expected `pattern_type!(char is 'a'..='y')`, found `char`
    |
-   = note: expected pattern type `(char) is 'a'..='y'`
+   = note: expected pattern type `pattern_type!(char is 'a'..='y')`
                       found type `char`
 
 error[E0308]: mismatched types
   --> $DIR/literals.rs:60:5
    |
 LL | fn char_lit_out_of_range() -> pattern_type!(char is 'a'..'z') {
-   |                               ------------------------------- expected `(char) is 'a'..='y'` because of return type
+   |                               ------------------------------- expected `pattern_type!(char is 'a'..='y')` because of return type
 LL |     'A'
-   |     ^^^ expected `(char) is 'a'..='y'`, found `char`
+   |     ^^^ expected `pattern_type!(char is 'a'..='y')`, found `char`
    |
-   = note: expected pattern type `(char) is 'a'..='y'`
+   = note: expected pattern type `pattern_type!(char is 'a'..='y')`
                       found type `char`
 
 error[E0308]: mismatched types
   --> $DIR/literals.rs:73:5
    |
 LL | fn lit_oob_single_element_range() -> pattern_type!(u32 is 0..=0) {
-   |                                      --------------------------- expected `(u32) is 0..=0` because of return type
+   |                                      --------------------------- expected `pattern_type!(u32 is 0..=0)` because of return type
 LL |     1
-   |     ^ expected `(u32) is 0..=0`, found integer
+   |     ^ expected `pattern_type!(u32 is 0..=0)`, found integer
    |
-   = note: expected pattern type `(u32) is 0..=0`
+   = note: expected pattern type `pattern_type!(u32 is 0..=0)`
                       found type `{integer}`
 
 error[E0308]: mismatched types
   --> $DIR/literals.rs:78:5
    |
 LL | fn lit_oob_single_element_range_exclusive() -> pattern_type!(u32 is 0..1) {
-   |                                                -------------------------- expected `(u32) is 0..=0` because of return type
+   |                                                -------------------------- expected `pattern_type!(u32 is 0..=0)` because of return type
 LL |     1
-   |     ^ expected `(u32) is 0..=0`, found integer
+   |     ^ expected `pattern_type!(u32 is 0..=0)`, found integer
    |
-   = note: expected pattern type `(u32) is 0..=0`
+   = note: expected pattern type `pattern_type!(u32 is 0..=0)`
                       found type `{integer}`
 
 error: pattern type ranges cannot wrap: 1..=0
@@ -134,22 +134,22 @@ error[E0308]: mismatched types
   --> $DIR/literals.rs:97:5
    |
 LL | fn empty_range() -> pattern_type!(u32 is 1..1) {
-   |                     -------------------------- expected `(u32) is 1..=0` because of return type
+   |                     -------------------------- expected `pattern_type!(u32 is 1..=0)` because of return type
 LL |     0
-   |     ^ expected `(u32) is 1..=0`, found integer
+   |     ^ expected `pattern_type!(u32 is 1..=0)`, found integer
    |
-   = note: expected pattern type `(u32) is 1..=0`
+   = note: expected pattern type `pattern_type!(u32 is 1..=0)`
                       found type `{integer}`
 
 error[E0308]: mismatched types
   --> $DIR/literals.rs:102:5
    |
 LL | fn empty_range2() -> pattern_type!(u32 is 1..1) {
-   |                      -------------------------- expected `(u32) is 1..=0` because of return type
+   |                      -------------------------- expected `pattern_type!(u32 is 1..=0)` because of return type
 LL |     1
-   |     ^ expected `(u32) is 1..=0`, found integer
+   |     ^ expected `pattern_type!(u32 is 1..=0)`, found integer
    |
-   = note: expected pattern type `(u32) is 1..=0`
+   = note: expected pattern type `pattern_type!(u32 is 1..=0)`
                       found type `{integer}`
 
 error: pattern type ranges cannot wrap: 2..=0
@@ -158,33 +158,33 @@ error[E0308]: mismatched types
   --> $DIR/literals.rs:122:5
    |
 LL | fn wraparound_range() -> pattern_type!(u32 is 2..1) {
-   |                          -------------------------- expected `(u32) is 2..=0` because of return type
+   |                          -------------------------- expected `pattern_type!(u32 is 2..=0)` because of return type
 LL |     1
-   |     ^ expected `(u32) is 2..=0`, found integer
+   |     ^ expected `pattern_type!(u32 is 2..=0)`, found integer
    |
-   = note: expected pattern type `(u32) is 2..=0`
+   = note: expected pattern type `pattern_type!(u32 is 2..=0)`
                       found type `{integer}`
 
 error[E0308]: mismatched types
   --> $DIR/literals.rs:127:5
    |
 LL | fn lit_in_wraparound_range() -> pattern_type!(u32 is 2..1) {
-   |                                 -------------------------- expected `(u32) is 2..=0` because of return type
+   |                                 -------------------------- expected `pattern_type!(u32 is 2..=0)` because of return type
 LL |     0
-   |     ^ expected `(u32) is 2..=0`, found integer
+   |     ^ expected `pattern_type!(u32 is 2..=0)`, found integer
    |
-   = note: expected pattern type `(u32) is 2..=0`
+   = note: expected pattern type `pattern_type!(u32 is 2..=0)`
                       found type `{integer}`
 
 error[E0308]: mismatched types
   --> $DIR/literals.rs:132:5
    |
 LL | fn lit_at_wraparound_range_start() -> pattern_type!(u32 is 2..1) {
-   |                                       -------------------------- expected `(u32) is 2..=0` because of return type
+   |                                       -------------------------- expected `pattern_type!(u32 is 2..=0)` because of return type
 LL |     2
-   |     ^ expected `(u32) is 2..=0`, found integer
+   |     ^ expected `pattern_type!(u32 is 2..=0)`, found integer
    |
-   = note: expected pattern type `(u32) is 2..=0`
+   = note: expected pattern type `pattern_type!(u32 is 2..=0)`
                       found type `{integer}`
 
 error: aborting due to 22 previous errors

--- a/tests/ui/type/pattern_types/matching_fail.stderr
+++ b/tests/ui/type/pattern_types/matching_fail.stderr
@@ -1,4 +1,4 @@
-error: constant of non-structural type `(u32) is 1..` in a pattern
+error: constant of non-structural type `pattern_type!(u32 is 1..)` in a pattern
   --> $DIR/matching_fail.rs:8:5
    |
 LL | const THREE: pattern_type!(u32 is 1..) = 3;
@@ -13,11 +13,11 @@ error[E0308]: mismatched types
   --> $DIR/matching_fail.rs:14:5
    |
 LL | const _: () = match THREE {
-   |                     ----- this expression has type `(u32) is 1..`
+   |                     ----- this expression has type `pattern_type!(u32 is 1..)`
 LL |     3 => {}
-   |     ^ expected `(u32) is 1..`, found integer
+   |     ^ expected `pattern_type!(u32 is 1..)`, found integer
    |
-   = note: expected pattern type `(u32) is 1..`
+   = note: expected pattern type `pattern_type!(u32 is 1..)`
                       found type `{integer}`
 
 error[E0308]: mismatched types
@@ -31,11 +31,11 @@ LL | const _: () = match 3 {
 LL |     THREE => {}
    |     ^^^^^
    |     |
-   |     expected integer, found `(u32) is 1..`
+   |     expected integer, found `pattern_type!(u32 is 1..)`
    |     `THREE` is interpreted as a constant, not a new binding
    |
    = note:      expected type `{integer}`
-           found pattern type `(u32) is 1..`
+           found pattern type `pattern_type!(u32 is 1..)`
 help: introduce a new binding instead
    |
 LL -     THREE => {}

--- a/tests/ui/type/pattern_types/nested.rs
+++ b/tests/ui/type/pattern_types/nested.rs
@@ -14,7 +14,7 @@ const BAD_NESTING: pattern_type!(pattern_type!(u32 is 1..) is 0..) = todo!();
 // We want to get the most narrowest version that a pattern could be
 const BAD_NESTING2: pattern_type!(pattern_type!(i32 is 1..) is ..=-1) = todo!();
 //~^ ERROR: not a valid base type for range patterns
-//~| ERROR: cannot apply unary operator `-` to type `(i32) is 1..`
+//~| ERROR: cannot apply unary operator `-` to type `pattern_type!(i32 is 1..)`
 
 const BAD_NESTING3: pattern_type!(pattern_type!(i32 is 1..) is ..0) = todo!();
 //~^ ERROR: not a valid base type for range patterns

--- a/tests/ui/type/pattern_types/nested.stderr
+++ b/tests/ui/type/pattern_types/nested.stderr
@@ -2,20 +2,20 @@ error[E0308]: mismatched types
   --> $DIR/nested.rs:10:63
    |
 LL | const BAD_NESTING: pattern_type!(pattern_type!(u32 is 1..) is 0..) = todo!();
-   |                                  -------------------------    ^ expected `(u32) is 1..`, found integer
+   |                                  -------------------------    ^ expected `pattern_type!(u32 is 1..)`, found integer
    |                                  |
    |                                  the pattern must match the type
    |
-   = note: expected pattern type `(u32) is 1..`
+   = note: expected pattern type `pattern_type!(u32 is 1..)`
                       found type `{integer}`
 
-error[E0277]: `(u32) is 1..` is not a valid base type for range patterns
+error[E0277]: `pattern_type!(u32 is 1..)` is not a valid base type for range patterns
   --> $DIR/nested.rs:10:34
    |
 LL | const BAD_NESTING: pattern_type!(pattern_type!(u32 is 1..) is 0..) = todo!();
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ only integer types and `char` are supported
    |
-   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `(u32) is 1..`
+   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `pattern_type!(u32 is 1..)`
    = help: the following other types implement trait `core::pat::RangePattern`:
              char
              i128
@@ -27,13 +27,13 @@ LL | const BAD_NESTING: pattern_type!(pattern_type!(u32 is 1..) is 0..) = todo!(
              u128
            and 5 others
 
-error[E0277]: `(i32) is 1..` is not a valid base type for range patterns
+error[E0277]: `pattern_type!(i32 is 1..)` is not a valid base type for range patterns
   --> $DIR/nested.rs:15:35
    |
 LL | const BAD_NESTING2: pattern_type!(pattern_type!(i32 is 1..) is ..=-1) = todo!();
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ only integer types and `char` are supported
    |
-   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `(i32) is 1..`
+   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `pattern_type!(i32 is 1..)`
    = help: the following other types implement trait `core::pat::RangePattern`:
              char
              i128
@@ -45,19 +45,19 @@ LL | const BAD_NESTING2: pattern_type!(pattern_type!(i32 is 1..) is ..=-1) = tod
              u128
            and 5 others
 
-error[E0600]: cannot apply unary operator `-` to type `(i32) is 1..`
+error[E0600]: cannot apply unary operator `-` to type `pattern_type!(i32 is 1..)`
   --> $DIR/nested.rs:15:67
    |
 LL | const BAD_NESTING2: pattern_type!(pattern_type!(i32 is 1..) is ..=-1) = todo!();
    |                                                                   ^^ cannot apply unary operator `-`
 
-error[E0277]: `(i32) is 1..` is not a valid base type for range patterns
+error[E0277]: `pattern_type!(i32 is 1..)` is not a valid base type for range patterns
   --> $DIR/nested.rs:19:35
    |
 LL | const BAD_NESTING3: pattern_type!(pattern_type!(i32 is 1..) is ..0) = todo!();
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ only integer types and `char` are supported
    |
-   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `(i32) is 1..`
+   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `pattern_type!(i32 is 1..)`
    = help: the following other types implement trait `core::pat::RangePattern`:
              char
              i128
@@ -75,10 +75,10 @@ error[E0308]: mismatched types
 LL | const BAD_NESTING3: pattern_type!(pattern_type!(i32 is 1..) is ..0) = todo!();
    |                                                                  ^
    |                                                                  |
-   |                                                                  expected `(i32) is 1..`, found integer
+   |                                                                  expected `pattern_type!(i32 is 1..)`, found integer
    |                                                                  arguments to this function are incorrect
    |
-   = note: expected pattern type `(i32) is 1..`
+   = note: expected pattern type `pattern_type!(i32 is 1..)`
                       found type `{integer}`
 help: the return type of this call is `{integer}` due to the type of the argument passed
   --> $DIR/nested.rs:19:66
@@ -88,13 +88,13 @@ LL | const BAD_NESTING3: pattern_type!(pattern_type!(i32 is 1..) is ..0) = todo!
 note: method defined here
   --> $SRC_DIR/core/src/pat.rs:LL:COL
 
-error[E0277]: `(i32) is 1..` is not a valid base type for range patterns
+error[E0277]: `pattern_type!(i32 is 1..)` is not a valid base type for range patterns
   --> $DIR/nested.rs:19:66
    |
 LL | const BAD_NESTING3: pattern_type!(pattern_type!(i32 is 1..) is ..0) = todo!();
    |                                                                  ^ only integer types and `char` are supported
    |
-   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `(i32) is 1..`
+   = help: the nightly-only, unstable trait `core::pat::RangePattern` is not implemented for `pattern_type!(i32 is 1..)`
    = help: the following other types implement trait `core::pat::RangePattern`:
              char
              i128

--- a/tests/ui/type/pattern_types/non_null.stderr
+++ b/tests/ui/type/pattern_types/non_null.stderr
@@ -1,4 +1,4 @@
-error: layout_of((*const T) is !null) = Layout {
+error: layout_of(pattern_type!(*const T is !null)) = Layout {
            size: Size(8 bytes),
            align: AbiAlign {
                abi: Align(8 bytes),
@@ -34,7 +34,7 @@ error: layout_of((*const T) is !null) = Layout {
 LL | type NonNull<T> = pattern_type!(*const T is !null);
    | ^^^^^^^^^^^^^^^
 
-error: layout_of(Option<(*const ()) is !null>) = Layout {
+error: layout_of(Option<pattern_type!(*const () is !null)>) = Layout {
            size: Size(8 bytes),
            align: AbiAlign {
                abi: Align(8 bytes),
@@ -102,7 +102,7 @@ error: layout_of(Option<(*const ()) is !null>) = Layout {
 LL | type Test = Option<NonNull<()>>;
    | ^^^^^^^^^
 
-error: layout_of((*const [u8]) is !null) = Layout {
+error: layout_of(pattern_type!(*const [u8] is !null)) = Layout {
            size: Size(16 bytes),
            align: AbiAlign {
                abi: Align(8 bytes),

--- a/tests/ui/type/pattern_types/or_patterns.stderr
+++ b/tests/ui/type/pattern_types/or_patterns.stderr
@@ -2,44 +2,44 @@ error[E0308]: mismatched types
   --> $DIR/or_patterns.rs:27:24
    |
 LL |     let _: NonNullI8 = 0;
-   |            ---------   ^ expected `(i8) is (i8::MIN..=-1 | 1..)`, found integer
+   |            ---------   ^ expected `pattern_type!(i8 is (i8::MIN..=-1 | 1..))`, found integer
    |            |
    |            expected due to this
    |
-   = note: expected pattern type `(i8) is (i8::MIN..=-1 | 1..)`
+   = note: expected pattern type `pattern_type!(i8 is (i8::MIN..=-1 | 1..))`
                       found type `{integer}`
 
-error[E0600]: cannot apply unary operator `-` to type `(i8) is (i8::MIN..=-1 | 1..)`
+error[E0600]: cannot apply unary operator `-` to type `pattern_type!(i8 is (i8::MIN..=-1 | 1..))`
   --> $DIR/or_patterns.rs:29:24
    |
 LL |     let _: NonNullI8 = -1;
    |                        ^^ cannot apply unary operator `-`
 
-error[E0600]: cannot apply unary operator `-` to type `(i8) is (i8::MIN..=-1 | 1..)`
+error[E0600]: cannot apply unary operator `-` to type `pattern_type!(i8 is (i8::MIN..=-1 | 1..))`
   --> $DIR/or_patterns.rs:31:24
    |
 LL |     let _: NonNullI8 = -128;
    |                        ^^^^ cannot apply unary operator `-`
 
-error[E0600]: cannot apply unary operator `-` to type `(i8) is (i8::MIN..=-2 | 0..)`
+error[E0600]: cannot apply unary operator `-` to type `pattern_type!(i8 is (i8::MIN..=-2 | 0..))`
   --> $DIR/or_patterns.rs:38:26
    |
 LL |     let _: NonNegOneI8 = -1;
    |                          ^^ cannot apply unary operator `-`
 
-error[E0600]: cannot apply unary operator `-` to type `(i8) is (i8::MIN..=-2 | 0..)`
+error[E0600]: cannot apply unary operator `-` to type `pattern_type!(i8 is (i8::MIN..=-2 | 0..))`
   --> $DIR/or_patterns.rs:40:26
    |
 LL |     let _: NonNegOneI8 = -2;
    |                          ^^ cannot apply unary operator `-`
 
-error[E0600]: cannot apply unary operator `-` to type `(i8) is (i8::MIN..=-2 | 0..)`
+error[E0600]: cannot apply unary operator `-` to type `pattern_type!(i8 is (i8::MIN..=-2 | 0..))`
   --> $DIR/or_patterns.rs:42:26
    |
 LL |     let _: NonNegOneI8 = -128;
    |                          ^^^^ cannot apply unary operator `-`
 
-error: layout_of((i8) is (i8::MIN..=-1 | 1..)) = Layout {
+error: layout_of(pattern_type!(i8 is (i8::MIN..=-1 | 1..))) = Layout {
            size: Size(1 bytes),
            align: AbiAlign {
                abi: Align(1 bytes),
@@ -75,7 +75,7 @@ error: layout_of((i8) is (i8::MIN..=-1 | 1..)) = Layout {
 LL | type NonNullI8 = pattern_type!(i8 is ..0 | 1..);
    | ^^^^^^^^^^^^^^
 
-error: layout_of((i8) is (i8::MIN..=-2 | 0..)) = Layout {
+error: layout_of(pattern_type!(i8 is (i8::MIN..=-2 | 0..))) = Layout {
            size: Size(1 bytes),
            align: AbiAlign {
                abi: Align(1 bytes),

--- a/tests/ui/type/pattern_types/or_patterns_invalid.stderr
+++ b/tests/ui/type/pattern_types/or_patterns_invalid.stderr
@@ -7,7 +7,7 @@ LL |     let not_adjacent: pattern_type!(i8 is -127..0 | 1..) = unsafe { std::me
    |                                                                     ^^^^^^^^^^^^^^^^^^^
    |
    = note: source type: `i32` (32 bits)
-   = note: target type: `(i8) is (-127..=-1 | 1..)` (the type has an unknown layout)
+   = note: target type: `pattern_type!(i8 is (-127..=-1 | 1..))` (the type has an unknown layout)
 
 error: one pattern needs to end at `i8::MAX`, but was 29 instead
 
@@ -18,7 +18,7 @@ LL |     let not_wrapping: pattern_type!(i8 is 10..20 | 20..30) = unsafe { std::
    |                                                                       ^^^^^^^^^^^^^^^^^^^
    |
    = note: source type: `i32` (32 bits)
-   = note: target type: `(i8) is (10..=19 | 20..=29)` (the type has an unknown layout)
+   = note: target type: `pattern_type!(i8 is (10..=19 | 20..=29))` (the type has an unknown layout)
 
 error: only signed integer base types are allowed for or-pattern pattern types at present
 
@@ -29,7 +29,7 @@ LL |     let not_signed: pattern_type!(u8 is 10.. | 0..5) = unsafe { std::mem::t
    |                                                                 ^^^^^^^^^^^^^^^^^^^
    |
    = note: source type: `i32` (32 bits)
-   = note: target type: `(u8) is (10.. | 0..=4)` (the type has an unknown layout)
+   = note: target type: `pattern_type!(u8 is (10.. | 0..=4))` (the type has an unknown layout)
 
 error: the only or-pattern types allowed are two range patterns that are directly connected at their overflow site
 
@@ -40,7 +40,7 @@ LL |         unsafe { std::mem::transmute(0) };
    |                  ^^^^^^^^^^^^^^^^^^^
    |
    = note: source type: `i32` (32 bits)
-   = note: target type: `(i8) is (i8::MIN..=-1 | 1..=9 | 10..)` (the type has an unknown layout)
+   = note: target type: `pattern_type!(i8 is (i8::MIN..=-1 | 1..=9 | 10..))` (the type has an unknown layout)
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/type/pattern_types/range_patterns.stderr
+++ b/tests/ui/type/pattern_types/range_patterns.stderr
@@ -34,7 +34,7 @@ error: layout_of(NonZero<u32>) = Layout {
 LL | type X = std::num::NonZeroU32;
    | ^^^^^^
 
-error: layout_of((u32) is 1..) = Layout {
+error: layout_of(pattern_type!(u32 is 1..)) = Layout {
            size: Size(4 bytes),
            align: AbiAlign {
                abi: Align(4 bytes),
@@ -70,7 +70,7 @@ error: layout_of((u32) is 1..) = Layout {
 LL | type Y = pattern_type!(u32 is 1..);
    | ^^^^^^
 
-error: layout_of(Option<(u32) is 1..>) = Layout {
+error: layout_of(Option<pattern_type!(u32 is 1..)>) = Layout {
            size: Size(4 bytes),
            align: AbiAlign {
                abi: Align(4 bytes),
@@ -270,7 +270,7 @@ error: the type has an unknown layout
 LL | type WRAP2 = pattern_type!(u32 is 5..2);
    | ^^^^^^^^^^
 
-error: layout_of((i8) is -10..=10) = Layout {
+error: layout_of(pattern_type!(i8 is -10..=10)) = Layout {
            size: Size(1 bytes),
            align: AbiAlign {
                abi: Align(1 bytes),
@@ -306,7 +306,7 @@ error: layout_of((i8) is -10..=10) = Layout {
 LL | type SIGN = pattern_type!(i8 is -10..=10);
    | ^^^^^^^^^
 
-error: layout_of((i8) is i8::MIN..=0) = Layout {
+error: layout_of(pattern_type!(i8 is i8::MIN..=0)) = Layout {
            size: Size(1 bytes),
            align: AbiAlign {
                abi: Align(1 bytes),

--- a/tests/ui/type/pattern_types/range_patterns_trait_impls2.stderr
+++ b/tests/ui/type/pattern_types/range_patterns_trait_impls2.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Eq for Y {}
    | ^^^^^^^^^^^^-
    |             |
-   |             `(u32) is 1..=` is not defined in the current crate
+   |             `pattern_type!(u32 is 1..=)` is not defined in the current crate
    |
    = note: impl doesn't have any local type before any uncovered type parameters
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules

--- a/tests/ui/type/pattern_types/range_patterns_unusable.stderr
+++ b/tests/ui/type/pattern_types/range_patterns_unusable.stderr
@@ -4,7 +4,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     let _: Option<u32> = unsafe { std::mem::transmute(z) };
    |                                   ^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: `Option<(u32) is 1..>` (32 bits)
+   = note: source type: `Option<pattern_type!(u32 is 1..)>` (32 bits)
    = note: target type: `Option<u32>` (64 bits)
 
 error: aborting due to 1 previous error

--- a/tests/ui/type/pattern_types/range_patterns_unusable_math.rs
+++ b/tests/ui/type/pattern_types/range_patterns_unusable_math.rs
@@ -11,5 +11,5 @@ type Z = Option<pattern_type!(u32 is 1..)>;
 
 fn main() {
     let x: Y = unsafe { std::mem::transmute(42_u32) };
-    let x = x + 1_u32; //~ ERROR cannot add `u32` to `(u32) is 1..`
+    let x = x + 1_u32; //~ ERROR cannot add `u32` to `pattern_type!(u32 is 1..)`
 }

--- a/tests/ui/type/pattern_types/range_patterns_unusable_math.stderr
+++ b/tests/ui/type/pattern_types/range_patterns_unusable_math.stderr
@@ -1,10 +1,10 @@
-error[E0369]: cannot add `u32` to `(u32) is 1..`
+error[E0369]: cannot add `u32` to `pattern_type!(u32 is 1..)`
   --> $DIR/range_patterns_unusable_math.rs:14:15
    |
 LL |     let x = x + 1_u32;
    |             - ^ ----- u32
    |             |
-   |             (u32) is 1..
+   |             pattern_type!(u32 is 1..)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/pattern_types/transmute.current.stderr
+++ b/tests/ui/type/pattern_types/transmute.current.stderr
@@ -4,7 +4,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     unsafe { std::mem::transmute(x) }
    |              ^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: `Option<(u32) is S..=E>` (size can vary because of u32)
+   = note: source type: `Option<pattern_type!(u32 is S..=E)>` (size can vary because of u32)
    = note: target type: `u32` (32 bits)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
@@ -13,7 +13,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     unsafe { std::mem::transmute(x) }
    |              ^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: `Option<(u32) is S..=E>` (size can vary because of u32)
+   = note: source type: `Option<pattern_type!(u32 is S..=E)>` (size can vary because of u32)
    = note: target type: `Option<u32>` (64 bits)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/type/pattern_types/transmute.next.stderr
+++ b/tests/ui/type/pattern_types/transmute.next.stderr
@@ -4,7 +4,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     unsafe { std::mem::transmute(x) }
    |              ^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: `Option<(u32) is S..=E>` (size can vary because of u32)
+   = note: source type: `Option<pattern_type!(u32 is S..=E)>` (size can vary because of u32)
    = note: target type: `u32` (32 bits)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
@@ -13,7 +13,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     unsafe { std::mem::transmute(x) }
    |              ^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: `Option<(u32) is S..=E>` (size can vary because of u32)
+   = note: source type: `Option<pattern_type!(u32 is S..=E)>` (size can vary because of u32)
    = note: target type: `Option<u32>` (64 bits)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/type/pattern_types/validity.stderr
+++ b/tests/ui/type/pattern_types/validity.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value of type (u32) is 1..: encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type pattern_type!(u32 is 1..): encountered 0, but expected something greater or equal to 1
   --> $DIR/validity.rs:10:1
    |
 LL | const BAD: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(0) };
@@ -28,7 +28,7 @@ LL | const BAD_PTR: pattern_type!(usize is 1..) = unsafe { std::mem::transmute(&
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error[E0080]: constructing invalid value of type ((u32) is 1.., u32): at .0, encountered 0, but expected something greater or equal to 1
+error[E0080]: constructing invalid value of type (pattern_type!(u32 is 1..), u32): at .0, encountered 0, but expected something greater or equal to 1
   --> $DIR/validity.rs:20:1
    |
 LL | const BAD_AGGREGATE: (pattern_type!(u32 is 1..), u32) = (unsafe { std::mem::transmute(0) }, 0);
@@ -60,7 +60,7 @@ LL | const CHAR_UNINIT: pattern_type!(char is 'A'..'Z') =
                __ __ __ __                                     │ ░░░░
            }
 
-error[E0080]: constructing invalid value of type (char) is 'A'..='Y': encountered 97, but expected something in the range 65..=89
+error[E0080]: constructing invalid value of type pattern_type!(char is 'A'..='Y'): encountered 97, but expected something in the range 65..=89
   --> $DIR/validity.rs:33:1
    |
 LL | const CHAR_OOB_PAT: pattern_type!(char is 'A'..'Z') = unsafe { std::mem::transmute('a') };
@@ -71,7 +71,7 @@ LL | const CHAR_OOB_PAT: pattern_type!(char is 'A'..'Z') = unsafe { std::mem::tr
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value of type (char) is 'A'..='Y': encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
+error[E0080]: constructing invalid value of type pattern_type!(char is 'A'..='Y'): encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
   --> $DIR/validity.rs:36:1
    |
 LL | const CHAR_OOB: pattern_type!(char is 'A'..'Z') = unsafe { std::mem::transmute(u32::MAX) };


### PR DESCRIPTION
Print a pattern type using the `pattern_type!(type is pattern)` syntax instead of `(type) is pattern`.

This helps for example when suggesting fixes:  `(type) is pattern` is not valid rust right now but  `pattern_type!(type is pattern)` is. 
This is not a bug as `pattern_type` is not on stable but it is a fairly impact-less change, just a print change.

discussion: [#t-compiler > pattern_type pretty format](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/pattern_type.20pretty.20format/with/618658793)

closes https://github.com/rust-lang/rust-clippy/pull/17613

 