### PR TITLE
Do not optimize MIR for comptime ConstFns

### DIFF
--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -5,6 +5,7 @@ use std::{fs, io};
 
 use rustc_abi::Size;
 use rustc_ast::InlineAsmTemplatePiece;
+use rustc_hir::ConstContext;
 use tracing::trace;
 use ty::print::PrettyPrinter;
 
@@ -338,14 +339,22 @@ pub fn write_mir_pretty<'tcx>(tcx: TyCtxt<'tcx>, w: &mut dyn io::Write) -> io::R
             Ok(())
         };
 
-        // For `const fn` we want to render both the optimized MIR and the MIR for ctfe.
-        if tcx.is_const_fn(def_id) {
+        // For `const fn` we want to render both the optimized MIR and the MIR for ctfe,
+        // but need to check whether comptime function, which do not have optimized MIR
+        let is_const_fn = tcx.is_const_fn(def_id);
+        let mir_is_optimizable =
+            matches!(tcx.hir_body_const_context(def_id), None | Some(ConstContext::ConstFn));
+        if is_const_fn && mir_is_optimizable {
             render_body(w, tcx.optimized_mir(def_id))?;
             writeln!(w)?;
             writeln!(w, "// MIR FOR CTFE")?;
             // Do not use `render_body`, as that would render the promoteds again, but these
             // are shared between mir_for_ctfe and optimized_mir
             writer.write_mir_fn(tcx.mir_for_ctfe(def_id), w)?;
+        } else if is_const_fn {
+            // In case where comptime const fn, should only render the MIR for ctfe,
+            // without attempting to optimize.
+            render_body(w, tcx.mir_for_ctfe(def_id))?;
         } else {
             if let Some((val, ty)) = tcx.trivial_const(def_id) {
                 ty::print::with_forced_impl_filename_line! {

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -5,7 +5,7 @@ use std::{fs, io};
 
 use rustc_abi::Size;
 use rustc_ast::InlineAsmTemplatePiece;
-use rustc_hir::ConstContext;
+use rustc_hir::Constness;
 use tracing::trace;
 use ty::print::PrettyPrinter;
 
@@ -339,22 +339,20 @@ pub fn write_mir_pretty<'tcx>(tcx: TyCtxt<'tcx>, w: &mut dyn io::Write) -> io::R
             Ok(())
         };
 
-        // For `const fn` we want to render both the optimized MIR and the MIR for ctfe,
-        // but need to check whether comptime function, which do not have optimized MIR
-        let is_const_fn = tcx.is_const_fn(def_id);
-        let mir_is_optimizable =
-            matches!(tcx.hir_body_const_context(def_id), None | Some(ConstContext::ConstFn));
-        if is_const_fn && mir_is_optimizable {
-            render_body(w, tcx.optimized_mir(def_id))?;
-            writeln!(w)?;
-            writeln!(w, "// MIR FOR CTFE")?;
-            // Do not use `render_body`, as that would render the promoteds again, but these
-            // are shared between mir_for_ctfe and optimized_mir
-            writer.write_mir_fn(tcx.mir_for_ctfe(def_id), w)?;
-        } else if is_const_fn {
+        // For `const fn` we want to render both the optimized MIR and the MIR for ctfe.
+        if tcx.is_const_fn(def_id) {
             // In case where comptime const fn, should only render the MIR for ctfe,
-            // without attempting to optimize.
-            render_body(w, tcx.mir_for_ctfe(def_id))?;
+            // since comptime functions cannot have their MIR optimized
+            if matches!(tcx.constness(def_id), Constness::Const { always: true }) {
+                render_body(w, tcx.mir_for_ctfe(def_id))?;
+            } else {
+                render_body(w, tcx.optimized_mir(def_id))?;
+                writeln!(w)?;
+                writeln!(w, "// MIR FOR CTFE")?;
+                // Do not use `render_body`, as that would render the promoteds again, but these
+                // are shared between mir_for_ctfe and optimized_mir
+                writer.write_mir_fn(tcx.mir_for_ctfe(def_id), w)?;
+            }
         } else {
             if let Some((val, ty)) = tcx.trivial_const(def_id) {
                 ty::print::with_forced_impl_filename_line! {

--- a/src/tools/clippy/clippy_lints/src/redundant_clone.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_clone.rs
@@ -7,7 +7,7 @@ use clippy_utils::{fn_has_unsatisfiable_clauses, sym};
 use rustc_errors::Applicability;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::intravisit::FnKind;
-use rustc_hir::{Body, ConstContext, FnDecl, def_id};
+use rustc_hir::{Body, Constness, FnDecl, def_id};
 use rustc_lint::{LateContext, LateLintPass, declare_lint_pass};
 use rustc_middle::mir;
 use rustc_middle::ty::{self, Ty};
@@ -64,19 +64,18 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClone {
         _: Span,
         def_id: LocalDefId,
     ) {
-        // Building MIR for `#[rustc_comptime]` functions causes ICE.
-        if !matches!(
-            cx.tcx.hir_body_const_context(def_id),
-            None | Some(ConstContext::ConstFn)
-        ) {
-            return;
-        }
         // Building MIR for `fn`s with unsatisfiable clauses results in ICE.
         if fn_has_unsatisfiable_clauses(cx, def_id.to_def_id()) {
             return;
         }
 
-        let mir = cx.tcx.optimized_mir(def_id.to_def_id());
+        // Optimizing MIR for `#[rustc_comptime]` functions causes ICE,
+        // so giving MIR for CTFE for comptime functions instead
+        let mir = if matches!(cx.tcx.constness(def_id.to_def_id()), Constness::Const { always: true }) {
+            cx.tcx.mir_for_ctfe(def_id.to_def_id())
+        } else {
+            cx.tcx.optimized_mir(def_id.to_def_id())
+        };
 
         let mut possible_borrower = PossibleBorrowerMap::new(cx, mir);
 

--- a/src/tools/clippy/clippy_lints/src/redundant_clone.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_clone.rs
@@ -7,7 +7,7 @@ use clippy_utils::{fn_has_unsatisfiable_clauses, sym};
 use rustc_errors::Applicability;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::intravisit::FnKind;
-use rustc_hir::{Body, FnDecl, def_id};
+use rustc_hir::{Body, ConstContext, FnDecl, def_id};
 use rustc_lint::{LateContext, LateLintPass, declare_lint_pass};
 use rustc_middle::mir;
 use rustc_middle::ty::{self, Ty};
@@ -64,6 +64,13 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClone {
         _: Span,
         def_id: LocalDefId,
     ) {
+        // Building MIR for `#[rustc_comptime]` functions causes ICE.
+        if !matches!(
+            cx.tcx.hir_body_const_context(def_id),
+            None | Some(ConstContext::ConstFn)
+        ) {
+            return;
+        }
         // Building MIR for `fn`s with unsatisfiable clauses results in ICE.
         if fn_has_unsatisfiable_clauses(cx, def_id.to_def_id()) {
             return;

--- a/src/tools/clippy/tests/ui/redundant_clone-comptime.fixed
+++ b/src/tools/clippy/tests/ui/redundant_clone-comptime.fixed
@@ -1,0 +1,20 @@
+// rustfix-only-machine-applicable
+#![feature(rustc_attrs, const_trait_impl, const_clone, const_destruct)]
+#![warn(clippy::redundant_clone)]
+
+struct S;
+
+const impl Clone for S {
+    fn clone(&self) -> Self {
+        Self
+    }
+}
+
+#[rustc_comptime]
+fn comptime_func() {
+    let a = S;
+    let _a = a;
+    //~^ redundant_clone
+}
+
+fn main() {}

--- a/src/tools/clippy/tests/ui/redundant_clone-comptime.rs
+++ b/src/tools/clippy/tests/ui/redundant_clone-comptime.rs
@@ -1,0 +1,20 @@
+// rustfix-only-machine-applicable
+#![feature(rustc_attrs, const_trait_impl, const_clone, const_destruct)]
+#![warn(clippy::redundant_clone)]
+
+struct S;
+
+const impl Clone for S {
+    fn clone(&self) -> Self {
+        Self
+    }
+}
+
+#[rustc_comptime]
+fn comptime_func() {
+    let a = S;
+    let _a = a.clone();
+    //~^ redundant_clone
+}
+
+fn main() {}

--- a/src/tools/clippy/tests/ui/redundant_clone-comptime.stderr
+++ b/src/tools/clippy/tests/ui/redundant_clone-comptime.stderr
@@ -1,0 +1,16 @@
+error: redundant clone
+  --> tests/ui/redundant_clone-comptime.rs:16:15
+   |
+LL |     let _a = a.clone();
+   |               ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> tests/ui/redundant_clone-comptime.rs:16:14
+   |
+LL |     let _a = a.clone();
+   |              ^
+   = note: `-D clippy::redundant-clone` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::redundant_clone)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/comptime/emit-mir.rs
+++ b/tests/ui/comptime/emit-mir.rs
@@ -1,0 +1,8 @@
+//@ check-pass
+//@ compile-flags: --emit=mir
+#![feature(rustc_attrs)]
+
+#[rustc_comptime]
+fn comptime_fn() {}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161859)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
Fixed rust-lang/rust#161770: ICE when trying to run clippy on core, etc. Two small changes, both involve checking that optimized MIR is not requested for comptime functions. 

First change is to Clippy, changed so impl LateLintPass for RedundantClone checks whether a function is optimizable or not (i.e., whether it is both a ConstFn && it is a runtime not a comptime function).

Second change is to the pretty print function write_mir_pretty in rustc_middle, which needs the same check to make sure it does not request optimization for comptime functions, even if they're ConstFn. 

Can check for the original bug with the following bootstrap.toml:
profile = "compiler"
change-id = 160100 
rust.deny-warnings = false

then run the following commands from 'rust' root:
``` shell
# first failure
RUSTFLAGS="--emit-mir" ./x.py clippy -- -Wclippy::redundant_clone

# second failure
rustc ./tests/ui/comptime/comptime_method_bounds.rs --emit=mir

# third failure
cd library/core
RUSTFLAGES="--emit=mir" cargo check
```

The first failure is fixed with just the change to impl<'tcx> LateLintPass for RedundantClone, while the second and third failures are fixed by the change to write_mir_pretty() which previously was trying to optimize MIR for comptime functions.
