### PR TITLE
Windows: document that `normalize_lexically` converts `/` to `\`

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3424,6 +3424,8 @@ impl Path {
     ///
     /// </div>
     ///
+    /// On Windows this will convert all `/` to `\` unless a [verbatim](Prefix::is_verbatim()) path is given.
+    ///
     /// [`path::absolute`](absolute) is an alternative that preserves `..`.
     /// Or [`Path::canonicalize`] can be used to resolve any `..` by querying the filesystem.
     #[unstable(feature = "normalize_lexically", issue = "134694")]


### PR DESCRIPTION
To be clear, this is the current behaviour and what we want so we should document it.

Tracking issue: rust-lang/rust#134694