### PR TITLE
Put data segment in specified section with link_section on wasm

### DIFF
--- a/compiler/rustc_codegen_llvm/src/consts.rs
+++ b/compiler/rustc_codegen_llvm/src/consts.rs
@@ -544,8 +544,9 @@ impl<'ll> CodegenCx<'ll, '_> {
         }
 
         // Wasm statics with custom link sections get special treatment as they
-        // go into custom sections of the wasm executable. The exception to this
-        // is the `.init_array` section which are treated specially by the wasm linker.
+        // also go into custom sections of the wasm executable. The exception to
+        // this is the `.init_array` section for which we can't emit a custom
+        // section as it contains relocations.
         if self.tcx.sess.target.is_like_wasm
             && attrs
                 .link_section
@@ -564,10 +565,9 @@ impl<'ll> CodegenCx<'ll, '_> {
                 let data = [section, alloc];
                 self.module_add_named_metadata_node(self.llmod(), c"wasm.custom_sections", &data);
             }
-        } else {
-            base::set_link_section(g, attrs);
         }
 
+        base::set_link_section(g, attrs);
         base::set_variable_sanitizer_attrs(g, attrs);
 
         if attrs.flags.contains(CodegenFnAttrFlags::USED_COMPILER) {

--- a/tests/codegen-llvm/wasm_custom_section.rs
+++ b/tests/codegen-llvm/wasm_custom_section.rs
@@ -1,0 +1,19 @@
+//@ only-wasm32
+// Check that link_section on wasm emits both a data segment in the given
+// section and a custom section.
+
+#![crate_type = "lib"]
+#![feature(core_intrinsics, link_llvm_intrinsics)]
+
+#[unsafe(link_section = "foo")]
+#[unsafe(no_mangle)]
+#[used]
+static FOO: [u8; 22] = *b"custom section content";
+
+// Data segment in foo section
+// CHECK: @FOO = dso_local constant [22 x i8] c"custom section content", section "foo"
+// CHECK: @llvm.used = appending global [1 x ptr] [ptr @FOO], section "llvm.metadata"
+
+// Custom section
+// CHECK: !wasm.custom_sections = !{!3}
+// CHECK: !3 = !{!"foo", !"custom section content"}

--- a/tests/ui/attributes/auxiliary/used_pre_main_constructor.rs
+++ b/tests/ui/attributes/auxiliary/used_pre_main_constructor.rs
@@ -22,6 +22,7 @@
         target_os = "openbsd",
         target_os = "fuchsia",
         target_os = "managarm",
+        target_family = "wasm",
     ),
     link_section = ".init_array"
 )]
@@ -34,3 +35,6 @@ static CONSTRUCTOR: extern "C" fn() = constructor;
 extern "C" fn constructor() {
     println!("constructor");
 }
+
+#[cfg(target_family = "wasm")]
+pub fn force_constructor_call() {}

--- a/tests/ui/attributes/used_with_archive.rs
+++ b/tests/ui/attributes/used_with_archive.rs
@@ -6,11 +6,14 @@
 //@ check-run-results
 //@ aux-build: used_pre_main_constructor.rs
 
-//@ ignore-wasm ctor doesn't work on WASM
-
 // Make sure `rustc` links the archive, but intentionally do not import/use any items.
-extern crate used_pre_main_constructor as _;
+extern crate used_pre_main_constructor;
 
 fn main() {
+    // For some reason wasm-ld ignores the constructor unless we reference the
+    // object file containing it.
+    #[cfg(target_family = "wasm")]
+    used_pre_main_constructor::force_constructor_call();
+
     println!("main");
 }


### PR DESCRIPTION
This is the normal behavior on other targets, but previously on wasm the data segment would be in the default section and instead a custom section with the given name would be added to the wasm module.

Fixes https://github.com/rust-lang/rust/issues/146538

r? alexcrichton 