### PR TITLE
Update expect messages in library/alloc/src/io/buffered/bufreader.rs and library/alloc/src/io/copy/generic.rs to follow the style guide #159882

### DIFF
--- a/library/alloc/src/io/buffered/bufreader.rs
+++ b/library/alloc/src/io/buffered/bufreader.rs
@@ -594,9 +594,8 @@ impl<R: ?Sized + Seek> Seek for BufReader<R> {
     fn stream_position(&mut self) -> io::Result<u64> {
         let remainder = (self.buf.filled() - self.buf.pos()) as u64;
         self.inner.stream_position().map(|pos| {
-            pos.checked_sub(remainder).expect(
-                "overflow when subtracting remaining buffer size from inner stream position",
-            )
+            pos.checked_sub(remainder)
+                .expect("remaining buffer size should not exceed inner stream position")
         })
     }
 

--- a/library/alloc/src/io/copy/generic.rs
+++ b/library/alloc/src/io/copy/generic.rs
@@ -222,7 +222,9 @@ impl BufferedWriterSpec for Vec<u8> {
     }
 
     fn copy_from<R: Read + ?Sized>(&mut self, reader: &mut R) -> Result<u64> {
-        reader.read_to_end(self).map(|bytes| u64::try_from(bytes).expect("usize overflowed u64"))
+        reader
+            .read_to_end(self)
+            .map(|bytes| u64::try_from(bytes).expect("usize shouldn't overflow u64"))
     }
 }
 


### PR DESCRIPTION
Related issue: https://github.com/rust-lang/rust/issues/159751

Updates the expect messages in library/alloc/src/io/buffered/bufreader.rs and library/alloc/src/io/copy/generic.rs to follow the style guide