### PR TITLE
Switch dist-aarch64-linux to EC2 and update dist-x86_64-linux

### DIFF
--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -87,31 +87,20 @@ images = {
     "arm64ami" = "latest-gha-runner-ami-arm64",
 }
 jit_runner = "organization"
+# Prices per hour of on-demand compute in us-east-2 (as of Aug 2026)
+# See build speed estimates in https://github.com/rust-lang/simpleinfra/issues/1132
 allowed_instances = [
-    # AMD Zen 5 (x86_64) instances, a subset of these is used in production.
-    # Prices per hour of on-demand compute in us-east-2 (as of Aug 2026)
-    # See rough assessment of build speed for dist-x86_64-quick in https://github.com/rust-lang/simpleinfra/issues/1132
-    # m8a.2x     8 vCPU, 32 GB   $0.48688/hr
-    # c8a.4x    16 vCPU, 32 GB   $0.86216/hr
-    # c8a.8x    32 vCPU, 64 GB   $1.72432/hr
-    # c8a.12x   48 vCPU, 96 GB   $2.58648/hr
-    # CodeBuild 36 vCPU          $4.78799/hr
-    "m8a.2xlarge",
-    "c8a.4xlarge",
-    "c8a.8xlarge",
-    "c8a.12xlarge",
+    # AMD Zen 5 (x86_64)
+    "m8a.2xlarge",  # $0.48688/hr
+    "c8a.4xlarge",  # $0.86216/hr
+    "c8a.8xlarge",  # $1.72432/hr
+    "c8a.12xlarge", # $2.58648/hr
 
-    # Graviton 4 (aarch64) instances, currently just for experimentation
-    "m8g.2xlarge",
-    "c8g.4xlarge",
-    "c8g.8xlarge",
-    "c8g.12xlarge",
-
-    # Graviton 5 (aarch64) instances, currently just for experimentation
-    "m9g.2xlarge",
-    "c9g.4xlarge",
-    "c9g.8xlarge",
-    "c9g.12xlarge",
+    # Graviton (aarch64)
+    "m9g.2xlarge",  # $0.39136/hr
+    "c9g.4xlarge",  # $0.69312/hr
+    "c9g.8xlarge",  # $1.38624/hr
+    "c9g.12xlarge", # $2.07936/hr
 ]
 
 # Enable unrolling of rollup member PRs after rollup merge

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -41,24 +41,24 @@ runners:
     os: ubuntu-24.04-arm
     <<: *base-job
 
-  - &job-aarch64-linux-8c
-    os: ubuntu-24.04-arm64-8core-32gb
+  - &job-linux-x86-8c-ec2
+    os: ec2-x86_64ami-m8a.2xlarge-x64-linux-$github.run_id-$github.run_attempt
     <<: *base-job
 
-  # Codebuild runners are provisioned in
-  # https://github.com/rust-lang/simpleinfra/blob/b7ddd5e6bec8a93ec30510cdddec02c5666fefe9/terragrunt/accounts/ci-prod/ci-runners/terragrunt.hcl#L2
-  - &job-linux-36c-codebuild
-    free_disk: true
-    codebuild: true
-    os: codebuild-ubuntu-22-36c-$github.run_id-$github.run_attempt
+  - &job-linux-x86-16c-ec2
+    os: ec2-x86_64ami-c8a.4xlarge-x64-linux-$github.run_id-$github.run_attempt
     <<: *base-job
 
   - &job-linux-x86-32c-ec2
     os: ec2-x86_64ami-c8a.8xlarge-x64-linux-$github.run_id-$github.run_attempt
     <<: *base-job
 
-  - &job-linux-x86-8c-ec2
-    os: ec2-x86_64ami-m8a.2xlarge-x64-linux-$github.run_id-$github.run_attempt
+  - &job-linux-aarch64-8c-ec2
+    os: ec2-arm64ami-m9g.2xlarge-aarch64-linux-$github.run_id-$github.run_attempt
+    <<: *base-job
+
+  - &job-linux-aarch64-16c-ec2
+    os: ec2-arm64ami-c9g.4xlarge-aarch64-linux-$github.run_id-$github.run_attempt
     <<: *base-job
 
 envs:
@@ -96,6 +96,11 @@ jobs:
       IMAGE: dist-x86_64-linux
       CODEGEN_BACKENDS: llvm,cranelift
       DOCKER_SCRIPT: dist.sh
+  dist-aarch64-linux: &job-dist-aarch64-linux
+    name: dist-aarch64-linux
+    env:
+      IMAGE: dist-aarch64-linux
+      CODEGEN_BACKENDS: llvm,cranelift
 
 
 # Jobs that run on each push to a pull request (PR).
@@ -167,6 +172,17 @@ pr:
 try:
   - <<: [*job-dist-x86_64-linux, *job-linux-x86-32c-ec2]
     name: dist-x86_64-linux-quick
