### PR TITLE
Abort instead of unwinding out of an inconsistent BTreeMap::split_off

### DIFF
--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -2428,6 +2428,31 @@ fn test_split_off_large_random_sorted() {
     assert!(right.into_iter().eq(data.into_iter().filter(|x| x.0 >= key)));
 }
 
+// Regression test for #158165: a comparator that panics partway through
+// `split_off`, after a suffix has already been moved into the new right-hand
+// tree, used to leave `self` with a tree structure inconsistent with its own
+// recorded length. Iterating or dropping the map afterwards could then double
+// free values that had already been moved into the right-hand tree.
+// `split_off` now aborts the process instead of unwinding out of that
+// inconsistent state; the abort can't be observed from within a single
+// process, so this test only checks that ordinary multi-level splits remain
+// correct. See the reproducer on the issue for the double free.
+#[test]
+fn test_split_off_multi_level_panic_guard_happy_path() {
+    // MIN_INSERTS_HEIGHT_2 consecutive keys guarantee a 3-level tree, so
+    // `split_off` walks down and moves a suffix at more than one level for
+    // most of these split points.
+    let n = MIN_INSERTS_HEIGHT_2;
+    for split_at in [0, 1, 2, n / 2, n - 2, n - 1, n] {
+        let mut map = BTreeMap::from_iter((0..n).map(|i| (i, i)));
+        let right = map.split_off(&split_at);
+        map.check();
+        right.check();
+        assert!(map.keys().copied().eq(0..split_at));
+        assert!(right.keys().copied().eq(split_at..n));
+    }
+}
+
 #[test]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_into_iter_drop_leak_height_0() {

--- a/library/alloc/src/collections/btree/split.rs
+++ b/library/alloc/src/collections/btree/split.rs
@@ -1,5 +1,6 @@
 use core::alloc::Allocator;
 use core::borrow::Borrow;
+use core::{intrinsics, mem};
 
 use super::node::ForceResult::*;
 use super::node::Root;
@@ -44,13 +45,25 @@ impl<K, V> Root<K, V> {
         let mut left_node = left_root.borrow_mut();
         let mut right_node = right_root.borrow_mut();
 
-        loop {
-            let mut split_edge = match left_node.search_node(key) {
-                // key is going to the right tree
-                Found(kv) => kv.left_edge(),
-                GoDown(edge) => edge,
-            };
+        // The first search runs before anything has moved, so a panic from the
+        // caller's `Ord`/`Borrow` impl here can unwind safely: `self` is
+        // untouched and the new right tree is still empty.
+        let mut split_edge = match left_node.search_node(key) {
+            // key is going to the right tree
+            Found(kv) => kv.left_edge(),
+            GoDown(edge) => edge,
+        };
 
+        // From the first `move_suffix` on, `left_root` and `right_root` share
+        // key-value pairs through two temporarily invalid tree structures, and
+        // neither is independently droppable until `fix_right_border` /
+        // `fix_left_border` repair them and the caller recomputes both lengths.
+        // A panic from a later `search_node` comparison would unwind out of
+        // that state and double-free the shared values (#158165), so abort
+        // instead of exposing it.
+        let guard = mem::DropGuard::new((), |()| intrinsics::abort());
+
+        loop {
             split_edge.move_suffix(&mut right_node);
 
             match (split_edge.force(), right_node.force()) {
@@ -61,10 +74,16 @@ impl<K, V> Root<K, V> {
                 (Leaf(_), Leaf(_)) => break,
                 _ => unreachable!(),
             }
+
+            split_edge = match left_node.search_node(key) {
+                Found(kv) => kv.left_edge(),
+                GoDown(edge) => edge,
+            };
         }
 
         left_root.fix_right_border(alloc.clone());
         right_root.fix_left_border(alloc);
+        mem::DropGuard::dismiss(guard);
         right_root
     }
 

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -28,6 +28,7 @@
 #![feature(const_try)]
 #![feature(copied_into_inner)]
 #![feature(core_intrinsics)]
+#![feature(drop_guard)]
 #![feature(exact_size_is_empty)]
 #![feature(extend_one)]
 #![feature(extend_one_unchecked)]


### PR DESCRIPTION
Fixes rust-lang/rust#158165. Supersedes rust-lang/rust#161784, which I had to abandon after a bad force-push from a shallow clone left its head detached.

`BTreeMap::split_off` runs the caller's `Ord`/`Borrow` impl via `search_node` inside `Root::split_off`'s descent. After the first `move_suffix`, the two roots alias the same values through structurally invalid trees until the borders are fixed; a comparator panic there unwinds with a stale length and double-frees on later iteration or drop. It is reachable from `#![forbid(unsafe_code)]` on stable (reproducer on the issue).

Guard the descent loop with an abort-on-panic `PanicGuard`, as `btree::mem::replace` already does. `catch_unwind` isnt available in `alloc` (no_std), and I kept an inline guard rather than the unstable `DropGuard`. It is armed once before the loop; the first `search_node` stays outside it, since a panic there can still unwind safely (nothing has moved yet).

Verified with Miri: the reproducer goes from a double-free to a clean abort, and normal multi-level splits are unaffected. Adds a happy-path regression test.

Credit to @ostrowr for the report and to rust-lang/rust#158710 for the original approach.

r? @nia-e
