### PR TITLE
fix ICE in generic_const_parameter_types with inherents

### DIFF
--- a/compiler/rustc_traits/src/normalize_projection_ty.rs
+++ b/compiler/rustc_traits/src/normalize_projection_ty.rs
@@ -59,12 +59,6 @@ fn normalize_canonicalized_projection<'tcx>(
                 0,
                 &mut obligations,
             );
-            obligations.extend(const_arg_has_type_obligation(
-                tcx,
-                param_env,
-                normalized_term,
-                goal,
-            ));
             ocx.register_obligations(obligations);
             // #112047: With projections and opaques, we are able to create opaques that
             // are recursive (given some generic parameters of the opaque's type variables).
@@ -147,12 +141,6 @@ fn normalize_canonicalized_inherent_projection<'tcx>(
                 0,
                 &mut obligations,
             );
-            obligations.extend(const_arg_has_type_obligation(
-                tcx,
-                param_env,
-                normalized_term,
-                goal,
-            ));
             ocx.register_obligations(obligations);
 
             Ok(NormalizationResult { normalized_term })

--- a/tests/ui/const-generics/generic_const_parameter_types/inherent-type-const.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/inherent-type-const.rs
@@ -1,0 +1,22 @@
+//@ check-pass
+#![feature(
+    min_generic_const_args,
+    generic_const_parameter_types,
+    inherent_associated_types,
+    min_adt_const_params,
+    const_param_ty_trait
+)]
+
+struct ThreeTypes<T1, T2, T3>(T1, T2, T3);
+
+impl<T1, T2, T3: std::marker::ConstParamTy_> ThreeTypes<T1, T2, T3> {
+    type const INHERENT: [T3; 0] = [];
+}
+
+struct Struct<const O: [u32; 0]>;
+
+fn f() -> Struct<{ core::direct_const_arg!(ThreeTypes::<u8, u16, u32>::INHERENT) }> {
+    Struct
+}
+
+fn main() {}


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/137626

relevant PR where the code was added: https://github.com/rust-lang/rust/pull/154853 (fyi ping @lapla-cogito - nws that this was buggy, it's extreeeemely subtle and easy to miss! :heart: I mean, I also reviewed that PR and missed it too :3 )

discovered when implementing a change that explicitly tracks whether the args for inherent associated consts are in "self form" or "impl form"

Following along the test case:

- `normalize_canonicalized_inherent_projection` is called with `AliasTermKind::InherentConst` with the generic args being in "self form", i.e. `[ThreeTypes<u8, u16, u32>]`
- `traits::normalize_inherent_projection` is called with said alias
  - it calls `compute_inherent_assoc_term_args`, which does the dance of generating fresh vars for each param in the impl block, equating with the self type, and returning what the fresh vars solved to. This converts from "self args" to "impl args", i.e. `[u8, u16, u32]`
  - it then calls `const_of_item` and instantiates with `[u8, u16, u32]`. this is correct and good, `const_of_item` expects "impl form" args.
  - it then calls `push_const_arg_has_type_obligation`
    - which calls `type_of` and instantiates with `[u8, u16, u32]` to fetch the type of the const, to be able to register a `ConstArgHasType`. this is correct and good, `type_of` expects "impl form" args.
  - `traits::normalize_inherent_projection` returns, dropping the impl form args it computed
- `normalize_canonicalized_inherent_projection` calls `ocx.register_obligations(const_arg_has_type_obligation(...))`, passing `goal`. Remember that `goal` has the original "self args" generic arg format.
  - `const_arg_has_type_obligation` calls `type_of` and instantiates with `[ThreeTypes<u8, u16, u32>]`. This is no good very bad!! `type_of` expects "impl form" args, not "self form"!!
  - ICE!! `type parameter T3/#2 (T3/#2/2) out of range when instantiating, args=[ThreeTypes<u8, u16, u32>]`

The reason I filed this under `feature(generic_const_parameter_types)` is because for this bug to manifest, `type_of` must return a type that actually references a generic param to be able to trigger an ICE. Otherwise, the buggy incorrect args are silently ignored and compilation continues "fine".

The fix:

`normalize_inherent_projection` already registers a `ConstArgHasType`. why are we doing it a second time. just delete it. :skull:

r? @BoxyUwU