### PR TITLE
 Support type-relative assoc item paths in generic param defaults & const param types

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1745,28 +1745,24 @@ fn rendered_precise_capturing_args<'tcx>(
 
 fn const_param_default<'tcx>(
     tcx: TyCtxt<'tcx>,
-    local_def_id: LocalDefId,
+    param_def_id: LocalDefId,
 ) -> ty::EarlyBinder<'tcx, Const<'tcx>> {
     let hir::Node::GenericParam(hir::GenericParam {
-        kind: hir::GenericParamKind::Const { default: Some(default_ct), .. },
+        kind: hir::GenericParamKind::Const { default: Some(ct), .. },
         ..
-    }) = tcx.hir_node_by_def_id(local_def_id)
+    }) = tcx.hir_node_by_def_id(param_def_id)
     else {
         span_bug!(
-            tcx.def_span(local_def_id),
-            "`const_param_default` expected a generic parameter with a constant"
+            tcx.def_span(param_def_id),
+            "const_param_default: expected a const parameter with a default value"
         )
     };
 
-    let icx = ItemCtxt::new(tcx, local_def_id);
+    let icx = ItemCtxt::new(tcx, param_def_id);
 
-    let def_id = local_def_id.to_def_id();
-    let identity_args = ty::GenericArgs::identity_for_item(tcx, tcx.parent(def_id));
-
-    let ct = icx.lowerer().lower_const_arg(
-        default_ct,
-        tcx.type_of(def_id).instantiate(tcx, identity_args).skip_norm_wip(),
-    );
+    let ct = icx
+        .lowerer()
+        .lower_const_arg(ct, tcx.type_of(param_def_id).instantiate_identity().skip_norm_wip());
     ty::EarlyBinder::bind(tcx, ct)
 }
 

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1758,7 +1758,8 @@ fn const_param_default<'tcx>(
         )
     };
 
-    let icx = ItemCtxt::new(tcx, param_def_id);
+    let item_def_id = tcx.local_parent(param_def_id);
+    let icx = ItemCtxt::new(tcx, item_def_id);
 
     let ct = icx
         .lowerer()

--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -237,7 +237,7 @@ pub(super) fn generics_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generics {
     let opt_self = if let Node::Item(item) = node
         && let ItemKind::Trait { .. } | ItemKind::TraitAlias(..) = item.kind
     {
-        // Something of a hack: We reuse the node ID of the trait for the self type parameter.
+        // Something of a hack: We reuse the DefId of the trait for the self type parameter.
         Some(ty::GenericParamDef {
             index: 0,
             name: kw::SelfUpper,

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -101,7 +101,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
                 .unwrap_or_else(|| icx.lower_ty(ty)),
             TraitItemKind::Type(_, Some(ty)) => icx.lower_ty(ty),
             TraitItemKind::Type(_, None) => {
-                span_bug!(item.span, "associated type missing default");
+                span_bug!(item.span, "type_of: associated type missing default");
             }
         },
 
@@ -196,7 +196,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
             | ItemKind::ExternCrate(..)
             | ItemKind::Use(..)
             | ItemKind::TestBinderConstraints { .. } => {
-                span_bug!(item.span, "compute_type_of_item: unexpected item type: {:?}", item.kind);
+                span_bug!(item.span, "type_of: unexpected item kind: {:?}", item.kind);
             }
         },
 
@@ -254,12 +254,10 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
                     lowered_ty
                 }
             }
-            x => bug!("unexpected non-type Node::GenericParam: {:?}", x),
+            _ => bug!("type_of: unexpected node kind {hir_node:?}"),
         },
 
-        x => {
-            bug!("unexpected sort of node in type_of(): {:?}", x);
-        }
+        node => bug!("type_of: unexpected node kind: {node:?}"),
     };
     if let Err(e) = icx.check_tainted_by_errors()
         && !output.references_error()

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -60,10 +60,6 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
         None => {}
     }
 
-    let hir_id = tcx.local_def_id_to_hir_id(def_id);
-
-    let icx = ItemCtxt::new(tcx, def_id);
-
     let new_bound_fn_def = |hir: HirId, did| {
         let args = ty::GenericArgs::identity_for_item(tcx, def_id);
         Ty::new_fn_def(
@@ -81,7 +77,16 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
         )
     };
 
