### PR TITLE
Don't emit InlineAsm terminator if input operand is `!`.

### DIFF
--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -714,13 +714,21 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let mut targets =
                     if asm_macro.diverges(options) { vec![] } else { vec![destination_block] };
 
+                // If any input operand is `!`, then  we don't need to generate the asm terminator,
+                // but we still need to evaluate the operands.
+                // Fixes an ICE with `!` inline asm inputs (#154904).
+                let mut has_never_input = false;
+
                 let operands = operands
                     .into_iter()
                     .map(|op| match *op {
-                        thir::InlineAsmOperand::In { reg, expr } => mir::InlineAsmOperand::In {
-                            reg,
-                            value: unpack!(block = this.as_local_operand(block, expr)),
-                        },
+                        thir::InlineAsmOperand::In { reg, expr } => {
+                            let value = unpack!(block = this.as_local_operand(block, expr));
+                            if value.ty(&this.local_decls, this.tcx).is_never() {
+                                has_never_input = true;
+                            }
+                            mir::InlineAsmOperand::In { reg, value }
+                        }
                         thir::InlineAsmOperand::Out { reg, late, expr } => {
                             mir::InlineAsmOperand::Out {
                                 reg,
@@ -729,7 +737,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             }
                         }
                         thir::InlineAsmOperand::InOut { reg, late, expr } => {
+                            // We don't need to check for `!` input types here,
+                            // since `!` is disallowed as an output type.
                             let place = unpack!(block = this.as_place(block, expr));
+                            debug_assert!(!place.ty(&this.local_decls, this.tcx).ty.is_never());
                             mir::InlineAsmOperand::InOut {
                                 reg,
                                 late,
@@ -739,10 +750,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             }
                         }
                         thir::InlineAsmOperand::SplitInOut { reg, late, in_expr, out_expr } => {
+                            let in_value = unpack!(block = this.as_local_operand(block, in_expr));
+                            if in_value.ty(&this.local_decls, this.tcx).is_never() {
+                                has_never_input = true;
+                            }
                             mir::InlineAsmOperand::InOut {
                                 reg,
                                 late,
-                                in_value: unpack!(block = this.as_local_operand(block, in_expr)),
+                                in_value,
                                 out_place: out_expr.map(|out_expr| {
                                     unpack!(block = this.as_place(block, out_expr))
                                 }),
@@ -794,21 +809,28 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 this.cfg.terminate(
                     block,
                     source_info,
-                    TerminatorKind::InlineAsm {
-                        asm_macro,
-                        template,
-                        operands,
-                        options,
-                        line_spans,
-                        targets: targets.into_boxed_slice(),
-                        unwind: if options.contains(InlineAsmOptions::MAY_UNWIND) {
-                            UnwindAction::Continue
-                        } else {
-                            UnwindAction::Unreachable
-                        },
+                    if has_never_input {
+                        // Codegen can't handle `Operand::ZeroSized` asm inputs,
+                        // so don't emit an asm terminator if the inputs include `!`,
+                        // since the asm would be unreachable anyway.
+                        TerminatorKind::Unreachable
+                    } else {
+                        TerminatorKind::InlineAsm {
+                            asm_macro,
+                            template,
+                            operands,
+                            options,
+                            line_spans,
+                            targets: targets.into_boxed_slice(),
+                            unwind: if options.contains(InlineAsmOptions::MAY_UNWIND) {
+                                UnwindAction::Continue
+                            } else {
+                                UnwindAction::Unreachable
+                            },
+                        }
                     },
                 );
-                if options.contains(InlineAsmOptions::MAY_UNWIND) {
+                if !has_never_input && options.contains(InlineAsmOptions::MAY_UNWIND) {
                     this.diverge_from(block);
                 }
                 destination_block.unit()

--- a/tests/ui/never_type/diverging-inline-asm-input-place-copy.rs
+++ b/tests/ui/never_type/diverging-inline-asm-input-place-copy.rs
@@ -1,0 +1,48 @@
+//@ build-pass
+// Regression test for #154904
+#![crate_type = "lib"]
+#![feature(asm_unwind)] // for `bar`/`bar2`
+
+#[inline(never)]
+pub fn foo(x: &!) {
+    unsafe {
+        std::arch::asm!(
+            "/* {} */",
+            in(reg) *x,
+        );
+    }
+}
+
+#[inline(never)]
+pub fn bar(x: &!) {
+    unsafe {
+        std::arch::asm!(
+            "/* {} */",
+            in(reg) *x,
+            options(may_unwind),
+        );
+    }
+}
+
+// in case we make `&!` uninhabited in the future, also test the a copy from
+// an unsafe place still doesn't trigger the ICE
+#[inline(never)]
+pub unsafe fn foo2(x: *const !) {
+    unsafe {
+        std::arch::asm!(
+            "/* {} */",
+            in(reg) *x,
+        );
+    }
+}
+
+#[inline(never)]
+pub unsafe fn bar2(x: *const !) {
+    unsafe {
+        std::arch::asm!(
+            "/* {} */",
+            in(reg) *x,
+            options(may_unwind),
+        );
+    }
+}


### PR DESCRIPTION
Fixes rust-lang/rust#154904

`!` is currently allowed in asm inputs, which is usually fine since the `asm` is marked unreachable and never reaches codegen (it seems? [playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=3c632f45f608b1f93c5293873a062f72)), but if the `!` operand is a deref/index that happens in the `asm` operand expression, then the `asm` does reach codegen and ICEs since codegen assumes all inline asm operands are `OperandValue::Immediate`, which `!` is not (it's `OperandValue::ZeroSized`) (rust-lang/rust#154904)

This PR fixes this by not emitting the `TerminatorKind::InlineAsm` terminator if any input is `!` (instead emitting `TerminatorKind::Unreachable`), since the `InlineAsm` terminator would be unreachable anyway.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
