### PR TITLE
Use `saturating_cast` for env key length

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -357,6 +357,7 @@
 #![feature(hashmap_internals)]
 #![feature(hint_must_use)]
 #![feature(int_from_ascii)]
+#![feature(integer_casts)]
 #![feature(io_error_inprogress)]
 #![feature(io_error_input_output_error)]
 #![feature(io_error_more)]

--- a/library/std/src/sys/process/windows.rs
+++ b/library/std/src/sys/process/windows.rs
@@ -74,11 +74,13 @@ impl EnvKey {
 impl Ord for EnvKey {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         unsafe {
+            // Note that keys will only be compared up to lengths of i32::MAX.
+            // Larger keys are not supported by the OS.
             let result = c::CompareStringOrdinal(
                 self.utf16.as_ptr(),
-                self.utf16.len() as _,
+                self.utf16.len().saturating_cast(),
                 other.utf16.as_ptr(),
-                other.utf16.len() as _,
+                other.utf16.len().saturating_cast(),
                 c::TRUE,
             );
             match result {
@@ -124,7 +126,11 @@ impl PartialEq<str> for EnvKey {
 // they are compared using a caseless string mapping.
 impl From<OsString> for EnvKey {
     fn from(k: OsString) -> Self {
-        EnvKey { utf16: k.encode_wide().collect(), os_string: k }
+        let utf16 = k.encode_wide().collect();
+        // We only support keys up to lengths of i32::MAX.
+        // Keys beyond that size will error on spawn in any case.
+        debug_assert!(self.utf16.len() <= i32::MAX as usize);
+        EnvKey { utf16, os_string: k }
     }
 }
 
@@ -930,6 +936,7 @@ fn make_envp(maybe_env: Option<BTreeMap<EnvKey, OsString>>) -> io::Result<(*mut 
         }
 
         for (k, v) in env {
+            debug_assert!(k.utf16.len() <= i32::MAX as usize);
             ensure_no_nuls(k.os_string)?;
             blk.extend(k.utf16);
             blk.push('=' as u16);


### PR DESCRIPTION
Fixes rust-lang/rust#160893 

I considered looping over `CompareStringOrdinal` but on balance I don't think the extra complexity is worth doing for something that isn't going to happen in practice. I cannot fathom a reason for wanting a >2 GiB environment key but even if that was wanted, it isn't supported in practical testing. While the maximum supported size of an environment variable key is not explicitly documented, the [size of a variable is](https://learn.microsoft.com/en-us/windows/win32/procthread/environment-variables) and it's not unreasonable to assume:
> The maximum size of a user-defined environment variable is 32,767 characters

Which is `i16::MAX`. Although I would note "supported" and "works" are not necessarily equivalent.

I have added some `debug_asserts` and an explicit error during spawn, which is the only place we can error given the `Command::env` API.