### PR TITLE
Add link to ownership section in ptr::read docs

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1620,6 +1620,8 @@ pub const unsafe fn replace<T>(dst: *mut T, src: T) -> T {
 ///
 /// Note that even if `T` has size `0`, the pointer must be properly aligned.
 ///
+/// Care must be taken around [ownership of the returned value](#ownership-of-the-returned-value).
+///
 /// # Examples
 ///
 /// Basic usage:


### PR DESCRIPTION
This one has annoyed me for a while but I never found it worth fixing.

One of the safety requirements of `read` is that you handle ownership correctly.

All `read`-like functions in the `ptr` module (e.g. `copy`, `read_unaligned`) state that "just like `read`", you have to take care around this, and they link to the section on ownership in the `read` docs.
However, `read` does not do so in its own safety requirements, and worse yet, you have to *scroll down* to see the section.

Every so often I look at this function and think ownership is missing from the docs, before remembering this.
This PR just adds a link to make sure users don't miss this.

r? libs
