### PR TITLE
Stabilize `Result::into_{ok,err}`

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -11,13 +11,13 @@
 #![allow(clippy::mut_from_ref)] // Arena allocators are one place where this pattern is fine.
 #![allow(internal_features)]
 #![cfg_attr(bootstrap, feature(never_type))]
+#![cfg_attr(bootstrap, feature(unwrap_infallible))]
 #![cfg_attr(test, feature(test))]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![doc(test(no_crate_inject, attr(deny(warnings))))]
 #![feature(decl_macro)]
 #![feature(dropck_eyepatch)]
 #![feature(rustc_attrs)]
-#![feature(unwrap_infallible)]
 // tidy-alphabetical-end
 
 use std::alloc::Layout;

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -11,6 +11,7 @@
 #![allow(rustc::default_hash_types)]
 #![allow(rustc::potential_query_instability)]
 #![cfg_attr(bootstrap, feature(never_type))]
+#![cfg_attr(bootstrap, feature(unwrap_infallible))]
 #![cfg_attr(test, feature(test))]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![feature(allocator_api)]
@@ -34,7 +35,6 @@
 #![feature(thread_id_value)]
 #![feature(trusted_len)]
 #![feature(type_alias_impl_trait)]
-#![feature(unwrap_infallible)]
 // tidy-alphabetical-end
 
 // This allows derive macros to reference this crate

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -57,12 +57,12 @@ This API is completely unstable and subject to change.
 
 // tidy-alphabetical-start
 #![cfg_attr(bootstrap, feature(never_type))]
+#![cfg_attr(bootstrap, feature(unwrap_infallible))]
 #![feature(default_field_values)]
 #![feature(gen_blocks)]
 #![feature(iter_intersperse)]
 #![feature(slice_partition_dedup)]
 #![feature(try_blocks)]
-#![feature(unwrap_infallible)]
 // tidy-alphabetical-end
 
 // These are used by Clippy.

--- a/compiler/rustc_trait_selection/src/lib.rs
+++ b/compiler/rustc_trait_selection/src/lib.rs
@@ -12,6 +12,7 @@
 
 // tidy-alphabetical-start
 #![cfg_attr(bootstrap, feature(never_type))]
+#![cfg_attr(bootstrap, feature(unwrap_infallible))]
 #![feature(associated_type_defaults)]
 #![feature(default_field_values)]
 #![feature(deref_patterns)]
@@ -20,7 +21,6 @@
 #![feature(iterator_try_reduce)]
 #![feature(option_into_flat_iter)]
 #![feature(try_blocks)]
-#![feature(unwrap_infallible)]
 #![feature(yeet_expr)]
 #![recursion_limit = "512"] // For rustdoc
 // tidy-alphabetical-end

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -186,7 +186,6 @@
 #![feature(ub_checks)]
 #![feature(unicode_internals)]
 #![feature(unsize)]
-#![feature(unwrap_infallible)]
 #![feature(write_all_vectored)]
 #![feature(wtf8_internals)]
 // tidy-alphabetical-end

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -52,7 +52,6 @@
 #![feature(trusted_random_access)]
 #![feature(try_reserve_kind)]
 #![feature(try_trait_v2)]
-#![feature(unwrap_infallible)]
 #![feature(wtf8_internals)]
 // tidy-alphabetical-end
 //

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1343,8 +1343,6 @@ impl<T, E> Result<T, E> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(unwrap_infallible)]
-    ///
     /// fn only_good_news() -> Result<String, !> {
     ///     Ok("this is fine".into())
     /// }
@@ -1352,7 +1350,7 @@ impl<T, E> Result<T, E> {
     /// let s: String = only_good_news().into_ok();
     /// println!("{s}");
     /// ```
-    #[unstable(feature = "unwrap_infallible", issue = "61695")]
+    #[stable(feature = "unwrap_infallible", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
     #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
@@ -1379,8 +1377,6 @@ impl<T, E> Result<T, E> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(unwrap_infallible)]
-    ///
     /// fn only_bad_news() -> Result<!, String> {
     ///     Err("Oops, it failed".into())
     /// }