+    env:
+      IMAGE: dist-x86_64-linux
+      CODEGEN_BACKENDS: llvm,cranelift
+      DOCKER_SCRIPT: dist.sh
+      DIST_TRY_BUILD: 1
+  - <<: [*job-dist-aarch64-linux, *job-linux-aarch64-16c-ec2]
+    name: dist-aarch64-linux-quick
+    env:
+      IMAGE: dist-aarch64-linux
+      CODEGEN_BACKENDS: llvm,cranelift
+      DIST_TRY_BUILD: 1
 
 # Jobs that only run when explicitly invoked in one of the following ways:
 # - comment `@bors try jobs=<job-name>`
@@ -178,19 +194,20 @@ optional:
     env:
       IMAGE: pr-check-1
     <<: *job-linux-4c
-  - <<: [*job-dist-x86_64-linux, *job-linux-36c-codebuild]
-    name: dist-x86_64-linux-codebuild
-  - <<: [*job-dist-x86_64-linux, *job-linux-36c-codebuild]
-    name: dist-x86_64-linux-quick-codebuild
+  # Duplicate the try jobs here so that we can run them via jobs=...
+  - <<: [*job-dist-x86_64-linux, *job-linux-x86-32c-ec2]
+    name: dist-x86_64-linux-quick
     env:
       IMAGE: dist-x86_64-linux
       CODEGEN_BACKENDS: llvm,cranelift
       DOCKER_SCRIPT: dist.sh
       DIST_TRY_BUILD: 1
-  # We repeat the try job here so that it can be explicitly executed using `@bors try jobs`, to test
-  # full x64 Linux dist try builds on EC2.
-  - <<: [*job-dist-x86_64-linux, *job-linux-x86-32c-ec2]
-    name: dist-x86_64-linux-quick
+  - <<: [*job-dist-aarch64-linux, *job-linux-aarch64-16c-ec2]
+    name: dist-aarch64-linux-quick
+    env:
+      IMAGE: dist-aarch64-linux
+      CODEGEN_BACKENDS: llvm,cranelift
+      DIST_TRY_BUILD: 1
 
 # Main CI jobs that have to be green to merge a commit into the default branch.
 #
@@ -218,10 +235,7 @@ auto:
   - name: armhf-gnu
     <<: *job-linux-4c
 
-  - name: dist-aarch64-linux
-    env:
-      CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-aarch64-linux-8c
+  - <<: [*job-dist-aarch64-linux, *job-linux-aarch64-16c-ec2]
 
   - name: dist-android
     <<: *job-linux-4c
@@ -298,7 +312,7 @@ auto:
   - name: dist-x86_64-illumos
     <<: *job-linux-4c
 
-  - <<: [*job-dist-x86_64-linux, *job-linux-x86-32c-ec2]
+  - <<: [*job-dist-x86_64-linux, *job-linux-x86-16c-ec2]
 
   - name: dist-x86_64-linux-alt
     env:


### PR DESCRIPTION
For dist-aarch64-linux (full):

* GHA 8c takes 2h25m ($2.03/build) - current
* c8g.8xl takes 1h20m ($1.69/build)
* c9g.8xl takes 1h ($1.38/build)
* c9g.4xl takes 1h10m ($0.81/build)
* m9g.2xl takes 1h30m ($0.59/build) - selected

Adds a dist-aarch64-linux-quick (default enabled in try builds):

* c8g.8xl takes 50m ($1.059/build)
* c9g.8xl takes 40m ($0.924/build)
* c9g.4xl takes 47m ($0.543/build) - selected
* m9g.2xl takes 64m ($0.417/build)

For now I've chosen a balance between cost and speed (c9g.4xl). This is still faster than the x86 build so shouldn't slow us down.

For dist-x86_64-linux-full this reduces core count to be a bit more cost efficient:

* c8a.8xl takes 1h34m ($2.64/build) - current
* c8a.4xl takes 1h45m ($1.51/build) - selected
* m8a.2xl takes 2h10m ($1.05/build)

I'll re-benchmark dist-x86_64-linux-quick in a future PR, for now it will stay on c8a.8xl. This PR also drops codebuild configuration (but not yet cleaning up various related pieces that are more tied into our CI) since it doesn't seem relevant anymore.

Testing:

* Regular try (no jobs selected) - https://github.com/rust-lang/rust/actions/runs/33395505441
  * Runs both x86 and aarch64, both in quick variants
* Try with jobs=dist-x86_64-linux*,dist-aarch64-linux* - https://github.com/rust-lang/rust/actions/runs/33394676009
  * Runs both x86 and aarch64, quick and non-quick
  * This fixes a bug where dist-x86_64-linux-quick via explicit request used to not be a quick job AFAICT; nothing set DIST_TRY_BUILD on it.

r? @Kobzol 
