### PR TITLE
run `extern "tail"` with `byval` argument test

### DIFF
--- a/tests/ui/explicit-tail-calls/tailcc-no-signature-restriction.rs
+++ b/tests/ui/explicit-tail-calls/tailcc-no-signature-restriction.rs
@@ -1,9 +1,9 @@
 //@ run-pass
 //@ ignore-backends: gcc
-//@ min-llvm-version: 22
-//@ revisions: x86_64 aarch64
+//@ min-llvm-version: 23
+//@ revisions: x86 x86_64 aarch64
 //
-// FIXME: enable x86 on LLVM 23.
+//@ [x86] only-x86
 //@ [x86_64] only-x86_64
 //@ [aarch64] only-aarch64
 #![feature(explicit_tail_calls, rust_tail_cc)]
@@ -18,6 +18,7 @@ pub extern "tail" fn add() -> u64 {
     become add(1, 2);
 }
 
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), not(windows)))]
 #[inline(never)]
 pub extern "tail" fn pass_struct(a: u64, d: u64) -> u64 {
     #[derive(Clone, Copy)]
@@ -42,8 +43,7 @@ pub extern "tail" fn pass_struct(a: u64, d: u64) -> u64 {
 fn main() {
     assert_eq!(add(), 3);
 
-    // FIXME: LLVM 22 has a bug which makes this miscompile.
-    if false {
-        assert_eq!(pass_struct(5, 6), 5 + 6);
-    }
+    // Windows and Aarch64 in LLVM 23 does not support byval arguments.
+    #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), not(windows)))]
+    assert_eq!(pass_struct(5, 6), 5 + 6);
 }


### PR DESCRIPTION
With LLVM 23 we can run `extern "tail"` tests with `byval` arguments on x86 and x86_64. AArch64 does not (yet) support this, see https://github.com/llvm/llvm-project/pull/206718.