### PR TITLE
Exclude relnotes issues from going in the triage queue

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -226,6 +226,10 @@ new_issue = true
 exclude_labels = [
     "C-tracking-issue",
     "A-diagnostics",
+    "relnotes",
+    "relnotes-perf",
+    "relnotes-tracking-issue",
+    "relnotes-blogpost",
 ]
 
 [autolabel."I-prioritize"]


### PR DESCRIPTION
We have too many open issues (629, [at the time of writing](https://github.com/rust-lang/rust/issues?q=is%3Aissue%20state%3Aopen%20label%3Aneeds-triage)) that are labeled with `needs-triage`, we cannot keep up with them, we don't see what really needs to be triaged.

For a start, all issues that are about release notes probably don't need this label.


For more context, read this [Zulip topic](https://rust-lang.zulipchat.com/#narrow/channel/244344-t-compiler.2Fcontrib-private/topic/rust-lang.2Frust.20untriaged.20issue.20backlog/near/619737804).

CC'ing interested groups, I'd like to hear an opinion if this is fine
cc @rust-lang/triage
cc @rust-lang/release

thanks