### PR TITLE
Add config for gram editor to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Session.vim
 .vim/
 .helix/
 .zed/
+.gram/
 .favorites.json
 .settings/
 .vs/


### PR DESCRIPTION
Gram is fork of Zed to remove AI branding/features: https://codeberg.org/GramEditor/gram

Initially was going to propose adding it to the editor list since it just copies Zed config to another filename, but since in the past we've been resistant to adding configs for editors which aren't widespread-used, I instead just added it to .gitignore.

---
LLM disclosure: Do not use, per personal policy. [ltdk.xyz/slop](https://ltdk.xyz/slop)