### PR TITLE
[experiment] Don't store point->basic_block mapping in DenseLocationMap at all

### DIFF
--- a/compiler/rustc_mir_dataflow/src/points.rs
+++ b/compiler/rustc_mir_dataflow/src/points.rs
@@ -6,10 +6,6 @@ pub struct DenseLocationMap {
     /// For each basic block, how many points are contained within?
     statements_before_block: IndexVec<BasicBlock, usize>,
 
-    /// Map backward from each point to the basic block that it
-    /// belongs to.
-    basic_blocks: IndexVec<PointIndex, BasicBlock>,
-
     num_points: usize,
 }
 
@@ -26,14 +22,9 @@ impl DenseLocationMap {
                 v
             })
             .collect();
-
-        let mut basic_blocks = IndexVec::with_capacity(num_points);
-        for (bb, bb_data) in body.basic_blocks.iter_enumerated() {
-            basic_blocks.extend((0..=bb_data.statements.len()).map(|_| bb));
-        }
         // Invariant: no block is preceded by more than all statements.
         debug_assert!(*statements_before_block.iter().max().unwrap() < num_points);
-        Self { statements_before_block, basic_blocks, num_points }
+        Self { statements_before_block, num_points }
     }
 
     /// Total number of point indices
@@ -64,17 +55,24 @@ impl DenseLocationMap {
     /// Return the PointIndex for the block start of this index.
     #[inline]
     pub fn to_block_start(&self, index: PointIndex) -> PointIndex {
-        PointIndex::new(self.statements_before_block[self.basic_blocks[index]])
+        PointIndex::new(self.statements_before_block[self.find_basic_block(index)])
     }
 
     /// Converts a `PointIndex` back to a location. O(1).
     #[inline]
     pub fn to_location(&self, index: PointIndex) -> Location {
         assert!(index.index() < self.num_points);
-        let block = self.basic_blocks[index];
+        let block = self.find_basic_block(index);
         let start_index = self.statements_before_block[block];
         let statement_index = index.index() - start_index;
         Location { block, statement_index }
+    }
+
+    #[inline]
+    fn find_basic_block(&self, index: PointIndex) -> BasicBlock {
+        self.statements_before_block
+            .binary_search(&index.index())
+            .unwrap_or_else(|i| BasicBlock::new(i.index() - 1))
     }
 
     /// Sometimes we get point-indices back from bitsets that may be


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Alternative to https://github.com/rust-lang/rust/pull/161980