### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,6 @@ dependencies = [
  "shim_utils",
  "tracing",
  "tracing-subscriber",
- "unified-diff",
  "walkdir",
  "windows 0.61.3",
 ]
@@ -6207,15 +6206,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unified-diff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496a3d395ed0c30f411ceace4a91f7d93b148fb5a9b383d5d4cff7850f048d5f"
-dependencies = [
- "diff",
-]
 
 [[package]]
 name = "unit-prefix"

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -21,16 +21,19 @@ use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::IndexVec;
-use rustc_infer::infer::NllRegionVariableOrigin;
+use rustc_infer::infer::{NllRegionVariableOrigin, TyCtxtInferExt};
+use rustc_infer::traits::ObligationCause;
 use rustc_macros::extension;
 use rustc_middle::mir::RETURN_PLACE;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{
     self, BoundVariableKind, GenericArgs, GenericArgsRef, InlineConstArgs, InlineConstArgsParts,
-    List, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, fold_regions,
+    List, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, TypingMode,
+    fold_regions,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{ErrorGuaranteed, kw, sym};
+use rustc_trait_selection::traits::ObligationCtxt;
 use tracing::{debug, instrument};
 
 use crate::BorrowckInferCtxt;
@@ -133,12 +136,32 @@ pub(crate) enum DefiningTy<'tcx> {
     GlobalAsm(DefId),
 }
 
