### PR TITLE
remove rustc_never_type_options attr remnants

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -257,8 +257,6 @@ pub static BUILTIN_ATTRIBUTES: &[Symbol] = &[
     sym::fundamental,
     sym::may_dangle,
 
-    sym::rustc_never_type_options,
-
     // ==========================================================================
     // Internal attributes: Runtime related:
     // ==========================================================================

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1842,7 +1842,6 @@ symbols! {
         rustc_must_implement_one_of,
         rustc_must_match_exhaustively,
         rustc_never_returns_null_ptr,
-        rustc_never_type_options,
         rustc_no_implicit_autorefs,
         rustc_no_implicit_bounds,
         rustc_no_mir_inline,


### PR DESCRIPTION
While fuzzing I noticed we would now ICE in two places when encountering an empty or filled `#![rustc_never_type_options()]` attr:

compiler/rustc_passes/src/check_attr.rs:160:33: builtin attribute "rustc_never_type_options" not handled by `CheckAttrVisitor`
compiler/rustc_attr_parsing/src/validate_attr.rs:42:17: assertion failed: lint_attrs.contains(name)

So remove these two entries after which we will just error with `error: cannot find attribute`

r? @WaffleLapkin 