### PR TITLE
Improve to_int_checked performance

### DIFF
--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -34,13 +34,41 @@ macro_rules! impl_float_to_int {
                 }
                 #[inline]
                 fn to_int_checked(self) -> Option<$Int> {
-                    // `as` truncates toward zero and these bounds are exact for
-                    // that: `MAX + 1` rounds up to the first out-of-range value,
-                    // and the `- MIN` offset keeps the low comparison exact even
-                    // when `MIN - 1` is not representable. `NaN` and infinities
-                    // fail both comparisons.
-                    if self - (<$Int>::MIN as $Float) > -1.0 && self < <$Int>::MAX as $Float + 1.0 {
-                        Some(self as $Int)
+                    // We will compute LOW_THRESHOLD and HIGH_THRESHOLD
+                    // as <$Int>::MIN - 1 and <$Int>::MAX + 1 respectively,
+                    // or the next lower/higher value in case those are not
+                    // representable exactly. These thresholds represent the
+                    // first disallowed values.
+
+                    const LOW_THRESHOLD: $Float = {
+                        // The minimum of an integer type is representable or -INF
+                        // for all floats, as it is zero or a power of two.
+                        let int_min = <$Int>::MIN as $Float;
+                        let one_below_if_representable = int_min - 1.0;
+                        if one_below_if_representable == int_min {
+                            // We must allow int_min itself. In case int_min is
+                            // -INF this stays -INF, allowing any finite value.
+                            int_min.next_down()
+                        } else {
+                            one_below_if_representable
+                        }
+                    };
+
+                    const HIGH_THRESHOLD: $Float = {
+                        // The maximum of an integer type is always of the form
+                        // 2^k - 1 for some reasonable k. We can construct 2^k
+                        // exactly by summing 2^(k-1) twice, which fits in the
+                        // integer. The outcome will be exactly <$Int>::MAX + 1,
+                        // or INF allowing any finite value.
+                        let half = (<$Int>::MAX / 2) + 1;
+                        half as $Float + half as $Float
+                    };
+
+                    // NaN always fails these comparisons, and infinities at
+                    // least one.
+                    if LOW_THRESHOLD < self && self < HIGH_THRESHOLD {
+                        // SAFETY: we made sure we are in-bounds and finite.
+                        Some(unsafe { self.to_int_unchecked() })
                     } else {
                         None
                     }


### PR DESCRIPTION
Related tracking issue: https://github.com/rust-lang/rust/issues/159913.

This PR improves the performance of `to_int_checked` by pre-computing the precise bounds needed instead of arithmetic at runtime, and also avoids the extra clamping that `as` introduces by dispatching to the `unchecked` variant once the bound checks have succeeded. The precise performance improvement may depend on your machine, but the new version simply does strictly less work. E.g. on x86-64 compare the new vs old assembly for `f64 -> i32`:

```asm
new:
        vmovsd  xmm1, qword ptr [rip + .LCPI1_0]
        vcmpltsd        xmm1, xmm1, xmm0
        vcmpltsd        xmm2, xmm0, qword ptr [rip + .LCPI1_1]
        vandpd  xmm1, xmm1, xmm2
        vcvttsd2si      edx, xmm0
        vmovd   eax, xmm1
        and     eax, 1
        ret


old:
        vmovsd  xmm1, qword ptr [rip + .LCPI0_0]
        vaddsd  xmm2, xmm0, xmm1
        vcmpltsd        xmm1, xmm0, xmm1
        vmovsd  xmm3, qword ptr [rip + .LCPI0_1]
        vcmpltsd        xmm2, xmm3, xmm2
        vandpd  xmm1, xmm1, xmm2
        vmaxsd  xmm2, xmm0, qword ptr [rip + .LCPI0_2]
        vminsd  xmm2, xmm2, qword ptr [rip + .LCPI0_3]
        vcvttsd2si      eax, xmm2
        xor     edx, edx
        vucomisd        xmm0, xmm0
        cmovnp  edx, eax
        vmovd   eax, xmm1
        and     eax, 1
        ret
```

