### PR TITLE
Fix a compile error on the ESP-IDF target

### DIFF
--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -67,7 +67,7 @@ impl Thread {
             assert_eq!(
                 libc::pthread_attr_setstacksize(
                     attr.get(),
-                    cmp::max(stack, min_stack_size(attr.as_ptr()))
+                    cmp::max(stack, min_stack_size(attr.get()))
                 ),
                 0
             );


### PR DESCRIPTION
PR rust-lang/rust#160848 accidentally broke the Tier-3 ESP-IDF target by leaving out one reference to `attr.as_ptr()` which should've been changed to `attr.get()`.

This PR does the absolute minimum to restore correct behavior for the ESP-IDF target (and Nuttx).

CC
@joboet 
@nia-e 
