### PR TITLE
prevent `Freeze` and `UnsafeUnpin` from being implemented outside of `core`

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -899,11 +899,9 @@ pub trait DiscriminantKind {
 ///
 /// This trait is a core part of the language, it is just expressed as a trait in libcore for
 /// convenience. Do *not* implement it for other types.
-// FIXME: Eventually this trait should become `#[rustc_deny_explicit_impl]`.
-// That requires porting the impls below to native internal impls.
 #[lang = "freeze"]
 #[unstable(feature = "freeze", issue = "121675")]
-pub unsafe auto trait Freeze {}
+pub impl(crate) unsafe auto trait Freeze {}
 
 #[unstable(feature = "freeze", issue = "121675")]
 impl<T: PointeeSized> !Freeze for UnsafeCell<T> {}
@@ -915,6 +913,8 @@ marker_impls! {
         {T: PointeeSized} *mut T,
         {T: PointeeSized} &T,
         {T: PointeeSized} &mut T,
+        {T: PointeeSized} pattern_type!(*const T is !null),
+        {T: PointeeSized} pattern_type!(*mut T is !null),
 }
 
 /// Used to determine whether a type contains any `UnsafePinned` (or `PhantomPinned`) internally,
@@ -925,7 +925,7 @@ marker_impls! {
 /// tracked by [#125735](https://github.com/rust-lang/rust/issues/125735).
 #[lang = "unsafe_unpin"]
 #[unstable(feature = "unsafe_unpin", issue = "125735")]
-pub unsafe auto trait UnsafeUnpin {}
+pub impl(crate) unsafe auto trait UnsafeUnpin {}
 
 #[unstable(feature = "unsafe_unpin", issue = "125735")]
 impl<T: PointeeSized> !UnsafeUnpin for UnsafePinned<T> {}

--- a/library/core/src/pat.rs
+++ b/library/core/src/pat.rs
@@ -1,6 +1,6 @@
 //! Helper module for exporting the `pattern_type` macro
 
-use crate::marker::{Freeze, PointeeSized, Unsize};
+use crate::marker::{PointeeSized, Unsize};
 use crate::ops::{CoerceUnsized, DispatchFromDyn};
 
 /// Creates a pattern type.
@@ -85,7 +85,3 @@ impl<T: PointeeSized, U: PointeeSized> CoerceUnsized<pattern_type!(*const U is !
 impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<pattern_type!(U is !null)> for pattern_type!(T is !null) {}
 
 impl<T: PointeeSized> Unpin for pattern_type!(*const T is !null) {}
-
-unsafe impl<T: PointeeSized> Freeze for pattern_type!(*const T is !null) {}
-
-unsafe impl<T: PointeeSized> Freeze for pattern_type!(*mut T is !null) {}


### PR DESCRIPTION
Fixes rust-lang/rust#161630

`impl(crate)` only prevents explicit implementations, but not the automatically derived ones ([playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=bfd5ec9901e83c1f2ed672f7e55b1240)), so we can use it to the same effect as `#[rustc_deny_explicit_impl]` while still having the fundamental implementations of these traits in `core`.