### PR TITLE
fix rustc_lint_defs doctest issues

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -798,7 +798,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```rust,compile_fail
     /// #![deny(dead_code_pub_in_binary)]
     ///
     /// pub fn unused_pub_fn() {}
@@ -1107,9 +1107,9 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```rust,compile_fail
     /// #![deny(warnings)]
-    /// fn foo() {}
+    /// struct non_standard_name;
     /// ```
     ///
     /// {{produces}}


### PR DESCRIPTION
Some of these doctests should fail, but due to various complications they accidentally pass when executed in "merged" rustdoc mode. Mark them as fail, which leads to them being run as separate doctests, and then they behave as expected.

See [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/266220-t-rustdoc/topic/Strange.20behavior.20for.20rustc_builtin_lints.20doctests/with/619604902) for the journey of discovery that led to this. ;)