### PR TITLE
compiletest: add auxiliary dylib path for CDB tests

### DIFF
--- a/src/tools/compiletest/src/runtest/debuginfo.rs
+++ b/src/tools/compiletest/src/runtest/debuginfo.rs
@@ -89,10 +89,12 @@ impl TestCx<'_> {
             .arg(&debugger_script)
             .arg(&exe_file);
 
+        let aux_dir = self.aux_output_dir_name();
+
         let debugger_run_result = self.compose_and_run(
             cdb,
             self.config.target_run_lib_path.as_path(),
-            None, // aux_path
+            Some(aux_dir.as_path()),
             None, // input
         );
 

--- a/tests/debuginfo/issue-13213.rs
+++ b/tests/debuginfo/issue-13213.rs
@@ -1,5 +1,3 @@
-//@ ignore-cdb: Fails with exit code 0xc0000135 ("the application failed to initialize properly")
-
 //@ aux-build:issue-13213-aux.rs
 
 extern crate issue_13213_aux;


### PR DESCRIPTION
Addresses rust-lang/rust#134469.

In my reproduction, CDB itself initialized correctly; the failure happened while loading the debuggee.

I reproduced the failure locally on `x86_64-pc-windows-msvc` while investigating rust-lang/rust#134469. For `issue-13213.rs`, the auxiliary dylib directory was missing from the runtime search path, causing the generated executable to fail with `0xc0000135` because `issue_13213_aux.dll` could not be found.

This change passes `aux_output_dir_name()` through the existing `aux_path` mechanism, so `compose_and_run` adds the auxiliary dylib directory to the runtime search path. With that change, the CDB variant of `issue-13213.rs` runs successfully, so the old `ignore-cdb` directive can be removed.

Testing performed locally on `x86_64-pc-windows-msvc`:

- `./x test tests/debuginfo/issue-13213.rs --force-rerun`
- `./x test src/tools/compiletest --force-rerun`

Both completed with no failures.