### PR TITLE
fix(lint): preserve opening paren in raw-borrows suggestion for parenthesized casts

### DIFF
--- a/compiler/rustc_lint/src/raw_borrows_via_references.rs
+++ b/compiler/rustc_lint/src/raw_borrows_via_references.rs
@@ -65,7 +65,7 @@ impl<'tcx> LateLintPass<'tcx> for RawBorrowsViaReferences {
                 && ty_span.can_be_used_for_suggestions()
             {
                 RawBorrowViaReferenceSuggestion::Spanful {
-                    left: expr.span.until(addr_of_span),
+                    left: exp.span.until(addr_of_span),
                     right: addr_of_span.shrink_to_hi().until(ty_span.shrink_to_hi()),
                     mutbl: mutbl.ptr_str(),
                 }

--- a/tests/ui/lint/lint-raw-borrows-via-references.fixed
+++ b/tests/ui/lint/lint-raw-borrows-via-references.fixed
@@ -74,6 +74,17 @@ fn from_macro(x: *const i32) -> *const i32 {
     unsafe { ref_cast!(*x) }
 }
 
+fn parenthesized() {
+    let x = 0;
+    let _ = (&raw const x);
+    //~^ WARN creating an intermediate reference implies aliasing requirements even when immediately cast to a raw pointers [raw_borrows_via_references]
+    let mut y = 0;
+    let _ = (&raw mut y);
+    //~^ WARN creating an intermediate reference implies aliasing requirements even when immediately cast to a raw pointers [raw_borrows_via_references]
+    let _ = (&raw const x).wrapping_add(1);
+    //~^ WARN creating an intermediate reference implies aliasing requirements even when immediately cast to a raw pointers [raw_borrows_via_references]
+}
+
 fn main() {
     let a = 0;
     let a = &raw const a;

--- a/tests/ui/lint/lint-raw-borrows-via-references.rs
+++ b/tests/ui/lint/lint-raw-borrows-via-references.rs
@@ -74,6 +74,17 @@ fn from_macro(x: *const i32) -> *const i32 {
     unsafe { ref_cast!(*x) }
 }
 
+fn parenthesized() {
+    let x = 0;
+    let _ = (&x as *const i32);
+    //~^ WARN creating an intermediate reference implies aliasing requirements even when immediately cast to a raw pointers [raw_borrows_via_references]
+    let mut y = 0;
+    let _ = (&mut y as *mut i32);
+    //~^ WARN creating an intermediate reference implies aliasing requirements even when immediately cast to a raw pointers [raw_borrows_via_references]
+    let _ = (&x as *const i32).wrapping_add(1);
+    //~^ WARN creating an intermediate reference implies aliasing requirements even when immediately cast to a raw pointers [raw_borrows_via_references]
+}
+
 fn main() {
     let a = 0;
     let a = &a as *const i32;

--- a/tests/ui/lint/lint-raw-borrows-via-references.stderr
+++ b/tests/ui/lint/lint-raw-borrows-via-references.stderr
@@ -123,5 +123,41 @@ LL -     let b = &mut b as *mut i32;
 LL +     let b = &raw mut b;
    |
 
-warning: 10 warnings emitted
+warning: creating an intermediate reference implies aliasing requirements even when immediately cast to a raw pointers
+  --> $DIR/lint-raw-borrows-via-references.rs:79:14
+   |
+LL |     let _ = (&x as *const i32);
+   |              ^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `&raw const` for a safer and more explicit raw pointer
+   |
+LL -     let _ = (&x as *const i32);
+LL +     let _ = (&raw const x);
+   |
+
+warning: creating an intermediate reference implies aliasing requirements even when immediately cast to a raw pointers
+  --> $DIR/lint-raw-borrows-via-references.rs:82:14
+   |
+LL |     let _ = (&mut y as *mut i32);
+   |              ^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `&raw mut` for a safer and more explicit raw pointer
+   |
+LL -     let _ = (&mut y as *mut i32);
+LL +     let _ = (&raw mut y);
+   |
+
+warning: creating an intermediate reference implies aliasing requirements even when immediately cast to a raw pointers
+  --> $DIR/lint-raw-borrows-via-references.rs:84:14
+   |
+LL |     let _ = (&x as *const i32).wrapping_add(1);
+   |              ^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `&raw const` for a safer and more explicit raw pointer
+   |
+LL -     let _ = (&x as *const i32).wrapping_add(1);
+LL +     let _ = (&raw const x).wrapping_add(1);
+   |
+
+warning: 13 warnings emitted
 


### PR DESCRIPTION
Fixes rust-lang/rust#161693.

The raw-borrows-via-references multipart suggestion dropped the opening paren on parenthesized casts like (&x as \*const T). Using expr.span.until(addr_of_span) where expr is the outer Cast includes (& and replaces it with &raw const, leaving a stray ) and producing a syntax error.

Use exp.span (the AddrOf &x / &mut x span) instead, so only & / &mut is replaced and parentheses are preserved, yielding (&raw const x) correctly.

Verified RED->GREEN via stash comparison and span logic check, no other files touched.

No em dashes.

Written in conjunction with my pair programmer Claude.