### PR TITLE
Store LiveLoans more densely packed

### DIFF
--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -144,6 +144,8 @@ pub(crate) fn compute_regions<'tcx>(
         &lowered_constraints,
     );
 
+    let num_points = location_map.num_points();
+
     // If requested for `-Zpolonius=next`, compute loan liveness information.
     // This is done prior to `RegionInferenceContext::new`, because we may add
     // additional liveness constraints.
@@ -155,6 +157,7 @@ pub(crate) fn compute_regions<'tcx>(
             &universal_region_relations.universal_regions,
             body,
             borrow_set,
+            num_points,
         );
     }
 

--- a/compiler/rustc_borrowck/src/polonius/mod.rs
+++ b/compiler/rustc_borrowck/src/polonius/mod.rs
@@ -41,7 +41,7 @@ mod liveness_constraints;
 use std::collections::BTreeMap;
 
 use rustc_data_structures::fx::FxHashSet;
-use rustc_index::bit_set::SparseBitMatrix;
+use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::{Body, Local};
 use rustc_middle::ty::RegionVid;
 use rustc_mir_dataflow::points::PointIndex;
@@ -55,7 +55,28 @@ use crate::dataflow::BorrowIndex;
 use crate::region_infer::values::LivenessValues;
 use crate::universal_regions::UniversalRegions;
 
-pub(crate) type LiveLoans = SparseBitMatrix<PointIndex, BorrowIndex>;
+#[derive(Clone)]
+pub(crate) struct LiveLoans {
+    num_points: usize,
+    // This matrix always has more rows (PointIndex) than columns (BorrowIndex),
+    // and the borrow dimension is usually very low (single digit in 90% of cases in our benchmark suite),
+    // so we store it packed in a single bitset. Rows are points, columns are borrows.
+    flat_matrix: DenseBitSet<usize>,
+}
+
+impl LiveLoans {
+    pub(crate) fn new(num_points: usize, num_borrows: usize) -> Self {
+        Self { num_points, flat_matrix: DenseBitSet::new_empty(num_points * num_borrows) }
+    }
+    pub(crate) fn insert(&mut self, row: PointIndex, col: BorrowIndex) {
+        let bit_index = row.index() + self.num_points * col.index();
+        self.flat_matrix.insert(bit_index);
+    }
+    pub(crate) fn contains(&self, row: PointIndex, col: BorrowIndex) -> bool {
+        let bit_index = row.index() + self.num_points * col.index();
+        self.flat_matrix.contains(bit_index)
+    }
+}
 
 /// This struct holds the necessary
 ///  - liveness data, created during MIR typeck, and which will be used to lazily compute the
@@ -109,6 +130,7 @@ impl PoloniusContext {
         universal_regions: &UniversalRegions<'tcx>,
         body: &Body<'tcx>,
         borrow_set: &BorrowSet<'tcx>,
+        num_points: usize,
     ) {
         // We don't need to prepare the graph (index NLL constraints, etc.) if we have no loans to
         // trace throughout localized constraints.
@@ -118,7 +140,7 @@ impl PoloniusContext {
             // step in the chain (the NLL loan scope and active loans computations).
             let graph = LocalizedConstraintGraph::new(liveness, outlives_constraints);
 
-            let mut live_loans = LiveLoans::new(borrow_set.len());
+            let mut live_loans = LiveLoans::new(num_points, borrow_set.len());
             let mut visitor = LoanLivenessVisitor { liveness, live_loans: &mut live_loans };
             graph.traverse(
                 body,


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161850)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

`LiveLoans` originally used `SparseBitMatrix<PointIndex, BorrowIndex>` in a way that didn't use "the sparseness" very effectively. The borrow dimension is usually very low (<10 bits 90% of the time), while the point dimension is typically order of magnitude higher.

This means that we used to allocate a bunch of 32-byte `DenseBitSet`s that only point to a few bits in heap-allocated `u64`. We only saved some memory by not allocating the whole `PointIndex` range, but we still often need to allocatate most of it.

This PR changes the representation to use a single flat representation with `GrowableBitSet` storing all bits in a single Vec. There's still a room for improvement but this should be a positive step forward.

r? lqd
