### PR TITLE
Add performance notes for the floating-point round method

### DIFF
--- a/library/std/src/num/f32.rs
+++ b/library/std/src/num/f32.rs
@@ -80,6 +80,11 @@ impl f32 {
     ///
     /// This function always returns the precise result.
     ///
+    /// On most hardware platforms, [`round_ties_even`](Self::round_ties_even) may execute faster
+    /// than `round`. If both rounding methods fit the use case, consider using `round_ties_even`.
+    /// Note that the two methods apply different rounding rules to values exactly halfway between
+    /// two integers.
+    ///
     /// # Examples
     ///
     /// ```

--- a/library/std/src/num/f64.rs
+++ b/library/std/src/num/f64.rs
@@ -80,6 +80,11 @@ impl f64 {
     ///
     /// This function always returns the precise result.
     ///
+    /// On most hardware platforms, [`round_ties_even`](Self::round_ties_even) may execute faster
+    /// than `round`. If both rounding methods fit the use case, consider using `round_ties_even`.
+    /// Note that the two methods apply different rounding rules to values exactly halfway between
+    /// two integers.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
This update has revised the documentation for f32::round and f64::round, stating that round_ties_even typically offers better performance on most hardware platforms, and reminding readers that the rounding rules at the midpoint are different for the two methods. This update addresses the unfinished documentation task in issue rust-lang/rust#55107.