### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,8 +48,8 @@
       "groupName": "Cargo lock file maintenance",
       "commitMessageAction": "Compiler and tools lock file update",
       // Renovate merges all matching rules, so the lockfiles rules below
-      // also inherits this note and asks Triagebot for a dep-bumps reviewer.
-      "prBodyNotes": ["r? dep-bumps"]
+      // also inherits these notes and asks Triagebot for a dep-bumps reviewer.
+      "prBodyNotes": ["r? dep-bumps", "⚠️ Supply chain security safety: wait 3 days until the last commit to this PR before running `bors try` or `bors r+`"]
     },
     {
       // Update library/Cargo.lock in a dedicated PR.

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -621,14 +621,10 @@ pub trait Machine<'tcx>: Sized {
         interp_ok(ReturnAction::Normal)
     }
 
-    /// Called immediately after an "immediate" local variable is read in a given frame
+    /// Called immediately after an "immediate" local variable is read
     /// (i.e., this is called for reads that do not end up accessing addressable memory).
     #[inline(always)]
-    fn after_local_read(
-        _ecx: &InterpCx<'tcx, Self>,
-        _frame: &Frame<'tcx, Self::Provenance, Self::FrameExtra>,
-        _local: mir::Local,
-    ) -> InterpResult<'tcx> {
+    fn after_local_read(_ecx: &InterpCx<'tcx, Self>, _local: mir::Local) -> InterpResult<'tcx> {
         interp_ok(())
     }
 

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -135,10 +135,10 @@ pub struct Memory<'tcx, M: Machine<'tcx>> {
     // FIXME: this should not be public, but interning currently needs access to it
     pub(super) dead_alloc_map: FxIndexMap<AllocId, (Size, Align)>,
 
-    /// This stores whether we are currently doing reads purely for the purpose of validation.
-    /// Those reads do not trigger the machine's hooks for memory reads.
+    /// This stores whether we are currently doing reads/writes that aren't "real".
+    /// Those accesses do not trigger the machine's hooks.
     /// Needless to say, this must only be set with great care!
-    validation_in_progress: Cell<bool>,
+    ghost_mode: Cell<bool>,
 }
 
 /// A reference to some allocation that was already bounds-checked for the given region
@@ -166,7 +166,7 @@ impl<'tcx, M: Machine<'tcx>> Memory<'tcx, M> {
             extra_fn_ptr_map: FxIndexMap::default(),
             va_list_map: FxIndexMap::default(),
             dead_alloc_map: FxIndexMap::default(),
-            validation_in_progress: Cell::new(false),
+            ghost_mode: Cell::new(false),
         }
     }
 
@@ -768,7 +768,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // We want to call the hook on *all* accesses that involve an AllocId, including zero-sized
         // accesses. That means we cannot rely on the closure above or the `Some` branch below. We
         // do this after `check_and_deref_ptr` to ensure some basic sanity has already been checked.
-        if !self.memory.validation_in_progress.get() {
+        if !self.memory.ghost_mode.get() {
             if let Ok((alloc_id, ..)) = self.ptr_try_get_alloc_id(ptr, size_i64) {
                 M::before_alloc_access(self.tcx, &self.machine, alloc_id)?;
             }
@@ -776,7 +776,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
         if let Some((alloc_id, offset, prov, alloc)) = ptr_and_alloc {
             let range = alloc_range(offset, size);
-            if !self.memory.validation_in_progress.get() {
+            if !self.memory.ghost_mode.get() {
                 M::before_memory_read(
                     self.tcx,
                     &self.machine,
@@ -856,7 +856,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     ) -> InterpResult<'tcx, Option<AllocRefMut<'a, 'tcx, M::Provenance, M::AllocExtra, M::Bytes>>>
     {
         let tcx = self.tcx;
-        let validation_in_progress = self.memory.validation_in_progress.get();
+        let validation_in_progress = self.memory.ghost_mode.get();
 
         let size_i64 = i64::try_from(size.bytes()).unwrap(); // it would be an error to even ask for more than isize::MAX bytes
         let ptr_and_alloc = Self::check_and_deref_ptr(
@@ -1204,48 +1204,44 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         result
     }
 
-    /// Runs the closure in "validation" mode, which means the machine's memory read hooks will be
+    /// Runs the closure in "ghost" mode, which means the machine's memory read hooks will be
     /// suppressed. Needless to say, this must only be set with great care! Cannot be nested.
     ///
     /// We do this so Miri's allocation access tracking does not show the validation
-    /// reads as spurious accesses.
-    pub fn run_for_validation_mut<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+    /// reads as spurious accesses as those aren't "real" reads. Also useful for debuggers
+    /// that want to just display the Miri machine state.
+    pub fn ghost_run_mut<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
         // This deliberately uses `==` on `bool` to follow the pattern
         // `assert!(val.replace(new) == old)`.
-        assert!(
-            self.memory.validation_in_progress.replace(true) == false,
-            "`validation_in_progress` was already set"
-        );
+        assert!(self.memory.ghost_mode.replace(true) == false, "`ghost_mode` was already set");
         let res = f(self);
         assert!(
-            self.memory.validation_in_progress.replace(false) == true,
-            "`validation_in_progress` was unset by someone else"
+            self.memory.ghost_mode.replace(false) == true,
+            "`ghost_mode` was unset by someone else"
         );
         res
     }
 
-    /// Runs the closure in "validation" mode, which means the machine's memory read hooks will be
+    /// Runs the closure in "ghost" mode, which means the machine's memory read hooks will be
     /// suppressed. Needless to say, this must only be set with great care! Cannot be nested.
     ///
     /// We do this so Miri's allocation access tracking does not show the validation
-    /// reads as spurious accesses.
-    pub fn run_for_validation_ref<R>(&self, f: impl FnOnce(&Self) -> R) -> R {
+    /// reads as spurious accesses as those aren't "real" reads. Also useful for debuggers
+    /// that want to just display the Miri machine state.
+    pub fn ghost_run<R>(&self, f: impl FnOnce(&Self) -> R) -> R {
         // This deliberately uses `==` on `bool` to follow the pattern
         // `assert!(val.replace(new) == old)`.
-        assert!(
-            self.memory.validation_in_progress.replace(true) == false,
-            "`validation_in_progress` was already set"
-        );
+        assert!(self.memory.ghost_mode.replace(true) == false, "`ghost_mode` was already set");
         let res = f(self);
         assert!(
-            self.memory.validation_in_progress.replace(false) == true,
-            "`validation_in_progress` was unset by someone else"
+            self.memory.ghost_mode.replace(false) == true,
+            "`ghost_mode` was unset by someone else"
         );
         res
     }
 
     pub(super) fn validation_in_progress(&self) -> bool {
-        self.memory.validation_in_progress.get()
+        self.memory.ghost_mode.get()
     }
 }
 
@@ -1516,7 +1512,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         };
         let src_alloc = self.get_alloc_raw(src_alloc_id)?;
         let src_range = alloc_range(src_offset, size);
-        assert!(!self.memory.validation_in_progress.get(), "we can't be copying during validation");
+        assert!(!self.memory.ghost_mode.get(), "we can't be copying during validation");
 
         // Trigger read hook.
         // For the overlapping case, it is crucial that we trigger the read hook

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -16,9 +16,9 @@ use tracing::field::Empty;
 use tracing::trace;
 
 use super::{
-    CtfeProvenance, InterpCx, InterpResult, MPlaceTy, Machine, MemPlace, MemPlaceMeta, OffsetMode,
-    PlaceTy, Pointer, Projectable, Provenance, Scalar, alloc_range, err_ub, from_known_layout,
-    interp_ok, mir_assign_valid_types, throw_ub,
+    CtfeProvenance, Frame, InterpCx, InterpResult, MPlaceTy, Machine, MemPlace, MemPlaceMeta,
+    OffsetMode, PlaceTy, Pointer, Projectable, Provenance, Scalar, alloc_range, err_ub,
+    from_known_layout, interp_ok, mir_assign_valid_types, throw_ub,
 };
 use crate::enter_trace_span;
 
@@ -738,6 +738,22 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 M::after_local_read(self, local)?;
             }
         }
+        interp_ok(OpTy { op, layout })
+    }
+
+    /// Tools like Priroda and [Aquascope](https://github.com/cognitive-engineering-lab/aquascope/)
+    /// need to access any local without triggering any access hook, since these are not actual
+    /// AM-level accesses. Do not call this from inside the interpreter!
+    ///
+    /// Remember to use `ghost_run` when accessing memory for such purposes, to suppress
+    /// the access hooks for that as well.
+    pub fn ghost_local_in_frame_to_op(
+        &self,
+        frame: &Frame<'tcx, M::Provenance, M::FrameExtra>,
+        local: mir::Local,
+    ) -> InterpResult<'tcx, OpTy<'tcx, M::Provenance>> {
+        let layout = self.layout_of_local(frame, local, None)?;
+        let op = *frame.locals[local].access()?;
         interp_ok(OpTy { op, layout })
     }
 

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -16,9 +16,9 @@ use tracing::field::Empty;
 use tracing::trace;
 
 use super::{
-    CtfeProvenance, Frame, InterpCx, InterpResult, MPlaceTy, Machine, MemPlace, MemPlaceMeta,
-    OffsetMode, PlaceTy, Pointer, Projectable, Provenance, Scalar, alloc_range, err_ub,
-    from_known_layout, interp_ok, mir_assign_valid_types, throw_ub,
+    CtfeProvenance, InterpCx, InterpResult, MPlaceTy, Machine, MemPlace, MemPlaceMeta, OffsetMode,
+    PlaceTy, Pointer, Projectable, Provenance, Scalar, alloc_range, err_ub, from_known_layout,
+    interp_ok, mir_assign_valid_types, throw_ub,
 };
 use crate::enter_trace_span;
 
@@ -722,32 +722,22 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         interp_ok(s)
     }
 
-    /// Read from a local of the current frame. Convenience method for [`InterpCx::local_at_frame_to_op`].
+    /// Read from a local of a current frame.
+    /// Will not access memory, instead an indirect `Operand` is returned.
     pub fn local_to_op(
         &self,
         local: mir::Local,
         layout: Option<TyAndLayout<'tcx>>,
     ) -> InterpResult<'tcx, OpTy<'tcx, M::Provenance>> {
-        self.local_at_frame_to_op(self.frame(), local, layout)
-    }
-
-    /// Read from a local of a given frame.
-    /// Will not access memory, instead an indirect `Operand` is returned.
-    ///
-    /// This is public because it is used by [Aquascope](https://github.com/cognitive-engineering-lab/aquascope/)
-    /// to get an OpTy from a local.
-    pub fn local_at_frame_to_op(
-        &self,
-        frame: &Frame<'tcx, M::Provenance, M::FrameExtra>,
-        local: mir::Local,
-        layout: Option<TyAndLayout<'tcx>>,
-    ) -> InterpResult<'tcx, OpTy<'tcx, M::Provenance>> {
+        let frame = self.frame();
         let layout = self.layout_of_local(frame, local, layout)?;
         let op = *frame.locals[local].access()?;
         if matches!(op, Operand::Immediate(_)) {
             assert!(!layout.is_unsized());
+            if !self.validation_in_progress() {
+                M::after_local_read(self, local)?;
+            }
         }
-        M::after_local_read(self, frame, local)?;
         interp_ok(OpTy { op, layout })
     }
 

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -90,7 +90,7 @@ pub struct Frame<'tcx, Prov: Provenance = CtfeProvenance, Extra = ()> {
     /// can either directly contain `Scalar` or refer to some part of an `Allocation`.
     ///
     /// Do *not* access this directly; always go through the machine hook!
-    pub locals: IndexVec<mir::Local, LocalState<'tcx, Prov>>,
+    pub(super) locals: IndexVec<mir::Local, LocalState<'tcx, Prov>>,
 
     /// The complete variable argument list of this frame. Its elements must be dropped when the
     /// frame is popped.