+fn normalized_type_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
+    let ty = tcx.type_of(def_id).instantiate_identity();
+    if !tcx.next_trait_solver_globally() {
+        return ty.skip_normalization();
+    }
+
+    let typing_mode = if tcx.use_typing_mode_post_typeck_until_borrowck() {
+        TypingMode::borrowck(tcx, def_id)
+    } else {
+        TypingMode::analysis_in_body(tcx, def_id)
+    };
+    let infcx = tcx.infer_ctxt().build(typing_mode);
+    let ocx = ObligationCtxt::new(&infcx);
+    let span = tcx.def_span(def_id);
+    let cause = ObligationCause::misc(span, def_id);
+    ocx.deeply_normalize(&cause, tcx.param_env(def_id), ty).unwrap()
+}
+
 impl<'tcx> DefiningTy<'tcx> {
     #[instrument(level = "debug", skip(tcx), ret)]
     fn new(tcx: TyCtxt<'tcx>, body_def_id: LocalDefId) -> DefiningTy<'tcx> {
         match tcx.hir_body_owner_kind(body_def_id) {
             BodyOwnerKind::Closure | BodyOwnerKind::Fn => {
-                let defining_ty = tcx.type_of(body_def_id).instantiate_identity().skip_norm_wip();
+                // Normalize after instantiation so coroutine yield/resume
+                // types in the args are rigid under the next solver.
+                let defining_ty = normalized_type_of(tcx, body_def_id);
                 match *defining_ty.kind() {
                     ty::Closure(def_id, args) => DefiningTy::Closure(def_id, args),
                     ty::Coroutine(def_id, args) => DefiningTy::Coroutine(def_id, args),

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -455,8 +455,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // compile time.
         M::check_fn_target_features(self, instance)?;
 
+        // If the signature says this cannot unwind, reflect this in the unwind destination so that
+        // we don't have to check this later. (`init_fn_call` already did this for the caller so
+        // here we only have to check the callee.)
         if !callee_fn_abi.can_unwind {
-            // The callee cannot unwind, so force the `Unreachable` unwind handling.
             match &mut cont {
                 ReturnContinuation::Stop { .. } => {}
                 ReturnContinuation::Goto { unwind, .. } => {
@@ -677,11 +679,17 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         with_caller_location: bool,
         destination: &PlaceTy<'tcx, M::Provenance>,
         target: Option<mir::BasicBlock>,
-        unwind: mir::UnwindAction,
+        mut unwind: mir::UnwindAction,
     ) -> InterpResult<'tcx> {
         let _trace =
             enter_trace_span!(M, step::init_fn_call, tracing_separate_thread = Empty, ?fn_val)
                 .or_if_tracing_disabled(|| trace!("init_fn_call: {:#?}", fn_val));
+
+        // If the signature says this cannot unwind, reflect this in the unwind destination
+        // so that we don't have to check this later.
+        if caller_fn_abi.is_some_and(|abi| !abi.can_unwind) {
+            unwind = mir::UnwindAction::Unreachable;
+        }
 
         let instance = match fn_val {
             FnVal::Instance(instance) => instance,

--- a/compiler/rustc_middle/src/hooks/mod.rs
+++ b/compiler/rustc_middle/src/hooks/mod.rs
@@ -58,12 +58,6 @@ declare_hooks! {
     /// Getting a &core::panic::Location referring to a span.
     hook const_caller_location(file: rustc_span::Symbol, line: u32, col: u32) -> mir::ConstValue;
 
-    /// Returns `true` if this def is a function-like thing that is eligible for
-    /// coverage instrumentation under `-Cinstrument-coverage`.
-    ///
-    /// (Eligible functions might nevertheless be skipped for other reasons.)
-    hook is_eligible_for_coverage(key: LocalDefId) -> bool;
-
     /// Imports all `SourceFile`s from the given crate into the current session.
     /// This normally happens automatically when we decode a `Span` from
     /// that crate's metadata - however, the incr comp cache needs

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -714,6 +714,14 @@ rustc_queries! {
         separate_provide_extern
     }
 
+    /// Returns `true` if this def is a function-like thing that is eligible for
+    /// coverage instrumentation under `-Cinstrument-coverage`.
+    ///
+    /// (Eligible functions might nevertheless be skipped for other reasons.)
+    query is_eligible_for_coverage(key: LocalDefId) -> bool {
+        desc { "checking whether `{}` is eligible for coverage", tcx.def_path_str(key) }
+    }
+
     /// Checks for the nearest `#[coverage(off)]` or `#[coverage(on)]` on
     /// this def and any enclosing defs, up to the crate root.
     ///

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -33,6 +33,7 @@ use rustc_hir::{self as hir, BindingMode, ByRef, HirId, ItemLocalId, Node, find_
 use rustc_index::bit_set::GrowableBitSet;
 use rustc_index::{Idx, IndexSlice, IndexVec};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
+use rustc_infer::traits::ObligationCause;
 use rustc_middle::hir::place::PlaceBase as HirPlaceBase;
 use rustc_middle::middle::region;
 use rustc_middle::mir::*;
@@ -40,6 +41,7 @@ use rustc_middle::thir::{self, ExprId, LocalVarId, Param, ParamId, PatKind, Thir
 use rustc_middle::ty::{self, ScalarInt, Ty, TyCtxt, TypeVisitableExt, TypingMode};
 use rustc_middle::{bug, span_bug};
 use rustc_span::{Span, Symbol};
+use rustc_trait_selection::traits::ObligationCtxt;
 
 use crate::builder::expr::as_place::PlaceBuilder;
 use crate::builder::scope::LintLevel;
@@ -477,15 +479,6 @@ fn construct_fn<'tcx>(
     let arguments = &thir.params;
 
     let return_ty = fn_sig.output();
-    let coroutine = match tcx.type_of(fn_def).instantiate_identity().skip_norm_wip().kind() {
-        ty::Coroutine(_, args) => Some(Box::new(CoroutineInfo::initial(
-            tcx.coroutine_kind(fn_def).unwrap(),
-            args.as_coroutine().yield_ty(),
-            args.as_coroutine().resume_ty(),
-        ))),
-        ty::Closure(..) | ty::CoroutineClosure(..) | ty::FnDef(..) => None,
-        ty => span_bug!(span_with_body, "unexpected type of body: {ty:?}"),
-    };
 
     if let Some((dialect, phase)) =
         find_attr!(tcx, fn_id, CustomMir(dialect, phase) => (dialect, phase))
@@ -514,6 +507,17 @@ fn construct_fn<'tcx>(
     };
 
     let infcx = tcx.infer_ctxt().build(typing_mode);
+
+    let coroutine = match normalized_type_of(&infcx, fn_def).kind() {
+        ty::Coroutine(_, args) => Some(Box::new(CoroutineInfo::initial(
+            tcx.coroutine_kind(fn_def).unwrap(),
+            args.as_coroutine().yield_ty(),
+            args.as_coroutine().resume_ty(),
+        ))),
+        ty::Closure(..) | ty::CoroutineClosure(..) | ty::FnDef(..) => None,
+        ty => span_bug!(span_with_body, "unexpected type of body: {ty:?}"),
+    };
+
     let mut builder = Builder::new(
         thir,
         infcx,
@@ -560,6 +564,18 @@ fn construct_fn<'tcx>(
     };
 
     body
+}
+
+fn normalized_type_of<'tcx>(infcx: &InferCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
+    let tcx = infcx.tcx;
+    let ty = tcx.type_of(def_id).instantiate_identity();
+    if !infcx.next_trait_solver() {
+        return ty.skip_normalization();
+    }
+
+    let ocx = ObligationCtxt::new(infcx);
+    let cause = ObligationCause::misc(tcx.def_span(def_id), def_id);
+    ocx.deeply_normalize(&cause, tcx.param_env(def_id), ty).unwrap()
 }
 
 fn construct_const<'a, 'tcx>(

--- a/compiler/rustc_mir_transform/src/coverage/query.rs
+++ b/compiler/rustc_mir_transform/src/coverage/query.rs
@@ -14,12 +14,12 @@ use crate::coverage::counters::{CoverageCounters, transcribe_counters};
 
 /// Registers query/hook implementations related to coverage.
 pub(crate) fn provide(providers: &mut Providers) {
-    providers.hooks.is_eligible_for_coverage = is_eligible_for_coverage;
+    providers.queries.is_eligible_for_coverage = is_eligible_for_coverage;
     providers.queries.coverage_attr_on = coverage_attr_on;
     providers.queries.coverage_ids_info = coverage_ids_info;
 }
 
-/// Hook implementation for [`TyCtxt::is_eligible_for_coverage`].
+/// Query implementation for [`TyCtxt::is_eligible_for_coverage`].
 fn is_eligible_for_coverage(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     // Only instrument functions, methods, and closures (not constants since they are evaluated
     // at compile time by Miri).

--- a/compiler/rustc_thread_pool/Cargo.toml
+++ b/compiler/rustc_thread_pool/Cargo.toml
@@ -8,7 +8,6 @@ authors = [
 description = "Core APIs for Rayon - fork for rustc"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-readme = "README.md"
 keywords = ["parallel", "thread", "concurrency", "join", "performance"]
 categories = ["concurrency"]
 

--- a/library/alloc/src/boxed/thin.rs
+++ b/library/alloc/src/boxed/thin.rs
@@ -11,7 +11,7 @@ use core::marker::PhantomData;
 use core::marker::Unsize;
 #[cfg(not(no_global_oom_handling))]
 use core::mem;
-use core::mem::SizedTypeProperties;
+use core::mem::{DropGuard, SizedTypeProperties};
 use core::ops::{Deref, DerefMut};
 use core::ptr::{self, NonNull, Pointee};
 
@@ -360,38 +360,23 @@ impl<H> WithHeader<H> {
     // - Assumes that either `value` can be dereferenced, or is the
     //   `NonNull::dangling()` we use when both `T` and `H` are ZSTs.
     unsafe fn drop<T: ?Sized>(&self, value: *mut T) {
-        struct DropGuard<H> {
-            ptr: NonNull<u8>,
-            value_layout: Layout,
-            _marker: PhantomData<H>,
-        }
-
-        impl<H> Drop for DropGuard<H> {
-            fn drop(&mut self) {
-                // All ZST are allocated statically.
-                if self.value_layout.size() == 0 {
-                    return;
-                }
-
-                unsafe {
-                    // SAFETY: Layout must have been computable if we're in drop
-                    let (layout, value_offset) =
-                        WithHeader::<H>::alloc_layout(self.value_layout).unwrap_unchecked();
-
-                    // Since we only allocate for non-ZSTs, the layout size cannot be zero.
-                    debug_assert!(layout.size() != 0);
-                    alloc::dealloc(self.ptr.as_ptr().sub(value_offset), layout);
-                }
-            }
-        }
-
         unsafe {
             // `_guard` will deallocate the memory when dropped, even if `drop_in_place` unwinds.
-            let _guard = DropGuard {
-                ptr: self.0,
-                value_layout: Layout::for_value_raw(value),
-                _marker: PhantomData::<H>,
-            };
+            let _guard =
+                DropGuard::new((self.0, Layout::for_value_raw(value)), |(ptr, value_layout)| {
+                    // All ZST are allocated statically.
+                    if value_layout.size() == 0 {
+                        return;
+                    }
+
+                    // SAFETY: Layout must have been computable if we're in drop
+                    let (layout, value_offset) =
+                        WithHeader::<H>::alloc_layout(value_layout).unwrap_unchecked();
+
+                    // Since we only allocate for non-ZSTs, the layout size cannot be zero.
+                    debug_assert_ne!(layout.size(), 0);
+                    alloc::dealloc(ptr.as_ptr().sub(value_offset), layout);
+                });
 
             // We only drop the value because the Pointee trait requires that the metadata is copy
             // aka trivially droppable.

--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -145,7 +145,7 @@
 
 use core::alloc::Allocator;
 use core::iter::{FusedIterator, InPlaceIterable, SourceIter, TrustedFused, TrustedLen};
-use core::mem::{self, ManuallyDrop, swap};
+use core::mem::{DropGuard, ManuallyDrop, swap};
 use core::num::NonZero;
 use core::ops::{Deref, DerefMut};
 use core::{fmt, ptr};
@@ -1907,18 +1907,10 @@ impl<'a, T: Ord, A: Allocator> DrainSorted<'a, T, A> {
 impl<'a, T: Ord, A: Allocator> Drop for DrainSorted<'a, T, A> {
     /// Removes heap elements in heap order.
     fn drop(&mut self) {
-        struct DropGuard<'r, 'a, T: Ord, A: Allocator>(&'r mut DrainSorted<'a, T, A>);
-
-        impl<'r, 'a, T: Ord, A: Allocator> Drop for DropGuard<'r, 'a, T, A> {
-            fn drop(&mut self) {
-                while self.0.inner.pop().is_some() {}
-            }
-        }
-
         while let Some(item) = self.inner.pop() {
-            let guard = DropGuard(self);
+            let guard = DropGuard::new(&mut *self, |this| while this.inner.pop().is_some() {});
             drop(item);
-            mem::forget(guard);
+            DropGuard::dismiss(guard);
         }
     }
 }

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -5,7 +5,7 @@ use core::fmt::{self, Debug};
 use core::hash::{Hash, Hasher};
 use core::iter::{FusedIterator, TrustedLen};
 use core::marker::PhantomData;
-use core::mem::{self, ManuallyDrop};
+use core::mem::{self, DropGuard, ManuallyDrop};
 use core::ops::{Bound, Index, RangeBounds};
 use core::ptr;
 
@@ -1904,24 +1904,18 @@ impl<K, V, A: AllocatorClone> IntoIterator for BTreeMap<K, V, A> {
 #[stable(feature = "btree_drop", since = "1.7.0")]
 impl<K, V, A: AllocatorClone> Drop for IntoIter<K, V, A> {
     fn drop(&mut self) {
-        struct DropGuard<'a, K, V, A: AllocatorClone>(&'a mut IntoIter<K, V, A>);
-
-        impl<'a, K, V, A: AllocatorClone> Drop for DropGuard<'a, K, V, A> {
-            fn drop(&mut self) {
+        while let Some(kv) = self.dying_next() {
+            let guard = DropGuard::new(&mut *self, |this| {
                 // Continue the same loop we perform below. This only runs when unwinding, so we
                 // don't have to care about panics this time (they'll abort).
-                while let Some(kv) = self.0.dying_next() {
+                while let Some(kv) = this.dying_next() {
                     // SAFETY: we consume the dying handle immediately.
                     unsafe { kv.drop_key_val() };
                 }
-            }
-        }
-
-        while let Some(kv) = self.dying_next() {
-            let guard = DropGuard(self);
+            });
             // SAFETY: we don't touch the tree before consuming the dying handle.
             unsafe { kv.drop_key_val() };
-            mem::forget(guard);
+            DropGuard::dismiss(guard);
         }
     }
 }

--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -32,7 +32,7 @@
 //   an edge both identifies a position and contains a pointer to a child node.
 
 use core::marker::PhantomData;
-use core::mem::{self, MaybeUninit};
+use core::mem::{self, DropGuard, MaybeUninit};
 use core::num::NonZero;
 use core::ptr::{self, NonNull};
 use core::slice::SliceIndex;
@@ -1192,23 +1192,13 @@ impl<K, V, NodeType> Handle<NodeRef<marker::Dying, K, V, NodeType>, marker::KV> 
     /// The node that the handle refers to must not yet have been deallocated.
     #[inline]
     pub(super) unsafe fn drop_key_val(mut self) {
-        // Run the destructor of the value even if the destructor of the key panics.
-        struct Dropper<'a, T>(&'a mut MaybeUninit<T>);
-        impl<T> Drop for Dropper<'_, T> {
-            #[inline]
-            fn drop(&mut self) {
-                unsafe {
-                    self.0.assume_init_drop();
-                }
-            }
-        }
-
         debug_assert!(self.idx < self.node.len());
         let leaf = self.node.as_leaf_dying();
         unsafe {
             let key = leaf.keys.get_unchecked_mut(self.idx);
             let val = leaf.vals.get_unchecked_mut(self.idx);
-            let _guard = Dropper(val);
+            // Run the destructor of the value even if the destructor of the key panics.
+            let _guard = DropGuard::new(val, |val| val.assume_init_drop());
             key.assume_init_drop();
             // dropping the guard will drop the value
         }

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -17,6 +17,7 @@ use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::iter::{FusedIterator, TrustedLen};
 use core::marker::PhantomData;
+use core::mem::DropGuard;
 use core::ptr::NonNull;
 use core::{fmt, mem};
 
@@ -1177,20 +1178,15 @@ impl<T, A: Allocator> LinkedList<T, A> {
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T, A: Allocator> Drop for LinkedList<T, A> {
     fn drop(&mut self) {
-        struct DropGuard<'a, T, A: Allocator>(&'a mut LinkedList<T, A>);
-
-        impl<'a, T, A: Allocator> Drop for DropGuard<'a, T, A> {
-            fn drop(&mut self) {
-                // Continue the same loop we do below. This only runs when a destructor has
-                // panicked. If another one panics this will abort.
-                while self.0.pop_front_node().is_some() {}
-            }
-        }
-
         // Wrap self so that if a destructor panics, we can try to keep looping
-        let guard = DropGuard(self);
-        while guard.0.pop_front_node().is_some() {}
-        mem::forget(guard);
+        let mut guard = DropGuard::new(self, |this| {
+            // Continue the same loop we do below. This only runs when a destructor has
+            // panicked. If another one panics this will abort.
+            while this.pop_front_node().is_some() {}
+        });
+
+        while guard.pop_front_node().is_some() {}
+        DropGuard::dismiss(guard);
     }
 }
 

--- a/library/alloc/src/collections/vec_deque/drain.rs
+++ b/library/alloc/src/collections/vec_deque/drain.rs
@@ -1,6 +1,6 @@
 use core::iter::FusedIterator;
 use core::marker::PhantomData;
-use core::mem::{self, SizedTypeProperties};
+use core::mem::{self, DropGuard, SizedTypeProperties};
 use core::ptr::NonNull;
 use core::{fmt, ptr};
 
@@ -93,140 +93,133 @@ unsafe impl<T: Send, A: Allocator + Send> Send for Drain<'_, T, A> {}
 #[stable(feature = "drain", since = "1.6.0")]
 impl<T, A: Allocator> Drop for Drain<'_, T, A> {
     fn drop(&mut self) {
-        struct DropGuard<'r, 'a, T, A: Allocator>(&'r mut Drain<'a, T, A>);
+        // Dropping `guard` handles moving the remaining elements into place.
+        let mut guard = DropGuard::new(self, |this| {
+            if mem::needs_drop::<T>() && this.remaining != 0 {
+                unsafe {
+                    // SAFETY: We just checked that `self.remaining != 0`.
+                    let (front, back) = this.as_slices();
+                    ptr::drop_in_place(front);
+                    ptr::drop_in_place(back);
+                }
+            }
 
-        let guard = DropGuard(self);
+            let source_deque = unsafe { this.deque.as_mut() };
 
-        if mem::needs_drop::<T>() && guard.0.remaining != 0 {
+            let drain_len = this.drain_len;
+            let head_len = source_deque.len; // #elements in front of the drain
+            let tail_len = this.tail_len; // #elements behind the drain
+            let new_len = head_len + tail_len;
+
+            if T::IS_ZST {
+                // no need to copy around any memory if T is a ZST
+                source_deque.len = new_len;
+                return;
+            }
+
+            // Next, we will fill the hole left by the drain with as few writes as possible.
+            // The code below handles the following control flow and reduces the amount of
+            // branches under the assumption that `head_len == 0 || tail_len == 0`, i.e.
+            // draining at the front or at the back of the dequeue is especially common.
+            //
+            // H = "head index" = `deque.head`
+            // h = elements in front of the drain
+            // d = elements in the drain
+            // t = elements behind the drain
+            //
+            // Note that the buffer may wrap at any point and the wrapping is handled by
+            // `wrap_copy` and `to_physical_idx`.
+            //
+            // Case 1: if `head_len == 0 && tail_len == 0`
+            // Everything was drained, reset the head index back to 0.
+            //             H
+            // [ . . . . . d d d d . . . . . ]
+            //   H
+            // [ . . . . . . . . . . . . . . ]
+            //
+            // Case 2: else if `tail_len == 0`
+            // Don't move data or the head index.
+            //         H
+            // [ . . . h h h h d d d d . . . ]
+            //         H
+            // [ . . . h h h h . . . . . . . ]
+            //
+            // Case 3: else if `head_len == 0`
+            // Don't move data, but move the head index.
+            //         H
+            // [ . . . d d d d t t t t . . . ]
+            //                 H
+            // [ . . . . . . . t t t t . . . ]
+            //
+            // Case 4: else if `tail_len <= head_len`
+            // Move data, but not the head index.
+            //       H
+            // [ . . h h h h d d d d t t . . ]
+            //       H
+            // [ . . h h h h t t . . . . . . ]
+            //
+            // Case 5: else
+            // Move data and the head index.
+            //       H
+            // [ . . h h d d d d t t t t . . ]
+            //               H
+            // [ . . . . . . h h t t t t . . ]
+
+            // When draining at the front (`.drain(..n)`) or at the back (`.drain(n..)`),
+            // we don't need to copy any data. The number of elements copied would be 0.
+            if head_len != 0 && tail_len != 0 {
+                join_head_and_tail_wrapping(source_deque, drain_len, head_len, tail_len);
+                // Marking this function as cold helps LLVM to eliminate it entirely if
+                // this branch is never taken.
+                // We use `#[cold]` instead of `#[inline(never)]`, because inlining this
+                // function into the general case (`.drain(n..m)`) is fine.
+                // See `tests/codegen-llvm/vecdeque-drain.rs` for a test.
+                #[cold]
+                fn join_head_and_tail_wrapping<T, A: Allocator>(
+                    source_deque: &mut VecDeque<T, A>,
+                    drain_len: usize,
+                    head_len: usize,
+                    tail_len: usize,
+                ) {
+                    // Pick whether to move the head or the tail here.
+                    let (src, dst, len);
+                    if head_len < tail_len {
+                        src = source_deque.head;
+                        dst = source_deque.to_wrapped_index(drain_len);
+                        len = head_len;
+                    } else {
+                        src = source_deque.to_wrapped_index(head_len + drain_len);
+                        dst = source_deque.to_wrapped_index(head_len);
+                        len = tail_len;
+                    };
+
+                    unsafe {
+                        source_deque.wrap_copy(src, dst, len);
+                    }
+                }
+            }
+
+            if new_len == 0 {
+                // Special case: If the entire deque was drained, reset the head back to 0,
+                // like `.clear()` does.
+                source_deque.head = WrappedIndex::zero();
+            } else if head_len < tail_len {
+                // If we moved the head above, then we need to adjust the head index here.
+                source_deque.head = source_deque.to_wrapped_index(drain_len);
+            }
+            source_deque.len = new_len;
+        });
+
+        if mem::needs_drop::<T>() && guard.remaining != 0 {
             unsafe {
                 // SAFETY: We just checked that `self.remaining != 0`.
-                let (front, back) = guard.0.as_slices();
+                let (front, back) = guard.as_slices();
                 // since idx is a logical index, we don't need to worry about wrapping.
-                guard.0.idx += front.len();
-                guard.0.remaining -= front.len();
+                guard.idx += front.len();
+                guard.remaining -= front.len();
                 ptr::drop_in_place(front);
-                guard.0.remaining = 0;
+                guard.remaining = 0;
                 ptr::drop_in_place(back);
-            }
-        }
-
-        // Dropping `guard` handles moving the remaining elements into place.
-        impl<'r, 'a, T, A: Allocator> Drop for DropGuard<'r, 'a, T, A> {
-            #[inline]
-            fn drop(&mut self) {
-                if mem::needs_drop::<T>() && self.0.remaining != 0 {
-                    unsafe {
-                        // SAFETY: We just checked that `self.remaining != 0`.
-                        let (front, back) = self.0.as_slices();
-                        ptr::drop_in_place(front);
-                        ptr::drop_in_place(back);
-                    }
-                }
-
-                let source_deque = unsafe { self.0.deque.as_mut() };
-
-                let drain_len = self.0.drain_len;
-                let head_len = source_deque.len; // #elements in front of the drain
-                let tail_len = self.0.tail_len; // #elements behind the drain
-                let new_len = head_len + tail_len;
-
-                if T::IS_ZST {
-                    // no need to copy around any memory if T is a ZST
-                    source_deque.len = new_len;
-                    return;
-                }
-
-                // Next, we will fill the hole left by the drain with as few writes as possible.
-                // The code below handles the following control flow and reduces the amount of
-                // branches under the assumption that `head_len == 0 || tail_len == 0`, i.e.
-                // draining at the front or at the back of the dequeue is especially common.
-                //
-                // H = "head index" = `deque.head`
-                // h = elements in front of the drain
-                // d = elements in the drain
-                // t = elements behind the drain
-                //
-                // Note that the buffer may wrap at any point and the wrapping is handled by
-                // `wrap_copy` and `to_physical_idx`.
-                //
-                // Case 1: if `head_len == 0 && tail_len == 0`
-                // Everything was drained, reset the head index back to 0.
-                //             H
-                // [ . . . . . d d d d . . . . . ]
-                //   H
-                // [ . . . . . . . . . . . . . . ]
-                //
-                // Case 2: else if `tail_len == 0`
-                // Don't move data or the head index.
-                //         H
-                // [ . . . h h h h d d d d . . . ]
-                //         H
-                // [ . . . h h h h . . . . . . . ]
-                //
-                // Case 3: else if `head_len == 0`
-                // Don't move data, but move the head index.
-                //         H
-                // [ . . . d d d d t t t t . . . ]
-                //                 H
-                // [ . . . . . . . t t t t . . . ]
-                //
-                // Case 4: else if `tail_len <= head_len`
-                // Move data, but not the head index.
-                //       H
-                // [ . . h h h h d d d d t t . . ]
-                //       H
-                // [ . . h h h h t t . . . . . . ]
-                //
-                // Case 5: else
-                // Move data and the head index.
-                //       H
-                // [ . . h h d d d d t t t t . . ]
-                //               H
-                // [ . . . . . . h h t t t t . . ]
-
-                // When draining at the front (`.drain(..n)`) or at the back (`.drain(n..)`),
-                // we don't need to copy any data. The number of elements copied would be 0.
-                if head_len != 0 && tail_len != 0 {
-                    join_head_and_tail_wrapping(source_deque, drain_len, head_len, tail_len);
-                    // Marking this function as cold helps LLVM to eliminate it entirely if
-                    // this branch is never taken.
-                    // We use `#[cold]` instead of `#[inline(never)]`, because inlining this
-                    // function into the general case (`.drain(n..m)`) is fine.
-                    // See `tests/codegen-llvm/vecdeque-drain.rs` for a test.
-                    #[cold]
-                    fn join_head_and_tail_wrapping<T, A: Allocator>(
-                        source_deque: &mut VecDeque<T, A>,
-                        drain_len: usize,
-                        head_len: usize,
-                        tail_len: usize,
-                    ) {
-                        // Pick whether to move the head or the tail here.
-                        let (src, dst, len);
-                        if head_len < tail_len {
-                            src = source_deque.head;
-                            dst = source_deque.to_wrapped_index(drain_len);
-                            len = head_len;
-                        } else {
-                            src = source_deque.to_wrapped_index(head_len + drain_len);
-                            dst = source_deque.to_wrapped_index(head_len);
-                            len = tail_len;
-                        };
-
-                        unsafe {
-                            source_deque.wrap_copy(src, dst, len);
-                        }
-                    }
-                }
-
-                if new_len == 0 {
-                    // Special case: If the entire deque was drained, reset the head back to 0,
-                    // like `.clear()` does.
-                    source_deque.head = WrappedIndex::zero();
-                } else if head_len < tail_len {
-                    // If we moved the head above, then we need to adjust the head index here.
-                    source_deque.head = source_deque.to_wrapped_index(drain_len);
-                }
-                source_deque.len = new_len;
             }
         }
     }

--- a/library/alloc/src/collections/vec_deque/into_iter.rs
+++ b/library/alloc/src/collections/vec_deque/into_iter.rs
@@ -1,5 +1,5 @@
 use core::iter::{FusedIterator, TrustedLen};
-use core::mem::MaybeUninit;
+use core::mem::{DropGuard, MaybeUninit};
 use core::num::NonZero;
 use core::ops::Try;
 use core::{array, fmt, ptr};
@@ -78,28 +78,20 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
         F: FnMut(B, Self::Item) -> R,
         R: Try<Output = B>,
     {
-        struct Guard<'a, T, A: Allocator> {
-            deque: &'a mut VecDeque<T, A>,
-            // `consumed <= deque.len` always holds.
-            consumed: usize,
-        }
+        // `consumed <= deque.len` always holds.
+        let mut guard = DropGuard::new((&mut self.inner, 0), |(deque, consumed)| {
+            deque.len -= consumed;
+            deque.head = deque.to_wrapped_index(consumed);
+        });
 
-        impl<'a, T, A: Allocator> Drop for Guard<'a, T, A> {
-            fn drop(&mut self) {
-                self.deque.len -= self.consumed;
-                self.deque.head = self.deque.to_wrapped_index(self.consumed);
-            }
-        }
-
-        let mut guard = Guard { deque: &mut self.inner, consumed: 0 };
-
-        let (head, tail) = guard.deque.as_slices();
+        let (deque, consumed) = &mut *guard;
+        let (head, tail) = deque.as_slices();
 
         init = head
             .iter()
             .map(|elem| {
-                guard.consumed += 1;
-                // SAFETY: Because we incremented `guard.consumed`, the
+                *consumed += 1;
+                // SAFETY: Because we incremented `consumed`, the
                 // deque effectively forgot the element, so we can take
                 // ownership
                 unsafe { ptr::read(elem) }
@@ -108,7 +100,7 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
 
         tail.iter()
             .map(|elem| {
-                guard.consumed += 1;
+                *consumed += 1;
                 // SAFETY: Same as above.
                 unsafe { ptr::read(elem) }
             })
@@ -201,26 +193,18 @@ impl<T, A: Allocator> DoubleEndedIterator for IntoIter<T, A> {
         F: FnMut(B, Self::Item) -> R,
         R: Try<Output = B>,
     {
-        struct Guard<'a, T, A: Allocator> {
-            deque: &'a mut VecDeque<T, A>,
-            // `consumed <= deque.len` always holds.
-            consumed: usize,
-        }
+        // `consumed <= deque.len` always holds.
+        let mut guard = DropGuard::new((&mut self.inner, 0), |(deque, consumed)| {
+            deque.len -= consumed;
+        });
 
-        impl<'a, T, A: Allocator> Drop for Guard<'a, T, A> {
-            fn drop(&mut self) {
-                self.deque.len -= self.consumed;
-            }
-        }
-
-        let mut guard = Guard { deque: &mut self.inner, consumed: 0 };
-
-        let (head, tail) = guard.deque.as_slices();
+        let (deque, consumed) = &mut *guard;
+        let (head, tail) = deque.as_slices();
 
         init = tail
             .iter()
             .map(|elem| {
-                guard.consumed += 1;
+                *consumed += 1;
                 // SAFETY: See `try_fold`'s safety comment.
                 unsafe { ptr::read(elem) }
             })
@@ -228,7 +212,7 @@ impl<T, A: Allocator> DoubleEndedIterator for IntoIter<T, A> {
 
         head.iter()
             .map(|elem| {
-                guard.consumed += 1;
+                *consumed += 1;
                 // SAFETY: Same as above.
                 unsafe { ptr::read(elem) }
             })

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -17,7 +17,7 @@ use core::iter::{ByRefSized, repeat_n, repeat_with};
 // failures in linkchecker even though rustdoc built the docs just fine.
 #[allow(unused_imports)]
 use core::mem;
-use core::mem::{ManuallyDrop, SizedTypeProperties};
+use core::mem::{DropGuard, ManuallyDrop, SizedTypeProperties};
 use core::ops::{Index, IndexMut, Range, RangeBounds};
 use core::{fmt, ptr, slice};
 
@@ -632,35 +632,23 @@ impl<T, A: Allocator> VecDeque<T, A> {
         mut iter: impl Iterator<Item = T>,
         len: usize,
     ) -> usize {
-        struct Guard<'a, T, A: Allocator> {
-            deque: &'a mut VecDeque<T, A>,
-            written: usize,
-        }
-
-        impl<'a, T, A: Allocator> Drop for Guard<'a, T, A> {
-            fn drop(&mut self) {
-                self.deque.len += self.written;
-            }
-        }
-
         let head_room = self.capacity() - dst.as_index();
 
-        let mut guard = Guard { deque: self, written: 0 };
+        let mut guard = DropGuard::new((self, 0), |(deque, written)| {
+            deque.len += written;
+        });
+        let (deque, written) = &mut *guard;
 
         if head_room >= len {
-            unsafe { guard.deque.write_iter(dst, iter, &mut guard.written) };
+            unsafe { deque.write_iter(dst, iter, written) };
         } else {
             unsafe {
-                guard.deque.write_iter(
-                    dst,
-                    ByRefSized(&mut iter).take(head_room),
-                    &mut guard.written,
-                );
-                guard.deque.write_iter(WrappedIndex::zero(), iter, &mut guard.written)
+                deque.write_iter(dst, ByRefSized(&mut iter).take(head_room), written);
+                deque.write_iter(WrappedIndex::zero(), iter, written)
             };
         }
 
-        guard.written
+        *written
     }
 
     /// Frobs the head and tail sections around to handle the fact that we

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2396,45 +2396,31 @@ impl<T> Rc<[T]> {
     /// Behavior is undefined should the size be wrong.
     #[cfg(not(no_global_oom_handling))]
     unsafe fn from_iter_exact(iter: impl Iterator<Item = T>, len: usize) -> Rc<[T]> {
-        // Panic guard while cloning T elements.
-        // In the event of a panic, elements that have been written
-        // into the new RcInner will be dropped, then the memory freed.
-        struct Guard<T> {
-            mem: NonNull<u8>,
-            elems: *mut T,
-            layout: Layout,
-            n_elems: usize,
-        }
-
-        impl<T> Drop for Guard<T> {
-            fn drop(&mut self) {
-                unsafe {
-                    let slice = from_raw_parts_mut(self.elems, self.n_elems);
-                    ptr::drop_in_place(slice);
-
-                    Global.deallocate(self.mem, self.layout);
-                }
-            }
-        }
+        use core::mem::DropGuard;
 
         unsafe {
             let ptr = Self::allocate_for_slice(len);
-
-            let mem = ptr as *mut _ as *mut u8;
             let layout = Layout::for_value_raw(ptr);
 
             // Pointer to first element
-            let elems = (&raw mut (*ptr).value) as *mut T;
+            let elems = (&raw mut (*ptr).value).as_mut_ptr();
 
-            let mut guard = Guard { mem: NonNull::new_unchecked(mem), elems, layout, n_elems: 0 };
+            // Panic guard while cloning T elements.
+            // In the event of a panic, elements that have been written
+            // into the new RcInner will be dropped, then the memory freed.
+            let mut guard = DropGuard::new(0, |n_elems| {
+                let slice = from_raw_parts_mut(elems, n_elems);
+                ptr::drop_in_place(slice);
+                Global.deallocate(NonNull::new_unchecked(ptr.cast()), layout);
+            });
 
             for (i, item) in iter.enumerate() {
                 ptr::write(elems.add(i), item);
-                guard.n_elems += 1;
+                *guard += 1;
             }
 
-            // All clear. Forget the guard so it doesn't free the new RcInner.
-            mem::forget(guard);
+            // All clear. Dismiss the guard so it doesn't free the new RcInner.
+            DropGuard::dismiss(guard);
 
             Self::from_ptr(ptr)
         }

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -408,35 +408,30 @@ impl<T> [T] {
         impl<T: Clone> ConvertVec for T {
             #[inline]
             default fn to_vec<A: Allocator>(s: &[Self], alloc: A) -> Vec<Self, A> {
-                struct DropGuard<'a, T, A: Allocator> {
-                    vec: &'a mut Vec<T, A>,
-                    num_init: usize,
-                }
-                impl<'a, T, A: Allocator> Drop for DropGuard<'a, T, A> {
-                    #[inline]
-                    fn drop(&mut self) {
+                use core::mem::DropGuard;
+
+                let mut guard = DropGuard::new(
+                    (0, Vec::with_capacity_in(s.len(), alloc)),
+                    |(num_init, mut vec)| {
                         // SAFETY:
                         // items were marked initialized in the loop below
-                        unsafe {
-                            self.vec.set_len(self.num_init);
-                        }
-                    }
-                }
-                let mut vec = Vec::with_capacity_in(s.len(), alloc);
-                let mut guard = DropGuard { vec: &mut vec, num_init: 0 };
-                let slots = guard.vec.spare_capacity_mut();
+                        unsafe { vec.set_len(num_init) }
+                    },
+                );
+                let (num_init, vec) = &mut *guard;
+
+                let slots = vec.spare_capacity_mut();
                 // .take(slots.len()) is necessary for LLVM to remove bounds checks
                 // and has better codegen than zip.
                 for (i, b) in s.iter().enumerate().take(slots.len()) {
-                    guard.num_init = i;
+                    *num_init = i;
                     slots[i].write(b.clone());
                 }
-                core::mem::forget(guard);
+
+                let (_, mut vec) = DropGuard::dismiss(guard);
                 // SAFETY:
                 // the vec was allocated and initialized above to at least this length.
-                unsafe {
-                    vec.set_len(s.len());
-                }
+                unsafe { vec.set_len(s.len()) };
                 vec
             }
         }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -19,6 +19,8 @@ use core::intrinsics::abort;
 #[cfg(not(no_global_oom_handling))]
 use core::iter;
 use core::marker::{PhantomData, Unsize};
+#[cfg(not(no_global_oom_handling))]
+use core::mem::DropGuard;
 use core::mem::{self, Alignment, ManuallyDrop};
 use core::num::NonZeroUsize;
 use core::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn, LegacyReceiver};
@@ -2360,45 +2362,30 @@ impl<T> Arc<[T]> {
     /// Behavior is undefined should the size be wrong.
     #[cfg(not(no_global_oom_handling))]
     unsafe fn from_iter_exact(iter: impl Iterator<Item = T>, len: usize) -> Arc<[T]> {
-        // Panic guard while cloning T elements.
-        // In the event of a panic, elements that have been written
-        // into the new ArcInner will be dropped, then the memory freed.
-        struct Guard<T> {
-            mem: NonNull<u8>,
-            elems: *mut T,
-            layout: Layout,
-            n_elems: usize,
-        }
-
-        impl<T> Drop for Guard<T> {
-            fn drop(&mut self) {
-                unsafe {
-                    let slice = from_raw_parts_mut(self.elems, self.n_elems);
-                    ptr::drop_in_place(slice);
-
-                    Global.deallocate(self.mem, self.layout);
-                }
-            }
-        }
-
         unsafe {
             let ptr = Self::allocate_for_slice(len);
-
-            let mem = ptr as *mut _ as *mut u8;
             let layout = Layout::for_value_raw(ptr);
 
             // Pointer to first element
-            let elems = (&raw mut (*ptr).data) as *mut T;
+            let elems = (&raw mut (*ptr).data).as_mut_ptr();
 
-            let mut guard = Guard { mem: NonNull::new_unchecked(mem), elems, layout, n_elems: 0 };
+            // Panic guard while cloning T elements.
+            // In the event of a panic, elements that have been written
+            // into the new ArcInner will be dropped, then the memory freed.
+            let mut guard = DropGuard::new(0, |n_elems| {
+                let slice = from_raw_parts_mut(elems, n_elems);
+                ptr::drop_in_place(slice);
+
+                Global.deallocate(NonNull::new_unchecked(ptr.cast()), layout);
+            });
 
             for (i, item) in iter.enumerate() {
                 ptr::write(elems.add(i), item);
-                guard.n_elems += 1;
+                *guard += 1;
             }
 
-            // All clear. Forget the guard so it doesn't free the new ArcInner.
-            mem::forget(guard);
+            // All clear. Dismiss the guard so it doesn't free the new ArcInner.
+            DropGuard::dismiss(guard);
 
             Self::from_ptr(ptr)
         }
@@ -2616,15 +2603,7 @@ impl<T: ?Sized + CloneToUninit, A: AllocatorClone> Arc<T, A> {
             // If we unwind before the Arc is overwritten, we expose a strong
             // count of 0, resulting in a UAF (#155746, #157203).
             // Until the new Arc is written, the old Arc must remain valid
-            struct Guard<'a, T: ?Sized> {
-                inner: &'a ArcInner<T>,
-            }
-            impl<'a, T: ?Sized> Drop for Guard<'a, T> {
-                fn drop(&mut self) {
-                    self.inner.strong.store(1, Release);
-                }
-            }
-            let guard = Guard { inner: this.inner() };
+            let guard = DropGuard::new(this.inner(), |inner| inner.strong.store(1, Release));
 
             // Can just steal the data, all that's left is Weaks
             // Note that this can panic in two ways:
@@ -2644,7 +2623,7 @@ impl<T: ?Sized + CloneToUninit, A: AllocatorClone> Arc<T, A> {
                 );
 
                 // We are now safe from panics.
-                mem::forget(guard);
+                DropGuard::dismiss(guard);
 
                 // Materialize our own implicit weak pointer, so that it can clean
                 // up the ArcInner as needed.

--- a/library/alloc/src/vec/drain.rs
+++ b/library/alloc/src/vec/drain.rs
@@ -1,5 +1,5 @@
 use core::iter::{FusedIterator, TrustedLen};
-use core::mem::{self, ManuallyDrop, SizedTypeProperties};
+use core::mem::{self, DropGuard, ManuallyDrop, SizedTypeProperties};
 use core::ptr::{self, NonNull};
 use core::{fmt, slice};
 
@@ -172,28 +172,6 @@ impl<T, A: Allocator> DoubleEndedIterator for Drain<'_, T, A> {
 #[stable(feature = "drain", since = "1.6.0")]
 impl<T, A: Allocator> Drop for Drain<'_, T, A> {
     fn drop(&mut self) {
-        /// Moves back the un-`Drain`ed elements to restore the original `Vec`.
-        struct DropGuard<'r, 'a, T, A: Allocator>(&'r mut Drain<'a, T, A>);
-
-        impl<'r, 'a, T, A: Allocator> Drop for DropGuard<'r, 'a, T, A> {
-            fn drop(&mut self) {
-                if self.0.tail_len > 0 {
-                    unsafe {
-                        let source_vec = self.0.vec.as_mut();
-                        // memmove back untouched tail, update to new length
-                        let start = source_vec.len();
-                        let tail = self.0.tail_start;
-                        if tail != start {
-                            let src = source_vec.as_ptr().add(tail);
-                            let dst = source_vec.as_mut_ptr().add(start);
-                            ptr::copy(src, dst, self.0.tail_len);
-                        }
-                        source_vec.set_len(start + self.0.tail_len);
-                    }
-                }
-            }
-        }
-
         let iter = mem::take(&mut self.iter);
         let drop_len = iter.len();
 
@@ -213,7 +191,22 @@ impl<T, A: Allocator> Drop for Drain<'_, T, A> {
         }
 
         // ensure elements are moved back into their appropriate places, even when drop_in_place panics
-        let _guard = DropGuard(self);
+        let _guard = DropGuard::new(self, |this| {
+            if this.tail_len > 0 {
+                unsafe {
+                    let source_vec = this.vec.as_mut();
+                    // memmove back untouched tail, update to new length
+                    let start = source_vec.len();
+                    let tail = this.tail_start;
+                    if tail != start {
+                        let src = source_vec.as_ptr().add(tail);
+                        let dst = source_vec.as_mut_ptr().add(start);
+                        ptr::copy(src, dst, this.tail_len);
+                    }
+                    source_vec.set_len(start + this.tail_len);
+                }
+            }
+        });
 
         if drop_len == 0 {
             return;

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -3,7 +3,7 @@ use core::iter::{
     TrustedRandomAccessNoCoerce,
 };
 use core::marker::PhantomData;
-use core::mem::{ManuallyDrop, MaybeUninit, SizedTypeProperties};
+use core::mem::{DropGuard, ManuallyDrop, MaybeUninit, SizedTypeProperties};
 use core::num::NonZero;
 #[cfg(not(no_global_oom_handling))]
 use core::ops::Deref;
@@ -581,21 +581,9 @@ impl<T: Clone, A: Allocator + Clone> Clone for IntoIter<T, A> {
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T, A: Allocator> Drop for IntoIter<T, A> {
     fn drop(&mut self) {
-        struct DropGuard<'a, T, A: Allocator>(&'a mut IntoIter<T, A>);
-
-        impl<T, A: Allocator> Drop for DropGuard<'_, T, A> {
-            fn drop(&mut self) {
-                unsafe {
-                    self.0.dealloc_only();
-                }
-            }
-        }
-
-        let guard = DropGuard(self);
+        let mut guard = DropGuard::new(self, |this| unsafe { this.dealloc_only() });
         // destroy the remaining elements
-        unsafe {
-            ptr::drop_in_place(guard.0.as_raw_mut_slice());
-        }
+        unsafe { ptr::drop_in_place(guard.as_raw_mut_slice()) }
         // now `guard` will be dropped and do the rest
     }
 }

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -170,6 +170,9 @@ use self::spec_extend::SpecExtend;
 #[cfg(not(no_global_oom_handling))]
 mod spec_extend;
 
+#[cfg(all(target_arch = "aarch64", target_feature = "sve"))]
+mod sve_retain;
+
 /// A contiguous growable array type, written as `Vec<T>`, short for 'vector'.
 ///
 /// # Examples
@@ -2513,6 +2516,22 @@ impl<T, A: Allocator> Vec<T, A> {
         if original_len == 0 {
             // Empty case: explicit return allows better optimization, vs letting compiler infer it
             return;
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "sve"))]
+        {
+            let long_enough = match mem::size_of::<T>() {
+                1 => original_len >= sve_retain::MIN_SVE_SIZE_1,
+                2 => original_len >= sve_retain::MIN_SVE_SIZE_2,
+                4 => original_len >= sve_retain::MIN_SVE_SIZE_4,
+                8 => original_len >= sve_retain::MIN_SVE_SIZE_8,
+                _ => false,
+            };
+            if long_enough {
+                // SAFETY: size_of::<T>() is 1, 2, 4 or 8, matching
+                // the kernel lane widths.
+                return unsafe { sve_retain::chunked_retain(self, f) };
+            }
         }
 
         // Vec: [Kept, Kept, Hole, Hole, Hole, Hole, Unchecked, Unchecked]

--- a/library/alloc/src/vec/sve_retain.rs
+++ b/library/alloc/src/vec/sve_retain.rs
@@ -1,0 +1,251 @@
+//! SVE-accelerated `Vec::retain_mut` implementation.
+//!
+//! Two-phase algorithm per 64-element chunk:
+//! - Phase A (scalar): evaluates predicate exactly once, in order, into a bool mask.
+//! - Phase B (SVE): uses `COMPACT` instruction to compress retained elements.
+
+use core::{cmp, mem, ptr};
+
+use super::Vec;
+use crate::alloc::Allocator;
+
+const CHUNK_SIZE: usize = 64;
+
+pub(super) const MIN_SVE_SIZE_1: usize = 32;
+pub(super) const MIN_SVE_SIZE_2: usize = 32;
+pub(super) const MIN_SVE_SIZE_4: usize = 64;
+pub(super) const MIN_SVE_SIZE_8: usize = 64;
+
+/// Guard for the SVE retain path. On panic, this guard:
+/// 1. Scalar-compresses the already-decided prefix of the current chunk.
+/// 2. Copies the untouched tail forward.
+/// 3. Sets the Vec length.
+struct PanicGuard<'a, T, A: Allocator> {
+    v: &'a mut Vec<T, A>,
+    /// Start index of the current chunk within the Vec.
+    read: usize,
+    /// Write cursor (accumulated from previous chunks).
+    write: usize,
+    /// How many elements in the current chunk have been decided by the predicate.
+    decided: usize,
+
+    mask: &'a mut [bool; CHUNK_SIZE],
+    /// Original length of the Vec.
+    original_len: usize,
+}
+
+impl<T, A: Allocator> Drop for PanicGuard<'_, T, A> {
+    #[cold]
+    fn drop(&mut self) {
+        // Scalar-compress the decided prefix: move kept elements to write position.
+        let mut dst = self.write;
+        for i in 0..self.decided {
+            if self.mask[i] {
+                // SAFETY: read + i < original_len (in-bounds).
+                let src = unsafe { self.v.as_ptr().add(self.read + i) };
+                let dst_ptr = unsafe { self.v.as_mut_ptr().add(dst) };
+                // SAFETY: src and dst_ptr < original_len
+                unsafe { ptr::copy(src, dst_ptr, 1) };
+                dst += 1;
+            }
+        }
+
+        // Copy the untouched tail.
+        let untouched_start = self.read + self.decided;
+        let untouched_len = self.original_len - untouched_start;
+        if untouched_len > 0 {
+            // SAFETY: untouched_start..original_len are valid; dst + untouched_len <= original_len.
+            unsafe {
+                ptr::copy(
+                    self.v.as_ptr().add(untouched_start),
+                    self.v.as_mut_ptr().add(dst),
+                    untouched_len,
+                );
+            }
+            dst += untouched_len;
+        }
+
+        // SAFETY: After filling holes, all items are in contiguous memory.
+        unsafe { self.v.set_len(dst) };
+    }
+}
+
+/// # Safety
+///
+/// - `size_of::<T>() == 1/2/4/8`
+/// - Called on aarch64 + SVE target.
+pub(crate) unsafe fn chunked_retain<T, F, A: Allocator>(v: &mut Vec<T, A>, mut f: F)
+where
+    F: FnMut(&mut T) -> bool,
+{
+    let original_len = v.len();
+    let mut guard = PanicGuard {
+        v,
+        read: 0,
+        write: 0,
+        decided: 0,
+        mask: &mut [false; CHUNK_SIZE],
+        original_len,
+    };
+
+    while guard.read < guard.original_len {
+        let chunk_len = cmp::min(CHUNK_SIZE, guard.original_len - guard.read);
+
+        guard.decided = 0;
+
+        // Phase A: scalar predicate evaluation (exactly once, in order).
+        for i in 0..chunk_len {
+            // SAFETY: read + i < original_len
+            let cur = unsafe { &mut *guard.v.as_mut_ptr().add(guard.read + i) };
+            guard.mask[i] = f(cur);
+            guard.decided = i + 1;
+            if !guard.mask[i] {
+                // SAFETY: read + i < original_len, and after marking `mask` and `decided`,
+                // the guard can properly handles the case where drop_in_place panics.
+                unsafe { ptr::drop_in_place(cur) };
+            }
+        }
+
+        // Phase B: SVE compress.
+        // SAFETY: write <= read and the dispatch guarantees size_of::<T>() matches the kernel lane width.
+        let kept = match mem::size_of::<T>() {
+            1 => unsafe {
+                compact8_kernel(
+                    guard.v.as_mut_ptr().add(guard.read),
+                    guard.v.as_mut_ptr().add(guard.write),
+                    guard.mask.as_ptr(),
+                    chunk_len,
+                )
+            },
+            2 => unsafe {
+                compact16_kernel(
+                    guard.v.as_mut_ptr().add(guard.read),
+                    guard.v.as_mut_ptr().add(guard.write),
+                    guard.mask.as_ptr(),
+                    chunk_len,
+                )
+            },
+            4 => unsafe {
+                compact32_kernel(
+                    guard.v.as_mut_ptr().add(guard.read),
+                    guard.v.as_mut_ptr().add(guard.write),
+                    guard.mask.as_ptr(),
+                    chunk_len,
+                )
+            },
+            8 => unsafe {
+                compact64_kernel(
+                    guard.v.as_mut_ptr().add(guard.read),
+                    guard.v.as_mut_ptr().add(guard.write),
+                    guard.mask.as_ptr(),
+                    chunk_len,
+                )
+            },
+            _ => unreachable!(),
+        };
+
+        guard.write += kept;
+        guard.read += chunk_len;
+    }
+
+    // SAFETY: write <= original_len, all retained elements are packed at the front.
+    unsafe { guard.v.set_len(guard.write) };
+    mem::forget(guard);
+}
+
+macro_rules! sve_compact_kernel {
+    (
+        $name:ident,
+        size = $size:literal,
+        lane = $lane:literal,
+        mem_lane = $mem_lane:literal,
+        shift = $shift:literal,
+        inc = $inc:literal
+    ) => {
+        /// SVE compress kernel: pack retained elements from `src` to `dst`
+        /// according to `mask`. Returns the number of retained elements.
+        ///
+        /// # Safety
+        ///
+        /// - `src` is valid for `chunk_len` reads of `T`, `dst` for `chunk_len`
+        ///   writes, `mask` for `chunk_len` bool reads.
+        /// - `size_of::<T>()` equals this kernel's lane width in bytes.
+        #[target_feature(enable = "sve")]
+        #[inline]
+        unsafe fn $name<T>(
+            src: *const T,
+            dst: *mut T,
+            mask: *const bool,
+            chunk_len: usize,
+        ) -> usize {
+            debug_assert_eq!(mem::size_of::<T>(), $size);
+
+            let idx_in = 0usize;
+            let mut idx_out = 0usize;
+            // SVE intrinsics require treating the data as integers, which doesn't
+            // correctly handle provenance and uninitialized padding.
+            //
+            // SAFETY: whilelo predicates every load/store to the remaining elements.
+            unsafe {
+                core::arch::asm!(
+                    concat!("whilelo p0.", $lane, ", xzr, {len}"),
+                    "2:",
+                    concat!("ld1b {{ z0.", $lane, " }}, p0/z, [{mask}, {idx_in}]"),
+                    concat!("cmpne p1.", $lane, ", p0/z, z0.", $lane, ", #0"),
+                    concat!("ld1", $mem_lane, " {{ z1.", $lane, " }}, p1/z, [{src}, {idx_in}", $shift, "]"),
+                    concat!("compact z1.", $lane, ", p1, z1.", $lane),
+                    concat!("cntp {kept}, p0, p1.", $lane),
+                    concat!("whilelo p2.", $lane, ", xzr, {kept}"),
+                    concat!("st1", $mem_lane, " {{ z1.", $lane, " }}, p2, [{dst}, {idx_out}", $shift, "]"),
+                    concat!("add {idx_out}, {idx_out}, {kept}"),
+                    concat!("inc", $inc, " {idx_in}"),
+                    concat!("whilelo p0.", $lane, ", {idx_in}, {len}"),
+                    "b.first 2b",
+                    src = in(reg) src,
+                    dst = in(reg) dst,
+                    mask = in(reg) mask,
+                    len = in(reg) chunk_len,
+                    idx_in = inout(reg) idx_in => _,
+                    idx_out = inout(reg) idx_out,
+                    kept = out(reg) _,
+                    out("p0") _,
+                    out("p1") _,
+                    out("p2") _,
+                    out("z0") _,
+                    out("z1") _,
+                    options(nostack),
+                );
+            }
+            idx_out
+        }
+    };
+}
+
+sve_compact_kernel!(compact8_kernel, size = 1, lane = "s", mem_lane = "b", shift = "", inc = "w");
+
+sve_compact_kernel!(
+    compact16_kernel,
+    size = 2,
+    lane = "s",
+    mem_lane = "h",
+    shift = ", lsl #1",
+    inc = "w"
+);
+
+sve_compact_kernel!(
+    compact32_kernel,
+    size = 4,
+    lane = "s",
+    mem_lane = "w",
+    shift = ", lsl #2",
+    inc = "w"
+);
+
+sve_compact_kernel!(
+    compact64_kernel,
+    size = 8,
+    lane = "d",
+    mem_lane = "d",
+    shift = ", lsl #3",
+    inc = "d"
+);

--- a/library/alloctests/benches/lib.rs
+++ b/library/alloctests/benches/lib.rs
@@ -2,6 +2,7 @@
 #![cfg(not(miri))]
 #![allow(internal_features)]
 #![feature(iter_next_chunk)]
+#![feature(macro_metavar_expr_concat)]
 #![feature(repr_simd)]
 #![feature(slice_partition_dedup)]
 #![feature(strict_provenance_lints)]

--- a/library/alloctests/benches/vec.rs
+++ b/library/alloctests/benches/vec.rs
@@ -857,6 +857,69 @@ fn bench_retain_whole_100000(b: &mut Bencher) {
     b.iter(|| v.retain(|x| *x == 826u32));
 }
 
+macro_rules! retain_type_benches {
+    (
+        len = $len:literal,
+        suffix = $suffix:literal,
+        types = [$($ty:ident),*]
+    ) => {
+        $(
+            #[bench]
+            fn ${concat(bench_retain_, $ty, _, $suffix)}(b: &mut Bencher) {
+                let mut v: Vec<$ty> = Vec::with_capacity($len);
+                b.iter(|| {
+                    v.clear();
+                    v.extend(black_box((0..$len).map(|x| { x as $ty })));
+                    v.retain(|x| *x & 1 == 0)
+                });
+            }
+
+            #[bench]
+            fn ${concat(bench_retain_whole_, $ty, _, $suffix)}(b: &mut Bencher) {
+                let mut v = black_box(vec![82 as $ty; $len]);
+                b.iter(|| v.retain(|x| *x == 82 ));
+            }
+        )*
+    };
+}
+
+macro_rules! retain_matrix_benches {
+    ($($len:literal => $suffix:literal;)*) => {
+        $(
+            retain_type_benches! {
+                len = $len,
+                suffix = $suffix,
+                types = [u8, u16, u32, u64]
+            }
+
+            #[bench]
+            fn ${concat(bench_retain_iter_u32_, $suffix)}(b: &mut Bencher) {
+                let mut v: Vec<u32> = Vec::with_capacity($len);
+                b.iter(|| {
+                    let mut tmp = std::mem::take(&mut v);
+                    tmp.clear();
+                    tmp.extend(black_box(1..=$len as u32));
+                    v = tmp.into_iter().filter(|x| x & 1 == 0).collect();
+                });
+            }
+        )*
+    };
+}
+
+retain_matrix_benches! {
+    4 => "000004";
+    8 => "000008";
+    16 => "000016";
+    32 => "000032";
+    64 => "000064";
+    128 => "000128";
+    256 => "000256";
+    512 => "000512";
+    1000 => "001000";
+    10000 => "010000";
+    100000 => "100000";
+}
+
 #[bench]
 fn bench_next_chunk(b: &mut Bencher) {
     let v = vec![13u8; 2048];

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -28,6 +28,7 @@
 #![feature(const_try)]
 #![feature(copied_into_inner)]
 #![feature(core_intrinsics)]
+#![feature(drop_guard)]
 #![feature(exact_size_is_empty)]
 #![feature(extend_one)]
 #![feature(extend_one_unchecked)]

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -26,7 +26,10 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 mod bytewise;
+mod clamp;
 pub(crate) use bytewise::BytewiseEq;
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+pub use clamp::ClampBounds;
 
 use self::Ordering::*;
 use crate::marker::{Destruct, PointeeSized};
@@ -1120,6 +1123,35 @@ pub const trait Ord: [const] Eq + [const] PartialOrd<Self> + PointeeSized {
         } else {
             self
         }
+    }
+
+    /// Restrict a value to a certain range.
+    ///
+    /// This is equal to `max`, `min`, or `clamp`, depending on whether the range is `min..`,
+    /// `..=max`, or `min..=max`, respectively. Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3).clamp_to(-2..=1), -2);
+    /// assert_eq!(0.clamp_to(-2..=1), 0);
+    /// assert_eq!(2.clamp_to(..=1), 1);
+    /// assert_eq!(5.clamp_to(7..), 7);
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    fn clamp_to<R>(self, range: R) -> Self
+    where
+        Self: Sized + [const] Destruct,
+        R: [const] ClampBounds<Self>,
+    {
+        range.clamp(self)
     }
 }
 

--- a/library/core/src/cmp/clamp.rs
+++ b/library/core/src/cmp/clamp.rs
@@ -1,0 +1,100 @@
+use crate::marker::Destruct;
+use crate::ops::{RangeFrom, RangeFull, RangeInclusive, RangeToInclusive};
+
+/// Trait for ranges supported by [`Ord::clamp_to`].
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+pub const trait ClampBounds<T>: Sized {
+    /// The implementation of [`Ord::clamp_to`].
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct;
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeFrom<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        value.max(self.start)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeToInclusive<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        value.min(self.end)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeInclusive<T>
+where
+    T: [const] Ord,
+{
+    fn clamp(self, value: T) -> T
+    where
+        T: [const] Destruct,
+    {
+        let (start, end) = self.into_inner();
+        value.clamp(start, end)
+    }
+}
+
+#[unstable(feature = "clamp_bounds", issue = "147781")]
+#[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+const impl<T> ClampBounds<T> for RangeFull {
+    fn clamp(self, value: T) -> T {
+        value
+    }
+}
+
+macro impl_for_float($t:ty) {
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeFrom<$t> {
+        fn clamp(self, value: $t) -> $t {
+            assert!(!self.start.is_nan(), "start was NaN");
+            value.max(self.start)
+        }
+    }
+
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeToInclusive<$t> {
+        fn clamp(self, value: $t) -> $t {
+            assert!(!self.end.is_nan(), "end was NaN");
+            value.min(self.end)
+        }
+    }
+
+    #[unstable(feature = "clamp_bounds", issue = "147781")]
+    #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
+    const impl ClampBounds<$t> for RangeInclusive<$t> {
+        fn clamp(self, value: $t) -> $t {
+            let (start, end) = self.into_inner();
+            assert!(start <= end, "start > end, or either was NaN");
+            value.clamp(start, end)
+        }
+    }
+}
+
+// #[unstable(feature = "f16", issue = "116909")]
+impl_for_float!(f16);
+impl_for_float!(f32);
+impl_for_float!(f64);
+// #[unstable(feature = "f128", issue = "116909")]
+impl_for_float!(f128);

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1388,7 +1388,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(target_has_reliable_f128)] {
+    /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// assert!((-3.0f128).clamp(-2.0, 1.0) == -2.0);
     /// assert!((0.0f128).clamp(-2.0, 1.0) == 0.0);
@@ -1453,6 +1453,43 @@ impl f128 {
         assert!(limit >= 0.0, "limit must be non-negative");
         let limit = limit.abs(); // Canonicalises -0.0 to 0.0
         self.clamp(-limit, limit)
+    }
+
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(f128, clamp_to)]
+    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// assert_eq!((-3.0f128).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f128.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f128.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f128.clamp_to(7.0..), 7.0);
+    /// assert!(f128::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// # }
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
     }
 
     /// Computes the absolute value of `self`.

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1374,7 +1374,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16)] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// assert!((-3.0f16).clamp(-2.0, 1.0) == -2.0);
     /// assert!((0.0f16).clamp(-2.0, 1.0) == 0.0);
@@ -1439,6 +1439,43 @@ impl f16 {
         assert!(limit >= 0.0, "limit must be non-negative");
         let limit = limit.abs(); // Canonicalises -0.0 to 0.0
         self.clamp(-limit, limit)
+    }
+
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(f16, clamp_to)]
+    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// assert_eq!((-3.0f16).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f16.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f16.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f16.clamp_to(7.0..), 7.0);
+    /// assert!(f16::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// # }
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
     }
 
     /// Computes the absolute value of `self`.

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1609,6 +1609,41 @@ impl f32 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3.0f32).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f32.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f32.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f32.clamp_to(7.0..), 7.0);
+    /// assert!(f32::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1589,6 +1589,41 @@ impl f64 {
         self.clamp(-limit, limit)
     }
 
+    /// Restrict a value to a certain range, unless it is NaN.
+    ///
+    /// This is largely equal to `max`, `min`, or `clamp`, depending on whether the range is
+    /// `min..`, `..=max`, or `min..=max`, respectively. However, unlike `max` and `min`, it will
+    /// panic if any bound is NaN.
+    ///
+    /// Note that this function returns NaN if the initial value was NaN as
+    /// well.
+    ///
+    /// Exclusive ranges are not permitted.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `min..=max` if `min > max`, or if any bound is NaN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(clamp_to)]
+    /// assert_eq!((-3.0f64).clamp_to(-2.0..=1.0), -2.0);
+    /// assert_eq!(0.0f64.clamp_to(-2.0..=1.0), 0.0);
+    /// assert_eq!(2.0f64.clamp_to(..=1.0), 1.0);
+    /// assert_eq!(5.0f64.clamp_to(7.0..), 7.0);
+    /// assert!(f64::NAN.clamp_to(1.0..=2.0).is_nan());
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "clamp_to", issue = "147781")]
+    pub fn clamp_to<R>(self, range: R) -> Self
+    where
+        R: crate::cmp::ClampBounds<Self>,
+    {
+        range.clamp(self)
+    }
+
     /// Computes the absolute value of `self`.
     ///
     /// This function always returns the precise result.

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -13,6 +13,7 @@
 #![feature(casefold)]
 #![feature(cfg_target_has_reliable_f16_f128)]
 #![feature(char_internals)]
+#![feature(clamp_to)]
 #![feature(clone_to_uninit)]
 #![feature(cmp_minmax)]
 #![feature(const_array)]

--- a/library/coretests/tests/num/floats.rs
+++ b/library/coretests/tests/num/floats.rs
@@ -1321,10 +1321,10 @@ float_test! {
     name: clamp_min_greater_than_max,
     attrs: {
         const: #[cfg(false)],
-        f16: #[should_panic, cfg(target_has_reliable_f16)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
         f32: #[should_panic],
         f64: #[should_panic],
-        f128: #[should_panic, cfg(target_has_reliable_f128)],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
     },
     test {
         let _ = Float::ONE.clamp(3.0, 1.0);
@@ -1335,10 +1335,10 @@ float_test! {
     name: clamp_min_is_nan,
     attrs: {
         const: #[cfg(false)],
-        f16: #[should_panic, cfg(target_has_reliable_f16)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
         f32: #[should_panic],
         f64: #[should_panic],
-        f128: #[should_panic, cfg(target_has_reliable_f128)],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
     },
     test {
         let _ = Float::ONE.clamp(Float::NAN, 1.0);
@@ -1349,13 +1349,55 @@ float_test! {
     name: clamp_max_is_nan,
     attrs: {
         const: #[cfg(false)],
-        f16: #[should_panic, cfg(target_has_reliable_f16)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
         f32: #[should_panic],
         f64: #[should_panic],
-        f128: #[should_panic, cfg(target_has_reliable_f128)],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
     },
     test {
         let _ = Float::ONE.clamp(3.0, Float::NAN);
+    }
+}
+
+float_test! {
+    name: clamp_to_min_greater_than_max,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(3.0..=1.0);
+    }
+}
+
+float_test! {
+    name: clamp_to_min_is_nan,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(Float::NAN..=1.0);
+    }
+}
+
+float_test! {
+    name: clamp_to_max_is_nan,
+    attrs: {
+        const: #[cfg(false)],
+        f16: #[should_panic, cfg(target_has_reliable_f16_math)],
+        f32: #[should_panic],
+        f64: #[should_panic],
+        f128: #[should_panic, cfg(target_has_reliable_f128_math)],
+    },
+    test {
+        let _ = Float::ONE.clamp_to(3.0..=Float::NAN);
     }
 }
 

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -2239,19 +2239,6 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
 #[cfg(target_vendor = "apple")]
 pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
     const COPYFILE_ALL: libc::copyfile_flags_t = libc::COPYFILE_METADATA | libc::COPYFILE_DATA;
-
-    struct FreeOnDrop(libc::copyfile_state_t);
-    impl Drop for FreeOnDrop {
-        fn drop(&mut self) {
-            // The code below ensures that `FreeOnDrop` is never a null pointer
-            unsafe {
-                // `copyfile_state_free` returns -1 if the `to` or `from` files
-                // cannot be closed. However, this is not considered an error.
-                libc::copyfile_state_free(self.0);
-            }
-        }
-    }
-
     let (reader, reader_metadata) = open_from(from)?;
 
     let clonefile_result = run_path_with_cstr(to, &|to| {
@@ -2272,24 +2259,29 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
     // Fall back to using `fcopyfile` if `fclonefileat` does not succeed.
     let (writer, writer_metadata) = open_to_and_set_permissions(to, &reader_metadata)?;
 
-    // We ensure that `FreeOnDrop` never contains a null pointer so it is
+    let state = unsafe { libc::copyfile_state_alloc() };
+    // We ensure that the guard never contains a null pointer so it is
     // always safe to call `copyfile_state_free`
-    let state = unsafe {
-        let state = libc::copyfile_state_alloc();
-        if state.is_null() {
-            return Err(crate::io::Error::last_os_error());
+    if state.is_null() {
+        return Err(crate::io::Error::last_os_error());
+    }
+    let state = crate::mem::DropGuard::new(state, |state| {
+        // SAFETY: just checked it's not null
+        unsafe {
+            // `copyfile_state_free` returns -1 if the `to` or `from` files
+            // cannot be closed. However, this is not considered an error.
+            libc::copyfile_state_free(state);
         }
-        FreeOnDrop(state)
-    };
+    });
 
     let flags = if writer_metadata.is_file() { COPYFILE_ALL } else { libc::COPYFILE_DATA };
 
-    cvt(unsafe { libc::fcopyfile(reader.as_raw_fd(), writer.as_raw_fd(), state.0, flags) })?;
+    cvt(unsafe { libc::fcopyfile(reader.as_raw_fd(), writer.as_raw_fd(), *state, flags) })?;
 
     let mut bytes_copied: libc::off_t = 0;
     cvt(unsafe {
         libc::copyfile_state_get(
-            state.0,
+            *state,
             libc::COPYFILE_STATE_COPIED as u32,
             (&raw mut bytes_copied) as *mut libc::c_void,
         )

--- a/library/std/src/sys/pal/unix/sync/condvar.rs
+++ b/library/std/src/sys/pal/unix/sync/condvar.rs
@@ -150,26 +150,19 @@ impl Condvar {
     /// # Safety
     /// May only be called once per instance of `Self`.
     pub unsafe fn init(self: Pin<&mut Self>) {
-        use crate::mem::MaybeUninit;
-
-        struct AttrGuard<'a>(pub &'a mut MaybeUninit<libc::pthread_condattr_t>);
-        impl Drop for AttrGuard<'_> {
-            fn drop(&mut self) {
-                unsafe {
-                    let result = libc::pthread_condattr_destroy(self.0.as_mut_ptr());
-                    assert_eq!(result, 0);
-                }
-            }
-        }
+        use crate::mem::{DropGuard, MaybeUninit};
 
         unsafe {
             let mut attr = MaybeUninit::<libc::pthread_condattr_t>::uninit();
             let r = libc::pthread_condattr_init(attr.as_mut_ptr());
             assert_eq!(r, 0);
-            let attr = AttrGuard(&mut attr);
-            let r = libc::pthread_condattr_setclock(attr.0.as_mut_ptr(), Self::CLOCK);
+            let mut attr = DropGuard::new(&mut attr, |attr| {
+                let result = libc::pthread_condattr_destroy(attr.as_mut_ptr());
+                assert_eq!(result, 0);
+            });
+            let r = libc::pthread_condattr_setclock(attr.as_mut_ptr(), Self::CLOCK);
             assert_eq!(r, 0);
-            let r = libc::pthread_cond_init(self.raw(), attr.0.as_ptr());
+            let r = libc::pthread_cond_init(self.raw(), attr.as_ptr());
             assert_eq!(r, 0);
         }
     }

--- a/library/std/src/sys/process/unix/unix.rs
+++ b/library/std/src/sys/process/unix/unix.rs
@@ -394,19 +394,13 @@ impl Command {
         // want to be sure to restore the global environment back to what it
         // once was, ensuring that our temporary override, when free'd, doesn't
         // corrupt our process's environment.
-        let mut _reset = None;
+        let _reset;
         if let Some(envp) = maybe_envp {
-            struct Reset(*const *const libc::c_char);
+            use core::mem::DropGuard;
 
-            impl Drop for Reset {
-                fn drop(&mut self) {
-                    unsafe {
-                        *sys::env::environ() = self.0;
-                    }
-                }
-            }
-
-            _reset = Some(Reset(*sys::env::environ()));
+            _reset = DropGuard::new(*sys::env::environ(), |prev| unsafe {
+                *sys::env::environ() = prev;
+            });
             *sys::env::environ() = envp.as_ptr();
         }
 
@@ -677,65 +671,51 @@ impl Command {
 
         let pgroup = self.get_pgroup();
 
-        struct PosixSpawnFileActions<'a>(&'a mut MaybeUninit<libc::posix_spawn_file_actions_t>);
-
-        impl Drop for PosixSpawnFileActions<'_> {
-            fn drop(&mut self) {
-                unsafe {
-                    libc::posix_spawn_file_actions_destroy(self.0.as_mut_ptr());
-                }
-            }
-        }
-
-        struct PosixSpawnattr<'a>(&'a mut MaybeUninit<libc::posix_spawnattr_t>);
-
-        impl Drop for PosixSpawnattr<'_> {
-            fn drop(&mut self) {
-                unsafe {
-                    libc::posix_spawnattr_destroy(self.0.as_mut_ptr());
-                }
-            }
-        }
-
         unsafe {
+            use core::mem::DropGuard;
+
             let mut attrs = MaybeUninit::uninit();
             cvt_nz(libc::posix_spawnattr_init(attrs.as_mut_ptr()))?;
-            let attrs = PosixSpawnattr(&mut attrs);
+            let mut attrs = DropGuard::new(&mut attrs, |attrs| {
+                libc::posix_spawnattr_destroy(attrs.as_mut_ptr());
+            });
 
             let mut flags = 0;
 
             let mut file_actions = MaybeUninit::uninit();
             cvt_nz(libc::posix_spawn_file_actions_init(file_actions.as_mut_ptr()))?;
-            let file_actions = PosixSpawnFileActions(&mut file_actions);
+            let mut file_actions = DropGuard::new(&mut file_actions, |file_actions| {
+                libc::posix_spawn_file_actions_destroy(file_actions.as_mut_ptr());
+            });
 
             if let Some(fd) = stdio.stdin.fd() {
                 cvt_nz(libc::posix_spawn_file_actions_adddup2(
-                    file_actions.0.as_mut_ptr(),
+                    file_actions.as_mut_ptr(),
                     fd,
                     libc::STDIN_FILENO,
                 ))?;
             }
             if let Some(fd) = stdio.stdout.fd() {
                 cvt_nz(libc::posix_spawn_file_actions_adddup2(
-                    file_actions.0.as_mut_ptr(),
+                    file_actions.as_mut_ptr(),
                     fd,
                     libc::STDOUT_FILENO,
                 ))?;
             }
             if let Some(fd) = stdio.stderr.fd() {
                 cvt_nz(libc::posix_spawn_file_actions_adddup2(
-                    file_actions.0.as_mut_ptr(),
+                    file_actions.as_mut_ptr(),
                     fd,
                     libc::STDERR_FILENO,
                 ))?;
             }
             if let Some((f, cwd)) = addchdir {
-                cvt_nz(f(file_actions.0.as_mut_ptr(), cwd.as_ptr()))?;
+                cvt_nz(f(file_actions.as_mut_ptr(), cwd.as_ptr()))?;
             }
 
             if let Some(pgroup) = pgroup {
                 flags |= libc::POSIX_SPAWN_SETPGROUP;
-                cvt_nz(libc::posix_spawnattr_setpgroup(attrs.0.as_mut_ptr(), pgroup))?;
+                cvt_nz(libc::posix_spawnattr_setpgroup(attrs.as_mut_ptr(), pgroup))?;
             }
 
             // Inherit the signal mask from this process rather than resetting it (i.e. do not call
@@ -754,7 +734,7 @@ impl Command {
                     cvt(sigaddset(default_set.as_mut_ptr(), libc::SIGLOST))?;
                 }
                 cvt_nz(libc::posix_spawnattr_setsigdefault(
-                    attrs.0.as_mut_ptr(),
+                    attrs.as_mut_ptr(),
                     default_set.as_ptr(),
                 ))?;
                 flags |= libc::POSIX_SPAWN_SETSIGDEF;
@@ -771,7 +751,7 @@ impl Command {
                 }
             }
 
-            cvt_nz(libc::posix_spawnattr_setflags(attrs.0.as_mut_ptr(), flags as _))?;
+            cvt_nz(libc::posix_spawnattr_setflags(attrs.as_mut_ptr(), flags as _))?;
 
             // Make sure we synchronize access to the global `environ` resource
             let _env_lock = sys::env::env_read_lock();
@@ -788,8 +768,8 @@ impl Command {
                 let spawn_res = pidfd_spawnp.get().unwrap()(
                     &mut pidfd,
                     self.get_program_cstr().as_ptr(),
-                    file_actions.0.as_ptr(),
-                    attrs.0.as_ptr(),
+                    file_actions.as_ptr(),
+                    attrs.as_ptr(),
                     self.get_argv().as_ptr() as *const _,
                     envp as *const _,
                 );
@@ -830,8 +810,8 @@ impl Command {
             let spawn_res = spawn_fn(
                 &mut p.pid,
                 self.get_program_cstr().as_ptr(),
-                file_actions.0.as_ptr(),
-                attrs.0.as_ptr(),
+                file_actions.as_ptr(),
+                attrs.as_ptr(),
                 self.get_argv().as_ptr() as *const _,
                 envp as *const _,
             );

--- a/library/std/src/sys/process/windows/tests.rs
+++ b/library/std/src/sys/process/windows/tests.rs
@@ -1,6 +1,7 @@
 use super::child_pipe::{Pipes, child_pipe};
 use super::{Arg, make_command_line};
 use crate::ffi::{OsStr, OsString};
+use crate::mem::DropGuard;
 use crate::os::windows::io::AsHandle;
 use crate::process::{Command, Stdio};
 use crate::time::Duration;
@@ -36,14 +37,7 @@ fn test_thread_handle() {
     assert!(p.is_ok());
 
     // Ensure the process is killed in the event something goes wrong.
-    struct DropGuard(crate::process::Child);
-    impl Drop for DropGuard {
-        fn drop(&mut self) {
-            let _ = self.0.kill();
-        }
-    }
-    let mut p = DropGuard(p.unwrap());
-    let p = &mut p.0;
+    let mut p = DropGuard::new(p.unwrap(), |p| p.kill());
 
     unsafe extern "system" {
         unsafe fn ResumeThread(hHandle: BorrowedHandle<'_>) -> u32;

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -34,7 +34,6 @@ serde_json = "1.0"
 shim_utils = { path = "../../shim_utils" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", default-features = false, features = ["ansi", "env-filter", "fmt", "parking_lot", "smallvec"] }
-unified-diff = "0.2.1"
 walkdir = "2"
 # tidy-alphabetical-end
 

--- a/src/tools/miri/src/shims/alloc.rs
+++ b/src/tools/miri/src/shims/alloc.rs
@@ -124,7 +124,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         match method {
             SpecialAllocatorMethod::Alloc | SpecialAllocatorMethod::AllocZeroed => {
                 let [size, align] = this.check_shim_sig(
-                    shim_sig_nounwind!(extern "Rust" fn(usize, core::mem::Alignment) -> *_),
+                    shim_sig!(extern "Rust" fn(usize, core::mem::Alignment) -> *_),
                     (link_name, abi, args),
                 )?;
                 let size = this.read_target_usize(size)?;
@@ -147,7 +147,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             SpecialAllocatorMethod::Dealloc => {
                 let [ptr, old_size, align] = this.check_shim_sig(
-                    shim_sig_nounwind!(extern "Rust" fn(*_, usize, core::mem::Alignment) -> ()),
+                    shim_sig!(extern "Rust" fn(*_, usize, core::mem::Alignment) -> ()),
                     (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
@@ -163,7 +163,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             SpecialAllocatorMethod::Realloc => {
                 let [ptr, old_size, align, new_size] = this.check_shim_sig(
-                    shim_sig_nounwind!(extern "Rust" fn(*_, usize, core::mem::Alignment, usize) -> *_),
+                    shim_sig!(extern "Rust" fn(*_, usize, core::mem::Alignment, usize) -> *_),
                     (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -318,7 +318,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // This is a no-op shim that only exists to prevent making the allocator shims
                 // instantly stable.
                 let [] = this.check_shim_sig(
-                    shim_sig_nounwind!(extern "Rust" fn() -> ()),
+                    shim_sig!(extern "Rust" fn() -> ()),
                     (link_name, abi, args),
                 )?;
             }

--- a/src/tools/miri/src/shims/sig.rs
+++ b/src/tools/miri/src/shims/sig.rs
@@ -12,7 +12,6 @@ pub struct ShimSig<'tcx, const ARGS: usize> {
     pub abi: ExternAbi,
     pub args: [Ty<'tcx>; ARGS],
     pub ret: Ty<'tcx>,
-    pub nounwind: bool,
     pub c_variadic: bool,
 }
 
@@ -36,24 +35,6 @@ macro_rules! shim_sig {
                 abi: std::str::FromStr::from_str($abi).expect("incorrect abi specified"),
                 args,
                 ret: shim_sig_arg!(this, $($ret)*),
-                nounwind: false,
-                c_variadic,
-            }
-        }
-    };
-}
-
-/// Same as `shim_sig!` but promises that this function will not unwind, even if the ABI allows it.
-#[macro_export]
-macro_rules! shim_sig_nounwind {
-    (extern $abi:literal fn($($args:tt)*) -> $($ret:tt)*) => {
-        |this| {
-            let (args, c_variadic) = shim_sig_args_sep!(this, [$($args)*]);
-            $crate::shims::sig::ShimSig {
-                abi: std::str::FromStr::from_str($abi).expect("incorrect abi specified"),
-                args,
-                ret: shim_sig_arg!(this, $($ret)*),
-                nounwind: true,
                 c_variadic,
             }
         }
@@ -213,7 +194,6 @@ fn check_shim_abi<'tcx>(
     this: &MiriInterpCx<'tcx>,
     link_name: Symbol,
     callee_abi: &FnAbi<'tcx, Ty<'tcx>>,
-    callee_nounwind: bool,
     caller_abi: &FnAbi<'tcx, Ty<'tcx>>,
 ) -> InterpResult<'tcx> {
     if callee_abi.conv != caller_abi.conv {
@@ -223,12 +203,9 @@ fn check_shim_abi<'tcx>(
             caller = caller_abi.conv,
         );
     }
-    // FIXME: is this needed? Or is it enough to just check this if/when an actual unwind happens?
-    if callee_abi.can_unwind && !callee_nounwind && !caller_abi.can_unwind {
-        throw_ub_format!(
-            "ABI mismatch: callee may unwind, but caller asumes that no unwinding will occur",
-        );
-    }
+    // No need to check unwinding: if the caller signature forbids unwinding, that's already
+    // reflected in the unwind destination so if an unwind occurs it will be reported as UB.
+
     if caller_abi.c_variadic && !callee_abi.c_variadic {
         throw_ub_format!(
             "ABI mismatch: `{link_name}` is a non-variadic function, but the caller is using a variadic signature"
@@ -352,7 +329,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let callee_fn_abi = shim_sig.as_abi(this);
 
         // Check everything.
-        check_shim_abi(this, link_name, callee_fn_abi, shim_sig.nounwind, caller_fn_abi)?;
+        check_shim_abi(this, link_name, callee_fn_abi, caller_fn_abi)?;
         this.check_shim_symbol_clash(link_name)?;
 
         // Return arguments.
@@ -378,7 +355,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let callee_fn_abi = shim_sig.as_abi(this);
 
         // Check everything.
-        check_shim_abi(this, link_name, callee_fn_abi, shim_sig.nounwind, caller_fn_abi)?;
+        check_shim_abi(this, link_name, callee_fn_abi, caller_fn_abi)?;
         this.check_shim_symbol_clash(link_name)?;
 
         // Return arguments.

--- a/src/tools/miri/tests/pass/function_calls/unwind_abi_mismatch.rs
+++ b/src/tools/miri/tests/pass/function_calls/unwind_abi_mismatch.rs
@@ -1,0 +1,29 @@
+#![feature(rustc_attrs)]
+
+#[unsafe(no_mangle)]
+extern "C-unwind" fn does_not_unwind_but_could() {}
+
+fn main() {
+    // Calling a maybe-unwinding function with a non-unwinding ABI is okay if the function
+    // does not actually unwind. See `tests/fail/panic/bad_unwind.rs` for the dual test that is UB.
+    let f: extern "C-unwind" fn() = does_not_unwind_but_could;
+    let f: extern "C" fn() = unsafe { std::mem::transmute(f) };
+    f();
+
+    // The same applies when we call such a function via an extern import.
+    // This is the dual to `tests/fail/function_calls/exported_symbol_bad_unwind1.rs`.
+    extern "C" {
+        #[link_name = "does_not_unwind_but_could"]
+        fn imported();
+    }
+    unsafe { imported() };
+
+    // The same does for shims: we can invoke maybe-unwinding shims via a non-unwinding declaration.
+    // We don't have "C-unwind" shims that we could import with "C" so the closest thing we can test
+    // are "Rust" shims imported via `#[rustc_nounwind]`.
+    extern "Rust" {
+        #[rustc_nounwind]
+        pub fn miri_spin_loop();
+    }
+    unsafe { miri_spin_loop() };
+}

--- a/tests/ui/traits/next-solver/coroutine-yield-unnormalized-alias.rs
+++ b/tests/ui/traits/next-solver/coroutine-yield-unnormalized-alias.rs
@@ -1,0 +1,27 @@
+//@ check-pass
+//@ edition: 2024
+//@ compile-flags: -Znext-solver=globally
+//! Regression test for #160652. Yielding an item from `impl Iterator` without an
+//! explicit `Item` bound used to ICE in NLL type relating: both the MIR `yield_ty`
+//! and the yielded local `i` were `<impl Iterator as Iterator>::Item`.
+
+#![feature(coroutines, coroutine_trait)]
+
+use std::ops::Coroutine;
+
+fn iter() -> impl Iterator {
+    Some(()).into_iter()
+}
+
+fn yield_unnormalized_item() -> impl Coroutine {
+    #[coroutine]
+    move || {
+        for i in iter() {
+            yield i
+        }
+    }
+}
+
+fn main() {
+    let _ = yield_unnormalized_item();
+}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#150075 (Implement clamp_to)
 - rust-lang/rust#161034 (Add SVE-accelerated Vec::retain_mut for aarch64)
 - rust-lang/rust#161628 (interpret: ensure that calls via no-unwind ABIs do not unwind)
 - rust-lang/rust#161012 (borrowck: Normalize non-rigid aliases in NLL type relating)
 - rust-lang/rust#161702 (Use `drop_guard` in some places in {core,alloc,std})
 - rust-lang/rust#161813 (Change `is_eligible_for_coverage` from a hook to a query)
 - rust-lang/rust#161842 (chore: fix cargo lints)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=150075,161034,161628,161012,161702,161813,161842)
<!-- homu-ignore:end -->

