### PR TITLE
Stop rustfmt deleting attributes in fn params

### DIFF
--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -2361,7 +2361,14 @@ impl Rewrite for ast::Param {
 
             Ok(result)
         } else {
-            self.ty.rewrite_result(context, shape)
+            combine_strs_with_missing_comments(
+                context,
+                &param_attrs_result,
+                &self.ty.rewrite_result(context, shape)?,
+                span,
+                shape,
+                !has_multiple_attr_lines && !has_doc_comments,
+            )
         }
     }
 }

--- a/src/tools/rustfmt/tests/source/issue-6561/trait-fn.rs
+++ b/src/tools/rustfmt/tests/source/issue-6561/trait-fn.rs
@@ -1,0 +1,6 @@
+// rustfmt-edition: 2015
+
+trait A {
+    fn f1(#[allow()] u32);
+    fn f2(#[allow()] u32, #[allow()] u32);
+}

--- a/src/tools/rustfmt/tests/source/issue-6561/variadic.rs
+++ b/src/tools/rustfmt/tests/source/issue-6561/variadic.rs
@@ -1,0 +1,5 @@
+#[allow()]
+unsafe extern "C" {
+    #[allow()]
+    pub fn foo(#[allow()] arg: *mut u8, #[allow()]...);
+}

--- a/src/tools/rustfmt/tests/source/issue-6607/fn-type.rs
+++ b/src/tools/rustfmt/tests/source/issue-6607/fn-type.rs
@@ -1,0 +1,3 @@
+struct Foo {
+    v: fn(#[cfg(false)] i32),
+}

--- a/src/tools/rustfmt/tests/target/issue-6561/trait-fn.rs
+++ b/src/tools/rustfmt/tests/target/issue-6561/trait-fn.rs
@@ -1,0 +1,6 @@
+// rustfmt-edition: 2015
+
+trait A {
+    fn f1(#[allow()] u32);
+    fn f2(#[allow()] u32, #[allow()] u32);
+}

--- a/src/tools/rustfmt/tests/target/issue-6561/variadic.rs
+++ b/src/tools/rustfmt/tests/target/issue-6561/variadic.rs
@@ -1,0 +1,5 @@
+#[allow()]
+unsafe extern "C" {
+    #[allow()]
+    pub fn foo(#[allow()] arg: *mut u8, #[allow()] ...);
+}

--- a/src/tools/rustfmt/tests/target/issue-6607/fn-type.rs
+++ b/src/tools/rustfmt/tests/target/issue-6607/fn-type.rs
@@ -1,0 +1,3 @@
+struct Foo {
+    v: fn(#[cfg(false)] i32),
+}


### PR DESCRIPTION
Currently, rustfmt deletes attributes in function type parameters, for example:
```rust
type F = fn(#[rustc_splat] ());
```

Becomes:
```rust
type F = fn(());
```

[Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=f56e4727022f44a6e5c937c1521830f9)

This is an annoying and confusing bug, and causes formatted code to silently change meaning, or fail compilation.

This PR cherry-picks the fix and tests from https://github.com/rust-lang/rustfmt/pull/6590 to `rust-lang/rust`.

We're discussing a potential beta backport in [Zulip #t-rustfmt > Attributes in fn type deleted on stable but not nightly](https://rust-lang.zulipchat.com/#narrow/channel/357797-t-rustfmt/topic/Attributes.20in.20fn.20type.20deleted.20on.20stable.20but.20not.20nightly/with/618688539), which is why this PR is separate to the subtree sync.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Tracking issue: https://github.com/rust-lang/rust/issues/153629
- This formatting bug impacts splatted function pointers
- We just published [a "call for experiment" blog post](https://blog.rust-lang.org/inside-rust/2026/08/19/overloading-experiment/), including experiments with splatted function pointers

r? @ytmimi