@@ -168,8 +168,9 @@ impl<'tcx, Prov: Provenance> LocalState<'tcx, Prov> {
 
     /// This is a hack because Miri needs a way to visit all the provenance in a `LocalState`
     /// without having a layout or `TyCtxt` available, and we want to keep the `Operand` type
-    /// private.
-    pub fn as_mplace_or_imm(
+    /// private. Does not count as a read of the local for the AM! It's a "ghost" read, like for
+    /// validation or similar purposes.
+    pub fn as_mplace_or_imm_for_validation(
         &self,
     ) -> Option<Either<(Pointer<Option<Prov>>, MemPlaceMeta<Prov>), Immediate<Prov>>> {
         match self.value {
@@ -291,6 +292,10 @@ impl<'tcx, Prov: Provenance, Extra> Frame<'tcx, Prov, Extra> {
 
     pub fn return_cont(&self) -> ReturnContinuation {
         self.return_cont
+    }
+
+    pub fn locals(&self) -> &IndexVec<mir::Local, LocalState<'tcx, Prov>> {
+        &self.locals
     }
 
     /// Return the `SourceInfo` of the current instruction.

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -170,7 +170,7 @@ impl<'tcx, Prov: Provenance> LocalState<'tcx, Prov> {
     /// without having a layout or `TyCtxt` available, and we want to keep the `Operand` type
     /// private. Does not count as a read of the local for the AM! It's a "ghost" read, like for
     /// validation or similar purposes.
-    pub fn as_mplace_or_imm_for_validation(
+    pub fn as_mplace_or_imm_ghost(
         &self,
     ) -> Option<Either<(Pointer<Option<Prov>>, MemPlaceMeta<Prov>), Immediate<Prov>>> {
         match self.value {

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -1611,7 +1611,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         trace!("validate_place_internal: {:?}, {:?}", *val, val.layout.ty);
 
         // Run the visitor.
-        self.run_for_validation_mut(|ecx| {
+        self.ghost_run_mut(|ecx| {
             let reset_padding = reset_provenance_and_padding && {
                 // Check if `val` is actually stored in memory. If not, padding is not even
                 // represented and we need not reset it.

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "moto-rt"
-version = "0.16.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd8eb21b606833bc3a8c1c343bc75eb1999b288b2c2d515ae872e9e2f153187"
+checksum = "9f3c01b588c6d37e3f4f065712c4f33e12fad17ad4152a70e8346991e2bbe92e"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",

--- a/library/alloc/src/boxed/thin.rs
+++ b/library/alloc/src/boxed/thin.rs
@@ -11,7 +11,7 @@ use core::marker::PhantomData;
 use core::marker::Unsize;
 #[cfg(not(no_global_oom_handling))]
 use core::mem;
-use core::mem::SizedTypeProperties;
+use core::mem::{DropGuard, SizedTypeProperties};
 use core::ops::{Deref, DerefMut};
 use core::ptr::{self, NonNull, Pointee};
 
@@ -360,38 +360,23 @@ impl<H> WithHeader<H> {
     // - Assumes that either `value` can be dereferenced, or is the
     //   `NonNull::dangling()` we use when both `T` and `H` are ZSTs.
     unsafe fn drop<T: ?Sized>(&self, value: *mut T) {
-        struct DropGuard<H> {
-            ptr: NonNull<u8>,
-            value_layout: Layout,
-            _marker: PhantomData<H>,
-        }
-
-        impl<H> Drop for DropGuard<H> {
-            fn drop(&mut self) {
-                // All ZST are allocated statically.
-                if self.value_layout.size() == 0 {
-                    return;
-                }
-
-                unsafe {
-                    // SAFETY: Layout must have been computable if we're in drop
-                    let (layout, value_offset) =
-                        WithHeader::<H>::alloc_layout(self.value_layout).unwrap_unchecked();
-
-                    // Since we only allocate for non-ZSTs, the layout size cannot be zero.
-                    debug_assert!(layout.size() != 0);
-                    alloc::dealloc(self.ptr.as_ptr().sub(value_offset), layout);
-                }
-            }
-        }
-
         unsafe {
             // `_guard` will deallocate the memory when dropped, even if `drop_in_place` unwinds.
-            let _guard = DropGuard {
-                ptr: self.0,
-                value_layout: Layout::for_value_raw(value),
-                _marker: PhantomData::<H>,
-            };
+            let _guard =
+                DropGuard::new((self.0, Layout::for_value_raw(value)), |(ptr, value_layout)| {
+                    // All ZST are allocated statically.
+                    if value_layout.size() == 0 {
+                        return;
+                    }
+
+                    // SAFETY: Layout must have been computable if we're in drop
+                    let (layout, value_offset) =
+                        WithHeader::<H>::alloc_layout(value_layout).unwrap_unchecked();
+
+                    // Since we only allocate for non-ZSTs, the layout size cannot be zero.
+                    debug_assert_ne!(layout.size(), 0);
+                    alloc::dealloc(ptr.as_ptr().sub(value_offset), layout);
+                });
 
             // We only drop the value because the Pointee trait requires that the metadata is copy
             // aka trivially droppable.

--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -145,7 +145,7 @@
 
 use core::alloc::Allocator;
 use core::iter::{FusedIterator, InPlaceIterable, SourceIter, TrustedFused, TrustedLen};
-use core::mem::{self, ManuallyDrop, swap};
+use core::mem::{DropGuard, ManuallyDrop, swap};
 use core::num::NonZero;
 use core::ops::{Deref, DerefMut};
 use core::{fmt, ptr};
@@ -1907,18 +1907,10 @@ impl<'a, T: Ord, A: Allocator> DrainSorted<'a, T, A> {
 impl<'a, T: Ord, A: Allocator> Drop for DrainSorted<'a, T, A> {
     /// Removes heap elements in heap order.
     fn drop(&mut self) {
-        struct DropGuard<'r, 'a, T: Ord, A: Allocator>(&'r mut DrainSorted<'a, T, A>);
-
-        impl<'r, 'a, T: Ord, A: Allocator> Drop for DropGuard<'r, 'a, T, A> {
-            fn drop(&mut self) {
-                while self.0.inner.pop().is_some() {}
-            }
-        }
-
         while let Some(item) = self.inner.pop() {
-            let guard = DropGuard(self);
+            let guard = DropGuard::new(&mut *self, |this| while this.inner.pop().is_some() {});
             drop(item);
-            mem::forget(guard);
+            DropGuard::dismiss(guard);
         }
     }
 }

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -5,7 +5,7 @@ use core::fmt::{self, Debug};
 use core::hash::{Hash, Hasher};
 use core::iter::{FusedIterator, TrustedLen};
 use core::marker::PhantomData;
-use core::mem::{self, ManuallyDrop};
+use core::mem::{self, DropGuard, ManuallyDrop};
 use core::ops::{Bound, Index, RangeBounds};
 use core::ptr;
 
@@ -1904,24 +1904,18 @@ impl<K, V, A: Allocator + Clone> IntoIterator for BTreeMap<K, V, A> {
 #[stable(feature = "btree_drop", since = "1.7.0")]
 impl<K, V, A: Allocator + Clone> Drop for IntoIter<K, V, A> {
     fn drop(&mut self) {
-        struct DropGuard<'a, K, V, A: Allocator + Clone>(&'a mut IntoIter<K, V, A>);
-
-        impl<'a, K, V, A: Allocator + Clone> Drop for DropGuard<'a, K, V, A> {
-            fn drop(&mut self) {
+        while let Some(kv) = self.dying_next() {
+            let guard = DropGuard::new(&mut *self, |this| {
                 // Continue the same loop we perform below. This only runs when unwinding, so we
                 // don't have to care about panics this time (they'll abort).
-                while let Some(kv) = self.0.dying_next() {
+                while let Some(kv) = this.dying_next() {
                     // SAFETY: we consume the dying handle immediately.
                     unsafe { kv.drop_key_val() };
                 }
-            }
-        }
-
-        while let Some(kv) = self.dying_next() {
-            let guard = DropGuard(self);
+            });
             // SAFETY: we don't touch the tree before consuming the dying handle.
             unsafe { kv.drop_key_val() };
-            mem::forget(guard);
+            DropGuard::dismiss(guard);
         }
     }
 }

--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -32,7 +32,7 @@
 //   an edge both identifies a position and contains a pointer to a child node.
 
 use core::marker::PhantomData;
-use core::mem::{self, MaybeUninit};
+use core::mem::{self, DropGuard, MaybeUninit};
 use core::num::NonZero;
 use core::ptr::{self, NonNull};
 use core::slice::SliceIndex;
@@ -1192,23 +1192,13 @@ impl<K, V, NodeType> Handle<NodeRef<marker::Dying, K, V, NodeType>, marker::KV> 
     /// The node that the handle refers to must not yet have been deallocated.
     #[inline]
     pub(super) unsafe fn drop_key_val(mut self) {
-        // Run the destructor of the value even if the destructor of the key panics.
-        struct Dropper<'a, T>(&'a mut MaybeUninit<T>);
-        impl<T> Drop for Dropper<'_, T> {
-            #[inline]
-            fn drop(&mut self) {
-                unsafe {
-                    self.0.assume_init_drop();
-                }
-            }
-        }
-
         debug_assert!(self.idx < self.node.len());
         let leaf = self.node.as_leaf_dying();
         unsafe {
             let key = leaf.keys.get_unchecked_mut(self.idx);
             let val = leaf.vals.get_unchecked_mut(self.idx);
-            let _guard = Dropper(val);
+            // Run the destructor of the value even if the destructor of the key panics.
+            let _guard = DropGuard::new(val, |val| val.assume_init_drop());
             key.assume_init_drop();
             // dropping the guard will drop the value
         }

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -17,6 +17,7 @@ use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::iter::{FusedIterator, TrustedLen};
 use core::marker::PhantomData;
+use core::mem::DropGuard;
 use core::ptr::NonNull;
 use core::{fmt, mem};
 
@@ -1177,20 +1178,15 @@ impl<T, A: Allocator> LinkedList<T, A> {
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T, A: Allocator> Drop for LinkedList<T, A> {
     fn drop(&mut self) {
-        struct DropGuard<'a, T, A: Allocator>(&'a mut LinkedList<T, A>);
-
-        impl<'a, T, A: Allocator> Drop for DropGuard<'a, T, A> {
-            fn drop(&mut self) {
-                // Continue the same loop we do below. This only runs when a destructor has
-                // panicked. If another one panics this will abort.
-                while self.0.pop_front_node().is_some() {}
-            }
-        }
-
         // Wrap self so that if a destructor panics, we can try to keep looping
-        let guard = DropGuard(self);
-        while guard.0.pop_front_node().is_some() {}
-        mem::forget(guard);
+        let mut guard = DropGuard::new(self, |this| {
+            // Continue the same loop we do below. This only runs when a destructor has
+            // panicked. If another one panics this will abort.
+            while this.pop_front_node().is_some() {}
+        });
+
+        while guard.pop_front_node().is_some() {}
+        DropGuard::dismiss(guard);
     }
 }
 

--- a/library/alloc/src/collections/vec_deque/drain.rs
+++ b/library/alloc/src/collections/vec_deque/drain.rs
@@ -1,6 +1,6 @@
 use core::iter::FusedIterator;
 use core::marker::PhantomData;
-use core::mem::{self, SizedTypeProperties};
+use core::mem::{self, DropGuard, SizedTypeProperties};
 use core::ptr::NonNull;
 use core::{fmt, ptr};
 
@@ -93,140 +93,133 @@ unsafe impl<T: Send, A: Allocator + Send> Send for Drain<'_, T, A> {}
 #[stable(feature = "drain", since = "1.6.0")]
 impl<T, A: Allocator> Drop for Drain<'_, T, A> {
     fn drop(&mut self) {
-        struct DropGuard<'r, 'a, T, A: Allocator>(&'r mut Drain<'a, T, A>);
+        // Dropping `guard` handles moving the remaining elements into place.
+        let mut guard = DropGuard::new(self, |this| {
+            if mem::needs_drop::<T>() && this.remaining != 0 {
+                unsafe {
+                    // SAFETY: We just checked that `self.remaining != 0`.
+                    let (front, back) = this.as_slices();
+                    ptr::drop_in_place(front);
+                    ptr::drop_in_place(back);
+                }
+            }
 
-        let guard = DropGuard(self);
+            let source_deque = unsafe { this.deque.as_mut() };
 
-        if mem::needs_drop::<T>() && guard.0.remaining != 0 {
+            let drain_len = this.drain_len;
+            let head_len = source_deque.len; // #elements in front of the drain
+            let tail_len = this.tail_len; // #elements behind the drain
+            let new_len = head_len + tail_len;
+
+            if T::IS_ZST {
+                // no need to copy around any memory if T is a ZST
+                source_deque.len = new_len;
+                return;
+            }
+
+            // Next, we will fill the hole left by the drain with as few writes as possible.
+            // The code below handles the following control flow and reduces the amount of
+            // branches under the assumption that `head_len == 0 || tail_len == 0`, i.e.
+            // draining at the front or at the back of the dequeue is especially common.
+            //
+            // H = "head index" = `deque.head`
+            // h = elements in front of the drain
+            // d = elements in the drain
+            // t = elements behind the drain
+            //
+            // Note that the buffer may wrap at any point and the wrapping is handled by
+            // `wrap_copy` and `to_physical_idx`.
+            //
+            // Case 1: if `head_len == 0 && tail_len == 0`
+            // Everything was drained, reset the head index back to 0.
+            //             H
+            // [ . . . . . d d d d . . . . . ]
+            //   H
+            // [ . . . . . . . . . . . . . . ]
+            //
+            // Case 2: else if `tail_len == 0`
+            // Don't move data or the head index.
+            //         H
+            // [ . . . h h h h d d d d . . . ]
+            //         H
+            // [ . . . h h h h . . . . . . . ]
+            //
+            // Case 3: else if `head_len == 0`
+            // Don't move data, but move the head index.
+            //         H
+            // [ . . . d d d d t t t t . . . ]
+            //                 H
+            // [ . . . . . . . t t t t . . . ]
+            //
+            // Case 4: else if `tail_len <= head_len`
+            // Move data, but not the head index.
+            //       H
+            // [ . . h h h h d d d d t t . . ]
+            //       H
+            // [ . . h h h h t t . . . . . . ]
+            //
+            // Case 5: else
+            // Move data and the head index.
+            //       H
+            // [ . . h h d d d d t t t t . . ]
+            //               H
+            // [ . . . . . . h h t t t t . . ]
+
+            // When draining at the front (`.drain(..n)`) or at the back (`.drain(n..)`),
+            // we don't need to copy any data. The number of elements copied would be 0.
+            if head_len != 0 && tail_len != 0 {
+                join_head_and_tail_wrapping(source_deque, drain_len, head_len, tail_len);
+                // Marking this function as cold helps LLVM to eliminate it entirely if
+                // this branch is never taken.
+                // We use `#[cold]` instead of `#[inline(never)]`, because inlining this
+                // function into the general case (`.drain(n..m)`) is fine.
+                // See `tests/codegen-llvm/vecdeque-drain.rs` for a test.
+                #[cold]
+                fn join_head_and_tail_wrapping<T, A: Allocator>(
+                    source_deque: &mut VecDeque<T, A>,
+                    drain_len: usize,
+                    head_len: usize,
+                    tail_len: usize,
+                ) {
+                    // Pick whether to move the head or the tail here.
+                    let (src, dst, len);
+                    if head_len < tail_len {
+                        src = source_deque.head;
+                        dst = source_deque.to_wrapped_index(drain_len);
+                        len = head_len;
+                    } else {
+                        src = source_deque.to_wrapped_index(head_len + drain_len);
+                        dst = source_deque.to_wrapped_index(head_len);
+                        len = tail_len;
+                    };
+
+                    unsafe {
+                        source_deque.wrap_copy(src, dst, len);
+                    }
+                }
+            }
+
+            if new_len == 0 {
+                // Special case: If the entire deque was drained, reset the head back to 0,
+                // like `.clear()` does.
+                source_deque.head = WrappedIndex::zero();
+            } else if head_len < tail_len {
+                // If we moved the head above, then we need to adjust the head index here.
+                source_deque.head = source_deque.to_wrapped_index(drain_len);
+            }
+            source_deque.len = new_len;
+        });
+
+        if mem::needs_drop::<T>() && guard.remaining != 0 {
             unsafe {
                 // SAFETY: We just checked that `self.remaining != 0`.
-                let (front, back) = guard.0.as_slices();
+                let (front, back) = guard.as_slices();
                 // since idx is a logical index, we don't need to worry about wrapping.
-                guard.0.idx += front.len();
-                guard.0.remaining -= front.len();
+                guard.idx += front.len();
+                guard.remaining -= front.len();
                 ptr::drop_in_place(front);
-                guard.0.remaining = 0;
+                guard.remaining = 0;
                 ptr::drop_in_place(back);
-            }
-        }
-
-        // Dropping `guard` handles moving the remaining elements into place.
-        impl<'r, 'a, T, A: Allocator> Drop for DropGuard<'r, 'a, T, A> {
-            #[inline]
-            fn drop(&mut self) {
-                if mem::needs_drop::<T>() && self.0.remaining != 0 {
-                    unsafe {
-                        // SAFETY: We just checked that `self.remaining != 0`.
-                        let (front, back) = self.0.as_slices();
-                        ptr::drop_in_place(front);
-                        ptr::drop_in_place(back);
-                    }
-                }
-
-                let source_deque = unsafe { self.0.deque.as_mut() };
-
-                let drain_len = self.0.drain_len;
-                let head_len = source_deque.len; // #elements in front of the drain
-                let tail_len = self.0.tail_len; // #elements behind the drain
-                let new_len = head_len + tail_len;
-
-                if T::IS_ZST {
-                    // no need to copy around any memory if T is a ZST
-                    source_deque.len = new_len;
-                    return;
-                }
-
-                // Next, we will fill the hole left by the drain with as few writes as possible.
-                // The code below handles the following control flow and reduces the amount of
-                // branches under the assumption that `head_len == 0 || tail_len == 0`, i.e.
-                // draining at the front or at the back of the dequeue is especially common.
-                //
-                // H = "head index" = `deque.head`
-                // h = elements in front of the drain
-                // d = elements in the drain
-                // t = elements behind the drain
-                //
-                // Note that the buffer may wrap at any point and the wrapping is handled by
-                // `wrap_copy` and `to_physical_idx`.
-                //
-                // Case 1: if `head_len == 0 && tail_len == 0`
-                // Everything was drained, reset the head index back to 0.
-                //             H
-                // [ . . . . . d d d d . . . . . ]
-                //   H
-                // [ . . . . . . . . . . . . . . ]
-                //
-                // Case 2: else if `tail_len == 0`
-                // Don't move data or the head index.
-                //         H
-                // [ . . . h h h h d d d d . . . ]
-                //         H
-                // [ . . . h h h h . . . . . . . ]
-                //
-                // Case 3: else if `head_len == 0`
-                // Don't move data, but move the head index.
-                //         H
-                // [ . . . d d d d t t t t . . . ]
-                //                 H
-                // [ . . . . . . . t t t t . . . ]
-                //
-                // Case 4: else if `tail_len <= head_len`
-                // Move data, but not the head index.
-                //       H
-                // [ . . h h h h d d d d t t . . ]
-                //       H
-                // [ . . h h h h t t . . . . . . ]
-                //
-                // Case 5: else
-                // Move data and the head index.
-                //       H
-                // [ . . h h d d d d t t t t . . ]
-                //               H
-                // [ . . . . . . h h t t t t . . ]
-
-                // When draining at the front (`.drain(..n)`) or at the back (`.drain(n..)`),
-                // we don't need to copy any data. The number of elements copied would be 0.
-                if head_len != 0 && tail_len != 0 {
-                    join_head_and_tail_wrapping(source_deque, drain_len, head_len, tail_len);
-                    // Marking this function as cold helps LLVM to eliminate it entirely if
-                    // this branch is never taken.
-                    // We use `#[cold]` instead of `#[inline(never)]`, because inlining this
-                    // function into the general case (`.drain(n..m)`) is fine.
-                    // See `tests/codegen-llvm/vecdeque-drain.rs` for a test.
-                    #[cold]
-                    fn join_head_and_tail_wrapping<T, A: Allocator>(
-                        source_deque: &mut VecDeque<T, A>,
-                        drain_len: usize,
-                        head_len: usize,
-                        tail_len: usize,
-                    ) {
-                        // Pick whether to move the head or the tail here.
-                        let (src, dst, len);
-                        if head_len < tail_len {
-                            src = source_deque.head;
-                            dst = source_deque.to_wrapped_index(drain_len);
-                            len = head_len;
-                        } else {
-                            src = source_deque.to_wrapped_index(head_len + drain_len);
-                            dst = source_deque.to_wrapped_index(head_len);
-                            len = tail_len;
-                        };
-
-                        unsafe {
-                            source_deque.wrap_copy(src, dst, len);
-                        }
-                    }
-                }
-
-                if new_len == 0 {
-                    // Special case: If the entire deque was drained, reset the head back to 0,
-                    // like `.clear()` does.
-                    source_deque.head = WrappedIndex::zero();
-                } else if head_len < tail_len {
-                    // If we moved the head above, then we need to adjust the head index here.
-                    source_deque.head = source_deque.to_wrapped_index(drain_len);
-                }
-                source_deque.len = new_len;
             }
         }
     }

--- a/library/alloc/src/collections/vec_deque/into_iter.rs
+++ b/library/alloc/src/collections/vec_deque/into_iter.rs
@@ -1,5 +1,5 @@
 use core::iter::{FusedIterator, TrustedLen};
-use core::mem::MaybeUninit;
+use core::mem::{DropGuard, MaybeUninit};
 use core::num::NonZero;
 use core::ops::Try;
 use core::{array, fmt, ptr};
@@ -78,28 +78,20 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
         F: FnMut(B, Self::Item) -> R,
         R: Try<Output = B>,
     {
-        struct Guard<'a, T, A: Allocator> {
-            deque: &'a mut VecDeque<T, A>,
-            // `consumed <= deque.len` always holds.
-            consumed: usize,
-        }
+        // `consumed <= deque.len` always holds.
+        let mut guard = DropGuard::new((&mut self.inner, 0), |(deque, consumed)| {
+            deque.len -= consumed;
+            deque.head = deque.to_wrapped_index(consumed);
+        });
 
-        impl<'a, T, A: Allocator> Drop for Guard<'a, T, A> {
-            fn drop(&mut self) {
-                self.deque.len -= self.consumed;
-                self.deque.head = self.deque.to_wrapped_index(self.consumed);
-            }
-        }
-
-        let mut guard = Guard { deque: &mut self.inner, consumed: 0 };
-
-        let (head, tail) = guard.deque.as_slices();
+        let (deque, consumed) = &mut *guard;
+        let (head, tail) = deque.as_slices();
 
         init = head
             .iter()
             .map(|elem| {
-                guard.consumed += 1;
-                // SAFETY: Because we incremented `guard.consumed`, the
+                *consumed += 1;
+                // SAFETY: Because we incremented `consumed`, the
                 // deque effectively forgot the element, so we can take
                 // ownership
                 unsafe { ptr::read(elem) }
@@ -108,7 +100,7 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
 
         tail.iter()
             .map(|elem| {
-                guard.consumed += 1;
+                *consumed += 1;
                 // SAFETY: Same as above.
                 unsafe { ptr::read(elem) }
             })
@@ -201,26 +193,18 @@ impl<T, A: Allocator> DoubleEndedIterator for IntoIter<T, A> {
         F: FnMut(B, Self::Item) -> R,
         R: Try<Output = B>,
     {
-        struct Guard<'a, T, A: Allocator> {
-            deque: &'a mut VecDeque<T, A>,
-            // `consumed <= deque.len` always holds.
-            consumed: usize,
-        }
+        // `consumed <= deque.len` always holds.
+        let mut guard = DropGuard::new((&mut self.inner, 0), |(deque, consumed)| {
+            deque.len -= consumed;
+        });
 
-        impl<'a, T, A: Allocator> Drop for Guard<'a, T, A> {
-            fn drop(&mut self) {
-                self.deque.len -= self.consumed;
-            }
-        }
-
-        let mut guard = Guard { deque: &mut self.inner, consumed: 0 };
-
-        let (head, tail) = guard.deque.as_slices();
+        let (deque, consumed) = &mut *guard;
+        let (head, tail) = deque.as_slices();
 
         init = tail
             .iter()
             .map(|elem| {
-                guard.consumed += 1;
+                *consumed += 1;
                 // SAFETY: See `try_fold`'s safety comment.
                 unsafe { ptr::read(elem) }
             })
@@ -228,7 +212,7 @@ impl<T, A: Allocator> DoubleEndedIterator for IntoIter<T, A> {
 
         head.iter()
             .map(|elem| {
-                guard.consumed += 1;
+                *consumed += 1;
                 // SAFETY: Same as above.
                 unsafe { ptr::read(elem) }
             })

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -17,7 +17,7 @@ use core::iter::{ByRefSized, repeat_n, repeat_with};
 // failures in linkchecker even though rustdoc built the docs just fine.
 #[allow(unused_imports)]
 use core::mem;
-use core::mem::{ManuallyDrop, SizedTypeProperties};
+use core::mem::{DropGuard, ManuallyDrop, SizedTypeProperties};
 use core::ops::{Index, IndexMut, Range, RangeBounds};
 use core::{fmt, ptr, slice};
 
@@ -632,35 +632,23 @@ impl<T, A: Allocator> VecDeque<T, A> {
         mut iter: impl Iterator<Item = T>,
         len: usize,
     ) -> usize {
-        struct Guard<'a, T, A: Allocator> {
-            deque: &'a mut VecDeque<T, A>,
-            written: usize,
-        }
-
-        impl<'a, T, A: Allocator> Drop for Guard<'a, T, A> {
-            fn drop(&mut self) {
-                self.deque.len += self.written;
-            }
-        }
-
         let head_room = self.capacity() - dst.as_index();
 
-        let mut guard = Guard { deque: self, written: 0 };
+        let mut guard = DropGuard::new((self, 0), |(deque, written)| {
+            deque.len += written;
+        });
+        let (deque, written) = &mut *guard;
 
         if head_room >= len {
-            unsafe { guard.deque.write_iter(dst, iter, &mut guard.written) };
+            unsafe { deque.write_iter(dst, iter, written) };
         } else {
             unsafe {
-                guard.deque.write_iter(
-                    dst,
-                    ByRefSized(&mut iter).take(head_room),
-                    &mut guard.written,
-                );
-                guard.deque.write_iter(WrappedIndex::zero(), iter, &mut guard.written)
+                deque.write_iter(dst, ByRefSized(&mut iter).take(head_room), written);
+                deque.write_iter(WrappedIndex::zero(), iter, written)
             };
         }
 
-        guard.written
+        *written
     }
 
     /// Frobs the head and tail sections around to handle the fact that we

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2388,45 +2388,31 @@ impl<T> Rc<[T]> {
     /// Behavior is undefined should the size be wrong.
     #[cfg(not(no_global_oom_handling))]
     unsafe fn from_iter_exact(iter: impl Iterator<Item = T>, len: usize) -> Rc<[T]> {
-        // Panic guard while cloning T elements.
-        // In the event of a panic, elements that have been written
-        // into the new RcInner will be dropped, then the memory freed.
-        struct Guard<T> {
-            mem: NonNull<u8>,
-            elems: *mut T,
-            layout: Layout,
-            n_elems: usize,
-        }
-
-        impl<T> Drop for Guard<T> {
-            fn drop(&mut self) {
-                unsafe {
-                    let slice = from_raw_parts_mut(self.elems, self.n_elems);
-                    ptr::drop_in_place(slice);
-
-                    Global.deallocate(self.mem, self.layout);
-                }
-            }
-        }
+        use core::mem::DropGuard;
 
         unsafe {
             let ptr = Self::allocate_for_slice(len);
-
-            let mem = ptr as *mut _ as *mut u8;
             let layout = Layout::for_value_raw(ptr);
 
             // Pointer to first element
-            let elems = (&raw mut (*ptr).value) as *mut T;
+            let elems = (&raw mut (*ptr).value).as_mut_ptr();
 
-            let mut guard = Guard { mem: NonNull::new_unchecked(mem), elems, layout, n_elems: 0 };
+            // Panic guard while cloning T elements.
+            // In the event of a panic, elements that have been written
+            // into the new RcInner will be dropped, then the memory freed.
+            let mut guard = DropGuard::new(0, |n_elems| {
+                let slice = from_raw_parts_mut(elems, n_elems);
+                ptr::drop_in_place(slice);
+                Global.deallocate(NonNull::new_unchecked(ptr.cast()), layout);
+            });
 
             for (i, item) in iter.enumerate() {
                 ptr::write(elems.add(i), item);
-                guard.n_elems += 1;
+                *guard += 1;
             }
 
-            // All clear. Forget the guard so it doesn't free the new RcInner.
-            mem::forget(guard);
+            // All clear. Dismiss the guard so it doesn't free the new RcInner.
+            DropGuard::dismiss(guard);
 
             Self::from_ptr(ptr)
         }

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -408,35 +408,30 @@ impl<T> [T] {
         impl<T: Clone> ConvertVec for T {
             #[inline]
             default fn to_vec<A: Allocator>(s: &[Self], alloc: A) -> Vec<Self, A> {
-                struct DropGuard<'a, T, A: Allocator> {
-                    vec: &'a mut Vec<T, A>,
-                    num_init: usize,
-                }
-                impl<'a, T, A: Allocator> Drop for DropGuard<'a, T, A> {
-                    #[inline]
-                    fn drop(&mut self) {
+                use core::mem::DropGuard;
+
+                let mut guard = DropGuard::new(
+                    (0, Vec::with_capacity_in(s.len(), alloc)),
+                    |(num_init, mut vec)| {
                         // SAFETY:
                         // items were marked initialized in the loop below
-                        unsafe {
-                            self.vec.set_len(self.num_init);
-                        }
-                    }
-                }
-                let mut vec = Vec::with_capacity_in(s.len(), alloc);
-                let mut guard = DropGuard { vec: &mut vec, num_init: 0 };
-                let slots = guard.vec.spare_capacity_mut();
+                        unsafe { vec.set_len(num_init) }
+                    },
+                );
+                let (num_init, vec) = &mut *guard;
+
+                let slots = vec.spare_capacity_mut();
                 // .take(slots.len()) is necessary for LLVM to remove bounds checks
                 // and has better codegen than zip.
                 for (i, b) in s.iter().enumerate().take(slots.len()) {
-                    guard.num_init = i;
+                    *num_init = i;
                     slots[i].write(b.clone());
                 }
-                core::mem::forget(guard);
+
+                let (_, mut vec) = DropGuard::dismiss(guard);
                 // SAFETY:
                 // the vec was allocated and initialized above to at least this length.
-                unsafe {
-                    vec.set_len(s.len());
-                }
+                unsafe { vec.set_len(s.len()) };
                 vec
             }
         }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -19,6 +19,8 @@ use core::intrinsics::abort;
 #[cfg(not(no_global_oom_handling))]
 use core::iter;
 use core::marker::{PhantomData, Unsize};
+#[cfg(not(no_global_oom_handling))]
+use core::mem::DropGuard;
 use core::mem::{self, Alignment, ManuallyDrop};
 use core::num::NonZeroUsize;
 use core::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};
@@ -2352,45 +2354,30 @@ impl<T> Arc<[T]> {
     /// Behavior is undefined should the size be wrong.
     #[cfg(not(no_global_oom_handling))]
     unsafe fn from_iter_exact(iter: impl Iterator<Item = T>, len: usize) -> Arc<[T]> {
-        // Panic guard while cloning T elements.
-        // In the event of a panic, elements that have been written
-        // into the new ArcInner will be dropped, then the memory freed.
-        struct Guard<T> {
-            mem: NonNull<u8>,
-            elems: *mut T,
-            layout: Layout,
-            n_elems: usize,
-        }
-
-        impl<T> Drop for Guard<T> {
-            fn drop(&mut self) {
-                unsafe {
-                    let slice = from_raw_parts_mut(self.elems, self.n_elems);
-                    ptr::drop_in_place(slice);
-
-                    Global.deallocate(self.mem, self.layout);
-                }
-            }
-        }
-
         unsafe {
             let ptr = Self::allocate_for_slice(len);
-
-            let mem = ptr as *mut _ as *mut u8;
             let layout = Layout::for_value_raw(ptr);
 
             // Pointer to first element
-            let elems = (&raw mut (*ptr).data) as *mut T;
+            let elems = (&raw mut (*ptr).data).as_mut_ptr();
 
-            let mut guard = Guard { mem: NonNull::new_unchecked(mem), elems, layout, n_elems: 0 };
+            // Panic guard while cloning T elements.
+            // In the event of a panic, elements that have been written
+            // into the new ArcInner will be dropped, then the memory freed.
+            let mut guard = DropGuard::new(0, |n_elems| {
+                let slice = from_raw_parts_mut(elems, n_elems);
+                ptr::drop_in_place(slice);
+
+                Global.deallocate(NonNull::new_unchecked(ptr.cast()), layout);
+            });
 
             for (i, item) in iter.enumerate() {
                 ptr::write(elems.add(i), item);
-                guard.n_elems += 1;
+                *guard += 1;
             }
 
-            // All clear. Forget the guard so it doesn't free the new ArcInner.
-            mem::forget(guard);
+            // All clear. Dismiss the guard so it doesn't free the new ArcInner.
+            DropGuard::dismiss(guard);
 
             Self::from_ptr(ptr)
         }
@@ -2608,15 +2595,7 @@ impl<T: ?Sized + CloneToUninit, A: AllocatorClone> Arc<T, A> {
             // If we unwind before the Arc is overwritten, we expose a strong
             // count of 0, resulting in a UAF (#155746, #157203).
             // Until the new Arc is written, the old Arc must remain valid
-            struct Guard<'a, T: ?Sized> {
-                inner: &'a ArcInner<T>,
-            }
-            impl<'a, T: ?Sized> Drop for Guard<'a, T> {
-                fn drop(&mut self) {
-                    self.inner.strong.store(1, Release);
-                }
-            }
-            let guard = Guard { inner: this.inner() };
+            let guard = DropGuard::new(this.inner(), |inner| inner.strong.store(1, Release));
 
             // Can just steal the data, all that's left is Weaks
             // Note that this can panic in two ways:
@@ -2636,7 +2615,7 @@ impl<T: ?Sized + CloneToUninit, A: AllocatorClone> Arc<T, A> {
                 );
 
                 // We are now safe from panics.
-                mem::forget(guard);
+                DropGuard::dismiss(guard);
 
                 // Materialize our own implicit weak pointer, so that it can clean
                 // up the ArcInner as needed.

--- a/library/alloc/src/vec/drain.rs
+++ b/library/alloc/src/vec/drain.rs
@@ -1,5 +1,5 @@
 use core::iter::{FusedIterator, TrustedLen};
-use core::mem::{self, ManuallyDrop, SizedTypeProperties};
+use core::mem::{self, DropGuard, ManuallyDrop, SizedTypeProperties};
 use core::ptr::{self, NonNull};
 use core::{fmt, slice};
 
@@ -172,28 +172,6 @@ impl<T, A: Allocator> DoubleEndedIterator for Drain<'_, T, A> {
 #[stable(feature = "drain", since = "1.6.0")]
 impl<T, A: Allocator> Drop for Drain<'_, T, A> {
     fn drop(&mut self) {
-        /// Moves back the un-`Drain`ed elements to restore the original `Vec`.
-        struct DropGuard<'r, 'a, T, A: Allocator>(&'r mut Drain<'a, T, A>);
-
-        impl<'r, 'a, T, A: Allocator> Drop for DropGuard<'r, 'a, T, A> {
-            fn drop(&mut self) {
-                if self.0.tail_len > 0 {
-                    unsafe {
-                        let source_vec = self.0.vec.as_mut();
-                        // memmove back untouched tail, update to new length
-                        let start = source_vec.len();
-                        let tail = self.0.tail_start;
-                        if tail != start {
-                            let src = source_vec.as_ptr().add(tail);
-                            let dst = source_vec.as_mut_ptr().add(start);
-                            ptr::copy(src, dst, self.0.tail_len);
-                        }
-                        source_vec.set_len(start + self.0.tail_len);
-                    }
-                }
-            }
-        }
-
         let iter = mem::take(&mut self.iter);
         let drop_len = iter.len();
 
@@ -213,7 +191,22 @@ impl<T, A: Allocator> Drop for Drain<'_, T, A> {
         }
 
         // ensure elements are moved back into their appropriate places, even when drop_in_place panics
-        let _guard = DropGuard(self);
+        let _guard = DropGuard::new(self, |this| {
+            if this.tail_len > 0 {
+                unsafe {
+                    let source_vec = this.vec.as_mut();
+                    // memmove back untouched tail, update to new length
+                    let start = source_vec.len();
+                    let tail = this.tail_start;
+                    if tail != start {
+                        let src = source_vec.as_ptr().add(tail);
+                        let dst = source_vec.as_mut_ptr().add(start);
+                        ptr::copy(src, dst, this.tail_len);
+                    }
+                    source_vec.set_len(start + this.tail_len);
+                }
+            }
+        });
 
         if drop_len == 0 {
             return;

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -3,7 +3,7 @@ use core::iter::{
     TrustedRandomAccessNoCoerce,
 };
 use core::marker::PhantomData;
-use core::mem::{ManuallyDrop, MaybeUninit, SizedTypeProperties};
+use core::mem::{DropGuard, ManuallyDrop, MaybeUninit, SizedTypeProperties};
 use core::num::NonZero;
 #[cfg(not(no_global_oom_handling))]
 use core::ops::Deref;
@@ -581,21 +581,9 @@ impl<T: Clone, A: Allocator + Clone> Clone for IntoIter<T, A> {
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T, A: Allocator> Drop for IntoIter<T, A> {
     fn drop(&mut self) {
-        struct DropGuard<'a, T, A: Allocator>(&'a mut IntoIter<T, A>);
-
-        impl<T, A: Allocator> Drop for DropGuard<'_, T, A> {
-            fn drop(&mut self) {
-                unsafe {
-                    self.0.dealloc_only();
-                }
-            }
-        }
-
-        let guard = DropGuard(self);
+        let mut guard = DropGuard::new(self, |this| unsafe { this.dealloc_only() });
         // destroy the remaining elements
-        unsafe {
-            ptr::drop_in_place(guard.0.as_raw_mut_slice());
-        }
+        unsafe { ptr::drop_in_place(guard.as_raw_mut_slice()) }
         // now `guard` will be dropped and do the rest
     }
 }

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -28,6 +28,7 @@
 #![feature(const_try)]
 #![feature(copied_into_inner)]
 #![feature(core_intrinsics)]
+#![feature(drop_guard)]
 #![feature(exact_size_is_empty)]
 #![feature(extend_one)]
 #![feature(extend_one_unchecked)]

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1561,7 +1561,10 @@ macro_rules! nonzero_integer_signedness_dependent_impls {
                           without modifying the original"]
             #[inline]
             pub const fn div_ceil(self, rhs: Self) -> Self {
-                let v = self.get().div_ceil(rhs.get());
+                // An implementation of the function without calculating the remainder.
+                // It is better than the implementation for normal integers, but it can only
+                // be used here because of the possibility to subtract by one without overflow.
+                let v = (self.get() - 1) / rhs.get() + 1;
                 // SAFETY: ceiled division of two positive integers can never be zero.
                 unsafe { Self::new_unchecked(v) }
             }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -71,7 +71,7 @@ fortanix-sgx-abi = { version = "0.6.1", features = [
 ], public = true }
 
 [target.'cfg(target_os = "motor")'.dependencies]
-moto-rt = { version = "0.16", features = ['rustc-dep-of-std'], public = true }
+moto-rt = { version = "0.17", features = ['rustc-dep-of-std'], public = true }
 
 [target.'cfg(target_os = "hermit")'.dependencies]
 hermit-abi = { version = "0.5.0", features = [

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1578,6 +1578,63 @@ impl Dir {
             .map(|inner| Self { inner })
     }
 
+    /// Attempts to open a directory at `path` according to `opts`.
+    ///
+    /// This function opens a directory. To open a file instead, see [`File::open`].
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if `path` does not point to an existing directory.
+    /// Other errors may also be returned according to [`OpenOptions::open`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(dirfd)]
+    /// use std::{fs::{Dir, OpenOptions}, io};
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let dir = Dir::open_with("foo", &OpenOptions::new().read(true))?;
+    ///     let mut f = dir.open_file("bar.txt")?;
+    ///     let contents = io::read_to_string(f)?;
+    ///     assert_eq!(contents, "Hello, world!");
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "dirfd", issue = "120426")]
+    pub fn open_with<P: AsRef<Path>>(path: P, opts: &OpenOptions) -> io::Result<Self> {
+        fs_imp::Dir::open(path.as_ref(), &opts.0).map(|inner| Self { inner })
+    }
+
+    /// Attempts to open a directory at `path` with the minimum permissions for traversal.
+    ///
+    /// The permissions requested by this function are guaranteed to be sufficient to open a child
+    /// file or folder, but not necessarily to list all children.
+    ///
+    /// # Errors
+    ///
+    /// This function may return an error according to [`OpenOptions::open`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(dirfd)]
+    /// use std::{fs::Dir, io};
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let foo = Dir::open_for_traversal("foo")?;
+    ///     let foobar = foo.open_dir("bar")?;
+    ///     let mut foobarbaz = foobar.open_file("baz")?;
+    ///     let contents = io::read_to_string(foobarbaz)?;
+    ///     assert_eq!(contents, "Hello, world!");
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "dirfd", issue = "120426")]
+    pub fn open_for_traversal<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        fs_imp::Dir::open_for_traversal(path.as_ref()).map(|inner| Self { inner })
+    }
+
     /// Queries metadata about the underlying directory.
     ///
     /// # Examples
@@ -1718,6 +1775,99 @@ impl Dir {
         to: Q,
     ) -> io::Result<()> {
         self.inner.rename(from.as_ref(), &to_dir.inner, to.as_ref())
+    }
+
+    /// Attempts to create a directory relative to this directory.
+    ///
+    /// This function interprets `path` relative to the directory provided by `self`. To create a directory
+    /// relative to the current working directory, or at an absolute path, see
+    /// [`fs::create_dir`][crate::fs::create_dir].
+    #[unstable(feature = "dirfd", issue = "120426")]
+    pub fn create_dir<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        self.inner.create_dir(path.as_ref())
+    }
+
+    /// Attempts to open a directory in read-only mode relative to this directory.
+    ///
+    /// This function interprets `path` relative to the directory provided by `self`. To open a directory
+    /// relative to the current working directory, or at an absolute path, see [`Dir::open`].
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if `path` does not point to an existing directory.
+    /// Other errors may also be returned according to [`OpenOptions::open`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(dirfd)]
+    /// use std::{fs::Dir};
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let dir = Dir::open("foo")?;
+    ///     let foobar = dir.open_dir("bar")?;
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "dirfd", issue = "120426")]
+    pub fn open_dir<P: AsRef<Path>>(&self, path: P) -> io::Result<Self> {
+        self.inner
+            .open_dir(path.as_ref(), &OpenOptions::new().read(true).0)
+            .map(|inner| Self { inner })
+    }
+
+    /// Attempts to open a directory relative to this directory according to `opts`.
+    ///
+    /// This function interprets `path` relative to the directory provided by `self`. To open a directory
+    /// relative to the current working directory, or at an absolute path, see [`Dir::open`].
+    ///
+    /// # Errors
+    ///
+    /// This function will return errors according to [`OpenOptions::open`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(dirfd)]
+    /// use std::fs::{Dir, OpenOptions};
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let dir = Dir::open("foo")?;
+    ///     let foobar_w = dir.open_dir_with("bar", &OpenOptions::new().write(true))?;
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "dirfd", issue = "120426")]
+    pub fn open_dir_with<P: AsRef<Path>>(&self, path: P, opts: &OpenOptions) -> io::Result<Self> {
+        self.inner.open_dir(path.as_ref(), &opts.0).map(|inner| Self { inner })
+    }
+
+    /// Attempts to remove a directory relative to this directory.
+    ///
+    /// This function interprets `path` relative to the directory provided by `self`. To remove a directory
+    /// relative to the current working directory, or at an absolute path, see
+    /// [`fs::remove_dir`][crate::fs::remove_dir].
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if `path` does not point to an existing directory.
+    /// Other errors may also be returned according to [`OpenOptions::open`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(dirfd)]
+    /// use std::{fs::Dir};
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let dir = Dir::open("foo")?;
+    ///     dir.remove_dir("bar")?;
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "dirfd", issue = "120426")]
+    pub fn remove_dir<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        self.inner.remove_dir(path.as_ref())
     }
 }
 

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -2756,3 +2756,38 @@ fn test_dir_rename_file() {
     check!(f.read_exact(&mut buf));
     assert_eq!(b"bar", &buf);
 }
+
+#[test]
+fn test_dir_remove_dir() {
+    let tmpdir = tmpdir();
+    check!(fs::create_dir(tmpdir.join("foo")));
+    let dir = check!(Dir::open(tmpdir.path()));
+    check!(dir.remove_dir("foo"));
+    assert!(!matches!(exists(tmpdir.join("foo")), Ok(true)));
+}
+
+#[test]
+fn test_dir_create_dir() {
+    let tmpdir = tmpdir();
+    let dir = check!(Dir::open(tmpdir.path()));
+    check!(dir.create_dir("foo"));
+    check!(Dir::open(tmpdir.join("foo")));
+}
+
+#[test]
+fn test_dir_open_dir() {
+    let tmpdir = tmpdir();
+    let dir1 = check!(Dir::open(tmpdir.path()));
+    check!(dir1.create_dir("foo"));
+    let dir2 = check!(Dir::open(tmpdir.path().join("foo")));
+    let mut f =
+        check!(dir2.open_file_with("bar.txt", &OpenOptions::new().create(true).write(true)));
+    check!(f.write(b"baz"));
+    check!(f.flush());
+    drop(f);
+    let dir3 = check!(dir1.open_dir("foo"));
+    let mut f = check!(dir3.open_file("bar.txt"));
+    let mut buf = [0u8; 3];
+    check!(f.read_exact(&mut buf));
+    assert_eq!(b"baz", &buf);
+}

--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -16,14 +16,12 @@ fn known_command() -> Command {
     }
 }
 
-#[cfg(target_os = "android")]
 fn shell_cmd() -> Command {
-    Command::new("/system/bin/sh")
-}
-
-#[cfg(not(target_os = "android"))]
-fn shell_cmd() -> Command {
-    Command::new("/bin/sh")
+    if cfg!(target_os = "android") || cfg!(target_os = "motor") {
+        Command::new("/system/bin/sh")
+    } else {
+        Command::new("/bin/sh")
+    }
 }
 
 #[test]

--- a/library/std/src/sys/fd/motor.rs
+++ b/library/std/src/sys/fd/motor.rs
@@ -2,7 +2,7 @@
 
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, Read};
 use crate::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
-use crate::sys::{AsInner, FromInner, IntoInner, map_motor_error};
+use crate::sys::{AsInner, FromInner, IntoInner, io_slices, io_slices_mut, map_motor_error};
 
 #[derive(Debug)]
 pub struct FileDesc(OwnedFd);
@@ -17,7 +17,8 @@ impl FileDesc {
     }
 
     pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-        io::default_read_vectored(|b| self.read(b), bufs)
+        moto_rt::fs::read_vectored(self.as_raw_fd(), &mut io_slices_mut(bufs))
+            .map_err(map_motor_error)
     }
 
     pub fn read_to_end(&self, buf: &mut Vec<u8>) -> io::Result<usize> {
@@ -30,16 +31,16 @@ impl FileDesc {
     }
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        crate::io::default_write_vectored(|b| self.write(b), bufs)
+        moto_rt::fs::write_vectored(self.as_raw_fd(), &io_slices(bufs)).map_err(map_motor_error)
     }
 
     pub fn is_write_vectored(&self) -> bool {
-        false
+        true
     }
 
     #[inline]
     pub fn is_read_vectored(&self) -> bool {
-        false
+        true
     }
 
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {

--- a/library/std/src/sys/fs/common.rs
+++ b/library/std/src/sys/fs/common.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)] // not used on all platforms
 
-use crate::fs::{remove_file, rename};
+use crate::fs::{create_dir, remove_dir, remove_file, rename};
 use crate::io::{self, Error, ErrorKind};
 use crate::path::{Path, PathBuf};
 use crate::sys::IntoInner;
@@ -71,6 +71,12 @@ impl Dir {
         path.canonicalize().map(|path| Self { path })
     }
 
+    pub fn open_for_traversal(path: &Path) -> io::Result<Self> {
+        let mut opts = OpenOptions::new();
+        opts.read(true);
+        Self::open(path, &opts)
+    }
+
     pub fn open_file(&self, path: &Path, opts: &OpenOptions) -> io::Result<File> {
         File::open(&self.path.join(path), opts)
     }
@@ -85,6 +91,18 @@ impl Dir {
 
     pub fn rename(&self, from: &Path, to_dir: &Self, to: &Path) -> io::Result<()> {
         rename(self.path.join(from), to_dir.path.join(to))
+    }
+
+    pub fn create_dir(&self, path: &Path) -> io::Result<()> {
+        create_dir(self.path.join(path))
+    }
+
+    pub fn open_dir(&self, path: &Path, opts: &OpenOptions) -> io::Result<Self> {
+        Self::open(&self.path.join(path), opts)
+    }
+
+    pub fn remove_dir(&self, path: &Path) -> io::Result<()> {
+        remove_dir(path)
     }
 }
 

--- a/library/std/src/sys/fs/motor.rs
+++ b/library/std/src/sys/fs/motor.rs
@@ -6,7 +6,21 @@ use crate::path::{Path, PathBuf};
 use crate::sys::fd::FileDesc;
 pub use crate::sys::fs::common::{Dir, exists};
 use crate::sys::time::SystemTime;
-use crate::sys::{AsInner, AsInnerMut, FromInner, IntoInner, map_motor_error, unsupported};
+use crate::sys::{
+    AsInner, AsInnerMut, FromInner, IntoInner, io_slices, io_slices_mut, map_motor_error,
+    unsupported,
+};
+
+fn try_lock(fd: RawFd, operation: u8) -> Result<(), crate::fs::TryLockError> {
+    moto_rt::fs::file_lock(fd, operation).map_err(|err| {
+        let err = map_motor_error(err);
+        if err.kind() == io::ErrorKind::WouldBlock {
+            crate::fs::TryLockError::WouldBlock
+        } else {
+            crate::fs::TryLockError::Error(err)
+        }
+    })
+}
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FileType {
@@ -196,11 +210,12 @@ impl File {
     }
 
     pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
-        crate::io::default_read_vectored(|b| self.read(b), bufs)
+        moto_rt::fs::read_vectored(self.as_raw_fd(), &mut io_slices_mut(bufs))
+            .map_err(map_motor_error)
     }
 
     pub fn is_read_vectored(&self) -> bool {
-        false
+        true
     }
 
     pub fn read_buf(&self, cursor: BorrowedCursor<'_, u8>) -> io::Result<()> {
@@ -212,11 +227,11 @@ impl File {
     }
 
     pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        crate::io::default_write_vectored(|b| self.write(b), bufs)
+        moto_rt::fs::write_vectored(self.as_raw_fd(), &io_slices(bufs)).map_err(map_motor_error)
     }
 
     pub fn is_write_vectored(&self) -> bool {
-        false
+        true
     }
 
     pub fn flush(&self) -> io::Result<()> {
@@ -259,23 +274,24 @@ impl File {
     }
 
     pub fn lock(&self) -> io::Result<()> {
-        unsupported()
+        moto_rt::fs::file_lock(self.as_raw_fd(), moto_rt::fs::LOCK_EXCLUSIVE)
+            .map_err(map_motor_error)
     }
 
     pub fn lock_shared(&self) -> io::Result<()> {
-        unsupported()
+        moto_rt::fs::file_lock(self.as_raw_fd(), moto_rt::fs::LOCK_SHARED).map_err(map_motor_error)
     }
 
     pub fn try_lock(&self) -> Result<(), crate::fs::TryLockError> {
-        Err(crate::fs::TryLockError::Error(io::Error::from(io::ErrorKind::Unsupported)))
+        try_lock(self.as_raw_fd(), moto_rt::fs::TRY_LOCK_EXCLUSIVE)
     }
 
     pub fn try_lock_shared(&self) -> Result<(), crate::fs::TryLockError> {
-        Err(crate::fs::TryLockError::Error(io::Error::from(io::ErrorKind::Unsupported)))
+        try_lock(self.as_raw_fd(), moto_rt::fs::TRY_LOCK_SHARED)
     }
 
     pub fn unlock(&self) -> io::Result<()> {
-        unsupported()
+        moto_rt::fs::file_lock(self.as_raw_fd(), moto_rt::fs::UNLOCK).map_err(map_motor_error)
     }
 
     pub fn size(&self) -> Option<io::Result<u64>> {

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2239,19 +2239,6 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
 #[cfg(target_vendor = "apple")]
 pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
     const COPYFILE_ALL: libc::copyfile_flags_t = libc::COPYFILE_METADATA | libc::COPYFILE_DATA;
-
-    struct FreeOnDrop(libc::copyfile_state_t);
-    impl Drop for FreeOnDrop {
-        fn drop(&mut self) {
-            // The code below ensures that `FreeOnDrop` is never a null pointer
-            unsafe {
-                // `copyfile_state_free` returns -1 if the `to` or `from` files
-                // cannot be closed. However, this is not considered an error.
-                libc::copyfile_state_free(self.0);
-            }
-        }
-    }
-
     let (reader, reader_metadata) = open_from(from)?;
 
     let clonefile_result = run_path_with_cstr(to, &|to| {
@@ -2272,24 +2259,29 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
     // Fall back to using `fcopyfile` if `fclonefileat` does not succeed.
     let (writer, writer_metadata) = open_to_and_set_permissions(to, &reader_metadata)?;
 
-    // We ensure that `FreeOnDrop` never contains a null pointer so it is
+    let state = unsafe { libc::copyfile_state_alloc() };
+    // We ensure that the guard never contains a null pointer so it is
     // always safe to call `copyfile_state_free`
-    let state = unsafe {
-        let state = libc::copyfile_state_alloc();
-        if state.is_null() {
-            return Err(crate::io::Error::last_os_error());
+    if state.is_null() {
+        return Err(crate::io::Error::last_os_error());
+    }
+    let state = crate::mem::DropGuard::new(state, |state| {
+        // SAFETY: just checked it's not null
+        unsafe {
+            // `copyfile_state_free` returns -1 if the `to` or `from` files
+            // cannot be closed. However, this is not considered an error.
+            libc::copyfile_state_free(state);
         }
-        FreeOnDrop(state)
-    };
+    });
 
     let flags = if writer_metadata.is_file() { COPYFILE_ALL } else { libc::COPYFILE_DATA };
 
-    cvt(unsafe { libc::fcopyfile(reader.as_raw_fd(), writer.as_raw_fd(), state.0, flags) })?;
+    cvt(unsafe { libc::fcopyfile(reader.as_raw_fd(), writer.as_raw_fd(), *state, flags) })?;
 
     let mut bytes_copied: libc::off_t = 0;
     cvt(unsafe {
         libc::copyfile_state_get(
-            state.0,
+            *state,
             libc::COPYFILE_STATE_COPIED as u32,
             (&raw mut bytes_copied) as *mut libc::c_void,
         )

--- a/library/std/src/sys/fs/unix/dir.rs
+++ b/library/std/src/sys/fs/unix/dir.rs
@@ -1,4 +1,4 @@
-use libc::{c_int, renameat, unlinkat};
+use libc::{c_int, mkdirat, renameat, unlinkat};
 
 cfg_select! {
     not(any(
@@ -28,6 +28,14 @@ use crate::sys::helpers::run_path_with_cstr;
 use crate::sys::{AsInner, FromInner, IntoInner, cvt, cvt_r};
 use crate::{fmt, fs, io};
 
+const TRAVERSE_DIRECTORY: i32 =
+    cfg_select! {
+        any(target_os = "freebsd", target_os = "aix") => libc::O_EXEC,
+        any(target_os = "linux", target_os = "android", target_os = "l4re") => libc::O_PATH,
+        target_os = "illumos" => libc::O_SEARCH,
+        _ => libc::O_RDONLY,
+    };
+
 pub struct Dir(OwnedFd);
 
 impl Dir {
@@ -35,8 +43,14 @@ impl Dir {
         run_path_with_cstr(path, &|path| Self::open_with_c(path, opts))
     }
 
+    pub fn open_for_traversal(path: &Path) -> io::Result<Self> {
+        run_path_with_cstr(path, &|path| Self::open_traversal_c(path))
+    }
+
     pub fn open_file(&self, path: &Path, opts: &OpenOptions) -> io::Result<File> {
-        run_path_with_cstr(path.as_ref(), &|path| self.open_file_c(path, opts))
+        run_path_with_cstr(path.as_ref(), &|path| self.open_file_c(path, opts, 0))
+            .map(|fd| FileDesc::from_inner(fd))
+            .map(File)
     }
 
     pub fn metadata(&self) -> io::Result<FileAttr> {
@@ -59,7 +73,19 @@ impl Dir {
         })
     }
 
-    pub fn open_with_c(path: &CStr, opts: &OpenOptions) -> io::Result<Self> {
+    pub fn open_dir(&self, path: &Path, opts: &OpenOptions) -> io::Result<Self> {
+        run_path_with_cstr(path, &|path| self.open_file_c(path, opts, libc::O_DIRECTORY)).map(Self)
+    }
+
+    pub fn create_dir(&self, path: &Path) -> io::Result<()> {
+        run_path_with_cstr(path.as_ref(), &|path| self.create_dir_c(path))
+    }
+
+    pub fn remove_dir(&self, path: &Path) -> io::Result<()> {
+        run_path_with_cstr(path, &|path| self.remove_c(path, true))
+    }
+
+    fn open_with_c(path: &CStr, opts: &OpenOptions) -> io::Result<Self> {
         let flags = libc::O_CLOEXEC
             | libc::O_DIRECTORY
             | opts.get_access_mode()?
@@ -69,15 +95,27 @@ impl Dir {
         Ok(Self(unsafe { OwnedFd::from_raw_fd(fd) }))
     }
 
-    fn open_file_c(&self, path: &CStr, opts: &OpenOptions) -> io::Result<File> {
+    fn open_traversal_c(path: &CStr) -> io::Result<Self> {
+        let flags = libc::O_CLOEXEC | libc::O_DIRECTORY | TRAVERSE_DIRECTORY;
+        let fd = cvt_r(|| unsafe { open64(path.as_ptr(), flags, 0) })?;
+        Ok(Self(unsafe { OwnedFd::from_raw_fd(fd) }))
+    }
+
+    fn open_file_c(
+        &self,
+        path: &CStr,
+        opts: &OpenOptions,
+        extra_flags: c_int,
+    ) -> io::Result<OwnedFd> {
         let flags = libc::O_CLOEXEC
             | opts.get_access_mode()?
             | opts.get_creation_mode()?
-            | (opts.custom_flags as c_int & !libc::O_ACCMODE);
+            | (opts.custom_flags as c_int & !libc::O_ACCMODE)
+            | extra_flags;
         let fd = cvt_r(|| unsafe {
             openat64(self.0.as_raw_fd(), path.as_ptr(), flags, opts.mode as c_int)
         })?;
-        Ok(File(unsafe { FileDesc::from_raw_fd(fd) }))
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
     }
 
     fn remove_c(&self, path: &CStr, remove_dir: bool) -> io::Result<()> {
@@ -96,6 +134,10 @@ impl Dir {
             renameat(self.0.as_raw_fd(), from.as_ptr(), to_dir.0.as_raw_fd(), to.as_ptr())
         })
         .map(|_| ())
+    }
+
+    fn create_dir_c(&self, path: &CStr) -> io::Result<()> {
+        cvt(unsafe { mkdirat(self.0.as_raw_fd(), path.as_ptr(), 0o777) }).map(|_| ())
     }
 }
 

--- a/library/std/src/sys/fs/windows/dir.rs
+++ b/library/std/src/sys/fs/windows/dir.rs
@@ -66,6 +66,12 @@ impl Dir {
         with_native_path(path, &|path| Self::open_with_native(path, opts))
     }
 
+    pub fn open_for_traversal(path: &Path) -> io::Result<Self> {
+        let mut opts = OpenOptions::new();
+        opts.access_mode(c::FILE_TRAVERSE);
+        with_native_path(path, &|path| Self::open_with_native(path, &opts))
+    }
+
     pub fn open_file(&self, path: &Path, opts: &OpenOptions) -> io::Result<File> {
         // NtCreateFile will fail if given an absolute path and a non-null RootDirectory
         if path.is_absolute() {
@@ -85,6 +91,24 @@ impl Dir {
         let from = to_u16s_without_nul(from)?;
         let to = to_u16s_without_nul(to)?;
         self.rename_native(&from, to_dir, &to, is_dir)
+    }
+
+    pub fn create_dir(&self, path: &Path) -> io::Result<()> {
+        let mut opts = OpenOptions::new();
+        opts.read(true);
+        opts.write(true);
+        opts.create_new(true);
+        self.open_dir(path, &opts).map(|_| ())
+    }
+
+    pub fn open_dir(&self, path: &Path, opts: &OpenOptions) -> io::Result<Self> {
+        let path = to_u16s_without_nul(&path)?;
+        self.open_file_native(&path, &opts, true).map(|handle| Self { handle })
+    }
+
+    pub fn remove_dir(&self, path: &Path) -> io::Result<()> {
+        let path = to_u16s_without_nul(&path)?;
+        self.remove_native(&path, true)
     }
 
     fn open_with_native(path: &WCStr, opts: &OpenOptions) -> io::Result<Self> {

--- a/library/std/src/sys/io/error/motor.rs
+++ b/library/std/src/sys/io/error/motor.rs
@@ -50,6 +50,7 @@ pub fn decode_error_kind(code: io::RawOsError) -> io::ErrorKind {
         moto_rt::Error::BadHandle => io::ErrorKind::InvalidInput,
         moto_rt::Error::FileTooLarge => io::ErrorKind::FileTooLarge,
         moto_rt::Error::NotConnected => io::ErrorKind::NotConnected,
+        moto_rt::Error::ConnectionReset => io::ErrorKind::ConnectionReset,
         moto_rt::Error::StorageFull => io::ErrorKind::StorageFull,
         moto_rt::Error::InvalidData => io::ErrorKind::InvalidData,
         _ => io::ErrorKind::Uncategorized,

--- a/library/std/src/sys/pal/motor/mod.rs
+++ b/library/std/src/sys/pal/motor/mod.rs
@@ -1,14 +1,38 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 
 use crate::io;
+use crate::vec::Vec;
 
 pub(crate) fn map_motor_error(err: moto_rt::Error) -> io::Error {
     let error_code: moto_rt::ErrorCode = err.into();
     io::Error::from_raw_os_error(error_code.into())
 }
 
+/// The buffer list `moto_rt::fs::write_vectored` takes.
+///
+/// Unix hands `writev` an `[IoSlice]` directly, but only because its `IoSlice`
+/// is documented to be ABI-compatible with `iovec`. Motor uses the generic
+/// representation, whose layout is deliberately unspecified, so the list is
+/// rebuilt through the public `Deref` rather than reinterpreted. That costs one
+/// small allocation against a filesystem or IPC round trip, and needs no
+/// `unsafe` and no assumption about a type shared with every other target.
+pub(crate) fn io_slices<'a>(bufs: &'a [io::IoSlice<'_>]) -> Vec<&'a [u8]> {
+    bufs.iter().map(|buf| &**buf).collect()
+}
+
+/// The buffer list `moto_rt::fs::read_vectored` takes. See [`io_slices`].
+pub(crate) fn io_slices_mut<'a>(bufs: &'a mut [io::IoSliceMut<'_>]) -> Vec<&'a mut [u8]> {
+    bufs.iter_mut().map(|buf| &mut **buf).collect()
+}
+
+// Weak: when a program is linked with mlibc (e.g. via the Motor clang
+// driver, which always links mlibc's crt1.o), crt1.o's strong motor_start
+// must win. mlibc's entry initializes the VDSO vtable and the C runtime
+// (TCB, stdio, .init_array constructors) and then calls the C `main`
+// that rustc generates, so Rust std works identically in both flows.
 #[cfg(not(test))]
 #[unsafe(no_mangle)]
+#[linkage = "weak"]
 pub extern "C" fn motor_start() -> ! {
     // Initialize the runtime.
     moto_rt::start();

--- a/library/std/src/sys/pal/unix/sync/condvar.rs
+++ b/library/std/src/sys/pal/unix/sync/condvar.rs
@@ -150,23 +150,16 @@ impl Condvar {
     /// # Safety
     /// May only be called once per instance of `Self`.
     pub unsafe fn init(self: Pin<&mut Self>) {
-        use crate::mem::MaybeUninit;
-
-        struct AttrGuard<'a>(pub &'a mut MaybeUninit<libc::pthread_condattr_t>);
-        impl Drop for AttrGuard<'_> {
-            fn drop(&mut self) {
-                unsafe {
-                    let result = libc::pthread_condattr_destroy(self.0.as_mut_ptr());
-                    assert_eq!(result, 0);
-                }
-            }
-        }
+        use crate::mem::{DropGuard, MaybeUninit};
 
         unsafe {
             let mut attr = MaybeUninit::<libc::pthread_condattr_t>::uninit();
             let r = libc::pthread_condattr_init(attr.as_mut_ptr());
             assert_eq!(r, 0);
-            let attr = AttrGuard(&mut attr);
+            let mut attr = DropGuard::new(&mut attr, |attr| unsafe {
+                let result = libc::pthread_condattr_destroy(self.0.as_mut_ptr());
+                assert_eq!(result, 0);
+            });
             let r = libc::pthread_condattr_setclock(attr.0.as_mut_ptr(), Self::CLOCK);
             assert_eq!(r, 0);
             let r = libc::pthread_cond_init(self.raw(), attr.0.as_ptr());

--- a/library/std/src/sys/paths/mod.rs
+++ b/library/std/src/sys/paths/mod.rs
@@ -15,9 +15,9 @@ cfg_select! {
         #[expect(dead_code)]
         mod unsupported;
         mod imp {
-            pub use super::motor::{chdir, current_exe, getcwd, temp_dir};
-            pub use super::unsupported::{
-                JoinPathsError, SplitPaths, home_dir, join_paths, split_paths,
+            pub use super::motor::{
+                JoinPathsError, SplitPaths, chdir, current_exe, getcwd, home_dir, join_paths,
+                split_paths, temp_dir,
             };
         }
     }

--- a/library/std/src/sys/paths/motor.rs
+++ b/library/std/src/sys/paths/motor.rs
@@ -1,7 +1,49 @@
-use crate::io;
+use crate::ffi::{OsStr, OsString};
 use crate::os::motor::ffi::OsStrExt;
 use crate::path::{self, PathBuf};
 use crate::sys::pal::map_motor_error;
+use crate::{fmt, io, iter, str};
+
+const PATH_SEPARATOR: char = ':';
+
+pub type SplitPaths<'a> = iter::Map<str::Split<'a, char>, fn(&str) -> PathBuf>;
+
+pub fn split_paths(unparsed: &OsStr) -> SplitPaths<'_> {
+    fn into_pathbuf(part: &str) -> PathBuf {
+        PathBuf::from(part)
+    }
+    unparsed.as_str().split(PATH_SEPARATOR).map(into_pathbuf as fn(&str) -> PathBuf)
+}
+
+#[derive(Debug)]
+pub struct JoinPathsError;
+
+pub fn join_paths<I, T>(paths: I) -> Result<OsString, JoinPathsError>
+where
+    I: Iterator<Item = T>,
+    T: AsRef<OsStr>,
+{
+    let mut joined = String::new();
+    for (i, path) in paths.enumerate() {
+        let path = path.as_ref().as_str();
+        if i > 0 {
+            joined.push(PATH_SEPARATOR);
+        }
+        if path.contains(PATH_SEPARATOR) {
+            return Err(JoinPathsError);
+        }
+        joined.push_str(path);
+    }
+    Ok(OsString::from(joined))
+}
+
+impl fmt::Display for JoinPathsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "path segment contains separator `{PATH_SEPARATOR}`")
+    }
+}
+
+impl crate::error::Error for JoinPathsError {}
 
 pub fn getcwd() -> io::Result<PathBuf> {
     moto_rt::fs::getcwd().map(PathBuf::from).map_err(map_motor_error)
@@ -11,10 +53,14 @@ pub fn chdir(path: &path::Path) -> io::Result<()> {
     moto_rt::fs::chdir(path.as_os_str().as_str()).map_err(map_motor_error)
 }
 
+pub fn home_dir() -> Option<PathBuf> {
+    Some(PathBuf::from("/user"))
+}
+
 pub fn current_exe() -> io::Result<PathBuf> {
     moto_rt::process::current_exe().map(PathBuf::from).map_err(map_motor_error)
 }
 
 pub fn temp_dir() -> PathBuf {
-    PathBuf::from(moto_rt::fs::TEMP_DIR)
+    crate::env::var_os("TMPDIR").map(PathBuf::from).unwrap_or_else(|| PathBuf::from("/user/tmp"))
 }

--- a/library/std/src/sys/process/mod.rs
+++ b/library/std/src/sys/process/mod.rs
@@ -49,8 +49,7 @@ pub use imp::{
             target_os = "l4re"
         ))
     ),
-    target_os = "windows",
-    target_os = "motor"
+    target_os = "windows"
 ))]
 pub fn output(cmd: &mut Command) -> crate::io::Result<(ExitStatus, Vec<u8>, Vec<u8>)> {
     let (mut process, mut pipes) = cmd.spawn(Stdio::MakePipe, false)?;
@@ -88,7 +87,6 @@ pub fn output(cmd: &mut Command) -> crate::io::Result<(ExitStatus, Vec<u8>, Vec<
             target_os = "l4re"
         ))
     ),
-    target_os = "windows",
-    target_os = "motor"
+    target_os = "windows"
 )))]
 pub use imp::output;

--- a/library/std/src/sys/process/motor.rs
+++ b/library/std/src/sys/process/motor.rs
@@ -3,39 +3,36 @@ use super::env::{CommandEnv, CommandResolvedEnvs};
 use crate::ffi::OsStr;
 pub use crate::ffi::OsString as EnvKey;
 use crate::num::NonZeroI32;
-use crate::os::fd::{FromRawFd, IntoRawFd};
+use crate::os::fd::{AsRawFd, FromRawFd};
 use crate::os::motor::ffi::OsStrExt;
 use crate::path::Path;
 use crate::process::StdioPipes;
 use crate::sys::fs::File;
-use crate::sys::{AsInner, FromInner, map_motor_error};
+use crate::sys::{IntoInner, map_motor_error};
 use crate::{fmt, io};
 
 pub enum Stdio {
     Inherit,
     Null,
     MakePipe,
+    // There is no public `From<io::Stdin>` conversion yet.
+    #[expect(dead_code)]
+    ParentStdin,
+    ParentStdout,
+    ParentStderr,
     Fd(crate::sys::fd::FileDesc),
 }
 
 impl Stdio {
-    fn into_rt(self) -> moto_rt::RtFd {
+    fn into_rt(&self) -> moto_rt::RtFd {
         match self {
             Stdio::Inherit => moto_rt::process::STDIO_INHERIT,
             Stdio::Null => moto_rt::process::STDIO_NULL,
             Stdio::MakePipe => moto_rt::process::STDIO_MAKE_PIPE,
-            Stdio::Fd(fd) => fd.into_raw_fd(),
-        }
-    }
-
-    fn try_clone(&self) -> io::Result<Self> {
-        match self {
-            Self::Fd(fd) => {
-                Ok(Self::Fd(crate::sys::fd::FileDesc::from_inner(fd.as_inner().try_clone()?)))
-            }
-            Self::Inherit => Ok(Self::Inherit),
-            Self::Null => Ok(Self::Null),
-            Self::MakePipe => Ok(Self::MakePipe),
+            Stdio::ParentStdin => moto_rt::process::STDIO_PARENT_STDIN,
+            Stdio::ParentStdout => moto_rt::process::STDIO_PARENT_STDOUT,
+            Stdio::ParentStderr => moto_rt::process::STDIO_PARENT_STDERR,
+            Stdio::Fd(fd) => fd.as_raw_fd(),
         }
     }
 }
@@ -53,10 +50,7 @@ pub struct Command {
 
 impl Command {
     pub fn new(program: &OsStr) -> Command {
-        let mut env = CommandEnv::default();
-        env.remove(OsStr::new(moto_rt::process::STDIO_IS_TERMINAL_ENV_KEY));
-
-        Command { program: program.as_str().to_owned(), env, ..Default::default() }
+        Command { program: program.as_str().to_owned(), ..Default::default() }
     }
 
     pub fn arg(&mut self, arg: &OsStr) {
@@ -114,21 +108,21 @@ impl Command {
         needs_stdin: bool,
     ) -> io::Result<(Process, StdioPipes)> {
         let stdin = if let Some(stdin) = self.stdin.as_ref() {
-            stdin.try_clone()?.into_rt()
+            stdin.into_rt()
         } else if needs_stdin {
-            default.try_clone()?.into_rt()
+            default.into_rt()
         } else {
             Stdio::Null.into_rt()
         };
         let stdout = if let Some(stdout) = self.stdout.as_ref() {
-            stdout.try_clone()?.into_rt()
+            stdout.into_rt()
         } else {
-            default.try_clone()?.into_rt()
+            default.into_rt()
         };
-        let stderr = if let Some(stderr) = self.stdout.as_ref() {
-            stderr.try_clone()?.into_rt()
+        let stderr = if let Some(stderr) = self.stderr.as_ref() {
+            stderr.into_rt()
         } else {
-            default.try_clone()?.into_rt()
+            default.into_rt()
         };
 
         let mut env = Vec::<(String, String)>::new();
@@ -146,11 +140,11 @@ impl Command {
             stderr,
         };
 
-        let (handle, stdin, stdout, stderr) =
-            moto_rt::process::spawn(args).map_err(map_motor_error)?;
+        let res = moto_rt::process::spawn(args).map_err(map_motor_error)?;
+        let (handle, stdin, stdout, stderr) = (res.handle, res.stdin, res.stdout, res.stderr);
 
         Ok((
-            Process { handle },
+            Process { handle, pid: res.pid as u32 },
             StdioPipes {
                 stdin: if stdin >= 0 {
                     Some(unsafe { ChildPipe::from_raw_fd(stdin) })
@@ -172,6 +166,29 @@ impl Command {
     }
 }
 
+pub fn output(cmd: &mut Command) -> io::Result<(ExitStatus, Vec<u8>, Vec<u8>)> {
+    let (mut process, mut pipes) = cmd.spawn(Stdio::MakePipe, false)?;
+
+    drop(pipes.stdin.take());
+    let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
+    crate::thread::scope(|scope| {
+        let waiter = scope.spawn(move || {
+            let status = process.wait();
+            drop(process);
+            status
+        });
+        let read_result = match (pipes.stdout.take(), pipes.stderr.take()) {
+            (None, None) => Ok(()),
+            (Some(out), None) => out.read_to_end(&mut stdout).map(|_| ()),
+            (None, Some(err)) => err.read_to_end(&mut stderr).map(|_| ()),
+            (Some(out), Some(err)) => read_output(out, &mut stdout, err, &mut stderr),
+        };
+        let status = waiter.join().expect("child wait thread panicked");
+        read_result?;
+        Ok((status?, stdout, stderr))
+    })
+}
+
 impl From<crate::sys::fd::FileDesc> for Stdio {
     fn from(fd: crate::sys::fd::FileDesc) -> Stdio {
         Stdio::Fd(fd)
@@ -179,20 +196,20 @@ impl From<crate::sys::fd::FileDesc> for Stdio {
 }
 
 impl From<File> for Stdio {
-    fn from(_file: File) -> Stdio {
-        panic!("Not implemented")
+    fn from(file: File) -> Stdio {
+        Stdio::Fd(file.into_inner())
     }
 }
 
 impl From<io::Stdout> for Stdio {
     fn from(_: io::Stdout) -> Stdio {
-        panic!("Not implemented")
+        Stdio::ParentStdout
     }
 }
 
 impl From<io::Stderr> for Stdio {
     fn from(_: io::Stderr) -> Stdio {
-        panic!("Not implemented")
+        Stdio::ParentStderr
     }
 }
 
@@ -255,6 +272,7 @@ impl From<u8> for ExitCode {
 
 pub struct Process {
     handle: u64,
+    pid: u32,
 }
 
 impl Drop for Process {
@@ -265,7 +283,9 @@ impl Drop for Process {
 
 impl Process {
     pub fn id(&self) -> u32 {
-        0
+        // The kernel bounds pids to the i32-positive range, so the pid the
+        // runtime reported at spawn is exact (pid-refactoring-design.md).
+        self.pid
     }
 
     pub fn kill(&mut self) -> io::Result<()> {
@@ -324,14 +344,25 @@ impl<'a> fmt::Debug for CommandArgs<'a> {
 pub type ChildPipe = crate::sys::pipe::Pipe;
 
 pub fn read_output(
-    _out: ChildPipe,
-    _stdout: &mut Vec<u8>,
-    _err: ChildPipe,
-    _stderr: &mut Vec<u8>,
+    out: ChildPipe,
+    stdout: &mut Vec<u8>,
+    err: ChildPipe,
+    stderr: &mut Vec<u8>,
 ) -> io::Result<()> {
-    Err(io::Error::from_raw_os_error(moto_rt::E_NOT_IMPLEMENTED.into()))
+    // Drain both pipes concurrently so the child can't deadlock filling one
+    // pipe while we block reading the other.
+    crate::thread::scope(|s| {
+        let err_reader = s.spawn(move || err.read_to_end(stderr));
+        let out_res = out.read_to_end(stdout);
+        let err_res = err_reader.join().expect("stderr reader thread panicked");
+        out_res?;
+        err_res?;
+        Ok(())
+    })
 }
 
 pub fn getpid() -> u32 {
-    panic!("Pids on Motor OS are u64.")
+    // Motor OS pids are u64 in the ABI, but the kernel bounds them to i32
+    // to be compatible with the wider ecosystem.
+    moto_rt::process::current_pid().try_into().expect("current_pid() too large")
 }

--- a/library/std/src/sys/process/unix/unix.rs
+++ b/library/std/src/sys/process/unix/unix.rs
@@ -394,19 +394,13 @@ impl Command {
         // want to be sure to restore the global environment back to what it
         // once was, ensuring that our temporary override, when free'd, doesn't
         // corrupt our process's environment.
-        let mut _reset = None;
+        let _reset;
         if let Some(envp) = maybe_envp {
-            struct Reset(*const *const libc::c_char);
+            use core::mem::DropGuard;
 
-            impl Drop for Reset {
-                fn drop(&mut self) {
-                    unsafe {
-                        *sys::env::environ() = self.0;
-                    }
-                }
-            }
-
-            _reset = Some(Reset(*sys::env::environ()));
+            _reset = DropGuard::new(*sys::env::environ(), |prev| unsafe {
+                *sys::env::environ() = prev;
+            });
             *sys::env::environ() = envp.as_ptr();
         }
 
@@ -677,65 +671,51 @@ impl Command {
 
         let pgroup = self.get_pgroup();
 
-        struct PosixSpawnFileActions<'a>(&'a mut MaybeUninit<libc::posix_spawn_file_actions_t>);
-
-        impl Drop for PosixSpawnFileActions<'_> {
-            fn drop(&mut self) {
-                unsafe {
-                    libc::posix_spawn_file_actions_destroy(self.0.as_mut_ptr());
-                }
-            }
-        }
-
-        struct PosixSpawnattr<'a>(&'a mut MaybeUninit<libc::posix_spawnattr_t>);
-
-        impl Drop for PosixSpawnattr<'_> {
-            fn drop(&mut self) {
-                unsafe {
-                    libc::posix_spawnattr_destroy(self.0.as_mut_ptr());
-                }
-            }
-        }
-
         unsafe {
+            use core::mem::DropGuard;
+
             let mut attrs = MaybeUninit::uninit();
             cvt_nz(libc::posix_spawnattr_init(attrs.as_mut_ptr()))?;
-            let attrs = PosixSpawnattr(&mut attrs);
+            let mut attrs = DropGuard::new(&mut attrs, |attrs| {
+                libc::posix_spawnattr_destroy(attrs.as_mut_ptr());
+            });
 
             let mut flags = 0;
 
             let mut file_actions = MaybeUninit::uninit();
             cvt_nz(libc::posix_spawn_file_actions_init(file_actions.as_mut_ptr()))?;
-            let file_actions = PosixSpawnFileActions(&mut file_actions);
+            let mut file_actions = DropGuard::new(&mut file_actions, |file_actions| {
+                libc::posix_spawn_file_actions_destroy(file_actions.as_mut_ptr());
+            });
 
             if let Some(fd) = stdio.stdin.fd() {
                 cvt_nz(libc::posix_spawn_file_actions_adddup2(
-                    file_actions.0.as_mut_ptr(),
+                    file_actions.as_mut_ptr(),
                     fd,
                     libc::STDIN_FILENO,
                 ))?;
             }
             if let Some(fd) = stdio.stdout.fd() {
                 cvt_nz(libc::posix_spawn_file_actions_adddup2(
-                    file_actions.0.as_mut_ptr(),
+                    file_actions.as_mut_ptr(),
                     fd,
                     libc::STDOUT_FILENO,
                 ))?;
             }
             if let Some(fd) = stdio.stderr.fd() {
                 cvt_nz(libc::posix_spawn_file_actions_adddup2(
-                    file_actions.0.as_mut_ptr(),
+                    file_actions.as_mut_ptr(),
                     fd,
                     libc::STDERR_FILENO,
                 ))?;
             }
             if let Some((f, cwd)) = addchdir {
-                cvt_nz(f(file_actions.0.as_mut_ptr(), cwd.as_ptr()))?;
+                cvt_nz(f(file_actions.as_mut_ptr(), cwd.as_ptr()))?;
             }
 
             if let Some(pgroup) = pgroup {
                 flags |= libc::POSIX_SPAWN_SETPGROUP;
-                cvt_nz(libc::posix_spawnattr_setpgroup(attrs.0.as_mut_ptr(), pgroup))?;
+                cvt_nz(libc::posix_spawnattr_setpgroup(attrs.as_mut_ptr(), pgroup))?;
             }
 
             // Inherit the signal mask from this process rather than resetting it (i.e. do not call
@@ -754,7 +734,7 @@ impl Command {
                     cvt(sigaddset(default_set.as_mut_ptr(), libc::SIGLOST))?;
                 }
                 cvt_nz(libc::posix_spawnattr_setsigdefault(
-                    attrs.0.as_mut_ptr(),
+                    attrs.as_mut_ptr(),
                     default_set.as_ptr(),
                 ))?;
                 flags |= libc::POSIX_SPAWN_SETSIGDEF;
@@ -771,7 +751,7 @@ impl Command {
                 }
             }
 
-            cvt_nz(libc::posix_spawnattr_setflags(attrs.0.as_mut_ptr(), flags as _))?;
+            cvt_nz(libc::posix_spawnattr_setflags(attrs.as_mut_ptr(), flags as _))?;
 
             // Make sure we synchronize access to the global `environ` resource
             let _env_lock = sys::env::env_read_lock();
@@ -788,8 +768,8 @@ impl Command {
                 let spawn_res = pidfd_spawnp.get().unwrap()(
                     &mut pidfd,
                     self.get_program_cstr().as_ptr(),
-                    file_actions.0.as_ptr(),
-                    attrs.0.as_ptr(),
+                    file_actions.as_ptr(),
+                    attrs.as_ptr(),
                     self.get_argv().as_ptr() as *const _,
                     envp as *const _,
                 );
@@ -830,8 +810,8 @@ impl Command {
             let spawn_res = spawn_fn(
                 &mut p.pid,
                 self.get_program_cstr().as_ptr(),
-                file_actions.0.as_ptr(),
-                attrs.0.as_ptr(),
+                file_actions.as_ptr(),
+                attrs.as_ptr(),
                 self.get_argv().as_ptr() as *const _,
                 envp as *const _,
             );

--- a/library/std/src/sys/process/windows/tests.rs
+++ b/library/std/src/sys/process/windows/tests.rs
@@ -1,6 +1,7 @@
 use super::child_pipe::{Pipes, child_pipe};
 use super::{Arg, make_command_line};
 use crate::ffi::{OsStr, OsString};
+use crate::mem::DropGuard;
 use crate::os::windows::io::AsHandle;
 use crate::process::{Command, Stdio};
 use crate::time::Duration;
@@ -36,14 +37,7 @@ fn test_thread_handle() {
     assert!(p.is_ok());
 
     // Ensure the process is killed in the event something goes wrong.
-    struct DropGuard(crate::process::Child);
-    impl Drop for DropGuard {
-        fn drop(&mut self) {
-            let _ = self.0.kill();
-        }
-    }
-    let mut p = DropGuard(p.unwrap());
-    let p = &mut p.0;
+    let mut p = DropGuard::new(p.unwrap(), |p| p.kill());
 
     unsafe extern "system" {
         unsafe fn ResumeThread(hHandle: BorrowedHandle<'_>) -> u32;

--- a/library/std/src/sys/stdio/motor.rs
+++ b/library/std/src/sys/stdio/motor.rs
@@ -1,5 +1,5 @@
 use crate::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
-use crate::sys::{AsInner, FromInner, IntoInner, map_motor_error};
+use crate::sys::{AsInner, FromInner, IntoInner, io_slices, io_slices_mut, map_motor_error};
 use crate::{io, process, sys};
 
 pub const STDIN_BUF_SIZE: usize = crate::sys::io::DEFAULT_BUF_SIZE;
@@ -38,6 +38,15 @@ impl io::Read for Stdin {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         moto_rt::fs::read(moto_rt::FD_STDIN, buf).map_err(map_motor_error)
     }
+
+    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+        moto_rt::fs::read_vectored(moto_rt::FD_STDIN, &mut io_slices_mut(bufs))
+            .map_err(map_motor_error)
+    }
+
+    fn is_read_vectored(&self) -> bool {
+        true
+    }
 }
 
 impl io::Write for Stdout {
@@ -48,6 +57,14 @@ impl io::Write for Stdout {
     fn flush(&mut self) -> io::Result<()> {
         moto_rt::fs::flush(moto_rt::FD_STDOUT).map_err(map_motor_error)
     }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        moto_rt::fs::write_vectored(moto_rt::FD_STDOUT, &io_slices(bufs)).map_err(map_motor_error)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
 }
 
 impl io::Write for Stderr {
@@ -57,6 +74,14 @@ impl io::Write for Stderr {
 
     fn flush(&mut self) -> io::Result<()> {
         moto_rt::fs::flush(moto_rt::FD_STDERR).map_err(map_motor_error)
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        moto_rt::fs::write_vectored(moto_rt::FD_STDERR, &io_slices(bufs)).map_err(map_motor_error)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
     }
 }
 

--- a/src/tools/miri/priroda/src/debugger.rs
+++ b/src/tools/miri/priroda/src/debugger.rs
@@ -890,13 +890,14 @@ impl<'tcx> PrirodaContext<'tcx> {
             value: "<unsupported>".to_string(),
         };
 
-        match &frame.locals()[local].as_mplace_or_imm_for_validation() {
+        match &frame.locals()[local].as_mplace_or_imm_ghost() {
             None => {
                 local_desc.value = "<dead>".to_string();
             }
             Some(Either::Right(Uninit)) => local_desc.value = "<uninit>".to_string(),
 
             Some(Either::Left(_) | Either::Right(_)) => {
+                // FIXME: This seems wrong, it ignore the frame.
                 let op = self
                     .ecx
                     .local_to_op(local, None)

--- a/src/tools/miri/priroda/src/debugger.rs
+++ b/src/tools/miri/priroda/src/debugger.rs
@@ -890,7 +890,7 @@ impl<'tcx> PrirodaContext<'tcx> {
             value: "<unsupported>".to_string(),
         };
 
-        match &frame.locals[local].as_mplace_or_imm() {
+        match &frame.locals()[local].as_mplace_or_imm_for_validation() {
             None => {
                 local_desc.value = "<dead>".to_string();
             }

--- a/src/tools/miri/src/concurrency/data_race.rs
+++ b/src/tools/miri/src/concurrency/data_race.rs
@@ -779,7 +779,7 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
         // Only metadata on the location itself is used.
 
         if let Some(genmc_ctx) = this.machine.data_race.as_genmc_ref() {
-            let old_val = this.run_for_validation_ref(|this| this.read_scalar(place)).discard_err();
+            let old_val = this.ghost_run(|this| this.read_scalar(place)).discard_err();
             return genmc_ctx.atomic_load(
                 this,
                 place.ptr().addr(),
@@ -811,7 +811,7 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
         // Read the previous value so we can put it in the store buffer later.
         // Both GenMC and Miri need this. This value is nonsense if there are concurrent writes
         // but the code consuming the value is aware of that.
-        let old_val = this.run_for_validation_ref(|this| this.read_scalar(dest)).discard_err();
+        let old_val = this.ghost_run(|this| this.read_scalar(dest)).discard_err();
 
         // Inform GenMC about the atomic store.
         if let Some(genmc_ctx) = this.machine.data_race.as_genmc_ref() {

--- a/src/tools/miri/src/concurrency/thread.rs
+++ b/src/tools/miri/src/concurrency/thread.rs
@@ -345,8 +345,8 @@ impl VisitProvenance for Thread<'_> {
 impl VisitProvenance for Frame<'_, Provenance, FrameExtra<'_>> {
     fn visit_provenance(&self, visit: &mut VisitWith<'_>) {
         let return_place = self.return_place();
+        let locals = self.locals();
         let Frame {
-            locals,
             extra,
             // There are some private fields we cannot access; they contain no tags.
             ..
@@ -356,7 +356,8 @@ impl VisitProvenance for Frame<'_, Provenance, FrameExtra<'_>> {
         return_place.visit_provenance(visit);
         // Locals.
         for local in locals.iter() {
-            match local.as_mplace_or_imm() {
+            // We only need the provenance so it's good for this to not be a real read.
+            match local.as_mplace_or_imm_for_validation() {
                 None => {}
                 Some(Either::Left((ptr, meta))) => {
                     ptr.visit_provenance(visit);

--- a/src/tools/miri/src/concurrency/thread.rs
+++ b/src/tools/miri/src/concurrency/thread.rs
@@ -357,7 +357,7 @@ impl VisitProvenance for Frame<'_, Provenance, FrameExtra<'_>> {
         // Locals.
         for local in locals.iter() {
             // We only need the provenance so it's good for this to not be a real read.
-            match local.as_mplace_or_imm_for_validation() {
+            match local.as_mplace_or_imm_ghost() {
                 None => {}
                 Some(Either::Left((ptr, meta))) => {
                     ptr.visit_provenance(visit);

--- a/src/tools/miri/src/diagnostics.rs
+++ b/src/tools/miri/src/diagnostics.rs
@@ -500,7 +500,7 @@ pub fn report_result<'tcx>(
         trace!("-------------------");
         trace!("Frame {}", i);
         trace!("    return: {:?}", frame.return_place());
-        for (i, local) in frame.locals.iter().enumerate() {
+        for (i, local) in frame.locals().iter().enumerate() {
             trace!("    local {}: {:?}", i, local);
         }
     }

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -2000,12 +2000,8 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
         res
     }
 
-    fn after_local_read(
-        ecx: &InterpCx<'tcx, Self>,
-        frame: &Frame<'tcx, Provenance, FrameExtra<'tcx>>,
-        local: mir::Local,
-    ) -> InterpResult<'tcx> {
-        if let Some(data_race) = &frame.extra.data_race {
+    fn after_local_read(ecx: &InterpCx<'tcx, Self>, local: mir::Local) -> InterpResult<'tcx> {
+        if let Some(data_race) = &ecx.frame().extra.data_race {
             let _trace = enter_trace_span!(data_race::after_local_read);
             data_race.local_read(local, &ecx.machine);
         }

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -2361,7 +2361,14 @@ impl Rewrite for ast::Param {
 
             Ok(result)
         } else {
-            self.ty.rewrite_result(context, shape)
+            combine_strs_with_missing_comments(
+                context,
+                &param_attrs_result,
+                &self.ty.rewrite_result(context, shape)?,
+                span,
+                shape,
+                !has_multiple_attr_lines && !has_doc_comments,
+            )
         }
     }
 }

--- a/src/tools/rustfmt/tests/source/issue-6561/trait-fn.rs
+++ b/src/tools/rustfmt/tests/source/issue-6561/trait-fn.rs
@@ -1,0 +1,6 @@
+// rustfmt-edition: 2015
+
+trait A {
+    fn f1(#[allow()] u32);
+    fn f2(#[allow()] u32, #[allow()] u32);
+}

--- a/src/tools/rustfmt/tests/source/issue-6561/variadic.rs
+++ b/src/tools/rustfmt/tests/source/issue-6561/variadic.rs
@@ -1,0 +1,5 @@
+#[allow()]
+unsafe extern "C" {
+    #[allow()]
+    pub fn foo(#[allow()] arg: *mut u8, #[allow()]...);
+}

--- a/src/tools/rustfmt/tests/source/issue-6607/fn-type.rs
+++ b/src/tools/rustfmt/tests/source/issue-6607/fn-type.rs
@@ -1,0 +1,3 @@
+struct Foo {
+    v: fn(#[cfg(false)] i32),
+}

--- a/src/tools/rustfmt/tests/target/issue-6561/trait-fn.rs
+++ b/src/tools/rustfmt/tests/target/issue-6561/trait-fn.rs
@@ -1,0 +1,6 @@
+// rustfmt-edition: 2015
+
+trait A {
+    fn f1(#[allow()] u32);
+    fn f2(#[allow()] u32, #[allow()] u32);
+}

--- a/src/tools/rustfmt/tests/target/issue-6561/variadic.rs
+++ b/src/tools/rustfmt/tests/target/issue-6561/variadic.rs
@@ -1,0 +1,5 @@
+#[allow()]
+unsafe extern "C" {
+    #[allow()]
+    pub fn foo(#[allow()] arg: *mut u8, #[allow()] ...);
+}

--- a/src/tools/rustfmt/tests/target/issue-6607/fn-type.rs
+++ b/src/tools/rustfmt/tests/target/issue-6607/fn-type.rs
@@ -1,0 +1,3 @@
+struct Foo {
+    v: fn(#[cfg(false)] i32),
+}

--- a/tests/crashes/108248.rs
+++ b/tests/crashes/108248.rs
@@ -1,4 +1,4 @@
-//@ known-bug: #108428
+//@ known-bug: #108248
 //@ needs-rustc-debug-assertions
 //@ compile-flags: -Wunused-lifetimes
 fn main() {

--- a/tests/crashes/138262.rs
+++ b/tests/crashes/138262.rs
@@ -1,0 +1,12 @@
+//@ known-bug: #138262
+//@ compile-flags: -Zsanitizer=cfi -Ccodegen-units=1 -Clto -Clink-dead-code=true -Cunsafe-allow-abi-mismatch=sanitizer -Ctarget-feature=-crt-static
+//@ ignore-backends: gcc
+//@ needs-sanitizer-cfi
+fn foo<const N: usize>() {}
+
+core::arch::global_asm!("/* {} */", sym foo::<{
+    || {};
+    0
+}>);
+
+fn main() {}

--- a/tests/crashes/142155.rs
+++ b/tests/crashes/142155.rs
@@ -1,0 +1,12 @@
+//@ known-bug: #142155
+//@ needs-rustc-debug-assertions
+//@ edition: 2021
+
+#![warn(tail_expr_drop_order)]
+use core::future::Future;
+
+fn f() -> impl Future<Output = Option<String>> {
+    async { Some("nope".into()) }
+}
+
+fn main() {}

--- a/tests/crashes/144241.rs
+++ b/tests/crashes/144241.rs
@@ -1,0 +1,4 @@
+//@ known-bug: #144241
+fn main() {
+    |_: dyn ?Sized + !Send| {}
+}

--- a/tests/crashes/149562.rs
+++ b/tests/crashes/149562.rs
@@ -1,0 +1,10 @@
+//@ known-bug: #149562
+//@ needs-rustc-debug-assertions
+fn a<T>() -> T
+where
+    T: ?Sized,
+    T: ?Sized,
+{
+}
+
+fn main() {}

--- a/tests/crashes/152414.rs
+++ b/tests/crashes/152414.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #152414
+//@ needs-rustc-debug-assertions
+#![feature(generic_assert)]
+fn main() {
+    assert!(size_of(val, 1) >= 1);
+}

--- a/tests/crashes/152416.rs
+++ b/tests/crashes/152416.rs
@@ -1,0 +1,17 @@
+//@ known-bug: #152416
+//@ needs-rustc-debug-assertions
+//@ compile-flags: -Zunstable-options
+
+trait AssetID {}
+trait Archive<X> {
+    fn name(&self);
+}
+struct NorthlightAssetID;
+impl AssetID for NorthlightAssetID {}
+fn get() -> Box<dyn Archive<impl AssetID>> {
+    let x: Box<dyn Archive<NorthlightAssetID>> = todo!();
+    x
+}
+fn main() {
+    get().name();
+}

--- a/tests/crashes/152626.rs
+++ b/tests/crashes/152626.rs
@@ -1,0 +1,7 @@
+//@ known-bug: #152626
+//@ needs-rustc-debug-assertions
+struct A<T: Into<u32>>(T);
+fn f() -> A<&'static ()> {
+    todo!()
+}
+fn main() {}

--- a/tests/crashes/154903.rs
+++ b/tests/crashes/154903.rs
@@ -1,0 +1,7 @@
+//@ known-bug: #154903
+//@ compile-flags: -Zlint-mir
+#![feature(guard_patterns)]
+
+fn a(((x if true, _) | (_, x)): (i32, i32)) {}
+
+fn main() {}

--- a/tests/crashes/154963.rs
+++ b/tests/crashes/154963.rs
@@ -1,0 +1,10 @@
+//@ known-bug: #154963
+#![feature(extern_types, negative_impls)]
+
+unsafe extern "C" {
+    type ExternType;
+}
+
+impl !Unpin for ExternType {}
+
+fn main() {}

--- a/tests/crashes/155053.rs
+++ b/tests/crashes/155053.rs
@@ -1,0 +1,11 @@
+//@ known-bug: #155053
+#![feature(pin_ergonomics)]
+#![feature(extern_types)]
+
+unsafe extern "C" {
+    type ExternType;
+}
+
+impl Unpin for ExternType {}
+
+fn main() {}

--- a/tests/crashes/156101.rs
+++ b/tests/crashes/156101.rs
@@ -1,0 +1,4 @@
+//@ known-bug: #156101
+fn main() {
+    format_args!(concat!("𐏿", "{f:?#}"));
+}

--- a/tests/crashes/156288.rs
+++ b/tests/crashes/156288.rs
@@ -1,0 +1,3 @@
+//@ known-bug: #156288
+#[warn(rust_2021_incompatible_closure_captures)]
+const _: () = |b| move || b;

--- a/tests/ui/float/classify-runtime-const.rs
+++ b/tests/ui/float/classify-runtime-const.rs
@@ -10,46 +10,40 @@
 
 // This tests the float classification functions, for regular runtime code and for const evaluation.
 
-
-use std::num::FpCategory::*;
-
 #[cfg(not(ctfe))]
 use std::hint::black_box;
+use std::num::FpCategory::*;
 #[cfg(ctfe)]
 #[allow(unused)]
-const fn black_box<T>(x: T) -> T { x }
+const fn black_box<T>(x: T) -> T {
+    x
+}
 
 #[cfg(not(ctfe))]
 macro_rules! assert_test {
-    ($a:expr, NonDet) => {
-        {
-            // Compute `a`, but do not compare with anything as the result is non-deterministic.
-            let _val = $a;
-        }
-    };
-    ($a:expr, $b:ident) => {
-        {
-            // Let-bind to avoid promotion.
-            // No black_box here! That can mask x87 failures.
-            let a = $a;
-            let b = $b;
-            assert_eq!(a, b, "{} produces wrong result", stringify!($a));
-        }
-    };
+    ($a:expr, NonDet) => {{
+        // Compute `a`, but do not compare with anything as the result is non-deterministic.
+        let _val = $a;
+    }};
+    ($a:expr, $b:ident) => {{
+        // Let-bind to avoid promotion.
+        // No black_box here! That can mask x87 failures.
+        let a = $a;
+        let b = $b;
+        assert_eq!(a, b, "{} produces wrong result", stringify!($a));
+    }};
 }
 #[cfg(ctfe)]
 macro_rules! assert_test {
-    ($a:expr, NonDet) => {
-        {
-            // Compute `a`, but do not compare with anything as the result is non-deterministic.
-            const _: () = { let _val = $a; };
-        }
-    };
-    ($a:expr, $b:ident) => {
-        {
-            const _: () = assert!(matches!($a, $b));
-        }
-    };
+    ($a:expr, NonDet) => {{
+        // Compute `a`, but do not compare with anything as the result is non-deterministic.
+        const _: () = {
+            let _val = $a;
+        };
+    }};
+    ($a:expr, $b:ident) => {{
+        const _: () = assert!(matches!($a, $b));
+    }};
 }
 
 macro_rules! suite {

--- a/tests/ui/float/classify-runtime-const.rs
+++ b/tests/ui/float/classify-runtime-const.rs
@@ -10,14 +10,8 @@
 
 // This tests the float classification functions, for regular runtime code and for const evaluation.
 
-#[cfg(not(ctfe))]
 use std::hint::black_box;
 use std::num::FpCategory::*;
-#[cfg(ctfe)]
-#[allow(unused)]
-const fn black_box<T>(x: T) -> T {
-    x
-}
 
 #[cfg(not(ctfe))]
 macro_rules! assert_test {

--- a/tests/ui/float/classify-runtime-const.rs
+++ b/tests/ui/float/classify-runtime-const.rs
@@ -2,11 +2,12 @@
 //@ revisions: opt noopt ctfe
 //@[opt] compile-flags: -O
 //@[noopt] compile-flags: -Zmir-opt-level=0
-//@ min-llvm-version: 22
-//@ compile-flags: --check-cfg=cfg(target_has_reliable_f16)
+//@ min-llvm-version: 23
+//@ compile-flags: --check-cfg=cfg(target_has_reliable_f16,target_has_reliable_f128)
 // ignore-tidy-file-linelength
 #![feature(cfg_target_has_reliable_f16_f128)]
 #![cfg_attr(target_has_reliable_f16, feature(f16))]
+#![cfg_attr(target_has_reliable_f128, feature(f128))]
 
 // This tests the float classification functions, for regular runtime code and for const evaluation.
 
@@ -59,6 +60,13 @@ macro_rules! suite {
             #[allow(unused)]
             type $tyname = f64;
             suite_inner!(f64 => $($tt)*);
+        }
+
+        #[cfg(target_has_reliable_f128)]
+        fn f128() {
+            #[allow(unused)]
+            type $tyname = f128;
+            suite_inner!(f128 => $($tt)*);
         }
     }
 }
@@ -124,5 +132,6 @@ fn main() {
     f16();
     f32();
     f64();
-    // FIXME(f128): also test f128
+    #[cfg(target_has_reliable_f128)]
+    f128();
 }


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#160533 (dirfd dir operations (3/4))
 - rust-lang/rust#161294 (add crashtests [6/N])
 - rust-lang/rust#160392 (library: motor: bump moto-rt ABI ver to 17)
 - rust-lang/rust#161646 (interpret: fix after_local_read handling)
 - rust-lang/rust#160819 (Rework `div_ceil` for nonzero integers)
 - rust-lang/rust#161591 (run `classify-runtime-const` test for `f128`)
 - rust-lang/rust#161680 (renovate: add lockfile update warning)
 - rust-lang/rust#161702 (Use `drop_guard` in some places in {core,alloc,std})
 - rust-lang/rust#161709 (Stop rustfmt deleting attributes in fn params)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=160533,161294,160392,161646,160819,161591,161680,161702,161709)
<!-- homu-ignore:end -->

