### PR TITLE
bootstrap: skip StdarchVerify when remote testing is enabled

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1021,7 +1021,12 @@ impl CommandLineStep for StdarchVerify {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(StdarchVerify);
+        let builder = run.builder;
+        if builder.remote_tested(run.target) {
+            builder.info("remote testing is not supported by stdarch-verify. skipping");
+            return;
+        }
+        builder.ensure(StdarchVerify);
     }
 
     fn run(self, builder: &Builder<'_>) {


### PR DESCRIPTION
When TEST_DEVICE_ADDR is set for cross-testing, the StdarchVerify step incorrectly attempts to run on the remote target. Since stdarch-verify is a host-only verification tool, skip it when remote testing is enabled.

Fixes : https://github.com/rust-lang/rust/issues/161800

r? @Kobzol 
