### PR TITLE
Make `tcx.def_id_partial_cmp` public

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -504,7 +504,7 @@ impl TyCtxt<'_> {
     /// Compare def-ids based on their position in def-id tree, ancestor def-ids are considered
     /// larger than descendant def-ids, and two different def-ids are considered unordered if
     /// neither of them is an ancestor of the other.
-    fn def_id_partial_cmp(self, lhs: DefId, rhs: DefId) -> Option<Ordering> {
+    pub fn def_id_partial_cmp(self, lhs: DefId, rhs: DefId) -> Option<Ordering> {
         // Def-ids from different crates are always unordered.
         if lhs.krate != rhs.krate {
             return None;


### PR DESCRIPTION
This is mainly because it would be very useful in Clippy to have a fast way to check if two DefIds are related (and what that relation is).

Related to Clippy performance.