### PR TITLE
rustdoc: Take into account edition information for keyword highlighting

### DIFF
--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -58,10 +58,15 @@ pub(crate) fn render_example_with_highlighting(
     tooltip: Option<&Tooltip>,
     playground_button: Option<&str>,
     extra_classes: &[String],
+    edition: Edition,
 ) -> impl Display {
     fmt::from_fn(move |f| {
         write_header("rust-example-rendered", tooltip, extra_classes).fmt(f)?;
-        write_code(f, src, None, None, None);
+        let edition = match tooltip {
+            Some(Tooltip::Edition(edition)) => *edition,
+            _ => edition,
+        };
+        write_code(f, src, None, None, edition, None);
         write_footer(playground_button).fmt(f)
     })
 }
@@ -553,6 +558,7 @@ pub(super) fn write_code(
     src: &str,
     href_context: Option<HrefContext<'_, '_>>,
     decoration_info: Option<&DecorationInfo>,
+    edition: Edition,
     line_info: Option<LineInfo>,
 ) {
     // This replace allows to fix how the code source with DOS backline characters is displayed.
@@ -606,6 +612,7 @@ pub(super) fn write_code(
         &src,
         token_handler.href_context.as_ref().map_or(DUMMY_SP, |c| c.file_span),
         decoration_info,
+        edition,
         &mut |span, highlight| match highlight {
             Highlight::Token { text, class } => {
                 token_handler.push_token(class, Cow::Borrowed(text));
@@ -892,6 +899,7 @@ fn classify<'src>(
     src: &'src str,
     file_span: Span,
     decoration_info: Option<&DecorationInfo>,
+    edition: Edition,
     sink: &mut dyn FnMut(Span, Highlight<'src>),
 ) {
     let offset = rustc_lexer::strip_shebang(src);
@@ -901,7 +909,7 @@ fn classify<'src>(
     }
 
     let mut classifier =
-        Classifier::new(src, offset.unwrap_or_default(), file_span, decoration_info);
+        Classifier::new(src, offset.unwrap_or_default(), file_span, decoration_info, edition);
 
     loop {
         if let Some(decs) = classifier.decorations.as_mut() {
@@ -946,6 +954,7 @@ struct Classifier<'src> {
     file_span: Span,
     src: &'src str,
     decorations: Option<Decorations>,
+    edition: Edition,
 }
 
 impl<'src> Classifier<'src> {
@@ -956,6 +965,7 @@ impl<'src> Classifier<'src> {
         byte_pos: usize,
         file_span: Span,
         decoration_info: Option<&DecorationInfo>,
+        edition: Edition,
     ) -> Self {
         Classifier {
             tokens: PeekIter::new(TokenIter::new(&src[byte_pos..])),
@@ -966,6 +976,7 @@ impl<'src> Classifier<'src> {
             file_span,
             src,
             decorations: decoration_info.map(Decorations::new),
+            edition,
         }
     }
 
@@ -996,7 +1007,7 @@ impl<'src> Classifier<'src> {
             if let Some((TokenKind::Ident, text)) =
                 self.tokens.peek_next_if(|(token, _)| token == TokenKind::Ident)
                 && let symbol = Symbol::intern(text)
-                && (symbol.is_path_segment_keyword() || !is_keyword(symbol))
+                && (symbol.is_path_segment_keyword() || !self.is_keyword(symbol))
             {
                 has_ident = true;
                 nb_items += 1;
@@ -1264,7 +1275,7 @@ impl<'src> Classifier<'src> {
                     "self" | "Self" => Class::Self_(span()),
                     "Option" | "Result" => Class::PreludeTy(span()),
                     "Some" | "None" | "Ok" | "Err" => Class::PreludeVal(span()),
-                    _ if self.is_weak_keyword(text) || is_keyword(Symbol::intern(text)) => {
+                    _ if self.is_weak_keyword(text) || self.is_keyword(Symbol::intern(text)) => {
                         // So if it's not a keyword which can be followed by a value (like `if` or
                         // `return`) and the next non-whitespace token is a `!`, then we consider
                         // it's a macro.
@@ -1319,6 +1330,10 @@ impl<'src> Classifier<'src> {
         matches!(self.peek_non_trivia(), Some((TokenKind::Ident, text)) if matches(text))
     }
 
+    fn is_keyword(&self, symbol: Symbol) -> bool {
+        symbol.is_reserved(|| self.edition)
+    }
+
     fn peek(&mut self) -> Option<TokenKind> {
         self.tokens.peek().map(|(kind, _)| kind)
     }
@@ -1368,11 +1383,6 @@ impl<'src> Classifier<'src> {
         self.tokens.stop_peeking();
         false
     }
-}
-
-fn is_keyword(symbol: Symbol) -> bool {
-    // FIXME(#148221): Don't hard-code the edition. The classifier should take it as an argument.
-    symbol.is_reserved(|| Edition::Edition2024)
 }
 
 fn generate_link_to_def(

--- a/src/librustdoc/html/highlight/tests.rs
+++ b/src/librustdoc/html/highlight/tests.rs
@@ -1,6 +1,7 @@
 use expect_test::expect_file;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_span::create_default_session_globals_then;
+use rustc_span::edition::Edition;
 use test::Bencher;
 
 use super::{DecorationInfo, write_code};
@@ -23,7 +24,7 @@ fn test_html_highlighting() {
         let src = include_str!("fixtures/sample.rs");
         let html = {
             let mut out = String::new();
-            write_code(&mut out, src, None, None, None);
+            write_code(&mut out, src, None, None, Edition::Edition2024, None);
             format!("{STYLE}<pre><code>{out}</code></pre>\n")
         };
         expect_file!["fixtures/sample.html"].assert_eq(&html);
@@ -37,7 +38,7 @@ fn test_dos_backline() {
     println!(\"foo\");\r\n\
 }\r\n";
         let mut html = String::new();
-        write_code(&mut html, src, None, None, None);
+        write_code(&mut html, src, None, None, Edition::Edition2024, None);
         expect_file!["fixtures/dos_line.html"].assert_eq(&html);
     });
 }
@@ -51,7 +52,7 @@ let x = super::b::foo;
 let y = Self::whatever;";
 
         let mut html = String::new();
-        write_code(&mut html, src, None, None, None);
+        write_code(&mut html, src, None, None, Edition::Edition2024, None);
         expect_file!["fixtures/highlight.html"].assert_eq(&html);
     });
 }
@@ -61,7 +62,7 @@ fn test_union_highlighting() {
     create_default_session_globals_then(|| {
         let src = include_str!("fixtures/union.rs");
         let mut html = String::new();
-        write_code(&mut html, src, None, None, None);
+        write_code(&mut html, src, None, None, Edition::Edition2024, None);
         expect_file!["fixtures/union.html"].assert_eq(&html);
     });
 }
@@ -78,7 +79,14 @@ let a = 4;";
         decorations.insert("example2", vec![(22, 32)]);
 
         let mut html = String::new();
-        write_code(&mut html, src, None, Some(&DecorationInfo(decorations)), None);
+        write_code(
+            &mut html,
+            src,
+            None,
+            Some(&DecorationInfo(decorations)),
+            Edition::Edition2024,
+            None,
+        );
         expect_file!["fixtures/decorations.html"].assert_eq(&html);
     });
 }
@@ -90,7 +98,7 @@ fn bench_html_highlighting(b: &mut Bencher) {
     create_default_session_globals_then(|| {
         b.iter(|| {
             let mut out = String::new();
-            write_code(&mut out, src, None, None, None);
+            write_code(&mut out, src, None, None, Edition::Edition2024, None);
             out
         });
     });

--- a/src/librustdoc/html/macro_expansion.rs
+++ b/src/librustdoc/html/macro_expansion.rs
@@ -107,12 +107,48 @@ impl<'ast> ExpandedCodeVisitor<'ast> {
     fn compute_expanded(mut self) -> FxHashMap<BytePos, Vec<ExpandedCode>> {
         self.expanded_codes.sort_unstable_by(|item1, item2| item1.span.cmp(&item2.span));
         let mut expanded: FxHashMap<BytePos, Vec<ExpandedCode>> = FxHashMap::default();
-        for ExpandedCodeInfo { span, code, .. } in self.expanded_codes {
+        for ExpandedCodeInfo { span, code, original_span, .. } in self.expanded_codes {
             if let Ok(lines) = self.source_map.span_to_lines(span)
                 && !lines.lines.is_empty()
             {
                 let mut out = String::new();
-                super::highlight::write_code(&mut out, &code, None, None, None);
+                super::highlight::write_code(
+                    &mut out,
+                    &code,
+                    None,
+                    None,
+                    // NOTE: This is only "an approximation" or "best effort" since the edition of
+                    // individual tokens contained in the expansion can differ from the the edition
+                    // of the entire expansion. And we can't fix that since code is just a `String`
+                    // that was produced by `rustc_ast_pretty` meaning more precise edition
+                    // information has been lost.
+                    //
+                    // Here is an example:
+                    //
+                    // ```edition2015
+                    // #[macro_export]
+                    // macro_rules! generate {
+                    //     ($kw:ident) => {
+                    //         pub fn host() {
+                    //             let _ = $kw {};
+                    //         }
+                    //     };
+                    // }
+                    // ```
+                    //
+                    // ```edition2024
+                    // dependency::generate!(async);
+                    // ```
+                    //
+                    // Here, the `async` keyword wouldn't be highlighted in the rendered expansion
+                    // `let _ = async {}` since it uses the edition of the entire expansion (which
+                    // is Rust 2015) but the `async` in the Rust 2015 expansion does actually refer
+                    // to Rust 2024 `async` keyword and thus contains an `async` block, not a struct
+                    // expression! That's because the keyword `async` originates from a Rust 2024
+                    // crate (root expansion).
+                    original_span.edition(),
+                    None,
+                );
                 let first = lines.lines.first().unwrap();
                 let end = lines.lines.last().unwrap();
                 expanded.entry(lines.file.start_pos).or_default().push(ExpandedCode {

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -352,6 +352,7 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
                 tooltip.as_ref(),
                 playground_button.as_deref(),
                 &added_classes,
+                edition,
             )
         );
         Some(Event::Html(s.into()))

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -329,7 +329,7 @@ pub(crate) fn print_src(
     mut writer: impl fmt::Write,
     s: &str,
     file_span: rustc_span::Span,
-    context: &Context<'_>,
+    cx: &Context<'_>,
     root_path: &str,
     decoration_info: &highlight::DecorationInfo,
     source_context: &SourceContext<'_>,
@@ -349,20 +349,20 @@ pub(crate) fn print_src(
         let current_href = if let SourceContext::Embedded(info) = source_context {
             info.url.to_string()
         } else {
-            context
-                .href_from_span(clean::Span::new(file_span), false)
+            cx.href_from_span(clean::Span::new(file_span), false)
                 .expect("only local crates should have sources emitted")
         };
         highlight::write_code(
             fmt,
             s,
             Some(highlight::HrefContext {
-                context,
+                context: cx,
                 file_span: file_span.into(),
                 root_path,
                 current_href,
             }),
             Some(decoration_info),
+            cx.tcx().sess.edition(),
             Some(line_info),
         );
         Ok(())

--- a/tests/rustdoc-html/doctest/editions.rs
+++ b/tests/rustdoc-html/doctest/editions.rs
@@ -1,0 +1,32 @@
+// This test ensures that the syntax highlighting is correctly set on code examples
+// if the `edition` attribute is used.
+// Regression test for <https://github.com/rust-lang/rust/issues/148221>.
+
+//@ edition:2024
+
+#![crate_name = "foo"]
+
+//@ has 'foo/fn.foo.html'
+// There should be two spans: one for `kw` and one for `number`. None for `async` because
+// in the 2015 edition, `async` is not a keyword.
+//@ count - '//*[@class="rust rust-example-rendered"]/code/span' 2
+//@ matches - '//*[@class="rust rust-example-rendered"]/code/span[@class="kw"]' '^let $'
+//@ matches - '//*[@class="rust rust-example-rendered"]/code/span[@class="number"]' '^2$'
+//@ has - '//*[@class="rust rust-example-rendered"]/code' 'let async = 2;'
+
+/// ```edition2015
+/// let async = 2;
+/// ```
+pub async fn foo() {}
+
+//@ has 'foo/fn.another.html'
+// There should be one span: `kw` (which includes all items at once). `async` is a keyword
+// here since there is no edition specified for the code block, so it inherits the crate's.
+//@ count - '//*[@class="rust rust-example-rendered"]/code/span' 1
+//@ matches - '//*[@class="rust rust-example-rendered"]/code/span[@class="kw"]' '^async fn $'
+//@ has - '//*[@class="rust rust-example-rendered"]/code' 'async fn bar() {}'
+
+/// ```
+/// async fn bar() {}
+/// ```
+pub fn another() {}

--- a/tests/rustdoc-html/macro-expansion/auxiliary/editions.rs
+++ b/tests/rustdoc-html/macro-expansion/auxiliary/editions.rs
@@ -1,0 +1,8 @@
+//@ edition:2015
+
+#[macro_export]
+macro_rules! tadam {
+    () => {
+        let async = 2;
+    }
+}

--- a/tests/rustdoc-html/macro-expansion/editions.rs
+++ b/tests/rustdoc-html/macro-expansion/editions.rs
@@ -1,0 +1,27 @@
+// This test ensures that the syntax highlighting is correctly set on the expanded
+// macro to match the original macro's crate's edition.
+// Regression test for <https://github.com/rust-lang/rust/issues/148221>.
+
+//@ edition:2024
+//@ aux-build:editions.rs
+//@ compile-flags: -Zunstable-options --generate-macro-expansion
+
+#![crate_name = "foo"]
+
+#[macro_use]
+extern crate editions;
+
+//@ has 'src/foo/editions.rs.html'
+
+// There should be one span: `kw` (which includes all items at once). `async` is a keyword
+// here since it's the 2024 edition.
+//@ matches - '//pre[@class="rust"]/code/span[@class="kw"]' '^async fn $'
+async fn foo() {
+    // There should be two spans: one for `kw` and one for `number`. None for `async` because
+    // in the 2015 edition, `async` is not a keyword.
+    //@ count - '//code/*[@class="expansion"]/*[@class="expanded"]/span' 2
+    //@ matches - '//code/*[@class="expansion"]/*[@class="expanded"]/span[@class="kw"]' '^let $'
+    //@ matches - '//code/*[@class="expansion"]/*[@class="expanded"]/span[@class="number"]' '^2$'
+    //@ has - '//code/*[@class="expansion"]/*[@class="expanded"]' 'let async = 2;'
+    tadam!();
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/148221.

The only thing that was missing was passing down an `Edition` to the highlighter (and adding tests).

r? @fmease 