### PR TITLE
emit fake reads for indexing after every bounds-check

### DIFF
--- a/compiler/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_place.rs
@@ -645,9 +645,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
         block = self.bounds_check(block, &base_place, idx, expr_span, source_info);
 
-        if is_outermost_index {
-            self.read_fake_borrows(block, fake_borrow_temps, source_info)
-        } else {
+        // Keep all fake borrows we've collected so far alive. If we only emitted fake reads at the
+        // end, diverging within an index expression could make them unreachable. This would allow
+        // bounds checks to perform out-of-bounds accesses (#161852).
+        self.read_fake_borrows(block, fake_borrow_temps, source_info);
+
+        if !is_outermost_index {
             self.add_fake_borrows_of_base(
                 base_place.to_place(self),
                 block,

--- a/tests/ui/indexing/divergent-indexing-chain-soundness-failure.rs
+++ b/tests/ui/indexing/divergent-indexing-chain-soundness-failure.rs
@@ -1,0 +1,10 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/161852>: we need to keep fake
+//! borrows on indexed-into slice pointers alive for bounds-checks even if the end of the indexing
+//! chain is unreachable. This prevents bounds-checks from performing out-of-bounds accesses.
+
+fn main() {
+    let mut x: &[&[&[u32]]] = &[&[&[0]]];
+    let y: &[&[&[u32]]] = &[];
+    x[0][{ x = y; 0 }][{ return; 0 }];
+    //~^ ERROR: cannot assign `x` in indexing expression
+}

--- a/tests/ui/indexing/divergent-indexing-chain-soundness-failure.stderr
+++ b/tests/ui/indexing/divergent-indexing-chain-soundness-failure.stderr
@@ -1,0 +1,11 @@
+error[E0510]: cannot assign `x` in indexing expression
+  --> $DIR/divergent-indexing-chain-soundness-failure.rs:8:12
+   |
+LL |     x[0][{ x = y; 0 }][{ return; 0 }];
+   |     ----   ^^^^^ cannot assign
+   |     |
+   |     value is immutable in indexing expression
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0510`.

--- a/tests/ui/indexing/divergent-indexing-chain-soundness-pass.rs
+++ b/tests/ui/indexing/divergent-indexing-chain-soundness-pass.rs
@@ -1,0 +1,11 @@
+//! Test documenting unusual behavior related to <https://github.com/rust-lang/rust/issues/161852>:
+//! currently, fake reads for fake borrows on indexed-into slice pointers are emitted after bounds-
+//! checks, to keep them alive for those. This does not keep fake borrows alive at points from which
+//! all further bounds-checks are unreachable.
+//@ check-pass
+
+fn main() {
+    let mut x: &[&[&[u32]]] = &[&[&[0]]];
+    let y: &[&[&[u32]]] = &[];
+    x[0][{ x = y; return; 0 }];
+}


### PR DESCRIPTION
To fix https://github.com/rust-lang/rust/issues/161852, we need fake borrows on indexed-into slice pointers to live through subsequent bounds-checks. This PR does that.

The following is now rejected:
```rust
fn main() {
    let mut x: &[&[&[u32]]] = &[&[&[0]]];
    let y: &[&[&[u32]]] = &[];
    x[0][{ x = y; 0 }][{ return; 0 }];
    //~^ ERROR: cannot assign `x` in indexing expression
}
```
This does not affect locations from which bounds-checks are unreachable. The following was already and is still accepted:
```rust
fn main() {
    let mut x: &[&[&[u32]]] = &[&[&[0]]];
    let y: &[&[&[u32]]] = &[];
    x[0][{ x = y; return; 0 }];
}
```
Similar to https://github.com/rust-lang/rust/pull/161581, I imagine if we want to be stricter about that, we'll either need fake reads at any point we diverge or some other mechanism for keeping fake borrows alive that isn't as sensitive to CFG structure.