### PR TITLE
Document PartialOrd behavior for Option<T> where T: PartialOrd

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2456,16 +2456,7 @@ const impl<T: [const] PartialEq> PartialEq for Option<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
 const impl<T: [const] PartialOrd> PartialOrd for Option<T> {
-    /// If `T` implements [`PartialOrd`], then [`Option<T>`] will derive its [`PartialOrd`] implementation.
-    /// With this order, `None` compares as less than any `Some`, and two `Some` values compare the
-    /// same way as their contained values would in `T`. If `T` also implements [`Ord`], then so does [`Option<T>`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// assert!(None < Some(0));
-    /// assert!(Some(0) < Some(1));
-    /// ```
+    /// See [the documentation](https://doc.rust-lang.org/std/option/#comparison-operators) for details.
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         match (self, other) {

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2456,6 +2456,16 @@ const impl<T: [const] PartialEq> PartialEq for Option<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
 const impl<T: [const] PartialOrd> PartialOrd for Option<T> {
+    /// If T implements PartialOrd then Option<T> will derive its PartialOrd implementation.
+    /// With this order, None compares as less than any Some, and two Some compare the same way
+    /// as their contained values would in T. If T also implements Ord, then so does Option<T>.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert!(None < Some(0));
+    /// assert!(Some(0) < Some(1));
+    /// ```
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         match (self, other) {

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2457,6 +2457,7 @@ const impl<T: [const] PartialEq> PartialEq for Option<T> {
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
 const impl<T: [const] PartialOrd> PartialOrd for Option<T> {
     /// See [the documentation](https://doc.rust-lang.org/std/option/#comparison-operators) for details.
+    /// [`None`] always compares less than any [`Some`]
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         match (self, other) {

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2456,9 +2456,9 @@ const impl<T: [const] PartialEq> PartialEq for Option<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
 const impl<T: [const] PartialOrd> PartialOrd for Option<T> {
-    /// If T implements PartialOrd then Option<T> will derive its PartialOrd implementation.
-    /// With this order, None compares as less than any Some, and two Some compare the same way
-    /// as their contained values would in T. If T also implements Ord, then so does Option<T>.
+    /// If `T` implements [`PartialOrd`], then [`Option<T>`] will derive its [`PartialOrd`] implementation.
+    /// With this order, `None` compares as less than any `Some`, and two `Some` values compare the
+    /// same way as their contained values would in `T`. If `T` also implements [`Ord`], then so does [`Option<T>`].
     ///
     /// # Examples
     ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
Fixes [#161746]("https://github.com/rust-lang/rust/issues/161746")
This is my first time contributing to Rust and all feedback is welcome.
I ran these after making changes.
`./x test library/core --stage 1`
`./x.py setup`
`./x test tidy --bless`