### PR TITLE
Do not load macro metadata for local definitions in rustdoc

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -250,17 +250,21 @@ pub(crate) fn get_item_path(tcx: TyCtxt<'_>, def_id: DefId, kind: ItemType) -> V
     if let ItemType::Macro = kind {
         // Check to see if it is a macro 2.0 or built-in macro
         // More information in <https://rust-lang.github.io/rfcs/1584-macros.html>.
-        if matches!(
-            CStore::from_tcx(tcx).load_macro_untracked(tcx, def_id),
-            LoadedMacro::MacroDef { def, .. } if !def.macro_rules
-        ) {
-            once(crate_name).chain(relative).collect()
+        let is_macro_2_0_or_builtin = if let Some(local_def_id) = def_id.as_local() {
+            let (_, macro_def, _) = tcx.hir_expect_item(local_def_id).expect_macro();
+            !macro_def.macro_rules
         } else {
-            vec![crate_name, *relative.last().expect("relative was empty")]
+            matches!(
+                CStore::from_tcx(tcx).load_macro_untracked(tcx, def_id),
+                LoadedMacro::MacroDef { def, .. } if !def.macro_rules
+            )
+        };
+        if !is_macro_2_0_or_builtin {
+            return vec![crate_name, *relative.last().expect("relative was empty")];
         }
-    } else {
-        once(crate_name).chain(relative).collect()
     }
+
+    once(crate_name).chain(relative).collect()
 }
 
 /// Record an external fully qualified name in the external_paths cache.

--- a/tests/rustdoc-ui/lints/redundant-explicit-links-ice.fixed
+++ b/tests/rustdoc-ui/lints/redundant-explicit-links-ice.fixed
@@ -1,0 +1,13 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/161837>.
+
+//@ run-rustfix
+
+#![deny(rustdoc::redundant_explicit_links)]
+
+//! [queue]
+//~^ ERROR redundant explicit link target
+
+#[macro_export]
+macro_rules! queue {
+    () => {};
+}

--- a/tests/rustdoc-ui/lints/redundant-explicit-links-ice.rs
+++ b/tests/rustdoc-ui/lints/redundant-explicit-links-ice.rs
@@ -1,0 +1,13 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/161837>.
+
+//@ run-rustfix
+
+#![deny(rustdoc::redundant_explicit_links)]
+
+//! [queue](macro.queue.html)
+//~^ ERROR redundant explicit link target
+
+#[macro_export]
+macro_rules! queue {
+    () => {};
+}

--- a/tests/rustdoc-ui/lints/redundant-explicit-links-ice.stderr
+++ b/tests/rustdoc-ui/lints/redundant-explicit-links-ice.stderr
@@ -1,0 +1,23 @@
+error: redundant explicit link target
+  --> $DIR/redundant-explicit-links-ice.rs:7:13
+   |
+LL | //! [queue](macro.queue.html)
+   |      -----  ^^^^^^^^^^^^^^^^ explicit target is redundant
+   |      |
+   |      because label contains path that resolves to same destination
+   |
+   = note: when a link's destination is not specified,
+           the label is used to resolve intra-doc links
+note: the lint level is defined here
+  --> $DIR/redundant-explicit-links-ice.rs:5:9
+   |
+LL | #![deny(rustdoc::redundant_explicit_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: remove explicit link target
+   |
+LL - //! [queue](macro.queue.html)
+LL + //! [queue]
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Follow up fix to rust-lang/rust#156009.

Closes rust-lang/rust#161837

r? @GuillaumeGomez 
