### PR TITLE
vector ABI check: reword so it makes more sense for non-obviously-vector types

### DIFF
--- a/compiler/rustc_monomorphize/src/diagnostics.rs
+++ b/compiler/rustc_monomorphize/src/diagnostics.rs
@@ -101,18 +101,23 @@ pub(crate) struct EncounteredErrorWhileInstantiatingGlobalAsm {
 pub(crate) struct StartNotFound;
 
 #[derive(Diagnostic)]
-#[diag("this function {$is_call ->
-    [true] call
-    *[false] definition
-} uses {$is_scalable ->
-    [true] scalable
-    *[false] SIMD
-} vector type `{$ty}` which (with the chosen ABI) requires the `{$required_feature}` target feature, which is not enabled{$is_call ->
-    [true] {\" \"}in the caller
-    *[false] {\"\"}
-}")]
+#[diag(
+    "this function {$is_call ->
+        [true] call
+        *[false] definition
+    } requires the `{$required_feature}` target feature, which is not enabled{$is_call ->
+        [true] {\" \"}in the caller
+        *[false] {\"\"}
+    }"
+)]
+#[note(
+    "the function has type `{$ty}` in its signature, which is passed in {$is_scalable ->
+        [true] scalable
+        *[false] SIMD
+    } vector registers under the \"{$abi}\" ABI"
+)]
 #[help(
-    "consider enabling it globally (`-C target-feature=+{$required_feature}`) or locally (`#[target_feature(enable=\"{$required_feature}\")]`)"
+    "consider enabling the missing target feature globally (`-C target-feature=+{$required_feature}`) or locally (`#[target_feature(enable=\"{$required_feature}\")]`)"
 )]
 pub(crate) struct AbiErrorDisabledVectorType<'a> {
     #[primary_span]
@@ -124,6 +129,7 @@ pub(crate) struct AbiErrorDisabledVectorType<'a> {
     )]
     pub span: Span,
     pub required_feature: &'a str,
+    pub abi: String,
     pub ty: Ty<'a>,
     /// Whether this is a problem at a call site or at a declaration.
     pub is_call: bool,

--- a/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
@@ -172,12 +172,8 @@ fn check_instance_abi<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) {
         tcx.dcx().delayed_bug("ABI computation failure should lead to compilation failure");
         return;
     };
