### PR TITLE
Fix ICE of getting item name from RPITIT

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -1374,7 +1374,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             (ty::Alias(kind1, alias1), ty::Alias(kind2, alias2)) if kind1 == kind2 => {
                 let mut values = (DiagStyledString::new(), DiagStyledString::new());
                 match (alias1.kind, alias2.kind) {
-                    (ty::Projection { def_id: def_id1 }, ty::Projection { def_id: def_id2 }) => {
+                    (ty::Projection { def_id: def_id1 }, ty::Projection { def_id: def_id2 })
+                        // RPITIT projections use anonymous associated type and have no item name,
+                        // so it will be ICE from call of `tcx.item_name(def_id)` below, issue #161915.
+                        if !self.tcx.is_impl_trait_in_trait(def_id1)
+                            && !self.tcx.is_impl_trait_in_trait(def_id2) =>
+                    {
                         // `<Type as Trait>::Name<args>`
                         values.0.push_normal("<");
                         values.1.push_normal("<");

--- a/tests/ui/impl-trait/in-trait/rpitit-mismatch-missing-item-name-issue-161915.rs
+++ b/tests/ui/impl-trait/in-trait/rpitit-mismatch-missing-item-name-issue-161915.rs
@@ -1,0 +1,17 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/161915>.
+//! Mismatched RPITIT projections should produce E0308 instead of an ICE.
+
+trait Parameter {
+    fn create() -> impl Form;
+}
+
+trait Form {}
+
+fn forms_at_phase<T: Parameter, U: Parameter>() -> impl Form {
+    match true {
+        true => T::create(),
+        false => U::create(), //~ ERROR `match` arms have incompatible types
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/rpitit-mismatch-missing-item-name-issue-161915.stderr
+++ b/tests/ui/impl-trait/in-trait/rpitit-mismatch-missing-item-name-issue-161915.stderr
@@ -1,0 +1,34 @@
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/rpitit-mismatch-missing-item-name-issue-161915.rs:13:18
+   |
+LL |   fn forms_at_phase<T: Parameter, U: Parameter>() -> impl Form {
+   |                     -             - found type parameter
+   |                     |
+   |                     expected type parameter
+LL | /     match true {
+LL | |         true => T::create(),
+   | |                 ----------- this is found to be of type `impl Form`
+LL | |         false => U::create(),
+   | |                  ^^^^^^^^^^^ expected type parameter `T`, found type parameter `U`
+LL | |     }
+   | |_____- `match` arms have incompatible types
+   |
+   = note: expected associated type `impl Form` (type parameter `T`)
+              found associated type `impl Form` (type parameter `U`)
+   = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+   = note: an associated type was expected, but a different one was found
+help: you could change the return type to be a boxed trait object
+   |
+LL - fn forms_at_phase<T: Parameter, U: Parameter>() -> impl Form {
+LL + fn forms_at_phase<T: Parameter, U: Parameter>() -> Box<dyn Form> {
+   |
+help: if you change the return type to expect trait objects, box the returned expressions
+   |
+LL ~         true => Box::new(T::create()),
+LL ~         false => Box::new(U::create()),
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#161915 

RPITIT projections use anonymous associated type and have no item name.