### PR TITLE
miri: enforce proper types for c-variadic arguments in shims

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -245,6 +245,16 @@ impl ReprOptions {
     pub fn inhibits_union_abi_opt(&self) -> bool {
         self.c()
     }
+
+    /// Ensures two `repr` are equal up to the seed.
+    pub fn equal_up_to_seed(&self, other: &Self) -> bool {
+        let ReprOptions { int, align, pack, flags, scalable, field_shuffle_seed: _ } = *self;
+        int == other.int
+            && align == other.align
+            && pack == other.pack
+            && flags == other.flags
+            && scalable == other.scalable
+    }
 }
 
 /// The maximum supported number of lanes in a SIMD vector.

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -9,7 +9,7 @@ use rustc_abi::{self as abi, ExternAbi, FieldIdx, Integer, VariantIdx};
 use rustc_hir::def_id::DefId;
 use rustc_hir::find_attr;
 use rustc_middle::ty::layout::{IntegerExt, TyAndLayout};
-use rustc_middle::ty::{self, AdtDef, Instance, Ty, VariantDef};
+use rustc_middle::ty::{self, AdtDef, FieldDef, Instance, Ty, VariantDef};
 use rustc_middle::{bug, mir, span_bug};
 use rustc_target::callconv::{ArgAbi, FnAbi};
 use tracing::field::Empty;
@@ -229,6 +229,48 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         })
     }
 
+    /// Determine whether the given types are identical types from the perspective of C.
+    pub(super) fn identical_c_types(&self, caller_type: Ty<'tcx>, callee_type: Ty<'tcx>) -> bool {
+        if caller_type == callee_type {
+            return true;
+        }
+
+        // C considers two structs to be the same if they have the same name and the same
+        // fields. We need a similar rules that that e.g. if caller and callee use the "same"
+        // type from two different versions of the same crate, that call is accepted.
+        let ty::Adt(caller_adt, caller_args) = caller_type.kind() else { return false };
+        let ty::Adt(callee_adt, callee_args) = callee_type.kind() else { return false };
+
+        if !(
+            // They must both be structs.
+            (caller_adt.is_struct() && callee_adt.is_struct())
+            // They must have equal `repr`, and it must be `repr(C)`.
+            && (caller_adt.repr().c() && caller_adt.repr().equal_up_to_seed(&callee_adt.repr()))
+            // They must have the same name.
+            && self.tcx.item_name(caller_adt.did()) == self.tcx.item_name(callee_adt.did())
+        ) {
+            return false;
+        }
+
+        // All fields must have the same names and types as well, where "same type" recursively
+        // uses this check.
+        let caller_fields = &caller_adt.non_enum_variant().fields;
+        let callee_fields = &callee_adt.non_enum_variant().fields;
+        caller_fields.len() == callee_fields.len()
+            && caller_fields.iter().zip(callee_fields).all(|(caller_field, callee_field)| {
+                if caller_field.name != callee_field.name {
+                    return false; // Bail on different name.
+                }
+                // Ensure the normalized type is the same.
+                let normalized_field_ty = |field: &FieldDef, args| {
+                    self.tcx.normalize_erasing_regions(self.typing_env, field.ty(*self.tcx, args))
+                };
+                let caller_ty = normalized_field_ty(caller_field, caller_args);
+                let callee_ty = normalized_field_ty(callee_field, callee_args);
+                self.identical_c_types(caller_ty, callee_ty)
+            })
+    }
+
     /// Check if these two layouts look like they are fn-ABI-compatible.
     /// (We also compare the `PassMode`, so this doesn't have to check everything. But it turns out
     /// that only checking the `PassMode` is insufficient.)
@@ -252,8 +294,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         };
         let caller = unfold(caller)?;
         let callee = unfold(callee)?;
