### PR TITLE
unseal std::io::IsTerminal

### DIFF
--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -1197,7 +1197,7 @@ pub(crate) fn attempt_print_to_stderr(args: fmt::Arguments<'_>) {
 
 /// Trait to determine if a descriptor/handle refers to a terminal/tty.
 #[stable(feature = "is_terminal", since = "1.70.0")]
-pub impl(crate) trait IsTerminal {
+pub trait IsTerminal {
     /// Returns `true` if the descriptor/handle refers to a terminal/tty.
     ///
     /// On platforms where Rust does not know how to detect a terminal yet, this will return


### PR DESCRIPTION
- Closes rust-lang/rust#161989
- See also: rust-lang/rust#161947

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
