### PR TITLE
make trivial ABI check resilient against new repr

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -184,6 +184,14 @@ impl ReprOptions {
         self.flags.contains(ReprFlags::IS_C)
     }
 
+    /// Returns whether this is (implicitly or explicitly) `repr(Rust)`, i.e., its layout
+    /// is defined by Rust and we make no stable commitments.
+    #[inline]
+    pub fn rust(&self) -> bool {
+        // `linear` is currently just an internal flag we set on Box; that's still `repr(Rust)`.
+        !self.c() & !self.simd() & !self.scalable() & !self.transparent()
+    }
+
     #[inline]
     pub fn packed(&self) -> bool {
         self.pack.is_some()

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -97,7 +97,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 } else if adt_def.repr().c() {
                     interp_ok(false)
                 } else {
-                    // Must be repr(Rust).
+                    // Can't be SIMD or Scalable (since this is a 1-ZST); only Rust is left.
+                    assert!(adt_def.repr().rust());
                     interp_ok(true)
                 }
             }


### PR DESCRIPTION
There's currently no way to exhaustively match on "what basic `repr` is this", which is kind of fragile as it means a new repr will get whatever the `else` branch happens to be everywhere. Changing this would be a major refactor, but let's at least make it possible to `assert!` that we covered all the cases by adding an explicit way to check for `repr(Rust)`.