-    // Unlike the call-site check, we do also check "Rust" ABI functions here.
-    // This should never trigger, *except* if we start making use of vector registers
-    // for the "Rust" ABI and the user disables those vector registers (which should trigger a
-    // warning as that's clearly disabling a "required" target feature for this target).
-    // Using such a function is where disabling the vector register actually can start leading
-    // to soundness issues, so erroring here seems good.
+    // Unlike the call-site check, we do also check "Rust" ABI functions here. This can actually
+    // trigger due to scalable vectors being require for the "Rust" ABI for some types.
     let loc = || {
         let def_id = instance.def_id();
         (

--- a/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
@@ -84,6 +84,7 @@ fn do_check_simd_vector_abi<'tcx>(
                     tcx.dcx().emit_err(diagnostics::AbiErrorDisabledVectorType {
                         span,
                         required_feature: feature,
+                        abi: abi.conv.to_string(),
                         ty: arg_abi.layout.ty,
                         is_call,
                         is_scalable: false,
@@ -101,6 +102,7 @@ fn do_check_simd_vector_abi<'tcx>(
                     tcx.dcx().emit_err(diagnostics::AbiErrorDisabledVectorType {
                         span,
                         required_feature,
+                        abi: abi.conv.to_string(),
                         ty: arg_abi.layout.ty,
                         is_call,
                         is_scalable: true,

--- a/tests/ui/abi/simd-abi-checks-avx.stderr
+++ b/tests/ui/abi/simd-abi-checks-avx.stderr
@@ -1,90 +1,101 @@
-error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+error: this function call requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks-avx.rs:59:11
    |
 LL |         f(g());
    |           ^^^ function called here
    |
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
+   = note: the function has type `std::arch::x86_64::__m256` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+error: this function call requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks-avx.rs:59:9
    |
 LL |         f(g());
    |         ^^^^^^ function called here
    |
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
+   = note: the function has type `std::arch::x86_64::__m256` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+error: this function call requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks-avx.rs:65:14
    |
 LL |         gavx(favx());
    |              ^^^^^^ function called here
    |
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
+   = note: the function has type `std::arch::x86_64::__m256` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+error: this function call requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks-avx.rs:65:9
    |
 LL |         gavx(favx());
    |         ^^^^^^^^^^^^ function called here
    |
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
+   = note: the function has type `std::arch::x86_64::__m256` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+error: this function call requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks-avx.rs:75:19
    |
 LL |         w(Wrapper(g()));
    |                   ^^^ function called here
    |
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
+   = note: the function has type `std::arch::x86_64::__m256` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-error: this function call uses SIMD vector type `Wrapper` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+error: this function call requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks-avx.rs:75:9
    |
 LL |         w(Wrapper(g()));
    |         ^^^^^^^^^^^^^^^ function called here
    |
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
+   = note: the function has type `Wrapper` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+error: this function call requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks-avx.rs:89:9
    |
 LL |         some_extern();
    |         ^^^^^^^^^^^^^ function called here
    |
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
+   = note: the function has type `std::arch::x86_64::__m256` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-error: this function definition uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
+error: this function definition requires the `avx` target feature, which is not enabled
   --> $DIR/simd-abi-checks-avx.rs:24:1
    |
 LL | unsafe extern "C" fn g() -> __m256 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
+   = note: the function has type `std::arch::x86_64::__m256` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-error: this function definition uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
+error: this function definition requires the `avx` target feature, which is not enabled
   --> $DIR/simd-abi-checks-avx.rs:19:1
    |
 LL | unsafe extern "C" fn f(_: __m256) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
+   = note: the function has type `std::arch::x86_64::__m256` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-error: this function definition uses SIMD vector type `Wrapper` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
+error: this function definition requires the `avx` target feature, which is not enabled
   --> $DIR/simd-abi-checks-avx.rs:14:1
    |
 LL | unsafe extern "C" fn w(_: Wrapper) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
+   = note: the function has type `Wrapper` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+error: this function call requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks-avx.rs:53:8
    |
 LL |     || g()
    |        ^^^ function called here
    |
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
+   = note: the function has type `std::arch::x86_64::__m256` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
 note: the above error was encountered while instantiating `fn in_closure::{closure#0}`
   --> $DIR/simd-abi-checks-avx.rs:81:9

--- a/tests/ui/abi/simd-abi-checks-s390x.z10.stderr
+++ b/tests/ui/abi/simd-abi-checks-s390x.z10.stderr
@@ -1,20 +1,22 @@
-error: this function definition uses SIMD vector type `Simd<i8, 8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:33:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Simd<i8, 8>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Simd<i8, 16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:38:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Simd<i8, 16>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:84:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
@@ -22,9 +24,10 @@ LL | |     x: &TransparentWrapper<i8x8>,
 LL | | ) -> TransparentWrapper<i8x8> {
    | |_____________________________^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `TransparentWrapper<Simd<i8, 8>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:91:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
@@ -32,55 +35,62 @@ LL | |     x: &TransparentWrapper<i8x16>,
 LL | | ) -> TransparentWrapper<i8x16> {
    | |______________________________^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `TransparentWrapper<Simd<i8, 16>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Simd<i8, 8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:106:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Simd<i8, 8>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Simd<i8, 16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:111:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Simd<i8, 16>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Wrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:122:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Wrapper<Simd<i8, 8>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Wrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:127:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Wrapper<Simd<i8, 16>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:138:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `TransparentWrapper<Simd<i8, 8>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:143:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `TransparentWrapper<Simd<i8, 16>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/abi/simd-abi-checks-s390x.z13_no_vector.stderr
+++ b/tests/ui/abi/simd-abi-checks-s390x.z13_no_vector.stderr
@@ -1,20 +1,22 @@
-error: this function definition uses SIMD vector type `Simd<i8, 8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:33:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Simd<i8, 8>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Simd<i8, 16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:38:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Simd<i8, 16>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:84:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
@@ -22,9 +24,10 @@ LL | |     x: &TransparentWrapper<i8x8>,
 LL | | ) -> TransparentWrapper<i8x8> {
    | |_____________________________^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `TransparentWrapper<Simd<i8, 8>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:91:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
@@ -32,55 +35,62 @@ LL | |     x: &TransparentWrapper<i8x16>,
 LL | | ) -> TransparentWrapper<i8x16> {
    | |______________________________^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `TransparentWrapper<Simd<i8, 16>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Simd<i8, 8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:106:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Simd<i8, 8>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Simd<i8, 16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:111:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Simd<i8, 16>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Wrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:122:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Wrapper<Simd<i8, 8>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Wrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:127:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Wrapper<Simd<i8, 16>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:138:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `TransparentWrapper<Simd<i8, 8>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:143:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `TransparentWrapper<Simd<i8, 16>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/abi/simd-abi-checks-s390x.z13_soft_float.stderr
+++ b/tests/ui/abi/simd-abi-checks-s390x.z13_soft_float.stderr
@@ -8,23 +8,25 @@ warning: target feature `soft-float` must be disabled to ensure that the ABI of 
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
 
-error: this function definition uses SIMD vector type `Simd<i8, 8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:33:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Simd<i8, 8>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Simd<i8, 16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:38:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Simd<i8, 16>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:84:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
@@ -32,9 +34,10 @@ LL | |     x: &TransparentWrapper<i8x8>,
 LL | | ) -> TransparentWrapper<i8x8> {
    | |_____________________________^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `TransparentWrapper<Simd<i8, 8>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:91:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
@@ -42,55 +45,62 @@ LL | |     x: &TransparentWrapper<i8x16>,
 LL | | ) -> TransparentWrapper<i8x16> {
    | |______________________________^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `TransparentWrapper<Simd<i8, 16>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Simd<i8, 8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:106:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Simd<i8, 8>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Simd<i8, 16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:111:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Simd<i8, 16>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Wrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:122:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Wrapper<Simd<i8, 8>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `Wrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:127:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `Wrapper<Simd<i8, 16>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 8>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:138:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `TransparentWrapper<Simd<i8, 8>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses SIMD vector type `TransparentWrapper<Simd<i8, 16>>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:143:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
+   = note: the function has type `TransparentWrapper<Simd<i8, 16>>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: aborting due to 10 previous errors; 2 warnings emitted
 

--- a/tests/ui/abi/simd-abi-checks-sse.rs
+++ b/tests/ui/abi/simd-abi-checks-sse.rs
@@ -6,6 +6,7 @@
 //@ build-fail
 //@ needs-llvm-components: x86
 //@ ignore-backends: gcc
+//@ dont-require-annotations: NOTE
 #![feature(no_core)]
 #![no_core]
 #![allow(improper_ctypes_definitions)]
@@ -15,5 +16,6 @@ use minicore::simd::Simd;
 
 #[no_mangle]
 pub unsafe extern "C" fn f(_: Simd<i64, 2>) {
-    //~^ ERROR: this function definition uses SIMD vector type `Simd<i64, 2>` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
+    //~^ ERROR: requires the `sse` target feature
+    //~| NOTE: the function has type `Simd<i64, 2>` in its signature, which is passed in SIMD vector registers under the "C" ABI
 }

--- a/tests/ui/abi/simd-abi-checks-sse.stderr
+++ b/tests/ui/abi/simd-abi-checks-sse.stderr
@@ -1,10 +1,11 @@
-error: this function definition uses SIMD vector type `Simd<i64, 2>` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-sse.rs:17:1
+error: this function definition requires the `sse` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-sse.rs:18:1
    |
 LL | pub unsafe extern "C" fn f(_: Simd<i64, 2>) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+sse`) or locally (`#[target_feature(enable="sse")]`)
+   = note: the function has type `Simd<i64, 2>` in its signature, which is passed in SIMD vector registers under the "C" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+sse`) or locally (`#[target_feature(enable="sse")]`)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/scalable-vectors/require-target-feature.rs
+++ b/tests/ui/scalable-vectors/require-target-feature.rs
@@ -1,17 +1,26 @@
 //@ build-fail
-//@ compile-flags: --crate-type=lib
-//@ only-aarch64
+//@ compile-flags: --crate-type=lib --target=aarch64-unknown-linux-gnu
+//@ needs-llvm-components: aarch64
+//@ add-minicore
+//@ dont-require-annotations: NOTE
+
 #![allow(incomplete_features, internal_features)]
 #![feature(
     simd_ffi,
     rustc_attrs,
-    link_llvm_intrinsics
+    link_llvm_intrinsics,
+    no_core
 )]
+#![no_core]
 
-#[derive(Copy, Clone)]
+extern crate minicore;
+use minicore::*;
+
 #[rustc_scalable_vector(4)]
 #[allow(non_camel_case_types)]
 pub struct svint32_t(i32);
+
+impl Copy for svint32_t {}
 
 #[inline(never)]
 #[target_feature(enable = "sve")]
@@ -25,7 +34,8 @@ pub unsafe fn svdup_n_s32(op: i32) -> svint32_t {
 }
 
 pub fn non_annotated_callee(x: svint32_t) {}
-//~^ ERROR: this function definition uses scalable vector type `svint32_t`
+//~^ ERROR: this function definition requires the `sve` target feature
+//~| NOTE: the function has type `svint32_t` in its signature, which is passed in scalable vector registers under the "Rust" ABI
 
 #[target_feature(enable = "sve")]
 pub fn annotated_callee(x: svint32_t) {} // okay!

--- a/tests/ui/scalable-vectors/require-target-feature.stderr
+++ b/tests/ui/scalable-vectors/require-target-feature.stderr
@@ -1,5 +1,5 @@
 warning: `extern` block uses type `svint32_t`, which is not FFI-safe
-  --> $DIR/require-target-feature.rs:21:37
+  --> $DIR/require-target-feature.rs:30:37
    |
 LL |         fn _svdup_n_s32(op: i32) -> svint32_t;
    |                                     ^^^^^^^^^ not FFI-safe
@@ -7,19 +7,20 @@ LL |         fn _svdup_n_s32(op: i32) -> svint32_t;
    = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
    = note: this struct has unspecified layout
 note: the type is defined here
-  --> $DIR/require-target-feature.rs:14:1
+  --> $DIR/require-target-feature.rs:21:1
    |
 LL | pub struct svint32_t(i32);
    | ^^^^^^^^^^^^^^^^^^^^
    = note: `#[warn(improper_ctypes)]` on by default
 
-error: this function definition uses scalable vector type `svint32_t` which (with the chosen ABI) requires the `sve` target feature, which is not enabled
-  --> $DIR/require-target-feature.rs:27:1
+error: this function definition requires the `sve` target feature, which is not enabled
+  --> $DIR/require-target-feature.rs:36:1
    |
 LL | pub fn non_annotated_callee(x: svint32_t) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = help: consider enabling it globally (`-C target-feature=+sve`) or locally (`#[target_feature(enable="sve")]`)
+   = note: the function has type `svint32_t` in its signature, which is passed in scalable vector registers under the "Rust" ABI
+   = help: consider enabling the missing target feature globally (`-C target-feature=+sve`) or locally (`#[target_feature(enable="sve")]`)
 
 error: aborting due to 1 previous error; 1 warning emitted
 


### PR DESCRIPTION
Talking about "SIMD vector type `Complex<f16>`" would be a bit confusing. So instead we talk about "the function has type `$TYPE` in its signature, which is passed in SIMD vector registers".

r? @folkertdev 