### PR TITLE
Make the LLVM version mismatch ICE a fatal error

### DIFF
--- a/compiler/rustc_codegen_llvm/src/diagnostics.rs
+++ b/compiler/rustc_codegen_llvm/src/diagnostics.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::{CString, c_uint};
 use std::path::Path;
 
 use rustc_data_structures::small_c_str::SmallCStr;
@@ -264,4 +264,16 @@ pub(crate) struct IntrinsicWrongArch<'a> {
 #[note("features must begin with a `+` to enable or `-` to disable it")]
 pub(crate) struct UnknownLlvmTargetFeaturePrefix<'a> {
     pub feature: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag(
+    "LLVM version mismatch: this compiler was built for LLVM {$expected_version}, but LLVM {$llvm_major}.{$llvm_minor}.{$llvm_patch} was found{$dll_loc}"
+)]
+pub(crate) struct LlvmVersionMismatch<'a> {
+    pub expected_version: c_uint,
+    pub llvm_major: c_uint,
+    pub llvm_minor: c_uint,
+    pub llvm_patch: c_uint,
+    pub dll_loc: &'a str,
 }

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -56,20 +56,17 @@ unsafe fn configure_llvm(sess: &Session) {
         llvm::LLVMGetVersion(&mut llvm_major, &mut llvm_minor, &mut llvm_patch);
         let expected_version = llvm::LLVMRustVersionMajor();
         if llvm_major != expected_version {
-            panic!(
-                concat!(
-                    "LLVM version mismatch: this compiler was built for LLVM {}, ",
-                    "but LLVM {}.{}.{} was found{}"
-                ),
+            sess.dcx().emit_fatal(diagnostics::LlvmVersionMismatch {
                 expected_version,
                 llvm_major,
                 llvm_minor,
                 llvm_patch,
-                match rustc_session::filesearch::dll_path(llvm::LLVMGetVersion as *mut _) {
+                dll_loc: &match rustc_session::filesearch::dll_path(llvm::LLVMGetVersion as *mut _)
+                {
                     Ok(path) => format!(" at {}", path.display()),
                     Err(_) => String::new(),
-                }
-            );
+                },
+            })
         }
     }
 

--- a/compiler/rustc_macros/src/diagnostics/message.rs
+++ b/compiler/rustc_macros/src/diagnostics/message.rs
@@ -133,6 +133,7 @@ const ALLOWED_CAPITALIZED_WORDS: &[&str] = &[
     "Cargo",
     "Ferris",
     "GCC",
+    "LLVM",
     "MIR",
     "NaNs",
     "OK",


### PR DESCRIPTION
It was pointed out to me that the diatnostic in https://github.com/rust-lang/rust/pull/161788 has the usual ICE messages about how this is a bug and we'd appreciate a report. But it isn't, and a fatal error is a better way to report the problem. Manually tested on MacOS:
```
$ export DYLD_LIBRARY_PATH=/opt/homebrew/opt/llvm@21/lib
$ rustc +stage1 --print=sysroot
error: LLVM version mismatch: this compiler was built for LLVM 23, but LLVM 21.1.8 was found at /opt/homebrew/Cellar/llvm@21/21.1.8/lib/libLLVM.dylib

$ unset DYLD_LIBRARY_PATH
$ rustc +stage1 --print=sysroot
/Users/ben.kimock/rust/build/aarch64-apple-darwin/stage1
```