### PR TITLE
declare C and C-unwind as mutually ABI-compatible

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1810,9 +1810,14 @@ const _: () = ();
 /// `fn name(...) -> ...` implicitly uses the `"Rust"` ABI string and `extern fn name(...) -> ...`
 /// implicitly uses the `"C"` ABI string.
 ///
-/// The ABI strings are guaranteed to be compatible if they are the same, or if the caller ABI
-/// string is `$X-unwind` and the callee ABI string is `$X`, where `$X` is one of the following:
-/// "C", "aapcs", "fastcall", "stdcall", "system", "sysv64", "thiscall", "vectorcall", "win64".
+/// The ABI strings are guaranteed to be compatible if they are the same, or if one of them is
+/// `$X-unwind` and the other one is `$X`, where `$X` is one of the following: "C", "aapcs",
+/// "fastcall", "stdcall", "system", "sysv64", "thiscall", "vectorcall", "win64". (Note that [it is
+/// undefined behavior][unwind-ub] for a function to unwind unless *both* caller and callee use a
+/// signature that permits unwinding, such as "C-unwind". Rust ensures that a function defined with
+/// a non-unwinding ABI such as "C" never unwinds due to a panic, so undefined behavior can only
+/// arise if the callee ABI is `$X-unwind` and the caller ABI is `$X`, or if a non-Rust unwind
+/// occurs.)
 ///
 /// The following types are guaranteed to be ABI-compatible:
 ///
@@ -1878,7 +1883,8 @@ const _: () = ();
 /// Behavior since transmuting `None::<NonZero<i32>>` to `NonZero<i32>` violates the non-zero
 /// requirement.
 ///
-/// [cfi-docs]: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#controlflowintegrity
+/// [unwind-ub]: ../reference/behavior-considered-undefined.html#r-undefined.call
+/// [cfi-docs]: ../unstable-book/compiler-flags/sanitizer.html#controlflowintegrity
 ///
 /// ### Trait implementations
 ///


### PR DESCRIPTION
We left this conservative in https://github.com/rust-lang/rust/pull/115476. That means the following code is currently UB:
```rust
extern "C-unwind" fn does_not_unwind_but_could() {}

fn main() {
    let f: extern "C-unwind" fn() = does_not_unwind_but_could;
    let f: extern "C" fn() = unsafe { std::mem::transmute(f) };
    f();
}
```
I think this code should be allowed. [Zulip discussion](https://rust-lang.zulipchat.com/#narrow/channel/136281-t-opsem/topic/ABI.20compatibility.20of.20.22C.22.20vs.20.22C-unwind.22) also led to the conclusion that this should be fine in LLVM -- the `nounwind` attribute does not affect the ABI. This is widely relied upon in the C ecosystem when doing calls between C and C++.
Cc @nikic to confirm.

I am not sure why rust-lang/rust#115476 left this conservative. There was discussion about explicitly listing the ABIs rather than saying this holds universally for all `*-unwind` that we may add in the future, but there was no discussion I could find about allowing a mismatch both ways.

Cc @rust-lang/opsem @rust-lang/lang 