### PR TITLE
Initial implementation of `Stopwatch`

### DIFF
--- a/library/core/src/num/niche_types.rs
+++ b/library/core/src/num/niche_types.rs
@@ -135,6 +135,9 @@ define_valid_range_type! {
     pub struct U64NotAllOnes(u64 is 0..u64::MAX);
     pub struct I64NotAllOnes(i64 is ..-1 | 0..);
 
+    pub struct PositiveNonZeroI64(i64 is 1..);
+    pub struct PositiveI64(i64 is 0..);
+
     pub struct NonZeroCharInner(char is '\u{1}' ..= '\u{10ffff}');
 }
 

--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -229,3 +229,20 @@ impl __timespec64 {
         Self { tv_sec, tv_nsec, _padding: 0 }
     }
 }
+
+#[cfg(target_vendor = "apple")]
+#[repr(C)]
+pub(crate) struct mach_timebase_info {
+    pub numer: u32,
+    pub denom: u32,
+}
+
+#[cfg(target_vendor = "apple")]
+pub(crate) fn mach_timebase_info() -> mach_timebase_info {
+    unsafe extern "C" {
+        unsafe fn mach_timebase_info(info: *mut mach_timebase_info) -> libc::kern_return_t;
+    }
+    let mut timebase = mach_timebase_info { numer: 0, denom: 0 };
+    assert_eq!(unsafe { mach_timebase_info(&mut timebase) }, libc::KERN_SUCCESS);
+    timebase
+}

