### PR TITLE
Sort symbol names by demangled name first to avoid different ordering on hash changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4412,6 +4412,7 @@ dependencies = [
  "gsgdt",
  "parking_lot",
  "polonius-engine",
+ "rustc-demangle",
  "rustc_abi",
  "rustc_apfloat",
  "rustc_arena",

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 For a detailed explanation of the compiler's architecture and how to begin contributing, see the [rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/).
 
+test
+
 ## License
 
 Rust is primarily distributed under the terms of both the MIT license and the

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 For a detailed explanation of the compiler's architecture and how to begin contributing, see the [rustc-dev-guide](https://rustc-dev-guide.rust-lang.org/).
 
-test
+test1
 
 ## License
 

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -10,6 +10,7 @@ either = "1.5.0"
 gsgdt = "0.1.2"
 parking_lot = "0.12"
 polonius-engine = "0.13.0"
+rustc-demangle = "0.1.28"
 rustc_abi = { path = "../rustc_abi" }
 rustc_apfloat = "0.2.0"
 rustc_arena = { path = "../rustc_arena" }

--- a/compiler/rustc_middle/src/mono.rs
+++ b/compiler/rustc_middle/src/mono.rs
@@ -586,7 +586,12 @@ impl<'tcx> CodegenUnit<'tcx> {
             // See https://github.com/rust-lang/rust/pull/145358 for more details.
             //
             // Sorting by symbol name should not incur any new non-determinism.
-            items.sort_by_cached_key(|&(i, _)| i.symbol_name(tcx));
+            items.sort_by_cached_key(|&(i, _)| {
+                let symbol_name = i.symbol_name(tcx);
+                let demangled = rustc_demangle::demangle(symbol_name.name);
+                let name_without_disambiguator = format!("{:#}", demangled);
+                (name_without_disambiguator, symbol_name)
+            });
         } else {
             items.sort_by_cached_key(|&(i, _)| item_sort_key(tcx, i));
         }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162003)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

fixes https://github.com/rust-lang/rust/issues/152910

For now just experimenting here to see whether this helps `rustc-perf` noise