### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -64,7 +64,7 @@ fn process_builtin_attrs(
     codegen_fn_attrs: &mut CodegenFnAttrs,
 ) -> InterestingAttributeDiagnosticSpans {
     let mut interesting_spans = InterestingAttributeDiagnosticSpans::default();
-    let rust_target_features = tcx.rust_target_features(LOCAL_CRATE);
+    let rust_target_features = tcx.all_rust_target_features(LOCAL_CRATE);
 
     let parsed_attrs = attrs
         .iter()

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -528,7 +528,7 @@ pub fn sanitizer_features_by_flags(sess: &Session, features: &mut Vec<String>) {
 
 pub(crate) fn provide(providers: &mut Providers) {
     *providers = Providers {
-        rust_target_features: |tcx, cnum| {
+        all_rust_target_features: |tcx, cnum| {
             assert_eq!(cnum, LOCAL_CRATE);
             if tcx.sess.opts.actually_rustdoc {
                 // HACK: rustdoc would like to pretend that we have all the target features, so we

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -2648,8 +2648,9 @@ rustc_queries! {
         desc { "computing proof tree for `{}` with depth `{}`", key.0.canonical.value.goal.predicate, key.1 }
     }
 
-    /// Returns the Rust target features for the current target. These are not always the same as LLVM target features!
-    query rust_target_features(_: CrateNum) -> &'tcx UnordMap<String, rustc_target::target_features::Stability> {
+    /// Returns a list of all Rust target features for the current target (not just the ones that
+    /// are enabled). These are not always the same as LLVM target features!
+    query all_rust_target_features(_: CrateNum) -> &'tcx UnordMap<String, rustc_target::target_features::Stability> {
         arena_cache
         eval_always
         desc { "looking up Rust target features" }

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -628,17 +628,19 @@ impl<'a> Parser<'a> {
                         }
 
                         // help: extract the expr into a `const VAL: _ = expr`
-                        let ident = match self.field {
-                            Some(field) => field.ident.as_str().to_uppercase(),
-                            None => "VAL".to_owned(),
-                        };
-                        err.subdiagnostic(UnexpectedExpressionInPatternSugg::Const {
-                            stmt_lo: line_lo,
-                            ident_span: expr_span,
-                            expr,
-                            ident,
-                            indentation,
-                        });
+                        if !line_lo.overlaps(expr_span) {
+                            let ident = match self.field {
+                                Some(field) => field.ident.as_str().to_uppercase(),
+                                None => "VAL".to_owned(),
+                            };
+                            err.subdiagnostic(UnexpectedExpressionInPatternSugg::Const {
+                                stmt_lo: line_lo,
+                                ident_span: expr_span,
+                                expr,
+                                ident,
+                                indentation,
+                            });
+                        }
                     },
                 );
             }

--- a/compiler/rustc_target/src/spec/targets/mipsel_sony_psp_linker_script.ld
+++ b/compiler/rustc_target/src/spec/targets/mipsel_sony_psp_linker_script.ld
@@ -41,5 +41,5 @@ SECTIONS
   .gcc_except_table : { *(.gcc_except_table .gcc_except_table.*) }
   .bss : { *(.bss .bss.*) }
 
-  /DISCARD/ : { *(.rel.sceStub.text .MIPS.abiflags .reginfo) }
+  /DISCARD/ : { *(.rel.sceStub.text .MIPS.abiflags .reginfo .pdr) }
 }

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -116,12 +116,12 @@ impl CommandLineStep for UnstableBook {
     }
 
     fn run(self, builder: &Builder<'_>) {
-        builder
+        let unstable_book_md_dir = builder
             .ensure(UnstableBookGen { build_compiler: self.build_compiler, target: self.target });
         builder.ensure(RustbookSrc {
             target: self.target,
             name: "unstable-book".to_owned(),
-            src: builder.md_doc_out(self.target).join("unstable-book"),
+            src: unstable_book_md_dir,
             parent: Some(self),
             languages: vec![],
             build_compiler: None,
@@ -1293,6 +1293,8 @@ impl CommandLineStep for ErrorIndex {
     }
 }
 
+/// Runs the `unstable-book-gen` tool and returns a path to the generate unstable book markdown
+/// files.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct UnstableBookGen {
     build_compiler: Compiler,
@@ -1300,7 +1302,7 @@ pub struct UnstableBookGen {
 }
 
 impl CommandLineStep for UnstableBookGen {
-    type Output = ();
+    type Output = PathBuf;
     const IS_HOST: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
@@ -1318,12 +1320,12 @@ impl CommandLineStep for UnstableBookGen {
         });
     }
 
-    fn run(self, builder: &Builder<'_>) {
+    fn run(self, builder: &Builder<'_>) -> Self::Output {
         let target = self.target;
         let rustc_path = builder.rustc(self.build_compiler);
 
         builder.info(&format!("Generating unstable book md files ({target})"));
-        let out = builder.md_doc_out(target).join("unstable-book");
+        let out = builder.out.join(target).join("md-doc").join("unstable-book");
         builder.create_dir(&out);
         builder.remove_dir(&out);
         let mut cmd = builder.tool_cmd(Tool::UnstableBookGen);
@@ -1331,13 +1333,14 @@ impl CommandLineStep for UnstableBookGen {
         cmd.arg(builder.src.join("compiler"));
         cmd.arg(builder.src.join("src"));
         cmd.arg(rustc_path);
-        cmd.arg(out);
+        cmd.arg(&out);
 
         // Running rustc requires the library path if rust.rpath = false
         // or any other libraries are in a custom location.
         builder.add_rustc_lib_path(self.build_compiler, &mut cmd);
 
         cmd.run(builder);
+        out
     }
 }
 
@@ -1419,7 +1422,7 @@ impl CommandLineStep for RustcBook {
             return;
         }
 
-        let out_base = builder.md_doc_out(self.target).join("rustc");
+        let out_base = builder.out.join(self.target).join("md-doc").join("rustc");
         t!(fs::create_dir_all(&out_base));
         let out_listing = out_base.join("src/lints");
         builder.cp_link_r(&builder.src.join("src/doc/rustc"), &out_base);

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2620,13 +2620,9 @@ Please disable assertions with `rust.debug-assertions = false`.
 
         // Provide `rust_test_helpers` for both host and target.
         if suite == "ui" || suite == "incremental" {
-            builder.ensure(TestHelpers { target: test_compiler.host });
-            builder.ensure(TestHelpers { target });
-            hostflags.push(format!(
-                "-Lnative={}",
-                builder.test_helpers_out(test_compiler.host).display()
-            ));
-            let target_helpers = builder.test_helpers_out(target);
+            let host_test_helpers = builder.ensure(TestHelpers { target: test_compiler.host });
+            let target_helpers = builder.ensure(TestHelpers { target });
+            hostflags.push(format!("-Lnative={}", host_test_helpers.display()));
             targetflags.push(format!("-Lnative={}", target_helpers.display()));
             if target.is_pauthtest() {
                 // For the pauthtest target, embed an rpath to the directory containing the helper
@@ -4250,28 +4246,28 @@ impl CommandLineStep for RustInstaller {
     }
 }
 
+/// Compiles native (C/C++) code that is used as helper code for tests.
+///
+/// Returns a path to the directory where the native test helpers have been built into.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TestHelpers {
     pub target: TargetSelection,
 }
 
 impl CommandLineStep for TestHelpers {
-    type Output = ();
+    type Output = PathBuf;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("tests/auxiliary/rust_test_helpers.c")
     }
 
     fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(TestHelpers { target: run.target })
+        run.builder.ensure(TestHelpers { target: run.target });
     }
 
     /// Compiles the `rust_test_helpers.c` library which we used in various
     /// `run-pass` tests for ABI testing.
-    fn run(self, builder: &Builder<'_>) {
-        if builder.config.dry_run() {
-            return;
-        }
+    fn run(self, builder: &Builder<'_>) -> Self::Output {
         // The x86_64-fortanix-unknown-sgx target doesn't have a working C
         // toolchain. However, some x86_64 ELF objects can be linked
         // without issues. Use this hack to compile the test helpers.
@@ -4280,7 +4276,11 @@ impl CommandLineStep for TestHelpers {
         } else {
             self.target
         };
-        let dst = builder.test_helpers_out(target);
+        let dst = builder.native_dir(target).join("rust-test-helpers");
+        if builder.config.dry_run() {
+            return dst;
+        }
+
         let src = builder.src.join("tests/auxiliary/rust_test_helpers.c");
         let _guard = builder.msg_unstaged(Kind::Build, "test helpers", target);
         t!(fs::create_dir_all(&dst));
@@ -4310,7 +4310,7 @@ impl CommandLineStep for TestHelpers {
         if target.is_pauthtest() {
             let so = dst.join("librust_test_helpers.so");
             if up_to_date(&src, &so) {
-                return;
+                return dst;
             }
 
             let status = Command::new(builder.cc(target))
@@ -4330,6 +4330,7 @@ impl CommandLineStep for TestHelpers {
                 panic!("Linking of librust_test_helpers.so failed (target: {})", target.triple);
             }
         }
+        dst
     }
 }
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1565,7 +1565,7 @@ impl CommandLineStep for RustdocGUI {
 
         let mut cmd = builder.tool_cmd(Tool::RustdocGUITest);
 
-        let out_dir = builder.test_out(self.target).join("rustdoc-gui");
+        let out_dir = builder.out.join(self.target).join("test").join("rustdoc-gui");
         build_stamp::clear_if_dirty(
             builder,
             &out_dir,

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1046,7 +1046,6 @@ impl Builder<'_> {
         // These variables are primarily all read by
         // src/bootstrap/bin/{rustc.rs,rustdoc.rs}
         cargo
-            .env("RUSTBUILD_NATIVE_DIR", self.native_dir(target))
             .env("RUSTC_REAL", self.rustc(compiler))
             .env("RUSTC_STAGE", build_compiler_stage.to_string())
             .env("RUSTC_SYSROOT", sysroot)

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1052,8 +1052,7 @@ impl Builder<'_> {
             .env("RUSTC_LIBDIR", &libdir)
             .env("RUSTDOC_LIBDIR", libdir)
             .env("RUSTDOC", self.bootstrap_out.join("rustdoc"))
-            .env("RUSTDOC_REAL", rustdoc_path)
-            .env("RUSTC_ERROR_METADATA_DST", self.extended_error_dir());
+            .env("RUSTDOC_REAL", rustdoc_path);
 
         if self.config.rust_break_on_ice {
             cargo.env("RUSTC_BREAK_ON_ICE", "1");

--- a/src/bootstrap/src/core/session.rs
+++ b/src/bootstrap/src/core/session.rs
@@ -841,12 +841,6 @@ impl Build {
         self.out.join(target).join("native")
     }
 
-    /// Root output directory for rust_test_helpers library compiled for
-    /// `target`
-    pub(crate) fn test_helpers_out(&self, target: TargetSelection) -> PathBuf {
-        self.native_dir(target).join("rust-test-helpers")
-    }
-
     /// Adds the `RUST_TEST_THREADS` env var if necessary
     pub(crate) fn add_rust_test_threads(&self, cmd: &mut BootstrapCommand) {
         if env::var_os("RUST_TEST_THREADS").is_none() {

--- a/src/bootstrap/src/core/session.rs
+++ b/src/bootstrap/src/core/session.rs
@@ -817,10 +817,6 @@ impl Build {
         self.out.join(target).join("json-doc")
     }
 
-    pub(crate) fn test_out(&self, target: TargetSelection) -> PathBuf {
-        self.out.join(target).join("test")
-    }
-
     /// Output directory for all documentation for a target
     pub(crate) fn compiler_doc_out(&self, target: TargetSelection) -> PathBuf {
         self.out.join(target).join("compiler-doc")

--- a/src/bootstrap/src/core/session.rs
+++ b/src/bootstrap/src/core/session.rs
@@ -822,11 +822,6 @@ impl Build {
         self.out.join(target).join("compiler-doc")
     }
 
-    /// Output directory for some generated md crate documentation for a target (temporary)
-    pub(crate) fn md_doc_out(&self, target: TargetSelection) -> PathBuf {
-        self.out.join(target).join("md-doc")
-    }
-
     /// Path to the vendored Rust crates.
     pub(crate) fn vendored_crates_path(&self) -> Option<PathBuf> {
         if self.config.vendor { Some(self.src.join(VENDOR_DIR)) } else { None }

--- a/src/bootstrap/src/core/session.rs
+++ b/src/bootstrap/src/core/session.rs
@@ -1307,11 +1307,6 @@ impl Build {
         self.config.target_config.get(&target).and_then(|t| t.qemu_rootfs.as_ref()).map(|p| &**p)
     }
 
-    /// Temporary directory that extended error information is emitted to.
-    pub(crate) fn extended_error_dir(&self) -> PathBuf {
-        self.out.join("tmp/extended-error-metadata")
-    }
-
     /// Tests whether the `compiler` compiling for `target` should be forced to
     /// use a stage1 compiler instead.
     ///

--- a/tests/ui/parser/recover/recover-pat-range-macro-span-overlap.rs
+++ b/tests/ui/parser/recover/recover-pat-range-macro-span-overlap.rs
@@ -1,0 +1,15 @@
+// test for issue - https://github.com/rust-lang/rust/issues/161213
+macro_rules! m {
+    ($value:expr) => {
+        enum Foo {
+            Bar = $value,
+            //~^ error: expected a pattern range bound, found an expression
+        }
+        fn main() {
+            match 0 {
+                0..Foo::Bar + $value | _ => (),
+            }
+        }
+    };
+}
+m!(1);

--- a/tests/ui/parser/recover/recover-pat-range-macro-span-overlap.stderr
+++ b/tests/ui/parser/recover/recover-pat-range-macro-span-overlap.stderr
@@ -1,0 +1,20 @@
+error: expected a pattern range bound, found an expression
+  --> $DIR/recover-pat-range-macro-span-overlap.rs:5:19
+   |
+LL |               Bar = $value,
+   |  ___________________^
+LL | |
+LL | |         }
+LL | |         fn main() {
+LL | |             match 0 {
+LL | |                 0..Foo::Bar + $value | _ => (),
+   | |_____________________________^ not a pattern
+...
+LL |   m!(1);
+   |   ----- in this macro invocation
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#161411 (avoid overlapping const suggestions)
 - rust-lang/rust#161484 (Discard `.pdr` in the PSP linker script)
 - rust-lang/rust#161663 (Reduce dependency on implicit paths in bootstrap)
 - rust-lang/rust#161720 (rename rust_target_features query to make it clear that these are *all* target features)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=161411,161484,161663,161720)
<!-- homu-ignore:end -->

