### PR TITLE
Prefer ambiguous candidates when deduplicating traits in scope, so `ambiguous_glob_imported_traits` doesn't depend on import order

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1085,7 +1085,9 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         if let Some(applicable_traits) = opt_applicable_traits {
             for trait_candidate in applicable_traits.iter() {
                 let trait_did = trait_candidate.def_id;
-                if duplicates.insert(trait_did) {
+                // If we have the same trait in scope but one of them is ambiguous and the other
+                // is not, we should treat them differently and then handle them later on.
+                if duplicates.insert((trait_did, trait_candidate.lint_ambiguous)) {
                     self.assemble_extension_candidates_for_trait(
                         &trait_candidate.import_ids,
                         trait_did,
@@ -2379,10 +2381,11 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             }
         }
 
-        let lint_ambiguous = match probes[0].0.kind {
+        // They are all the same, so if any of them is ambiguous, we report the pick as ambiguous.
+        let lint_ambiguous = probes.iter().any(|(p, _)| match p.kind {
             TraitCandidate(_, lint) => lint,
             _ => false,
-        };
+        });
 
         // FIXME: check the return type here somehow.
         // If so, just use this trait and call it a day.

--- a/tests/ui/imports/ambiguous-trait-in-scope-and-underscore.first.stderr
+++ b/tests/ui/imports/ambiguous-trait-in-scope-and-underscore.first.stderr
@@ -1,0 +1,16 @@
+warning: Use of ambiguously glob imported trait `Foo`
+  --> $DIR/ambiguous-trait-in-scope-and-underscore.rs:40:10
+   |
+LL | use export::*;
+   |     ------ `Foo` imported ambiguously here
+...
+LL |     1i32.method();
+   |          ^^^^^^
+   |
+   = help: Import `Foo` explicitly
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
+   = note: `#[warn(ambiguous_glob_imported_traits)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/imports/ambiguous-trait-in-scope-and-underscore.last.stderr
+++ b/tests/ui/imports/ambiguous-trait-in-scope-and-underscore.last.stderr
@@ -1,0 +1,16 @@
+warning: Use of ambiguously glob imported trait `Foo`
+  --> $DIR/ambiguous-trait-in-scope-and-underscore.rs:40:10
+   |
+LL | use export::*;
+   |     ------ `Foo` imported ambiguously here
+...
+LL |     1i32.method();
+   |          ^^^^^^
+   |
+   = help: Import `Foo` explicitly
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
+   = note: `#[warn(ambiguous_glob_imported_traits)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/imports/ambiguous-trait-in-scope-and-underscore.rs
+++ b/tests/ui/imports/ambiguous-trait-in-scope-and-underscore.rs
@@ -1,0 +1,43 @@
+//@ check-pass
+//@ revisions: first last
+//
+// `Foo` is in scope both via an ambiguous named import and an unambiguous
+// `as _` one. The lint reports regardless of the order of the two `pub use`s.
+//
+// Issue: #160742
+
+mod alias {
+    pub type Foo = u8;
+}
+
+mod def {
+    pub trait Foo {
+        fn method(self);
+    }
+
+    impl Foo for i32 {
+        fn method(self) {}
+    }
+}
+
+#[cfg(first)]
+mod export {
+    pub use crate::def::Foo as _;
+    pub use crate::def::Foo;
+}
+
+#[cfg(last)]
+mod export {
+    pub use crate::def::Foo;
+    pub use crate::def::Foo as _;
+}
+
+#[allow(unused_imports)] // needed only to make the trait ambiguous
+use alias::*;
+use export::*;
+
+fn main() {
+    1i32.method();
+    //~^ WARNING Use of ambiguously glob imported trait `Foo` [ambiguous_glob_imported_traits]
+    //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/160742

When inserting candidates for a method pick we deduplicate candidates based on the trait id, this "deleted" traits that where (not) ambiguous:
```rust
// depending on the order, the second one is removed
mod prelude {
    pub use crate::expression::IntoSql;
    pub use crate::expression::IntoSql as _;
}

use module::*; // imports some item names IntoSql
use prelude::*; // imports trait `IntoSql` and `IntoSql as _`
```

This caused the lint `ambiguous_glob_imported_traits` to not be triggered if the `as _` came first, even though both are actually in scope.

We now deduplicate based on `(def_id, lint_ambiguous)` and later check that if an ambiguous candidate is present in `collapse_candidates_to_trait_pick`, we mark the pick as `lint_ambiguous`. (its also easy to reverse the behaviour of this change).

Also added a test with 2 revisions placing the `as _` export first or last.

It's the most "clean" way I could come up, hopefully someone more versed in this part of the compiler could tell me how it is done in a better way :). 

cc @petrochenkov, since I feel like you know if the lint should be triggered or not in this case.


LLM disclosure: I used a LLM to create a shorter PR title, because i couldn't come up with a short one.
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
