### PR TITLE
Check to ensure we're running against the correct LLVM version

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -894,6 +894,8 @@ unsafe extern "C" {
         SLen: c_uint,
     ) -> MetadataKindId;
 
+    pub(crate) fn LLVMGetVersion(major: &mut c_uint, minor: &mut c_uint, patch: &mut c_uint);
+
     pub(crate) fn LLVMDisposeTargetMachine(T: ptr::NonNull<TargetMachine>);
 
     // Create modules.

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -48,6 +48,24 @@ unsafe fn configure_llvm(sess: &Session) {
     let mut llvm_c_strs = Vec::with_capacity(n_args + 1);
     let mut llvm_args = Vec::with_capacity(n_args + 1);
 
+    // Check to ensure we're running against the correct LLVM version.
+    unsafe {
+        let mut llvm_major = 0;
+        let mut llvm_minor = 0;
+        let mut llvm_patch = 0;
+        llvm::LLVMGetVersion(&mut llvm_major, &mut llvm_minor, &mut llvm_patch);
+        let expected_version = llvm::LLVMRustVersionMajor();
+        if llvm_major != expected_version {
+            panic!(
+                concat!(
+                    "LLVM version mismatch: this compiler was built for LLVM {}, ",
+                    "but LLVM {}.{}.{} is loaded"
+                ),
+                expected_version, llvm_major, llvm_minor, llvm_patch
+            );
+        }
+    }
+
     unsafe {
         llvm::LLVMRustInstallErrorHandlers();
     }

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -59,9 +59,16 @@ unsafe fn configure_llvm(sess: &Session) {
             panic!(
                 concat!(
                     "LLVM version mismatch: this compiler was built for LLVM {}, ",
-                    "but LLVM {}.{}.{} is loaded"
+                    "but LLVM {}.{}.{} was found{}"
                 ),
-                expected_version, llvm_major, llvm_minor, llvm_patch
+                expected_version,
+                llvm_major,
+                llvm_minor,
+                llvm_patch,
+                match rustc_session::filesearch::dll_path(llvm::LLVMGetVersion as *mut _) {
+                    Ok(path) => format!(" at {}", path.display()),
+                    Err(_) => String::new(),
+                }
             );
         }
     }

--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -146,86 +146,78 @@ pub fn make_target_bin_path(sysroot: &Path, target_triple: &str) -> PathBuf {
     sysroot.join(rustlib_path).join("bin")
 }
 
+/// Attempts to find the path to the dynamic library containing a function.
+///
+/// SAFETY: `function` must be a valid pointer to some function.
 #[cfg(unix)]
