### PR TITLE
Remove `RawDefPathHash`

### DIFF
--- a/compiler/rustc_data_structures/src/stable_hash.rs
+++ b/compiler/rustc_data_structures/src/stable_hash.rs
@@ -8,6 +8,8 @@ use rustc_index::{Idx, IndexSlice, IndexVec};
 use smallvec::SmallVec;
 use thin_vec::ThinVec;
 
+use crate::fingerprint::Fingerprint;
+
 #[cfg(test)]
 mod tests;
 
@@ -24,8 +26,8 @@ pub trait StableHashCtxt {
     /// The main event: stable hashing of a span.
     fn stable_hash_span(&mut self, span: RawSpan, hasher: &mut StableHasher);
 
-    /// Compute a `DefPathHash`.
-    fn def_path_hash(&self, def_id: RawDefId) -> RawDefPathHash;
+    /// Compute a `Fingerprint`, which can be trivially turned into a `DefPathHash`.
+    fn def_path_hash(&self, def_id: RawDefId) -> Fingerprint;
 
     /// Get the stable hash controls.
     fn stable_hash_controls(&self) -> StableHashControls;
@@ -42,10 +44,6 @@ pub struct RawSpan(pub u32, pub u16, pub u16);
 // A type used to work around `DefId` not being visible in this crate. It is the same size as
 // `DefId`.
 pub struct RawDefId(pub u32, pub u32);
-
-// A type used to work around `DefPathHash` not being visible in this crate. It is the same size as
-// `DefPathHash`.
-pub struct RawDefPathHash(pub [u8; 16]);
 
 /// Something that implements `StableHash` can be hashed in a way that is
 /// stable across multiple compilation sessions.

--- a/compiler/rustc_data_structures/src/stable_hash/tests.rs
+++ b/compiler/rustc_data_structures/src/stable_hash/tests.rs
@@ -11,7 +11,7 @@ impl StableHashCtxt for () {
     fn stable_hash_span(&mut self, _: RawSpan, _: &mut StableHasher) {
         panic!();
     }
-    fn def_path_hash(&self, _: RawDefId) -> RawDefPathHash {
+    fn def_path_hash(&self, _: RawDefId) -> Fingerprint {
         panic!();
     }
     fn stable_hash_controls(&self) -> StableHashControls {

--- a/compiler/rustc_middle/src/ich.rs
+++ b/compiler/rustc_middle/src/ich.rs
@@ -1,8 +1,9 @@
 use std::hash::Hash;
 
 use rustc_crate_store::Untracked;
+use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::stable_hash::{
-    RawDefId, RawDefPathHash, RawSpan, StableHash, StableHashControls, StableHashCtxt, StableHasher,
+    RawDefId, RawSpan, StableHash, StableHashControls, StableHashCtxt, StableHasher,
 };
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_session::Session;
@@ -159,14 +160,14 @@ impl<'a> StableHashCtxt for StableHashState<'a> {
     }
 
     #[inline]
-    fn def_path_hash(&self, raw_def_id: RawDefId) -> RawDefPathHash {
+    fn def_path_hash(&self, raw_def_id: RawDefId) -> Fingerprint {
         let def_id = DefId::from_raw_def_id(raw_def_id);
         if let Some(def_id) = def_id.as_local() {
             self.untracked.definitions.read().def_path_hash(def_id)
         } else {
             self.untracked.cstore.read().def_path_hash(def_id)
         }
-        .to_raw_def_path_hash()
+        .0
     }
 
     /// Assert that the provided `StableHashCtxt` is configured with the default

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -4,7 +4,7 @@ use std::hash::{BuildHasherDefault, Hash, Hasher};
 use rustc_data_structures::AtomicRef;
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::stable_hash::{
-    RawDefId, RawDefPathHash, StableHash, StableHashCtxt, StableHasher, StableOrd, ToStableHashKey,
+    RawDefId, StableHash, StableHashCtxt, StableHasher, StableOrd, ToStableHashKey,
 };
 use rustc_data_structures::unhash::Unhasher;
 use rustc_hashes::Hash64;
@@ -115,16 +115,6 @@ impl DefPathHash {
     #[inline]
     pub fn new(stable_crate_id: StableCrateId, local_hash: Hash64) -> DefPathHash {
         DefPathHash(Fingerprint::new(stable_crate_id.0, local_hash))
-    }
-
-    #[inline]
-    pub fn to_raw_def_path_hash(self) -> RawDefPathHash {
-        RawDefPathHash(self.0.to_le_bytes())
-    }
-
-    #[inline]
-    pub fn from_raw_def_path_hash(RawDefPathHash(a): RawDefPathHash) -> DefPathHash {
-        DefPathHash(Fingerprint::from_le_bytes(a))
     }
 }
 
@@ -453,7 +443,7 @@ impl ToStableHashKey for DefId {
 
     #[inline]
     fn to_stable_hash_key<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx) -> DefPathHash {
-        DefPathHash::from_raw_def_path_hash(hcx.def_path_hash(self.to_raw_def_id()))
+        DefPathHash(hcx.def_path_hash(self.to_raw_def_id()))
     }
 }
 


### PR DESCRIPTION
`RawSpan`, `RawDefId`, and `RawDefPathHash` were all introduced to work around the fact that `StableHashCtxt` in `rustc_data_structure` is upstream of `rustc_span`. However, `DefPathHash` is just a newtype around `Fingerprint`, which is defined  in `rustc_data_structure`. So by working directly with `Fingerprint` we can remove `RawDefPathHash`, which is a nice simplification.

r? @fee1-dead 