### PR TITLE
Treat identity region outlives as true

### DIFF
--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -681,6 +681,10 @@ fn pull_region_outlives_constraints_out_of_universe<
             constraint
         }
         RegionOutlives(region_1, region_2, ()) => {
+            if region_1 == region_2 {
+                return RegionConstraint::new_true();
+            }
+
             let region_1_u = max_universe(infcx, region_1);
             let region_2_u = max_universe(infcx, region_2);
 

--- a/tests/ui/assumptions_on_binders/identity_region_outlives.rs
+++ b/tests/ui/assumptions_on_binders/identity_region_outlives.rs
@@ -1,0 +1,29 @@
+//@ compile-flags: -Zassumptions-on-binders
+//@ check-pass
+
+// Regression test for #161733.
+// Previously we didn't properly handle identity region outlives
+// and it was mistakenly considered as false region constraint.
+// The closure is needed to register the type outlives obligation
+// in borrowck.
+
+#![feature(test_binder_constraints)]
+
+fn foo<T>()
+where
+    for<'a> &'a T: 'a,
+{
+    || {};
+}
+
+core::test_binder_constraints! {
+    impl<T> {
+        forall<'a> where T: 'a {
+            'a: 'a,
+            T: 'a,
+        } expect {
+        }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
Fixes rust-lang/rust#161733

We rewrite region outlives to `Or` by combining upper bounds of one region and lower bounds of the other. However, regions in identity region outlives may have no relation to other regions. So it was considered as false.

An alternative is to eagerly handle identity region outlives at the construction sites. That's a lot and covering all current and future creation is difficult.

The real purpose of this PR is to play with the new DSL :3
r? @khyperia 