### PR TITLE
Avoid global trait caches while defining opaque types

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1477,8 +1477,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             // it's not worth going to more trouble to increase the
             // hit-rate, I don't think.
             TypingMode::Coherence => false,
-            // Avoid using the global cache when we're defining opaque types
-            // as their hidden type may impact the result of candidate selection.
+            // Avoid using the global cache when defining opaque types, as goals can
+            // indirectly depend on them without mentioning them directly. See #159932.
             TypingMode::Typeck { defining_opaque_types_and_generators: defining_opaque_types }
             | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types } => {
                 defining_opaque_types.is_empty()

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1479,16 +1479,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             TypingMode::Coherence => false,
             // Avoid using the global cache when we're defining opaque types
             // as their hidden type may impact the result of candidate selection.
-            //
-            // HACK: This is still theoretically unsound. Goals can indirectly rely
-            // on opaques in the defining scope, and it's easier to do so with TAIT.
-            // However, if we disqualify *all* goals from being cached, perf suffers.
-            // This is likely fixed by better caching in general in the new solver.
-            // See: <https://github.com/rust-lang/rust/issues/132064>.
             TypingMode::Typeck { defining_opaque_types_and_generators: defining_opaque_types }
             | TypingMode::PostTypeckUntilBorrowck { defining_opaque_types } => {
                 defining_opaque_types.is_empty()
-                    || (!pred.has_opaque_types() && !pred.has_coroutines())
             }
             // Impls that are not fully generic are completely ignored as "nonexistent"
             // in this mode, so the results wildly differ from normal trait solving.

--- a/tests/incremental/issue-159932.rs
+++ b/tests/incremental/issue-159932.rs
@@ -1,0 +1,34 @@
+//@ revisions: bpass1 bpass2
+//@ edition: 2024
+//@ compile-flags: --emit=obj
+//@ ignore-backends: gcc
+
+use std::future::{Future, ready};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+struct Join<I>(I);
+
+impl<I: IntoIterator> Future for Join<I> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<()> {
+        loop {}
+    }
+}
+
+fn spawn(_: impl Future + Send) {}
+
+async fn bar() {
+    Join([ready(())].into_iter().map(async |ready| ready.await)).await;
+}
+
+fn main() {
+    spawn(async {
+        #[cfg(bpass1)]
+        let _ = bar().await;
+
+        #[cfg(bpass2)]
+        let result = bar().await;
+    });
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->


Fixes rust-lang/rust#159932.

The old trait solver stores evaluated obligations in a global cache so they can be reused across inference contexts. While type checking a body that defines opaque types or coroutines, it avoided the global cache only when the current predicate mentioned one directly.

However, that check was insufficient. A predicate can depend on an opaque type through another obligation without mentioning the opaque type itself. A small source change could alter the order in which obligations were evaluated and therefore change the contents of the global cache. On the next incremental build, rustc could evaluate the same query key with different cache state and produce a different result. Incremental verification detected the changed fingerprint and raised the ICE.

So, this PR removes that exception. While a body defines opaque types or coroutines, the old trait solver now uses only the inference context's local caches. (These still avoid repeated work during the current type-checking run, but results are no longer shared between inference contexts where they may depend on an opaque type being defined.)

Do note that this may reduce global cache hits for async code and return-position `impl Trait`. It also removes part of the caching compromise introduced in rust-lang/rust#132625 for the compile-time regression tracked in rust-lang/rust#132064.


