### PR TITLE
Fix toml syntax in bors config

### DIFF
--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -83,8 +83,8 @@ runner_group_id = 8
 label_prefix = "ec2"
 region = "us-east-2"
 images = {
-    "x86_64ami" = "latest-gha-runner-ami"
-    "arm64ami" = "latest-gha-runner-ami-arm64"
+    "x86_64ami" = "latest-gha-runner-ami",
+    "arm64ami" = "latest-gha-runner-ami-arm64",
 }
 jit_runner = "organization"
 allowed_instances = [


### PR DESCRIPTION
bors production is logging "Could not deserialize repository config: missing comma between key-value pairs, expected `,`" for at least a week (since landing https://github.com/rust-lang/rust/pull/161562, I think). I assume it would fail to start if restarted? (Reproducible here: https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=9e7d78b0ae002de5d73c9c9f8f518f38).

I think we'll want to follow up to gate bors *merging* a PR breaking the toml syntax, I cut https://github.com/rust-lang/bors/issues/829 to track that.

r? @Kobzol