### PR TITLE
Generalise (most) impls on `Box`

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -2473,7 +2473,7 @@ impl<F: ?Sized + Future + Unpin, A: Allocator> Future for Box<F, A> {
 }
 
 #[stable(feature = "box_error", since = "1.8.0")]
-impl<E: Error> Error for Box<E> {
+impl<E: Error, A: Allocator> Error for Box<E, A> {
     #[allow(deprecated)]
     fn cause(&self) -> Option<&dyn Error> {
         Error::cause(&**self)

--- a/library/alloc/src/io/impls.rs
+++ b/library/alloc/src/io/impls.rs
@@ -92,7 +92,7 @@ impl<B: BufRead + ?Sized> BufRead for &mut B {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<R: Read + ?Sized> Read for Box<R> {
+impl<R: Read + ?Sized, A: Allocator> Read for Box<R, A> {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         (**self).read(buf)
@@ -148,7 +148,7 @@ impl<T> SizeHint for Box<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<W: Write + ?Sized> Write for Box<W> {
+impl<W: Write + ?Sized, A: Allocator> Write for Box<W, A> {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         (**self).write(buf)
@@ -185,7 +185,7 @@ impl<W: Write + ?Sized> Write for Box<W> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<S: Seek + ?Sized> Seek for Box<S> {
+impl<S: Seek + ?Sized, A: Allocator> Seek for Box<S, A> {
     #[inline]
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         (**self).seek(pos)
@@ -212,7 +212,7 @@ impl<S: Seek + ?Sized> Seek for Box<S> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<B: BufRead + ?Sized> BufRead for Box<B> {
+impl<B: BufRead + ?Sized, A: Allocator> BufRead for Box<B, A> {
     #[inline]
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         (**self).fill_buf()

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -7,6 +7,7 @@
 use moto_rt::libc;
 
 use super::raw::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use crate::alloc::Allocator;
 #[cfg(not(target_os = "trusty"))]
 use crate::fs;
 use crate::marker::PhantomData;
@@ -474,7 +475,7 @@ impl<T: AsFd + ?Sized> AsFd for crate::rc::UniqueRc<T> {
 }
 
 #[stable(feature = "asfd_ptrs", since = "1.64.0")]
-impl<T: AsFd + ?Sized> AsFd for Box<T> {
+impl<T: AsFd + ?Sized, A: Allocator> AsFd for Box<T, A> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
         (**self).as_fd()

--- a/library/std/src/os/fd/raw.rs
+++ b/library/std/src/os/fd/raw.rs
@@ -9,6 +9,7 @@ use moto_rt::libc;
 
 #[cfg(target_os = "motor")]
 use super::owned::OwnedFd;
+use crate::alloc::Allocator;
 #[cfg(not(target_os = "trusty"))]
 use crate::fs;
 use crate::io;
@@ -282,7 +283,7 @@ impl<T: AsRawFd + ?Sized> AsRawFd for crate::rc::UniqueRc<T> {
 }
 
 #[stable(feature = "asrawfd_ptrs", since = "1.63.0")]
-impl<T: AsRawFd> AsRawFd for Box<T> {
+impl<T: AsRawFd, A: Allocator> AsRawFd for Box<T, A> {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
         (**self).as_raw_fd()

--- a/library/std/src/os/solid/io.rs
+++ b/library/std/src/os/solid/io.rs
@@ -46,6 +46,7 @@
 
 #![unstable(feature = "solid_ext", issue = "none")]
 
+use crate::alloc::Allocator;
 use crate::marker::PhantomData;
 use crate::mem::ManuallyDrop;
 use crate::sys::{AsInner, FromInner, IntoInner};
@@ -283,7 +284,7 @@ impl<T: AsFd> AsFd for crate::rc::Rc<T> {
     }
 }
 
-impl<T: AsFd> AsFd for Box<T> {
+impl<T: AsFd, A: Allocator> AsFd for Box<T, A> {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
         (**self).as_fd()

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -3,6 +3,7 @@
 #![stable(feature = "io_safety", since = "1.63.0")]
 
 use super::raw::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle};
+use crate::alloc::Allocator;
 use crate::marker::PhantomData;
 use crate::mem::ManuallyDrop;
 use crate::sys::{AsInner, FromInner, IntoInner, cvt};
@@ -491,7 +492,7 @@ impl<T: AsHandle + ?Sized> AsHandle for crate::rc::UniqueRc<T> {
 }
 
 #[stable(feature = "as_windows_ptrs", since = "1.71.0")]
-impl<T: AsHandle + ?Sized> AsHandle for Box<T> {
+impl<T: AsHandle + ?Sized, A: Allocator> AsHandle for Box<T, A> {
     #[inline]
     fn as_handle(&self) -> BorrowedHandle<'_> {
         (**self).as_handle()

--- a/library/std/src/os/windows/io/socket.rs
+++ b/library/std/src/os/windows/io/socket.rs
@@ -3,6 +3,7 @@
 #![stable(feature = "io_safety", since = "1.63.0")]
 
 use super::raw::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
+use crate::alloc::Allocator;
 use crate::marker::PhantomData;
 use crate::mem::{self, ManuallyDrop};
 #[cfg(not(target_vendor = "uwp"))]
@@ -275,7 +276,7 @@ impl<T: AsSocket + ?Sized> AsSocket for crate::rc::UniqueRc<T> {
 }
 
 #[stable(feature = "as_windows_ptrs", since = "1.71.0")]
-impl<T: AsSocket> AsSocket for Box<T> {
+impl<T: AsSocket, A: Allocator> AsSocket for Box<T, A> {
     #[inline]
     fn as_socket(&self) -> BorrowedSocket<'_> {
         (**self).as_socket()


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/161946)*
<!-- homu-ignore:end -->

Resolves the trait impl concern for rust-lang/rust#156882; `Default` wasn't touched since changing that would be breaking, but hopefully all of this should be fine - I'll do a crater run to be sure. Certain impls that were for one reason or another Annoying to generalise (e.g. `Clone for Box<Path>`) were also untouched since I believe we can add those in the future, as they're on concrete types.

r? clarfonthey