### PR TITLE
docs(readme): align Getting Started link reference casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
          width="50%">
   </picture>
 
-[Website][Rust] | [Getting started] | [Learn] | [Documentation] | [Contributing]
+[Website][Rust] | [Getting Started] | [Learn] | [Documentation] | [Contributing]
 </div>
 
 This is the main source code repository for [Rust]. It contains the compiler,


### PR DESCRIPTION
Aligns the link label casing in `README.md` header (`[Getting started]` -> `[Getting Started]`) with its reference definition `[Getting Started]: https://www.rust-lang.org/learn/get-started`.