### PR TITLE
Fix the wasm32-unknown-unknown target feature/cfg bug

### DIFF
--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -44,8 +44,9 @@ pub struct Compiler {
 }
 
 /// Converts strings provided as `--cfg [cfgspec]` into a `Cfg`.
-pub(crate) fn parse_cfg(dcx: DiagCtxtHandle<'_>, cfgs: Vec<String>) -> Cfg {
-    cfgs.into_iter()
+pub(crate) fn parse_cfg(sess: &Session, cfgs: Vec<String>) -> Cfg {
+    let cfg = cfgs
+        .into_iter()
         .map(|s| {
             let psess = ParseSess::emitter_with_note(format!(
                 "this occurred on the command line: `--cfg={s}`"
@@ -54,7 +55,7 @@ pub(crate) fn parse_cfg(dcx: DiagCtxtHandle<'_>, cfgs: Vec<String>) -> Cfg {
 
             macro_rules! error {
                 ($reason: expr) => {
-                    dcx.fatal(format!("invalid `--cfg` argument: `{s}` ({})", $reason));
+                    sess.dcx().fatal(format!("invalid `--cfg` argument: `{s}` ({})", $reason));
                 };
             }
 
@@ -106,11 +107,13 @@ pub(crate) fn parse_cfg(dcx: DiagCtxtHandle<'_>, cfgs: Vec<String>) -> Cfg {
                 error!(r#"expected `key` or `key="value"`"#);
             }
         })
-        .collect::<Cfg>()
+        .collect::<Cfg>();
+
+    config::build_configuration(sess, cfg)
 }
 
 /// Converts strings provided as `--check-cfg [specs]` into a `CheckCfg`.
-pub(crate) fn parse_check_cfg(dcx: DiagCtxtHandle<'_>, specs: Vec<String>) -> CheckCfg {
+pub(crate) fn parse_check_cfg(sess: &Session, specs: Vec<String>) -> CheckCfg {
     // If any --check-cfg is passed then exhaustive_values and exhaustive_names
     // are enabled by default.
     let exhaustive_names = !specs.is_empty();
@@ -128,13 +131,15 @@ pub(crate) fn parse_check_cfg(dcx: DiagCtxtHandle<'_>, specs: Vec<String>) -> Ch
 
         macro_rules! error {
             ($reason:expr) => {{
-                let mut diag = dcx.struct_fatal(format!("invalid `--check-cfg` argument: `{s}`"));
+                let mut diag =
+                    sess.dcx().struct_fatal(format!("invalid `--check-cfg` argument: `{s}`"));
                 diag.note($reason);
                 diag.note(VISIT);
                 diag.emit()
             }};
             (in $arg:expr, $reason:expr) => {{
-                let mut diag = dcx.struct_fatal(format!("invalid `--check-cfg` argument: `{s}`"));
+                let mut diag =
+                    sess.dcx().struct_fatal(format!("invalid `--check-cfg` argument: `{s}`"));
 
                 let pparg = rustc_ast_pretty::pprust::meta_list_item_to_string($arg);
                 if let Some(lit) = $arg.lit() {
@@ -304,6 +309,8 @@ pub(crate) fn parse_check_cfg(dcx: DiagCtxtHandle<'_>, specs: Vec<String>) -> Ch
         }
     }
 
+    check_cfg.fill_well_known(&sess.target);
+
     check_cfg
 }
 
@@ -443,14 +450,11 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
             sess.fallback_intrinsics = FxHashSet::from_iter(codegen_backend.fallback_intrinsics());
             sess.thin_lto_supported = codegen_backend.thin_lto_supported();
 
-            let cfg = parse_cfg(sess.dcx(), config.crate_cfg);
-            let mut cfg = config::build_configuration(&sess, cfg);
+            let mut cfg = parse_cfg(&sess, config.crate_cfg);
             util::add_configuration(&mut cfg, &mut sess, &*codegen_backend);
             sess.config = cfg;
 
-            let mut check_cfg = parse_check_cfg(sess.dcx(), config.crate_check_cfg);
-            check_cfg.fill_well_known(&sess.target);
-            sess.check_config = check_cfg;
+            sess.check_config = parse_check_cfg(&sess, config.crate_check_cfg);
 
             if let Some(psess_created) = config.psess_created {
                 psess_created(&mut sess.psess);

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -452,6 +452,11 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
 
             let target_config = codegen_backend.target_config(&sess);
 
+            // Store all of the target features in the session.
+            // Needs to be done before `parse_cfg` because it checks this list.
+            sess.internal_target_features
+                .extend(target_config.internal_target_features.to_sorted_stable_ord());
+
             sess.config = parse_cfg(&sess, config.crate_cfg);
             let is_nightly_build = sess.is_nightly_build();
             let is_crt_static = sess.crt_static(None);
@@ -462,10 +467,6 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
                 is_nightly_build,
                 is_crt_static,
             );
-
-            // Store all of the target features in the session.
-            sess.internal_target_features
-                .extend(target_config.internal_target_features.into_sorted_stable_ord());
 
             sess.check_config = parse_check_cfg(&sess, config.crate_check_cfg);
 

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -450,9 +450,22 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
             sess.fallback_intrinsics = FxHashSet::from_iter(codegen_backend.fallback_intrinsics());
             sess.thin_lto_supported = codegen_backend.thin_lto_supported();
 
-            let mut cfg = parse_cfg(&sess, config.crate_cfg);
-            util::add_configuration(&mut cfg, &mut sess, &*codegen_backend);
-            sess.config = cfg;
+            let target_config = codegen_backend.target_config(&sess);
+
+            sess.config = parse_cfg(&sess, config.crate_cfg);
+            let is_nightly_build = sess.is_nightly_build();
+            let is_crt_static = sess.crt_static(None);
+            util::add_configuration(
+                &mut sess.config,
+                &target_config,
+                &sess.target,
+                is_nightly_build,
+                is_crt_static,
+            );
+
+            // Store all of the target features in the session.
+            sess.internal_target_features
+                .extend(target_config.internal_target_features.into_sorted_stable_ord());
 
             sess.check_config = parse_check_cfg(&sess, config.crate_check_cfg);
 

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -17,7 +17,7 @@ use rustc_session::config::{
     LinkerPluginLto, LocationDetail, LtoCli, MirIncludeSpans, NextSolverConfig, Offload, Options,
     OutFileName, OutputType, OutputTypes, PAuthKey, PacRet, Passes, PatchableFunctionEntry,
     Polonius, ProcMacroExecutionStrategy, Strip, SwitchWithOptPath, SymbolManglingVersion,
-    WasiExecModel, build_configuration, build_session_options, rustc_optgroups,
+    WasiExecModel, build_session_options, rustc_optgroups,
 };
 use rustc_session::search_paths::SearchPath;
 use rustc_session::utils::{CanonicalizedPath, NativeLib};
@@ -75,8 +75,7 @@ where
             None,
             &USING_INTERNAL_FEATURES,
         );
-        let cfg = parse_cfg(sess.dcx(), matches.opt_strs("cfg"));
-        let cfg = build_configuration(&sess, cfg);
+        let cfg = parse_cfg(&sess, matches.opt_strs("cfg"));
         f(sess, cfg)
     });
 }

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -42,52 +42,47 @@ type MakeBackendFn = fn() -> Box<dyn CodegenBackend>;
 /// specific features (SSE, NEON etc.).
 ///
 /// This is performed by checking whether a set of permitted features
-/// is available on the target machine, by querying the codegen backend.
+/// is available on the target machine, by querying the `TargetConfig` from the codegen backend.
 pub(crate) fn add_configuration(
     cfg: &mut Cfg,
-    sess: &mut Session,
-    codegen_backend: &dyn CodegenBackend,
+    target_config: &TargetConfig,
+    target: &Target,
+    is_nightly_build: bool,
+    is_crt_static: bool,
 ) {
-    let tf = sym::target_feature;
-    let tf_cfg = codegen_backend.target_config(sess);
-
     // Add some of the target features to `cfg`.
     cfg.extend(
-        sess.target
+        target
             .rust_target_features()
             .iter()
             .filter_map(|(feature, gate, _)| {
                 if gate.in_cfg()
-                    && (sess.is_nightly_build()
-                        || gate.requires_nightly(/* in_cfg */ true).is_none())
+                    && (is_nightly_build || gate.requires_nightly(/* in_cfg */ true).is_none())
                 {
                     Some(Symbol::intern(feature))
                 } else {
                     None
                 }
             })
-            .filter(|feature| tf_cfg.internal_target_features.contains(&feature))
+            .filter(|feature| target_config.internal_target_features.contains(&feature))
             .map(|feature| (sym::target_feature, Some(feature))),
     );
 
-    // Store all of them in the session.
-    sess.internal_target_features.extend(tf_cfg.internal_target_features.into_sorted_stable_ord());
-
-    if tf_cfg.has_reliable_f16 {
+    if target_config.has_reliable_f16 {
         cfg.insert((sym::target_has_reliable_f16, None));
     }
-    if tf_cfg.has_reliable_f16_math {
+    if target_config.has_reliable_f16_math {
         cfg.insert((sym::target_has_reliable_f16_math, None));
     }
-    if tf_cfg.has_reliable_f128 {
+    if target_config.has_reliable_f128 {
         cfg.insert((sym::target_has_reliable_f128, None));
     }
-    if tf_cfg.has_reliable_f128_math {
+    if target_config.has_reliable_f128_math {
         cfg.insert((sym::target_has_reliable_f128_math, None));
     }
 
-    if sess.crt_static(None) {
-        cfg.insert((tf, Some(sym::crt_dash_static)));
+    if is_crt_static {
+        cfg.insert((sym::target_feature, Some(sym::crt_dash_static)));
     }
 }
 

--- a/tests/run-make/print-cfg/rmake.rs
+++ b/tests/run-make/print-cfg/rmake.rs
@@ -6,7 +6,7 @@
 //! It also checks that some targets have the correct set cfgs.
 
 // ignore-tidy-linelength
-//@ needs-llvm-components: arm x86
+//@ needs-llvm-components: arm x86 webassembly
 // Note: without the needs-llvm-components it will fail on LLVM built without the required
 // components listed above.
 
@@ -18,6 +18,7 @@ use run_make_support::{rfs, rustc};
 
 struct PrintCfg {
     target: &'static str,
+    args: &'static [&'static str],
     includes: &'static [&'static str],
     disallow: &'static [&'static str],
 }
@@ -25,38 +26,57 @@ struct PrintCfg {
 fn main() {
     check(PrintCfg {
         target: "x86_64-pc-windows-gnu",
+        args: &[],
         includes: &["windows", "target_arch=\"x86_64\""],
         disallow: &["unix"],
     });
     check(PrintCfg {
         target: "i686-pc-windows-msvc",
+        args: &[],
         includes: &["windows", "target_env=\"msvc\""],
         disallow: &["unix"],
     });
     check(PrintCfg {
         target: "i686-apple-darwin",
+        args: &[],
         includes: &["unix", "target_os=\"macos\"", "target_vendor=\"apple\""],
         disallow: &["windows"],
     });
     check(PrintCfg {
         target: "i686-unknown-linux-gnu",
+        args: &[],
         includes: &["unix", "target_env=\"gnu\""],
         disallow: &["windows"],
     });
     check(PrintCfg {
         target: "arm-unknown-linux-gnueabihf",
+        args: &[],
         includes: &["unix", "target_abi=\"eabihf\""],
         disallow: &["windows"],
     });
     // Regression test for #90834: Android must not have `target_env="gnu"`.
     check(PrintCfg {
         target: "i686-linux-android",
+        args: &[],
         includes: &["unix", "target_os=\"android\""],
         disallow: &["windows", "target_env=\"gnu\""],
     });
+    check(PrintCfg {
+        target: "wasm32-unknown-unknown",
+        args: &[],
+        includes: &[],
+        disallow: &["target_has_threads"],
+    });
+    // FIXME: `target_has_threads` is not set; it should be.
+    check(PrintCfg {
+        target: "wasm32-unknown-unknown",
+        args: &["-Ctarget-feature=+atomics"],
+        includes: &[],
+        disallow: &["target_has_threads"],
+    });
 }
 
-fn check(PrintCfg { target, includes, disallow }: PrintCfg) {
+fn check(PrintCfg { target, args, includes, disallow }: PrintCfg) {
     fn check_(output: &str, includes: &[&str], disallow: &[&str]) {
         let mut found = HashSet::<String>::new();
         let mut recorded = HashSet::<String>::new();
@@ -92,7 +112,7 @@ fn check(PrintCfg { target, includes, disallow }: PrintCfg) {
 
     // --print=cfg
     {
-        let output = rustc().target(target).print("cfg").run();
+        let output = rustc().target(target).args(args).print("cfg").run();
         let stdout = output.stdout_utf8();
 
         check_(&stdout, includes, disallow);
@@ -102,7 +122,7 @@ fn check(PrintCfg { target, includes, disallow }: PrintCfg) {
     {
         let tmp_path = PathBuf::from(format!("{target}.cfg"));
 
-        rustc().target(target).print(&format!("cfg={}", tmp_path.display())).run();
+        rustc().target(target).args(args).print(&format!("cfg={}", tmp_path.display())).run();
 
         let output = rfs::read_to_string(&tmp_path);
 

--- a/tests/run-make/print-cfg/rmake.rs
+++ b/tests/run-make/print-cfg/rmake.rs
@@ -67,12 +67,11 @@ fn main() {
         includes: &[],
         disallow: &["target_has_threads"],
     });
-    // FIXME: `target_has_threads` is not set; it should be.
     check(PrintCfg {
         target: "wasm32-unknown-unknown",
         args: &["-Ctarget-feature=+atomics"],
-        includes: &[],
-        disallow: &["target_has_threads"],
+        includes: &["target_has_threads"],
+        disallow: &[],
     });
 }
 


### PR DESCRIPTION
Due to some bad ordering of session/config initialization code, `cfg(target_has_threads)` fails to be set for the `wasm32-unknown-unknown` platform when `-Ctarget-feature=+atomics` is specified. This PR fixes the problem. Details in individual commits.

r? @Mark-Simulacrum 