### PR TITLE
Add regression test for associated const equality param out of range ICE

### DIFF
--- a/tests/ui/associated-consts/assoc-const-equality-param-out-of-range.rs
+++ b/tests/ui/associated-consts/assoc-const-equality-param-out-of-range.rs
@@ -1,0 +1,34 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/145824.
+//!
+//! An associated const equality bound whose value refers to the impl's own const parameter
+//! used to ICE with "type parameter out of range when instantiating".
+
+trait Widget {
+    const WIDTH: usize;
+}
+
+struct Boxed<const WIDTH: usize, T> {
+    inner: T,
+}
+
+impl<const WIDTH: usize, T> Boxed<WIDTH, T> {
+    fn new(_: T) -> Self
+    where
+        T: Widget<WIDTH = { WIDTH }>,
+        //~^ ERROR associated const equality is incomplete
+    {
+        loop {}
+    }
+
+    fn empty<const X: usize>() -> Boxed<X, Empty<{ X }>> {
+        Boxed::new(Empty)
+    }
+}
+
+struct Empty<const WIDTH: usize>;
+
+impl<const WIDTH: usize> Widget for Empty<WIDTH> {
+    const WIDTH: usize = WIDTH;
+}
+
+fn main() {}

--- a/tests/ui/associated-consts/assoc-const-equality-param-out-of-range.stderr
+++ b/tests/ui/associated-consts/assoc-const-equality-param-out-of-range.stderr
@@ -1,0 +1,13 @@
+error[E0658]: associated const equality is incomplete
+  --> $DIR/assoc-const-equality-param-out-of-range.rs:17:19
+   |
+LL |         T: Widget<WIDTH = { WIDTH }>,
+   |                   ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Fixes rust-lang/rust#145824