@@ -1388,7 +1384,7 @@ impl<T, E> Result<T, E> {
     /// let error: String = only_bad_news().into_err();
     /// println!("{error}");
     /// ```
-    #[unstable(feature = "unwrap_infallible", issue = "61695")]
+    #[stable(feature = "unwrap_infallible", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
     #[rustc_const_unstable(feature = "const_convert", issue = "143773")]

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -129,7 +129,6 @@
 #![feature(uint_gather_scatter_bits)]
 #![feature(unicode_internals)]
 #![feature(unsize)]
-#![feature(unwrap_infallible)]
 // tidy-alphabetical-end
 #![allow(internal_features)]
 #![deny(implicit_provenance_casts)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -313,7 +313,6 @@
 #![feature(try_blocks)]
 #![feature(try_trait_v2)]
 #![feature(type_alias_impl_trait)]
-#![feature(unwrap_infallible)]
 // tidy-alphabetical-end
 //
 // Library features (core):

--- a/src/tools/clippy/clippy_lints/src/lib.rs
+++ b/src/tools/clippy/clippy_lints/src/lib.rs
@@ -8,9 +8,9 @@
 #![feature(macro_metavar_expr)]
 #![feature(macro_metavar_expr_concat)]
 #![cfg_attr(bootstrap, feature(never_type))]
+#![cfg_attr(bootstrap, feature(unwrap_infallible))]
 #![feature(rustc_private)]
 #![feature(stmt_expr_attributes)]
-#![feature(unwrap_infallible)]
 #![recursion_limit = "512"]
 #![expect(clippy::literal_string_with_formatting_args, clippy::must_use_candidate)]
 #![warn(

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -1,7 +1,7 @@
+#![cfg_attr(bootstrap, feature(unwrap_infallible))]
 #![feature(deref_patterns)]
 #![feature(macro_metavar_expr)]
 #![feature(rustc_private)]
-#![feature(unwrap_infallible)]
 #![recursion_limit = "512"]
 #![expect(clippy::missing_errors_doc, clippy::missing_panics_doc, clippy::must_use_candidate)]
 #![warn(


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/61695

---

As evidence of the demand of this API, here are some instances of people having written functions for this functionality:
* https://github.com/meteroid-oss/meteroid/blob/6cc14c4a444c6ae4889c603f5cb275ea626d7507/crates/common-utils/src/misc.rs#L7
* https://github.com/mokeyish/smartdns-rs/blob/788e83fa72477ebcf1c6a7f4482359353d29c480/src/server/http.rs#L93
* https://github.com/nostrdevkit/nostr/blob/ea38c0e3b2fc2717a4a55d019560a5574baf8cd0/nostr/src/util/mod.rs#L120
* https://github.com/ngrok/ngrok-rust/blob/3d5131559948ba9932dd0a450474fd1d19d206eb/ngrok/examples/tls.rs#L92
* https://github.com/octopii-rs/octopii/blob/b54c112d7db7ed1195dd4f600b4b786df85c8e7e/openraft/openraft/src/error/into_ok.rs#L10
* https://github.com/TeXitoi/keyseebee/blob/30956f62e618ed754c15af66f8ade70269fef89a/firmware/src/main.rs#L54

---

API being stabilized:

```rust
impl<T, E> Result<T, E> {
    pub fn into_ok(self) -> T
    where
        E: Into<!>
    { .... }
    pub fn into_err(self) -> E
    where
        T: Into<!>,
    { .... }
}
```

---

Implementation history: (I'm including only ones that touches the public API being stabilized, and not documentation or constification)

* https://github.com/rust-lang/rfcs/pull/2799
* https://github.com/rust-lang/rust/pull/66045
* https://github.com/rust-lang/rust/pull/83421
* https://github.com/rust-lang/rust/pull/92444