### PR TITLE
rustdoc: fix lint `cargo::non_kebab_case_bins`

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -797,7 +797,7 @@ impl CommandLineStep for Rustdoc {
                 // Cargo adds a number of paths to the dylib search path on windows, which results in
                 // the wrong rustdoc being executed. To avoid the conflicting rustdocs, we name the "tool"
                 // rustdoc a different name.
-                tool: "rustdoc_tool_binary",
+                tool: "rustdoc-tool-binary",
                 mode: Mode::ToolRustcPrivate,
                 path: "src/tools/rustdoc",
                 source_type: SourceType::InTree,

--- a/src/tools/rustdoc/Cargo.toml
+++ b/src/tools/rustdoc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 # the wrong rustdoc being executed. To avoid the conflicting rustdocs, we name the "tool"
 # rustdoc a different name.
 [[bin]]
-name = "rustdoc_tool_binary"
+name = "rustdoc-tool-binary"
 path = "main.rs"
 
 [dependencies]


### PR DESCRIPTION
```
warning: binary `rustdoc_tool_binary` should have a kebab-case name
   |
 1 | /checkout/obj/build/x86_64-unknown-linux-gnu/bootstrap-tools/.../rustdoc_tool_binary
   |                                                                  ^^^^^^^^^^^^^^^^^^^
   |
   = note: `cargo::non_kebab_case_bins` is set to `warn` by default
help: to change the binary name to `rustdoc-tool-binary`, convert `bin.name`
  --> src/tools/rustdoc/Cargo.toml:10:8
   |
10 - name = "rustdoc_tool_binary"
10 + name = "rustdoc-tool-binary"
   |
warning: `rustdoc-tool` (manifest) generated 1 warning
```

See
<https://triage.rust-lang.org/gha-logs/rust-lang/rust/98030530980#L2026-08-26T03:05:00.5389265Z-L2026-08-26T03:05:00.5392627Z>

This was found in <https://github.com/rust-lang/rust/pull/161789>.