### PR TITLE
[perf] Use SmallVec in `smart_resolve_path`

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -4556,7 +4556,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
     ) {
         self.smart_resolve_path_fragment(
             qself,
-            &Segment::from_path(path),
+            &Segment::from_path_smallvec(path),
             source,
             Finalize::new(id, path.span),
             RecordPartialRes::Yes,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -371,6 +371,10 @@ impl Segment {
         path.segments.iter().map(|s| s.into()).collect()
     }
 
+    fn from_path_smallvec(path: &Path) -> SmallVec<[Segment; 4]> {
+        path.segments.iter().map(|s| s.into()).collect()
+    }
+
     fn from_ident(ident: Ident) -> Segment {
         Segment {
             ident,


### PR DESCRIPTION
Perf experiment.
