### PR TITLE
Add f16 summary provider for PDB debug info

### DIFF
--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -39,6 +39,7 @@ from lldb_providers import (
     MSVCTupleSyntheticProvider,
     ClangEncodedEnumSummaryProvider,
     StructSummaryProvider,
+    f16SummaryProvider,
     # re-exports
     get_template_args as get_template_args,
     resolve_msvc_template_arg as resolve_msvc_template_arg,
@@ -136,6 +137,16 @@ def register_providers_compatibility():
             lldb.eTypeOptionCascade
             | lldb.eTypeOptionHideEmptyAggregates
             | lldb.eTypeOptionHideChildren,
+        )
+
+        # Force f16 summary on windows-msvc since PDB does not have a node for f16
+        register_summary(
+            f16SummaryProvider,
+            lldb.SBTypeNameSpecifier(
+                MOD_PREFIX + is_msvc_f16.__name__,
+                lldb.eFormatterMatchCallback,
+            ),
+            DEFAULT_TYPE_OPTIONS | lldb.eTypeOptionHideChildren,
         )
 
         # Tuple-structs
@@ -450,6 +461,11 @@ def is_gnu_enum(type: lldb.SBType, _dict: LLDBOpaque) -> bool:
 def is_tuple_type(type: lldb.SBType, _dict: LLDBOpaque) -> bool:
     fields = type.fields
     return len(fields) != 0 and is_tuple_fields(fields)
+
+
+def is_msvc_f16(type: lldb.SBType, _dict: LLDBOpaque) -> bool:
+    # DWARF has a proper tag for f16, PDB does not.
+    return type.GetName() == "f16" and type.IsAggregateType()
 
 
 def classify_rust_type(type: lldb.SBType, is_msvc: bool) -> RustType:

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -505,6 +505,14 @@ def StdPathSummaryProvider(valobj: SBValue, _dict: LLDBOpaque) -> str:
     return read_string(process, start, length)
 
 
+def f16SummaryProvider(valobj: SBValue, _dict: LLDBOpaque) -> str:
+    return (
+        valobj.GetChildAtIndex(0)
+        .Cast(valobj.GetTarget().GetBasicType(eBasicTypeHalf))
+        .GetValue()
+    )
+
+
 def sequence_formatter(output: str, valobj: SBValue, _dict: LLDBOpaque):
     length: int = valobj.GetNumChildren()
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

`f16`  doesn't have a proper node in the PDB format, so it ends up output as a struct with a `bits` field. This change adds a summary provider that casts to a clang `half` type and retrieves the summary from that. Neither of these operations can fail since `half` is built-in as far as clang/lldb are concerned.

Fixes `tests\debuginfo\borrowed-basic.rs` and `tests\debuginfo\reference-debuginfo.rs`, which [currently fail on `windows-msvc`](https://github.com/rust-lang/rust/issues/161657)


