### PR TITLE
Output `tests/debuginfo` raw JSON data on failure in CI

### DIFF
--- a/src/etc/lldb_batchmode/common.py
+++ b/src/etc/lldb_batchmode/common.py
@@ -572,6 +572,12 @@ generated for this test yet, consider using the `--bless` option."
             f.write(x)
             f.write("\n")
 
+    def print_json(self, metadata: BlessMetadata):
+        """Prints `self` to `stdout` in json format with no formatting. This output is identicall to
+        what would be saved via `TargetData.save_blessing`"""
+        self.bless_metadata = metadata
+        print(json.dumps(clean_nones(asdict(self))))
+
 
 def clean_nones(value):
     """

--- a/src/etc/lldb_batchmode/runner.py
+++ b/src/etc/lldb_batchmode/runner.py
@@ -301,14 +301,35 @@ def main():
             # this point are either from the `bless` not working properly, or some other issue with
             # the test itself. In either case, we probably don't want to update the test data until
             # those are resolved.
-            # Only runs if the test contains a repr command, as we don't want to create an input
-            # file for a test that won't ever use it.
+
+            # If we're running CI though, the runner may be on a target that the PR author doesn't
+            # have access to. In such cases, we want to dump the json output so they can "manually
+            # bless" when necessary.
+            if (
+                not all_ok
+                and (is_ci := os.environ.get("CI")) is not None
+                and is_ci == "true"
+            ):
+                from lldb_providers import FEATURE_FLAGS
+
+                path = os.path.relpath(os.environ["LLDB_BATCHMODE_INPUT_DATA_PATH"])
+
+                print(f"[repr] If you do not have access to this target, you can manually update \
+the test data by overwriting the data in {path} with the following:")
+
+                INPUT_DATA.print_json(
+                    BlessMetadata(
+                        sys.version, debugger.GetVersionString(), str(FEATURE_FLAGS)
+                    )
+                )
 
             if not tested_all_types() or not tested_all_variables():
                 debugger.HandleCommand("quit 1")
             elif BLESS:
                 from lldb_providers import FEATURE_FLAGS
 
+                # Only runs if the test contains a repr command, as we don't want to create an input
+                # file for a test that won't ever use it.
                 INPUT_DATA.save_blessing(
                     BlessMetadata(
                         sys.version, debugger.GetVersionString(), str(FEATURE_FLAGS)


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

As discussed a few days ago, this change allows people to "manually bless" in cases where they do not have access to the target that caused the failure in CI. When run outside of CI, no json is dumped (since it's assumed you're running it locally and thus can just use `--bless`).

It makes things a lot easier (for the user) to present this as minified, single-line json, but obviously we'd prefer if it's formatted after they copypaste it. Maybe a tidy pass to enforce that? I'm not sure if we have anything that currently handles JSON, but I can look into it.

r? @Kobzol , @jieyouxu 