### PR TITLE
Mark `extern_item_impls` feature as incomplete

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -538,7 +538,7 @@ declare_features! (
     /// Allows using `#[export_stable]` which indicates that an item is exportable.
     (incomplete, export_stable, "1.88.0", Some(139939)),
     /// Externally implementable items
-    (unstable, extern_item_impls, "1.94.0", Some(125418)),
+    (incomplete, extern_item_impls, "1.94.0", Some(125418)),
     /// Allows defining `extern type`s.
     (unstable, extern_types, "1.23.0", Some(43467)),
     /// Allow using 128-bit (quad precision) floating point numbers.


### PR DESCRIPTION
context: https://github.com/rust-lang/rust/pull/161873#discussion_r3873029239

> If they are so unstable, maybe they should have a separate feature gate that's marked as `incomplete`. Or the entire `extern_item_impls` should be marked "incomplete".

I think it's just best to mark the entire thing as incomplete for now. Later, when the implementation matures we can consider removing the incompleteness or splitting the feature in unstable and incomplete parts.



r? @bjorn3 @RalfJung 