-    let output = match tcx.hir_node(hir_id) {
+    let hir_id = tcx.local_def_id_to_hir_id(def_id);
+    let hir_node = tcx.hir_node(hir_id);
+    let def_id = match hir_node {
+        Node::GenericParam(_) => tcx.local_parent(def_id),
+        _ => def_id,
+    };
+
+    let icx = ItemCtxt::new(tcx, def_id);
+
+    let output = match hir_node {
         Node::TraitItem(item) => match item.kind {
             TraitItemKind::Fn(_, _) => new_bound_fn_def(item.hir_id(), def_id.to_def_id()),
             TraitItemKind::Const(ty, rhs) => rhs

--- a/tests/ui/associated-types/type-relative-in-const-param-ty.rs
+++ b/tests/ui/associated-types/type-relative-in-const-param-ty.rs
@@ -1,0 +1,21 @@
+// Test that we can resolve type-relative associated type paths inside const parameter types
+// where the self type is a simple type parameter.
+
+//@ check-pass
+#![feature(generic_const_parameter_types, adt_const_params, const_param_ty_trait)]
+
+trait Trait {
+    type Type;
+}
+
+// Below, `T::Type` resolves to `<T as Trait>::Type` since the owner has bound `T: Trait`.
+
+struct Owner0<T, const N: T::Type>(T)
+where
+    T: Trait<Type = usize>;
+
+struct Owner1<T, const N: T::Type>(T)
+where
+    T: Trait<Type: std::marker::ConstParamTy_>;
+
+fn main() {}

--- a/tests/ui/associated-types/type-relative-in-ty-param-default.rs
+++ b/tests/ui/associated-types/type-relative-in-ty-param-default.rs
@@ -1,0 +1,20 @@
+// Test that we can resolve type-relative associated type paths inside type parameter defaults
+// where the self type is a simple type parameter.
+//
+// issue: <https://github.com/rust-lang/rust/issues/87682>
+
+//@ check-pass
+
+trait Trait {
+    type Type;
+}
+
+// Below, `T::Type` resolves to `<T as Trait>::Type` since the owner has bound `T: Trait`.
+
+struct Owner0<T: Trait, U = T::Type>(T, U);
+
+struct Owner1<T, U = T::Type>(T, U)
+where
+    T: Trait;
+
+fn main() {}

--- a/tests/ui/const-generics/defaults/type-relative-assoc-const.rs
+++ b/tests/ui/const-generics/defaults/type-relative-assoc-const.rs
@@ -1,0 +1,18 @@
+// Test that we can resolve type-relative associated const paths inside const parameter defaults
+// where the self type is a simple type parameter.
+
+//@ check-pass
+#![feature(min_generic_const_args)]
+
+extern crate core;
+use core::direct_const_arg as lift;
+
+trait Trait {
+    type const CT: usize;
+}
+
+// Below, `T::CT` resolves to `<T as Trait>::CT` since the owner has bound `T: Trait`.
+
+struct Owner<T: Trait, const N: usize = { lift!(T::CT) }>(T);
+
+fn main() {}


### PR DESCRIPTION
Background info: For resolving type-relative associated item paths, we only support a tiny set of self types (cc https://github.com/rust-lang/rust/issues/22519). If it's a non-`Self` type parameter we'll look through the "type param bounds" of the overarching item.

*However*, in the case of generic parameter defaults and const parameter types this overarching "item" was set to the generic parameter. This meant that in these places we didn't look at the list of bounds of the overarching item when trying to resolve such type-relative associated item paths but at the one of the generic parameter which is always empty[^1] and thus failed unconditionally.

Fixes https://github.com/rust-lang/rust/issues/87682.

For the types FCP: This PR makes us accept the following code (stably):

```rs
trait Trait { type Type; }

struct Owner<T: Trait, U = T::Type>(T, U);
//                         ~~~~~~~ now successfully resolves to <T as Trait>::Type
```

As alluded to, this PR also affects the resolution in const param defaults+types (intentionally, of course). However, I don't think this can be observed without the use of unstable features (like `min_generic_const_args` and `generic_const_parameter_types`). Nonetheless if you're interested in that, too, please check out the added UI tests.

To the best of my knowledge this change *doesn't* make us reject more code (via new ambiguities or query cycles for example).

<sub>(No LLM was or will be used by me during the entire creation process of this PR)</sub>

[^1]: Generic params obviously never have generic params or bounds (à la (pseudo) `struct S<T<X: Trait> = X::Type>`) in the current version of Rust.