### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -494,7 +494,7 @@ impl<'a> TraitDef<'a> {
                     Some(Attribute::Parsed(AttributeKind::Repr { reprs, .. })) if reprs.iter().any(|(x, _)| matches!(x, ReprPacked(..)))
                 );
 
-                let newitem = match &item.kind {
+                let mut newitem = match &item.kind {
                     ast::ItemKind::Struct(ident, generics, struct_def) => self.expand_struct_def(
                         cx,
                         struct_def,
@@ -530,8 +530,7 @@ impl<'a> TraitDef<'a> {
                 };
                 // Keep the lint attributes of the previous item to control how the
                 // generated implementations are linted
-                let mut attrs = newitem.attrs.clone();
-                attrs.extend(
+                newitem.attrs.extend(
                     item.attrs
                         .iter()
                         .filter(|a| {
@@ -546,7 +545,7 @@ impl<'a> TraitDef<'a> {
                         })
                         .cloned(),
                 );
-                push(Annotatable::Item(Box::new(ast::Item { attrs, ..(*newitem).clone() })))
+                push(Annotatable::Item(newitem))
             }
             _ => unreachable!(),
         }

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/covfun.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use rustc_abi::Align;
 use rustc_codegen_ssa::traits::{BaseTypeCodegenMethods as _, ConstCodegenMethods};
 use rustc_middle::mir::coverage::{
-    BasicCoverageBlock, CounterId, CovTerm, CoverageIdsInfo, Expression, ExpressionId,
-    FunctionCoverageInfo, Mapping, MappingKind, Op,
+    BasicCoverageBlock, CounterId, CovTerm, CoverageCodegenInfo, CoverageMirInfo, Expression,
+    ExpressionId, Mapping, MappingKind, Op,
 };
 use rustc_middle::ty::{Instance, TyCtxt};
 use rustc_span::{SourceFile, Span};
@@ -52,22 +52,22 @@ pub(crate) fn prepare_covfun_record<'tcx>(
     instance: Instance<'tcx>,
     is_used: bool,
 ) -> Option<CovfunRecord<'tcx>> {
-    let fn_cov_info = tcx.instance_mir(instance.def).function_coverage_info.as_deref()?;
-    let ids_info = tcx.coverage_ids_info(instance.def)?;
+    let mir_info = tcx.instance_mir(instance.def).coverage_mir_info.as_deref()?;
+    let cg_info = tcx.coverage_codegen_info(instance.def)?;
 
-    let expressions = prepare_expressions(ids_info);
+    let expressions = prepare_expressions(cg_info);
 
     let mut covfun = CovfunRecord {
         _instance: instance,
         mangled_function_name: tcx.symbol_name(instance).name,
-        source_hash: if is_used { fn_cov_info.function_source_hash } else { 0 },
+        source_hash: if is_used { mir_info.function_source_hash } else { 0 },
         is_used,
         virtual_file_mapping: VirtualFileMapping::default(),
         expressions,
         regions: llvm_cov::Regions::default(),
     };
 
-    fill_region_tables(tcx, fn_cov_info, ids_info, &mut covfun);
+    fill_region_tables(tcx, mir_info, cg_info, &mut covfun);
 
     if covfun.regions.has_no_regions() {
         debug!(?covfun, "function has no mappings to embed; skipping");
@@ -91,12 +91,12 @@ pub(crate) fn counter_for_term(term: CovTerm) -> ffi::Counter {
 }
 
 /// Convert the function's coverage-counter expressions into a form suitable for FFI.
-fn prepare_expressions(ids_info: &CoverageIdsInfo) -> Vec<ffi::CounterExpression> {
+fn prepare_expressions(cg_info: &CoverageCodegenInfo) -> Vec<ffi::CounterExpression> {
     // We know that LLVM will optimize out any unused expressions before
     // producing the final coverage map, so there's no need to do the same
     // thing on the Rust side unless we're confident we can do much better.
     // (See `CounterExpressionsMinimizer` in `CoverageMappingWriter.cpp`.)
-    ids_info
+    cg_info
         .expressions
         .iter()
         .map(move |&Expression { lhs, op, rhs }| ffi::CounterExpression {
@@ -113,14 +113,14 @@ fn prepare_expressions(ids_info: &CoverageIdsInfo) -> Vec<ffi::CounterExpression
 /// Populates the mapping region tables in the current function's covfun record.
 fn fill_region_tables<'tcx>(
     tcx: TyCtxt<'tcx>,
-    fn_cov_info: &'tcx FunctionCoverageInfo,
-    ids_info: &'tcx CoverageIdsInfo,
+    mir_info: &'tcx CoverageMirInfo,
+    cg_info: &'tcx CoverageCodegenInfo,
     covfun: &mut CovfunRecord<'tcx>,
 ) {
     // If this function is unused, replace all counters with zero.
     let counter_for_bcb = |bcb: BasicCoverageBlock| -> ffi::Counter {
         let term = if covfun.is_used {
-            ids_info.term_for_bcb[bcb].expect("every BCB in a mapping was given a term")
+            cg_info.term_for_bcb[bcb].expect("every BCB in a mapping was given a term")
         } else {
             CovTerm::Zero
         };
@@ -130,7 +130,7 @@ fn fill_region_tables<'tcx>(
     // Currently a function's mappings must all be in the same file, so use the
     // first mapping's span to determine the file.
     let source_map = tcx.sess.source_map();
-    let Some(first_span) = (try { fn_cov_info.mappings.first()?.span }) else {
+    let Some(first_span) = (try { mir_info.mappings.first()?.span }) else {
         debug_assert!(false, "function has no mappings: {covfun:?}");
         return;
     };
@@ -155,7 +155,7 @@ fn fill_region_tables<'tcx>(
 
     // For each counter/region pair in this function+file, convert it to a
     // form suitable for FFI.
-    for &Mapping { ref kind, span } in &fn_cov_info.mappings {
+    for &Mapping { ref kind, span } in &mir_info.mappings {
         let Some(coords) = make_coords(span) else { continue };
         let cov_span = coords.make_coverage_span(local_file_id);
 

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/unused.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen/unused.rs
@@ -145,7 +145,7 @@ fn prepare_usage_sets<'tcx>(tcx: TyCtxt<'tcx>) -> UsageSets<'tcx> {
             }
         }
 
-        if !saw_own_coverage && body.function_coverage_info.is_some() {
+        if !saw_own_coverage && body.coverage_mir_info.is_some() {
             missing_own_coverage.insert(def_id);
         }
     }

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
@@ -101,14 +101,12 @@ impl<'tcx> CoverageInfoBuilderMethods<'tcx> for Builder<'_, '_, 'tcx> {
         // FIXME(Zalathar): Find a better solution for mixed-coverage builds.
         let Some(_coverage_cx) = &bx.cx.coverage_cx else { return };
 
-        let Some(function_coverage_info) =
-            bx.tcx.instance_mir(instance.def).function_coverage_info.as_deref()
-        else {
+        let Some(mir_info) = bx.tcx.instance_mir(instance.def).coverage_mir_info.as_deref() else {
             debug!("function has a coverage statement but no coverage info");
             return;
         };
-        let Some(ids_info) = bx.tcx.coverage_ids_info(instance.def) else {
-            debug!("function has a coverage statement but no IDs info");
+        let Some(cg_info) = bx.tcx.coverage_codegen_info(instance.def) else {
+            debug!("function has a coverage statement but no codegen info");
             return;
         };
 
@@ -117,11 +115,11 @@ impl<'tcx> CoverageInfoBuilderMethods<'tcx> for Builder<'_, '_, 'tcx> {
                 "marker statement {kind:?} should have been removed by CleanupPostBorrowck"
             ),
             CoverageKind::VirtualCounter { bcb }
-                if let Some(&id) = ids_info.phys_counter_for_node.get(&bcb) =>
+                if let Some(&id) = cg_info.phys_counter_for_node.get(&bcb) =>
             {
                 let fn_name = bx.ensure_pgo_func_name_var(instance);
-                let hash = bx.const_u64(function_coverage_info.function_source_hash);
-                let num_counters = bx.const_u32(ids_info.num_counters);
+                let hash = bx.const_u64(mir_info.function_source_hash);
+                let num_counters = bx.const_u32(cg_info.num_counters);
                 let index = bx.const_u32(id.as_u32());
                 debug!(
                     "codegen intrinsic instrprof.increment(fn_name={:?}, hash={:?}, num_counters={:?}, index={:?})",

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -79,7 +79,7 @@ pub enum CoverageKind {
     SpanMarker,
 
     /// Marks its enclosing basic block with an ID that can be referred to by
-    /// side data in [`CoverageInfoHi`].
+    /// side data in [`CoverageEarlyInfo`].
     ///
     /// Should be erased before codegen (at some point after `InstrumentCoverage`).
     BlockMarker { id: BlockMarkerId },
@@ -144,12 +144,11 @@ pub struct Mapping {
     pub span: Span,
 }
 
-/// Stores per-function coverage information attached to a `mir::Body`,
-/// to be used in conjunction with the individual coverage statements injected
-/// into the function's basic blocks.
+/// Coverage information for a function, collected during the `InstrumentCoverage`
+/// MIR pass and stored in the `mir::Body` for later use by coverage codegen.
 #[derive(Clone, Debug)]
 #[derive(TyEncodable, TyDecodable, Hash, StableHash)]
-pub struct FunctionCoverageInfo {
+pub struct CoverageMirInfo {
     pub function_source_hash: u64,
 
     /// Used in conjunction with `priority_list` to create physical counters
@@ -160,15 +159,17 @@ pub struct FunctionCoverageInfo {
     pub mappings: Vec<Mapping>,
 }
 
-/// Coverage information for a function, recorded during MIR building and
-/// attached to the corresponding `mir::Body`. Used by the `InstrumentCoverage`
-/// MIR pass.
+/// Coverage information for a function, collected in advance at the THIR/MIR
+/// boundary during MIR building, and attached to the corresponding `mir::Body`.
 ///
-/// ("Hi" indicates that this is "high-level" information collected at the
-/// THIR/MIR boundary, before the MIR-based coverage instrumentation pass.)
+/// This side-data is "early" in that it must be collected prior to the main
+/// instrumentation step, in contrast to the main [`CoverageMirInfo`] produced
+/// by instrumentation itself.
+///
+/// Used by the `InstrumentCoverage` MIR pass.
 #[derive(Clone, Debug)]
 #[derive(TyEncodable, TyDecodable, Hash, StableHash)]
-pub struct CoverageInfoHi {
+pub struct CoverageEarlyInfo {
     /// 1 more than the highest-numbered [`CoverageKind::BlockMarker`] that was
     /// injected into the MIR body. This makes it possible to allocate per-ID
     /// data structures without having to scan the entire body first.
@@ -187,9 +188,9 @@ pub struct BranchSpan {
 /// Contains information needed during codegen, obtained by inspecting the
 /// function's MIR after MIR optimizations.
 ///
-/// Returned by the `coverage_ids_info` query.
+/// Returned by the [`coverage_codegen_info`](crate::ty::TyCtxt::coverage_codegen_info) query.
 #[derive(Clone, TyEncodable, TyDecodable, Debug, StableHash)]
-pub struct CoverageIdsInfo {
+pub struct CoverageCodegenInfo {
     pub num_counters: u32,
     pub phys_counter_for_node: FxIndexMap<BasicCoverageBlock, CounterId>,
     pub term_for_bcb: IndexVec<BasicCoverageBlock, Option<CovTerm>>,

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -310,14 +310,14 @@ pub struct Body<'tcx> {
 
     pub tainted_by_errors: Option<ErrorGuaranteed>,
 
-    /// Coverage information collected from THIR/MIR during MIR building,
-    /// to be used by the `InstrumentCoverage` pass.
+    /// Coverage information collected at the THIR/MIR boundary during MIR
+    /// building, to be used by the `InstrumentCoverage` pass.
     ///
     /// Only present if coverage is enabled and this function is eligible.
     /// Boxed to limit space overhead in non-coverage builds.
     #[type_foldable(identity)]
     #[type_visitable(ignore)]
-    pub coverage_info_hi: Option<Box<coverage::CoverageInfoHi>>,
+    pub coverage_early_info: Option<Box<coverage::CoverageEarlyInfo>>,
 
     /// Per-function coverage information added by the `InstrumentCoverage`
     /// pass, to be used in conjunction with the coverage statements injected
@@ -327,7 +327,7 @@ pub struct Body<'tcx> {
     /// is not eligible for coverage, then this should always be `None`.
     #[type_foldable(identity)]
     #[type_visitable(ignore)]
-    pub function_coverage_info: Option<Box<coverage::FunctionCoverageInfo>>,
+    pub coverage_mir_info: Option<Box<coverage::CoverageMirInfo>>,
 }
 
 impl<'tcx> Body<'tcx> {
@@ -369,8 +369,8 @@ impl<'tcx> Body<'tcx> {
             is_polymorphic: false,
             injection_phase: None,
             tainted_by_errors,
-            coverage_info_hi: None,
-            function_coverage_info: None,
+            coverage_early_info: None,
+            coverage_mir_info: None,
         };
         body.is_polymorphic = body.has_non_region_param();
         body
@@ -400,8 +400,8 @@ impl<'tcx> Body<'tcx> {
             is_polymorphic: false,
             injection_phase: None,
             tainted_by_errors: None,
-            coverage_info_hi: None,
-            function_coverage_info: None,
+            coverage_early_info: None,
+            coverage_mir_info: None,
         };
         body.is_polymorphic = body.has_non_region_param();
         body

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -630,21 +630,21 @@ fn write_mir_intro<'tcx>(
     // Add an empty line before the first block is printed.
     writeln!(w)?;
 
-    if let Some(coverage_info_hi) = &body.coverage_info_hi {
-        write_coverage_info_hi(coverage_info_hi, w)?;
+    if let Some(early_info) = &body.coverage_early_info {
+        write_coverage_early_info(early_info, w)?;
     }
-    if let Some(function_coverage_info) = &body.function_coverage_info {
-        write_function_coverage_info(function_coverage_info, w)?;
+    if let Some(mir_info) = &body.coverage_mir_info {
+        write_coverage_mir_info(mir_info, w)?;
     }
 
     Ok(())
 }
 
-fn write_coverage_info_hi(
-    coverage_info_hi: &coverage::CoverageInfoHi,
+fn write_coverage_early_info(
+    early_info: &coverage::CoverageEarlyInfo,
     w: &mut dyn io::Write,
 ) -> io::Result<()> {
-    let coverage::CoverageInfoHi { num_block_markers: _, branch_spans } = coverage_info_hi;
+    let coverage::CoverageEarlyInfo { num_block_markers: _, branch_spans } = early_info;
 
     // Only add an extra trailing newline if we printed at least one thing.
     let mut did_print = false;
@@ -664,11 +664,11 @@ fn write_coverage_info_hi(
     Ok(())
 }
 
-fn write_function_coverage_info(
-    function_coverage_info: &coverage::FunctionCoverageInfo,
+fn write_coverage_mir_info(
+    mir_info: &coverage::CoverageMirInfo,
     w: &mut dyn io::Write,
 ) -> io::Result<()> {
-    let coverage::FunctionCoverageInfo { mappings, .. } = function_coverage_info;
+    let coverage::CoverageMirInfo { mappings, .. } = mir_info;
 
     for coverage::Mapping { kind, span } in mappings {
         writeln!(w, "{INDENT}coverage {kind:?} => {span:?};")?;

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -415,7 +415,7 @@ pub enum StatementKind<'tcx> {
     ///
     /// Coverage statements are used in conjunction with the coverage mappings and other
     /// information stored in the function's
-    /// [`mir::Body::function_coverage_info`](crate::mir::Body::function_coverage_info).
+    /// [`mir::Body::coverage_mir_info`](crate::mir::Body::coverage_mir_info).
     /// (For inlined MIR, take care to look up the *original function's* coverage info.)
     ///
     /// Interpreters and codegen backends that don't support coverage instrumentation

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -747,13 +747,11 @@ rustc_queries! {
     /// intrinsics, and the expression tables to be embedded in the function's
     /// coverage metadata.
     ///
-    /// FIXME(Zalathar): This query's purpose has drifted a bit and should
-    /// probably be renamed, but that can wait until after the potential
-    /// follow-ups to #136053 have settled down.
-    ///
     /// Returns `None` for functions that were not instrumented.
-    query coverage_ids_info(key: ty::InstanceKind<'tcx>) -> Option<&'tcx mir::coverage::CoverageIdsInfo> {
-        desc { "retrieving coverage IDs info from MIR for `{}`", tcx.def_path_str(key.def_id()) }
+    query coverage_codegen_info(key: ty::InstanceKind<'tcx>)
+        -> Option<&'tcx mir::coverage::CoverageCodegenInfo>
+    {
+        desc { "retrieving coverage codegen info from MIR for `{}`", tcx.def_path_str(key.def_id()) }
         arena_cache
     }
 

--- a/compiler/rustc_mir_build/src/builder/coverageinfo.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo.rs
@@ -2,7 +2,7 @@ use std::assert_matches;
 use std::collections::hash_map::Entry;
 
 use rustc_data_structures::fx::FxHashMap;
-use rustc_middle::mir::coverage::{BlockMarkerId, BranchSpan, CoverageInfoHi, CoverageKind};
+use rustc_middle::mir::coverage::{BlockMarkerId, BranchSpan, CoverageEarlyInfo, CoverageKind};
 use rustc_middle::mir::{self, BasicBlock, SourceInfo, UnOp};
 use rustc_middle::thir::{ExprId, ExprKind, Pat, Thir};
 use rustc_middle::ty::TyCtxt;
@@ -11,7 +11,7 @@ use rustc_span::def_id::LocalDefId;
 use crate::builder::{Builder, CFG};
 
 /// Collects coverage-related information during MIR building, to eventually be
-/// turned into a function's [`CoverageInfoHi`] when MIR building is complete.
+/// turned into a function's [`CoverageEarlyInfo`] when MIR building is complete.
 pub(crate) struct CoverageInfoBuilder {
     /// Maps condition expressions to their enclosing `!`, for better instrumentation.
     nots: FxHashMap<ExprId, NotInfo>,
@@ -147,7 +147,7 @@ impl CoverageInfoBuilder {
         });
     }
 
-    pub(crate) fn into_done(self) -> Box<CoverageInfoHi> {
+    pub(crate) fn into_done(self) -> Box<CoverageEarlyInfo> {
         let Self { nots: _, markers: BlockMarkerGen { num_block_markers }, branch_info } = self;
 
         let branch_spans =
@@ -155,10 +155,10 @@ impl CoverageInfoBuilder {
 
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.
-        Box::new(CoverageInfoHi { num_block_markers, branch_spans })
+        Box::new(CoverageEarlyInfo { num_block_markers, branch_spans })
     }
 
-    pub(crate) fn as_done(&self) -> Box<CoverageInfoHi> {
+    pub(crate) fn as_done(&self) -> Box<CoverageEarlyInfo> {
         let &Self { nots: _, markers: BlockMarkerGen { num_block_markers }, ref branch_info } =
             self;
 
@@ -170,7 +170,7 @@ impl CoverageInfoBuilder {
 
         // For simplicity, always return an info struct (without Option), even
         // if there's nothing interesting in it.
-        Box::new(CoverageInfoHi { num_block_markers, branch_spans })
+        Box::new(CoverageEarlyInfo { num_block_markers, branch_spans })
     }
 }
 

--- a/compiler/rustc_mir_build/src/builder/custom/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/custom/mod.rs
@@ -60,8 +60,8 @@ pub(super) fn build_custom_mir<'tcx>(
         tainted_by_errors: None,
         injection_phase: None,
         pass_count: 0,
-        coverage_info_hi: None,
-        function_coverage_info: None,
+        coverage_early_info: None,
+        coverage_mir_info: None,
     };
 
     body.local_decls.push(LocalDecl::new(return_ty, return_ty_span));

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -839,7 +839,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.coroutine.clone(),
             None,
         );
-        body.coverage_info_hi = self.coverage_info.as_ref().map(|b| b.as_done());
+        body.coverage_early_info = self.coverage_info.as_ref().map(|b| b.as_done());
 
         let writer = pretty::MirWriter::new(self.tcx);
         writer.write_mir_fn(&body, &mut std::io::stdout()).unwrap();
@@ -858,7 +858,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.coroutine,
             None,
         );
-        body.coverage_info_hi = self.coverage_info.map(|b| b.into_done());
+        body.coverage_early_info = self.coverage_info.map(|b| b.into_done());
 
         let writer = pretty::MirWriter::new(self.tcx);
         for (index, block) in body.basic_blocks.iter().enumerate() {

--- a/compiler/rustc_mir_transform/src/coverage/expansion.rs
+++ b/compiler/rustc_mir_transform/src/coverage/expansion.rs
@@ -173,8 +173,8 @@ pub(crate) fn build_expn_tree(
 
     // Associate each branch span (recorded during MIR building) with its
     // corresponding expansion tree node.
-    if let Some(coverage_info_hi) = mir_body.coverage_info_hi.as_deref() {
-        for branch_span in &coverage_info_hi.branch_spans {
+    if let Some(early_info) = mir_body.coverage_early_info.as_deref() {
+        for branch_span in &early_info.branch_spans {
             if let Some(node) = nodes.get_mut(&branch_span.span.ctxt()) {
                 node.branch_spans.push(BranchSpan::clone(branch_span));
             }

--- a/compiler/rustc_mir_transform/src/coverage/mappings.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mappings.rs
@@ -1,6 +1,6 @@
 use rustc_index::IndexVec;
 use rustc_middle::mir::coverage::{
-    BlockMarkerId, BranchSpan, CoverageInfoHi, CoverageKind, Mapping, MappingKind,
+    BlockMarkerId, BranchSpan, CoverageEarlyInfo, CoverageKind, Mapping, MappingKind,
 };
 use rustc_middle::mir::{self, BasicBlock, StatementKind};
 use rustc_middle::ty::TyCtxt;
@@ -48,12 +48,12 @@ pub(crate) fn extract_mappings_from_mir<'tcx>(
 }
 
 fn resolve_block_markers(
-    coverage_info_hi: &CoverageInfoHi,
+    early_info: &CoverageEarlyInfo,
     mir_body: &mir::Body<'_>,
 ) -> IndexVec<BlockMarkerId, Option<BasicBlock>> {
     let mut block_markers = IndexVec::<BlockMarkerId, Option<BasicBlock>>::from_elem_n(
         None,
-        coverage_info_hi.num_block_markers,
+        early_info.num_block_markers,
     );
 
     // Fill out the mapping from block marker IDs to their enclosing blocks.
@@ -75,8 +75,8 @@ fn extract_branch_mappings(
     expn_tree: &ExpnTree,
     mappings: &mut Vec<Mapping>,
 ) {
-    let Some(coverage_info_hi) = mir_body.coverage_info_hi.as_deref() else { return };
-    let block_markers = resolve_block_markers(coverage_info_hi, mir_body);
+    let Some(early_info) = mir_body.coverage_early_info.as_deref() else { return };
+    let block_markers = resolve_block_markers(early_info, mir_body);
 
     // For now, ignore any branch span that was introduced by
     // expansion. This makes things like assert macros less noisy.

--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -1,4 +1,4 @@
-use rustc_middle::mir::coverage::{CoverageKind, FunctionCoverageInfo};
+use rustc_middle::mir::coverage::{CoverageKind, CoverageMirInfo};
 use rustc_middle::mir::{self, BasicBlock, Statement, StatementKind, TerminatorKind};
 use rustc_middle::ty::TyCtxt;
 use tracing::{debug, debug_span, trace};
@@ -87,7 +87,7 @@ fn instrument_function_for_coverage<'tcx>(tcx: TyCtxt<'tcx>, mir_body: &mut mir:
     // Inject coverage statements into MIR.
     inject_coverage_statements(mir_body, &graph);
 
-    mir_body.function_coverage_info = Some(Box::new(FunctionCoverageInfo {
+    mir_body.coverage_mir_info = Some(Box::new(CoverageMirInfo {
         function_source_hash: hir_info.function_source_hash,
 
         node_flow_data,

--- a/compiler/rustc_mir_transform/src/coverage/query.rs
+++ b/compiler/rustc_mir_transform/src/coverage/query.rs
@@ -2,7 +2,9 @@ use rustc_hir::attrs::CoverageAttrKind;
 use rustc_hir::find_attr;
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
-use rustc_middle::mir::coverage::{BasicCoverageBlock, CoverageIdsInfo, CoverageKind, MappingKind};
+use rustc_middle::mir::coverage::{
+    BasicCoverageBlock, CoverageCodegenInfo, CoverageKind, MappingKind,
+};
 use rustc_middle::mir::{Body, Statement, StatementKind};
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_middle::util::Providers;
@@ -16,7 +18,7 @@ use crate::coverage::counters::{CoverageCounters, transcribe_counters};
 pub(crate) fn provide(providers: &mut Providers) {
     providers.queries.is_eligible_for_coverage = is_eligible_for_coverage;
     providers.queries.coverage_attr_on = coverage_attr_on;
-    providers.queries.coverage_ids_info = coverage_ids_info;
+    providers.queries.coverage_codegen_info = coverage_codegen_info;
 }
 
 /// Query implementation for [`TyCtxt::is_eligible_for_coverage`].
@@ -75,17 +77,17 @@ fn coverage_attr_on(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     }
 }
 
-/// Query implementation for `coverage_ids_info`.
-fn coverage_ids_info<'tcx>(
+/// Query implementation for [`TyCtxt::coverage_codegen_info`].
+fn coverage_codegen_info<'tcx>(
     tcx: TyCtxt<'tcx>,
     instance_def: ty::InstanceKind<'tcx>,
-) -> Option<CoverageIdsInfo> {
+) -> Option<CoverageCodegenInfo> {
     let mir_body = tcx.instance_mir(instance_def);
-    let fn_cov_info = mir_body.function_coverage_info.as_deref()?;
+    let mir_info = mir_body.coverage_mir_info.as_deref()?;
 
     // Scan through the final MIR to see which BCBs survived MIR opts.
     // Any BCB not in this set was optimized away.
-    let mut bcbs_seen = DenseBitSet::new_empty(fn_cov_info.priority_list.len());
+    let mut bcbs_seen = DenseBitSet::new_empty(mir_info.priority_list.len());
     for kind in all_coverage_in_mir_body(mir_body) {
         match *kind {
             CoverageKind::VirtualCounter { bcb } => {
@@ -99,8 +101,8 @@ fn coverage_ids_info<'tcx>(
     // need a counter. Any node not in this set will only get a counter if it
     // is part of the counter expression for a node that is in the set.
     let mut bcb_needs_counter =
-        DenseBitSet::<BasicCoverageBlock>::new_empty(fn_cov_info.priority_list.len());
-    for mapping in &fn_cov_info.mappings {
+        DenseBitSet::<BasicCoverageBlock>::new_empty(mir_info.priority_list.len());
+    for mapping in &mir_info.mappings {
         match mapping.kind {
             MappingKind::Code { bcb } => {
                 bcb_needs_counter.insert(bcb);
@@ -113,7 +115,7 @@ fn coverage_ids_info<'tcx>(
     }
 
     // Clone the priority list so that we can re-sort it.
-    let mut priority_list = fn_cov_info.priority_list.clone();
+    let mut priority_list = mir_info.priority_list.clone();
     // The first ID in the priority list represents the synthetic "sink" node,
     // and must remain first so that it _never_ gets a physical counter.
     debug_assert_eq!(priority_list[0], priority_list.iter().copied().max().unwrap());
@@ -125,14 +127,14 @@ fn coverage_ids_info<'tcx>(
     // (The original ordering remains in effect within both partitions.)
     priority_list[1..].sort_by_key(|&bcb| !bcbs_seen.contains(bcb));
 
-    let node_counters = make_node_counters(&fn_cov_info.node_flow_data, &priority_list);
+    let node_counters = make_node_counters(&mir_info.node_flow_data, &priority_list);
     let coverage_counters = transcribe_counters(&node_counters, &bcb_needs_counter, &bcbs_seen);
 
     let CoverageCounters {
         phys_counter_for_node, next_counter_id, node_counters, expressions, ..
     } = coverage_counters;
 
-    Some(CoverageIdsInfo {
+    Some(CoverageCodegenInfo {
         num_counters: next_counter_id.as_u32(),
         phys_counter_for_node,
         term_for_bcb: node_counters,

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -221,7 +221,6 @@ fn common_inputs_stamp(config: &Config) -> Stamp {
         "src/etc/gdb_load_rust_pretty_printers.py",
         "src/etc/gdb_lookup.py",
         "src/etc/gdb_providers.py",
-        "src/etc/lldb_batchmode",
         "src/etc/lldb_lookup.py",
         "src/etc/lldb_providers.py",
     ];
@@ -231,6 +230,7 @@ fn common_inputs_stamp(config: &Config) -> Stamp {
     }
 
     stamp.add_dir(&src_root.join("src/etc/natvis"));
+    stamp.add_dir(&src_root.join("src/etc/lldb_batchmode"));
 
     stamp.add_dir(&config.target_run_lib_path);
 
@@ -506,7 +506,7 @@ fn files_related_to_test(
     config: &Config,
     testpaths: &TestPaths,
     aux_props: &AuxProps,
-    revision: Option<&str>,
+    variant: &TestVariant,
 ) -> Vec<Utf8PathBuf> {
     let mut related = vec![];
 
@@ -533,12 +533,29 @@ fn files_related_to_test(
 
     // UI test files.
     for extension in UI_EXTENSIONS {
-        let path = expected_output_path(testpaths, revision, &config.compare_mode, extension);
+        let path =
+            expected_output_path(testpaths, variant.revision(), &config.compare_mode, extension);
         related.push(path);
     }
 
     // `minicore.rs` test auxiliary: we need to make sure tests get rerun if this changes.
     related.push(config.src_root.join("tests").join("auxiliary").join("minicore.rs"));
+
+    // `tests/debuginfo` blessed files
+    match variant.debugger {
+        Some(debugger @ Debugger::Lldb | debugger @ Debugger::Gdb) => {
+            let bless_path: Utf8PathBuf =
+                testpaths.file.parent().unwrap().join(format!("{}_input", debugger.to_str()));
+            if bless_path.is_dir() {
+                related.extend(
+                    WalkDir::new(bless_path)
+                        .into_iter()
+                        .map(|entry| Utf8PathBuf::from(entry.unwrap().path().to_str().unwrap())),
+                );
+            }
+        }
+        Some(Debugger::Cdb) | None => {}
+    }
 
     related
 }
@@ -572,7 +589,7 @@ fn is_up_to_date(
     // Check the timestamp of the stamp file against the last modified time
     // of all files known to be relevant to the test.
     let mut inputs_stamp = cx.common_inputs_stamp.clone();
-    for path in files_related_to_test(&cx.config, testpaths, aux_props, variant.revision()) {
+    for path in files_related_to_test(&cx.config, testpaths, aux_props, variant) {
         inputs_stamp.add_path(&path);
     }
 

--- a/tests/ui/codegen/target-cpus.rs
+++ b/tests/ui/codegen/target-cpus.rs
@@ -1,10 +1,4 @@
 //@ needs-llvm-components: webassembly
 //@ compile-flags: --print=target-cpus --target=wasm32-unknown-unknown
 //@ check-pass
-
-// LLVM at HEAD has added support for the `lime1` CPU. Remove it from the
-// output so that the stdout with LLVM-at-HEAD matches the output of the LLVM
-// versions currently used by default.
-// FIXME(#133919): Once Rust upgrades to LLVM 20, remove this.
-//@ normalize-stdout: "(?m)^ *lime1\n" -> ""
 //@ ignore-backends: gcc

--- a/tests/ui/codegen/target-cpus.stdout
+++ b/tests/ui/codegen/target-cpus.stdout
@@ -1,4 +1,5 @@
 Available CPUs for this target:
     bleeding-edge
     generic       - This is the default target CPU for the current build target (currently wasm32-unknown-unknown).
+    lime1
     mvp


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#162004 (Remove unneeded clone in macro deriving)
 - rust-lang/rust#161902 (coverage: Rename the three main coverage-info structs)
 - rust-lang/rust#161967 (Rerun `tests/debuginfo` tests if repr data has changed)
 - rust-lang/rust#161977 (update target-cpus test)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=162004,161902,161967,161977)
<!-- homu-ignore:end -->

