### PR TITLE
Add missing option to `-Zself-profile-event` help message as well as information about what the default options are

### DIFF
--- a/compiler/rustc_data_structures/src/profiling.rs
+++ b/compiler/rustc_data_structures/src/profiling.rs
@@ -120,6 +120,7 @@ bitflags::bitflags! {
         /// Store aggregated counts of cache hits per query invocation.
         const QUERY_CACHE_HIT_COUNTS  = 1 << 10;
 
+        // keep this in sync with the `-Z self-profile-events` help message in rustc_session/options.rs
         const DEFAULT = Self::GENERIC_ACTIVITIES.bits() |
                         Self::QUERY_PROVIDERS.bits() |
                         Self::QUERY_BLOCKED.bits() |
@@ -128,6 +129,7 @@ bitflags::bitflags! {
                         Self::ARTIFACT_SIZES.bits() |
                         Self::QUERY_CACHE_HIT_COUNTS.bits();
 
+        // keep this in sync with the `-Z self-profile-events` help message in rustc_session/options.rs
         const ARGS = Self::QUERY_KEYS.bits() | Self::FUNCTION_ARGS.bits();
         const QUERY_CACHE_HIT_COMBINED = Self::QUERY_CACHE_HITS.bits() | Self::QUERY_CACHE_HIT_COUNTS.bits();
     }

--- a/compiler/rustc_data_structures/src/profiling.rs
+++ b/compiler/rustc_data_structures/src/profiling.rs
@@ -120,7 +120,7 @@ bitflags::bitflags! {
         /// Store aggregated counts of cache hits per query invocation.
         const QUERY_CACHE_HIT_COUNTS  = 1 << 10;
 
-        // keep this in sync with the `-Z self-profile-events` help message in rustc_session/options.rs
+        // keep this in sync with the `-Z self-profile-events` help message in rustc_session/src/options.rs
         const DEFAULT = Self::GENERIC_ACTIVITIES.bits() |
                         Self::QUERY_PROVIDERS.bits() |
                         Self::QUERY_BLOCKED.bits() |
@@ -129,13 +129,13 @@ bitflags::bitflags! {
                         Self::ARTIFACT_SIZES.bits() |
                         Self::QUERY_CACHE_HIT_COUNTS.bits();
 
-        // keep this in sync with the `-Z self-profile-events` help message in rustc_session/options.rs
+        // keep this in sync with the `-Z self-profile-events` help message in rustc_session/src/options.rs
         const ARGS = Self::QUERY_KEYS.bits() | Self::FUNCTION_ARGS.bits();
         const QUERY_CACHE_HIT_COMBINED = Self::QUERY_CACHE_HITS.bits() | Self::QUERY_CACHE_HIT_COUNTS.bits();
     }
 }
 
-// keep this in sync with the `-Z self-profile-events` help message in rustc_session/options.rs
+// keep this in sync with the `-Z self-profile-events` help message in rustc_session/src/options.rs
 const EVENT_FILTERS_BY_NAME: &[(&str, EventFilter)] = &[
     ("none", EventFilter::empty()),
     ("all", EventFilter::all()),

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2843,8 +2843,11 @@ written to standard error output)"),
     self_profile_events: Option<Vec<String>> = (None, parse_opt_comma_list, [UNTRACKED],
         "specify the events recorded by the self profiler;
         for example: `-Z self-profile-events=default,query-keys`
-        all options: none, all, default, generic-activity, query-provider, query-cache-hit
-                     query-blocked, incr-cache-load, incr-result-hashing, query-keys, function-args, args, llvm, artifact-sizes"),
+        all option groups: none, all, default, args
+          `default` contains: generic-activity, query-provider, query-cache-hit-count, \
+                            query-blocked, incr-cache-load, incr-result-hashing, artifact-sizes
+             `args` contains: query-keys, function-args
+        remaining (ungrouped) options: query-cache-hit, llvm"),
     share_generics: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "make the current crate share its generic instantiations"),
     shell_argfiles: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2839,7 +2839,7 @@ written to standard error output)"),
         `instructions:u` (retired instructions, userspace-only)
         `instructions-minus-irqs:u` (subtracting hardware interrupt counts for extra accuracy)"
     ),
-    /// keep this in sync with the event filter names in librustc_data_structures/profiling.rs
+    /// keep this in sync with the event filter names and defaults in rustc_data_structures/src/profiling.rs
     self_profile_events: Option<Vec<String>> = (None, parse_opt_comma_list, [UNTRACKED],
         "specify the events recorded by the self profiler;
         for example: `-Z self-profile-events=default,query-keys`


### PR DESCRIPTION
The `query-cache-hit-count` option was forgotten to be added to the help text when it was added.

The new help text also documents which of the options are part of `default`, and now conveys the information that `args` is also a compound/group option and what it contains.