--- a/library/std/src/sys/pal/windows/time.rs
+++ b/library/std/src/sys/pal/windows/time.rs
@@ -21,16 +21,105 @@ pub fn intervals2dur(intervals: u64) -> Duration {
 pub mod perf_counter {
     use super::NANOS_PER_SEC;
     use crate::sync::atomic::{AtomicI64, Ordering};
-    use crate::sys::{c, cvt};
+    use crate::sys::c;
+    use crate::sys::helpers::mul_div_u64;
     use crate::time::Duration;
 
-    pub fn now() -> i64 {
-        let mut qpc_value: i64 = 0;
-        cvt(unsafe { c::QueryPerformanceCounter(&mut qpc_value) }).unwrap();
-        qpc_value
+    pub fn convert(counter: Counter, frequency: Frequency, magnitude: u64) -> u64 {
+        let counter = counter.as_u64();
+        let freq = frequency.as_u64();
+        // This looks redundant but it allows the optimizer to optimize
+        // for common values 10_000_000 (on x86/x64) and 24_000_000 (on aarch64).
+        // Note: the `10_000_000` branch is never taken on aarch64 but it's necessary
+        // to improve codegen. See #162074.
+        if freq == 10_000_000 {
+            mul_div_u64(counter, magnitude, freq)
+        } else if freq == 24_000_000 && cfg!(target_arch = "aarch64") {
+            mul_div_u64(counter, magnitude, freq)
+        } else {
+            mul_div_u64(counter, magnitude, freq)
+        }
     }
 
-    pub fn frequency() -> i64 {
+    type ValidCounter = core::num::niche_types::PositiveI64;
+    #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
+    #[repr(transparent)]
+    pub struct Counter {
+        value: ValidCounter,
+    }
+    impl Counter {
+        pub fn query() -> Self {
+            let mut qpc_value: i64 = 0;
+            // `QueryPerformanceCounter` will never fail (since XP).
+            unsafe { c::QueryPerformanceCounter(&mut qpc_value) };
+            // SAFETY: qpc_value will always be a positive integer since QueryPerformanceCounter
+            // "reads the performance counter and returns the total number of ticks that have
+            // occurred since the Windows operating system was started"
+            // See: https://learn.microsoft.com/en-us/windows/win32/sysinfo/acquiring-high-resolution-time-stamps
+            unsafe { Self::new_unchecked(qpc_value) }
+        }
+
+        pub fn checked_sub(self, other: Self) -> Option<Self> {
+            self.as_u64()
+                .checked_sub(other.as_u64())
+                // SAFETY: unsigned `checked_sub` ensure that self >= other and both
+                // are positive integers <=i64::MAX so the result will also
+                // be in the range 0..=i64::MAX.
+                .map(|n| unsafe { Self::new_unchecked(n as i64) })
+        }
+
+        pub fn as_u64(self) -> u64 {
+            // self always holds a positive i64 value.
+            self.value.as_inner() as u64
+        }
+
+        /// Construct a Counter from the result of `QueryPerformanceCounter`
+        ///
+        /// # Safety
+        ///
+        /// `freq` must be a positive integer.
+        /// The result of `QueryPerformanceCounter` fulfills this requirement.
+        unsafe fn new_unchecked(freq: i64) -> Self {
+            // SAFETY: The caller must ensure this is safe.
+            unsafe { Self { value: ValidCounter::new_unchecked(freq) } }
+        }
+    }
+
+    // This type helps the compiler to optimize calculations involving QueryPerformanceFrequency.
+    type ValidFrequency = core::num::niche_types::PositiveNonZeroI64;
+    #[derive(Clone, Copy)]
+    #[repr(transparent)]
+    pub struct Frequency {
+        value: ValidFrequency,
+    }
+
+    impl Frequency {
+        pub fn query() -> Self {
+            let freq = frequency();
+            // SAFETY: According to the MSDN entry for `QueryPerformanceFrequency`,
+            // a value of 0 will never be returned starting from Windows XP.
+            // A frequency will also always be a positive value.
+            unsafe { Self::new_unchecked(freq) }
+        }
+
+        fn as_u64(self) -> u64 {
+            // self always holds a positive i64 value.
+            self.value.as_inner() as u64
+        }
+
+        /// Construct a Frequency from the result of `QueryPerformanceFrequency`
+        ///
+        /// # Safety
+        ///
+        /// `freq` must be a positive integer greater than 0.
+        /// The result of `QueryPerformanceFrequency` fulfills this requirement (since XP).
+        unsafe fn new_unchecked(freq: i64) -> Self {
+            // SAFETY: The caller must ensure this is safe.
+            unsafe { Self { value: ValidFrequency::new_unchecked(freq) } }
+        }
+    }
+
+    fn frequency() -> i64 {
         // Either the cached result of `QueryPerformanceFrequency` or `0` for
         // uninitialized. Storing this as a single `AtomicI64` allows us to use
         // `Relaxed` operations, as we are only interested in the effects on a
@@ -49,13 +138,9 @@ pub mod perf_counter {
     #[cold]
     fn frequency_init(cache: &AtomicI64) -> i64 {
         let mut frequency = 0;
-        unsafe {
-            cvt(c::QueryPerformanceFrequency(&mut frequency)).unwrap();
-        }
-
-        // SAFETY: According to the MSDN entry for `QueryPerformanceFrequency`,
-        // a value of 0 will never be returned starting from Windows XP.
-        unsafe { crate::hint::assert_unchecked(frequency != 0) }
+        // `QueryPerformanceFrequency` will never fail (since XP).
+        // SAFETY: it just writes to frequency.
+        unsafe { c::QueryPerformanceFrequency(&mut frequency) };
 
         cache.store(frequency, Ordering::Relaxed);
         frequency

--- a/library/std/src/sys/time/mod.rs
+++ b/library/std/src/sys/time/mod.rs
@@ -43,3 +43,32 @@ cfg_select! {
 }
 
 pub use imp::{Instant, SystemTime, UNIX_EPOCH};
+
+cfg_select! {
+    any(
+        target_os = "windows",
+        target_os = "hermit",
+        target_os = "teeos",
+        target_family = "unix",
+        target_os = "wasi"
+    ) => {
+        pub use imp::Stopwatch;
+    }
+    _ => {
+        // The default implementation of Stopwatch simply wraps an Instant.
+        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
+        pub struct Stopwatch {
+            t: Instant,
+        }
+
+        impl Stopwatch {
+            pub fn start() -> Self {
+                Self { t: Instant::now() }
+            }
+
+            pub fn checked_duration_since(self, other: Stopwatch) -> Option<crate::time::Duration> {
+                self.t.checked_sub_instant(&other.t)
+            }
+        }
+    }
+}

--- a/library/std/src/sys/time/unix.rs
+++ b/library/std/src/sys/time/unix.rs
@@ -3,6 +3,9 @@ use crate::sys::pal::time::Timespec;
 use crate::time::Duration;
 use crate::{fmt, io};
 
+#[cfg(target_vendor = "apple")]
+mod apple;
+
 pub const UNIX_EPOCH: SystemTime = SystemTime { t: Timespec::zero() };
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -100,20 +103,8 @@ impl Instant {
     /// representable value.
     #[cfg(target_vendor = "apple")]
     pub fn into_mach_absolute_time_ceil(self) -> Option<u128> {
-        #[repr(C)]
-        struct mach_timebase_info {
-            numer: u32,
-            denom: u32,
-        }
-
-        unsafe extern "C" {
-            unsafe fn mach_timebase_info(info: *mut mach_timebase_info) -> libc::kern_return_t;
-        }
-
         let secs = u64::try_from(self.t.tv_sec).ok()?;
-
-        let mut timebase = mach_timebase_info { numer: 0, denom: 0 };
-        assert_eq!(unsafe { mach_timebase_info(&mut timebase) }, libc::KERN_SUCCESS);
+        let timebase = crate::sys::pal::time::mach_timebase_info();
 
         // Since `tv_sec` is 64-bit and `tv_nsec` is smaller than 1 billion,
         // this cannot overflow. The resulting number needs at most 94 bits.
@@ -139,6 +130,36 @@ impl AsInner<Timespec> for Instant {
 impl fmt::Debug for Instant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Instant")
+            .field("tv_sec", &self.t.tv_sec)
+            .field("tv_nsec", &self.t.tv_nsec)
+            .finish()
+    }
+}
+
+#[cfg(target_vendor = "apple")]
+pub use apple::Stopwatch;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg(not(target_vendor = "apple"))]
+pub struct Stopwatch {
+    t: Timespec,
+}
+
+#[cfg(not(target_vendor = "apple"))]
+impl Stopwatch {
+    pub fn start() -> Self {
+        Self { t: Timespec::now(libc::CLOCK_MONOTONIC) }
+    }
+
+    pub fn checked_duration_since(self, other: Stopwatch) -> Option<Duration> {
+        self.t.sub_timespec(&other.t).ok()
+    }
+}
+
+#[cfg(not(target_vendor = "apple"))]
+impl fmt::Debug for Stopwatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Stopwatch")
             .field("tv_sec", &self.t.tv_sec)
             .field("tv_nsec", &self.t.tv_nsec)
             .finish()

--- a/library/std/src/sys/time/unix/apple.rs
+++ b/library/std/src/sys/time/unix/apple.rs
@@ -1,0 +1,25 @@
+use crate::sys::helpers::mul_div_u64;
+use crate::sys::pal::time::mach_timebase_info;
+use crate::time::Duration;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Stopwatch {
+    ticks: u64,
+}
+
+impl Stopwatch {
+    pub fn start() -> Self {
+        unsafe extern "C" {
+            // SAFETY: it only retrieves ticks as a u64
+            pub safe fn mach_absolute_time() -> u64;
+        }
+        Self { ticks: mach_absolute_time() }
+    }
+
+    pub fn checked_duration_since(self, other: Stopwatch) -> Option<Duration> {
+        let diff = self.ticks.checked_sub(other.ticks)?;
+        let timebase = mach_timebase_info();
+        let nanos = mul_div_u64(diff, timebase.numer as u64, timebase.denom as u64);
+        Some(Duration::from_nanos(nanos))
+    }
+}

--- a/library/std/src/sys/time/windows.rs
+++ b/library/std/src/sys/time/windows.rs
@@ -67,6 +67,31 @@ impl Instant {
     }
 }
 
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
+pub struct Stopwatch {
+    ticks: i64,
+}
+
+impl Stopwatch {
+    pub fn start() -> Self {
+        Self { ticks: perf_counter::now() }
+    }
+
+    pub fn checked_duration_since(self, other: Stopwatch) -> Option<Duration> {
+        let diff = self.ticks - other.ticks;
+        if diff < -1 {
+            None
+        } else if diff <= 1 {
+            // When QPC is used across threads, equivalent tick counts might differ by +/- 1.
+            Some(Duration::ZERO)
+        } else {
+            let freq = perf_counter::frequency() as u64;
+            let nanos = mul_div_u64(diff as u64, NANOS_PER_SEC, freq);
+            Some(Duration::from_nanos(nanos))
+        }
+    }
+}
+
 impl SystemTime {
     pub const MAX: SystemTime = SystemTime::from_intervals(i64::MAX);
     pub const MIN: SystemTime = SystemTime::from_intervals(0);

--- a/library/std/src/sys/time/windows.rs
+++ b/library/std/src/sys/time/windows.rs
@@ -1,6 +1,6 @@
 use crate::cmp::Ordering;
 use crate::hash::{Hash, Hasher};
-use crate::sys::helpers::mul_div_u64;
+use crate::sys::pal::time::perf_counter::Frequency;
 use crate::sys::pal::time::{
     INTERVALS_PER_SEC, checked_dur2intervals, intervals2dur, perf_counter,
 };
@@ -33,11 +33,11 @@ impl Instant {
         // In order to keep unit conversions out of normal interval math, we
         // measure in QPC units and immediately convert to nanoseconds.
 
-        let freq = perf_counter::frequency() as u64;
-        let now = perf_counter::now();
+        let freq = perf_counter::Frequency::query();
+        let now = perf_counter::Counter::query();
 
-        // We convert now to `u64` to be able to use `Duration`.
-        let instant_nsec = mul_div_u64(now as u64, NANOS_PER_SEC, freq);
+        // We convert to `u64` to be able to use `Duration`.
+        let instant_nsec = perf_counter::convert(now, freq, NANOS_PER_SEC) as u64;
         // We can add an arbitrary offset to shift the epoch of this clock. We do that to avoid
         // being too close to 0 which would lead to underflow when computing times in the past. Also
         // see <https://github.com/rust-lang/rust/issues/156142>.
@@ -69,24 +69,21 @@ impl Instant {
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 pub struct Stopwatch {
-    ticks: i64,
+    ticks: perf_counter::Counter,
 }
 
 impl Stopwatch {
     pub fn start() -> Self {
-        Self { ticks: perf_counter::now() }
+        Self { ticks: perf_counter::Counter::query() }
     }
 
     pub fn checked_duration_since(self, other: Stopwatch) -> Option<Duration> {
-        let diff = self.ticks - other.ticks;
-        if diff < -1 {
-            None
-        } else if diff <= 1 {
+        let diff = self.ticks.checked_sub(other.ticks)?;
+        if diff.as_u64() <= 1 {
             // When QPC is used across threads, equivalent tick counts might differ by +/- 1.
             Some(Duration::ZERO)
         } else {
-            let freq = perf_counter::frequency() as u64;
-            let nanos = mul_div_u64(diff as u64, NANOS_PER_SEC, freq);
+            let nanos = perf_counter::convert(diff, Frequency::query(), NANOS_PER_SEC);
             Some(Duration::from_nanos(nanos))
         }
     }

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -155,6 +155,29 @@ use crate::sys::{FromInner, IntoInner, time};
 #[cfg_attr(not(test), rustc_diagnostic_item = "Instant")]
 pub struct Instant(time::Instant);
 
+/// A timer optimized for performance measurements.
+///
+/// Calling [`Stopwatch::start`] is as cheap as possible so can be used
+/// as a low-impact way to capture a point in time.
+/// [`elapsed`](Stopwatch::elapsed) or [`duration_since`](Stopwatch::duration_since) can
+/// then resolve the duration the timer has been running.
+///
+/// Unlike [`Instant`] you cannot add or subtract durations therefore there can never be
+/// a `Stopwatch` that represents a time before the first call to `Stopwatch::start`.
+///
+/// # Underlying System calls
+///
+/// On most systems this currently uses the same underlying system call as [`Instant`].
+/// The exception is Darwin, which uses [`mach_absolute_time`] directly instead of
+/// `CLOCK_UPTIME_RAW`.
+///
+/// [`mach_absolute_time`]: https://developer.apple.com/documentation/kernel/1462446-mach_absolute_time
+///
+/// **Disclaimer:** System calls might change over time.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[unstable(feature = "stopwatch", issue = "161809")]
+pub struct Stopwatch(time::Stopwatch);
+
 /// A measurement of the system clock, useful for talking to
 /// external entities like the file system or other processes.
 ///
@@ -474,6 +497,101 @@ impl Sub<Instant> for Instant {
 
 #[stable(feature = "time2", since = "1.8.0")]
 impl fmt::Debug for Instant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Stopwatch {
+    /// Begins the timer for a `Stopwatch`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(stopwatch)]
+    /// use std::time::Stopwatch;
+    ///
+    /// let now = Stopwatch::start();
+    /// ```
+    #[must_use]
+    #[unstable(feature = "stopwatch", issue = "161809")]
+    pub fn start() -> Self {
+        Self(time::Stopwatch::start())
+    }
+
+    /// Returns the amount of time elapsed from another `Stopwatch` to this one,
+    /// or zero duration if that Stopwatch is later than this one.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(stopwatch)]
+    /// use std::time::{Duration, Stopwatch};
+    /// use std::thread::sleep;
+    ///
+    /// let start = Stopwatch::start();
+    /// sleep(Duration::new(1, 0));
+    /// let end = Stopwatch::start();
+    /// println!("{:?}", end.duration_since(start));
+    /// println!("{:?}", start.duration_since(end)); // 0ns
+    /// ```
+    #[must_use]
+    #[unstable(feature = "stopwatch", issue = "161809")]
+    pub fn duration_since(self, earlier: Self) -> Duration {
+        self.checked_duration_since(earlier).unwrap_or_default()
+    }
+
+    /// Returns the amount of time elapsed from another `Stopwatch` to this one,
+    /// or `None` if that `Stopwatch` is later than this one.
+    ///
+    /// Under rare circumstances this may return `None` even if the other `Stopwatch` was earlier.
+    /// See [Monotonicity].
+    ///
+    /// [Monotonicity]: Instant#monotonicity
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(stopwatch)]
+    /// use std::time::{Duration, Stopwatch};
+    /// use std::thread::sleep;
+    ///
+    /// let start = Stopwatch::start();
+    /// sleep(Duration::new(1, 0));
+    /// let end = Stopwatch::start();
+    /// println!("{:?}", end.checked_duration_since(start));
+    /// println!("{:?}", start.checked_duration_since(end)); // None
+    /// ```
+    #[must_use]
+    #[unstable(feature = "stopwatch", issue = "161809")]
+    pub fn checked_duration_since(self, earlier: Self) -> Option<Duration> {
+        self.0.checked_duration_since(earlier.0)
+    }
+
+    /// Returns the amount of time elapsed since this Stopwatch was started.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(stopwatch)]
+    /// use std::thread::sleep;
+    /// use std::time::{Duration, Stopwatch};
+    ///
+    /// let stopwatch = Stopwatch::start();
+    /// let three_secs = Duration::from_secs(3);
+    /// sleep(three_secs);
+    /// assert!(stopwatch.elapsed() >= three_secs);
+    /// ```
+    #[must_use]
+    #[unstable(feature = "stopwatch", issue = "161809")]
+    pub fn elapsed(self) -> Duration {
+        let end = Self::start();
+        end.checked_duration_since(self).unwrap_or_default()
+    }
+}
+
+#[unstable(feature = "stopwatch", issue = "161809")]
+impl fmt::Debug for Stopwatch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161817)*
<!-- homu-ignore:end -->

For most platforms this currently delegates to `Instant` but they could drift apart later. For Linux I considered `CLOCK_MONOTONIC_RAW` but I wasn't fully convinced it was the right thing to do since adjustments do make `CLOCK_MONOTONIC` more accurate (and apparently there's a bug in older kernels that make calls to `CLOCK_MONOTONIC_RAW` [slower](https://bugzilla.kernel.org/show_bug.cgi?id=198961)). Windows currently uses `QueryPerformanceCounter` for both `Instant` and `Stopwatch` but without the need to convert to a duration as soon as getting the counter. It is expected for `Instant` to change in the future to use the same clock as timeouts, etc.

Tracking issue: rust-lang/rust#161809

r? joboet