### PR TITLE
use IPV6 loopback and documentation address in documentation over V4 by default

### DIFF
--- a/library/alloc/src/io/buffered/bufwriter.rs
+++ b/library/alloc/src/io/buffered/bufwriter.rs
@@ -34,7 +34,7 @@ use crate::vec::Vec;
 /// use std::io::prelude::*;
 /// use std::net::TcpStream;
 ///
-/// let mut stream = TcpStream::connect("127.0.0.1:34254").unwrap();
+/// let mut stream = TcpStream::connect("[::1]:34254").unwrap();
 ///
 /// for i in 0..10 {
 ///     stream.write(&[i+1]).unwrap();
@@ -50,7 +50,7 @@ use crate::vec::Vec;
 /// use std::io::BufWriter;
 /// use std::net::TcpStream;
 ///
-/// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+/// let mut stream = BufWriter::new(TcpStream::connect("[::1]:34254").unwrap());
 ///
 /// for i in 0..10 {
 ///     stream.write(&[i+1]).unwrap();
@@ -91,7 +91,7 @@ impl<W: Write> BufWriter<W> {
     /// use std::net::TcpStream;
     ///
     /// # #[expect(unused_mut)]
-    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let mut buffer = BufWriter::new(TcpStream::connect("[::1]:34254").unwrap());
     /// ```
     #[cfg(not(no_global_oom_handling))]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -122,7 +122,7 @@ impl<W: Write> BufWriter<W> {
     /// use std::io::BufWriter;
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:34254").unwrap();
+    /// let stream = TcpStream::connect("[::1]:34254").unwrap();
     /// # #[expect(unused_mut)]
     /// let mut buffer = BufWriter::with_capacity(100, stream);
     /// ```
@@ -147,7 +147,7 @@ impl<W: Write> BufWriter<W> {
     /// use std::net::TcpStream;
     ///
     /// # #[expect(unused_mut)]
-    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let mut buffer = BufWriter::new(TcpStream::connect("[::1]:34254").unwrap());
     ///
     /// // unwrap the TcpStream and flush the buffer
     /// let stream = buffer.into_inner().unwrap();
@@ -301,7 +301,7 @@ impl<W: ?Sized + Write> BufWriter<W> {
     /// use std::net::TcpStream;
     ///
     /// # #[expect(unused_mut)]
-    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let mut buffer = BufWriter::new(TcpStream::connect("[::1]:34254").unwrap());
     ///
     /// // we can use reference just like buffer
     /// let reference = buffer.get_ref();
@@ -321,7 +321,7 @@ impl<W: ?Sized + Write> BufWriter<W> {
     /// use std::io::BufWriter;
     /// use std::net::TcpStream;
     ///
-    /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let mut buffer = BufWriter::new(TcpStream::connect("[::1]:34254").unwrap());
     ///
     /// // we can use reference just like buffer
     /// let reference = buffer.get_mut();
@@ -339,7 +339,7 @@ impl<W: ?Sized + Write> BufWriter<W> {
     /// use std::io::BufWriter;
     /// use std::net::TcpStream;
     ///
-    /// let buf_writer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let buf_writer = BufWriter::new(TcpStream::connect("[::1]:34254").unwrap());
     ///
     /// // See how many bytes are currently buffered
     /// let bytes_buffered = buf_writer.buffer().len();
@@ -371,7 +371,7 @@ impl<W: ?Sized + Write> BufWriter<W> {
     /// use std::io::BufWriter;
     /// use std::net::TcpStream;
     ///
-    /// let buf_writer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let buf_writer = BufWriter::new(TcpStream::connect("[::1]:34254").unwrap());
     ///
     /// // Check the capacity of the inner buffer
     /// let capacity = buf_writer.capacity();

--- a/library/alloc/src/io/buffered/mod.rs
+++ b/library/alloc/src/io/buffered/mod.rs
@@ -25,7 +25,7 @@ use crate::io::Error;
 /// use std::net::TcpStream;
 ///
 /// # #[expect(unused_mut)]
-/// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+/// let mut stream = BufWriter::new(TcpStream::connect("[::1]:34254").unwrap());
 ///
 /// // do stuff with the stream
 ///
@@ -68,7 +68,7 @@ impl<W> IntoInnerError<W> {
     /// use std::net::TcpStream;
     ///
     /// # #[expect(unused_mut)]
-    /// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let mut stream = BufWriter::new(TcpStream::connect("[::1]:34254").unwrap());
     ///
     /// // do stuff with the stream
     ///
@@ -103,7 +103,7 @@ impl<W> IntoInnerError<W> {
     /// use std::net::TcpStream;
     ///
     /// # #[expect(unused_mut)]
-    /// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
+    /// let mut stream = BufWriter::new(TcpStream::connect("[::1]:34254").unwrap());
     ///
     /// // do stuff with the stream
     ///

--- a/library/core/src/error.md
+++ b/library/core/src/error.md
@@ -52,7 +52,7 @@ Of the two, `expect` is generally preferred since its `msg` field allows you
 to convey your intent and assumptions which makes tracking down the source
 of a panic easier. `unwrap` on the other hand can still be a good fit in
 situations where you can trivially show that a piece of code will never
-panic, such as `"127.0.0.1".parse::<std::net::IpAddr>().unwrap()` or early
+panic, such as `"[::1]".parse::<std::net::IpAddr>().unwrap()` or early
 prototyping.
 
 # Common Message Styles

--- a/library/core/src/error.md
+++ b/library/core/src/error.md
@@ -52,7 +52,7 @@ Of the two, `expect` is generally preferred since its `msg` field allows you
 to convey your intent and assumptions which makes tracking down the source
 of a panic easier. `unwrap` on the other hand can still be a good fit in
 situations where you can trivially show that a piece of code will never
-panic, such as `"[::1]".parse::<std::net::IpAddr>().unwrap()` or early
+panic, such as `"::1".parse::<std::net::IpAddr>().unwrap()` or early
 prototyping.
 
 # Common Message Styles

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2440,7 +2440,7 @@ impl<'a> Formatter<'a> {
     ///     format!("{:?}", Foo {
     ///         bar: 10,
     ///         baz: "Hello World".to_string(),
-    ///         addr: Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
+    ///         addr: Ipv6Addr::LOCALHOST,
     ///     })
     /// );
     /// ```

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2417,12 +2417,12 @@ impl<'a> Formatter<'a> {
     ///
     /// ```rust
     /// use std::fmt;
-    /// use std::net::Ipv4Addr;
+    /// use std::net::Ipv6Addr;
     ///
     /// struct Foo {
     ///     bar: i32,
     ///     baz: String,
-    ///     addr: Ipv4Addr,
+    ///     addr: Ipv6Addr,
     /// }
     ///
     /// impl fmt::Debug for Foo {
@@ -2436,11 +2436,11 @@ impl<'a> Formatter<'a> {
     /// }
     ///
     /// assert_eq!(
-    ///     "Foo { bar: 10, baz: \"Hello World\", addr: 127.0.0.1 }",
+    ///     "Foo { bar: 10, baz: \"Hello World\", addr: ::1 }",
     ///     format!("{:?}", Foo {
     ///         bar: 10,
     ///         baz: "Hello World".to_string(),
-    ///         addr: Ipv4Addr::new(127, 0, 0, 1),
+    ///         addr: Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
     ///     })
     /// );
     /// ```

--- a/library/core/src/net/parser.rs
+++ b/library/core/src/net/parser.rs
@@ -471,7 +471,7 @@ enum AddrKind {
 ///
 /// ```should_panic
 /// use std::net::IpAddr;
-/// let _foo: IpAddr = "127.0.0.1:8080".parse().expect("Cannot handle the socket port");
+/// let _foo: IpAddr = "[::1]:8080".parse().expect("Cannot handle the socket port");
 /// ```
 ///
 /// [`IpAddr`] doesn't handle the port. Use [`SocketAddr`] instead.
@@ -480,7 +480,7 @@ enum AddrKind {
 /// use std::net::SocketAddr;
 ///
 /// // No problem, the `panic!` message has disappeared.
-/// let _foo: SocketAddr = "127.0.0.1:8080".parse().expect("`parse` should succeed");
+/// let _foo: SocketAddr = "[::1]:8080".parse().expect("`parse` should succeed");
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/library/core/src/net/socket_addr.rs
+++ b/library/core/src/net/socket_addr.rs
@@ -204,7 +204,9 @@ impl SocketAddr {
     /// ```
     /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     ///
+    /// // [::1]
     /// let mut socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
+    /// // [2001:db8::1]
     /// socket.set_ip(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
     /// assert_eq!(socket.ip(), IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
     /// ```

--- a/library/core/src/net/socket_addr.rs
+++ b/library/core/src/net/socket_addr.rs
@@ -22,7 +22,7 @@ use crate::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 /// ```
 /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 ///
-/// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
+/// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080);
 ///
 /// assert_eq!("[::1]:8080".parse(), Ok(socket));
 /// assert_eq!(socket.port(), 8080);
@@ -161,8 +161,8 @@ impl SocketAddr {
     /// ```
     /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     ///
-    /// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
-    /// assert_eq!(socket.ip(), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)));
+    /// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080);
+    /// assert_eq!(socket.ip(), IpAddr::V6(Ipv6Addr::LOCALHOST));
     /// assert_eq!(socket.port(), 8080);
     /// ```
     #[stable(feature = "ip_addr", since = "1.7.0")]
@@ -183,8 +183,8 @@ impl SocketAddr {
     /// ```
     /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     ///
-    /// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
-    /// assert_eq!(socket.ip(), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)));
+    /// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080);
+    /// assert_eq!(socket.ip(), IpAddr::V6(Ipv6Addr::LOCALHOST));
     /// ```
     #[must_use]
     #[stable(feature = "ip_addr", since = "1.7.0")]
@@ -205,7 +205,7 @@ impl SocketAddr {
     /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     ///
     /// // [::1]
-    /// let mut socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
+    /// let mut socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080);
     /// // [2001:db8::1]
     /// socket.set_ip(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
     /// assert_eq!(socket.ip(), IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
@@ -229,7 +229,7 @@ impl SocketAddr {
     /// ```
     /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     ///
-    /// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
+    /// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080);
     /// assert_eq!(socket.port(), 8080);
     /// ```
     #[must_use]
@@ -250,7 +250,7 @@ impl SocketAddr {
     /// ```
     /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     ///
-    /// let mut socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
+    /// let mut socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080);
     /// socket.set_port(1025);
     /// assert_eq!(socket.port(), 1025);
     /// ```
@@ -467,7 +467,7 @@ impl SocketAddrV6 {
     /// ```
     /// use std::net::{SocketAddrV6, Ipv6Addr};
     ///
-    /// let socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
+    /// let socket = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
@@ -484,8 +484,8 @@ impl SocketAddrV6 {
     /// ```
     /// use std::net::{SocketAddrV6, Ipv6Addr};
     ///
-    /// let socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
-    /// assert_eq!(socket.ip(), &Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+    /// let socket = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0);
+    /// assert_eq!(socket.ip(), &Ipv6Addr::LOCALHOST);
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -502,7 +502,7 @@ impl SocketAddrV6 {
     /// ```
     /// use std::net::{SocketAddrV6, Ipv6Addr};
     ///
-    /// let mut socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
+    /// let mut socket = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0);
     /// socket.set_ip(Ipv6Addr::new(76, 45, 0, 0, 0, 0, 0, 0));
     /// assert_eq!(socket.ip(), &Ipv6Addr::new(76, 45, 0, 0, 0, 0, 0, 0));
     /// ```
@@ -520,7 +520,7 @@ impl SocketAddrV6 {
     /// ```
     /// use std::net::{SocketAddrV6, Ipv6Addr};
     ///
-    /// let socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
+    /// let socket = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0);
     /// assert_eq!(socket.port(), 8080);
     /// ```
     #[must_use]
@@ -538,7 +538,7 @@ impl SocketAddrV6 {
     /// ```
     /// use std::net::{SocketAddrV6, Ipv6Addr};
     ///
-    /// let mut socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 0);
+    /// let mut socket = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0);
     /// socket.set_port(4242);
     /// assert_eq!(socket.port(), 4242);
     /// ```
@@ -566,7 +566,7 @@ impl SocketAddrV6 {
     /// ```
     /// use std::net::{SocketAddrV6, Ipv6Addr};
     ///
-    /// let socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 10, 0);
+    /// let socket = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 10, 0);
     /// assert_eq!(socket.flowinfo(), 10);
     /// ```
     #[must_use]
@@ -586,7 +586,7 @@ impl SocketAddrV6 {
     /// ```
     /// use std::net::{SocketAddrV6, Ipv6Addr};
     ///
-    /// let mut socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 10, 0);
+    /// let mut socket = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 10, 0);
     /// socket.set_flowinfo(56);
     /// assert_eq!(socket.flowinfo(), 56);
     /// ```
@@ -609,7 +609,7 @@ impl SocketAddrV6 {
     /// ```
     /// use std::net::{SocketAddrV6, Ipv6Addr};
     ///
-    /// let socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 78);
+    /// let socket = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 78);
     /// assert_eq!(socket.scope_id(), 78);
     /// ```
     #[must_use]
@@ -629,7 +629,7 @@ impl SocketAddrV6 {
     /// ```
     /// use std::net::{SocketAddrV6, Ipv6Addr};
     ///
-    /// let mut socket = SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080, 0, 78);
+    /// let mut socket = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 78);
     /// socket.set_scope_id(42);
     /// assert_eq!(socket.scope_id(), 42);
     /// ```

--- a/library/core/src/net/socket_addr.rs
+++ b/library/core/src/net/socket_addr.rs
@@ -20,13 +20,13 @@ use crate::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 /// # Examples
 ///
 /// ```
-/// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+/// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 ///
-/// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+/// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
 ///
-/// assert_eq!("127.0.0.1:8080".parse(), Ok(socket));
+/// assert_eq!("[::1]:8080".parse(), Ok(socket));
 /// assert_eq!(socket.port(), 8080);
-/// assert_eq!(socket.is_ipv4(), true);
+/// assert_eq!(socket.is_ipv6(), true);
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/net/socket_addr.rs
+++ b/library/core/src/net/socket_addr.rs
@@ -204,7 +204,6 @@ impl SocketAddr {
     /// ```
     /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     ///
-    /// // [::1]
     /// let mut socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080);
     /// // [2001:db8::1]
     /// socket.set_ip(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));

--- a/library/core/src/net/socket_addr.rs
+++ b/library/core/src/net/socket_addr.rs
@@ -181,7 +181,7 @@ impl SocketAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     ///
     /// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
     /// assert_eq!(socket.ip(), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)));
@@ -202,7 +202,7 @@ impl SocketAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     ///
     /// let mut socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
     /// socket.set_ip(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
@@ -225,7 +225,7 @@ impl SocketAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     ///
     /// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
     /// assert_eq!(socket.port(), 8080);
@@ -246,7 +246,7 @@ impl SocketAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     ///
     /// let mut socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
     /// socket.set_port(1025);

--- a/library/core/src/net/socket_addr.rs
+++ b/library/core/src/net/socket_addr.rs
@@ -159,10 +159,10 @@ impl SocketAddr {
     /// # Examples
     ///
     /// ```
-    /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    /// use std::net::{IpAddr, Ipv6Addr, SocketAddr};
     ///
-    /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-    /// assert_eq!(socket.ip(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+    /// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
+    /// assert_eq!(socket.ip(), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)));
     /// assert_eq!(socket.port(), 8080);
     /// ```
     #[stable(feature = "ip_addr", since = "1.7.0")]
@@ -183,8 +183,8 @@ impl SocketAddr {
     /// ```
     /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     ///
-    /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-    /// assert_eq!(socket.ip(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+    /// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
+    /// assert_eq!(socket.ip(), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)));
     /// ```
     #[must_use]
     #[stable(feature = "ip_addr", since = "1.7.0")]
@@ -204,9 +204,9 @@ impl SocketAddr {
     /// ```
     /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     ///
-    /// let mut socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-    /// socket.set_ip(IpAddr::V4(Ipv4Addr::new(10, 10, 0, 1)));
-    /// assert_eq!(socket.ip(), IpAddr::V4(Ipv4Addr::new(10, 10, 0, 1)));
+    /// let mut socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
+    /// socket.set_ip(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
+    /// assert_eq!(socket.ip(), IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
     /// ```
     #[inline]
     #[stable(feature = "sockaddr_setters", since = "1.9.0")]
@@ -227,7 +227,7 @@ impl SocketAddr {
     /// ```
     /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     ///
-    /// let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+    /// let socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
     /// assert_eq!(socket.port(), 8080);
     /// ```
     #[must_use]
@@ -248,7 +248,7 @@ impl SocketAddr {
     /// ```
     /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     ///
-    /// let mut socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+    /// let mut socket = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080);
     /// socket.set_port(1025);
     /// assert_eq!(socket.port(), 1025);
     /// ```

--- a/library/std/src/net/socket_addr.rs
+++ b/library/std/src/net/socket_addr.rs
@@ -73,7 +73,7 @@ use crate::{io, iter, option, slice, vec};
 /// ```no_run
 /// use std::net::{SocketAddr, ToSocketAddrs};
 ///
-/// // assuming 'localhost' resolves to [::1]
+/// // assuming 'localhost' resolves to ::1
 /// let mut addrs_iter = "localhost:443".to_socket_addrs().unwrap();
 /// assert_eq!(addrs_iter.next(), Some(SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 443))));
 /// assert!(addrs_iter.next().is_none());

--- a/library/std/src/net/socket_addr.rs
+++ b/library/std/src/net/socket_addr.rs
@@ -61,7 +61,7 @@ use crate::{io, iter, option, slice, vec};
 /// ```
 /// use std::net::{ToSocketAddrs, SocketAddr};
 ///
-/// let addr = SocketAddr::from(([127, 0, 0, 1], 443));
+/// let addr = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 443));
 /// let mut addrs_iter = addr.to_socket_addrs().unwrap();
 ///
 /// assert_eq!(Some(addr), addrs_iter.next());

--- a/library/std/src/net/socket_addr.rs
+++ b/library/std/src/net/socket_addr.rs
@@ -87,7 +87,9 @@ use crate::{io, iter, option, slice, vec};
 /// ```
 /// use std::net::{SocketAddr, ToSocketAddrs};
 ///
+/// // [2001:db8::1]
 /// let addr1 = SocketAddr::from(([0x2001, 0xdb8, 0, 0, 0, 0, 0, 1], 80));
+/// // [::1]
 /// let addr2 = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 443));
 /// let addrs = vec![addr1, addr2];
 ///

--- a/library/std/src/net/socket_addr.rs
+++ b/library/std/src/net/socket_addr.rs
@@ -118,7 +118,7 @@ use crate::{io, iter, option, slice, vec};
 /// ```no_run
 /// use std::net::{TcpStream, Ipv6Addr};
 ///
-/// let stream = TcpStream::connect(("[::1]", 443));
+/// let stream = TcpStream::connect(("::1", 443));
 /// // or
 /// let stream = TcpStream::connect("[::1]:443");
 /// // or

--- a/library/std/src/net/socket_addr.rs
+++ b/library/std/src/net/socket_addr.rs
@@ -73,9 +73,9 @@ use crate::{io, iter, option, slice, vec};
 /// ```no_run
 /// use std::net::{SocketAddr, ToSocketAddrs};
 ///
-/// // assuming 'localhost' resolves to 127.0.0.1
+/// // assuming 'localhost' resolves to [::1]
 /// let mut addrs_iter = "localhost:443".to_socket_addrs().unwrap();
-/// assert_eq!(addrs_iter.next(), Some(SocketAddr::from(([127, 0, 0, 1], 443))));
+/// assert_eq!(addrs_iter.next(), Some(SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 443))));
 /// assert!(addrs_iter.next().is_none());
 ///
 /// // assuming 'foo' does not resolve
@@ -87,8 +87,8 @@ use crate::{io, iter, option, slice, vec};
 /// ```
 /// use std::net::{SocketAddr, ToSocketAddrs};
 ///
-/// let addr1 = SocketAddr::from(([0, 0, 0, 0], 80));
-/// let addr2 = SocketAddr::from(([127, 0, 0, 1], 443));
+/// let addr1 = SocketAddr::from(([0x2001, 0xdb8, 0, 0, 0, 0, 0, 1], 80));
+/// let addr2 = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 443));
 /// let addrs = vec![addr1, addr2];
 ///
 /// let mut addrs_iter = (&addrs[..]).to_socket_addrs().unwrap();
@@ -105,7 +105,7 @@ use crate::{io, iter, option, slice, vec};
 /// use std::io;
 /// use std::net::ToSocketAddrs;
 ///
-/// let err = "127.0.0.1".to_socket_addrs().unwrap_err();
+/// let err = "[::1]".to_socket_addrs().unwrap_err();
 /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
 /// ```
 ///
@@ -114,13 +114,13 @@ use crate::{io, iter, option, slice, vec};
 /// different types:
 ///
 /// ```no_run
-/// use std::net::{TcpStream, Ipv4Addr};
+/// use std::net::{TcpStream, Ipv6Addr};
 ///
-/// let stream = TcpStream::connect(("127.0.0.1", 443));
+/// let stream = TcpStream::connect(("[::1]", 443));
 /// // or
-/// let stream = TcpStream::connect("127.0.0.1:443");
+/// let stream = TcpStream::connect("[::1]:443");
 /// // or
-/// let stream = TcpStream::connect((Ipv4Addr::new(127, 0, 0, 1), 443));
+/// let stream = TcpStream::connect((Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 443));
 /// ```
 ///
 /// [`TcpStream::connect`]: crate::net::TcpStream::connect

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -200,7 +200,7 @@ impl TcpStream {
     /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// assert_eq!(stream.peer_addr().unwrap(),
-    ///     SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0)));
+    ///            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0)));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -196,7 +196,12 @@ impl TcpStream {
     /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// assert_eq!(stream.peer_addr().unwrap(),
-    ///            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080)));
+    ///            SocketAddr::V6(SocketAddrV6::new(
+    ///                 Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
+    ///                 8080,
+    ///                 0,
+    ///                 0
+    /// )));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
@@ -845,7 +850,12 @@ impl TcpListener {
     ///
     /// let listener = TcpListener::bind("[::1]:8080").unwrap();
     /// assert_eq!(listener.local_addr().unwrap(),
-    ///            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080)));
+    ///            SocketAddr::V6(SocketAddrV6::new(
+    ///                 Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
+    ///                 8080,
+    ///                 0,
+    ///                 0
+    /// )));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -200,12 +200,7 @@ impl TcpStream {
     /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// assert_eq!(stream.peer_addr().unwrap(),
-    ///            SocketAddr::V6(SocketAddrV6::new(
-    ///                 Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
-    ///                 8080,
-    ///                 0,
-    ///                 0
-    /// )));
+    ///     SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0)));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
@@ -222,7 +217,7 @@ impl TcpStream {
     /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// assert_eq!(stream.local_addr().unwrap().ip(),
-    ///            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)));
+    ///            IpAddr::V6(Ipv6Addr::LOCALHOST));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
@@ -854,12 +849,7 @@ impl TcpListener {
     ///
     /// let listener = TcpListener::bind("[::1]:8080").unwrap();
     /// assert_eq!(listener.local_addr().unwrap(),
-    ///            SocketAddr::V6(SocketAddrV6::new(
-    ///                 Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
-    ///                 8080,
-    ///                 0,
-    ///                 0
-    /// )));
+    ///            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 8080, 0, 0)));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -47,6 +47,8 @@ use crate::time::Duration;
 ///
 /// fn main() -> std::io::Result<()> {
 ///     let mut stream = TcpStream::connect("[::1]:34254")?;
+/// #   #[allow(unused)]
+///     let mut ipv4_stream = TcpStream::connect("127.0.0.1:34254")?;
 ///
 ///     stream.write(&[1])?;
 ///     stream.read(&mut [0; 128])?;
@@ -87,6 +89,8 @@ pub struct TcpStream(net_imp::TcpStream);
 ///
 /// fn main() -> std::io::Result<()> {
 ///     let listener = TcpListener::bind("[::1]:80")?;
+/// #   #[allow(unused)]
+///     let ipv4_listener = TcpListener::bind("127.0.0.1:80")?;
 ///
 ///     // accept connections and process them serially
 ///     for stream in listener.incoming() {

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -992,7 +992,7 @@ impl TcpListener {
     /// use std::net::{TcpListener, TcpStream};
     ///
     /// fn listen_on(port: u16) -> impl Iterator<Item = TcpStream> {
-    ///     let listener = TcpListener::bind(("[::1]", port)).unwrap();
+    ///     let listener = TcpListener::bind(("::1", port)).unwrap();
     ///     listener.into_incoming()
     ///         .filter_map(Result::ok) /* Ignore failed connections */
     /// }

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -156,8 +156,8 @@ impl TcpStream {
     /// use std::net::{SocketAddr, TcpStream};
     ///
     /// let addrs = [
-    ///     SocketAddr::from(([127, 0, 0, 1], 8080)),
-    ///     SocketAddr::from(([127, 0, 0, 1], 8081)),
+    ///     SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 8080)),
+    ///     SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 8081)),
     /// ];
     /// if let Ok(stream) = TcpStream::connect(&addrs[..]) {
     ///     println!("Connected to the server!");

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -46,7 +46,7 @@ use crate::time::Duration;
 /// use std::net::TcpStream;
 ///
 /// fn main() -> std::io::Result<()> {
-///     let mut stream = TcpStream::connect("127.0.0.1:34254")?;
+///     let mut stream = TcpStream::connect("[::1]:34254")?;
 ///
 ///     stream.write(&[1])?;
 ///     stream.read(&mut [0; 128])?;
@@ -86,7 +86,7 @@ pub struct TcpStream(net_imp::TcpStream);
 /// }
 ///
 /// fn main() -> std::io::Result<()> {
-///     let listener = TcpListener::bind("127.0.0.1:80")?;
+///     let listener = TcpListener::bind("[::1]:80")?;
 ///
 ///     // accept connections and process them serially
 ///     for stream in listener.incoming() {
@@ -137,20 +137,20 @@ impl TcpStream {
     ///
     /// # Examples
     ///
-    /// Open a TCP connection to `127.0.0.1:8080`:
+    /// Open a TCP connection to `[::1]:8080`:
     ///
     /// ```no_run
     /// use std::net::TcpStream;
     ///
-    /// if let Ok(stream) = TcpStream::connect("127.0.0.1:8080") {
+    /// if let Ok(stream) = TcpStream::connect("[::1]:8080") {
     ///     println!("Connected to the server!");
     /// } else {
     ///     println!("Couldn't connect to server...");
     /// }
     /// ```
     ///
-    /// Open a TCP connection to `127.0.0.1:8080`. If the connection fails, open
-    /// a TCP connection to `127.0.0.1:8081`:
+    /// Open a TCP connection to `[::1]:8080`. If the connection fails, open
+    /// a TCP connection to `[::1]:8081`:
     ///
     /// ```no_run
     /// use std::net::{SocketAddr, TcpStream};
@@ -191,12 +191,12 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpStream};
+    /// use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6, TcpStream};
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// assert_eq!(stream.peer_addr().unwrap(),
-    ///            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080)));
+    ///            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080)));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
@@ -208,12 +208,12 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// use std::net::{IpAddr, Ipv4Addr, TcpStream};
+    /// use std::net::{IpAddr, Ipv6Addr, TcpStream};
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// assert_eq!(stream.local_addr().unwrap().ip(),
-    ///            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+    ///            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
@@ -238,7 +238,7 @@ impl TcpStream {
     /// ```no_run
     /// use std::net::{Shutdown, TcpStream};
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.shutdown(Shutdown::Both).expect("shutdown should succeed");
     /// ```
@@ -259,7 +259,7 @@ impl TcpStream {
     /// ```no_run
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// let stream_clone = stream.try_clone().expect("clone should succeed");
     /// ```
@@ -289,7 +289,7 @@ impl TcpStream {
     /// ```no_run
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_read_timeout(None).expect("set_read_timeout should succeed");
     /// ```
@@ -302,7 +302,7 @@ impl TcpStream {
     /// use std::net::TcpStream;
     /// use std::time::Duration;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080").unwrap();
+    /// let stream = TcpStream::connect("[::1]:8080").unwrap();
     /// let result = stream.set_read_timeout(Some(Duration::new(0, 0)));
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
@@ -333,7 +333,7 @@ impl TcpStream {
     /// ```no_run
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_write_timeout(None).expect("set_write_timeout should succeed");
     /// ```
@@ -346,7 +346,7 @@ impl TcpStream {
     /// use std::net::TcpStream;
     /// use std::time::Duration;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080").unwrap();
+    /// let stream = TcpStream::connect("[::1]:8080").unwrap();
     /// let result = stream.set_write_timeout(Some(Duration::new(0, 0)));
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
@@ -371,7 +371,7 @@ impl TcpStream {
     /// ```no_run
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_read_timeout(None).expect("set_read_timeout should succeed");
     /// assert_eq!(stream.read_timeout().unwrap(), None);
@@ -396,7 +396,7 @@ impl TcpStream {
     /// ```no_run
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_write_timeout(None).expect("set_write_timeout should succeed");
     /// assert_eq!(stream.write_timeout().unwrap(), None);
@@ -418,7 +418,7 @@ impl TcpStream {
     /// ```no_run
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8000")
+    /// let stream = TcpStream::connect("[::1]:8000")
     ///                        .expect("Couldn't connect to the server...");
     /// let mut buf = [0; 10];
     /// let len = stream.peek(&mut buf).expect("peek should succeed");
@@ -444,7 +444,7 @@ impl TcpStream {
     /// use std::net::TcpStream;
     /// use std::time::Duration;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_linger(Some(Duration::from_secs(0))).expect("set_linger should succeed");
     /// ```
@@ -465,7 +465,7 @@ impl TcpStream {
     /// use std::net::TcpStream;
     /// use std::time::Duration;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_linger(Some(Duration::from_secs(0))).expect("set_linger should succeed");
     /// assert_eq!(stream.linger().unwrap(), Some(Duration::from_secs(0)));
@@ -497,7 +497,7 @@ impl TcpStream {
     ///
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_keepalive(true).expect("set_keepalive should succeed");
     #[unstable(feature = "tcp_keepalive", issue = "155889")]
@@ -516,7 +516,7 @@ impl TcpStream {
     ///
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_keepalive(true).expect("set_keepalive should succeed");
     /// assert_eq!(stream.keepalive().unwrap_or(false), true);
@@ -539,7 +539,7 @@ impl TcpStream {
     /// ```no_run
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_nodelay(true).expect("set_nodelay should succeed");
     /// ```
@@ -557,7 +557,7 @@ impl TcpStream {
     /// ```no_run
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_nodelay(true).expect("set_nodelay should succeed");
     /// assert_eq!(stream.nodelay().unwrap_or(false), true);
@@ -577,7 +577,7 @@ impl TcpStream {
     /// ```no_run
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_ttl(100).expect("set_ttl should succeed");
     /// ```
@@ -595,7 +595,7 @@ impl TcpStream {
     /// ```no_run
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_ttl(100).expect("set_ttl should succeed");
     /// assert_eq!(stream.ttl().unwrap_or(0), 100);
@@ -616,7 +616,7 @@ impl TcpStream {
     /// ```no_run
     /// use std::net::TcpStream;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///                        .expect("Couldn't connect to the server...");
     /// stream.take_error().expect("No error was expected...");
     /// ```
@@ -646,7 +646,7 @@ impl TcpStream {
     /// use std::io::{self, Read};
     /// use std::net::TcpStream;
     ///
-    /// let mut stream = TcpStream::connect("127.0.0.1:7878")
+    /// let mut stream = TcpStream::connect("[::1]:7878")
     ///     .expect("Couldn't connect to the server...");
     /// stream.set_nonblocking(true).expect("set_nonblocking should succeed");
     ///
@@ -802,34 +802,34 @@ impl TcpListener {
     ///
     /// # Examples
     ///
-    /// Creates a TCP listener bound to `127.0.0.1:80`:
+    /// Creates a TCP listener bound to `[::1]:80`:
     ///
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
+    /// let listener = TcpListener::bind("[::1]:80").unwrap();
     /// ```
     ///
-    /// Creates a TCP listener bound to `127.0.0.1:80`. If that fails, create a
-    /// TCP listener bound to `127.0.0.1:443`:
+    /// Creates a TCP listener bound to `[::1]:80`. If that fails, create a
+    /// TCP listener bound to `[::1]:443`:
     ///
     /// ```no_run
     /// use std::net::{SocketAddr, TcpListener};
     ///
     /// let addrs = [
-    ///     SocketAddr::from(([127, 0, 0, 1], 80)),
-    ///     SocketAddr::from(([127, 0, 0, 1], 443)),
+    ///     SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 80)),
+    ///     SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 443)),
     /// ];
     /// let listener = TcpListener::bind(&addrs[..]).unwrap();
     /// ```
     ///
     /// Creates a TCP listener bound to a port assigned by the operating system
-    /// at `127.0.0.1`.
+    /// at `[::1]`.
     ///
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let socket = TcpListener::bind("127.0.0.1:0").unwrap();
+    /// let socket = TcpListener::bind("[::1]:0").unwrap();
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<TcpListener> {
@@ -841,11 +841,11 @@ impl TcpListener {
     /// # Examples
     ///
     /// ```no_run
-    /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpListener};
+    /// use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6, TcpListener};
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:8080").unwrap();
+    /// let listener = TcpListener::bind("[::1]:8080").unwrap();
     /// assert_eq!(listener.local_addr().unwrap(),
-    ///            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080)));
+    ///            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 8080)));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
@@ -863,7 +863,7 @@ impl TcpListener {
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:8080").unwrap();
+    /// let listener = TcpListener::bind("[::1]:8080").unwrap();
     /// let listener_clone = listener.try_clone().unwrap();
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -905,7 +905,7 @@ impl TcpListener {
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:8080").unwrap();
+    /// let listener = TcpListener::bind("[::1]:8080").unwrap();
     /// match listener.accept() {
     ///     Ok((_socket, addr)) => println!("new client: {addr:?}"),
     ///     Err(e) => println!("couldn't get client: {e:?}"),
@@ -941,7 +941,7 @@ impl TcpListener {
     /// }
     ///
     /// fn main() -> std::io::Result<()> {
-    ///     let listener = TcpListener::bind("127.0.0.1:80")?;
+    ///     let listener = TcpListener::bind("[::1]:80")?;
     ///
     ///     for stream in listener.incoming() {
     ///         match stream {
@@ -978,7 +978,7 @@ impl TcpListener {
     /// use std::net::{TcpListener, TcpStream};
     ///
     /// fn listen_on(port: u16) -> impl Iterator<Item = TcpStream> {
-    ///     let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+    ///     let listener = TcpListener::bind(("[::1]", port)).unwrap();
     ///     listener.into_incoming()
     ///         .filter_map(Result::ok) /* Ignore failed connections */
     /// }
@@ -1006,7 +1006,7 @@ impl TcpListener {
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
+    /// let listener = TcpListener::bind("[::1]:80").unwrap();
     /// listener.set_ttl(100).expect("set_ttl should succeed");
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
@@ -1023,7 +1023,7 @@ impl TcpListener {
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
+    /// let listener = TcpListener::bind("[::1]:80").unwrap();
     /// listener.set_ttl(100).expect("set_ttl should succeed");
     /// assert_eq!(listener.ttl().unwrap_or(0), 100);
     /// ```
@@ -1057,7 +1057,7 @@ impl TcpListener {
     /// ```no_run
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
+    /// let listener = TcpListener::bind("[::1]:80").unwrap();
     /// listener.take_error().expect("`take_error` should succeed");
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
@@ -1086,7 +1086,7 @@ impl TcpListener {
     /// use std::io;
     /// use std::net::TcpListener;
     ///
-    /// let listener = TcpListener::bind("127.0.0.1:7878").unwrap();
+    /// let listener = TcpListener::bind("[::1]:7878").unwrap();
     /// listener.set_nonblocking(true).expect("set_nonblocking should succeed");
     ///
     /// # fn wait_for_fd() { unimplemented!() }

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -833,7 +833,7 @@ impl TcpListener {
     /// ```
     ///
     /// Creates a TCP listener bound to a port assigned by the operating system
-    /// at `[::1]`.
+    /// at `::1`.
     ///
     /// ```no_run
     /// use std::net::TcpListener;

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -258,12 +258,7 @@ impl UdpSocket {
     ///
     /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// assert_eq!(socket.local_addr().unwrap(),
-    ///            SocketAddr::V6(SocketAddrV6::new(
-    ///                 Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
-    ///                 34254,
-    ///                 0,
-    ///                 0
-    /// )));
+    ///            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 34254, 0, 0)));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -223,7 +223,12 @@ impl UdpSocket {
     /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// socket.connect("[2001:db8::]:41203").expect("connect should succeed");
     /// assert_eq!(socket.peer_addr().unwrap(),
-    ///            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0), 41203)));
+    ///            SocketAddr::V6(SocketAddrV6::new(
+    ///                 Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0),
+    ///                 41203,
+    ///                 0,
+    ///                 0
+    /// )));
     /// ```
     ///
     /// If the socket isn't connected, it will return a [`NotConnected`] error.
@@ -251,7 +256,12 @@ impl UdpSocket {
     ///
     /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// assert_eq!(socket.local_addr().unwrap(),
-    ///            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 34254)));
+    ///            SocketAddr::V6(SocketAddrV6::new(
+    ///                 Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1),
+    ///                 34254,
+    ///                 0,
+    ///                 0
+    /// )));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -103,7 +103,7 @@ impl UdpSocket {
     /// ```
     ///
     /// Creates a UDP socket bound to a port assigned by the operating system
-    /// at `[::1]`.
+    /// at `::1`.
     ///
     /// ```no_run
     /// use std::net::UdpSocket;

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -524,7 +524,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// socket.set_multicast_loop_v6(false).expect("set_multicast_loop_v6 should succeed");
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
@@ -541,7 +541,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// socket.set_multicast_loop_v6(false).expect("set_multicast_loop_v6 should succeed");
     /// assert_eq!(socket.multicast_loop_v6().unwrap(), false);
     /// ```

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -48,7 +48,7 @@ use crate::time::Duration;
 ///
 /// fn main() -> std::io::Result<()> {
 ///     {
-///         let socket = UdpSocket::bind("127.0.0.1:34254")?;
+///         let socket = UdpSocket::bind("[::1]:34254")?;
 ///
 ///         // Receives a single datagram message on the socket. If `buf` is too small to hold
 ///         // the message, it will be cut off.
@@ -79,34 +79,34 @@ impl UdpSocket {
     ///
     /// # Examples
     ///
-    /// Creates a UDP socket bound to `127.0.0.1:3400`:
+    /// Creates a UDP socket bound to `[::1]:3400`:
     ///
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:3400").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:3400").expect("bind should succeed");
     /// ```
     ///
-    /// Creates a UDP socket bound to `127.0.0.1:3400`. If the socket cannot be
-    /// bound to that address, create a UDP socket bound to `127.0.0.1:3401`:
+    /// Creates a UDP socket bound to `[::1]:3400`. If the socket cannot be
+    /// bound to that address, create a UDP socket bound to `[::1]:3401`:
     ///
     /// ```no_run
     /// use std::net::{SocketAddr, UdpSocket};
     ///
     /// let addrs = [
-    ///     SocketAddr::from(([127, 0, 0, 1], 3400)),
-    ///     SocketAddr::from(([127, 0, 0, 1], 3401)),
+    ///     SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 3400)),
+    ///     SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 3401)),
     /// ];
     /// let socket = UdpSocket::bind(&addrs[..]).expect("bind should succeed");
     /// ```
     ///
     /// Creates a UDP socket bound to a port assigned by the operating system
-    /// at `127.0.0.1`.
+    /// at `[::1]`.
     ///
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+    /// let socket = UdpSocket::bind("[::1]:0").unwrap();
     /// ```
     ///
     /// Note that `bind` declares the scope of your network connection.
@@ -117,7 +117,7 @@ impl UdpSocket {
     /// in your local network.
     ///
     /// In order to limit your view of the network the least, `bind` to
-    /// [`Ipv4Addr::UNSPECIFIED`] or [`Ipv6Addr::UNSPECIFIED`].
+    /// [`Ipv6Addr::UNSPECIFIED`] or [`Ipv4Addr::UNSPECIFIED`].
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<UdpSocket> {
         net_imp::UdpSocket::bind(addr).map(UdpSocket)
@@ -139,7 +139,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// let mut buf = [0; 10];
     /// let (number_of_bytes, src_addr) = socket.recv_from(&mut buf)
     ///                                         .expect("recv_from should succeed");
@@ -168,7 +168,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// let mut buf = [0; 10];
     /// let (number_of_bytes, src_addr) = socket.peek_from(&mut buf)
     ///                                         .expect("recv_from should succeed");
@@ -200,8 +200,8 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
-    /// socket.send_to(&[0; 10], "127.0.0.1:4242").expect("send_to should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
+    /// socket.send_to(&[0; 10], "[::1]:4242").expect("send_to should succeed");
     /// ```
     ///
     /// [Issue #34202]: https://github.com/rust-lang/rust/issues/34202
@@ -218,12 +218,12 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, UdpSocket};
+    /// use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6, UdpSocket};
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
-    /// socket.connect("192.168.0.1:41203").expect("connect should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
+    /// socket.connect("[2001:db8::]:41203").expect("connect should succeed");
     /// assert_eq!(socket.peer_addr().unwrap(),
-    ///            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 0, 1), 41203)));
+    ///            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0), 41203)));
     /// ```
     ///
     /// If the socket isn't connected, it will return a [`NotConnected`] error.
@@ -233,7 +233,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// assert_eq!(socket.peer_addr().unwrap_err().kind(),
     ///            std::io::ErrorKind::NotConnected);
     /// ```
@@ -247,11 +247,11 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, UdpSocket};
+    /// use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6, UdpSocket};
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// assert_eq!(socket.local_addr().unwrap(),
-    ///            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 34254)));
+    ///            SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 34254)));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
@@ -269,7 +269,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// let socket_clone = socket.try_clone().expect("try_clone should succeed");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -298,7 +298,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// socket.set_read_timeout(None).expect("set_read_timeout should succeed");
     /// ```
     ///
@@ -310,7 +310,7 @@ impl UdpSocket {
     /// use std::net::UdpSocket;
     /// use std::time::Duration;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").unwrap();
+    /// let socket = UdpSocket::bind("[::1]:34254").unwrap();
     /// let result = socket.set_read_timeout(Some(Duration::new(0, 0)));
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
@@ -341,7 +341,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// socket.set_write_timeout(None).expect("set_write_timeout should succeed");
     /// ```
     ///
@@ -353,7 +353,7 @@ impl UdpSocket {
     /// use std::net::UdpSocket;
     /// use std::time::Duration;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").unwrap();
+    /// let socket = UdpSocket::bind("[::1]:34254").unwrap();
     /// let result = socket.set_write_timeout(Some(Duration::new(0, 0)));
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
@@ -374,7 +374,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// socket.set_read_timeout(None).expect("set_read_timeout should succeed");
     /// assert_eq!(socket.read_timeout().unwrap(), None);
     /// ```
@@ -394,7 +394,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// socket.set_write_timeout(None).expect("set_write_timeout should succeed");
     /// assert_eq!(socket.write_timeout().unwrap(), None);
     /// ```
@@ -413,7 +413,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// socket.set_broadcast(false).expect("set_broadcast should succeed");
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
@@ -430,7 +430,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// socket.set_broadcast(false).expect("set_broadcast should succeed");
     /// assert_eq!(socket.broadcast().unwrap(), false);
     /// ```
@@ -560,7 +560,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// socket.set_ttl(42).expect("set_ttl should succeed");
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
@@ -577,7 +577,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// socket.set_ttl(42).expect("set_ttl should succeed");
     /// assert_eq!(socket.ttl().unwrap(), 42);
     /// ```
@@ -635,7 +635,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
     /// match socket.take_error() {
     ///     Ok(Some(error)) => println!("UdpSocket error: {error:?}"),
     ///     Ok(None) => println!("No error"),
@@ -661,14 +661,14 @@ impl UdpSocket {
     ///
     /// # Examples
     ///
-    /// Creates a UDP socket bound to `127.0.0.1:3400` and connect the socket to
-    /// `127.0.0.1:8080`:
+    /// Creates a UDP socket bound to `[::1]:3400` and connect the socket to
+    /// `[::1]:8080`:
     ///
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:3400").expect("bind should succeed");
-    /// socket.connect("127.0.0.1:8080").expect("connect should succeed");
+    /// let socket = UdpSocket::bind("[::1]:3400").expect("bind should succeed");
+    /// socket.connect("[::1]:8080").expect("connect should succeed");
     /// ```
     ///
     /// Unlike in the TCP case, passing an array of addresses to the `connect`
@@ -697,8 +697,8 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
-    /// socket.connect("127.0.0.1:8080").expect("connect should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
+    /// socket.connect("[::1]:8080").expect("connect should succeed");
     /// socket.send(&[0, 1, 2]).expect("send should succeed");
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
@@ -725,8 +725,8 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
-    /// socket.connect("127.0.0.1:8080").expect("connect should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
+    /// socket.connect("[::1]:8080").expect("connect should succeed");
     /// let mut buf = [0; 10];
     /// match socket.recv(&mut buf) {
     ///     Ok(received) => println!("received {received} bytes {:?}", &buf[..received]),
@@ -765,8 +765,8 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
-    /// socket.connect("127.0.0.1:8080").expect("connect should succeed");
+    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
+    /// socket.connect("[::1]:8080").expect("connect should succeed");
     /// let mut buf = [0; 10];
     /// match socket.peek(&mut buf) {
     ///     Ok(received) => println!("received {received} bytes"),
@@ -793,14 +793,14 @@ impl UdpSocket {
     ///
     /// # Examples
     ///
-    /// Creates a UDP socket bound to `127.0.0.1:7878` and read bytes in
+    /// Creates a UDP socket bound to `[::1]:7878` and read bytes in
     /// nonblocking mode:
     ///
     /// ```no_run
     /// use std::io;
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("127.0.0.1:7878").unwrap();
+    /// let socket = UdpSocket::bind("[::1]:7878").unwrap();
     /// socket.set_nonblocking(true).unwrap();
     ///
     /// # fn wait_for_fd() { unimplemented!() }

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -425,7 +425,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
     /// socket.set_broadcast(false).expect("set_broadcast should succeed");
     /// ```
     #[stable(feature = "net2_mutators", since = "1.9.0")]
@@ -442,7 +442,7 @@ impl UdpSocket {
     /// ```no_run
     /// use std::net::UdpSocket;
     ///
-    /// let socket = UdpSocket::bind("[::1]:34254").expect("bind should succeed");
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("bind should succeed");
     /// socket.set_broadcast(false).expect("set_broadcast should succeed");
     /// assert_eq!(socket.broadcast().unwrap(), false);
     /// ```

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -49,6 +49,8 @@ use crate::time::Duration;
 /// fn main() -> std::io::Result<()> {
 ///     {
 ///         let socket = UdpSocket::bind("[::1]:34254")?;
+///         # #[allow(unused)]
+///         let ipv4_socket = UdpSocket::bind("127.0.0.1:34254")?;
 ///
 ///         // Receives a single datagram message on the socket. If `buf` is too small to hold
 ///         // the message, it will be cut off.

--- a/library/std/src/os/net/linux_ext/tcp.rs
+++ b/library/std/src/os/net/linux_ext/tcp.rs
@@ -37,7 +37,7 @@ pub impl(self) trait TcpStreamExt {
     /// #[cfg(target_os = "android")]
     /// use std::os::android::net::TcpStreamExt;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///         .expect("Couldn't connect to the server...");
     /// stream.set_quickack(true).expect("set_quickack call failed");
     /// ```
@@ -64,7 +64,7 @@ pub impl(self) trait TcpStreamExt {
     /// #[cfg(target_os = "android")]
     /// use std::os::android::net::TcpStreamExt;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///         .expect("Couldn't connect to the server...");
     /// stream.set_quickack(true).expect("set_quickack call failed");
     /// assert_eq!(stream.quickack().unwrap_or(false), true);
@@ -92,7 +92,7 @@ pub impl(self) trait TcpStreamExt {
     /// use std::os::linux::net::TcpStreamExt;
     /// use std::time::Duration;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///         .expect("Couldn't connect to the server...");
     /// stream.set_deferaccept(Duration::from_secs(1u64)).expect("set_deferaccept call failed");
     /// ```
@@ -119,7 +119,7 @@ pub impl(self) trait TcpStreamExt {
     /// use std::os::linux::net::TcpStreamExt;
     /// use std::time::Duration;
     ///
-    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    /// let stream = TcpStream::connect("[::1]:8080")
     ///         .expect("Couldn't connect to the server...");
     /// stream.set_deferaccept(Duration::from_secs(1u64)).expect("set_deferaccept call failed");
     /// assert_eq!(stream.deferaccept().unwrap(), Duration::from_secs(1u64));


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161879)*
<!-- homu-ignore:end -->

This defaults all documentation unrelated to specific IP versions to the current IPv6.

Related to issue rust-lang/rust#161832 

I didn't touch any tests, as I'm pretty new and don't know much about the test infrastructure, but maybe it should be considered to run all the tests via the v6 loopback by default too.

Feel free to discuss and / or critique!