### PR TITLE
Only check `#[allow(dead_code)]` on the trait

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -601,15 +601,12 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
         {
             if defer_seeds_come_from_allow {
                 return ImplItemCheckResult::Dead { require: adt_def_id };
-            } else {
-                let comes_from_allow = trait_comes_from_allow
-                    .or_else(|| has_allow_dead_code_or_lang_attr(self.tcx, adt_def_id));
-
-                return match comes_from_allow {
-                    Some(comes_from_allow) => ImplItemCheckResult::Live(comes_from_allow),
-                    None => ImplItemCheckResult::Dead { require: adt_def_id },
-                };
             }
+
+            return match trait_comes_from_allow {
+                Some(comes_from_allow) => ImplItemCheckResult::Live(comes_from_allow),
+                None => ImplItemCheckResult::Dead { require: adt_def_id },
+            };
         }
 
         ImplItemCheckResult::Live(ComesFromAllowExpect::No)

--- a/tests/ui/lint/dead-code/allow-adt-propagation-to-impls.rs
+++ b/tests/ui/lint/dead-code/allow-adt-propagation-to-impls.rs
@@ -1,0 +1,18 @@
+#![deny(dead_code)]
+
+pub trait Tr {
+    fn foo(&self);
+}
+
+#[allow(dead_code)]
+struct Foo;
+
+impl Tr for Foo {
+    fn foo(&self) {
+        bar();
+    }
+}
+
+fn bar() {} //~ ERROR function `bar` is never used
+
+fn main() {}

--- a/tests/ui/lint/dead-code/allow-adt-propagation-to-impls.stderr
+++ b/tests/ui/lint/dead-code/allow-adt-propagation-to-impls.stderr
@@ -1,0 +1,14 @@
+error: function `bar` is never used
+  --> $DIR/allow-adt-propagation-to-impls.rs:16:4
+   |
+LL | fn bar() {}
+   |    ^^^
+   |
+note: the lint level is defined here
+  --> $DIR/allow-adt-propagation-to-impls.rs:1:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
I edited on an old branch (on another machine) when trying to resolve the first comment in https://github.com/rust-lang/rust/pull/161571, and then force-pushed it. So it introduced the behavior in https://github.com/rust-lang/rust/pull/157885 partially.

I found this when rebasing https://github.com/rust-lang/rust/pull/157885, and I was expecting a conflict about this.

r? chenyukang