### PR TITLE
sanitizers: Implicitly disable mutually exclusive sanitizers

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -95,13 +95,15 @@ mod target_modifier_consistency_check {
         l: &TargetModifier,
         r: Option<&TargetModifier>,
     ) -> bool {
-        let mut lparsed: SanitizerSet = sess.target.options.default_sanitizers;
+        let mut lparsed: SanitizerSet = SanitizerSet::empty();
         let lval = if l.value_name.is_empty() { None } else { Some(l.value_name.as_str()) };
         parse::parse_sanitizers(&mut lparsed, lval);
+        let lparsed = lparsed.combine_with_defaults(sess.target.options.default_sanitizers);
 
-        let mut rparsed: SanitizerSet = sess.target.options.default_sanitizers;
+        let mut rparsed: SanitizerSet = SanitizerSet::empty();
         let rval = r.filter(|v| !v.value_name.is_empty()).map(|v| v.value_name.as_str());
         parse::parse_sanitizers(&mut rparsed, rval);
+        let rparsed = rparsed.combine_with_defaults(sess.target.options.default_sanitizers);
 
         // Some sanitizers need to be target modifiers, and some do not.
         // For now, we should mark all sanitizers as target modifiers except for these:

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -929,7 +929,7 @@ impl Session {
             let more_names = self.opts.output_types.contains_key(&OutputType::LlvmAssembly)
                 || self.opts.output_types.contains_key(&OutputType::Bitcode)
                 // AddressSanitizer and MemorySanitizer use alloca name when reporting an issue.
-                || self.opts.unstable_opts.sanitizer.intersects(SanitizerSet::ADDRESS | SanitizerSet::MEMORY);
+                || self.sanitizers().intersects(SanitizerSet::ADDRESS | SanitizerSet::MEMORY);
             !more_names
         }
     }
@@ -1178,7 +1178,10 @@ impl Session {
     }
 
     pub fn sanitizers(&self) -> SanitizerSet {
-        return self.opts.unstable_opts.sanitizer | self.target.options.default_sanitizers;
+        self.opts
+            .unstable_opts
+            .sanitizer
+            .combine_with_defaults(self.target.options.default_sanitizers)
     }
 
     pub fn pointer_authentication(&self) -> bool {
@@ -1497,7 +1500,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
 
     // Sanitizers can only be used on platforms that we know have working sanitizer codegen.
     let supported_sanitizers = sess.target.options.supported_sanitizers;
-    let mut unsupported_sanitizers = sess.opts.unstable_opts.sanitizer - supported_sanitizers;
+    let mut unsupported_sanitizers = sess.sanitizers() - supported_sanitizers;
     // Niche: if `fixed-x18`, or effectively switching on `reserved-x18` flag, is enabled
     // we should allow Shadow Call Stack sanitizer.
     if sess.opts.unstable_opts.fixed_x18 && sess.target.arch == Arch::AArch64 {
@@ -1518,7 +1521,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     }
 
     // Cannot mix and match mutually-exclusive sanitizers.
-    if let Some((first, second)) = sess.opts.unstable_opts.sanitizer.mutually_exclusive() {
+    if let Some((first, second)) = sess.sanitizers().mutually_exclusive() {
         sess.dcx().emit_err(diagnostics::CannotMixAndMatchSanitizers {
             first: first.to_string(),
             second: second.to_string(),
@@ -1526,10 +1529,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     }
 
     // Cannot enable crt-static with sanitizers on Linux
-    if sess.crt_static(None)
-        && !sess.opts.unstable_opts.sanitizer.is_empty()
-        && !sess.target.is_like_msvc
-    {
+    if sess.crt_static(None) && !sess.sanitizers().is_empty() && !sess.target.is_like_msvc {
         sess.dcx().emit_err(diagnostics::CannotEnableCrtStaticLinux);
     }
 

--- a/compiler/rustc_structures/src/lib.rs
+++ b/compiler/rustc_structures/src/lib.rs
@@ -13,3 +13,6 @@ pub use crate_type::CrateType;
 pub use limit::Limit;
 pub use native_lib_kind::NativeLibKind;
 pub use sanitizer_set::SanitizerSet;
+
+#[cfg(test)]
+mod tests;

--- a/compiler/rustc_structures/src/sanitizer_set.rs
+++ b/compiler/rustc_structures/src/sanitizer_set.rs
@@ -95,6 +95,20 @@ impl SanitizerSet {
             .find(|&(a, b)| self.contains(*a) && self.contains(*b))
             .copied()
     }
+
+    /// Disable default sanitizers that are incompatible with explicitly requested ones,
+    /// matching Clang's `SanitizerArgs` driver logic.
+    pub fn combine_with_defaults(self, mut defaults: SanitizerSet) -> SanitizerSet {
+        for &(a, b) in Self::MUTUALLY_EXCLUSIVE {
+            if defaults.contains(a) && self.contains(b) {
+                defaults -= a;
+            }
+            if defaults.contains(b) && self.contains(a) {
+                defaults -= b;
+            }
+        }
+        self | defaults
+    }
 }
 
 /// Formats a sanitizer set as a comma separated list of sanitizers' names.

--- a/compiler/rustc_structures/src/tests.rs
+++ b/compiler/rustc_structures/src/tests.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+#[test]
+fn test_combine_with_defaults_no_conflict() {
+    let defaults = SanitizerSet::SHADOWCALLSTACK;
+    let explicit = SanitizerSet::ADDRESS;
+    assert_eq!(
+        explicit.combine_with_defaults(defaults),
+        SanitizerSet::ADDRESS | SanitizerSet::SHADOWCALLSTACK
+    );
+}
+
+#[test]
+fn test_combine_with_defaults_safestack_address_conflict() {
+    let defaults = SanitizerSet::SAFESTACK;
+    let explicit = SanitizerSet::ADDRESS;
+    // SafeStack should be implicitly disabled when Address is explicitly provided.
+    assert_eq!(explicit.combine_with_defaults(defaults), SanitizerSet::ADDRESS);
+}
+
+#[test]
+fn test_combine_with_defaults_empty_explicit() {
+    let defaults = SanitizerSet::SAFESTACK;
+    let explicit = SanitizerSet::empty();
+    assert_eq!(explicit.combine_with_defaults(defaults), SanitizerSet::SAFESTACK);
+}
+
+#[test]
+fn test_combine_with_defaults_safestack_cfi() {
+    let defaults = SanitizerSet::SAFESTACK;
+    let explicit = SanitizerSet::CFI;
+    assert_eq!(
+        explicit.combine_with_defaults(defaults),
+        SanitizerSet::CFI | SanitizerSet::SAFESTACK
+    );
+}


### PR DESCRIPTION
This attempts to match clang's behavior of implicitly disabling sanitizers that are incompatible. Specifically, if a set of default sanitizers would be incompatible with ones provided by -Zsanitize=..., then clang (and now rust) will opt for keeping the ones specified via flags over the ones used as platform defaults. This helps maintain build consistency where we can just enable sanitizers via flags for both rust and c++ code without needing to manually disable others.

The driving reason for this is asan and safestack where we'd like to enable safestack by default for x86_64 fuchsia but disable it if -Zsanitize=address is passed (matching clang's behavior).

This commit also refactors all uses of `self.opts.unstable_opts.sanitizer` to go through the updated `sanitizer()` method.

AI: Gemini was used to help review the code and write some tests, but it did not generate the whole patch. I edited and reviewed this PR to the best of my ability before pushing for review.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
