### PR TITLE
Recover inner attributes in algebraic data types

### DIFF
--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -545,4 +545,18 @@ impl<'a> Parser<'a> {
 
         Ok(())
     }
+
+    /// Parse inner attributes and error if they are present
+    /// Returns whether any inner attributes were discarded
+    pub fn recover_inner_attributes(&mut self) -> PResult<'a, bool> {
+        let attributes = self.parse_inner_attributes()?;
+        for attr in &attributes {
+            self.error_on_forbidden_inner_attr(
+                attr.span,
+                InnerAttrPolicy::Forbidden(Some(InnerAttrForbiddenReason::InCodeBlock)),
+                true,
+            );
+        }
+        Ok(!attributes.is_empty())
+    }
 }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1936,6 +1936,9 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_enum_variant(&mut self, span: Span) -> PResult<'a, Option<Variant>> {
+        if self.recover_inner_attributes()? && self.check(exp![CloseBrace]) {
+            return Ok(None);
+        }
         self.recover_vcs_conflict_marker();
         let variant_attrs = self.parse_outer_attributes()?;
         self.recover_vcs_conflict_marker();
@@ -2139,6 +2142,7 @@ impl<'a> Parser<'a> {
         let mut fields = ThinVec::new();
         let mut recovered = Recovered::No;
         if self.eat(exp!(OpenBrace)) {
+            self.recover_inner_attributes()?;
             while self.token != token::CloseBrace {
                 match self.parse_field_def(adt_ty, ident_span) {
                     Ok(field) => {

--- a/tests/ui/parser/empty-adt-inner-attributes.rs
+++ b/tests/ui/parser/empty-adt-inner-attributes.rs
@@ -1,0 +1,17 @@
+struct Test1 {
+    #![inline]
+    //~^ ERROR an inner attribute is not permitted in this context
+}
+
+enum Test2 {
+    #![inline]
+    //~^ ERROR an inner attribute is not permitted in this context
+}
+
+union Test3 {
+    //~^ ERROR unions cannot have zero fields
+    #![inline]
+    //~^ ERROR an inner attribute is not permitted in this context
+}
+
+fn main() { }

--- a/tests/ui/parser/empty-adt-inner-attributes.stderr
+++ b/tests/ui/parser/empty-adt-inner-attributes.stderr
@@ -1,23 +1,14 @@
 error: an inner attribute is not permitted in this context
-  --> $DIR/empty-struct-inner-attributes.rs:2:5
+  --> $DIR/empty-adt-inner-attributes.rs:2:5
    |
 LL |     #![inline]
    |     ^^^^^^^^^^
    |
    = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
    = note: outer attributes, like `#[test]`, annotate the item following them
-
-error: expected identifier, found `}`
-  --> $DIR/empty-struct-inner-attributes.rs:4:1
-   |
-LL | struct Test1 {
-   |        ----- while parsing this struct
-...
-LL | }
-   | ^ expected identifier
 
 error: an inner attribute is not permitted in this context
-  --> $DIR/empty-struct-inner-attributes.rs:7:5
+  --> $DIR/empty-adt-inner-attributes.rs:7:5
    |
 LL |     #![inline]
    |     ^^^^^^^^^^
@@ -25,16 +16,24 @@ LL |     #![inline]
    = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
    = note: outer attributes, like `#[test]`, annotate the item following them
 
-error: expected identifier, found `}`
-  --> $DIR/empty-struct-inner-attributes.rs:9:1
+error: an inner attribute is not permitted in this context
+  --> $DIR/empty-adt-inner-attributes.rs:13:5
    |
-LL | enum Test2 {
-   |      ----- while parsing this enum
-...
-LL | }
-   | ^ expected identifier
+LL |     #![inline]
+   |     ^^^^^^^^^^
    |
-   = help: enum variants can be `Variant`, `Variant = <integer>`, `Variant(Type, ..., TypeN)` or `Variant { fields: Types }`
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
+
+error: unions cannot have zero fields
+  --> $DIR/empty-adt-inner-attributes.rs:11:1
+   |
+LL | / union Test3 {
+LL | |
+LL | |     #![inline]
+LL | |
+LL | | }
+   | |_^
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/parser/empty-adt-inner-attributes.stderr
+++ b/tests/ui/parser/empty-adt-inner-attributes.stderr
@@ -1,0 +1,40 @@
+error: an inner attribute is not permitted in this context
+  --> $DIR/empty-struct-inner-attributes.rs:2:5
+   |
+LL |     #![inline]
+   |     ^^^^^^^^^^
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
+
+error: expected identifier, found `}`
+  --> $DIR/empty-struct-inner-attributes.rs:4:1
+   |
+LL | struct Test1 {
+   |        ----- while parsing this struct
+...
+LL | }
+   | ^ expected identifier
+
+error: an inner attribute is not permitted in this context
+  --> $DIR/empty-struct-inner-attributes.rs:7:5
+   |
+LL |     #![inline]
+   |     ^^^^^^^^^^
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
+
+error: expected identifier, found `}`
+  --> $DIR/empty-struct-inner-attributes.rs:9:1
+   |
+LL | enum Test2 {
+   |      ----- while parsing this enum
+...
+LL | }
+   | ^ expected identifier
+   |
+   = help: enum variants can be `Variant`, `Variant = <integer>`, `Variant(Type, ..., TypeN)` or `Variant { fields: Types }`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Previously, if you'd put an inner attribute in an empty ADT, such as a struct:
```rust
struct Test1 {
    #![inline]
}
```
You'd get the following errors
```
error: an inner attribute is not permitted in this context
 --> src/lib.rs:5:5
  |
5 |     #![cfg(false)]
  |     ^^^^^^^^^^^^^^
  |
  = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
  = note: outer attributes, like `#[test]`, annotate the item following them

error: expected identifier, found `}`
 --> src/lib.rs:6:1
  |
4 | struct Test3 {
  |        ----- while parsing this struct
5 |     #![cfg(false)]
6 | }
  | ^ expected identifier

error: could not compile `rust-test` (lib) due to 2 previous errors
```

The second error is spurious. It was caused by us only recovering inner attributes just before parsing a field, meaning if we see an inner attribute and recover we expect a field next. This PR fixes that by recovering inner attributes just after the curly brace as well.

