### PR TITLE
Improve type mismatch annotation for lets with block-wrapped initializers

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -711,9 +711,31 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expr: &hir::Expr<'_>,
         error: Option<TypeError<'tcx>>,
     ) {
-        match (self.tcx.parent_hir_node(expr.hir_id), error) {
+        // Skip nested block to find the correct parent node to point at.
+        let mut current_hir_id = expr.hir_id;
+        let parent = self
+            .tcx
+            .hir_parent_iter(expr.hir_id)
+            .find_map(|(parent_hir_id, parent)| match parent {
+                hir::Node::Block(block)
+                    if block.expr.is_some_and(|expr| expr.hir_id == current_hir_id) =>
+                {
+                    current_hir_id = parent_hir_id;
+                    None
+                }
+                hir::Node::Expr(hir::Expr { kind: hir::ExprKind::Block(block, _), .. })
+                    if block.hir_id == current_hir_id =>
+                {
+                    current_hir_id = parent_hir_id;
+                    None
+                }
+                parent => Some(parent),
+            })
+            .expect("an expression must have a non-block ancestor");
+
+        match (parent, error) {
             (hir::Node::LetStmt(hir::LetStmt { ty: Some(ty), init: Some(init), .. }), _)
-                if init.hir_id == expr.hir_id && !ty.span.source_equal(init.span) =>
+                if init.hir_id == current_hir_id && !ty.span.source_equal(init.span) =>
             {
                 // Point at `let` assignment type.
                 err.span_label(ty.span, "expected due to this");

--- a/tests/ui/async-await/suggest-async-fn-for-returned-future-ineligible-issue-159495.stderr
+++ b/tests/ui/async-await/suggest-async-fn-for-returned-future-ineligible-issue-159495.stderr
@@ -2,7 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/suggest-async-fn-for-returned-future-ineligible-issue-159495.rs:12:20
    |
 LL |     let _: i32 = { number() };
-   |                    ^^^^^^^^ expected `i32`, found future
+   |            ---     ^^^^^^^^ expected `i32`, found future
+   |            |
+   |            expected due to this
 
 error[E0308]: mismatched types
   --> $DIR/suggest-async-fn-for-returned-future-ineligible-issue-159495.rs:24:9

--- a/tests/ui/closures/closure-return-block-note-issue-155670.stderr
+++ b/tests/ui/closures/closure-return-block-note-issue-155670.stderr
@@ -1,18 +1,24 @@
 error[E0308]: mismatched types
   --> $DIR/closure-return-block-note-issue-155670.rs:9:9
    |
+LL |     let _: String = {
+   |            ------ expected due to this
 LL |         SmolStr
    |         ^^^^^^^ expected `String`, found `SmolStr`
 
 error[E0308]: mismatched types
   --> $DIR/closure-return-block-note-issue-155670.rs:20:9
    |
+LL |     let _: String = {
+   |            ------ expected due to this
 LL |         SmolStr
    |         ^^^^^^^ expected `String`, found `SmolStr`
 
 error[E0308]: mismatched types
   --> $DIR/closure-return-block-note-issue-155670.rs:32:9
    |
+LL |     let _: String = {
+   |            ------ expected due to this
 LL |         SmolStr
    |         ^^^^^^^ expected `String`, found `SmolStr`
 

--- a/tests/ui/closures/local-type-mismatch-attribution-issue-127048.rs
+++ b/tests/ui/closures/local-type-mismatch-attribution-issue-127048.rs
@@ -1,0 +1,69 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/127048.
+//! A nested initializer block should still attribute a mismatch to the local type.
+
+//@ edition: 2021
+
+fn direct_initializer() {
+    || {
+        Ok::<(), ()>(())?;
+        let _: i32 = false;
+        //~^ ERROR mismatched types
+        todo!()
+    };
+}
+
+fn nested_initializer() {
+    || {
+        Ok::<(), ()>(())?;
+        let _: i32 = {
+            false
+            //~^ ERROR mismatched types
+        };
+        todo!()
+    };
+}
+
+fn explicit_closure_return_type() {
+    || -> Result<(), ()> {
+        Ok::<(), ()>(())?;
+        let _: i32 = {
+            false
+            //~^ ERROR mismatched types
+        };
+        todo!()
+    };
+}
+
+fn async_block() {
+    async {
+        Ok::<(), ()>(())?;
+        let _: i32 = {
+            false
+            //~^ ERROR mismatched types
+        };
+        todo!()
+    };
+}
+
+fn assignment_rhs() {
+    let mut value: i32 = 0;
+    value = false;
+    //~^ ERROR mismatched types
+    value = {
+        let _ = ();
+        false
+        //~^ ERROR mismatched types
+    };
+}
+
+fn binary_rhs() {
+    let _ = true && 1;
+    //~^ ERROR mismatched types
+    let _ = true && {
+        let _ = ();
+        1
+        //~^ ERROR mismatched types
+    };
+}
+
+fn main() {}

--- a/tests/ui/closures/local-type-mismatch-attribution-issue-127048.stderr
+++ b/tests/ui/closures/local-type-mismatch-attribution-issue-127048.stderr
@@ -1,0 +1,57 @@
+error[E0308]: mismatched types
+  --> $DIR/local-type-mismatch-attribution-issue-127048.rs:9:22
+   |
+LL |         let _: i32 = false;
+   |                ---   ^^^^^ expected `i32`, found `bool`
+   |                |
+   |                expected due to this
+
+error[E0308]: mismatched types
+  --> $DIR/local-type-mismatch-attribution-issue-127048.rs:19:13
+   |
+LL |             false
+   |             ^^^^^ expected `i32`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/local-type-mismatch-attribution-issue-127048.rs:30:13
+   |
+LL |             false
+   |             ^^^^^ expected `i32`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/local-type-mismatch-attribution-issue-127048.rs:41:13
+   |
+LL |             false
+   |             ^^^^^ expected `i32`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/local-type-mismatch-attribution-issue-127048.rs:50:13
+   |
+LL |     let mut value: i32 = 0;
+   |                    --- expected due to this type
+LL |     value = false;
+   |             ^^^^^ expected `i32`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/local-type-mismatch-attribution-issue-127048.rs:54:9
+   |
+LL |         false
+   |         ^^^^^ expected `i32`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/local-type-mismatch-attribution-issue-127048.rs:60:21
+   |
+LL |     let _ = true && 1;
+   |             ----    ^ expected `bool`, found integer
+   |             |
+   |             expected because this is `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/local-type-mismatch-attribution-issue-127048.rs:64:9
+   |
+LL |         1
+   |         ^ expected `bool`, found integer
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/closures/local-type-mismatch-attribution-issue-127048.stderr
+++ b/tests/ui/closures/local-type-mismatch-attribution-issue-127048.stderr
@@ -9,18 +9,24 @@ LL |         let _: i32 = false;
 error[E0308]: mismatched types
   --> $DIR/local-type-mismatch-attribution-issue-127048.rs:19:13
    |
+LL |         let _: i32 = {
+   |                --- expected due to this
 LL |             false
    |             ^^^^^ expected `i32`, found `bool`
 
 error[E0308]: mismatched types
   --> $DIR/local-type-mismatch-attribution-issue-127048.rs:30:13
    |
+LL |         let _: i32 = {
+   |                --- expected due to this
 LL |             false
    |             ^^^^^ expected `i32`, found `bool`
 
 error[E0308]: mismatched types
   --> $DIR/local-type-mismatch-attribution-issue-127048.rs:41:13
    |
+LL |         let _: i32 = {
+   |                --- expected due to this
 LL |             false
    |             ^^^^^ expected `i32`, found `bool`
 

--- a/tests/ui/coercion/unboxing-needing-parenthases-issue-132924.stderr
+++ b/tests/ui/coercion/unboxing-needing-parenthases-issue-132924.stderr
@@ -17,7 +17,9 @@ error[E0308]: mismatched types
   --> $DIR/unboxing-needing-parenthases-issue-132924.rs:8:31
    |
 LL |     let test: Option<i32> = { x as Box<Option<i32>> };
-   |                               ^^^^^^^^^^^^^^^^^^^^^ expected `Option<i32>`, found `Box<Option<i32>>`
+   |               -----------     ^^^^^^^^^^^^^^^^^^^^^ expected `Option<i32>`, found `Box<Option<i32>>`
+   |               |
+   |               expected due to this
    |
    = note: expected enum `Option<_>`
             found struct `Box<Option<_>>`

--- a/tests/ui/did_you_mean/compatible-variants.stderr
+++ b/tests/ui/did_you_mean/compatible-variants.stderr
@@ -103,6 +103,8 @@ LL |     let _: Option<()> = Some(while false {});
 error[E0308]: mismatched types
   --> $DIR/compatible-variants.rs:46:9
    |
+LL |     let _: Option<()> = {
+   |            ---------- expected due to this
 LL |         while false {}
    |         ^^^^^^^^^^^^^^ expected `Option<()>`, found `()`
    |

--- a/tests/ui/for-loop-while/break-while-condition.stderr
+++ b/tests/ui/for-loop-while/break-while-condition.stderr
@@ -1,6 +1,8 @@
 error[E0308]: mismatched types
   --> $DIR/break-while-condition.rs:8:13
    |
+LL |         let _: ! = {
+   |                - expected due to this
 LL |             'a: while break 'a {}
    |             ^^^^^^^^^^^^^^^^^^^^^ expected `!`, found `()`
    |
@@ -15,6 +17,8 @@ LL |             'a: while break 'a {} /* `loop {}` or `panic!("...")` */
 error[E0308]: mismatched types
   --> $DIR/break-while-condition.rs:15:13
    |
+LL |           let _: ! = {
+   |                  - expected due to this
 LL | /             while false {
 LL | |
 LL | |                 break;
@@ -33,6 +37,8 @@ LL +             /* `loop {}` or `panic!("...")` */
 error[E0308]: mismatched types
   --> $DIR/break-while-condition.rs:24:13
    |
+LL |           let _: ! = {
+   |                  - expected due to this
 LL | /             while false {
 LL | |
 LL | |                 return;

--- a/tests/ui/mismatched_types/type-error-diagnostic-in-complex-return.stderr
+++ b/tests/ui/mismatched_types/type-error-diagnostic-in-complex-return.stderr
@@ -2,7 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/type-error-diagnostic-in-complex-return.rs:13:41
    |
 LL |             let value: &bool = unsafe { &42 };
-   |                                         ^^^ expected `&bool`, found `&{integer}`
+   |                        -----            ^^^ expected `&bool`, found `&{integer}`
+   |                        |
+   |                        expected due to this
    |
    = note: expected reference `&bool`
               found reference `&{integer}`

--- a/tests/ui/suggestions/raw-to-ref.stderr
+++ b/tests/ui/suggestions/raw-to-ref.stderr
@@ -2,7 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/raw-to-ref.rs:11:26
    |
 LL |     let _: &S = unsafe { *x };
-   |                          ^^ expected `&S`, found `S`
+   |            --            ^^ expected `&S`, found `S`
+   |            |
+   |            expected due to this
    |
 help: consider borrowing here
    |
@@ -13,7 +15,9 @@ error[E0308]: mismatched types
   --> $DIR/raw-to-ref.rs:16:30
    |
 LL |     let _: &mut S = unsafe { *x };
-   |                              ^^ expected `&mut S`, found `S`
+   |            ------            ^^ expected `&mut S`, found `S`
+   |            |
+   |            expected due to this
    |
 help: consider mutably borrowing here
    |


### PR DESCRIPTION
Fixes rust-lang/rust#127048