### PR TITLE
Use a simple arena for annotatable items

### DIFF
--- a/compiler/rustc_builtin_macros/src/alloc_error_handler.rs
+++ b/compiler/rustc_builtin_macros/src/alloc_error_handler.rs
@@ -14,7 +14,7 @@ pub(crate) fn expand(
     _span: Span,
     meta_item: &ast::MetaItem,
     item: Annotatable,
-) -> Vec<Annotatable> {
+) {
     check_builtin_macro_attribute(ecx, meta_item, sym::alloc_error_handler);
 
     let orig_item = item.clone();
@@ -32,7 +32,8 @@ pub(crate) fn expand(
         (item, fn_kind.ident, true, ecx.with_def_site_ctxt(fn_kind.sig.span))
     } else {
         ecx.dcx().emit_err(diagnostics::AllocErrorMustBeFn { span: item.span() });
-        return vec![orig_item];
+        ecx.annotatable_arena.push(orig_item);
+        return;
     };
 
     // Generate a bunch of new items using the AllocFnFactory
@@ -58,7 +59,8 @@ pub(crate) fn expand(
     };
 
     // Return the original item and the new methods.
-    vec![orig_item, const_item]
+    ecx.annotatable_arena.push(orig_item);
+    ecx.annotatable_arena.push(const_item);
 }
 
 // #[rustc_std_internal_symbol]

--- a/compiler/rustc_builtin_macros/src/autodiff.rs
+++ b/compiler/rustc_builtin_macros/src/autodiff.rs
@@ -166,7 +166,7 @@ mod llvm_enzyme {
         expand_span: Span,
         meta_item: &ast::MetaItem,
         item: Annotatable,
-    ) -> Vec<Annotatable> {
+    ) {
         expand_with_mode(ecx, expand_span, meta_item, item, DiffMode::Forward)
     }
 
@@ -175,7 +175,7 @@ mod llvm_enzyme {
         expand_span: Span,
         meta_item: &ast::MetaItem,
         item: Annotatable,
-    ) -> Vec<Annotatable> {
+    ) {
         expand_with_mode(ecx, expand_span, meta_item, item, DiffMode::Reverse)
     }
 
@@ -208,7 +208,7 @@ mod llvm_enzyme {
         meta_item: &ast::MetaItem,
         mut item: Annotatable,
         mode: DiffMode,
-    ) -> Vec<Annotatable> {
+    ) {
         let dcx = ecx.sess.dcx();
 
         // first get information about the annotable item: visibility, signature, name and generic
@@ -235,14 +235,16 @@ mod llvm_enzyme {
             _ => None,
         }) else {
             dcx.emit_err(diagnostics::AutoDiffInvalidApplication { span: item.span() });
-            return vec![item];
+            ecx.annotatable_arena.push(item);
+            return;
         };
 
         let meta_item_vec: ThinVec<MetaItemInner> = match meta_item.kind {
             ast::MetaItemKind::List(ref vec) => vec.clone(),
             _ => {
                 dcx.emit_err(diagnostics::AutoDiffMissingConfig { span: item.span() });
-                return vec![item];
+                ecx.annotatable_arena.push(item);
+                return;
             }
         };
 
