### PR TITLE
remove `_{style}` recovery for diagnostic structs

### DIFF
--- a/compiler/rustc_macros/src/diagnostics/utils.rs
+++ b/compiler/rustc_macros/src/diagnostics/utils.rs
@@ -13,7 +13,6 @@ use syn::spanned::Spanned;
 use syn::{Attribute, Field, LitStr, Meta, Path, Token, Type, TypeTuple, parenthesized};
 use synstructure::{BindingInfo, VariantInfo};
 
-use super::error::invalid_attr;
 use crate::diagnostics::error::{
     DiagnosticDeriveError, span_err, throw_invalid_attr, throw_span_err,
 };
@@ -542,16 +541,6 @@ impl SuggestionKind {
             }
         }
     }
-
-    fn from_suffix(s: &str) -> Option<Self> {
-        match s {
-            "" => Some(SuggestionKind::Normal),
-            "_short" => Some(SuggestionKind::Short),
-            "_hidden" => Some(SuggestionKind::Hidden),
-            "_verbose" => Some(SuggestionKind::Verbose),
-            _ => None,
-        }
-    }
 }
 
 /// Types of subdiagnostics that can be created using attributes
@@ -569,7 +558,7 @@ pub(super) enum SubdiagnosticKind {
     HelpOnce,
     /// `#[warning(...)]`
     Warn,
-    /// `#[suggestion{,_short,_hidden,_verbose}]`
+    /// `#[suggestion(..)]`
     Suggestion {
         suggestion_kind: SuggestionKind,
         applicability: SpannedOption<Applicability>,
@@ -580,7 +569,7 @@ pub(super) enum SubdiagnosticKind {
         /// `let __formatted_code = /* whatever */;`
         code_init: TokenStream,
     },
-    /// `#[multipart_suggestion{,_short,_hidden,_verbose}]`
+    /// `#[multipart_suggestion(..)]`
     MultipartSuggestion {
         suggestion_kind: SuggestionKind,
         applicability: SpannedOption<Applicability>,
@@ -618,44 +607,18 @@ impl SubdiagnosticVariant {
             "help" => SubdiagnosticKind::Help,
             "help_once" => SubdiagnosticKind::HelpOnce,
             "warning" => SubdiagnosticKind::Warn,
+            "suggestion" => SubdiagnosticKind::Suggestion {
+                suggestion_kind: SuggestionKind::Normal,
+                applicability: None,
+                code_field: new_code_ident(),
+                code_init: TokenStream::new(),
+            },
+            "multipart_suggestion" => SubdiagnosticKind::MultipartSuggestion {
+                suggestion_kind: SuggestionKind::Normal,
+                applicability: None,
+            },
             _ => {
-                // Recover old `#[(multipart_)suggestion_*]` syntaxes
-                // FIXME(#100717): remove
-                if let Some(suggestion_kind) =
-                    name.strip_prefix("suggestion").and_then(SuggestionKind::from_suffix)
-                {
-                    if suggestion_kind != SuggestionKind::Normal {
-                        invalid_attr(attr)
-                            .help(format!(
-                                r#"Use `#[suggestion(..., style = "{suggestion_kind}")]` instead"#
-                            ))
-                            .emit();
-                    }
-
-                    SubdiagnosticKind::Suggestion {
-                        suggestion_kind: SuggestionKind::Normal,
-                        applicability: None,
-                        code_field: new_code_ident(),
-                        code_init: TokenStream::new(),
-                    }
-                } else if let Some(suggestion_kind) =
-                    name.strip_prefix("multipart_suggestion").and_then(SuggestionKind::from_suffix)
-                {
-                    if suggestion_kind != SuggestionKind::Normal {
-                        invalid_attr(attr)
-                            .help(format!(
-                                r#"Use `#[multipart_suggestion(..., style = "{suggestion_kind}")]` instead"#
-                            ))
-                            .emit();
-                    }
-
-                    SubdiagnosticKind::MultipartSuggestion {
-                        suggestion_kind: SuggestionKind::Normal,
-                        applicability: None,
-                    }
-                } else {
-                    throw_invalid_attr!(attr);
-                }
+                throw_invalid_attr!(attr);
             }
         };
 

--- a/compiler/rustc_macros/src/lib.rs
+++ b/compiler/rustc_macros/src/lib.rs
@@ -191,10 +191,7 @@ decl_derive!(
         primary_span,
         label,
         subdiagnostic,
-        suggestion,
-        suggestion_short,
-        suggestion_hidden,
-        suggestion_verbose)] =>
+        suggestion)] =>
         #[doc = "See <https://rustc-dev-guide.rust-lang.org/diagnostics/diagnostic-structs.html#derivediagnostic>"]
         diagnostics::diagnostic_derive
 );
