### PR TITLE
Clarify that match_indices returns an iterator over byte indices

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2084,7 +2084,7 @@ impl str {
     }
 
     /// Returns an iterator over the disjoint matches of a pattern within this string
-    /// slice as well as the index that the match starts at.
+    /// slice as well as the byte index that the match starts at.
     ///
     /// For matches of `pat` within `self` that overlap, only the indices
     /// corresponding to the first match are returned.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
Addresses [#161812]("https://github.com/rust-lang/rust/issues/161812")
Ran the following tests:
`./x doc library/core`
`./x test library/core`
Successfully built docs website via
`./x doc library/core --open`