### PR TITLE
fix(infer): stop skipping Empty lifetime checks

### DIFF
--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -580,17 +580,13 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
                     let sub_data = var_data.value_mut(sub_vid);
                     debug!("contraction: {:?} == {:?}, {:?}", sub_vid, sub_data, c.sup);
 
-                    let VarValue::Value(sub_region) = *sub_data else {
-                        continue;
-                    };
-
                     // Do not report these errors immediately:
                     // instead, set the variable value to error and
                     // collect them later.
-                    if !self.sub_concrete_regions(sub_region, c.sup) {
+                    if !self.sub_region_values(*sub_data, VarValue::Value(c.sup)) {
                         debug!(
                             "region error at {:?}: cannot verify that {:?}={:?} <= {:?}",
-                            origin, sub_vid, sub_region, c.sup
+                            origin, sub_vid, sub_data, c.sup
                         );
                         *sub_data = VarValue::ErrorValue;
                     }

--- a/compiler/rustc_trait_selection/src/diagnostics/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/diagnostics/note_and_explain.rs
@@ -73,9 +73,11 @@ impl<'a> DescriptionCtx<'a> {
 
             ty::ReStatic => (alt_span, "restatic", String::new()),
 
-            ty::RePlaceholder(_) | ty::ReError(_) => return None,
+            ty::RePlaceholder(_) | ty::ReError(_) | ty::ReErased => return None,
 
-            ty::ReVar(_) | ty::ReBound(..) | ty::ReErased => {
+            ty::ReVar(_) => (alt_span, "revar", region.to_string()),
+
+            ty::ReBound(..) => {
                 bug!("unexpected region for DescriptionCtx: {:?}", region);
             }
         };

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-empty-region-outlives-soundness.rs
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-empty-region-outlives-soundness.rs
@@ -1,0 +1,34 @@
+// Regression test for https://github.com/rust-lang/rust/issues/161864
+
+use std::fmt::Display;
+
+trait ToObj<'a> {
+    fn to_obj(self) -> Box<dyn Display + 'a>;
+}
+
+impl<'a, T: Display + 'a> ToObj<'a> for T {
+    fn to_obj(self) -> Box<dyn Display + 'a> {
+        Box::new(self)
+    }
+}
+
+trait Super {
+    fn yeet(&self);
+}
+
+impl<'a> Super for ()
+where
+    for<'b> &'b str: ToObj<'a>,
+{
+    fn yeet(&self) {
+        let dangling = String::from("hello").as_str().to_obj();
+        println!("{dangling}");
+    }
+}
+
+trait Trait: Super {}
+impl Trait for () {} //~ ERROR the type `&'b str` does not fulfill the required lifetime
+
+fn main() {
+    let _ = (&() as &dyn Trait).yeet();
+}

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-empty-region-outlives-soundness.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-empty-region-outlives-soundness.stderr
@@ -1,0 +1,9 @@
+error[E0477]: the type `&'b str` does not fulfill the required lifetime
+  --> $DIR/hrtb-empty-region-outlives-soundness.rs:30:16
+   |
+LL | impl Trait for () {}
+   |                ^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0477`.


### PR DESCRIPTION
stop skipping the check in `lexical_region_resolve/mod.rs` and actually validate Empty lifetimes..

follow-up - make `note_and_explain.rs` handle `ReVar` and `ReErased` so it prints a normal error message instead of exploding.. - (added ui-test and .stderr)

fixes: rust-lang/rust#161864

r? @lcnr 