-        // Not-quite-so-fast path: if the types are equal now, they are compatible.
-        if caller.ty == callee.ty {
+        // Not-quite-so-fast path: if the types are c-equal now, they are compatible.
+        // FIXME: This is *not* currently guaranteed by our ABI compatibility docs, but it is needed
+        // for Miri itself when it checks whether shims were called with the right arguments.
+        // We should eventually put this into the docs as well.
+        if self.identical_c_types(caller.ty, callee.ty) {
             return interp_ok(true);
         }
         // Now see if these inner types are compatible.

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -71,6 +71,7 @@ pub enum VarArgCompatible {
     /// `T` and `U` are definitely not compatible.
     Incompatible,
     /// `T` and `U` are corresponding signed and unsigned integer types.
+    /// This is compatible only if the value can be represented in both types.
     CastIntTo { source_is_signed: bool },
 }
 
@@ -817,7 +818,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     /// integers of the same size but different signedness, the passed value must be representable
     /// in both types.
     fn validate_c_variadic_argument(
-        &mut self,
+        &self,
         arg_mplace: &MPlaceTy<'tcx, M::Provenance>,
         callee_type: TyAndLayout<'tcx>,
     ) -> InterpResult<'tcx> {
@@ -866,8 +867,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     /// - `T` and `U` are both pointers, and their target types are compatible.
     /// - `T` is a pointer to [`std::ffi::c_void`] and `U` is a pointer to [`i8`] or [`u8`],
     /// or vice versa.
+    ///
+    /// This is designed to match the C rules for variadics, it is incomparable to what we allow in
+    /// terms of ABI mismatches for regular (fixed) function arguments.
     pub fn validate_c_variadic_compatible_ty(
-        &mut self,
+        &self,
         caller_type: Ty<'tcx>,
         callee_type: Ty<'tcx>,
     ) -> InterpResult<'tcx, VarArgCompatible> {
@@ -884,7 +888,21 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let is_c_char = |ty: Ty<'_>| matches!(ty.kind(), ty::Uint(UintTy::U8) | ty::Int(IntTy::I8));
 
         match (caller_type.kind(), callee_type.kind()) {
-            (ty::RawPtr(caller_target_ty, _), ty::RawPtr(callee_target_ty, _)) => {
+            // Some types look different but are actually the same for ABI purposes.
+            (ty::Int(_), ty::Int(_)) | (ty::Uint(_), ty::Uint(_)) => {
+                // E.g. cast between `usize` and `u64` on a 64-bit platform.
+                interp_ok(VarArgCompatible::Compatible)
+            }
+            // C allows different types if...
+            // - "both types are pointers to qualified or unqualified versions of compatible types"
+            // - "one type is pointer to qualified or unqualified void and the other is a pointer to a qualified or
+            //   unqualified character type"
+            //
+            // As usual for the ABI, we treat references and raw pointers alike.
+            (
+                ty::RawPtr(caller_target_ty, _) | ty::Ref(_, caller_target_ty, _),
+                ty::RawPtr(callee_target_ty, _) | ty::Ref(_, callee_target_ty, _),
+            ) => {
                 // In C, types can be qualified by a combination of `const`, `volatile` and
                 // `restrict`. These properties are irrelevant for the ABI, and don't have an
                 // equivalent in rust.
@@ -910,16 +928,58 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     }
                 }
             }
+            // - "one type is a signed integer type, the other type is the corresponding unsigned integer type,
+            //   and the value is representable in both types"
             (ty::Int(_), ty::Uint(_)) => {
                 interp_ok(VarArgCompatible::CastIntTo { source_is_signed: true })
             }
             (ty::Uint(_), ty::Int(_)) => {
                 interp_ok(VarArgCompatible::CastIntTo { source_is_signed: false })
             }
-            (ty::Int(_), ty::Int(_)) | (ty::Uint(_), ty::Uint(_)) => {
-                // E.g. cast between `usize` and `u64` on a 64-bit platform.
-                interp_ok(VarArgCompatible::Compatible)
+            // - "or, the type of the next argument is nullptr_t and type is a pointer type that has the same
+            //   representation and alignment requirements as a pointer to a character type"
+            //   This one does not have an equivalent form in Rust.
+
+            // C also considers two structs to be the same if they have the same name and the same
+            // fields. We need a similar rules that that e.g. if caller and callee use the "same"
+            // type from two different versions of the same crate, that call is accepted.
+            (ty::Adt(caller_adt, caller_args), ty::Adt(callee_adt, callee_args))
+                if (caller_adt.is_struct() && callee_adt.is_struct())
+                    && (caller_adt.repr().c() && callee_adt.repr().c())
+                    && (self.tcx.item_name(caller_adt.did())
+                        == self.tcx.item_name(callee_adt.did())) =>
+            {
+                let caller_fields = &caller_adt.non_enum_variant().fields;
+                let callee_fields = &callee_adt.non_enum_variant().fields;
+                if caller_fields.len() == callee_fields.len()
+                    && caller_fields.iter().zip(callee_fields).try_fold(
+                        true,
+                        |acc, (caller_field, callee_field)| {
+                            if !acc {
+                                return interp_ok(false);
+                            }
+                            if caller_field.name != callee_field.name {
+                                return interp_ok(false);
+                            }
+                            let caller_ty = caller_field.ty(*self.tcx, caller_args);
+                            let caller_ty =
+                                self.tcx.normalize_erasing_regions(self.typing_env, caller_ty);
+                            let callee_ty = callee_field.ty(*self.tcx, callee_args);
+                            let callee_ty =
+                                self.tcx.normalize_erasing_regions(self.typing_env, callee_ty);
+                            interp_ok(matches!(
+                                self.validate_c_variadic_compatible_ty(caller_ty, callee_ty)?,
+                                VarArgCompatible::Compatible
+                            ))
+                        },
+                    )?
+                {
+                    interp_ok(VarArgCompatible::Compatible)
+                } else {
+                    interp_ok(VarArgCompatible::Incompatible)
+                }
             }
+
             _ => interp_ok(VarArgCompatible::Incompatible),
         }
     }

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -825,11 +825,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let callee_ty = callee_type.ty;
         let caller_ty = arg_mplace.layout.ty;
 
