### PR TITLE
Promote `wasm32-wasip3` to a tier 2 target

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -4129,7 +4129,7 @@ fn add_lld_args(
     // `lld` as the linker.
     //
     // Note that wasm targets skip this step since the only option there anyway
-    // is to use LLD but the `wasm32-wasip2` target relies on a wrapper around
+    // is to use LLD but component-producing targets rely on a wrapper around
     // this, `wasm-component-ld`, which is overridden if this option is passed.
     if !sess.target.is_like_wasm {
         cmd.cc_arg("-fuse-ld=lld");

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip3.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip3.rs
@@ -2,38 +2,44 @@
 //! `wasm32-wasip2`, then WASIp3. The main feature of WASIp3 is native async
 //! support in the component model itself.
 //!
-//! Like `wasm32-wasip2` this target produces a component by default. Support
-//! for `wasm32-wasip3` is very early as of the time of this writing so
-//! components produced will still import WASIp2 APIs, but that's ok since it's
-//! all component-model-level imports anyway. Over time the imports of the
-//! standard library will change to WASIp3.
+//! Like `wasm32-wasip2` this target produces a component by default.
 
 use crate::spec::{Cc, Env, LinkerFlavor, Target, add_link_args};
 
 pub(crate) fn target() -> Target {
-    // As of now WASIp3 is a lightly edited wasip2 target, so start with that
-    // and this may grow over time as more features are supported.
+    // For now wasip3 is a lightly-edited wasip2 target.
     let mut target = super::wasm32_wasip2::target();
     target.llvm_target = "wasm32-wasip3".into();
     target.metadata = crate::spec::TargetMetadata {
         description: Some("WebAssembly".into()),
-        tier: Some(3),
+        tier: Some(2),
         host_tools: Some(false),
         std: Some(true),
     };
     target.options.env = Env::P3;
 
-    // The `--cooperative-threading` flag to the linker dictates the ABI that's
-    // being used on this target which is to store the stack pointer in a
-    // component model intrinsic location, for example, rather than a wasm
-    // global.
-    //
-    // Note that this is only specified for `Cc::No`, because when `clang` is
-    // being used as a linker it'll already pass this.
     add_link_args(
         &mut target.pre_link_args,
         LinkerFlavor::WasmLld(Cc::No),
-        &["--cooperative-threading"],
+        &[
+            // The `--cooperative-threading` flag to the linker dictates the ABI
+            // that's being used on this target which is to store the stack
+            // pointer in a component model intrinsic location, for example,
+            // rather than a wasm global.
+            //
+            // Note that this is only specified for `Cc::No`, because when
+            // `clang` is being used as a linker it'll already pass this.
+            "--cooperative-threading",
+            // This is used as the wasi-libc-defined symbol here is required for
+            // this target to function. The Rust compiler's symbol exports
+            // otherwise don't know about this symbol so it's manually exported
+            // here.
+            //
+            // Note that this additionally is only specified for `Cc::No`
+            // because when `clang` is used the symbol exports happen naturally
+            // and this isn't needed.
+            "--export-if-defined=__wasm_task_hook",
+        ],
     );
 
     target

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -439,15 +439,6 @@ fn copy_self_contained_objects(
             )
         });
 
-        // wasm32-wasip3 doesn't exist in wasi-libc yet, so instead use libs
-        // from the wasm32-wasip2 target. Once wasi-libc supports wasip3 this
-        // should be deleted and the native objects should be used.
-        let srcdir = if target == "wasm32-wasip3" {
-            assert!(!srcdir.exists(), "wasip3 support is in wasi-libc, this should be updated now");
-            builder.wasi_libdir(TargetSelection::from_user("wasm32-wasip2")).unwrap()
-        } else {
-            srcdir
-        };
         for &obj in &["libc.a", "crt1-command.o", "crt1-reactor.o"] {
             copy_and_stamp(
                 builder,
@@ -2529,7 +2520,8 @@ impl CommandLineStep for Assemble {
         }
 
         // In addition to `rust-lld` also install `wasm-component-ld` when
-        // is enabled. This is used by the `wasm32-wasip2` target of Rust.
+        // is enabled. This is used by targets that produce WebAssembly
+        // components in Rust such as `wasm32-wasip{2,3}`.
         if builder.tool_enabled("wasm-component-ld") {
             let wasm_component = builder.ensure(
                 crate::core::build_steps::tool::WasmComponentLd::for_use_by_compiler(

--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -104,6 +104,7 @@ ENV TARGETS=$TARGETS,wasm32-unknown-unknown
 ENV TARGETS=$TARGETS,wasm32-wasip1
 ENV TARGETS=$TARGETS,wasm32-wasip1-threads
 ENV TARGETS=$TARGETS,wasm32-wasip2
+ENV TARGETS=$TARGETS,wasm32-wasip3
 ENV TARGETS=$TARGETS,wasm32v1-none
 ENV TARGETS=$TARGETS,x86_64-unknown-linux-gnux32
 ENV TARGETS=$TARGETS,x86_64-fortanix-unknown-sgx

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -218,6 +218,7 @@ target | std | notes
 [`wasm32-wasip1`](platform-support/wasm32-wasip1.md) | ✓ | WebAssembly with WASIp1
 [`wasm32-wasip1-threads`](platform-support/wasm32-wasip1-threads.md) | ✓ | WebAssembly with WASI Preview 1 and threads
 [`wasm32-wasip2`](platform-support/wasm32-wasip2.md) | ✓ | WebAssembly with WASIp2
+[`wasm32-wasip3`](platform-support/wasm32-wasip3.md) | ✓ | WebAssembly with WASIp3
 [`wasm32v1-none`](platform-support/wasm32v1-none.md) | * | WebAssembly limited to 1.0 features and no imports
 [`x86_64-apple-ios`](platform-support/apple-ios.md) | ✓ | 64-bit x86 iOS
 [`x86_64-apple-ios-macabi`](platform-support/apple-ios-macabi.md) | ✓ | Mac Catalyst on x86_64
@@ -445,7 +446,6 @@ target | std | host | notes
 [`thumbv8m.main-nuttx-eabihf`](platform-support/nuttx.md) | ✓ |  | ARMv8M Mainline with NuttX, hardfloat
 [`wasm64-unknown-unknown`](platform-support/wasm64-unknown-unknown.md) | ? |  | WebAssembly
 [`wasm32-wali-linux-musl`](platform-support/wasm32-wali-linux.md) | ? |  | WebAssembly with [WALI](https://github.com/arjunr2/WALI)
-[`wasm32-wasip3`](platform-support/wasm32-wasip3.md) | ✓ |  | WebAssembly with WASIp3
 [`x86_64-apple-tvos`](platform-support/apple-tvos.md) | ✓ |  | x86 64-bit tvOS
 [`x86_64-apple-watchos-sim`](platform-support/apple-watchos.md) | ✓ |  | x86 64-bit Apple WatchOS simulator
 [`x86_64-lynx-lynxos178`](platform-support/lynxos178.md) |  |  | x86_64 LynxOS-178

--- a/src/doc/rustc/src/platform-support/wasm32-unknown-emscripten.md
+++ b/src/doc/rustc/src/platform-support/wasm32-unknown-emscripten.md
@@ -25,14 +25,15 @@ does not (easily) support interop with C/C++ code. Please refer to the
 [wasm-bindgen](https://crates.io/crates/wasm-bindgen) crate in case you want to
 interoperate with JavaScript with this target.
 
-Like Emscripten, the WASI targets [`wasm32-wasip1`](./wasm32-wasip1.md) and
-[`wasm32-wasip2`](./wasm32-wasip2.md) also provide access to the host environment,
-support interop with C/C++ (and other languages), and support most of the Rust
-standard library. While the WASI targets are portable across different hosts
-(web and non-web), WASI has no standard way of accessing web APIs, whereas
-Emscripten has the ability to run arbitrary JS from WASM and access many web APIs.
-If you are only targeting the web and need to access web APIs, the
-`wasm32-unknown-emscripten` target may be preferable.
+Like Emscripten, the WASI targets [`wasm32-wasip1`](./wasm32-wasip1.md),
+[`wasm32-wasip2`](./wasm32-wasip2.md), and
+[`wasm32-wasip3`](./wasm32-wasip3.md), also provide access to the host
+environment, support interop with C/C++ (and other languages), and support most
+of the Rust standard library. While the WASI targets are portable across
+different hosts (web and non-web), WASI has no standard way of accessing web
+APIs, whereas Emscripten has the ability to run arbitrary JS from WASM and
+access many web APIs.  If you are only targeting the web and need to access web
+APIs, the `wasm32-unknown-emscripten` target may be preferable.
 
 ## Target maintainers
 

--- a/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
+++ b/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
@@ -15,8 +15,9 @@ but many parts of the standard library do not work and return errors. For
 example `println!` does nothing, `std::fs` always return errors, and
 `std::thread::spawn` will panic. There is no means by which this can be
 overridden. For a WebAssembly target that more fully supports the standard
-library see the [`wasm32-wasip1`](./wasm32-wasip1.md) or
-[`wasm32-wasip2`](./wasm32-wasip2.md) targets.
+library see the [`wasm32-wasip1`](./wasm32-wasip1.md),
+[`wasm32-wasip2`](./wasm32-wasip2.md), or
+[`wasm32-wasip3`](./wasm32-wasip3.md), targets.
 
 The `wasm32-unknown-unknown` target has full support for the `core` and `alloc`
 crates. It additionally supports the `HashMap` type in the `std` crate, although

--- a/src/doc/rustc/src/platform-support/wasm32-wasip3.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip3.md
@@ -1,42 +1,49 @@
 # `wasm32-wasip3`
 
-**Tier: 3**
+**Tier: 2**
 
 The `wasm32-wasip3` target is the next stage of evolution of the
 [`wasm32-wasip2`](./wasm32-wasip2.md) target. The `wasm32-wasip3` target enables
 the Rust standard library to use WASIp3 APIs to implement various pieces of
 functionality. WASIp3 brings native async support over WASIp2, which integrates
-well with Rust's `async` ecosystem.
+well with Rust's `async` ecosystem. Additionally a future release of Rust's
+`wasm32-wasip3` target will support cooperative threading and `std::thread`
+APIs.
 
-> **Note**: As of 2025-10-01 WASIp3 has not yet been approved by the WASI
-> subgroup of the WebAssembly Community Group. Development is expected to
-> conclude in late 2025 or early 2026. Until then the Rust standard library
-> won't actually use WASIp3 APIs on the `wasm32-wasip3` target as they are not
-> yet stable and would reduce the stability of this target. Once WASIp3 is
-> approved, however, the standard library will update to use WASIp3 natively.
+The original proposal for adding this target can be found in
+[rust-lang/compiler-team#1001] and this target is first available on stable in
+Rust 1.100.0. A notable major change from historical WebAssembly targets is that
+the ABI of this target is slightly different. The linear memory shadow stack
+pointer is stored in a component model task context slot instead of a
+WebAssembly` global`. Additionally the base pointer of TLS is managed
+differently than other targets. These changes are made to enable cooperative
+multithreading on this target.
 
-> **Note**: This target does not yet build as of 2025-10-01 due to and update
-> needed in the `libc` crate. Using it will require a `[patch]` for now.
+> **Note**: As of 2026-09-03 cooperative multithreading is not yet supported on
+> this target in Rust. The component model specification and library support
+> work for this is in-development and not yet complete, but it's expected to be
+> complete before the end of the year. Before that time spawning a thread via
+> `std::thread` will return an error. Note though that this support can be
+> tested through the [instructions below](#testing-cooperative-multithreading).
 
-> **Note**: Until the standard library is fully migrated to use the `wasip3`
-> crate then components produced for `wasm32-wasip3` may import WASIp2 APIs.
-> This is considered a transitionary phase until fully support of libstd is
-> implemented.
+[rust-lang/compiler-team#1001]: https://github.com/rust-lang/compiler-team/issues/1001
 
 ## Target maintainers
 
 [@alexcrichton](https://github.com/alexcrichton)
+[@yoshuawuyts](https://github.com/yoshuawuyts)
 
 ## Requirements
 
-This target is cross-compiled. The target supports `std` fully.
+This target is cross-compiled. The target supports `std` fully. This target
+requires LLVM 23 to be used and additionally requires `wasi-sdk-34`-or-later if
+you're building it locally or linking with this externally.
 
 ## Platform requirements
 
-The WebAssembly runtime should support both WASIp2 and WASIp3. Runtimes also
-are required to support components since this target outputs a component as
-opposed to a core wasm module. Two example runtimes for WASIp3 are [Wasmtime]
-and [Jco].
+WebAssembly runtimes that want to execute components compiled for this target
+must support WASI 0.3.0 and the requisite required component model features
+(notably async). Two example runtimes for WASIp3 are [Wasmtime] and [Jco].
 
 [Wasmtime]: https://wasmtime.dev/
 [Jco]: https://github.com/bytecodealliance/jco
@@ -44,14 +51,14 @@ and [Jco].
 ## Building the target
 
 To build this target first acquire a copy of
-[`wasi-sdk`](https://github.com/WebAssembly/wasi-sdk/). At this time version 22
+[`wasi-sdk`](https://github.com/WebAssembly/wasi-sdk/). At this time version 34
 is the minimum needed.
 
 Next configure the `WASI_SDK_PATH` environment variable to point to where this
 is installed. For example:
 
 ```text
-export WASI_SDK_PATH=/path/to/wasi-sdk-22.0
+export WASI_SDK_PATH=/path/to/wasi-sdk-34.0
 ```
 
 Next be sure to enable LLD when building Rust from source as LLVM's `wasm-ld`
@@ -81,3 +88,91 @@ It's recommended to conditionally compile code for this target with:
 The default set of WebAssembly features enabled for compilation is currently the
 same as [`wasm32-unknown-unknown`](./wasm32-unknown-unknown.md). See the
 documentation there for more information.
+
+## Testing Cooperative Multithreading
+
+The [component model specification][spec] is in the process of adding intrinsics
+to support cooperative multithreading in a component guest. These intrinsics can
+be found in the [explainer] and are all gated by the 🧵 emoji. Support for
+cooperative multithreading is a work-in-progress and not yet complete, but the
+adventurous can configure this target to go ahead and test things out.
+
+The majority of changes necessary to get cooperative multithreading lie within
+Rust's [wasi-libc dependency][wasi-libc]. This means that to test cooperative
+multithreading a different build than the default wasi-libc needs to be used.
+Starting with [wasi-sdk-34] there is a temporary sysroot which contains support
+for a wasip3 target that has multithreading enabled in wasi-libc. To test out
+the `wasm32-wasip3` Rust target with threads your compilation needs to be
+configured to use this sysroot.
+
+An example of doing this is this program:
+
+```rust
+fn main() {
+    std::thread::spawn(|| {
+        println!("hi");
+    })
+    .join()
+    .unwrap();
+}
+```
+
+is compiled and run by default as:
+
+```console
+$ rustc foo.rs --target wasm32-wasip3
+$ wasmtime foo.wasm
+
+thread 'main' (1) panicked at library/std/src/thread/functions.rs:131:29:
+failed to spawn thread: Os { code: 58, kind: Unsupported, message: "Not supported" }
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+Error: failed to run main module `foo.wasm`
+
+...
+```
+
+which shows that by default threads cannot be spawned. By configuring a custom
+sysroot to be used, however:
+
+```console
+$ rustc foo.rs --target wasm32-wasip3 \
+    -Clink-self-contained=n \
+    -Clinker=$WASI_SDK_PATH/bin/wasm32-wasip3-clang \
+    -Clink-arg=--sysroot=$WASI_SDK_PATH/share/wasi-sysroot/experimental-coop-threads \
+    -Clink-arg=-Wl,--export=cabi_realloc
+$ wasmtime -W component-model-threading foo.wasm
+hi
+```
+
+Here `-Clink-self-contained=n` avoids the vendored files in the standard library
+which come from a build of wasi-libc incompatible with cooperative
+multithreading. The `-Clinker` flag changes to use `clang` to be able to pass a
+custom `--sysroot` argument and follow its logic for startup objects. The
+`--sysroot` flag then points to the experimental sysroot for coop threads and
+`--export` is required right now as a minor workaround.
+
+When compiling with Cargo you can use these environment variables:
+
+```console
+$ export CARGO_TARGET_WASM32_WASIP3_LINKER=$WASI_SDK_PATH/bin/wasm32-wasip3-clang
+$ export CARGO_TARGET_WASM32_WASIP3_RUNNER='wasmtime -W component-model-threading'
+$ export CARGO_TARGET_WASM32_WASIP3_RUSTFLAGS="\
+    -Clink-self-contained=n \
+    -Clink-arg=--sysroot=$WASI_SDK_PATH/share/wasi-sysroot/experimental-coop-threads \
+    -Clink-arg=-Wl,--export=cabi_realloc"
+$ cargo run --target wasm32-wasip3
+hi
+```
+
+Standard synchronization primitives in `std::thread` and `std::sync` should all
+work on this target with cooperative multithreading. Should you run into any
+issues please don't hesitate to file an issue and cc the target maintainers.
+
+Note that it is currently intended that by the end of 2026 this support will all
+be enabled by default and this section of the documentation will be deleted
+since working with threads should "just work".
+
+[spec]: https://github.com/webassembly/component-model
+[explainer]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md
+[wasi-libc]: https://github.com/webassembly/wasi-libc
+[wasi-sdk-34]: https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-34


### PR DESCRIPTION
This commit updates documentation, configuration, etc, within the compiler to promote the `wasm32-wasip3` target to tier 2. This means that precompiled binaries will be made available in `rustup` for usage. This target MCP for this change is [rust-lang/compiler-team/100][mcp].

This target requires LLVM 23 which rustc recently has updated to, and then additionally requires wasi-sdk-34 which additionally uses LLVM 23 which was also updated recently. With these ingredients in place the ABI for `wasm32-wasip3` is all lined up and ready to go. These changes were all necessary to bring cooperative threading to the target in the future, but that's not quite ready in the ecosystem yet.

I've locally been testing this target and it's done well so far, but I suspect this'll need subsequent bug fixes here and there as other new issues crop up. I don't expect anything major will be necessary, however.

[mcp]: https://github.com/rust-lang/compiler-team/issues/1001

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
