### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -21,19 +21,16 @@ use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::IndexVec;
-use rustc_infer::infer::{NllRegionVariableOrigin, TyCtxtInferExt};
-use rustc_infer::traits::ObligationCause;
+use rustc_infer::infer::NllRegionVariableOrigin;
 use rustc_macros::extension;
 use rustc_middle::mir::RETURN_PLACE;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{
     self, BoundVariableKind, GenericArgs, GenericArgsRef, InlineConstArgs, InlineConstArgsParts,
-    List, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, TypingMode,
-    fold_regions,
+    List, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, fold_regions,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{ErrorGuaranteed, kw, sym};
-use rustc_trait_selection::traits::ObligationCtxt;
 use tracing::{debug, instrument};
 
 use crate::BorrowckInferCtxt;
@@ -136,32 +133,22 @@ pub(crate) enum DefiningTy<'tcx> {
     GlobalAsm(DefId),
 }
 
-fn normalized_type_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
-    let ty = tcx.type_of(def_id).instantiate_identity();
-    if !tcx.next_trait_solver_globally() {
-        return ty.skip_normalization();
-    }
-
-    let typing_mode = if tcx.use_typing_mode_post_typeck_until_borrowck() {
-        TypingMode::borrowck(tcx, def_id)
-    } else {
-        TypingMode::analysis_in_body(tcx, def_id)
-    };
-    let infcx = tcx.infer_ctxt().build(typing_mode);
-    let ocx = ObligationCtxt::new(&infcx);
-    let span = tcx.def_span(def_id);
-    let cause = ObligationCause::misc(span, def_id);
-    ocx.deeply_normalize(&cause, tcx.param_env(def_id), ty).unwrap()
-}
-
 impl<'tcx> DefiningTy<'tcx> {
     #[instrument(level = "debug", skip(tcx), ret)]
     fn new(tcx: TyCtxt<'tcx>, body_def_id: LocalDefId) -> DefiningTy<'tcx> {
         match tcx.hir_body_owner_kind(body_def_id) {
             BodyOwnerKind::Closure | BodyOwnerKind::Fn => {
-                // Normalize after instantiation so coroutine yield/resume
-                // types in the args are rigid under the next solver.
-                let defining_ty = normalized_type_of(tcx, body_def_id);
+                let defining_ty =
+                    tcx.type_of(body_def_id).instantiate_identity().skip_normalization();
+                let defining_ty = if tcx.next_trait_solver_globally() {
+                    // Closure types come from HIR typeck results, where they were already
+                    // normalized during writeback. Wrapping them in an `EarlyBinder`
+                    // conservatively makes aliases non-rigid, so restore their rigidness
+                    // instead of normalizing them again during borrowck.
+                    ty::set_aliases_to_rigid(tcx, defining_ty)
+                } else {
+                    defining_ty
+                };
                 match *defining_ty.kind() {
                     ty::Closure(def_id, args) => DefiningTy::Closure(def_id, args),
                     ty::Coroutine(def_id, args) => DefiningTy::Coroutine(def_id, args),

--- a/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
+++ b/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
@@ -19,8 +19,6 @@ extern "C" void LLVMRustSetLastError(const char *);
 enum class LLVMRustResult { Success, Failure };
 
 typedef struct OpaqueRustString *RustStringRef;
-typedef struct LLVMOpaqueTwine *LLVMTwineRef;
-typedef struct LLVMOpaqueSMDiagnostic *LLVMSMDiagnosticRef;
 
 extern "C" void LLVMRustStringWriteImpl(RustStringRef buf,
                                         const char *slice_ptr,

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -66,10 +66,8 @@ using namespace llvm;
 
 static codegen::RegisterCodeGenFlags CGF;
 
-typedef struct LLVMOpaquePass *LLVMPassRef;
 typedef struct LLVMOpaqueTargetMachine *LLVMTargetMachineRef;
 
-DEFINE_STDCXX_CONVERSION_FUNCTIONS(Pass, LLVMPassRef)
 DEFINE_STDCXX_CONVERSION_FUNCTIONS(TargetMachine, LLVMTargetMachineRef)
 
 extern "C" void LLVMRustTimeTraceProfilerInitialize() {

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1199,11 +1199,9 @@ extern "C" void LLVMRustWriteValueToString(LLVMValueRef V, RustStringRef Str) {
   }
 }
 
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(Twine, LLVMTwineRef)
-
-extern "C" void LLVMRustWriteTwineToString(LLVMTwineRef T, RustStringRef Str) {
+extern "C" void LLVMRustWriteTwineToString(const Twine *T, RustStringRef Str) {
   auto OS = RawRustStringOstream(Str);
-  unwrap(T)->print(OS);
+  T->print(OS);
 }
 
 extern "C" void LLVMRustUnpackOptimizationDiagnostic(
@@ -1239,13 +1237,13 @@ enum class LLVMRustDiagnosticLevel {
 
 extern "C" void LLVMRustUnpackInlineAsmDiagnostic(
     LLVMDiagnosticInfoRef DI, LLVMRustDiagnosticLevel *LevelOut,
-    uint64_t *CookieOut, LLVMTwineRef *MessageOut) {
+    uint64_t *CookieOut, const Twine **MessageOut) {
   // Undefined to call this not on an inline assembly diagnostic!
   llvm::DiagnosticInfoInlineAsm *IA =
       static_cast<llvm::DiagnosticInfoInlineAsm *>(unwrap(DI));
 
   *CookieOut = IA->getLocCookie();
-  *MessageOut = wrap(&IA->getMsgStr());
+  *MessageOut = &IA->getMsgStr();
 
   switch (IA->getSeverity()) {
   case DS_Error:
@@ -1334,22 +1332,20 @@ LLVMRustGetDiagInfoKind(LLVMDiagnosticInfoRef DI) {
   return toRust((DiagnosticKind)unwrap(DI)->getKind());
 }
 
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(SMDiagnostic, LLVMSMDiagnosticRef)
-
-extern "C" LLVMSMDiagnosticRef LLVMRustGetSMDiagnostic(LLVMDiagnosticInfoRef DI,
+extern "C" const SMDiagnostic *LLVMRustGetSMDiagnostic(LLVMDiagnosticInfoRef DI,
                                                        uint64_t *Cookie) {
   llvm::DiagnosticInfoSrcMgr *SM =
       static_cast<llvm::DiagnosticInfoSrcMgr *>(unwrap(DI));
   *Cookie = SM->getLocCookie();
-  return wrap(&SM->getSMDiag());
+  return &SM->getSMDiag();
 }
 
 extern "C" bool
-LLVMRustUnpackSMDiagnostic(LLVMSMDiagnosticRef DRef, RustStringRef MessageOut,
+LLVMRustUnpackSMDiagnostic(const SMDiagnostic *DRef, RustStringRef MessageOut,
                            RustStringRef BufferOut,
                            LLVMRustDiagnosticLevel *LevelOut, unsigned *LocOut,
                            unsigned *RangesOut, size_t *NumRanges) {
-  SMDiagnostic &D = *unwrap(DRef);
+  const SMDiagnostic &D = *DRef;
   auto MessageOS = RawRustStringOstream(MessageOut);
   MessageOS << D.getMessage();
 

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -33,7 +33,6 @@ use rustc_hir::{self as hir, BindingMode, ByRef, HirId, ItemLocalId, Node, find_
 use rustc_index::bit_set::GrowableBitSet;
 use rustc_index::{Idx, IndexSlice, IndexVec};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
-use rustc_infer::traits::ObligationCause;
 use rustc_middle::hir::place::PlaceBase as HirPlaceBase;
 use rustc_middle::middle::region;
 use rustc_middle::mir::*;
@@ -41,7 +40,6 @@ use rustc_middle::thir::{self, ExprId, LocalVarId, Param, ParamId, PatKind, Thir
 use rustc_middle::ty::{self, ScalarInt, Ty, TyCtxt, TypeVisitableExt, TypingMode};
 use rustc_middle::{bug, span_bug};
 use rustc_span::{Span, Symbol};
-use rustc_trait_selection::traits::ObligationCtxt;
 
 use crate::builder::expr::as_place::PlaceBuilder;
 use crate::builder::scope::LintLevel;
@@ -508,7 +506,17 @@ fn construct_fn<'tcx>(
 
     let infcx = tcx.infer_ctxt().build(typing_mode);
 
-    let coroutine = match normalized_type_of(&infcx, fn_def).kind() {
+    let defining_ty = tcx.type_of(fn_def).instantiate_identity().skip_normalization();
+    let defining_ty = if infcx.next_trait_solver() {
+        // Closure types come from HIR typeck results, where they were already
+        // normalized during writeback. Wrapping them in an `EarlyBinder`
+        // conservatively makes aliases non-rigid, so restore their rigidness
+        // instead of normalizing them again during MIR build.
+        ty::set_aliases_to_rigid(tcx, defining_ty)
+    } else {
+        defining_ty
+    };
+    let coroutine = match defining_ty.kind() {
         ty::Coroutine(_, args) => Some(Box::new(CoroutineInfo::initial(
             tcx.coroutine_kind(fn_def).unwrap(),
             args.as_coroutine().yield_ty(),
@@ -564,18 +572,6 @@ fn construct_fn<'tcx>(
     };
 
     body
-}
-
-fn normalized_type_of<'tcx>(infcx: &InferCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
-    let tcx = infcx.tcx;
-    let ty = tcx.type_of(def_id).instantiate_identity();
-    if !infcx.next_trait_solver() {
-        return ty.skip_normalization();
-    }
-
-    let ocx = ObligationCtxt::new(infcx);
-    let cause = ObligationCause::misc(tcx.def_span(def_id), def_id);
-    ocx.deeply_normalize(&cause, tcx.param_env(def_id), ty).unwrap()
 }
 
 fn construct_const<'a, 'tcx>(

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -657,6 +657,15 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         span_bug!(span, "coerce requirement gave wrong error: `{:?}`", predicate)
                     }
 
+                    ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(..))
+                        if self.next_trait_solver() =>
+                    {
+                        // We normalize `TypeOutlives` in the next solver, which is fallible
+                        return self.dcx().span_delayed_bug(
+                            span,
+                            "type outlives claues errored outside borrowck without any other error",
+                        );
+                    }
                     ty::PredicateKind::Clause(ty::ClauseKind::RegionOutlives(..))
                     | ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(..)) => {
                         span_bug!(

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -112,10 +112,11 @@ impl<I: Interner> AliasTyKind<I> {
 /// with `IsRigid::Yes`. At this point we no longer have to try and renormalize this alias
 /// later on.
 ///
-/// Rigidness is shared across inference contexts and compiler phases. For example, aliases
-/// normalized during HIR typeck can remain rigid when the resulting type is later used by
-/// borrowck. They must be made non-rigid again if they enter a typing mode or parameter
-/// environment in which further normalization may be possible.
+/// Rigidness becomes outdated when the surrounding typing mode or param env changes,
+/// because further normalization might be possible.
+/// We should also note that rigidness can be shared within some typing mode groups
+/// if the param env is the same, e.g., `Typeck/PostTypeckUntilBorrowck` and
+/// `PostAnalysis/Codegen`.
 ///
 /// FIXME(#155345): Alias handling is currently still in flux for the new trait
 /// solver and this is currently somewhat messy. Please reach out on

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -112,6 +112,11 @@ impl<I: Interner> AliasTyKind<I> {
 /// with `IsRigid::Yes`. At this point we no longer have to try and renormalize this alias
 /// later on.
 ///
+/// Rigidness is shared across inference contexts and compiler phases. For example, aliases
+/// normalized during HIR typeck can remain rigid when the resulting type is later used by
+/// borrowck. They must be made non-rigid again if they enter a typing mode or parameter
+/// environment in which further normalization may be possible.
+///
 /// FIXME(#155345): Alias handling is currently still in flux for the new trait
 /// solver and this is currently somewhat messy. Please reach out on
 /// #t-types/trait-system-refactor-initiative if you encounter this and it isn't

--- a/tests/ui/traits/next-solver/outlives-goal-error-due-to-normalization-failure-no-ice.rs
+++ b/tests/ui/traits/next-solver/outlives-goal-error-due-to-normalization-failure-no-ice.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -Znext-solver
+
+// Regression test for <https://github.com/rust-lang/rust/issues/161527>
+
+trait Z<'a, T: ?Sized>
+where
+    T: Z<'a, ()>, //~ ERROR: the trait bound `(): Z<'a, ()>` is not satisfied
+    for<'b> <T as Z<'b, ()>>::W: 'a,
+{
+    type W;
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/outlives-goal-error-due-to-normalization-failure-no-ice.stderr
+++ b/tests/ui/traits/next-solver/outlives-goal-error-due-to-normalization-failure-no-ice.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `(): Z<'a, ()>` is not satisfied
+  --> $DIR/outlives-goal-error-due-to-normalization-failure-no-ice.rs:7:8
+   |
+LL |     T: Z<'a, ()>,
+   |        ^^^^^^^^^ the trait `Z<'a, ()>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/outlives-goal-error-due-to-normalization-failure-no-ice.rs:5:1
+   |
+LL | trait Z<'a, T: ?Sized>
+   | ^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `Z`
+  --> $DIR/outlives-goal-error-due-to-normalization-failure-no-ice.rs:7:8
+   |
+LL | trait Z<'a, T: ?Sized>
+   |       - required by a bound in this trait
+LL | where
+LL |     T: Z<'a, ()>,
+   |        ^^^^^^^^^ required by this bound in `Z`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#161926 (borrowck: Restore alias rigidity from HIR typeck)
 - rust-lang/rust#162026 (Emit delayed bug instead of ICEing when `TypeOutlives` goal fails)
 - rust-lang/rust#162037 (LLVM wrapper cleanups)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=161926,162026,162037)
<!-- homu-ignore:end -->

