### PR TITLE
Remove dead parse error recovery (underscores in expressions)

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -85,30 +85,9 @@ impl<'a> Parser<'a> {
         self.parse_expr().map(|value| AnonConst { id: DUMMY_NODE_ID, value })
     }
 
-    fn parse_expr_catch_underscore(
-        &mut self,
-        restrictions: Restrictions,
-    ) -> PResult<'a, Box<Expr>> {
-        match self.parse_expr_res(restrictions) {
-            Ok(expr) => Ok(expr),
-            Err(err) => match self.token.ident() {
-                Some((Ident { name: kw::Underscore, .. }, IdentIsRaw::No))
-                    if self.may_recover() && self.look_ahead(1, |t| t == &token::Comma) =>
-                {
-                    // Special-case handling of `foo(_, _, _)`
-                    let guar = err.emit();
-                    self.bump();
-                    Ok(self.mk_expr(self.prev_token.span, ExprKind::Err(guar)))
-                }
-                _ => Err(err),
-            },
-        }
-    }
-
     /// Parses a sequence of expressions delimited by parentheses.
     fn parse_expr_paren_seq(&mut self) -> PResult<'a, ThinVec<Box<Expr>>> {
-        self.parse_paren_comma_seq(|p| p.parse_expr_catch_underscore(Restrictions::empty()))
-            .map(|(r, _)| r)
+        self.parse_paren_comma_seq(Self::parse_expr).map(|(r, _)| r)
     }
 
     /// Parses an expression, subject to the given restrictions.
@@ -1644,7 +1623,7 @@ impl<'a> Parser<'a> {
         let (es, trailing_comma) = match self.parse_seq_to_end(
             exp!(CloseParen),
             SeqSep::trailing_allowed(exp!(Comma)),
-            |p| p.parse_expr_catch_underscore(restrictions.intersection(Restrictions::ALLOW_LET)),
+            |p| p.parse_expr_res(restrictions.intersection(Restrictions::ALLOW_LET)),
         ) {
             Ok(x) => x,
             Err(err) => {


### PR DESCRIPTION
Back in https://github.com/rust-lang/rust/pull/63337/changes/b7f7756566c9e10983ee51bc97afe9852838299a (2019) the parser was extended to recover from `_`s as elements of tuple expressions (this was later extended to also cover call expressions). At the time, `_` obviously wasn't an expression yet.

Nowadays `parse_expr_res` will *always* successfully parse `_` as an `ExprKind::Underscore` (irrespective of the passed `Restrictions`). Consequently, we will never reach the special case in `parse_expr_catch_underscore`. Drop this entire wrapper function.

<sub>(No LLM was or will be used by me during the entire creation process of this PR)</sub>