### PR TITLE
always rerun if we normalize local opaques

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/project_goals/opaque_types.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/project_goals/opaque_types.rs
@@ -164,13 +164,16 @@ where
                 // this is the defining scope, and otherwise treat it as rigid.
                 // However, in `ErasedNotcoherence` we *always* treat it as rigid.
                 // This is the same as other modes if def_id is None, but wrong if we do have a DefId.
-                // So, if we have one, we register in the EvalCtxt that we may need that defid.
-                // We might then decide to rerun in the correct typing mode.
-                if let Some(def_id) = def_id.as_local() {
-                    self.opaque_accesses.rerun_if_opaque_in_opaque_type_storage(
-                        RerunReason::NormalizeOpaqueType,
-                        def_id,
-                    )?;
+                // Thus we should rerun if the opaque is in the defining scope. And we should do
+                // so immediately, otherwise we might continue evaluating with rigid opaques that
+                // should be revealed and trigger query cycle when leaking it for auto trait.
+                // See `tests/ui/traits/next-solver/normalize/always-rerun-normalizing-opaques.rs`.
+                //
+                // FIXME: verify that we can get away with not rerunning immediately when
+                // normalizing foreign opaques. Currently we don't do so because that would greatly
+                // worsen the compilation time of `wg-grammar`.
+                if def_id.as_local().is_some() {
+                    match self.opaque_accesses.rerun_always(RerunReason::NormalizeOpaqueType)? {}
                 } else {
                     self.opaque_accesses
                         .rerun_if_in_post_analysis(RerunReason::NormalizeOpaqueTypeRemoteCrate)?;

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -240,9 +240,6 @@ where
             goal.predicate.self_ty().kind()
         {
             debug_assert!(is_rigid == ty::IsRigid::Yes);
-            if ecx.opaque_accesses.might_rerun() {
-                match ecx.opaque_accesses.rerun_always(RerunReason::AutoTraitLeakage)? {}
-            }
 
             for item_bound in cx.item_self_bounds(def_id.into()).skip_binder() {
                 if item_bound

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -154,6 +154,10 @@ pub enum TypingMode<I: Interner, S: TypingModeErasedStatus = MayBeErased> {
     /// we bail out, setting a field on `EvalCtxt` that indicates the canonicalization must be
     /// rerun in the original typing mode.
     ///
+    /// Specifically, we always reveal auto traits for rigid aliases and thus we don't allow
+    /// incorrectly marked rigid local opaques. We ensure this by immediately bailing out
+    /// when normalizing local opaques.
+    ///
     /// `TypingMode::Coherence` is not replaced by this and is always kept as-is.
     ErasedNotCoherence(S),
 }

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -118,6 +118,10 @@ impl<I: Interner> AliasTyKind<I> {
 /// if the param env is the same, e.g., `Typeck/PostTypeckUntilBorrowck` and
 /// `PostAnalysis/Codegen`.
 ///
+/// We always reveal auto traits for rigid aliases and this can cause query cycle in
+/// `TypingMode::ErasedNotCoherence`. Thus we don't allow incorrectly marked rigid local
+/// opaques. We achieve this by immediately bailing out when normalizing local opaques.
+///
 /// FIXME(#155345): Alias handling is currently still in flux for the new trait
 /// solver and this is currently somewhat messy. Please reach out on
 /// #t-types/trait-system-refactor-initiative if you encounter this and it isn't

--- a/tests/ui/traits/next-solver/normalize/always_rerun_normalizing_opaques.rs
+++ b/tests/ui/traits/next-solver/normalize/always_rerun_normalizing_opaques.rs
@@ -1,0 +1,29 @@
+//@ edition: 2024
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// Previously we update the rerun flag when we normalize opaques and don't immedidately bail.
+// We normalize goals when adding them which is separate from their evaluation.
+// So we don't have the `might_rerun` flag when evaluating them.
+// This leads to query cycle in code where we need to leak opaque types for auto traits.
+
+fn is_send<T: Send>(_: T) {}
+
+fn inner() -> impl Sized {
+    is_send(outer());
+}
+
+fn outer() -> impl Sized {
+    inner()
+}
+
+// From #135062 which was fixed but broken again.
+async fn foo() {
+    is_send(bar())
+}
+
+async fn bar() {
+    foo().await;
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161795)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
Fixes rust-lang/rust#135062

The problem is that we rerun goals too late such that we compute auto trait for wrongly-marked-as-rigid opaques.
We call `type_of` on those opaques which would trigger query cycle if we're already in typeck/borrowck of the same opaques.

It's fixed by eagerly rerun if we ever normalize a local opaque. 
To be more consersative, we could also rerun if we normalize remote opaque. But that causes regression for `wg-grammar`. Since we wouldn't be in typeck/borrowck if we're in post analysis mode, we don't have the query cycle problem. We **might** get away with not rerunning there.

`OpaqueInStorage` removal doesn't affect behavior and can be done in a followup.

r? @lcnr