### PR TITLE
std: uefi: fix File::seek returning the EOF sentinel

### DIFF
--- a/library/std/src/sys/fs/uefi.rs
+++ b/library/std/src/sys/fs/uefi.rs
@@ -360,12 +360,7 @@ impl File {
         let off = match pos {
             SeekFrom::Start(p) => p,
             SeekFrom::End(p) => {
-                // Seeking to position 0xFFFFFFFFFFFFFFFF causes the current position to be set to the end of the file.
-                if p == 0 {
-                    0xFFFFFFFFFFFFFFFF
-                } else {
-                    self.file_attr()?.size().checked_add_signed(p).ok_or(NEG_OFF_ERR)?
-                }
+                self.file_attr()?.size().checked_add_signed(p).ok_or(NEG_OFF_ERR)?
             }
             SeekFrom::Current(p) => self.tell()?.checked_add_signed(p).ok_or(NEG_OFF_ERR)?,
         };


### PR DESCRIPTION
seek(SeekFrom::End(0)) special-cased the offset to the UEFI 0xFFFFFFFFFFFFFFFF "set position to end of file" sentinel, then returned that value as the new stream position. so seek reported u64::MAX instead of the file size, and the default Seek::stream_len did too. compute the offset from the file size in every End case instead.