### PR TITLE
Retroactively add relnotes for `bool::{ok_or,ok_or_else}` (1.98.0)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -67,6 +67,8 @@ Stabilized APIs
 - [`Atomic<T>::get_mut_slice`](https://doc.rust-lang.org/stable/core/sync/atomic/struct.Atomic.html#method.get_mut_slice)
 - [`Atomic<T>::from_mut_slice`](https://doc.rust-lang.org/stable/core/sync/atomic/struct.Atomic.html#method.from_mut_slice)
 - [`std::range::legacy`](https://doc.rust-lang.org/stable/std/range/legacy/index.html)
+- [`bool::ok_or`](https://doc.rust-lang.org/stable/std/primitive.bool.html#method.ok_or)
+- [`bool::ok_or_else`](https://doc.rust-lang.org/stable/std/primitive.bool.html#method.ok_or_else)
 
 
 <a id="1.98.0-Compatibility-Notes"></a>


### PR DESCRIPTION
Looks like this was lost:

- Relnotes issue: https://github.com/rust-lang/rust/issues/156336
- Tracking issue: https://github.com/rust-lang/rust/issues/142748
- Stabilization PR: https://github.com/rust-lang/rust/pull/156594

Closes rust-lang/rust#156336.