@@ -209,12 +206,7 @@ decl_derive!(
         warning,
         subdiagnostic,
         suggestion,
-        suggestion_short,
-        suggestion_hidden,
-        suggestion_verbose,
         multipart_suggestion,
-        multipart_suggestion_short,
-        multipart_suggestion_hidden,
         // field attributes
         primary_span,
         suggestion_part,

--- a/src/doc/rustc-dev-guide/src/diagnostics/diagnostic-structs.md
+++ b/src/doc/rustc-dev-guide/src/diagnostics/diagnostic-structs.md
@@ -152,7 +152,7 @@ tcx.dcx().emit_err(FieldAlreadyDeclared {
   - _Applied to struct or struct fields of type `Span`, `Option<()>`, `bool`, or `()`._
   - Adds a warning subdiagnostic.
   - Value is the warning's message.
-- `#[suggestion{,_hidden,_short,_verbose}("message", code = "...", applicability = "...")]`
+- `#[suggestion("message", code = "...", applicability = "...", style = "...")]`
   (_Optional_)
   - _Applied to `(Span, MachineApplicability)` or `Span` fields._
   - Adds a suggestion subdiagnostic.
@@ -165,6 +165,9 @@ tcx.dcx().emit_err(FieldAlreadyDeclared {
   - `applicability = "..."` (_Optional_)
     - String which must be one of `machine-applicable`, `maybe-incorrect`,
       `has-placeholders` or `unspecified`.
+  - `style = "..."` (_Optional_)
+    - Value is the style of the suggestion.
+    - String which must be one of `normal`, `short`, `hidden`, `verbose` or `tool-only`.
 - `#[subdiagnostic]`
   - _Applied to a type that implements `Subdiagnostic` (from `#[derive(Subdiagnostic)]`)._
   - Adds the subdiagnostic represented by the subdiagnostic struct.
@@ -209,7 +212,7 @@ Each `Subdiagnostic` should have one attribute applied to the struct or each var
 - `#[note(..)]` for defining a note
 - `#[help(..)]` for defining a help
 - `#[warning(..)]` for defining a warning
-- `#[suggestion{,_hidden,_short,_verbose}(..)]` for defining a suggestion
+- `#[suggestion(..)]` for defining a suggestion
 
 All of the above must provide a diagnostic message as the first positional argument.
 See [translation documentation](./translation.md) to learn more about how
@@ -305,7 +308,7 @@ Additionally, subdiagnostics can access arguments from the main diagnostic with 
   - Message (_Mandatory_)
     - The diagnostic message that will be shown to the user.
     - See [translation documentation](./translation.md).
-- `#[suggestion{,_hidden,_short,_verbose}("message", code = "...", applicability = "...")]`
+- `#[suggestion("message", code = "...", applicability = "...", style = "...")]`
   - _Applied to struct or enum variant.
     Mutually exclusive with struct/enum variant attributes._
   - _Mandatory_
@@ -324,13 +327,22 @@ Additionally, subdiagnostics can access arguments from the main diagnostic with 
       - `maybe-incorrect`
       - `has-placeholders`
       - `unspecified`
-- `#[multipart_suggestion{,_hidden,_short,_verbose}("message", applicability = "...")]`
+  - `style = "..."` (_Optional_)
+    - Value is the style of the suggestion.
+    - String which must be one of:
+      - `normal` (the default)
+      - `short`
+      - `hidden`
+      - `verbose`
+      - `tool-only`
+- `#[multipart_suggestion("message", applicability = "...", style = "...")]`
   - _Applied to struct or enum variant.
     Mutually exclusive with struct/enum variant attributes._
   - _Mandatory_
   - Defines the type to be representing a multipart suggestion.
   - Message (_Mandatory_): see `#[suggestion]`
   - `applicability = "..."` (_Optional_): see `#[suggestion]`
+  - `style = "..."` (_Optional_): see `#[suggestion]`
 - `#[primary_span]` (_Mandatory_ for labels and suggestions; _optional_ otherwise; not applicable
 to multipart suggestions)
   - _Applied to `Span` fields._

--- a/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive-inline.rs
+++ b/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive-inline.rs
@@ -746,7 +746,8 @@ struct SuggestionStyleTwice {
 
 #[derive(Subdiagnostic)]
 #[suggestion_hidden("example message", code = "")]
-//~^ ERROR #[suggestion_hidden(...)]` is not a valid attribute
+//~^ ERROR cannot find attribute `suggestion_hidden` in this scope
+//~| ERROR derive(Diagnostic): `#[suggestion_hidden(...)]` is not a valid attribute
 struct SuggestionStyleOldSyntax {
     #[primary_span]
     sub: Span,
@@ -754,7 +755,8 @@ struct SuggestionStyleOldSyntax {
 
 #[derive(Subdiagnostic)]
 #[suggestion_hidden("example message", code = "", style = "normal")]
-//~^ ERROR #[suggestion_hidden(...)]` is not a valid attribute
+//~^ ERROR cannot find attribute `suggestion_hidden` in this scope
+//~| ERROR derive(Diagnostic): `#[suggestion_hidden(...)]` is not a valid attribute
 struct SuggestionStyleOldAndNewSyntax {
     #[primary_span]
     sub: Span,

--- a/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive-inline.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/subdiagnostic-derive-inline.stderr
@@ -439,19 +439,15 @@ error: derive(Diagnostic): `#[suggestion_hidden(...)]` is not a valid attribute
    |
 LL | #[suggestion_hidden("example message", code = "")]
    | ^
-   |
-   = help: Use `#[suggestion(..., style = "hidden")]` instead
 
 error: derive(Diagnostic): `#[suggestion_hidden(...)]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive-inline.rs:756:1
+  --> $DIR/subdiagnostic-derive-inline.rs:757:1
    |
 LL | #[suggestion_hidden("example message", code = "", style = "normal")]
    | ^
-   |
-   = help: Use `#[suggestion(..., style = "hidden")]` instead
 
 error: derive(Diagnostic): invalid suggestion style
-  --> $DIR/subdiagnostic-derive-inline.rs:764:52
+  --> $DIR/subdiagnostic-derive-inline.rs:766:52
    |
 LL | #[suggestion("example message", code = "", style = "foo")]
    |                                                    ^^^^^
@@ -459,25 +455,25 @@ LL | #[suggestion("example message", code = "", style = "foo")]
    = help: valid styles are `normal`, `short`, `hidden`, `verbose` and `tool-only`
 
 error: expected string literal
-  --> $DIR/subdiagnostic-derive-inline.rs:772:52
+  --> $DIR/subdiagnostic-derive-inline.rs:774:52
    |
 LL | #[suggestion("example message", code = "", style = 42)]
    |                                                    ^^
 
 error: expected `=`
-  --> $DIR/subdiagnostic-derive-inline.rs:780:49
+  --> $DIR/subdiagnostic-derive-inline.rs:782:49
    |
 LL | #[suggestion("example message", code = "", style)]
    |                                                 ^
 
 error: expected `=`
-  --> $DIR/subdiagnostic-derive-inline.rs:788:49
+  --> $DIR/subdiagnostic-derive-inline.rs:790:49
    |
 LL | #[suggestion("example message", code = "", style("foo"))]
    |                                                 ^
 
 error: derive(Diagnostic): `#[primary_span]` is not a valid attribute
-  --> $DIR/subdiagnostic-derive-inline.rs:799:5
+  --> $DIR/subdiagnostic-derive-inline.rs:801:5
    |
 LL |     #[primary_span]
    |     ^
@@ -486,7 +482,7 @@ LL |     #[primary_span]
    = help: to create a suggestion with multiple spans, use `#[multipart_suggestion]` instead
 
 error: derive(Diagnostic): suggestion without `#[primary_span]` field
-  --> $DIR/subdiagnostic-derive-inline.rs:796:1
+  --> $DIR/subdiagnostic-derive-inline.rs:798:1
    |
 LL | #[suggestion("example message", code = "")]
    | ^
@@ -545,5 +541,17 @@ error: cannot find attribute `bar` in this scope
 LL |     #[bar("...")]
    |       ^^^
 
-error: aborting due to 82 previous errors
+error: cannot find attribute `suggestion_hidden` in this scope
+  --> $DIR/subdiagnostic-derive-inline.rs:748:3
+   |
+LL | #[suggestion_hidden("example message", code = "")]
+   |   ^^^^^^^^^^^^^^^^^
+
+error: cannot find attribute `suggestion_hidden` in this scope
+  --> $DIR/subdiagnostic-derive-inline.rs:757:3
+   |
+LL | #[suggestion_hidden("example message", code = "", style = "normal")]
+   |   ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 84 previous errors
 


### PR DESCRIPTION
Followup to https://github.com/rust-lang/rust/pull/103575

Also documents the `style = "..."` option.