### PR TITLE
Rerun `tests/debuginfo` tests if repr data has changed

### DIFF
--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -221,7 +221,6 @@ fn common_inputs_stamp(config: &Config) -> Stamp {
         "src/etc/gdb_load_rust_pretty_printers.py",
         "src/etc/gdb_lookup.py",
         "src/etc/gdb_providers.py",
-        "src/etc/lldb_batchmode",
         "src/etc/lldb_lookup.py",
         "src/etc/lldb_providers.py",
     ];
@@ -231,6 +230,7 @@ fn common_inputs_stamp(config: &Config) -> Stamp {
     }
 
     stamp.add_dir(&src_root.join("src/etc/natvis"));
+    stamp.add_dir(&src_root.join("src/etc/lldb_batchmode"));
 
     stamp.add_dir(&config.target_run_lib_path);
 
@@ -506,7 +506,7 @@ fn files_related_to_test(
     config: &Config,
     testpaths: &TestPaths,
     aux_props: &AuxProps,
-    revision: Option<&str>,
+    variant: &TestVariant,
 ) -> Vec<Utf8PathBuf> {
     let mut related = vec![];
 
@@ -533,12 +533,29 @@ fn files_related_to_test(
 
     // UI test files.
     for extension in UI_EXTENSIONS {
-        let path = expected_output_path(testpaths, revision, &config.compare_mode, extension);
+        let path =
+            expected_output_path(testpaths, variant.revision(), &config.compare_mode, extension);
         related.push(path);
     }
 
     // `minicore.rs` test auxiliary: we need to make sure tests get rerun if this changes.
     related.push(config.src_root.join("tests").join("auxiliary").join("minicore.rs"));
+
+    // `tests/debuginfo` blessed files
+    match variant.debugger {
+        Some(debugger @ Debugger::Lldb | debugger @ Debugger::Gdb) => {
+            let bless_path: Utf8PathBuf =
+                testpaths.file.parent().unwrap().join(format!("{}_input", debugger.to_str()));
+            if bless_path.is_dir() {
+                related.extend(
+                    WalkDir::new(bless_path)
+                        .into_iter()
+                        .map(|entry| Utf8PathBuf::from(entry.unwrap().path().to_str().unwrap())),
+                );
+            }
+        }
+        Some(Debugger::Cdb) | None => {}
+    }
 
     related
 }
@@ -572,7 +589,7 @@ fn is_up_to_date(
     // Check the timestamp of the stamp file against the last modified time
     // of all files known to be relevant to the test.
     let mut inputs_stamp = cx.common_inputs_stamp.clone();
-    for path in files_related_to_test(&cx.config, testpaths, aux_props, variant.revision()) {
+    for path in files_related_to_test(&cx.config, testpaths, aux_props, variant) {
         inputs_stamp.add_path(&path);
     }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Resolves https://github.com/rust-lang/rust/issues/161138

This also includes the necessary checking for GDB's data even though none exists atm (https://github.com/rust-lang/rust/pull/160377 will contain the first set). The extra handling doesn't hurt anything since we have to account for all the other tests that don't have repr data anyway.

In a followup, I can rename the `lldb_input` directory to something else (see: https://github.com/rust-lang/rust/pull/160137#discussion_r3748288184). Doing so requires me to touch a bunch of other places where the name is used, so it should probably be it's own PR. Making sure the tests rerun when the data changes is higher priority though atm.

r? @jieyouxu , @Kobzol 

cc @Mark-Simulacrum 

