### PR TITLE
Preserve parentheses in raw borrow suggestions

### DIFF
--- a/compiler/rustc_lint/src/raw_borrows_via_references.rs
+++ b/compiler/rustc_lint/src/raw_borrows_via_references.rs
@@ -57,15 +57,16 @@ impl<'tcx> LateLintPass<'tcx> for RawBorrowsViaReferences {
             && let TyKind::Ptr(_) = ty.kind
             && addr_of_exp.is_syntactic_place_expr()
         {
-            let suggestion = if let Some(addr_of_span) =
-                addr_of_exp.span.find_ancestor_in_same_ctxt(expr.span)
+            let suggestion = if let Some(borrow_span) =
+                exp.span.find_ancestor_inside_same_ctxt(expr.span)
+                && let Some(addr_of_span) = addr_of_exp.span.find_ancestor_in_same_ctxt(expr.span)
                 && let Some(ty_span) = ty.span.find_ancestor_in_same_ctxt(expr.span)
-                && expr.span.can_be_used_for_suggestions()
+                && borrow_span.can_be_used_for_suggestions()
                 && addr_of_span.can_be_used_for_suggestions()
                 && ty_span.can_be_used_for_suggestions()
             {
                 RawBorrowViaReferenceSuggestion::Spanful {
-                    left: expr.span.until(addr_of_span),
+                    left: borrow_span.until(addr_of_span),
                     right: addr_of_span.shrink_to_hi().until(ty_span.shrink_to_hi()),
                     mutbl: mutbl.ptr_str(),
                 }

--- a/tests/ui/lint/raw-borrows-via-references-parenthesized-issue-161693.fixed
+++ b/tests/ui/lint/raw-borrows-via-references-parenthesized-issue-161693.fixed
@@ -7,14 +7,14 @@
 
 const READ: () = unsafe {
     let x = 42i32;
-    let y = (&x as *const i32).read_volatile();
+    let y = (&raw const x).read_volatile();
     //~^ WARN creating an intermediate reference implies aliasing requirements
     assert!(x == y);
 };
 
 const WRITE: () = unsafe {
     let mut x = 42i32;
-    (&mut x as *mut i32).write_volatile(13);
+    (&raw mut x).write_volatile(13);
     //~^ WARN creating an intermediate reference implies aliasing requirements
     assert!(x == 13);
 };
@@ -28,7 +28,7 @@ macro_rules! make_borrow {
 fn macro_generated_borrow() {
     let value = 0;
     // the scenario of macro should also get valid fix suggestion
-    let _ = make_borrow!(value) as *const i32;
+    let _ = &raw const value;
     //~^ WARN creating an intermediate reference implies aliasing requirements
 }
 

--- a/tests/ui/lint/raw-borrows-via-references-parenthesized-issue-161693.rs
+++ b/tests/ui/lint/raw-borrows-via-references-parenthesized-issue-161693.rs
@@ -1,0 +1,22 @@
+//@ check-pass
+
+// Parenthesized reference-to-pointer casts should produce syntactically valid suggestions.
+
+#![feature(const_volatile)]
+#![warn(raw_borrows_via_references)]
+
+const READ: () = unsafe {
+    let x = 42i32;
+    let y = (&x as *const i32).read_volatile();
+    //~^ WARN creating an intermediate reference implies aliasing requirements
+    assert!(x == y);
+};
+
+const WRITE: () = unsafe {
+    let mut x = 42i32;
+    (&mut x as *mut i32).write_volatile(13);
+    //~^ WARN creating an intermediate reference implies aliasing requirements
+    assert!(x == 13);
+};
+
+fn main() {}

--- a/tests/ui/lint/raw-borrows-via-references-parenthesized-issue-161693.stderr
+++ b/tests/ui/lint/raw-borrows-via-references-parenthesized-issue-161693.stderr
@@ -12,7 +12,7 @@ LL | #![warn(raw_borrows_via_references)]
 help: consider using `&raw const` for a safer and more explicit raw pointer
    |
 LL -     let y = (&x as *const i32).read_volatile();
-LL +     let y = &raw const x).read_volatile();
+LL +     let y = (&raw const x).read_volatile();
    |
 
 warning: creating an intermediate reference implies aliasing requirements even when immediately cast to a raw pointers
@@ -24,8 +24,20 @@ LL |     (&mut x as *mut i32).write_volatile(13);
 help: consider using `&raw mut` for a safer and more explicit raw pointer
    |
 LL -     (&mut x as *mut i32).write_volatile(13);
-LL +     &raw mut x).write_volatile(13);
+LL +     (&raw mut x).write_volatile(13);
    |
 
-warning: 2 warnings emitted
+warning: creating an intermediate reference implies aliasing requirements even when immediately cast to a raw pointers
+  --> $DIR/raw-borrows-via-references-parenthesized-issue-161693.rs:31:13
+   |
+LL |     let _ = make_borrow!(value) as *const i32;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `&raw const` for a safer and more explicit raw pointer
+   |
+LL -     let _ = make_borrow!(value) as *const i32;
+LL +     let _ = &raw const value;
+   |
+
+warning: 3 warnings emitted
 

--- a/tests/ui/lint/raw-borrows-via-references-parenthesized-issue-161693.stderr
+++ b/tests/ui/lint/raw-borrows-via-references-parenthesized-issue-161693.stderr
@@ -1,0 +1,31 @@
+warning: creating an intermediate reference implies aliasing requirements even when immediately cast to a raw pointers
+  --> $DIR/raw-borrows-via-references-parenthesized-issue-161693.rs:10:13
+   |
+LL |     let y = (&x as *const i32).read_volatile();
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/raw-borrows-via-references-parenthesized-issue-161693.rs:6:9
+   |
+LL | #![warn(raw_borrows_via_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider using `&raw const` for a safer and more explicit raw pointer
+   |
+LL -     let y = (&x as *const i32).read_volatile();
+LL +     let y = &raw const x).read_volatile();
+   |
+
+warning: creating an intermediate reference implies aliasing requirements even when immediately cast to a raw pointers
+  --> $DIR/raw-borrows-via-references-parenthesized-issue-161693.rs:17:5
+   |
+LL |     (&mut x as *mut i32).write_volatile(13);
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `&raw mut` for a safer and more explicit raw pointer
+   |
+LL -     (&mut x as *mut i32).write_volatile(13);
+LL +     &raw mut x).write_volatile(13);
+   |
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
Fixes rust-lang/rust#161693