### PR TITLE
Fix debugger visualizer tuple child ordering w/ PDB debug info

### DIFF
--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -1029,19 +1029,14 @@ class TupleSyntheticProvider:
 
     def get_child_index(self, name: str) -> int:
         if name.isdigit():
-            return int(name)
+            return self.valobj.GetIndexOfChildWithName(f"__{name}")
         else:
             return -1
 
     def get_child_at_index(self, index: int) -> Optional[SBValue]:
-        if self.is_variant:
-            field = self.type.GetFieldAtIndex(index + 1)
-        else:
-            field = self.type.GetFieldAtIndex(index)
-        element = self.valobj.GetChildMemberWithName(field.name)
-        return self.valobj.CreateValueFromData(
-            str(index), element.GetData(), element.GetType()
-        )
+        return self.valobj.GetChildAtIndex(
+            self.valobj.GetIndexOfChildWithName(f"__{index}")
+        ).Clone(str(index))
 
     def update(self):
         pass
@@ -1060,12 +1055,15 @@ class MSVCTupleSyntheticProvider:
         return self.valobj.GetNumChildren()
 
     def get_child_index(self, name: str) -> int:
-        return self.valobj.GetIndexOfChildWithName(name)
+        if name.isdigit():
+            return self.valobj.GetIndexOfChildWithName(f"__{name}")
+        else:
+            return -1
 
     def get_child_at_index(self, index: int) -> Optional[SBValue]:
-        child: SBValue = self.valobj.GetChildAtIndex(index)
-        offset = self.valobj.GetType().GetFieldAtIndex(index).byte_offset
-        return self.valobj.CreateChildAtOffset(str(index), offset, child.GetType())
+        return self.valobj.GetChildAtIndex(
+            self.valobj.GetIndexOfChildWithName(f"__{index}")
+        ).Clone(str(index))
 
     def update(self):
         pass


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

see: https://github.com/llvm/llvm-project/issues/218613 for an explanation of the issue. tl;dr, PDB fields reflect rustc's reordering, whereas DWARF fields are in source-code-order. This causes issues with `GetChildAtIndex` in cases where both DWARF- and PDB-based types can interact with them.

This PR uses field names to retrieve field indexes, rather than blindly indexing into the field array.

I did a quick scan over the rest of the `GetChildAtIndex` calls, and they all fall under a few safe cases

1. in DWARF or PDB specific providers (mainly enum discriminants, which can't be reordered anyway)
2. used to get field `0` of a struct with only 1 field
3. in the summary provider where we're typically already interacting with the synthetic value and synthetic children anyway

cc https://github.com/rust-lang/rust/issues/161657, fixes `tests/debuginfo/tuple-struct.rs` on `windows-msvc`

<details><summary>`windows-msvc` `tests/debuginfo` results with this change</summary>

```
failures:
    [debuginfo-lldb] tests\debuginfo\associated-types.rs
    [debuginfo-lldb] tests\debuginfo\borrowed-basic.rs
    [debuginfo-lldb] tests\debuginfo\borrowed-unique-basic.rs
    [debuginfo-lldb] tests\debuginfo\basic-types-globals.rs#no-lto
    [debuginfo-lldb] tests\debuginfo\borrowed-tuple.rs
    [debuginfo-lldb] tests\debuginfo\boxed-struct.rs
    [debuginfo-lldb] tests\debuginfo\captured-fields-2.rs
    [debuginfo-lldb] tests\debuginfo\cross-crate-spans.rs
    [debuginfo-lldb] tests\debuginfo\coroutine-locals.rs
    [debuginfo-lldb] tests\debuginfo\box.rs
    [debuginfo-lldb] tests\debuginfo\captured-fields-1.rs
    [debuginfo-lldb] tests\debuginfo\c-style-enum-in-composite.rs
    [debuginfo-lldb] tests\debuginfo\by-value-self-argument-in-trait-impl.rs
    [debuginfo-lldb] tests\debuginfo\destructured-for-loop-variable.rs
    [debuginfo-lldb] tests\debuginfo\dummy_span.rs
    [debuginfo-lldb] tests\debuginfo\evec-in-struct.rs
    [debuginfo-lldb] tests\debuginfo\destructured-fn-argument.rs
    [debuginfo-lldb] tests\debuginfo\destructured-local.rs
    [debuginfo-lldb] tests\debuginfo\generic-struct.rs
    [debuginfo-lldb] tests\debuginfo\issue-22656.rs
    [debuginfo-lldb] tests\debuginfo\basic-types-globals.rs#lto
    [debuginfo-lldb] tests\debuginfo\lexical-scope-in-if.rs
    [debuginfo-lldb] tests\debuginfo\lexical-scope-in-stack-closure.rs
    [debuginfo-lldb] tests\debuginfo\lexical-scope-in-unconditional-loop.rs
    [debuginfo-lldb] tests\debuginfo\lexical-scope-with-macro.rs
    [debuginfo-lldb] tests\debuginfo\lexical-scope-in-unique-closure.rs
    [debuginfo-lldb] tests\debuginfo\lexical-scope-in-if-let.rs
    [debuginfo-lldb] tests\debuginfo\lexical-scopes-in-block-expression.rs
    [debuginfo-lldb] tests\debuginfo\method-on-generic-struct.rs
    [debuginfo-lldb] tests\debuginfo\lexical-scope-in-while.rs
    [debuginfo-lldb] tests\debuginfo\lexical-scope-in-for-loop.rs
    [debuginfo-lldb] tests\debuginfo\name-shadowing-and-scope-nesting.rs
    [debuginfo-lldb] tests\debuginfo\no_mangle-info.rs
    [debuginfo-lldb] tests\debuginfo\packed-struct-with-destructor.rs
    [debuginfo-lldb] tests\debuginfo\pretty-slices.rs
    [debuginfo-lldb] tests\debuginfo\packed-struct.rs
    [debuginfo-lldb] tests\debuginfo\reference-debuginfo.rs
    [debuginfo-lldb] tests\debuginfo\simple-struct.rs
    [debuginfo-lldb] tests\debuginfo\simple-lexical-scope.rs
    [debuginfo-lldb] tests\debuginfo\shadowed-variable.rs
    [debuginfo-lldb] tests\debuginfo\simple-tuple.rs
    [debuginfo-lldb] tests\debuginfo\shadowed-argument.rs
    [debuginfo-lldb] tests\debuginfo\struct-with-destructor.rs
    [debuginfo-lldb] tests\debuginfo\strings-and-strs.rs
    [debuginfo-lldb] tests\debuginfo\struct-in-struct.rs
    [debuginfo-lldb] tests\debuginfo\pretty-std-collections.rs
    [debuginfo-lldb] tests\debuginfo\tuple-in-tuple.rs
    [debuginfo-lldb] tests\debuginfo\thread-names.rs#win
    [debuginfo-lldb] tests\debuginfo\vec-slices.rs
    [debuginfo-lldb] tests\debuginfo\var-captured-in-sendable-closure.rs
    [debuginfo-lldb] tests\debuginfo\var-captured-in-stack-closure.rs
    [debuginfo-lldb] tests\debuginfo\var-captured-in-nested-closure.rs

test result: FAILED. 244 passed; 52 failed; 223 ignored; 0 measured; 0 filtered out; finished in 13.22s
```
</details> 