@@ -254,7 +256,8 @@ mod llvm_enzyme {
         if meta_item_vec.is_empty() {
             // At the bare minimum, we need a fnc name.
             dcx.emit_err(diagnostics::AutoDiffMissingConfig { span: item.span() });
-            return vec![item];
+            ecx.annotatable_arena.push(item);
+            return;
         }
 
         let mode_symbol = match mode {
@@ -311,7 +314,8 @@ mod llvm_enzyme {
         if !x.is_active() {
             // We encountered an error, so we return the original item.
             // This allows us to potentially parse other attributes.
-            return vec![item];
+            ecx.annotatable_arena.push(item);
+            return;
         }
         let span = ecx.with_def_site_ctxt(expand_span);
 
@@ -470,7 +474,8 @@ mod llvm_enzyme {
             }
         };
 
-        vec![orig_annotatable, d_annotatable]
+        ecx.annotatable_arena.push(orig_annotatable);
+        ecx.annotatable_arena.push(d_annotatable);
     }
 
     // shadow arguments (the extra ones which were not in the original (primal) function), in reverse mode must be

--- a/compiler/rustc_builtin_macros/src/cfg_accessible.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_accessible.rs
@@ -42,7 +42,7 @@ impl MultiItemModifier for Expander {
         meta_item: &ast::MetaItem,
         item: Annotatable,
         _is_derive_const: bool,
-    ) -> ExpandResult<Vec<Annotatable>, Annotatable> {
+    ) -> ExpandResult<(), Annotatable> {
         let template = AttributeTemplate { list: Some(&["path"]), ..Default::default() };
         validate_attr::check_builtin_meta_item(
             &ecx.sess.psess,
@@ -54,15 +54,19 @@ impl MultiItemModifier for Expander {
         );
 
         let Some(path) = validate_input(ecx, meta_item) else {
-            return ExpandResult::Ready(Vec::new());
+            return ExpandResult::Ready(());
         };
 
         match ecx.resolver.cfg_accessible(ecx.current_expansion.id, path) {
-            Ok(true) => ExpandResult::Ready(vec![item]),
-            Ok(false) => ExpandResult::Ready(Vec::new()),
+            Ok(true) => {
+                ecx.annotatable_arena.push(item);
+                ExpandResult::Ready(())
+            }
+            Ok(false) => ExpandResult::Ready(()),
             Err(Indeterminate) if ecx.force_mode => {
                 ecx.dcx().emit_err(diagnostics::CfgAccessibleIndeterminate { span });
-                ExpandResult::Ready(vec![item])
+                ecx.annotatable_arena.push(item);
+                ExpandResult::Ready(())
             }
             Err(Indeterminate) => ExpandResult::Retry(item),
         }

--- a/compiler/rustc_builtin_macros/src/cfg_eval.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_eval.rs
@@ -22,10 +22,15 @@ pub(crate) fn expand(
     _span: Span,
     meta_item: &ast::MetaItem,
     annotatable: Annotatable,
-) -> Vec<Annotatable> {
+) {
     check_builtin_macro_attribute(ecx, meta_item, sym::cfg_eval);
     warn_on_duplicate_attribute(ecx, &annotatable, sym::cfg_eval);
-    vec![cfg_eval(ecx.sess, ecx.ecfg.features, annotatable, ecx.current_expansion.lint_node_id)]
+    ecx.annotatable_arena.push(cfg_eval(
+        ecx.sess,
+        ecx.ecfg.features,
+        annotatable,
+        ecx.current_expansion.lint_node_id,
+    ));
 }
 
 pub(crate) fn cfg_eval(

--- a/compiler/rustc_builtin_macros/src/define_opaque.rs
+++ b/compiler/rustc_builtin_macros/src/define_opaque.rs
@@ -7,7 +7,7 @@ pub(crate) fn expand(
     _expand_span: Span,
     meta_item: &ast::MetaItem,
     mut item: Annotatable,
-) -> Vec<Annotatable> {
+) {
     let define_opaque = match &mut item {
         Annotatable::Item(p) => match &mut p.kind {
             ast::ItemKind::Fn(f) => Some(&mut f.define_opaque),
@@ -34,7 +34,8 @@ pub(crate) fn expand(
 
     let Some(list) = meta_item.meta_item_list() else {
         ecx.dcx().span_err(meta_item.span, "expected list of type aliases");
-        return vec![item];
+        ecx.annotatable_arena.push(item);
+        return;
     };
 
     if let Some(define_opaque) = define_opaque {
@@ -58,5 +59,5 @@ pub(crate) fn expand(
         );
     }
 
-    vec![item]
+    ecx.annotatable_arena.push(item);
 }

--- a/compiler/rustc_builtin_macros/src/derive.rs
+++ b/compiler/rustc_builtin_macros/src/derive.rs
@@ -22,12 +22,13 @@ impl MultiItemModifier for Expander {
         meta_item: &ast::MetaItem,
         item: Annotatable,
         _: bool,
-    ) -> ExpandResult<Vec<Annotatable>, Annotatable> {
+    ) -> ExpandResult<(), Annotatable> {
         let sess = ecx.sess;
         if report_bad_target(sess, &item, span).is_err() {
             // We don't want to pass inappropriate targets to derive macros to avoid
             // follow up errors, all other errors below are recoverable.
-            return ExpandResult::Ready(vec![item]);
+            ecx.annotatable_arena.push(item);
+            return ExpandResult::Ready(());
         }
 
         let (sess, features) = (ecx.sess, ecx.ecfg.features);
@@ -85,7 +86,10 @@ impl MultiItemModifier for Expander {
             });
 
         match result {
-            Ok(()) => ExpandResult::Ready(vec![item]),
+            Ok(()) => {
+                ecx.annotatable_arena.push(item);
+                ExpandResult::Ready(())
+            }
             Err(Indeterminate) => ExpandResult::Retry(item),
         }
     }

--- a/compiler/rustc_builtin_macros/src/deriving/bounds.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/bounds.rs
@@ -6,11 +6,11 @@ use crate::deriving::generic::*;
 use crate::deriving::path_std;
 
 pub(crate) fn expand_deriving_copy(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     is_const: bool,
 ) {
     let trait_def = TraitDef {
@@ -27,15 +27,15 @@ pub(crate) fn expand_deriving_copy(
         document: true,
     };
 
-    trait_def.expand(cx, mitem, item, push);
+    trait_def.expand(cx, mitem, item, transform);
 }
 
 pub(crate) fn expand_deriving_const_param_ty(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     is_const: bool,
 ) {
     let trait_def = TraitDef {
@@ -52,5 +52,5 @@ pub(crate) fn expand_deriving_const_param_ty(
         document: true,
     };
 
-    trait_def.expand(cx, mitem, item, push);
+    trait_def.expand(cx, mitem, item, transform);
 }

--- a/compiler/rustc_builtin_macros/src/deriving/clone.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/clone.rs
@@ -9,11 +9,11 @@ use crate::deriving::generic::*;
 use crate::deriving::path_std;
 
 pub(crate) fn expand_deriving_clone(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     is_const: bool,
 ) {
     // The simple form is `fn clone(&self) -> Self { *self }`, possibly with
@@ -82,7 +82,7 @@ pub(crate) fn expand_deriving_clone(
             document: false,
         };
 
-        trivial_def.expand_ext(cx, mitem, item, push, true);
+        trivial_def.expand_ext(cx, mitem, item, transform, true);
     }
 
     let trait_def = TraitDef {
@@ -108,7 +108,7 @@ pub(crate) fn expand_deriving_clone(
         document: true,
     };
 
-    trait_def.expand_ext(cx, mitem, item, push, is_simple)
+    trait_def.expand_ext(cx, mitem, item, transform, is_simple)
 }
 
 fn cs_clone_simple(

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
@@ -9,11 +9,11 @@ use crate::deriving::generic::*;
 use crate::deriving::path_std;
 
 pub(crate) fn expand_deriving_eq(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     is_const: bool,
 ) {
     let span = cx.with_def_site_ctxt(span);
@@ -46,7 +46,7 @@ pub(crate) fn expand_deriving_eq(
         safety: Safety::Default,
         document: true,
     };
-    trait_def.expand_ext(cx, mitem, item, push, true)
+    trait_def.expand_ext(cx, mitem, item, transform, true)
 }
 
 fn cs_total_eq_assert(

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
@@ -8,11 +8,11 @@ use crate::deriving::generic::*;
 use crate::deriving::path_std;
 
 pub(crate) fn expand_deriving_ord(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     is_const: bool,
 ) {
     let trait_def = TraitDef {
@@ -38,7 +38,7 @@ pub(crate) fn expand_deriving_ord(
         document: true,
     };
 
-    trait_def.expand(cx, mitem, item, push)
+    trait_def.expand(cx, mitem, item, transform)
 }
 
 pub(crate) fn cs_cmp(cx: &ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> BlockOrExpr {

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_eq.rs
@@ -10,11 +10,11 @@ use crate::deriving::path_std;
 /// Expands a `#[derive(PartialEq)]` attribute into an implementation for the
 /// target item.
 pub(crate) fn expand_deriving_partial_eq(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     is_const: bool,
 ) {
     let structural_trait_def = TraitDef {
@@ -35,7 +35,7 @@ pub(crate) fn expand_deriving_partial_eq(
         safety: Safety::Default,
         document: true,
     };
-    structural_trait_def.expand(cx, mitem, item, push);
+    structural_trait_def.expand(cx, mitem, item, transform);
 
     // No need to generate `ne`, the default suffices, and not generating it is
     // faster.
@@ -65,7 +65,7 @@ pub(crate) fn expand_deriving_partial_eq(
         safety: Safety::Default,
         document: true,
     };
-    trait_def.expand(cx, mitem, item, push)
+    trait_def.expand(cx, mitem, item, transform)
 }
 
 /// Generates the equality expression for a struct or enum variant when deriving

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
@@ -8,11 +8,11 @@ use crate::deriving::generic::*;
 use crate::deriving::{path_std, pathvec};
 
 pub(crate) fn expand_deriving_partial_ord(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     is_const: bool,
 ) {
     let ordering_ty = Path(path_std!(cmp::Ordering));
@@ -99,7 +99,7 @@ pub(crate) fn expand_deriving_partial_ord(
         safety: Safety::Default,
         document: true,
     };
-    trait_def.expand_ext(cx, mitem, item, push, is_simple)
+    trait_def.expand_ext(cx, mitem, item, transform, is_simple)
 }
 
 // Special case for the type deriving both `PartialOrd` and `Ord`. Builds:

--- a/compiler/rustc_builtin_macros/src/deriving/coerce_pointee.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/coerce_pointee.rs
@@ -19,11 +19,11 @@ macro_rules! path {
 }
 
 pub(crate) fn expand_deriving_coerce_pointee(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     _mitem: &MetaItem,
     item: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     _is_const: bool,
 ) {
     item.visit_with(&mut DetectNonGenericPointeeAttr { cx });
@@ -104,7 +104,7 @@ pub(crate) fn expand_deriving_coerce_pointee(
         let trait_path =
             cx.path_all(span, true, path!(span, core::marker::CoercePointeeValidated), vec![]);
         let trait_ref = cx.trait_ref(trait_path);
-        push(Annotatable::Item(
+        cx.annotatable_arena.push(transform(Annotatable::Item(
             cx.item(
                 span,
                 attrs.clone(),
@@ -144,9 +144,9 @@ pub(crate) fn expand_deriving_coerce_pointee(
                     items: ThinVec::new(),
                 }),
             ),
-        ));
+        )));
     }
-    let mut add_impl_block = |generics, trait_symbol, trait_args| {
+    let mut add_impl_block = |cx: &mut ExtCtxt<'_>, generics, trait_symbol, trait_args| {
         let mut parts = path!(span, core::ops);
         parts.push(Ident::new(trait_symbol, span));
         let trait_path = cx.path_all(span, true, parts, trait_args);
@@ -167,7 +167,7 @@ pub(crate) fn expand_deriving_coerce_pointee(
                 items: ThinVec::new(),
             }),
         );
-        push(Annotatable::Item(item));
+        cx.annotatable_arena.push(transform(Annotatable::Item(item)));
     };
 
     // Create unsized `self`, that is, one where the `#[pointee]` type arg is replaced with `__S`. For
@@ -321,8 +321,8 @@ pub(crate) fn expand_deriving_coerce_pointee(
 
     // Add the impl blocks for `DispatchFromDyn` and `CoerceUnsized`.
     let gen_args = vec![GenericArg::Type(alt_self_type)];
-    add_impl_block(impl_generics.clone(), sym::DispatchFromDyn, gen_args.clone());
-    add_impl_block(impl_generics.clone(), sym::CoerceUnsized, gen_args);
+    add_impl_block(cx, impl_generics.clone(), sym::DispatchFromDyn, gen_args.clone());
+    add_impl_block(cx, impl_generics.clone(), sym::CoerceUnsized, gen_args);
 }
 
 fn contains_maybe_sized_bound_on_pointee(predicates: &[WherePredicate], pointee: Symbol) -> bool {

--- a/compiler/rustc_builtin_macros/src/deriving/debug.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/debug.rs
@@ -9,11 +9,11 @@ use crate::deriving::generic::*;
 use crate::deriving::path_std;
 
 pub(crate) fn expand_deriving_debug(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     is_const: bool,
 ) {
     // &mut ::std::fmt::Formatter
@@ -42,7 +42,7 @@ pub(crate) fn expand_deriving_debug(
         safety: Safety::Default,
         document: true,
     };
-    trait_def.expand(cx, mitem, item, push)
+    trait_def.expand(cx, mitem, item, transform)
 }
 
 fn show_substructure(cx: &ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> BlockOrExpr {

--- a/compiler/rustc_builtin_macros/src/deriving/default.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/default.rs
@@ -12,11 +12,11 @@ use crate::deriving::generic::*;
 use crate::diagnostics;
 
 pub(crate) fn expand_deriving_default(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     mitem: &ast::MetaItem,
     item: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     is_const: bool,
 ) {
     item.visit_with(&mut DetectNonVariantDefaultAttr { cx });
@@ -53,7 +53,7 @@ pub(crate) fn expand_deriving_default(
         safety: Safety::Default,
         document: true,
     };
-    trait_def.expand(cx, mitem, item, push)
+    trait_def.expand(cx, mitem, item, transform)
 }
 
 fn default_call(cx: &ExtCtxt<'_>, span: Span) -> Box<ast::Expr> {

--- a/compiler/rustc_builtin_macros/src/deriving/from.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/from.rs
@@ -13,11 +13,11 @@ use crate::diagnostics;
 /// Generate an implementation of the `From` trait, provided that `item`
 /// is a struct or a tuple struct with exactly one field.
 pub(crate) fn expand_deriving_from(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     mitem: &ast::MetaItem,
     annotatable: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     is_const: bool,
 ) {
     let Annotatable::Item(item) = &annotatable else {
@@ -127,5 +127,5 @@ pub(crate) fn expand_deriving_from(
         document: true,
     };
 
-    from_trait_def.expand(cx, mitem, annotatable, push);
+    from_trait_def.expand(cx, mitem, annotatable, transform);
 }

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -471,20 +471,20 @@ fn find_type_parameters(
 impl<'a> TraitDef<'a> {
     pub(crate) fn expand(
         self,
-        cx: &ExtCtxt<'_>,
+        cx: &mut ExtCtxt<'_>,
         mitem: &ast::MetaItem,
         item: &'a Annotatable,
-        push: &mut dyn FnMut(Annotatable),
+        transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     ) {
-        self.expand_ext(cx, mitem, item, push, false);
+        self.expand_ext(cx, mitem, item, transform, false);
     }
 
     pub(crate) fn expand_ext(
         self,
-        cx: &ExtCtxt<'_>,
+        cx: &mut ExtCtxt<'_>,
         mitem: &ast::MetaItem,
         item: &'a Annotatable,
-        push: &mut dyn FnMut(Annotatable),
+        transform: &mut dyn FnMut(Annotatable) -> Annotatable,
         from_scratch: bool,
     ) {
         match item {
@@ -546,7 +546,8 @@ impl<'a> TraitDef<'a> {
                         })
                         .cloned(),
                 );
-                push(Annotatable::Item(Box::new(ast::Item { attrs, ..(*newitem).clone() })))
+                cx.annotatable_arena
+                    .push(transform(Annotatable::Item(Box::new(ast::Item { attrs, ..(*newitem).clone() }))));
             }
             _ => unreachable!(),
         }

--- a/compiler/rustc_builtin_macros/src/deriving/hash.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/hash.rs
@@ -8,11 +8,11 @@ use crate::deriving::generic::*;
 use crate::deriving::path_std;
 
 pub(crate) fn expand_deriving_hash(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     is_const: bool,
 ) {
     let path = path_std!(hash::Hash);
@@ -43,7 +43,7 @@ pub(crate) fn expand_deriving_hash(
         document: true,
     };
 
-    hash_trait_def.expand(cx, mitem, item, push);
+    hash_trait_def.expand(cx, mitem, item, transform);
 }
 
 fn hash_substructure(cx: &ExtCtxt<'_>, trait_span: Span, substr: &Substructure<'_>) -> BlockOrExpr {

--- a/compiler/rustc_builtin_macros/src/deriving/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/mod.rs
@@ -34,8 +34,14 @@ pub(crate) mod partial_ord;
 
 pub(crate) mod generic;
 
-pub(crate) type BuiltinDeriveFn =
-    fn(&ExtCtxt<'_>, Span, &MetaItem, &Annotatable, &mut dyn FnMut(Annotatable), bool);
+pub(crate) type BuiltinDeriveFn = fn(
+    &mut ExtCtxt<'_>,
+    Span,
+    &MetaItem,
+    &Annotatable,
+    &mut dyn FnMut(Annotatable) -> Annotatable,
+    bool,
+);
 
 pub(crate) struct BuiltinDerive(pub(crate) BuiltinDeriveFn);
 
@@ -47,11 +53,10 @@ impl MultiItemModifier for BuiltinDerive {
         meta_item: &MetaItem,
         item: Annotatable,
         is_derive_const: bool,
-    ) -> ExpandResult<Vec<Annotatable>, Annotatable> {
+    ) -> ExpandResult<(), Annotatable> {
         // FIXME: Built-in derives often forget to give spans contexts,
         // so we are doing it here in a centralized way.
         let span = ecx.with_def_site_ctxt(span);
-        let mut items = Vec::new();
         match item {
             Annotatable::Stmt(stmt) => {
                 if let ast::StmtKind::Item(item) = stmt.kind {
@@ -63,11 +68,11 @@ impl MultiItemModifier for BuiltinDerive {
                         &mut |a| {
                             // Cannot use 'ecx.stmt_item' here, because we need to pass 'ecx'
                             // to the function
-                            items.push(Annotatable::Stmt(Box::new(ast::Stmt {
+                            Annotatable::Stmt(Box::new(ast::Stmt {
                                 id: ast::DUMMY_NODE_ID,
                                 kind: ast::StmtKind::Item(a.expect_item()),
                                 span,
-                            })));
+                            }))
                         },
                         is_derive_const,
                     );
@@ -76,10 +81,10 @@ impl MultiItemModifier for BuiltinDerive {
                 }
             }
             _ => {
-                (self.0)(ecx, span, meta_item, &item, &mut |a| items.push(a), is_derive_const);
+                (self.0)(ecx, span, meta_item, &item, &mut |a| a, is_derive_const);
             }
         }
-        ExpandResult::Ready(items)
+        ExpandResult::Ready(())
     }
 }
 

--- a/compiler/rustc_builtin_macros/src/deriving/reborrow.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/reborrow.rs
@@ -12,26 +12,26 @@ macro_rules! path {
 }
 
 pub(crate) fn expand_deriving_reborrow(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     _mitem: &MetaItem,
     item: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     _is_const: bool,
 ) {
     let Some((ident, generics)) = struct_def(cx, span, item, sym::Reborrow) else {
         return;
     };
 
-    push_marker_impl(cx, span, ident, generics, sym::Reborrow, Vec::new(), push);
+    push_marker_impl(cx, span, ident, generics, sym::Reborrow, Vec::new(), transform);
 }
 
 pub(crate) fn expand_deriving_coerce_shared(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     _mitem: &MetaItem,
     item: &Annotatable,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
     _is_const: bool,
 ) {
     let Some((ident, generics)) = struct_def(cx, span, item, sym::CoerceShared) else {
@@ -48,7 +48,7 @@ pub(crate) fn expand_deriving_coerce_shared(
         generics,
         sym::CoerceShared,
         vec![GenericArg::Type(target)],
-        push,
+        transform,
     );
 }
 
@@ -124,13 +124,13 @@ fn coerce_shared_target(cx: &ExtCtxt<'_>, span: Span, item: &Annotatable) -> Opt
 }
 
 fn push_marker_impl(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     span: Span,
     ident: Ident,
     generics: &Generics,
     trait_name: Symbol,
     trait_args: Vec<GenericArg>,
-    push: &mut dyn FnMut(Annotatable),
+    transform: &mut dyn FnMut(Annotatable) -> Annotatable,
 ) {
     let mut trait_parts = path!(span, core::marker);
     trait_parts.push(Ident::new(trait_name, span));
@@ -154,7 +154,7 @@ fn push_marker_impl(
         .collect();
     let self_ty = cx.ty_path(cx.path_all(span, false, vec![ident], self_params));
 
-    push(Annotatable::Item(cx.item(
+    cx.annotatable_arena.push(transform(Annotatable::Item(cx.item(
         span,
         thin_vec::thin_vec![cx.attr_word(sym::automatically_derived, span)],
         ast::ItemKind::Impl(ast::Impl {
@@ -169,7 +169,7 @@ fn push_marker_impl(
             self_ty,
             items: ThinVec::new(),
         }),
-    )));
+    ))));
 }
 
 fn impl_generics(cx: &ExtCtxt<'_>, generics: &Generics) -> Generics {

--- a/compiler/rustc_builtin_macros/src/eii.rs
+++ b/compiler/rustc_builtin_macros/src/eii.rs
@@ -35,12 +35,7 @@ use crate::diagnostics::{
 /// #[eii_declaration(panic_handler)]
 /// macro panic_handler() {}
 /// ```
-pub(crate) fn eii(
-    ecx: &mut ExtCtxt<'_>,
-    span: Span,
-    meta_item: &ast::MetaItem,
-    item: Annotatable,
-) -> Vec<Annotatable> {
+pub(crate) fn eii(ecx: &mut ExtCtxt<'_>, span: Span, meta_item: &ast::MetaItem, item: Annotatable) {
     eii_(ecx, span, meta_item, item, false)
 }
 
@@ -49,7 +44,7 @@ pub(crate) fn unsafe_eii(
     span: Span,
     meta_item: &ast::MetaItem,
     item: Annotatable,
-) -> Vec<Annotatable> {
+) {
     eii_(ecx, span, meta_item, item, true)
 }
 
@@ -59,7 +54,7 @@ fn eii_(
     meta_item: &ast::MetaItem,
     orig_item: Annotatable,
     impl_unsafe: bool,
-) -> Vec<Annotatable> {
+) {
     let eii_attr_span = ecx.with_def_site_ctxt(eii_attr_span);
 
     let item = if let Annotatable::Item(item) = orig_item {
@@ -73,13 +68,15 @@ fn eii_(
             name: path_to_string(&meta_item.path),
             item_span: f.ident.span,
         });
-        return vec![orig_item];
+        ecx.annotatable_arena.push(orig_item);
+        return;
     } else {
         ecx.dcx().emit_err(EiiSharedMacroTarget {
             span: eii_attr_span,
             name: path_to_string(&meta_item.path),
         });
-        return vec![orig_item];
+        ecx.annotatable_arena.push(orig_item);
+        return;
     };
 
     let ast::Item { attrs, id: _, span: _, vis, kind, tokens: _ } = item.as_ref();
@@ -94,7 +91,7 @@ fn eii_(
                     span: expr.span,
                     name: path_to_string(&meta_item.path),
                 });
-                return vec![];
+                return;
             }
 
             // Statics must have an explicit name for the eii
@@ -103,7 +100,7 @@ fn eii_(
                     span: eii_attr_span,
                     name: path_to_string(&meta_item.path),
                 });
-                return vec![];
+                return;
             }
 
             // Mut statics are currently not supported
@@ -121,7 +118,8 @@ fn eii_(
                 span: eii_attr_span,
                 name: path_to_string(&meta_item.path),
             });
-            return vec![Annotatable::Item(item)];
+            ecx.annotatable_arena.push(Annotatable::Item(item));
+            return;
         }
     };
 
@@ -129,13 +127,15 @@ fn eii_(
         ItemKind::Fn(func) => {
             if func.eii_impl.is_some() {
                 ecx.dcx().emit_err(EiiBothDeclAndImpl { span: eii_attr_span });
-                return vec![Annotatable::Item(item)];
+                ecx.annotatable_arena.push(Annotatable::Item(item));
+                return;
             }
         }
         ItemKind::Static(stat) => {
             if stat.eii_impl.is_some() {
                 ecx.dcx().emit_err(EiiBothDeclAndImpl { span: eii_attr_span });
-                return vec![Annotatable::Item(item)];
+                ecx.annotatable_arena.push(Annotatable::Item(item));
+                return;
             }
         }
         _ => unreachable!("Target was checked earlier"),
@@ -152,7 +152,8 @@ fn eii_(
     let Ok(macro_name) = name_for_impl_macro(ecx, foreign_item_name, meta_item) else {
         // we don't need to wrap in Annotatable::Stmt conditionally since
         // EII can't be used on items in statement position
-        return vec![Annotatable::Item(item)];
+        ecx.annotatable_arena.push(Annotatable::Item(item));
+        return;
     };
 
     let mut module_items = Vec::new();
@@ -188,7 +189,7 @@ fn eii_(
 
     // we don't need to wrap in Annotatable::Stmt conditionally since
     // EII can't be used on items in statement position
-    module_items.into_iter().map(Annotatable::Item).collect()
+    ecx.annotatable_arena.extend(module_items.into_iter().map(Annotatable::Item));
 }
 
 fn split_attrs(
@@ -521,7 +522,7 @@ pub(crate) fn eii_declaration(
     span: Span,
     meta_item: &ast::MetaItem,
     mut item: Annotatable,
-) -> Vec<Annotatable> {
+) {
     let i = if let Annotatable::Item(ref mut item) = item {
         item
     } else if let Annotatable::Stmt(ref mut stmt) = item
@@ -530,28 +531,33 @@ pub(crate) fn eii_declaration(
         item
     } else {
         ecx.dcx().emit_err(EiiExternTargetExpectedMacro { span });
-        return vec![item];
+        ecx.annotatable_arena.push(item);
+        return;
     };
 
     let ItemKind::MacroDef(_, d) = &mut i.kind else {
         ecx.dcx().emit_err(EiiExternTargetExpectedMacro { span });
-        return vec![item];
+        ecx.annotatable_arena.push(item);
+        return;
     };
 
     let Some(list) = meta_item.meta_item_list() else {
         ecx.dcx().emit_err(EiiExternTargetExpectedList { span: meta_item.span });
-        return vec![item];
+        ecx.annotatable_arena.push(item);
+        return;
     };
 
     if list.len() > 2 {
         ecx.dcx().emit_err(EiiExternTargetExpectedList { span: meta_item.span });
-        return vec![item];
+        ecx.annotatable_arena.push(item);
+        return;
     }
 
     let Some(extern_item_path) = list.get(0).and_then(|i| i.meta_item()).map(|i| i.path.clone())
     else {
         ecx.dcx().emit_err(EiiExternTargetExpectedList { span: meta_item.span });
-        return vec![item];
+        ecx.annotatable_arena.push(item);
+        return;
     };
 
     let impl_unsafe = if let Some(i) = list.get(1) {
@@ -559,7 +565,8 @@ pub(crate) fn eii_declaration(
             true
         } else {
             ecx.dcx().emit_err(EiiExternTargetExpectedUnsafe { span: i.span() });
-            return vec![item];
+            ecx.annotatable_arena.push(item);
+            return;
         }
     } else {
         false
@@ -568,7 +575,7 @@ pub(crate) fn eii_declaration(
     d.eii_declaration = Some(EiiDecl { foreign_item: extern_item_path, impl_unsafe });
 
     // Return the original item and the new methods.
-    vec![item]
+    ecx.annotatable_arena.push(item);
 }
 
 /// all Eiis share this function as the implementation for their attribute.
@@ -577,7 +584,7 @@ pub(crate) fn eii_shared_macro(
     span: Span,
     meta_item: &ast::MetaItem,
     mut item: Annotatable,
-) -> Vec<Annotatable> {
+) {
     let i = if let Annotatable::Item(ref mut item) = item {
         item
     } else if let Annotatable::Stmt(ref mut stmt) = item
@@ -586,7 +593,8 @@ pub(crate) fn eii_shared_macro(
         item
     } else {
         ecx.dcx().emit_err(EiiSharedMacroTarget { span, name: path_to_string(&meta_item.path) });
-        return vec![item];
+        ecx.annotatable_arena.push(item);
+        return;
     };
 
     let eii_impl = match &mut i.kind {
@@ -595,7 +603,8 @@ pub(crate) fn eii_shared_macro(
         _ => {
             ecx.dcx()
                 .emit_err(EiiSharedMacroTarget { span, name: path_to_string(&meta_item.path) });
-            return vec![item];
+            ecx.annotatable_arena.push(item);
+            return;
         }
     };
 
@@ -611,7 +620,8 @@ pub(crate) fn eii_shared_macro(
             span: meta_item.span,
             name: path_to_string(&meta_item.path),
         });
-        return vec![item];
+        ecx.annotatable_arena.push(item);
+        return;
     };
 
     if eii_impl.is_some() {
@@ -627,5 +637,5 @@ pub(crate) fn eii_shared_macro(
         known_eii_macro_resolution: None,
     }));
 
-    vec![item]
+    ecx.annotatable_arena.push(item);
 }

--- a/compiler/rustc_builtin_macros/src/global_allocator.rs
+++ b/compiler/rustc_builtin_macros/src/global_allocator.rs
@@ -17,7 +17,7 @@ pub(crate) fn expand(
     _span: Span,
     meta_item: &ast::MetaItem,
     item: Annotatable,
-) -> Vec<Annotatable> {
+) {
     check_builtin_macro_attribute(ecx, meta_item, sym::global_allocator);
 
     let orig_item = item.clone();
@@ -35,14 +35,16 @@ pub(crate) fn expand(
         (item, *ident, true, ecx.with_def_site_ctxt(ty.span))
     } else {
         ecx.dcx().emit_err(diagnostics::AllocMustStatics { span: item.span() });
-        return vec![orig_item];
+        ecx.annotatable_arena.push(orig_item);
+        return;
     };
 
     // Forbid `#[thread_local]` attributes on the item
     if let Some(attr) = item.attrs.iter().find(|x| x.has_name(sym::thread_local)) {
         ecx.dcx()
             .emit_err(diagnostics::AllocCannotThreadLocal { span: item.span, attr: attr.span });
-        return vec![orig_item];
+        ecx.annotatable_arena.push(orig_item);
+        return;
     }
 
     // Generate a bunch of new items using the AllocFnFactory
@@ -69,7 +71,8 @@ pub(crate) fn expand(
     };
 
     // Return the original item and the new methods.
-    vec![orig_item, const_item]
+    ecx.annotatable_arena.push(orig_item);
+    ecx.annotatable_arena.push(const_item);
 }
 
 struct AllocFnFactory<'a, 'b> {

--- a/compiler/rustc_builtin_macros/src/offload.rs
+++ b/compiler/rustc_builtin_macros/src/offload.rs
@@ -64,12 +64,13 @@ pub(crate) fn expand_kernel(
     expand_span: Span,
     _meta_item: &ast::MetaItem,
     item: Annotatable,
-) -> Vec<Annotatable> {
+) {
     let dcx = ecx.sess.dcx();
 
     let Some((vis, sig, ident, generics, body)) = extract_fn(&item) else {
         dcx.emit_err(diagnostics::AutoDiffInvalidApplication { span: item.span() });
-        return vec![item];
+        ecx.annotatable_arena.push(item);
+        return;
     };
 
     let span = ecx.with_def_site_ctxt(expand_span);
@@ -180,5 +181,9 @@ pub(crate) fn expand_kernel(
         Annotatable::Item(item)
     };
 
-    if compile_for_device(ecx) { vec![device_item] } else { vec![host_item] }
+    if compile_for_device(ecx) {
+        ecx.annotatable_arena.push(device_item);
+    } else {
+        ecx.annotatable_arena.push(host_item);
+    }
 }

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -31,7 +31,7 @@ pub(crate) fn expand_test_case(
     attr_sp: Span,
     meta_item: &ast::MetaItem,
     anno_item: Annotatable,
-) -> Vec<Annotatable> {
+) {
     check_builtin_macro_attribute(ecx, meta_item, sym::test_case);
     warn_on_duplicate_attribute(ecx, &anno_item, sym::test_case);
 
@@ -47,12 +47,12 @@ pub(crate) fn expand_test_case(
         }
         _ => {
             ecx.dcx().emit_err(diagnostics::TestCaseNonItem { span: anno_item.span() });
-            return vec![];
+            return;
         }
     };
 
     if !ecx.ecfg.should_test {
-        return vec![];
+        return;
     }
 
     // `#[test_case]` is valid on functions, consts, and statics. Only modify
@@ -79,7 +79,7 @@ pub(crate) fn expand_test_case(
         Annotatable::Item(item)
     };
 
-    vec![ret]
+    ecx.annotatable_arena.push(ret);
 }
 
 pub(crate) fn expand_test(
@@ -87,10 +87,10 @@ pub(crate) fn expand_test(
     attr_sp: Span,
     meta_item: &ast::MetaItem,
     item: Annotatable,
-) -> Vec<Annotatable> {
+) {
     check_builtin_macro_attribute(cx, meta_item, sym::test);
     warn_on_duplicate_attribute(cx, &item, sym::test);
-    expand_test_or_bench(cx, attr_sp, item, false)
+    expand_test_or_bench(cx, attr_sp, item, false);
 }
 
 pub(crate) fn expand_bench(
@@ -98,39 +98,40 @@ pub(crate) fn expand_bench(
     attr_path_sp: Span,
     meta_item: &ast::MetaItem,
     item: Annotatable,
-) -> Vec<Annotatable> {
+) {
     check_builtin_macro_attribute(cx, meta_item, sym::bench);
     warn_on_duplicate_attribute(cx, &item, sym::bench);
-    expand_test_or_bench(cx, attr_path_sp, item, true)
+    expand_test_or_bench(cx, attr_path_sp, item, true);
 }
 
 pub(crate) fn expand_test_or_bench(
-    cx: &ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_>,
     attr_sp: Span,
     item: Annotatable,
     is_bench: bool,
-) -> Vec<Annotatable> {
+) {
     let (item, is_stmt) = match item {
         Annotatable::Item(i) => (i, false),
         Annotatable::Stmt(ast::Stmt { kind: ast::StmtKind::Item(i), .. }) => (i, true),
         other => {
             not_testable_error(cx, is_bench, attr_sp, None);
-            return vec![other];
+            cx.annotatable_arena.push(other);
+            return;
         }
     };
 
     let ast::ItemKind::Fn(fn_) = &item.kind else {
         not_testable_error(cx, is_bench, attr_sp, Some(&item));
         return if is_stmt {
-            vec![Annotatable::Stmt(Box::new(cx.stmt_item(item.span, item)))]
+            cx.annotatable_arena.push(Annotatable::Stmt(Box::new(cx.stmt_item(item.span, item))));
         } else {
-            vec![Annotatable::Item(item)]
+            cx.annotatable_arena.push(Annotatable::Item(item));
         };
     };
 
     // If we're not in test configuration, remove the annotated item
     if !cx.ecfg.should_test {
-        return vec![];
+        return;
     }
 
     if let Some(attr) = attr::find_by_name(&item.attrs, sym::naked) {
@@ -138,7 +139,8 @@ pub(crate) fn expand_test_or_bench(
             testing_span: attr_sp,
             naked_span: attr.span,
         });
-        return vec![Annotatable::Item(item)];
+        cx.annotatable_arena.push(Annotatable::Item(item));
+        return;
     }
 
     // check_*_signature will report any errors in the type so compilation
@@ -151,9 +153,9 @@ pub(crate) fn expand_test_or_bench(
     };
     if check_result.is_err() {
         return if is_stmt {
-            vec![Annotatable::Stmt(Box::new(cx.stmt_item(item.span, item)))]
+            cx.annotatable_arena.push(Annotatable::Stmt(Box::new(cx.stmt_item(item.span, item))));
         } else {
-            vec![Annotatable::Item(item)]
+            cx.annotatable_arena.push(Annotatable::Item(item));
         };
     }
 
@@ -389,23 +391,23 @@ pub(crate) fn expand_test_or_bench(
     debug!("synthetic test item:\n{}\n", pprust::item_to_string(&test_const));
 
     if is_stmt {
-        vec![
+        cx.annotatable_arena.extend([
             // Access to libtest under a hygienic name
             Annotatable::Stmt(Box::new(cx.stmt_item(sp, test_extern))),
             // The generated test case
             Annotatable::Stmt(Box::new(cx.stmt_item(sp, test_const))),
             // The original item
             Annotatable::Stmt(Box::new(cx.stmt_item(sp, item))),
-        ]
+        ]);
     } else {
-        vec![
+        cx.annotatable_arena.extend([
             // Access to libtest under a hygienic name
             Annotatable::Item(test_extern),
             // The generated test case
             Annotatable::Item(test_const),
             // The original item
             Annotatable::Item(item),
-        ]
+        ]);
     }
 }
 

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -41,6 +41,7 @@ use crate::stats::MacroStat;
 /// When adding new variants, make sure to adjust the `visit_*` / `flat_map_*`
 /// calls in `InvocationCollector` to use `assign_id!`
 #[derive(Debug, Clone)]
+#[must_use]
 pub enum Annotatable {
     Item(Box<ast::Item>),
     AssocItem(Box<ast::AssocItem>, AssocCtxt),
@@ -291,12 +292,12 @@ pub trait MultiItemModifier {
         meta_item: &ast::MetaItem,
         item: Annotatable,
         is_derive_const: bool,
-    ) -> ExpandResult<Vec<Annotatable>, Annotatable>;
+    ) -> ExpandResult<(), Annotatable>;
 }
 
 impl<F> MultiItemModifier for F
 where
-    F: Fn(&mut ExtCtxt<'_>, Span, &ast::MetaItem, Annotatable) -> Vec<Annotatable>,
+    F: Fn(&mut ExtCtxt<'_>, Span, &ast::MetaItem, Annotatable) -> (),
 {
     fn expand(
         &self,
@@ -305,7 +306,7 @@ where
         meta_item: &ast::MetaItem,
         item: Annotatable,
         _is_derive_const: bool,
-    ) -> ExpandResult<Vec<Annotatable>, Annotatable> {
+    ) -> ExpandResult<(), Annotatable> {
         ExpandResult::Ready(self(ecx, span, meta_item, item))
     }
 }
@@ -943,13 +944,8 @@ impl SyntaxExtension {
 
     /// A dummy derive macro `#[derive(Foo)]`.
     pub fn dummy_derive(edition: Edition) -> SyntaxExtension {
-        fn expander(
-            _: &mut ExtCtxt<'_>,
-            _: Span,
-            _: &ast::MetaItem,
-            _: Annotatable,
-        ) -> Vec<Annotatable> {
-            Vec::new()
+        fn expander(_: &mut ExtCtxt<'_>, _: Span, _: &ast::MetaItem, _: Annotatable) -> () {
+            ()
         }
         SyntaxExtension::default(SyntaxExtensionKind::Derive(Arc::new(expander)), edition)
     }
@@ -1198,6 +1194,9 @@ pub struct ExtCtxt<'a> {
     /// (or during eager expansion, but that's a hack).
     pub force_mode: bool,
     pub expansions: FxIndexMap<Span, Vec<String>>,
+    /// Cached arena to amortize allocations during macro expansion.
+    /// Individual expanders push their annotatables to this arena.
+    pub annotatable_arena: Vec<Annotatable>,
     /// Used for running pre-expansion lints on freshly loaded modules.
     pub(super) lint_store: LintStoreExpandDyn<'a>,
     /// Used for storing lints generated during expansion, like `NAMED_ARGUMENTS_USED_POSITIONALLY`
@@ -1240,6 +1239,7 @@ impl<'a> ExtCtxt<'a> {
             buffered_early_lint: vec![],
             macro_stats: Default::default(),
             nb_macro_errors: 0,
+            annotatable_arena: Vec::new(),
         }
     }
 

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -864,8 +864,12 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                     match validate_attr::parse_meta(&self.cx.sess.psess, &attr) {
                         Ok(meta) => {
                             let item_clone = macro_stats.then(|| item.clone());
-                            let items = match expander.expand(self.cx, span, &meta, item, false) {
-                                ExpandResult::Ready(items) => items,
+
+                            // Before each expansion, we clear the arena, and then we use its
+                            // gathered items below.
+                            self.cx.annotatable_arena.clear();
+                            match expander.expand(self.cx, span, &meta, item, false) {
+                                ExpandResult::Ready(_) => {}
                                 ExpandResult::Retry(item) => {
                                     // Reassemble the original invocation for retrying.
                                     return ExpandResult::Retry(Invocation {
@@ -874,6 +878,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                                     });
                                 }
                             };
+                            let items = &mut self.cx.annotatable_arena;
                             if matches!(
                                 fragment_kind,
                                 AstFragmentKind::Expr | AstFragmentKind::MethodReceiverExpr
@@ -882,7 +887,8 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                                 let guar = self.cx.dcx().emit_err(RemoveExprNotSupported { span });
                                 fragment_kind.dummy(span, guar)
                             } else {
-                                let fragment = fragment_kind.expect_from_annotatables(items);
+                                let fragment =
+                                    fragment_kind.expect_from_annotatables(items.drain(..));
                                 if macro_stats {
                                     update_attr_macro_stats(
                                         self.cx,
@@ -922,8 +928,12 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                         span,
                         path,
                     };
-                    let items = match expander.expand(self.cx, span, &meta, item, is_const) {
-                        ExpandResult::Ready(items) => items,
+
+                    // Before each expansion, we clear the arena, and then we use its
+                    // gathered items below.
+                    self.cx.annotatable_arena.clear();
+                    match expander.expand(self.cx, span, &meta, item, is_const) {
+                        ExpandResult::Ready(_) => {}
                         ExpandResult::Retry(item) => {
                             // Reassemble the original invocation for retrying.
                             return ExpandResult::Retry(Invocation {
@@ -932,7 +942,8 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                             });
                         }
                     };
-                    let fragment = fragment_kind.expect_from_annotatables(items);
+                    let items = &mut self.cx.annotatable_arena;
+                    let fragment = fragment_kind.expect_from_annotatables(items.drain(..));
                     if macro_stats {
                         update_derive_macro_stats(
                             self.cx,

--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -99,7 +99,7 @@ impl MultiItemModifier for DeriveProcMacro {
         _meta_item: &ast::MetaItem,
         item: Annotatable,
         _is_derive_const: bool,
-    ) -> ExpandResult<Vec<Annotatable>, Annotatable> {
+    ) -> ExpandResult<(), Annotatable> {
         let _timer = record_expand_proc_macro(ecx, "expand_derive_proc_macro_outer", span);
 
         // We need special handling for statement items
@@ -127,12 +127,11 @@ impl MultiItemModifier for DeriveProcMacro {
 
         let Ok(output) = res else {
             // error will already have been emitted
-            return ExpandResult::Ready(vec![]);
+            return ExpandResult::Ready(());
         };
 
         let error_count_before = ecx.dcx().err_count();
         let mut parser = Parser::new(&ecx.sess.psess, output, Some("proc-macro derive"));
-        let mut items = vec![];
 
         loop {
             match parser.parse_item(
@@ -142,9 +141,10 @@ impl MultiItemModifier for DeriveProcMacro {
                 Ok(None) => break,
                 Ok(Some(item)) => {
                     if is_stmt {
-                        items.push(Annotatable::Stmt(Box::new(ecx.stmt_item(span, item))));
+                        ecx.annotatable_arena
+                            .push(Annotatable::Stmt(Box::new(ecx.stmt_item(span, item))));
                     } else {
-                        items.push(Annotatable::Item(item));
+                        ecx.annotatable_arena.push(Annotatable::Item(item));
                     }
                 }
                 Err(err) => {
@@ -159,7 +159,7 @@ impl MultiItemModifier for DeriveProcMacro {
             ecx.dcx().emit_err(diagnostics::ProcMacroDeriveTokens { span });
         }
 
-        ExpandResult::Ready(items)
+        ExpandResult::Ready(())
     }
 }
 


### PR DESCRIPTION
When profiling bors with `dhat`, this was one of the places that were kinda hot for allocations. So I tried to use an amortized `Vec` for the annotatable items. I didn't store it in `MacroExpander`, because those are created repeatedly, but rather in `ExtCtxt`, so that it survives over multiple expansion calls, and the memory can be better reused.

Since we already pass `&mut ExtCtxt` to the expansion functions, I couldn't easily pass `&mut Vec<Annotatable>` to all the expansion functions too, because that would be a double `&mut` reference. So as an experiment for a benchmark, I just switched all the functions to directly push to the arena in `ExtCtxt`. This is not super pretty and only works since the `ExtCtxt` is currently not used from multiple threads. I wanted to refactor it, but I figured that it's maybe not so egregious? So first wanted to get a second opinion before I do that.

If we wanted to do this via `&mut Vec<Annotatable>`, I could store `RefCell<Vec<Annotatable>>` in `ExtCtxt`, and `borrow_mut()` it just before calling the expansion. But for that to work, I'd probably have to replace `&mut ExtCtxt` in the expansion calls (which might? be possible), or store `Rc<RefCell<Vec<Annotatable>>>` instead.

r? nnethercote
