### PR TITLE
explicitly state that allocations cannot grow to the left

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -159,10 +159,10 @@
 //!
 //! Allocations typically have a fixed size that cannot change. However, allocations created by
 //! directly invoking page table operations of the operating system, e.g. via `mmap`, are allowed to
-//! grow by adding more pages to them at the end. Unmapping parts of an allocation (i.e., shrinking
-//! it or punching holes into it) is currently not supported. Allocations created via
-//! "compiler-recognized" operations, such as `std::alloc` methods or `libc::malloc`, can never
-//! change their size, even if they use `mmap` under the hood.
+//! grow by adding more pages to them at the end. Adding more pages before the beginning, or
+//! unmapping parts of an allocation (i.e., shrinking it or punching holes into it), is currently
+//! not supported. Allocations created via "compiler-recognized" operations, such as `std::alloc`
+//! methods or `libc::malloc`, can never change their size, even if they use `mmap` under the hood.
 //!
 //! [`null()`]: null
 //!


### PR DESCRIPTION
This was already implied, but it seems better to make this explicit.

Cc @rust-lang/opsem 
