### PR TITLE
compiler: Make +fix-cortex-a53-835769 a default feature for aarch64 fuchsia

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_fuchsia.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_fuchsia.rs
@@ -5,7 +5,7 @@ use crate::spec::{
 pub(crate) fn target() -> Target {
     let mut base = base::fuchsia::opts();
     base.cpu = "generic".into();
-    base.features = "+v8a,+crc,+aes,+sha2,+neon".into();
+    base.features = "+v8a,+crc,+aes,+sha2,+neon,+fix-cortex-a53-835769".into();
     base.max_atomic_width = Some(128);
     base.stack_probes = StackProbeType::Inline;
     base.supported_sanitizers = SanitizerSet::ADDRESS

--- a/tests/codegen-llvm/aarch64-fuchsia-target-features.rs
+++ b/tests/codegen-llvm/aarch64-fuchsia-target-features.rs
@@ -1,0 +1,14 @@
+//@ add-minicore
+//@ compile-flags: --crate-type=rlib --target=aarch64-unknown-fuchsia
+//@ needs-llvm-components: aarch64
+
+// CHECK: attributes #0 = { {{.*}}"target-features"="{{.*}}+fix-cortex-a53-835769{{.*}}" }
+
+#![feature(no_core, lang_items)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+#[no_mangle]
+pub fn test() {}


### PR DESCRIPTION
This matches the default target features for aarch64 fuchsia emitted by clang.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
