### PR TITLE
[WIP] resolve: Concatenate reexport chains from all crates

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -412,6 +412,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 non_glob_decl: Some(decl),
                 orig_ident_span,
                 single_imports: Default::default(),
+                extern_reexport_chain: reexport_chain.clone(),
                 ..
             });
 

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -22,6 +22,7 @@ use rustc_session::diagnostics::feature_err;
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::hygiene::LocalExpnId;
 use rustc_span::{Ident, Span, Symbol, kw, sym};
+use smallvec::SmallVec;
 use tracing::debug;
 
 use crate::Namespace::{self, *};
@@ -277,6 +278,7 @@ pub(crate) struct NameResolution<'ra> {
     /// The glob declaration for this name, if it is known to exist.
     pub glob_decl: Option<Decl<'ra>> = None,
     pub orig_ident_span: Span,
+    pub extern_reexport_chain: SmallVec<[Reexport; 2]>,
 }
 
 /// `Interned` is used because values of this type have "identity" and compare as unequal even if
@@ -285,7 +287,12 @@ pub(crate) type NameResolutionRef<'ra> = Interned<'ra, CmRefCell<NameResolution<
 
 impl<'ra> NameResolution<'ra> {
     pub(crate) fn new(orig_ident_span: Span) -> Self {
-        NameResolution { single_imports: FxIndexSet::default(), orig_ident_span, .. }
+        NameResolution {
+            single_imports: FxIndexSet::default(),
+            orig_ident_span,
+            extern_reexport_chain: Default::default(),
+            ..
+        }
     }
 
     /// Returns the best declaration if it is not going to change, and `None` if the best
@@ -1890,30 +1897,41 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         let mut children = Vec::new();
         let mut ambig_children = Vec::new();
 
-        module.to_module().for_each_child(self, |this, ident, orig_ident_span, _, decl| {
-            let res = decl.res().expect_non_local();
-            if res != def::Res::Err {
-                let vis = if this.rust_embed_hack(module, decl) {
-                    Visibility::Public
-                } else {
-                    decl.vis()
-                };
-                let ident = ident.orig(orig_ident_span);
-                let child = |reexport_chain| ModChild { ident, res, vis, reexport_chain };
-                if let Some((ambig_binding1, ambig_binding2)) = decl.descent_to_ambiguity() {
-                    let main = child(ambig_binding1.reexport_chain());
-                    let second = ModChild {
-                        ident,
-                        res: ambig_binding2.res().expect_non_local(),
-                        vis: ambig_binding2.vis(),
-                        reexport_chain: ambig_binding2.reexport_chain(),
+        for (key, name_resolution) in self.resolutions(module.to_module()).iter() {
+            let name_resolution = name_resolution.borrow_checked(self);
+            if let Some(decl) = name_resolution.best_decl() {
+                let res = decl.res().expect_non_local();
+                if res != def::Res::Err {
+                    let ident = key.ident;
+                    let orig_ident_span = name_resolution.orig_ident_span;
+                    let vis = if self.rust_embed_hack(module, decl) {
+                        Visibility::Public
+                    } else {
+                        decl.vis()
                     };
-                    ambig_children.push(AmbigModChild { main, second })
-                } else {
-                    children.push(child(decl.reexport_chain()));
+                    let ident = ident.orig(orig_ident_span);
+                    let child = |reexport_chain| ModChild { ident, res, vis, reexport_chain };
+                    if let Some((ambig_binding1, ambig_binding2)) = decl.descent_to_ambiguity() {
+                        let mut reexport_chain = ambig_binding1.reexport_chain();
+                        reexport_chain
+                            .extend(name_resolution.extern_reexport_chain.iter().copied());
+                        let main = child(reexport_chain);
+                        let second = ModChild {
+                            ident,
+                            res: ambig_binding2.res().expect_non_local(),
+                            vis: ambig_binding2.vis(),
+                            reexport_chain: ambig_binding2.reexport_chain(),
+                        };
+                        ambig_children.push(AmbigModChild { main, second })
+                    } else {
+                        let mut reexport_chain = decl.reexport_chain();
+                        reexport_chain
+                            .extend(name_resolution.extern_reexport_chain.iter().copied());
+                        children.push(child(reexport_chain));
+                    }
                 }
             }
-        });
+        }
 
         if !children.is_empty() {
             module_children.insert(def_id.expect_local(), children);


### PR DESCRIPTION
This is needed for rustdoc, and rustdoc can technically do it by itself, but let's see if doing it in the compiler affects performance or not.

 cc https://github.com/rust-lang/rust/issues/81893