### PR TITLE
remove more trivial regions in evaluate_added_goals_and_make_canonical_response

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -18,8 +18,8 @@ use rustc_type_ir::solve::{
 };
 use rustc_type_ir::{
     self as ty, CanonicalVarValues, ClauseKind, InferCtxtLike, Interner, MayBeErased,
-    OpaqueTypeKey, PredicateKind, Region, TypeFoldable, TypeSuperVisitable, TypeVisitable,
-    TypeVisitableExt, TypeVisitor, TypingMode, eager_resolve_vars,
+    OpaqueTypeKey, PredicateKind, Region, RegionVid, TypeFoldable, TypeSuperVisitable,
+    TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode, eager_resolve_vars, max_universe,
 };
 use thin_vec::ThinVec;
 use tracing::{Level, debug, instrument, trace, warn};
@@ -1606,6 +1606,75 @@ where
         let mut unique = HashSet::default();
         if let ExternalRegionConstraints::Old(r) = &mut external_constraints.region_constraints {
             r.retain(|(outlives, _)| !outlives.is_trivial() && unique.insert(*outlives));
+        }
+
+        #[derive(Default)]
+        struct NonTrivialVars {
+            vars: HashSet<RegionVid>,
+        }
+        impl<I> TypeVisitor<I> for NonTrivialVars
+        where
+            I: Interner,
+        {
+            type Result = ();
+            fn visit_ty(&mut self, t: I::Ty) {
+                // If a nested type doesn't have any `ReVar`s, then we won't insert
+                // anything into `vars` anyway, so skip for better perf.
+                if !t.has_infer_regions() {
+                    return;
+                }
+                t.super_visit_with(self);
+            }
+            fn visit_const(&mut self, c: I::Const) {
+                // The same goes for consts.
+                if !c.has_infer_regions() {
+                    return;
+                }
+                c.super_visit_with(self);
+            }
+            fn visit_region(&mut self, r: Region<I>) {
+                if let ty::ReVar(vid) = r.kind() {
+                    self.vars.insert(vid);
+                }
+            }
+        }
+
+        // If we have a constraint like `'re: '?1`, where '?1 can name 're and '?1 appears
+        // only on the RHS of region constraints, then this kind of constraint is also trivial,
+        // since we're able to pick '?1 := 'empty, and 're: 'empty is always true for any 're.
+        if let ExternalRegionConstraints::Old(r) = &mut external_constraints.region_constraints
+            && !r.is_empty()
+        {
+            let mut vis = NonTrivialVars::default();
+            var_values.visit_with(&mut vis);
+            // We have to visit each component of `external_constraints` individually here
+            // because we skip the RHS of outlives constraints, and `TypeVisitor` doesn't
+            // have a method we can easily override in order to do this.
+            external_constraints.opaque_types.visit_with(&mut vis);
+            external_constraints.normalization_nested_goals.visit_with(&mut vis);
+            for (constraint, _) in r.iter() {
+                match constraint {
+                    ty::RegionConstraint::Outlives(ty::OutlivesClause(sup, _)) => {
+                        sup.visit_with(&mut vis)
+                    }
+                    ty::RegionConstraint::Eq(eq) => eq.visit_with(&mut vis),
+                }
+            }
+
+            r.retain(|(outlives, _)| {
+                if let ty::RegionConstraint::Outlives(ty::OutlivesClause(sup, re)) = *outlives
+                    && let Some(sup_re) = sup.as_region()
+                    && let ty::RegionKind::ReVar(vid) = re.kind()
+                    // This is only safe if we call `eager_resolve_vars` beforehand,
+                    // which we do.
+                    && self.delegate.universe_of_lt(vid).unwrap()
+                        .can_name(max_universe(&**self.delegate, sup_re))
+                {
+                    vis.vars.contains(&vid)
+                } else {
+                    true
+                }
+            });
         }
 
         let canonical = canonicalize_response(

--- a/tests/ui/traits/next-solver/no-dedup-universes.rs
+++ b/tests/ui/traits/next-solver/no-dedup-universes.rs
@@ -1,0 +1,21 @@
+//@ compile-flags: -Znext-solver -Zno-leak-check
+
+//! Make sure we don't drop trivial-looking region constraints that would otherwise fail
+//! leak check.
+
+trait Trait {}
+trait Other<'a, 'b> {}
+
+struct Foo;
+// We need this indirection because something direct like `for<'a> &'a (): 'b` gives us a
+// TypeOutlives constraint, whereas we want to be testing how we handle RegionOutlives, and
+// only `impl Other for Bar`'s where-clause can give us that.
+impl<'b> Trait for Foo where for<'a> Bar: Other<'a, 'b> {}
+
+struct Bar;
+impl<'a, 'b> Other<'a, 'b> for Bar where 'a: 'b {}
+
+fn f<T: Trait>(_: T) {}
+
+fn main() { f(Foo); }
+//~^ ERROR higher-ranked lifetime error

--- a/tests/ui/traits/next-solver/no-dedup-universes.stderr
+++ b/tests/ui/traits/next-solver/no-dedup-universes.stderr
@@ -1,0 +1,10 @@
+error: higher-ranked lifetime error
+  --> $DIR/no-dedup-universes.rs:20:13
+   |
+LL | fn main() { f(Foo); }
+   |             ^^^^^^
+   |
+   = note: could not prove `Foo: Trait`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162032)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

cc rust-lang/rust#161575. I don't think it *fixes* the issue per se, since the most principled fix would be to just deny unconstrained lifetime args like we do for types and consts already. At the very least, though, it Makes Things Go Faster.

In the example from https://github.com/rust-lang/rust/issues/161575#issuecomment-5385036070, each `'unconstrained` appears only once in the entire response: in the rhs of the `'a: 'unconstrained#N` bound. Since they are mentioned nowhere else and are created only when proving our own nested goals, these outlives constraints are all satisfiable by setting `'unconstrained := 'empty`, which tells us nothing about `'a`. Therefore, (I think) that makes it safe to treat all of these constraints as trivial and drop them entirely, drop all of these requirements entirely, similar to what we already do with reflexive or duplicate region constraints. In other words, if a `ReVar` appears only once in the entire response, and that place is the rhs of an outlives constraint, then it is safe to drop that constraint.

I'm a little worried about the perf impact of the visitor on "normal" code, but fwiw even a 100-deep nested version of the reproducer compiles in about 0.05s on my machine.

r? lcnr