### PR TITLE
loongarch: support passing `u128`/`i128` to inline assembly

### DIFF
--- a/compiler/rustc_target/src/asm/loongarch.rs
+++ b/compiler/rustc_target/src/asm/loongarch.rs
@@ -53,7 +53,7 @@ impl LoongArchInlineAsmRegClass {
             (Self::vreg, _) => {
                 if allow_experimental_reg {
                     types! {
-                        lsx: F16, F32, F64,
+                        lsx: I128, F16, F32, F64,
                             VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF32(4), VecF64(2);
                     }
                 } else {
@@ -63,7 +63,7 @@ impl LoongArchInlineAsmRegClass {
             (Self::xreg, _) => {
                 if allow_experimental_reg {
                     types! {
-                        lasx: F16, F32, F64,
+                        lasx: I128, F16, F32, F64,
                             VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF32(4), VecF64(2),
                             VecI8(32), VecI16(16), VecI32(8), VecI64(4), VecF32(8), VecF64(4);
                     }

--- a/src/doc/unstable-book/src/language-features/asm-experimental-reg.md
+++ b/src/doc/unstable-book/src/language-features/asm-experimental-reg.md
@@ -19,8 +19,8 @@ This tracks support for additional registers in architectures where inline assem
 
 | Architecture | Register class | Target feature | Allowed types |
 | ------------ | -------------- | -------------- | ------------- |
-| LoongArch | `vreg` | `lsx` | `f32`, `f64`, <br> `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2` |
-| LoongArch | `xreg` | `lasx` | `f32`, `f64`, <br> `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2`, <br> `i8x32`, `i16x16`, `i32x8`, `i64x4`, `f32x8`, `f64x4` |
+| LoongArch | `vreg` | `lsx` | `i128`, `f32`, `f64`, <br> `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2` |
+| LoongArch | `xreg` | `lasx` | `i128`, `f32`, `f64`, <br> `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2`, <br> `i8x32`, `i16x16`, `i32x8`, `i64x4`, `f32x8`, `f64x4` |
 
 ## Register aliases
 

--- a/tests/ui/asm/loongarch/bad-reg.loongarch32_ilp32d.stderr
+++ b/tests/ui/asm/loongarch/bad-reg.loongarch32_ilp32d.stderr
@@ -1,41 +1,51 @@
 error: invalid register `$r0`: constant zero cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:28:18
+  --> $DIR/bad-reg.rs:29:18
    |
 LL |         asm!("", out("$r0") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$tp`: reserved for TLS
-  --> $DIR/bad-reg.rs:30:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("$tp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("$sp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r21`: reserved by the ABI
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("$r21") _);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `$fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("$fp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r31`: $r31 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("$r31") _);
    |                  ^^^^^^^^^^^^^
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:52:26
+  --> $DIR/bad-reg.rs:53:26
+   |
+LL |         asm!("/* {} */", in(vreg) q);
+   |                          ^^^^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: register class `vreg` can only be used as a clobber in stable
+  --> $DIR/bad-reg.rs:56:26
    |
 LL |         asm!("/* {} */", in(vreg) f);
    |                          ^^^^^^^^^^
@@ -45,7 +55,7 @@ LL |         asm!("/* {} */", in(vreg) f);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:55:26
+  --> $DIR/bad-reg.rs:59:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
@@ -55,7 +65,7 @@ LL |         asm!("/* {} */", out(vreg) _);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:57:26
+  --> $DIR/bad-reg.rs:61:26
    |
 LL |         asm!("/* {} */", in(vreg) d);
    |                          ^^^^^^^^^^
@@ -65,7 +75,7 @@ LL |         asm!("/* {} */", in(vreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:60:26
+  --> $DIR/bad-reg.rs:64:26
    |
 LL |         asm!("/* {} */", out(vreg) d);
    |                          ^^^^^^^^^^^
@@ -75,7 +85,17 @@ LL |         asm!("/* {} */", out(vreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:65:26
+  --> $DIR/bad-reg.rs:69:26
+   |
+LL |         asm!("/* {} */", in(xreg) q);
+   |                          ^^^^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: register class `xreg` can only be used as a clobber in stable
+  --> $DIR/bad-reg.rs:72:26
    |
 LL |         asm!("/* {} */", in(xreg) f);
    |                          ^^^^^^^^^^
@@ -85,7 +105,7 @@ LL |         asm!("/* {} */", in(xreg) f);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:68:26
+  --> $DIR/bad-reg.rs:75:26
    |
 LL |         asm!("/* {} */", out(xreg) _);
    |                          ^^^^^^^^^^^
@@ -95,7 +115,7 @@ LL |         asm!("/* {} */", out(xreg) _);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:70:26
+  --> $DIR/bad-reg.rs:77:26
    |
 LL |         asm!("/* {} */", in(xreg) d);
    |                          ^^^^^^^^^^
@@ -105,7 +125,7 @@ LL |         asm!("/* {} */", in(xreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:73:26
+  --> $DIR/bad-reg.rs:80:26
    |
 LL |         asm!("/* {} */", out(xreg) d);
    |                          ^^^^^^^^^^^
@@ -115,7 +135,7 @@ LL |         asm!("/* {} */", out(xreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:77:31
+  --> $DIR/bad-reg.rs:84:31
    |
 LL |         asm!("", in("$f0") f, in("$vr0") d);
    |                               ^^^^^^^^^^^^
@@ -125,7 +145,7 @@ LL |         asm!("", in("$f0") f, in("$vr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:82:31
+  --> $DIR/bad-reg.rs:89:31
    |
 LL |         asm!("", in("$f0") f, in("$xr0") d);
    |                               ^^^^^^^^^^^^
@@ -135,7 +155,7 @@ LL |         asm!("", in("$f0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:87:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("$vr0") f, in("$xr0") d);
    |                  ^^^^^^^^^^^^
@@ -145,7 +165,7 @@ LL |         asm!("", in("$vr0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:87:32
+  --> $DIR/bad-reg.rs:94:32
    |
 LL |         asm!("", in("$vr0") f, in("$xr0") d);
    |                                ^^^^^^^^^^^^
@@ -154,8 +174,18 @@ LL |         asm!("", in("$vr0") f, in("$xr0") d);
    = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:53:35
+   |
+LL |         asm!("/* {} */", in(vreg) q);
+   |                                   ^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: type `f32` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:52:35
+  --> $DIR/bad-reg.rs:56:35
    |
 LL |         asm!("/* {} */", in(vreg) f);
    |                                   ^
@@ -165,7 +195,7 @@ LL |         asm!("/* {} */", in(vreg) f);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:57:35
+  --> $DIR/bad-reg.rs:61:35
    |
 LL |         asm!("/* {} */", in(vreg) d);
    |                                   ^
@@ -175,7 +205,7 @@ LL |         asm!("/* {} */", in(vreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:60:36
+  --> $DIR/bad-reg.rs:64:36
    |
 LL |         asm!("/* {} */", out(vreg) d);
    |                                    ^
@@ -184,8 +214,18 @@ LL |         asm!("/* {} */", out(vreg) d);
    = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:69:35
+   |
+LL |         asm!("/* {} */", in(xreg) q);
+   |                                   ^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: type `f32` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:65:35
+  --> $DIR/bad-reg.rs:72:35
    |
 LL |         asm!("/* {} */", in(xreg) f);
    |                                   ^
@@ -195,7 +235,7 @@ LL |         asm!("/* {} */", in(xreg) f);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:70:35
+  --> $DIR/bad-reg.rs:77:35
    |
 LL |         asm!("/* {} */", in(xreg) d);
    |                                   ^
@@ -205,7 +245,7 @@ LL |         asm!("/* {} */", in(xreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:73:36
+  --> $DIR/bad-reg.rs:80:36
    |
 LL |         asm!("/* {} */", out(xreg) d);
    |                                    ^
@@ -215,7 +255,7 @@ LL |         asm!("/* {} */", out(xreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:77:42
+  --> $DIR/bad-reg.rs:84:42
    |
 LL |         asm!("", in("$f0") f, in("$vr0") d);
    |                                          ^
@@ -225,7 +265,7 @@ LL |         asm!("", in("$f0") f, in("$vr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:82:42
+  --> $DIR/bad-reg.rs:89:42
    |
 LL |         asm!("", in("$f0") f, in("$xr0") d);
    |                                          ^
@@ -235,7 +275,7 @@ LL |         asm!("", in("$f0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f32` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:87:29
+  --> $DIR/bad-reg.rs:94:29
    |
 LL |         asm!("", in("$vr0") f, in("$xr0") d);
    |                             ^
@@ -245,7 +285,7 @@ LL |         asm!("", in("$vr0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:87:43
+  --> $DIR/bad-reg.rs:94:43
    |
 LL |         asm!("", in("$vr0") f, in("$xr0") d);
    |                                           ^
@@ -254,6 +294,6 @@ LL |         asm!("", in("$vr0") f, in("$xr0") d);
    = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 28 previous errors
+error: aborting due to 32 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/asm/loongarch/bad-reg.loongarch32_ilp32s.stderr
+++ b/tests/ui/asm/loongarch/bad-reg.loongarch32_ilp32s.stderr
@@ -1,41 +1,51 @@
 error: invalid register `$r0`: constant zero cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:28:18
+  --> $DIR/bad-reg.rs:29:18
    |
 LL |         asm!("", out("$r0") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$tp`: reserved for TLS
-  --> $DIR/bad-reg.rs:30:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("$tp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("$sp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r21`: reserved by the ABI
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("$r21") _);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `$fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("$fp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r31`: $r31 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("$r31") _);
    |                  ^^^^^^^^^^^^^
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:52:26
+  --> $DIR/bad-reg.rs:53:26
+   |
+LL |         asm!("/* {} */", in(vreg) q);
+   |                          ^^^^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: register class `vreg` can only be used as a clobber in stable
+  --> $DIR/bad-reg.rs:56:26
    |
 LL |         asm!("/* {} */", in(vreg) f);
    |                          ^^^^^^^^^^
@@ -45,7 +55,7 @@ LL |         asm!("/* {} */", in(vreg) f);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:55:26
+  --> $DIR/bad-reg.rs:59:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
@@ -55,7 +65,7 @@ LL |         asm!("/* {} */", out(vreg) _);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:57:26
+  --> $DIR/bad-reg.rs:61:26
    |
 LL |         asm!("/* {} */", in(vreg) d);
    |                          ^^^^^^^^^^
@@ -65,7 +75,7 @@ LL |         asm!("/* {} */", in(vreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:60:26
+  --> $DIR/bad-reg.rs:64:26
    |
 LL |         asm!("/* {} */", out(vreg) d);
    |                          ^^^^^^^^^^^
@@ -75,7 +85,17 @@ LL |         asm!("/* {} */", out(vreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:65:26
+  --> $DIR/bad-reg.rs:69:26
+   |
+LL |         asm!("/* {} */", in(xreg) q);
+   |                          ^^^^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: register class `xreg` can only be used as a clobber in stable
+  --> $DIR/bad-reg.rs:72:26
    |
 LL |         asm!("/* {} */", in(xreg) f);
    |                          ^^^^^^^^^^
@@ -85,7 +105,7 @@ LL |         asm!("/* {} */", in(xreg) f);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:68:26
+  --> $DIR/bad-reg.rs:75:26
    |
 LL |         asm!("/* {} */", out(xreg) _);
    |                          ^^^^^^^^^^^
@@ -95,7 +115,7 @@ LL |         asm!("/* {} */", out(xreg) _);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:70:26
+  --> $DIR/bad-reg.rs:77:26
    |
 LL |         asm!("/* {} */", in(xreg) d);
    |                          ^^^^^^^^^^
@@ -105,7 +125,7 @@ LL |         asm!("/* {} */", in(xreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:73:26
+  --> $DIR/bad-reg.rs:80:26
    |
 LL |         asm!("/* {} */", out(xreg) d);
    |                          ^^^^^^^^^^^
@@ -115,7 +135,7 @@ LL |         asm!("/* {} */", out(xreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:77:31
+  --> $DIR/bad-reg.rs:84:31
    |
 LL |         asm!("", in("$f0") f, in("$vr0") d);
    |                               ^^^^^^^^^^^^
@@ -125,7 +145,7 @@ LL |         asm!("", in("$f0") f, in("$vr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:82:31
+  --> $DIR/bad-reg.rs:89:31
    |
 LL |         asm!("", in("$f0") f, in("$xr0") d);
    |                               ^^^^^^^^^^^^
@@ -135,7 +155,7 @@ LL |         asm!("", in("$f0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:87:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("$vr0") f, in("$xr0") d);
    |                  ^^^^^^^^^^^^
@@ -145,7 +165,7 @@ LL |         asm!("", in("$vr0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:87:32
+  --> $DIR/bad-reg.rs:94:32
    |
 LL |         asm!("", in("$vr0") f, in("$xr0") d);
    |                                ^^^^^^^^^^^^
@@ -155,31 +175,41 @@ LL |         asm!("", in("$vr0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:42:26
+  --> $DIR/bad-reg.rs:43:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:44:26
+  --> $DIR/bad-reg.rs:45:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:46:26
+  --> $DIR/bad-reg.rs:47:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:48:26
+  --> $DIR/bad-reg.rs:49:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:53:35
+   |
+LL |         asm!("/* {} */", in(vreg) q);
+   |                                   ^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: type `f32` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:52:35
+  --> $DIR/bad-reg.rs:56:35
    |
 LL |         asm!("/* {} */", in(vreg) f);
    |                                   ^
@@ -189,7 +219,7 @@ LL |         asm!("/* {} */", in(vreg) f);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:57:35
+  --> $DIR/bad-reg.rs:61:35
    |
 LL |         asm!("/* {} */", in(vreg) d);
    |                                   ^
@@ -199,7 +229,7 @@ LL |         asm!("/* {} */", in(vreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:60:36
+  --> $DIR/bad-reg.rs:64:36
    |
 LL |         asm!("/* {} */", out(vreg) d);
    |                                    ^
@@ -208,8 +238,18 @@ LL |         asm!("/* {} */", out(vreg) d);
    = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:69:35
+   |
+LL |         asm!("/* {} */", in(xreg) q);
+   |                                   ^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: type `f32` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:65:35
+  --> $DIR/bad-reg.rs:72:35
    |
 LL |         asm!("/* {} */", in(xreg) f);
    |                                   ^
@@ -219,7 +259,7 @@ LL |         asm!("/* {} */", in(xreg) f);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:70:35
+  --> $DIR/bad-reg.rs:77:35
    |
 LL |         asm!("/* {} */", in(xreg) d);
    |                                   ^
@@ -229,7 +269,7 @@ LL |         asm!("/* {} */", in(xreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:73:36
+  --> $DIR/bad-reg.rs:80:36
    |
 LL |         asm!("/* {} */", out(xreg) d);
    |                                    ^
@@ -239,13 +279,13 @@ LL |         asm!("/* {} */", out(xreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:77:18
+  --> $DIR/bad-reg.rs:84:18
    |
 LL |         asm!("", in("$f0") f, in("$vr0") d);
    |                  ^^^^^^^^^^^
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:77:42
+  --> $DIR/bad-reg.rs:84:42
    |
 LL |         asm!("", in("$f0") f, in("$vr0") d);
    |                                          ^
@@ -255,13 +295,13 @@ LL |         asm!("", in("$f0") f, in("$vr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:82:18
+  --> $DIR/bad-reg.rs:89:18
    |
 LL |         asm!("", in("$f0") f, in("$xr0") d);
    |                  ^^^^^^^^^^^
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:82:42
+  --> $DIR/bad-reg.rs:89:42
    |
 LL |         asm!("", in("$f0") f, in("$xr0") d);
    |                                          ^
@@ -271,7 +311,7 @@ LL |         asm!("", in("$f0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f32` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:87:29
+  --> $DIR/bad-reg.rs:94:29
    |
 LL |         asm!("", in("$vr0") f, in("$xr0") d);
    |                             ^
@@ -281,7 +321,7 @@ LL |         asm!("", in("$vr0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:87:43
+  --> $DIR/bad-reg.rs:94:43
    |
 LL |         asm!("", in("$vr0") f, in("$xr0") d);
    |                                           ^
@@ -290,6 +330,6 @@ LL |         asm!("", in("$vr0") f, in("$xr0") d);
    = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 34 previous errors
+error: aborting due to 38 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/asm/loongarch/bad-reg.loongarch64_lp64d.stderr
+++ b/tests/ui/asm/loongarch/bad-reg.loongarch64_lp64d.stderr
@@ -1,41 +1,41 @@
 error: invalid register `$r0`: constant zero cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:28:18
+  --> $DIR/bad-reg.rs:29:18
    |
 LL |         asm!("", out("$r0") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$tp`: reserved for TLS
-  --> $DIR/bad-reg.rs:30:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("$tp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("$sp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r21`: reserved by the ABI
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("$r21") _);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `$fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("$fp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r31`: $r31 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("$r31") _);
    |                  ^^^^^^^^^^^^^
 
 error: register `$vr0` conflicts with register `$f0`
-  --> $DIR/bad-reg.rs:77:31
+  --> $DIR/bad-reg.rs:84:31
    |
 LL |         asm!("", in("$f0") f, in("$vr0") d);
    |                  -----------  ^^^^^^^^^^^^ register `$vr0`
@@ -43,7 +43,7 @@ LL |         asm!("", in("$f0") f, in("$vr0") d);
    |                  register `$f0`
 
 error: register `$xr0` conflicts with register `$f0`
-  --> $DIR/bad-reg.rs:82:31
+  --> $DIR/bad-reg.rs:89:31
    |
 LL |         asm!("", in("$f0") f, in("$xr0") d);
    |                  -----------  ^^^^^^^^^^^^ register `$xr0`
@@ -51,7 +51,7 @@ LL |         asm!("", in("$f0") f, in("$xr0") d);
    |                  register `$f0`
 
 error: register `$xr0` conflicts with register `$vr0`
-  --> $DIR/bad-reg.rs:87:32
+  --> $DIR/bad-reg.rs:94:32
    |
 LL |         asm!("", in("$vr0") f, in("$xr0") d);
    |                  ------------  ^^^^^^^^^^^^ register `$xr0`

--- a/tests/ui/asm/loongarch/bad-reg.loongarch64_lp64s.stderr
+++ b/tests/ui/asm/loongarch/bad-reg.loongarch64_lp64s.stderr
@@ -1,41 +1,51 @@
 error: invalid register `$r0`: constant zero cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:28:18
+  --> $DIR/bad-reg.rs:29:18
    |
 LL |         asm!("", out("$r0") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$tp`: reserved for TLS
-  --> $DIR/bad-reg.rs:30:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("$tp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("$sp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r21`: reserved by the ABI
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("$r21") _);
    |                  ^^^^^^^^^^^^^
 
 error: invalid register `$fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("$fp") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `$r31`: $r31 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("$r31") _);
    |                  ^^^^^^^^^^^^^
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:52:26
+  --> $DIR/bad-reg.rs:53:26
+   |
+LL |         asm!("/* {} */", in(vreg) q);
+   |                          ^^^^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: register class `vreg` can only be used as a clobber in stable
+  --> $DIR/bad-reg.rs:56:26
    |
 LL |         asm!("/* {} */", in(vreg) f);
    |                          ^^^^^^^^^^
@@ -45,7 +55,7 @@ LL |         asm!("/* {} */", in(vreg) f);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:55:26
+  --> $DIR/bad-reg.rs:59:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
@@ -55,7 +65,7 @@ LL |         asm!("/* {} */", out(vreg) _);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:57:26
+  --> $DIR/bad-reg.rs:61:26
    |
 LL |         asm!("/* {} */", in(vreg) d);
    |                          ^^^^^^^^^^
@@ -65,7 +75,7 @@ LL |         asm!("/* {} */", in(vreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:60:26
+  --> $DIR/bad-reg.rs:64:26
    |
 LL |         asm!("/* {} */", out(vreg) d);
    |                          ^^^^^^^^^^^
@@ -75,7 +85,17 @@ LL |         asm!("/* {} */", out(vreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:65:26
+  --> $DIR/bad-reg.rs:69:26
+   |
+LL |         asm!("/* {} */", in(xreg) q);
+   |                          ^^^^^^^^^^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: register class `xreg` can only be used as a clobber in stable
+  --> $DIR/bad-reg.rs:72:26
    |
 LL |         asm!("/* {} */", in(xreg) f);
    |                          ^^^^^^^^^^
@@ -85,7 +105,7 @@ LL |         asm!("/* {} */", in(xreg) f);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:68:26
+  --> $DIR/bad-reg.rs:75:26
    |
 LL |         asm!("/* {} */", out(xreg) _);
    |                          ^^^^^^^^^^^
@@ -95,7 +115,7 @@ LL |         asm!("/* {} */", out(xreg) _);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:70:26
+  --> $DIR/bad-reg.rs:77:26
    |
 LL |         asm!("/* {} */", in(xreg) d);
    |                          ^^^^^^^^^^
@@ -105,7 +125,7 @@ LL |         asm!("/* {} */", in(xreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:73:26
+  --> $DIR/bad-reg.rs:80:26
    |
 LL |         asm!("/* {} */", out(xreg) d);
    |                          ^^^^^^^^^^^
@@ -115,7 +135,7 @@ LL |         asm!("/* {} */", out(xreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:77:31
+  --> $DIR/bad-reg.rs:84:31
    |
 LL |         asm!("", in("$f0") f, in("$vr0") d);
    |                               ^^^^^^^^^^^^
@@ -125,7 +145,7 @@ LL |         asm!("", in("$f0") f, in("$vr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:82:31
+  --> $DIR/bad-reg.rs:89:31
    |
 LL |         asm!("", in("$f0") f, in("$xr0") d);
    |                               ^^^^^^^^^^^^
@@ -135,7 +155,7 @@ LL |         asm!("", in("$f0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:87:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("$vr0") f, in("$xr0") d);
    |                  ^^^^^^^^^^^^
@@ -145,7 +165,7 @@ LL |         asm!("", in("$vr0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: register class `xreg` can only be used as a clobber in stable
-  --> $DIR/bad-reg.rs:87:32
+  --> $DIR/bad-reg.rs:94:32
    |
 LL |         asm!("", in("$vr0") f, in("$xr0") d);
    |                                ^^^^^^^^^^^^
@@ -155,31 +175,41 @@ LL |         asm!("", in("$vr0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:42:26
+  --> $DIR/bad-reg.rs:43:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:44:26
+  --> $DIR/bad-reg.rs:45:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:46:26
+  --> $DIR/bad-reg.rs:47:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:48:26
+  --> $DIR/bad-reg.rs:49:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:53:35
+   |
+LL |         asm!("/* {} */", in(vreg) q);
+   |                                   ^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: type `f32` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:52:35
+  --> $DIR/bad-reg.rs:56:35
    |
 LL |         asm!("/* {} */", in(vreg) f);
    |                                   ^
@@ -189,7 +219,7 @@ LL |         asm!("/* {} */", in(vreg) f);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:57:35
+  --> $DIR/bad-reg.rs:61:35
    |
 LL |         asm!("/* {} */", in(vreg) d);
    |                                   ^
@@ -199,7 +229,7 @@ LL |         asm!("/* {} */", in(vreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:60:36
+  --> $DIR/bad-reg.rs:64:36
    |
 LL |         asm!("/* {} */", out(vreg) d);
    |                                    ^
@@ -208,8 +238,18 @@ LL |         asm!("/* {} */", out(vreg) d);
    = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: type `u128` cannot be used with this register class in stable
+  --> $DIR/bad-reg.rs:69:35
+   |
+LL |         asm!("/* {} */", in(xreg) q);
+   |                                   ^
+   |
+   = note: see issue #133416 <https://github.com/rust-lang/rust/issues/133416> for more information
+   = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: type `f32` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:65:35
+  --> $DIR/bad-reg.rs:72:35
    |
 LL |         asm!("/* {} */", in(xreg) f);
    |                                   ^
@@ -219,7 +259,7 @@ LL |         asm!("/* {} */", in(xreg) f);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:70:35
+  --> $DIR/bad-reg.rs:77:35
    |
 LL |         asm!("/* {} */", in(xreg) d);
    |                                   ^
@@ -229,7 +269,7 @@ LL |         asm!("/* {} */", in(xreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:73:36
+  --> $DIR/bad-reg.rs:80:36
    |
 LL |         asm!("/* {} */", out(xreg) d);
    |                                    ^
@@ -239,13 +279,13 @@ LL |         asm!("/* {} */", out(xreg) d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:77:18
+  --> $DIR/bad-reg.rs:84:18
    |
 LL |         asm!("", in("$f0") f, in("$vr0") d);
    |                  ^^^^^^^^^^^
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:77:42
+  --> $DIR/bad-reg.rs:84:42
    |
 LL |         asm!("", in("$f0") f, in("$vr0") d);
    |                                          ^
@@ -255,13 +295,13 @@ LL |         asm!("", in("$f0") f, in("$vr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:82:18
+  --> $DIR/bad-reg.rs:89:18
    |
 LL |         asm!("", in("$f0") f, in("$xr0") d);
    |                  ^^^^^^^^^^^
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:82:42
+  --> $DIR/bad-reg.rs:89:42
    |
 LL |         asm!("", in("$f0") f, in("$xr0") d);
    |                                          ^
@@ -271,7 +311,7 @@ LL |         asm!("", in("$f0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f32` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:87:29
+  --> $DIR/bad-reg.rs:94:29
    |
 LL |         asm!("", in("$vr0") f, in("$xr0") d);
    |                             ^
@@ -281,7 +321,7 @@ LL |         asm!("", in("$vr0") f, in("$xr0") d);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `f64` cannot be used with this register class in stable
-  --> $DIR/bad-reg.rs:87:43
+  --> $DIR/bad-reg.rs:94:43
    |
 LL |         asm!("", in("$vr0") f, in("$xr0") d);
    |                                           ^
@@ -290,6 +330,6 @@ LL |         asm!("", in("$vr0") f, in("$xr0") d);
    = help: add `#![feature(asm_experimental_reg)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 34 previous errors
+error: aborting due to 38 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/asm/loongarch/bad-reg.rs
+++ b/tests/ui/asm/loongarch/bad-reg.rs
@@ -8,6 +8,7 @@
 //@[loongarch64_lp64d] needs-llvm-components: loongarch
 //@[loongarch64_lp64s] compile-flags: --target loongarch64-unknown-none-softfloat
 //@[loongarch64_lp64s] needs-llvm-components: loongarch
+//@ min-llvm-version: 23
 //@ ignore-backends: gcc
 
 #![cfg_attr(loongarch64_lp64d, feature(asm_experimental_reg))]
@@ -20,7 +21,7 @@ extern crate minicore;
 use minicore::*;
 
 fn f() {
-    let mut x = 0;
+    let mut q = 0_u128;
     let mut f = 0.0_f32;
     let mut d = 0.0_f64;
     unsafe {
@@ -49,6 +50,9 @@ fn f() {
         //[loongarch32_ilp32s,loongarch64_lp64s]~^ ERROR register class `freg` requires at least one of the following target features: d, f
 
         asm!("", out("$vr0") _); // ok
+        asm!("/* {} */", in(vreg) q);
+        //[loongarch32_ilp32s,loongarch32_ilp32d,loongarch64_lp64s]~^ ERROR register class `vreg` can only be used as a clobber in stable
+        //[loongarch32_ilp32s,loongarch32_ilp32d,loongarch64_lp64s]~| ERROR type `u128` cannot be used with this register class in stable
         asm!("/* {} */", in(vreg) f);
         //[loongarch32_ilp32s,loongarch32_ilp32d,loongarch64_lp64s]~^ ERROR register class `vreg` can only be used as a clobber in stable
         //[loongarch32_ilp32s,loongarch32_ilp32d,loongarch64_lp64s]~| ERROR type `f32` cannot be used with this register class in stable
@@ -62,6 +66,9 @@ fn f() {
         //[loongarch32_ilp32s,loongarch32_ilp32d,loongarch64_lp64s]~| ERROR type `f64` cannot be used with this register class in stable
 
         asm!("", out("$xr0") _); // ok
+        asm!("/* {} */", in(xreg) q);
+        //[loongarch32_ilp32s,loongarch32_ilp32d,loongarch64_lp64s]~^ ERROR register class `xreg` can only be used as a clobber in stable
+        //[loongarch32_ilp32s,loongarch32_ilp32d,loongarch64_lp64s]~| ERROR type `u128` cannot be used with this register class in stable
         asm!("/* {} */", in(xreg) f);
         //[loongarch32_ilp32s,loongarch32_ilp32d,loongarch64_lp64s]~^ ERROR register class `xreg` can only be used as a clobber in stable
         //[loongarch32_ilp32s,loongarch32_ilp32d,loongarch64_lp64s]~| ERROR type `f32` cannot be used with this register class in stable


### PR DESCRIPTION
Tracking issue: rust-lang/rust#133416

LLVM support: https://github.com/llvm/llvm-project/pull/211464

cc @taiki-e