### PR TITLE
Emit delayed bug instead of ICEing when `TypeOutlives` goal fails

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -657,6 +657,15 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         span_bug!(span, "coerce requirement gave wrong error: `{:?}`", predicate)
                     }
 
+                    ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(..))
+                        if self.next_trait_solver() =>
+                    {
+                        // We normalize `TypeOutlives` in the next solver, which is fallible
+                        return self.dcx().span_delayed_bug(
+                            span,
+                            "type outlives claues errored outside borrowck without any other error",
+                        );
+                    }
                     ty::PredicateKind::Clause(ty::ClauseKind::RegionOutlives(..))
                     | ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(..)) => {
                         span_bug!(

--- a/tests/ui/traits/next-solver/outlives-goal-error-due-to-normalization-failure-no-ice.rs
+++ b/tests/ui/traits/next-solver/outlives-goal-error-due-to-normalization-failure-no-ice.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -Znext-solver
+
+// Regression test for <https://github.com/rust-lang/rust/issues/161527>
+
+trait Z<'a, T: ?Sized>
+where
+    T: Z<'a, ()>, //~ ERROR: the trait bound `(): Z<'a, ()>` is not satisfied
+    for<'b> <T as Z<'b, ()>>::W: 'a,
+{
+    type W;
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/outlives-goal-error-due-to-normalization-failure-no-ice.stderr
+++ b/tests/ui/traits/next-solver/outlives-goal-error-due-to-normalization-failure-no-ice.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `(): Z<'a, ()>` is not satisfied
+  --> $DIR/outlives-goal-error-due-to-normalization-failure-no-ice.rs:7:8
+   |
+LL |     T: Z<'a, ()>,
+   |        ^^^^^^^^^ the trait `Z<'a, ()>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/outlives-goal-error-due-to-normalization-failure-no-ice.rs:5:1
+   |
+LL | trait Z<'a, T: ?Sized>
+   | ^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `Z`
+  --> $DIR/outlives-goal-error-due-to-normalization-failure-no-ice.rs:7:8
+   |
+LL | trait Z<'a, T: ?Sized>
+   |       - required by a bound in this trait
+LL | where
+LL |     T: Z<'a, ()>,
+   |        ^^^^^^^^^ required by this bound in `Z`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes rust-lang/rust#161527 

They can actually fail with the next-solver 😄 

https://github.com/rust-lang/rust/blob/2e071b28ef7e8a066b49a179e1da753c53500c62/compiler/rustc_next_trait_solver/src/solve/mod.rs#L88-L93

I have once considered tinkering proof tree/`find_best_leaf_obligation` to make it suggest the failed normalization goal but I doubt it worths the extra complexity, since we prolly already have other failing obligations in these cases

r? adwinwhite