-        // Identical types are clearly compatible.
-        if caller_ty == callee_ty {
-            return interp_ok(());
-        }
-
         match self.validate_c_variadic_compatible_ty(arg_mplace.layout.ty, callee_type.ty)? {
             VarArgCompatible::Compatible => interp_ok(()),
             VarArgCompatible::Incompatible => throw_ub_format!(
@@ -875,7 +870,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         caller_type: Ty<'tcx>,
         callee_type: Ty<'tcx>,
     ) -> InterpResult<'tcx, VarArgCompatible> {
-        if caller_type == callee_type {
+        // FIXME: Accepting two copies of the same repr(C) type as compatible is currently not
+        // guaranteed by our `VaList::next_arg` docs, but it is needed for Miri itself when it
+        // checks whether shims were called with the right arguments. We should eventually put this
+        // into the docs as well.
+        if self.identical_c_types(caller_type, callee_type) {
             return interp_ok(VarArgCompatible::Compatible);
         }
 
@@ -939,47 +938,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             // - "or, the type of the next argument is nullptr_t and type is a pointer type that has the same
             //   representation and alignment requirements as a pointer to a character type"
             //   This one does not have an equivalent form in Rust.
-
-            // C also considers two structs to be the same if they have the same name and the same
-            // fields. We need a similar rules that that e.g. if caller and callee use the "same"
-            // type from two different versions of the same crate, that call is accepted.
-            (ty::Adt(caller_adt, caller_args), ty::Adt(callee_adt, callee_args))
-                if (caller_adt.is_struct() && callee_adt.is_struct())
-                    && (caller_adt.repr().c() && callee_adt.repr().c())
-                    && (self.tcx.item_name(caller_adt.did())
-                        == self.tcx.item_name(callee_adt.did())) =>
-            {
-                let caller_fields = &caller_adt.non_enum_variant().fields;
-                let callee_fields = &callee_adt.non_enum_variant().fields;
-                if caller_fields.len() == callee_fields.len()
-                    && caller_fields.iter().zip(callee_fields).try_fold(
-                        true,
-                        |acc, (caller_field, callee_field)| {
-                            if !acc {
-                                return interp_ok(false);
-                            }
-                            if caller_field.name != callee_field.name {
-                                return interp_ok(false);
-                            }
-                            let caller_ty = caller_field.ty(*self.tcx, caller_args);
-                            let caller_ty =
-                                self.tcx.normalize_erasing_regions(self.typing_env, caller_ty);
-                            let callee_ty = callee_field.ty(*self.tcx, callee_args);
-                            let callee_ty =
-                                self.tcx.normalize_erasing_regions(self.typing_env, callee_ty);
-                            interp_ok(matches!(
-                                self.validate_c_variadic_compatible_ty(caller_ty, callee_ty)?,
-                                VarArgCompatible::Compatible
-                            ))
-                        },
-                    )?
-                {
-                    interp_ok(VarArgCompatible::Compatible)
-                } else {
-                    interp_ok(VarArgCompatible::Incompatible)
-                }
-            }
-
             _ => interp_ok(VarArgCompatible::Incompatible),
         }
     }

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -418,7 +418,7 @@ pub enum UndefinedBehaviorInfo<'tcx> {
     InvalidNichedEnumVariantWritten { enum_ty: Ty<'tcx> },
     /// ABI-incompatible argument types.
     AbiMismatchArgument {
-        /// The index of the argument whose type is wrong.
+        /// The index of the argument whose type is wrong (starting at index 0).
         arg_idx: usize,
         caller_ty: Ty<'tcx>,
         callee_ty: Ty<'tcx>,

--- a/library/std/src/sys/sync/futex/unix.rs
+++ b/library/std/src/sys/sync/futex/unix.rs
@@ -62,7 +62,7 @@ pub fn futex_wait(futex: &Atomic<u32>, expected: u32, timeout: Option<Duration>)
                     // absolute time rather than a relative time.
                     libc::syscall(
                         libc::SYS_futex,
-                        futex as *const Atomic<u32>,
+                        futex as *const Atomic<u32> as *const u32,
                         libc::FUTEX_WAIT_BITSET | libc::FUTEX_PRIVATE_FLAG,
                         expected,
                         timespec.as_ref().map_or(null(), |t| t as *const libc::timespec),
@@ -92,7 +92,7 @@ pub fn futex_wait(futex: &Atomic<u32>, expected: u32, timeout: Option<Duration>)
 /// On some platforms, this always returns false.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn futex_wake(futex: &Atomic<u32>) -> bool {
-    let ptr = futex as *const Atomic<u32>;
+    let ptr = futex as *const Atomic<u32> as *const u32;
     let op = libc::FUTEX_WAKE | libc::FUTEX_PRIVATE_FLAG;
     unsafe { libc::syscall(libc::SYS_futex, ptr, op, 1) > 0 }
 }
@@ -100,7 +100,7 @@ pub fn futex_wake(futex: &Atomic<u32>) -> bool {
 /// Wakes up all threads that are waiting on `futex_wait` on this futex.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn futex_wake_all(futex: &Atomic<u32>) {
-    let ptr = futex as *const Atomic<u32>;
+    let ptr = futex as *const Atomic<u32> as *const u32;
     let op = libc::FUTEX_WAKE | libc::FUTEX_PRIVATE_FLAG;
     unsafe {
         libc::syscall(libc::SYS_futex, ptr, op, i32::MAX);

--- a/src/tools/miri/src/shims/sig.rs
+++ b/src/tools/miri/src/shims/sig.rs
@@ -150,8 +150,18 @@ macro_rules! shim_sig_arg {
         $this.tcx.types.bool
     };
     ($this:ident, *_) => {
+        // Pointee types usually don't matter so we allow it to be omitted.
         // Mutability does not matter for ABI.
         $this.machine.layouts.mut_raw_ptr.ty
+    };
+    ($this:ident, *$($ty:tt)*) => {
+        // Pointee types matter for varargs so we support explicitly giving them.
+        // Mutability does not matter for ABI.
+        rustc_middle::ty::Ty::new_ptr(
+            *$this.tcx,
+            shim_sig_arg!($this, $($ty)*),
+            rustc_middle::mir::Mutability::Mut,
+        )
     };
     ($this:ident, fn(..) -> _) => {
         // We currently treat fn ptrs as ABI-compatible with data ptrs so we can just use a raw ptr.
@@ -208,12 +218,12 @@ fn check_shim_abi<'tcx>(
 
     if caller_abi.c_variadic && !callee_abi.c_variadic {
         throw_ub_format!(
-            "ABI mismatch: `{link_name}` is a non-variadic function, but the caller is using a variadic signature"
+            "ABI mismatch: `{link_name}` is a non-variadic function, but the caller is using a c-variadic signature"
         );
     }
     if !caller_abi.c_variadic && callee_abi.c_variadic {
         throw_ub_format!(
-            "ABI mismatch: `{link_name}` is a variadic function, but the caller is using a non-variadic signature"
+            "ABI mismatch: `{link_name}` is a c-variadic function, but the caller is using a non-variadic signature"
         );
     }
 
@@ -254,7 +264,7 @@ fn check_shim_abi<'tcx>(
 // Deliberately not `Copy` so that we don't consume the same vararg multiple times accidentally.
 pub struct Varargs<'tcx, 'a> {
     args: &'a [OpTy<'tcx>],
-    /// Number of variadic arguments that have already been taken, for error messages.
+    /// Number of arguments (variadic and fixed) that have already been taken, for error messages.
     already_gone: usize,
 }
 
@@ -299,7 +309,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         }
         if abi.c_variadic {
             throw_ub_format!(
-                "calling a non-variadic function with a variadic caller-side signature"
+                "calling a non-variadic function with a c-variadic caller-side signature"
             );
         }
 
@@ -360,7 +370,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         // Return arguments.
         if let Some((fixed, var)) = caller_args.split_first_chunk() {
-            return interp_ok((fixed, Varargs { args: var, already_gone: 0 }));
+            return interp_ok((fixed, Varargs { args: var, already_gone: N }));
         }
         unreachable!()
     }
@@ -378,20 +388,45 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         let Some((now, tail)) = varargs.args.split_first_chunk::<N>() else {
             throw_ub_format!(
-                "not enough variadic arguments for `{fn_name}`: got {}, expected at least {}",
+                "not enough arguments for `{fn_name}`: got {}, expected at least {}",
                 varargs.already_gone.strict_add(varargs.args.len()),
                 varargs.already_gone.strict_add(N),
             )
         };
 
         for (n, (caller_gave, callee_expected)) in now.iter().zip(tys).enumerate() {
-            // Check ABI compatibility. This is less strict than `next_arg` but we're also
-            // not limited to just a few simple types.
-            let callee_expected = this.layout_of(callee_expected)?;
-
-            // FIXME: check compatibility once <https://github.com/rust-lang/rust/pull/161615>
-            // landed.
-            let _unused = (n, caller_gave, callee_expected);
+            // Check ABI compatibility.
+            let compatible =
+                this.validate_c_variadic_compatible_ty(caller_gave.layout.ty, callee_expected)?;
+            match compatible {
+                VarArgCompatible::Compatible => {}
+                VarArgCompatible::Incompatible => {
+                    throw_ub_format!(
+                        "incorrect c-variadic argument type for `{fn_name}`: \
+                        expected argument #{n} to have type `{callee_expected}` but got incompatible type `{caller_ty}`",
+                        n = varargs.already_gone.strict_add(n).strict_add(1),
+                        caller_ty = caller_gave.layout.ty,
+                    );
+                }
+                VarArgCompatible::CastIntTo { source_is_signed } => {
+                    // Check that the value can be represented in the target type.
+                    let size = caller_gave.layout.size;
+                    let scalar = this.read_scalar(caller_gave)?;
+                    if scalar.to_int(size)? < 0 {
+                        throw_ub_format!(
+                            "incorrect c-variadic argument type for `{fn_name}`: \
+                            argument #{n} has value `{value}_{caller_ty}` which cannot be represented in expected type `{callee_expected}`",
+                            n = varargs.already_gone.strict_add(n).strict_add(1),
+                            caller_ty = caller_gave.layout.ty,
+                            value = if source_is_signed {
+                                scalar.to_int(size)?.to_string()
+                            } else {
+                                scalar.to_uint(size)?.to_string()
+                            }
+                        )
+                    }
+                }
+            }
         }
 
         interp_ok((now, Varargs { args: tail, already_gone: varargs.already_gone.strict_add(N) }))

--- a/src/tools/miri/src/shims/unix/fs.rs
+++ b/src/tools/miri/src/shims/unix/fs.rs
@@ -460,11 +460,16 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let o_creat = this.eval_libc_i32("O_CREAT");
         if flag & o_creat == o_creat {
             flag &= !o_creat;
-            // Get the mode.  On macOS, the argument type `mode_t` is actually `u16`, but
-            // C integer promotion rules mean that on the ABI level, it gets passed as `u32`
-            // (see https://github.com/rust-lang/rust/issues/71915).
+            // Get the mode.
             let ([mode], _) = this.check_varargs(
-                shim_varargs![libc::mode_t],
+                if this.libc_ty_layout("mode_t").size.bytes() >= 4 {
+                    // `mode_t` is big enough, no C integer promotion.
+                    shim_varargs![libc::mode_t]
+                } else {
+                    // Types smaller than int get promoted to int
+                    // (see https://github.com/rust-lang/rust/issues/71915).
+                    shim_varargs![i32]
+                },
                 varargs,
                 "open(pathname, O_CREAT, ...)",
             )?;

--- a/src/tools/miri/src/shims/unix/linux_like/sync.rs
+++ b/src/tools/miri/src/shims/unix/linux_like/sync.rs
@@ -16,7 +16,7 @@ pub fn futex<'tcx>(
     dest: &MPlaceTy<'tcx>,
 ) -> InterpResult<'tcx> {
     let ([addr, op, val], varargs) =
-        ecx.check_varargs(shim_varargs![*_, i32, u32], varargs, "syscall(SYS_futex, ...)")?;
+        ecx.check_varargs(shim_varargs![*u32, i32, u32], varargs, "syscall(SYS_futex, ...)")?;
 
     // See <https://man7.org/linux/man-pages/man2/futex.2.html> for docs.
     // The first three arguments (after the syscall number itself) are the same to all futex operations:
@@ -52,7 +52,7 @@ pub fn futex<'tcx>(
 
             let (timeout, bitset) = if wait_bitset {
                 let ([timeout, uaddr2, bitset], _) = ecx.check_varargs(
-                    shim_varargs![*_, *_, u32],
+                    shim_varargs![*libc::timespec, *u32, u32],
                     varargs,
                     "syscall(SYS_futex, ...)",
                 )?;
@@ -62,8 +62,11 @@ pub fn futex<'tcx>(
                 }
                 (timeout, ecx.read_scalar(bitset)?.to_u32()?)
             } else {
-                let ([timeout], _) =
-                    ecx.check_varargs(shim_varargs![*_], varargs, "syscall(SYS_futex, ...)")?;
+                let ([timeout], _) = ecx.check_varargs(
+                    shim_varargs![*libc::timespec],
+                    varargs,
+                    "syscall(SYS_futex, ...)",
+                )?;
                 (timeout, u32::MAX)
             };
 
@@ -199,7 +202,7 @@ pub fn futex<'tcx>(
 
             let bitset = if op == futex_wake_bitset {
                 let ([timeout, uaddr2, bitset], _) = ecx.check_varargs(
-                    shim_varargs![*_, *_, u32],
+                    shim_varargs![*libc::timespec, *u32, u32],
                     varargs,
                     "syscall(SYS_futex, ...)",
                 )?;

--- a/src/tools/miri/src/shims/unix/linux_like/syscall.rs
+++ b/src/tools/miri/src/shims/unix/linux_like/syscall.rs
@@ -37,7 +37,7 @@ pub fn syscall<'tcx>(
             // Used by getrandom 0.1
             // The first argument is the syscall id, so skip over it.
             let ([ptr, len, flags], _) = ecx.check_varargs(
-                shim_varargs![*_, usize, i32],
+                shim_varargs![*libc::c_void, usize, i32],
                 varargs,
                 "syscall(SYS_getrandom, ...)",
             )?;
@@ -70,7 +70,7 @@ pub fn syscall<'tcx>(
         num if num == sys_accept4 => {
             // Used on Android.
             let ([socket, address, address_len, flags], _) = ecx.check_varargs(
-                shim_varargs![i32, *_, *_, i32],
+                shim_varargs![i32, *libc::sockaddr, *libc::socklen_t, i32],
                 varargs,
                 "syscall(SYS_accept4, ...)",
             )?;

--- a/src/tools/miri/src/shims/unix/linux_like/thread.rs
+++ b/src/tools/miri/src/shims/unix/linux_like/thread.rs
@@ -26,7 +26,7 @@ pub fn prctl<'tcx>(
     let res = match ecx.read_scalar(op)?.to_i32()? {
         op if op == pr_set_name => {
             let ([name], _) =
-                ecx.check_varargs(shim_varargs![*_], varargs, "prctl(PR_SET_NAME, ...)")?;
+                ecx.check_varargs(shim_varargs![*libc::c_char], varargs, "prctl(PR_SET_NAME, ...)")?;
 
             let name = ecx.read_scalar(name)?;
             let thread = ecx.pthread_self()?;
@@ -39,7 +39,7 @@ pub fn prctl<'tcx>(
         }
         op if op == pr_get_name => {
             let ([name], _) =
-                ecx.check_varargs(shim_varargs![*_], varargs, "prctl(PR_GET_NAME, ...)")?;
+                ecx.check_varargs(shim_varargs![*libc::c_char], varargs, "prctl(PR_GET_NAME, ...)")?;
 
             let name = ecx.read_scalar(name)?;
             let thread = ecx.pthread_self()?;

--- a/src/tools/miri/src/shims/unix/tcp_socket.rs
+++ b/src/tools/miri/src/shims/unix/tcp_socket.rs
@@ -208,7 +208,7 @@ impl UnixFileDescription for TcpSocket {
                 );
             }
 
-            let ([value_ptr], _) = ecx.check_varargs(shim_varargs![*_], args, "ioctl")?;
+            let ([value_ptr], _) = ecx.check_varargs(shim_varargs![*i32], args, "ioctl")?;
             let value = ecx.deref_pointer_as(value_ptr, ecx.machine.layouts.i32)?;
             let non_block = ecx.read_scalar(&value)?.to_i32()? != 0;
             self.is_non_block.set(non_block);

--- a/src/tools/miri/src/shims/unix/virtual_socket.rs
+++ b/src/tools/miri/src/shims/unix/virtual_socket.rs
@@ -291,7 +291,7 @@ impl UnixFileDescription for VirtualSocket {
                 );
             }
 
-            let ([value_ptr], _) = ecx.check_varargs(shim_varargs![*_], args, "ioctl")?;
+            let ([value_ptr], _) = ecx.check_varargs(shim_varargs![*i32], args, "ioctl")?;
             let value = ecx.deref_pointer_as(value_ptr, ecx.machine.layouts.i32)?;
             let non_block = ecx.read_scalar(&value)?.to_i32()? != 0;
             self.is_nonblock.set(non_block);

--- a/src/tools/miri/tests/fail-dep/libc/fs/unix_open_missing_required_mode.rs
+++ b/src/tools/miri/tests/fail-dep/libc/fs/unix_open_missing_required_mode.rs
@@ -7,5 +7,5 @@ fn main() {
 
 fn test_file_open_missing_needed_mode() {
     let name = c"missing_arg.txt".as_ptr();
-    let _fd = unsafe { libc::open(name, libc::O_CREAT) }; //~ ERROR: Undefined Behavior: not enough variadic arguments
+    let _fd = unsafe { libc::open(name, libc::O_CREAT) }; //~ ERROR: /Undefined Behavior: not enough arguments.*: got 2/
 }

--- a/src/tools/miri/tests/fail-dep/libc/fs/unix_open_missing_required_mode.stderr
+++ b/src/tools/miri/tests/fail-dep/libc/fs/unix_open_missing_required_mode.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: not enough variadic arguments for `open(pathname, O_CREAT, ...)`: got 0, expected at least 1
+error: Undefined Behavior: not enough arguments for `open(pathname, O_CREAT, ...)`: got 2, expected at least 3
   --> tests/fail-dep/libc/fs/unix_open_missing_required_mode.rs:LL:CC
    |
 LL |     let _fd = unsafe { libc::open(name, libc::O_CREAT) };

--- a/src/tools/miri/tests/fail-dep/libc/open_wrong_var_arg_type.rs
+++ b/src/tools/miri/tests/fail-dep/libc/open_wrong_var_arg_type.rs
@@ -1,20 +1,18 @@
 //@ignore-target: windows # File handling is not implemented yet
 //@compile-flags: -Zmiri-disable-isolation
+//@normalize-stderr-test: "to have type `(u32|i32)`" -> "to have type `$$TYPE`"
 
 #![allow(invalid_runtime_symbol_definitions)]
 
-use std::ffi::{CString, OsStr, c_char, c_int};
+use std::ffi::{CString, OsStr};
 use std::os::unix::ffi::OsStrExt;
 
-// Declare a variadic function as non-variadic.
-extern "C" {
-    fn open(path: *const c_char, oflag: c_int) -> c_int;
-}
+use libc::open;
 
 fn main() {
     let c_path = CString::new(OsStr::new("./text").as_bytes()).expect("CString::new failed");
     let _fd = unsafe {
-        open(c_path.as_ptr(), /* value does not matter */ 0)
-        //~^ ERROR: is a variadic function, but the caller is using a non-variadic signature
+        open(c_path.as_ptr(), libc::O_CREAT, /* should be mode_t */ 0u64)
+        //~^ ERROR: /expected argument #3 to have type `(u32|i32)` but got incompatible type `u64`/
     };
 }

--- a/src/tools/miri/tests/fail-dep/libc/open_wrong_var_arg_type.stderr
+++ b/src/tools/miri/tests/fail-dep/libc/open_wrong_var_arg_type.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: incorrect c-variadic argument type for `open(pathname, O_CREAT, ...)`: expected argument #3 to have type `$TYPE` but got incompatible type `u64`
+  --> tests/fail-dep/libc/open_wrong_var_arg_type.rs:LL:CC
+   |
+LL |         open(c_path.as_ptr(), libc::O_CREAT, /* should be mode_t */ 0u64)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/src/tools/miri/tests/fail/function_calls/not_the_same_c_type.rs
+++ b/src/tools/miri/tests/fail/function_calls/not_the_same_c_type.rs
@@ -1,0 +1,23 @@
+mod somewhere_else {
+    #[repr(C)]
+    struct CType {
+        field: i32,
+    }
+
+    #[unsafe(no_mangle)]
+    extern "C" fn work_with_c_type(_x: CType) {}
+    //~^ERROR: parameter #1 has type somewhere_else::CType passing argument of type CType
+}
+
+// Imagine we import the function from above but we end up with a copy of the type declaration.
+// We only accept this if the types are *exactly* the name, including the names of all fields.
+#[repr(C)]
+struct CType(i32);
+
+extern "C" {
+    fn work_with_c_type(_x: CType);
+}
+
+fn main() {
+    unsafe { work_with_c_type(CType(0)) };
+}

--- a/src/tools/miri/tests/fail/function_calls/not_the_same_c_type.stderr
+++ b/src/tools/miri/tests/fail/function_calls/not_the_same_c_type.stderr
@@ -1,0 +1,20 @@
+error: Undefined Behavior: calling a function whose parameter #1 has type somewhere_else::CType passing argument of type CType
+  --> tests/fail/function_calls/not_the_same_c_type.rs:LL:CC
+   |
+LL |     extern "C" fn work_with_c_type(_x: CType) {}
+   |                                    ^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
+   = help: if you think this code should be accepted anyway, please report an issue with Miri
+   = note: stack backtrace:
+           0: somewhere_else::work_with_c_type
+               at tests/fail/function_calls/not_the_same_c_type.rs:LL:CC
+           1: main
+               at tests/fail/function_calls/not_the_same_c_type.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/src/tools/miri/tests/fail/shims/vararg_callee_signature_mismatch.rs
+++ b/src/tools/miri/tests/fail/shims/vararg_callee_signature_mismatch.rs
@@ -1,0 +1,20 @@
+//@ignore-target: windows # File handling is not implemented yet
+//@compile-flags: -Zmiri-disable-isolation
+
+#![allow(invalid_runtime_symbol_definitions)]
+
+use std::ffi::{CString, OsStr, c_char, c_int};
+use std::os::unix::ffi::OsStrExt;
+
+// Declare a variadic function as non-variadic.
+extern "C" {
+    fn open(path: *const c_char, oflag: c_int) -> c_int;
+}
+
+fn main() {
+    let c_path = CString::new(OsStr::new("./text").as_bytes()).expect("CString::new failed");
+    let _fd = unsafe {
+        open(c_path.as_ptr(), /* value does not matter */ 0)
+        //~^ ERROR: is a c-variadic function, but the caller is using a non-variadic signature
+    };
+}

--- a/src/tools/miri/tests/fail/shims/vararg_callee_signature_mismatch.stderr
+++ b/src/tools/miri/tests/fail/shims/vararg_callee_signature_mismatch.stderr
@@ -1,5 +1,5 @@
-error: Undefined Behavior: ABI mismatch: `open` is a variadic function, but the caller is using a non-variadic signature
-  --> tests/fail/shims/non_vararg_signature_mismatch.rs:LL:CC
+error: Undefined Behavior: ABI mismatch: `open` is a c-variadic function, but the caller is using a non-variadic signature
+  --> tests/fail/shims/vararg_callee_signature_mismatch.rs:LL:CC
    |
 LL |         open(c_path.as_ptr(), /* value does not matter */ 0)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here

--- a/src/tools/miri/tests/fail/shims/vararg_caller_signature_mismatch.rs
+++ b/src/tools/miri/tests/fail/shims/vararg_caller_signature_mismatch.rs
@@ -9,6 +9,6 @@ extern "C" {
 fn main() {
     let mut fds = [-1, -1];
     let res = unsafe { pipe(fds.as_mut_ptr()) };
-    //~^ ERROR: is a non-variadic function, but the caller is using a variadic signature
+    //~^ ERROR: is a non-variadic function, but the caller is using a c-variadic signature
     assert_eq!(res, 0);
 }

--- a/src/tools/miri/tests/fail/shims/vararg_caller_signature_mismatch.stderr
+++ b/src/tools/miri/tests/fail/shims/vararg_caller_signature_mismatch.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: ABI mismatch: `pipe` is a non-variadic function, but the caller is using a variadic signature
+error: Undefined Behavior: ABI mismatch: `pipe` is a non-variadic function, but the caller is using a c-variadic signature
   --> tests/fail/shims/vararg_caller_signature_mismatch.rs:LL:CC
    |
 LL |     let res = unsafe { pipe(fds.as_mut_ptr()) };

--- a/src/tools/miri/tests/pass-dep/concurrency/linux-futex.rs
+++ b/src/tools/miri/tests/pass-dep/concurrency/linux-futex.rs
@@ -42,7 +42,7 @@ fn wake_nobody() {
 
 fn wake_dangling() {
     let futex = Box::new(0);
-    let ptr: *const i32 = &*futex;
+    let ptr: *const u32 = &*futex;
     drop(futex);
 
     // Expect error since this is now "unmapped" memory.
@@ -55,7 +55,7 @@ fn wake_dangling() {
 }
 
 fn wait_wrong_val() {
-    let futex: i32 = 123;
+    let futex: u32 = 123;
 
     // Only wait if the futex value is 456.
     unsafe {
@@ -76,7 +76,7 @@ fn wait_wrong_val() {
 fn wait_timeout() {
     let start = Instant::now();
 
-    let futex: i32 = 123;
+    let futex: u32 = 123;
 
     // Wait for 100ms, with nobody waking us up early.
     unsafe {
@@ -120,12 +120,12 @@ fn wait_absolute_timeout() {
         assert_eq!(
             libc::syscall(
                 libc::SYS_futex,
-                addr_of!(FUTEX),
-                libc::FUTEX_WAIT_BITSET,
-                123,
+                addr_of!(FUTEX),         // uaddr
+                libc::FUTEX_WAIT_BITSET, // op
+                123,                     // val
                 &timeout,
-                0usize,
-                u32::MAX,
+                ptr::null::<u32>(), // uaddr2
+                u32::MAX,           // val3 (bitset)
             ),
             -1,
         );
@@ -181,12 +181,12 @@ fn wait_wake_bitset() {
             assert_eq!(
                 libc::syscall(
                     libc::SYS_futex,
-                    addr_of!(FUTEX),
-                    libc::FUTEX_WAKE_BITSET,
-                    10, // Wake up at most 10 threads.
+                    addr_of!(FUTEX),         // uaddr
+                    libc::FUTEX_WAKE_BITSET, // op
+                    10,                      // val (max wake up count)
                     ptr::null::<libc::timespec>(),
-                    0usize,
-                    0b1001, // bitset
+                    ptr::null::<u32>(), // uaddr2
+                    0b1001,             // val3 (bitset)
                 ),
                 0, // Didn't match any thread.
             );
@@ -196,12 +196,12 @@ fn wait_wake_bitset() {
             assert_eq!(
                 libc::syscall(
                     libc::SYS_futex,
-                    addr_of!(FUTEX),
-                    libc::FUTEX_WAKE_BITSET,
-                    10, // Wake up at most 10 threads.
+                    addr_of!(FUTEX),         // uaddr
+                    libc::FUTEX_WAKE_BITSET, // op
+                    10,                      // val (max wake up count)
                     ptr::null::<libc::timespec>(),
-                    0usize,
-                    0b0110, // bitset
+                    ptr::null::<u32>(), // uaddr2
+                    0b0110,             // val3 (bitset)
                 ),
                 1, // Woken up one thread.
             );
@@ -214,12 +214,12 @@ fn wait_wake_bitset() {
         assert_eq!(
             libc::syscall(
                 libc::SYS_futex,
-                addr_of!(FUTEX),
-                libc::FUTEX_WAIT_BITSET,
-                0,
+                addr_of!(FUTEX),         // uaddr
+                libc::FUTEX_WAIT_BITSET, // op
+                0,                       // val
                 ptr::null::<libc::timespec>(),
-                0usize,
-                0b0100, // bitset
+                ptr::null::<u32>(), // uaddr2
+                0b0100,             // val3 (bitset)
             ),
             0,
         );
@@ -255,7 +255,7 @@ fn concurrent_wait_wake() {
             unsafe {
                 let ret = libc::syscall(
                     libc::SYS_futex,
-                    addr_of!(FUTEX),
+                    addr_of!(FUTEX).cast::<u32>(),
                     libc::FUTEX_WAIT,
                     HELD,
                     ptr::null::<libc::timespec>(),
@@ -277,7 +277,7 @@ fn concurrent_wait_wake() {
         FUTEX.store(FREE, Ordering::Relaxed);
         unsafe {
             DATA = 1;
-            libc::syscall(libc::SYS_futex, addr_of!(FUTEX), libc::FUTEX_WAKE, 1);
+            libc::syscall(libc::SYS_futex, addr_of!(FUTEX).cast::<u32>(), libc::FUTEX_WAKE, 1);
         }
 
         t.join().unwrap();

--- a/src/tools/miri/tests/pass/function_calls/exported_symbol.rs
+++ b/src/tools/miri/tests/pass/function_calls/exported_symbol.rs
@@ -24,6 +24,25 @@ impl AssocFn {
     }
 }
 
+mod somewhere_else {
+    #[repr(C)]
+    struct CType {
+        field: i32,
+    }
+
+    #[unsafe(no_mangle)]
+    extern "C" fn work_with_c_type(_x: CType) {}
+}
+
+// Imagine we import the function from above but we end up with a copy of the type declaration.
+#[repr(C)]
+struct CType {
+    field: i32,
+}
+extern "C" {
+    fn work_with_c_type(_x: CType);
+}
+
 fn main() {
     // Repeat calls to make sure the `Instance` cache is not broken.
     for _ in 0..3 {
@@ -77,5 +96,7 @@ fn main() {
                 assert_eq!(transmute(qux)(), -4);
             }
         }
+
+        unsafe { work_with_c_type(CType { field: 0 }) };
     }
 }


### PR DESCRIPTION
This adds proper type checks for c-variadic argument handling in Miri shims. So far we would have ICEd for many type mismatches since the innards of the interpreter generally assume that things are well-typed. The checks we are using are the same as for [`next_arg`](https://doc.rust-lang.org/nightly/std/ffi/struct.VaList.html#method.next_arg).

This uncovered some interesting points:
-  We should accept `&mut` as equivalent to `*mut`. We don't allow `&mut` as a type in `next_arg` but we do allow it for c-variadic calls, so this change also affects a bit more code in const-eval (if the caller passes an `&mut` and the callee expects a `*mut`). Even CFI is okay with treating `&mut` and `*mut` as equivalent so this should be fine. Cc @folkertdev 
- Some places in the standard library futex handling used types for their variadic arguments that are not quite correct according to these rules. I fixed those. Cc @m-ou-se
- One variadic function takes pointers to `libc::timespec`. A program with a libc dependency has two copies of libc (one in the sysroot, and the normal dependency). When Miri looks up the expected argument type, it picks one of them, leading to Miri seeing a type mismatch when there is a call using the other copy. C generally considers two copies of the same type to be identical, so I implemented logic that does the same: two `repr(C)` types are "identical" if the names of the types, and the names and types of all fields, are identical. I then also used that logic for the normal ABI checks, where it will also help since we had similar trouble there in the past (that we had to find other work-arounds for).