### PR TITLE
Add more splat fn type tests

### DIFF
--- a/tests/ui/splat/splat-invalid.rs
+++ b/tests/ui/splat/splat-invalid.rs
@@ -61,4 +61,27 @@ impl FooTrait for Foo {
     fn no_splat(#[rustc_splat] _: (u32, f64)) {} //~ ERROR method `no_splat` has an incompatible type for trait
 }
 
-fn main() {}
+#[rustfmt::skip]
+fn main() {
+    let multisplat_fn_bad_:
+        fn(#[rustc_splat] (u32, i8), #[rustc_splat] (u32, i8)) = multisplat_fn_bad;
+    //~^ ERROR multiple `#[rustc_splat]`s are not allowed in the same function argument list
+    let multisplat_arg_bad_: fn(
+        #[rustc_splat]
+        #[rustc_splat]
+        (u32, i8),
+    ) = multisplat_arg_bad;
+    let multisplat_arg_fn_bad_: fn(
+        #[rustc_splat]
+        //~^ ERROR multiple `#[rustc_splat]`s are not allowed in the same function argument list
+        #[rustc_splat]
+        (u32, i8),
+        #[rustc_splat] (u32, i8),
+    ) = multisplat_arg_fn_bad;
+
+    let splat_variadic_: unsafe extern "C" fn(#[rustc_splat] (u32, i8), ...) = splat_variadic;
+    //~^ ERROR `...` and `#[rustc_splat]` are not allowed in the same function argument list
+    let splat_variadic2_: unsafe extern "C" fn(..., #[rustc_splat] (u32, i8)) = splat_variadic2;
+    //~^ ERROR `...` must be the last argument of a C-variadic function
+    //~| ERROR `...` and `#[rustc_splat]` are not allowed in the same function argument list
+}

--- a/tests/ui/splat/splat-invalid.stderr
+++ b/tests/ui/splat/splat-invalid.stderr
@@ -87,6 +87,50 @@ LL |     fn splat_variadic4(..., #[rustc_splat] (_a, _b): (u32, i8)) {}
    |
    = help: remove `#[rustc_splat]` or remove `...`
 
+error: multiple `#[rustc_splat]`s are not allowed in the same function argument list
+  --> $DIR/splat-invalid.rs:67:12
+   |
+LL |         fn(#[rustc_splat] (u32, i8), #[rustc_splat] (u32, i8)) = multisplat_fn_bad;
+   |            ^^^^^^^^^^^^^^            ^^^^^^^^^^^^^^
+   |
+   = help: remove `#[rustc_splat]` from all but one argument
+
+error: multiple `#[rustc_splat]`s are not allowed in the same function argument list
+  --> $DIR/splat-invalid.rs:75:9
+   |
+LL |         #[rustc_splat]
+   |         ^^^^^^^^^^^^^^
+LL |
+LL |         #[rustc_splat]
+   |         ^^^^^^^^^^^^^^
+LL |         (u32, i8),
+LL |         #[rustc_splat] (u32, i8),
+   |         ^^^^^^^^^^^^^^
+   |
+   = help: remove `#[rustc_splat]` from all but one argument
+
+error: `...` and `#[rustc_splat]` are not allowed in the same function argument list
+  --> $DIR/splat-invalid.rs:82:47
+   |
+LL |     let splat_variadic_: unsafe extern "C" fn(#[rustc_splat] (u32, i8), ...) = splat_variadic;
+   |                                               ^^^^^^^^^^^^^^            ^^^
+   |
+   = help: remove `#[rustc_splat]` or remove `...`
+
+error: `...` must be the last argument of a C-variadic function
+  --> $DIR/splat-invalid.rs:84:48
+   |
+LL |     let splat_variadic2_: unsafe extern "C" fn(..., #[rustc_splat] (u32, i8)) = splat_variadic2;
+   |                                                ^^^
+
+error: `...` and `#[rustc_splat]` are not allowed in the same function argument list
+  --> $DIR/splat-invalid.rs:84:48
+   |
+LL |     let splat_variadic2_: unsafe extern "C" fn(..., #[rustc_splat] (u32, i8)) = splat_variadic2;
+   |                                                ^^^  ^^^^^^^^^^^^^^
+   |
+   = help: remove `#[rustc_splat]` or remove `...`
+
 error: multiple `rustc_splat` attributes
   --> $DIR/splat-invalid.rs:11:5
    |
@@ -139,6 +183,6 @@ LL |     fn no_splat(_: (u32, f64));
    = note: expected signature `fn((_, _))`
               found signature `fn(#[rustc_splat] (_, _))`
 
-error: aborting due to 14 previous errors
+error: aborting due to 19 previous errors
 
 For more information about this error, try `rustc --explain E0053`.

--- a/tests/ui/splat/splat-non-tuple.rs
+++ b/tests/ui/splat/splat-non-tuple.rs
@@ -84,6 +84,11 @@ fn main() {
     primitive_arg(1u32);
     enum_arg(NotATuple::A(1u32));
 
+    #[rustfmt::skip]
+    let primitive_arg_: fn(#[rustc_splat] u32) = primitive_arg;
+    primitive_arg_(1u32);
+    //~^ ERROR cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a u32
+
     let foo = Foo;
     struct_arg(foo);
     foo.tuple_2_self((1u32, 2i8));

--- a/tests/ui/splat/splat-non-tuple.stderr
+++ b/tests/ui/splat/splat-non-tuple.stderr
@@ -30,6 +30,12 @@ LL | fn enum_arg(#[rustc_splat] y: NotATuple) {}
 LL |     enum_arg(NotATuple::A(1u32));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a u32 (u32)
+  --> $DIR/splat-non-tuple.rs:89:5
+   |
+LL |     primitive_arg_(1u32);
+   |     ^^^^^^^^^^^^^^^^^^^^
+
 error[E0277]: cannot use `rustc_splat` attribute; the splatted argument type must be a tuple or unit, not a Foo (Foo)
   --> $DIR/splat-non-tuple.rs:25:33
    |
@@ -48,7 +54,7 @@ LL | fn tuple_struct_arg(#[rustc_splat] z: TupleStruct) {}
 LL |     tuple_struct_arg(tuple_struct);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0053, E0277.
 For more information about an error, try `rustc --explain E0053`.


### PR DESCRIPTION
Tracking issue: rust-lang/rust#153629 

This PR turns some rustfmt splat tests from https://github.com/rust-lang/rustfmt/pull/7032 into rustc UI tests. It is a test-only PR.

These tests check _invalid_ function pointer / function type splatting, which has had recent ICE fixes (rust-lang/rust#158603, rust-lang/rust#159643).

The `rustfmt::skip` is required until rust-lang/rust#161709 reaches stable.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
