### PR TITLE
rename rust_target_features query to make it clear that these are *all* target features

### DIFF
--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -64,7 +64,7 @@ fn process_builtin_attrs(
     codegen_fn_attrs: &mut CodegenFnAttrs,
 ) -> InterestingAttributeDiagnosticSpans {
     let mut interesting_spans = InterestingAttributeDiagnosticSpans::default();
-    let rust_target_features = tcx.rust_target_features(LOCAL_CRATE);
+    let rust_target_features = tcx.all_rust_target_features(LOCAL_CRATE);
 
     let parsed_attrs = attrs
         .iter()

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -528,7 +528,7 @@ pub fn sanitizer_features_by_flags(sess: &Session, features: &mut Vec<String>) {
 
 pub(crate) fn provide(providers: &mut Providers) {
     *providers = Providers {
-        rust_target_features: |tcx, cnum| {
+        all_rust_target_features: |tcx, cnum| {
             assert_eq!(cnum, LOCAL_CRATE);
             if tcx.sess.opts.actually_rustdoc {
                 // HACK: rustdoc would like to pretend that we have all the target features, so we

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -2648,8 +2648,9 @@ rustc_queries! {
         desc { "computing proof tree for `{}` with depth `{}`", key.0.canonical.value.goal.predicate, key.1 }
     }
 
-    /// Returns the Rust target features for the current target. These are not always the same as LLVM target features!
-    query rust_target_features(_: CrateNum) -> &'tcx UnordMap<String, rustc_target::target_features::Stability> {
+    /// Returns a list of all Rust target features for the current target (not just the ones that
+    /// are enabled). These are not always the same as LLVM target features!
+    query all_rust_target_features(_: CrateNum) -> &'tcx UnordMap<String, rustc_target::target_features::Stability> {
         arena_cache
         eval_always
         desc { "looking up Rust target features" }


### PR DESCRIPTION
r? @nnethercote 