### PR TITLE
Add FileCheck annotations for `matches_u8.rs`

### DIFF
--- a/tests/mir-opt/matches_u8.rs
+++ b/tests/mir-opt/matches_u8.rs
@@ -1,4 +1,3 @@
-//@ skip-filecheck
 //@ test-mir-pass: MatchBranchSimplification
 
 // EMIT_MIR matches_u8.exhaustive_match.MatchBranchSimplification.diff
@@ -11,6 +10,10 @@ pub enum E {
 
 #[no_mangle]
 pub fn exhaustive_match(e: E) -> u8 {
+    // CHECK-LABEL: fn exhaustive_match(
+    // CHECK: discriminant(
+    // CHECK-NOT: switchInt
+    // CHECK: return
     match e {
         E::A => 0,
         E::B => 1,
@@ -19,6 +22,10 @@ pub fn exhaustive_match(e: E) -> u8 {
 
 #[no_mangle]
 pub fn exhaustive_match_i8(e: E) -> i8 {
+    // CHECK-LABEL: fn exhaustive_match_i8(
+    // CHECK: discriminant(
+    // CHECK-NOT: switchInt
+    // CHECK: return
     match e {
         E::A => 0,
         E::B => 1,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Adds checkfile annotations to `matches_u8.rs` (part of https://github.com/rust-lang/rust/issues/116971).

This test asserts that `MatchBranchSimplification` removes branching and replaces with `switchInt` (done in `unify_by_int_to_int`). 

I was unsure if I should check `_0 = {{.*}} as i8/u8 (IntToInt)` since its part of the implementation of the transform however it would be good to the conversion respects the function signature.

r? cjgillot