### PR TITLE
core: fix the docs of PanicInfo::location

### DIFF
--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -68,29 +68,22 @@ impl<'a> PanicInfo<'a> {
     /// This method will currently always return [`Some`], but this may change
     /// in future versions.
     ///
-    /// # Examples
+    /// # Example
     ///
-    /// ```should_panic
-    /// use std::panic;
-    ///
-    /// panic::set_hook(Box::new(|panic_info| {
+    /// ```ignore (no_std)
+    /// #[panic_handler]
+    /// fn panic_handler(panic_info: &PanicInfo<'_>) -> ! {
     ///     if let Some(location) = panic_info.location() {
-    ///         println!("panic occurred in file '{}' at line {}",
-    ///             location.file(),
-    ///             location.line(),
-    ///         );
-    ///     } else {
-    ///         println!("panic occurred but can't get location information...");
+    ///         write!(DEBUG_OUTPUT, "panicked at {}", location);
     ///     }
-    /// }));
-    ///
-    /// panic!("Normal panic");
+    ///     loop {}
+    /// }
     /// ```
     #[must_use]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
     pub fn location(&self) -> Option<&'static Location<'static>> {
         // NOTE: If this is changed to sometimes return None,
-        // deal with that case in std::panicking::default_hook and core::panicking::panic_fmt.
+        // deal with that case in std::panicking::panic_handler and core::panicking::panic_fmt.
         Some(self.location)
     }
 

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -162,7 +162,7 @@ impl<'a> PanicHookInfo<'a> {
     #[stable(feature = "panic_hooks", since = "1.10.0")]
     pub fn location(&self) -> Option<&'static Location<'static>> {
         // NOTE: If this is changed to sometimes return None,
-        // deal with that case in std::panicking::default_hook and core::panicking::panic_fmt.
+        // deal with that case in std::panicking::default_hook and std::panicking::panic_with_hook.
         Some(self.location)
     }
 


### PR DESCRIPTION
After `core::panic::PanicInfo` and `std::panic::PanicHookInfo` [were split](https://github.com/rust-lang/rust/pull/115974), the docs for `location` still showed incorrect usage of `std::panic::set_hook` for `core::panic::PanicInfo` location, leftover from before the split.

Also notes for location methods of `PanicInfo` and `PanicHookInfo` were updated, explaining that if it is ever changed to return None, it should be addressed where the location is created and where it's unwrapped, to avoid unexpected behavior when callers may expect to always receive location.
- For `PanicInfo`, `panic_fmt` builds it, and `panic_handler` unwraps it. 
- For `PanicHookInfo`, `panic_with_hook` builds it, and `default_hook` unwraps it.

Addresses: rust-lang/rust#128788
@rustbot label +A-docs
r? libs
