### PR TITLE
borrowck: Restore alias rigidity from HIR typeck

### DIFF
--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -21,19 +21,16 @@ use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::IndexVec;
-use rustc_infer::infer::{NllRegionVariableOrigin, TyCtxtInferExt};
-use rustc_infer::traits::ObligationCause;
+use rustc_infer::infer::NllRegionVariableOrigin;
 use rustc_macros::extension;
 use rustc_middle::mir::RETURN_PLACE;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{
     self, BoundVariableKind, GenericArgs, GenericArgsRef, InlineConstArgs, InlineConstArgsParts,
-    List, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, TypingMode,
-    fold_regions,
+    List, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, fold_regions,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{ErrorGuaranteed, kw, sym};
-use rustc_trait_selection::traits::ObligationCtxt;
 use tracing::{debug, instrument};
 
 use crate::BorrowckInferCtxt;
@@ -136,32 +133,22 @@ pub(crate) enum DefiningTy<'tcx> {
     GlobalAsm(DefId),
 }
 
-fn normalized_type_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
-    let ty = tcx.type_of(def_id).instantiate_identity();
-    if !tcx.next_trait_solver_globally() {
-        return ty.skip_normalization();
-    }
-
-    let typing_mode = if tcx.use_typing_mode_post_typeck_until_borrowck() {
-        TypingMode::borrowck(tcx, def_id)
-    } else {
-        TypingMode::analysis_in_body(tcx, def_id)
-    };
-    let infcx = tcx.infer_ctxt().build(typing_mode);
-    let ocx = ObligationCtxt::new(&infcx);
-    let span = tcx.def_span(def_id);
-    let cause = ObligationCause::misc(span, def_id);
-    ocx.deeply_normalize(&cause, tcx.param_env(def_id), ty).unwrap()
-}
-
 impl<'tcx> DefiningTy<'tcx> {
     #[instrument(level = "debug", skip(tcx), ret)]
     fn new(tcx: TyCtxt<'tcx>, body_def_id: LocalDefId) -> DefiningTy<'tcx> {
         match tcx.hir_body_owner_kind(body_def_id) {
             BodyOwnerKind::Closure | BodyOwnerKind::Fn => {
-                // Normalize after instantiation so coroutine yield/resume
-                // types in the args are rigid under the next solver.
-                let defining_ty = normalized_type_of(tcx, body_def_id);
+                let defining_ty =
+                    tcx.type_of(body_def_id).instantiate_identity().skip_normalization();
+                let defining_ty = if tcx.next_trait_solver_globally() {
+                    // Closure types come from HIR typeck results, where they were already
+                    // normalized during writeback. Wrapping them in an `EarlyBinder`
+                    // conservatively makes aliases non-rigid, so restore their rigidness
+                    // instead of normalizing them again during borrowck.
+                    ty::set_aliases_to_rigid(tcx, defining_ty)
+                } else {
+                    defining_ty
+                };
                 match *defining_ty.kind() {
                     ty::Closure(def_id, args) => DefiningTy::Closure(def_id, args),
                     ty::Coroutine(def_id, args) => DefiningTy::Coroutine(def_id, args),

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -33,7 +33,6 @@ use rustc_hir::{self as hir, BindingMode, ByRef, HirId, ItemLocalId, Node, find_
 use rustc_index::bit_set::GrowableBitSet;
 use rustc_index::{Idx, IndexSlice, IndexVec};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
-use rustc_infer::traits::ObligationCause;
 use rustc_middle::hir::place::PlaceBase as HirPlaceBase;
 use rustc_middle::middle::region;
 use rustc_middle::mir::*;
@@ -41,7 +40,6 @@ use rustc_middle::thir::{self, ExprId, LocalVarId, Param, ParamId, PatKind, Thir
 use rustc_middle::ty::{self, ScalarInt, Ty, TyCtxt, TypeVisitableExt, TypingMode};
 use rustc_middle::{bug, span_bug};
 use rustc_span::{Span, Symbol};
-use rustc_trait_selection::traits::ObligationCtxt;
 
 use crate::builder::expr::as_place::PlaceBuilder;
 use crate::builder::scope::LintLevel;
@@ -508,7 +506,17 @@ fn construct_fn<'tcx>(
 
     let infcx = tcx.infer_ctxt().build(typing_mode);
 
-    let coroutine = match normalized_type_of(&infcx, fn_def).kind() {
+    let defining_ty = tcx.type_of(fn_def).instantiate_identity().skip_normalization();
+    let defining_ty = if infcx.next_trait_solver() {
+        // Closure types come from HIR typeck results, where they were already
+        // normalized during writeback. Wrapping them in an `EarlyBinder`
+        // conservatively makes aliases non-rigid, so restore their rigidness
+        // instead of normalizing them again during MIR build.
+        ty::set_aliases_to_rigid(tcx, defining_ty)
+    } else {
+        defining_ty
+    };
+    let coroutine = match defining_ty.kind() {
         ty::Coroutine(_, args) => Some(Box::new(CoroutineInfo::initial(
             tcx.coroutine_kind(fn_def).unwrap(),
             args.as_coroutine().yield_ty(),
@@ -564,18 +572,6 @@ fn construct_fn<'tcx>(
     };
 
     body
-}
-
-fn normalized_type_of<'tcx>(infcx: &InferCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
-    let tcx = infcx.tcx;
-    let ty = tcx.type_of(def_id).instantiate_identity();
-    if !infcx.next_trait_solver() {
-        return ty.skip_normalization();
-    }
-
-    let ocx = ObligationCtxt::new(infcx);
-    let cause = ObligationCause::misc(tcx.def_span(def_id), def_id);
-    ocx.deeply_normalize(&cause, tcx.param_env(def_id), ty).unwrap()
 }
 
 fn construct_const<'a, 'tcx>(

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -112,10 +112,11 @@ impl<I: Interner> AliasTyKind<I> {
 /// with `IsRigid::Yes`. At this point we no longer have to try and renormalize this alias
 /// later on.
 ///
-/// Rigidness is shared across inference contexts and compiler phases. For example, aliases
-/// normalized during HIR typeck can remain rigid when the resulting type is later used by
-/// borrowck. They must be made non-rigid again if they enter a typing mode or parameter
-/// environment in which further normalization may be possible.
+/// Rigidness becomes outdated when the surrounding typing mode or param env changes,
+/// because further normalization might be possible.
+/// We should also note that rigidness can be shared within some typing mode groups
+/// if the param env is the same, e.g., `Typeck/PostTypeckUntilBorrowck` and
+/// `PostAnalysis/Codegen`.
 ///
 /// FIXME(#155345): Alias handling is currently still in flux for the new trait
 /// solver and this is currently somewhat messy. Please reach out on

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -112,6 +112,11 @@ impl<I: Interner> AliasTyKind<I> {
 /// with `IsRigid::Yes`. At this point we no longer have to try and renormalize this alias
 /// later on.
 ///
+/// Rigidness is shared across inference contexts and compiler phases. For example, aliases
+/// normalized during HIR typeck can remain rigid when the resulting type is later used by
+/// borrowck. They must be made non-rigid again if they enter a typing mode or parameter
+/// environment in which further normalization may be possible.
+///
 /// FIXME(#155345): Alias handling is currently still in flux for the new trait
 /// solver and this is currently somewhat messy. Please reach out on
 /// #t-types/trait-system-refactor-initiative if you encounter this and it isn't


### PR DESCRIPTION
Follow-up to rust-lang/rust#161012. This came out of the review thread here:
https://github.com/rust-lang/rust/pull/161012#discussion_r3869892881

Borrowck was normalizing the closure type again in a fresh inference context. HIR writeback had already done that work. EarlyBinder only marked the aliases as non-rigid again because it has to be conservative. If the second normalization creates region constraints, they disappear with the temporary context.

I first thought normalizing again here was fine. After tracing the type back through writeback, I think it makes more sense to trust the result from HIR typeck. Borrowck now restores the rigid flag, and the IsRigid docs explain that this state can carry into borrowck and when it needs to be reset.

Tested with the coroutine regression and tidy.

cc @adwinwhite @lcnr