-fn current_dll_path() -> Result<PathBuf, String> {
-    use std::sync::OnceLock;
+pub unsafe fn dll_path(function: *mut std::ffi::c_void) -> Result<PathBuf, String> {
+    use std::ffi::{CStr, OsStr};
+    use std::os::unix::prelude::*;
 
-    // This is somewhat expensive relative to other work when compiling `fn main() {}` as `dladdr`
-    // needs to iterate over the symbol table of librustc_driver.so until it finds a match.
-    // As such cache this to avoid recomputing if we try to get the sysroot in multiple places.
-    static CURRENT_DLL_PATH: OnceLock<Result<PathBuf, String>> = OnceLock::new();
-    CURRENT_DLL_PATH
-        .get_or_init(|| {
-            use std::ffi::{CStr, OsStr};
-            use std::os::unix::prelude::*;
+    #[cfg(not(target_os = "aix"))]
+    unsafe {
+        let mut info = std::mem::zeroed();
+        if libc::dladdr(function, &mut info) == 0 {
+            return Err("dladdr failed".into());
+        }
+        #[cfg(target_os = "cygwin")]
+        let fname_ptr = info.dli_fname.as_ptr();
+        #[cfg(not(target_os = "cygwin"))]
+        let fname_ptr = {
+            assert!(!info.dli_fname.is_null(), "dli_fname cannot be null");
+            info.dli_fname
+        };
+        let bytes = CStr::from_ptr(fname_ptr).to_bytes();
+        let os = OsStr::from_bytes(bytes);
+        try_canonicalize(Path::new(os)).map_err(|e| e.to_string())
+    }
 
-            #[cfg(not(target_os = "aix"))]
-            unsafe {
-                let addr = current_dll_path as fn() -> Result<PathBuf, String> as *mut _;
-                let mut info = std::mem::zeroed();
-                if libc::dladdr(addr, &mut info) == 0 {
-                    return Err("dladdr failed".into());
+    #[cfg(target_os = "aix")]
+    unsafe {
+        // On AIX, the symbol references a function descriptor.
+        // A function descriptor is consisted of (See https://reviews.llvm.org/D62532)
+        // * The address of the entry point of the function.
+        // * The TOC base address for the function.
+        // * The environment pointer.
+        // The function descriptor is in the data section.
+        let addr = function as u64;
+        let mut buffer = vec![std::mem::zeroed::<libc::ld_info>(); 64];
+        loop {
+            if libc::loadquery(
+                libc::L_GETINFO,
+                buffer.as_mut_ptr() as *mut libc::c_void,
+                (size_of::<libc::ld_info>() * buffer.len()) as u32,
+            ) >= 0
+            {
+                break;
+            } else {
+                if std::io::Error::last_os_error().raw_os_error().unwrap() != libc::ENOMEM {
+                    return Err("loadquery failed".into());
                 }
-                #[cfg(target_os = "cygwin")]
-                let fname_ptr = info.dli_fname.as_ptr();
-                #[cfg(not(target_os = "cygwin"))]
-                let fname_ptr = {
-                    assert!(!info.dli_fname.is_null(), "dli_fname cannot be null");
-                    info.dli_fname
-                };
-                let bytes = CStr::from_ptr(fname_ptr).to_bytes();
+                buffer.resize(buffer.len() * 2, std::mem::zeroed::<libc::ld_info>());
+            }
+        }
+        let mut current = buffer.as_mut_ptr() as *mut libc::ld_info;
+        loop {
+            let data_base = (*current).ldinfo_dataorg as u64;
+            let data_end = data_base + (*current).ldinfo_datasize;
+            if (data_base..data_end).contains(&addr) {
+                let bytes = CStr::from_ptr(&(*current).ldinfo_filename[0]).to_bytes();
                 let os = OsStr::from_bytes(bytes);
-                try_canonicalize(Path::new(os)).map_err(|e| e.to_string())
+                return try_canonicalize(Path::new(os)).map_err(|e| e.to_string());
             }
-
-            #[cfg(target_os = "aix")]
-            unsafe {
-                // On AIX, the symbol `current_dll_path` references a function descriptor.
-                // A function descriptor is consisted of (See https://reviews.llvm.org/D62532)
-                // * The address of the entry point of the function.
-                // * The TOC base address for the function.
-                // * The environment pointer.
-                // The function descriptor is in the data section.
-                let addr = current_dll_path as u64;
-                let mut buffer = vec![std::mem::zeroed::<libc::ld_info>(); 64];
-                loop {
-                    if libc::loadquery(
-                        libc::L_GETINFO,
-                        buffer.as_mut_ptr() as *mut libc::c_void,
-                        (size_of::<libc::ld_info>() * buffer.len()) as u32,
-                    ) >= 0
-                    {
-                        break;
-                    } else {
-                        if std::io::Error::last_os_error().raw_os_error().unwrap() != libc::ENOMEM {
-                            return Err("loadquery failed".into());
-                        }
-                        buffer.resize(buffer.len() * 2, std::mem::zeroed::<libc::ld_info>());
-                    }
-                }
-                let mut current = buffer.as_mut_ptr() as *mut libc::ld_info;
-                loop {
-                    let data_base = (*current).ldinfo_dataorg as u64;
-                    let data_end = data_base + (*current).ldinfo_datasize;
-                    if (data_base..data_end).contains(&addr) {
-                        let bytes = CStr::from_ptr(&(*current).ldinfo_filename[0]).to_bytes();
-                        let os = OsStr::from_bytes(bytes);
-                        return try_canonicalize(Path::new(os)).map_err(|e| e.to_string());
-                    }
-                    if (*current).ldinfo_next == 0 {
-                        break;
-                    }
-                    current = (current as *mut i8).offset((*current).ldinfo_next as isize)
-                        as *mut libc::ld_info;
-                }
-                return Err(format!("current dll's address {} is not in the load map", addr));
+            if (*current).ldinfo_next == 0 {
+                break;
             }
-        })
-        .clone()
+            current =
+                (current as *mut i8).offset((*current).ldinfo_next as isize) as *mut libc::ld_info;
+        }
+        return Err(format!("current dll's address {} is not in the load map", addr));
+    }
 }
 
 #[cfg(windows)]
-fn current_dll_path() -> Result<PathBuf, String> {
+pub unsafe fn dll_path(function: *mut std::ffi::c_void) -> Result<PathBuf, String> {
     use std::ffi::OsString;
     use std::io;
     use std::os::windows::prelude::*;
@@ -240,10 +232,7 @@ fn current_dll_path() -> Result<PathBuf, String> {
     unsafe {
         GetModuleHandleExW(
             GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-            PCWSTR(
-                current_dll_path as fn() -> Result<std::path::PathBuf, std::string::String>
-                    as *mut u16,
-            ),
+            PCWSTR(function as *mut u16),
             &mut module,
         )
     }
@@ -269,8 +258,20 @@ fn current_dll_path() -> Result<PathBuf, String> {
 }
 
 #[cfg(target_os = "wasi")]
+pub unsafe fn dll_path(function: *mut std::ffi::c_void) -> Result<PathBuf, String> {
+    Err("dll_path is not supported on WASI".to_string())
+}
+
 fn current_dll_path() -> Result<PathBuf, String> {
-    Err("current_dll_path is not supported on WASI".to_string())
+    use std::sync::OnceLock;
+
+    // This is somewhat expensive relative to other work when compiling `fn main() {}` as `dladdr`
+    // needs to iterate over the symbol table of librustc_driver.so until it finds a match.
+    // As such cache this to avoid recomputing if we try to get the sysroot in multiple places.
+    static CURRENT_DLL_PATH: OnceLock<Result<PathBuf, String>> = OnceLock::new();
+    CURRENT_DLL_PATH
+        .get_or_init(|| unsafe { dll_path(current_dll_path as fn() -> _ as *mut _) })
+        .clone()
 }
 
 /// This function checks if sysroot is found using env::args().next(), and if it


### PR DESCRIPTION
The recent LLVM version bump exposed several cases of mishandling LLVM versions, both in-tree and downstream (rust-lang/rust#161335, rust-lang/rust#161377, rust-lang/rust#161572, rust-lang/rust#162013, https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/opt-dist.20pipeline.20failure.20in.20MSYS2.20CI.20when.20compiling.2E.2E.2E/with/619077952).

If the compiler is run against an incompatible LLVM version, the most common failure mode is a segfault within LLVM, often when looking up target information. This is not obvious to debug, so this PR adds an LLVM version check before initializing LLVM so that we can produce a clearer error.

The second commit in this PR performs a `dladdr` lookup to print the path to the LLVM we're using. We already have code to do this for finding the sysroot, which I repurposed. However, I don't mind reverting this if it's too complex/risky.

I would appreciate if someone with permissions could trigger a try build on AIX, Windows, and WASI as the second commit touches platform-specific code that I can't test locally.

Before:

```
error: rustc interrupted by SIGSEGV, printing backtrace
0   librustc_driver-18049a207bb38ba8.dy 0x000000010e09e9b8 _RNvNtCsfNrGi27GPxl_17rustc_driver_impl14signal_handler17print_stack_trace + 140
1   libsystem_platform.dylib            0x0000000184c7d744 _sigtramp + 56
2   libLLVM.dylib                       0x000000011a9e22e0 _ZNK4llvm15MCSubtargetInfo13checkFeaturesENS_9StringRefE + 40
3   librustc_driver-18049a207bb38ba8.dy 0x000000010e44c798 LLVMRustHasFeature + 104
4   librustc_driver-18049a207bb38ba8.dy 0x000000010e3c4e34 _RINvXs0_NtNtNtCsk8HLZXaYIk4_4core4iter8adapters3mapINtB6_3MapINtNtB8_7flatten7FlatMapINtNtB8_6filter6FilterINtNtNtBc_5slice4iter4IterTReNtNtCs79s86CIooN0_12rustc_target15target_features9StabilityRSB28_EENCINvNtCses5MBT5CPFU_17rustc_codegen_ssa15target_features24internal_target_featuresKj2_NCNvNtCsgXm2bqwPj4W_18rustc_codegen_llvm9llvm_util13target_config0NCB4G_s_0E0EIBO_INtNtNtNtCs99cPMl0y5Ob_3std11collections4hash3set8IntoIterB28_ENCNCB3h_s_00ENCB3h_s_0ENCINvXs8_NtCsdLs5ZkLaCXa_9hashbrown3setINtB7v_7HashSetNtNtCsSGoTcZpb2F_10rustc_span6symbol6SymbolNtCs5ZGGmiYplBm_10rustc_hash13FxBuildHasherEINtNtNtBa_6traits7collect6ExtendB8e_E6extendBX_E0ENtNtB9I_8iterator8Iterator4folduNCINvNvBar_8for_each4callTB8e_uENCINvXs1i_NtB7x_3mapINtBbD_7HashMapB8e_uB8V_EIB9E_Bbm_E6extendBN_E0E0EB4K_ + 880
5   librustc_driver-18049a207bb38ba8.dy 0x000000010e2ad884 _RINvXs1i_NtCsdLs5ZkLaCXa_9hashbrown3mapINtB7_7HashMapNtNtCsSGoTcZpb2F_10rustc_span6symbol6SymboluNtCs5ZGGmiYplBm_10rustc_hash13FxBuildHasherEINtNtNtNtCsk8HLZXaYIk4_4core4iter6traits7collect6ExtendTBP_uEE6extendINtNtNtB2m_8adapters3map3MapINtNtB3r_7flatten7FlatMapINtNtB3r_6filter6FilterINtNtNtB2o_5slice4iter4IterTReNtNtCs79s86CIooN0_12rustc_target15target_features9StabilityRSB52_EENCINvNtCses5MBT5CPFU_17rustc_codegen_ssa15target_features24internal_target_featuresKj2_NCNvNtCsgXm2bqwPj4W_18rustc_codegen_llvm9llvm_util13target_config0NCB7A_s_0E0EIB3n_INtNtNtNtCs99cPMl0y5Ob_3std11collections4hash3set8IntoIterB52_ENCNCB6b_s_00ENCB6b_s_0ENCINvXs8_NtB9_3setINtBaq_7HashSetBP_B1x_EIB2g_BP_E6extendB3O_E0EEB7E_ + 344
6   librustc_driver-18049a207bb38ba8.dy 0x000000010e2b1ec4 _RINvXs8_NtCsdLs5ZkLaCXa_9hashbrown3setINtB6_7HashSetNtNtCsSGoTcZpb2F_10rustc_span6symbol6SymbolNtCs5ZGGmiYplBm_10rustc_hash13FxBuildHasherEINtNtNtNtCsk8HLZXaYIk4_4core4iter6traits7collect6ExtendBO_E6extendINtNtNtB2k_8adapters7flatten7FlatMapINtNtB3m_6filter6FilterINtNtNtB2m_5slice4iter4IterTReNtNtCs79s86CIooN0_12rustc_target15target_features9StabilityRSB4G_EENCINvNtCses5MBT5CPFU_17rustc_codegen_ssa15target_features24internal_target_featuresKj2_NCNvNtCsgXm2bqwPj4W_18rustc_codegen_llvm9llvm_util13target_config0NCB7e_s_0E0EINtNtB3m_3map3MapINtNtNtNtCs99cPMl0y5Ob_3std11collections4hash3set8IntoIterB4G_ENCNCB5P_s_00ENCB5P_s_0EEB7i_ + 68
7   librustc_driver-18049a207bb38ba8.dy 0x000000010e2bfa90 _RINvNtCses5MBT5CPFU_17rustc_codegen_ssa15target_features24internal_target_featuresKj2_NCNvNtCsgXm2bqwPj4W_18rustc_codegen_llvm9llvm_util13target_config0NCB1o_s_0EB1s_ + 148
8   librustc_driver-18049a207bb38ba8.dy 0x000000010e2fb918 _RNvNtCsgXm2bqwPj4W_18rustc_codegen_llvm9llvm_util13target_config + 68
9   librustc_driver-18049a207bb38ba8.dy 0x000000010e292fb0 _RNvNtCs6x0lOIkloew_15rustc_interface4util17add_configuration + 48
10  librustc_driver-18049a207bb38ba8.dy 0x000000010e06b204 _RINvMs_Csfkr8sXZt4uY_10scoped_tlsINtB5_9ScopedKeyNtCsSGoTcZpb2F_10rustc_span14SessionGlobalsE3setNCNCNCINvNtCs6x0lOIkloew_15rustc_interface4util26run_in_thread_with_globalsNCINvB1G_31run_in_thread_pool_with_globalsNCINvNtB1I_9interface12run_compileruNCNvCsfNrGi27GPxl_17rustc_driver_impl12run_compiler0Es0_0uE0uE000uEB44_ + 1112
11  librustc_driver-18049a207bb38ba8.dy 0x000000010e090914 _RINvCsSGoTcZpb2F_10rustc_span27create_session_globals_thenuNCNCNCINvNtCs6x0lOIkloew_15rustc_interface4util26run_in_thread_with_globalsNCINvB14_31run_in_thread_pool_with_globalsNCINvNtB16_9interface12run_compileruNCNvCsfNrGi27GPxl_17rustc_driver_impl12run_compiler0Es0_0uE0uE000EB3s_ + 168
12  librustc_driver-18049a207bb38ba8.dy 0x000000010e07823c _RINvNtNtCs99cPMl0y5Ob_3std3sys9backtrace28___rust_begin_short_backtraceNCNCINvNtCs6x0lOIkloew_15rustc_interface4util26run_in_thread_with_globalsNCINvB1e_31run_in_thread_pool_with_globalsNCINvNtB1g_9interface12run_compileruNCNvCsfNrGi27GPxl_17rustc_driver_impl12run_compiler0Es0_0uE0uE00uEB3C_ + 112
13  librustc_driver-18049a207bb38ba8.dy 0x000000010e04efa4 _RNSNvYNCINvNtNtCs99cPMl0y5Ob_3std6thread9lifecycle15spawn_uncheckedNCNCINvNtCs6x0lOIkloew_15rustc_interface4util26run_in_thread_with_globalsNCINvB1a_31run_in_thread_pool_with_globalsNCINvNtB1c_9interface12run_compileruNCNvCsfNrGi27GPxl_17rustc_driver_impl12run_compiler0Es0_0uE0uE00uEs_0INtNtNtCsk8HLZXaYIk4_4core3ops8function6FnOnceuE9call_once6vtableB3y_ + 208
14  librustc_driver-18049a207bb38ba8.dy 0x0000000111697118 _RNvNvMs0_NtNtNtCs99cPMl0y5Ob_3std3sys6thread4unixNtB7_6Thread3new12thread_start + 392
15  libsystem_pthread.dylib             0x0000000184c73c58 _pthread_start + 136
16  libsystem_pthread.dylib             0x0000000184c6ec1c thread_start + 8

note: we would appreciate a report at https://github.com/rust-lang/rust
help: you can increase rustc's stack size by setting RUST_MIN_STACK=33554432
```

After:

```
thread 'rustc' (3568488) panicked at compiler/rustc_codegen_llvm/src/llvm_util.rs:59:13:
LLVM version mismatch: this compiler was built for LLVM 23, but LLVM 22.1.8 was found at /Users/keljonathan/code/rust/build/aarch64-apple-darwin/stage0/lib/libLLVM.dylib
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/std/src/panicking.rs:679:5
   1: core::panicking::panic_fmt
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/core/src/panicking.rs:80:14
   2: configure_llvm
             at ./compiler/rustc_codegen_llvm/src/llvm_util.rs:59:13
   3: {closure#0}
             at ./compiler/rustc_codegen_llvm/src/llvm_util.rs:35:13
   4: {closure#0}<rustc_codegen_llvm::llvm_util::init::{closure_env#0}>
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/std/src/sync/once.rs:166:41
   5: <std::sys::sync::once::queue::Once>::call
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/std/src/sys/sync/once/queue.rs:225:21
   6: call_once<rustc_codegen_llvm::llvm_util::init::{closure_env#0}>
             at /rustc/08d5b675a9b2abdca5e2fe4eabe0e07bbda15d49/library/std/src/sync/once.rs:166:20
   7: init
             at ./compiler/rustc_codegen_llvm/src/llvm_util.rs:34:14
   8: init
             at ./compiler/rustc_codegen_llvm/src/lib.rs:223:9
   9: {closure#2}<(), rustc_driver_impl::run_compiler::{closure_env#0}>
             at ./compiler/rustc_interface/src/interface.rs:440:29
  10: {closure#0}<rustc_interface::interface::run_compiler::{closure_env#2}<(), rustc_driver_impl::run_compiler::{closure_env#0}>, ()>
             at ./compiler/rustc_interface/src/util.rs:223:17
  11: {closure#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#2}<(), rustc_driver_impl::run_compiler::{closure_env#0}>, ()>, ()>
             at ./compiler/rustc_interface/src/util.rs:180:24
  12: set<rustc_span::SessionGlobals, rustc_interface::util::run_in_thread_with_globals::{closure#0}::{closure#0}::{closure_env#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#2}<(), rustc_driver_impl::run_compiler::{closure_env#0}>, ()>, ()>, ()>
             at /Users/keljonathan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/scoped-tls-1.0.1/src/lib.rs:137:9
  13: create_session_globals_then<(), rustc_interface::util::run_in_thread_with_globals::{closure#0}::{closure#0}::{closure_env#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#2}<(), rustc_driver_impl::run_compiler::{closure_env#0}>, ()>, ()>>
             at ./compiler/rustc_span/src/lib.rs:156:21
  14: {closure#0}<rustc_interface::util::run_in_thread_pool_with_globals::{closure_env#0}<rustc_interface::interface::run_compiler::{closure_env#2}<(), rustc_driver_impl::run_compiler::{closure_env#0}>, ()>, ()>
             at ./compiler/rustc_interface/src/util.rs:176:17
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

error: the compiler unexpectedly panicked. This is a bug

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: please make sure that you have updated to the latest nightly

note: please attach the file at `/Users/keljonathan/code/rust/rustc-ice-2026-08-25T22_23_11-1423.txt` to your bug report

note: rustc 1.100.0-dev running on aarch64-apple-darwin

note: compiler flags: -C rpath -C debuginfo=0 -Z unstable-options

query stack during panic:
end of query stack
```