### PR TITLE
Do not suppress the fn item uniqueness note for late bound lifetimes

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
@@ -521,7 +521,9 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 let found_sig =
                     self.normalize_fn_sig(self.tcx.fn_sig(*did2).instantiate(self.tcx, args2));
 
-                if self.same_type_modulo_infer(expected_sig, found_sig) {
+                let expected_sig_anon = self.tcx.anonymize_bound_vars(expected_sig);
+                let found_sig_anon = self.tcx.anonymize_bound_vars(found_sig);
+                if self.same_type_modulo_infer(expected_sig_anon, found_sig_anon) {
                     diag.subdiagnostic(FnUniqTypes);
                 }
 

--- a/tests/ui/fn/fn-item-type-note-late-bound-145558.rs
+++ b/tests/ui/fn/fn-item-type-note-late-bound-145558.rs
@@ -1,0 +1,19 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/145558
+//!
+//! The note explaining that distinct fn items have distinct types was suppressed when the
+//! signatures contained a late-bound lifetime, because the two binders name their bound
+//! region differently.
+
+//@ dont-require-annotations: NOTE
+
+struct A;
+
+fn f1<'a>(_: &'a A) {}
+fn f2<'a>(_: &'a A) {}
+
+fn main() {
+    let mut map = vec![];
+    map.push(f1);
+    map.push(f2);
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/fn/fn-item-type-note-late-bound-145558.rs
+++ b/tests/ui/fn/fn-item-type-note-late-bound-145558.rs
@@ -16,4 +16,5 @@ fn main() {
     map.push(f1);
     map.push(f2);
     //~^ ERROR mismatched types
+    //~| NOTE different fn items have unique types
 }

--- a/tests/ui/fn/fn-item-type-note-late-bound-145558.stderr
+++ b/tests/ui/fn/fn-item-type-note-late-bound-145558.stderr
@@ -12,6 +12,7 @@ LL |     map.push(f2);
    |
    = note: expected fn item `for<'a> fn(&'a A) {f1}`
               found fn item `for<'a> fn(&'a A) {f2}`
+   = note: different fn items have unique types, even if their signatures are the same
 note: method defined here
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 

--- a/tests/ui/fn/fn-item-type-note-late-bound-145558.stderr
+++ b/tests/ui/fn/fn-item-type-note-late-bound-145558.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> $DIR/fn-item-type-note-late-bound-145558.rs:17:14
+   |
+LL |     map.push(f1);
+   |     ---      -- this argument has type `for<'a> fn(&'a A) {f1}`...
+   |     |
+   |     ... which causes `map` to have type `Vec<for<'a> fn(&'a A) {f1}>`
+LL |     map.push(f2);
+   |         ---- ^^ expected fn item, found a different fn item
+   |         |
+   |         arguments to this method are incorrect
+   |
+   = note: expected fn item `for<'a> fn(&'a A) {f1}`
+              found fn item `for<'a> fn(&'a A) {f2}`
+note: method defined here
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#145558 `same_type_modulo_infer` compared the bound regions by identity, so the note was suppressed for late bound lifetimes and anonymizing the binders fixes it.
<!-- homu-ignore:start -->
I authored and reviewed the change and used LLM to help locate the code and validate the fix
<!-- homu-ignore:end -->
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
