### PR TITLE
Change some `Infallible` to `!` in std

### DIFF
--- a/library/alloc/src/bstr.rs
+++ b/library/alloc/src/bstr.rs
@@ -333,10 +333,10 @@ impl FromIterator<ByteString> for ByteString {
 
 #[unstable(feature = "bstr", issue = "134915")]
 impl FromStr for ByteString {
-    type Err = core::convert::Infallible;
+    type Err = !;
 
     #[inline]
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, !> {
         Ok(ByteString(s.as_bytes().to_vec()))
     }
 }

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2895,20 +2895,18 @@ impl ops::DerefMut for String {
     }
 }
 
-/// A type alias for [`Infallible`].
+/// A type alias for [`!`].
 ///
 /// This alias exists for backwards compatibility, and may be eventually deprecated.
-///
-/// [`Infallible`]: core::convert::Infallible "convert::Infallible"
 #[stable(feature = "str_parse_error", since = "1.5.0")]
-pub type ParseError = core::convert::Infallible;
+pub type ParseError = !;
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl FromStr for String {
-    type Err = core::convert::Infallible;
+    type Err = !;
     #[inline]
-    fn from_str(s: &str) -> Result<String, Self::Err> {
+    fn from_str(s: &str) -> Result<String, !> {
         Ok(String::from(s))
     }
 }

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -172,7 +172,7 @@ impl<T, const N: usize> IntoIter<T, N> {
     /// assert_eq!(empty.len(), 0);
     /// assert_eq!(empty.as_slice(), &[]);
     ///
-    /// let empty = IntoIter::<std::convert::Infallible, 200>::empty();
+    /// let empty = IntoIter::<!, 200>::empty();
     /// assert_eq!(empty.len(), 0);
     /// ```
     ///

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -7,7 +7,6 @@
 use crate::borrow::{Borrow, BorrowMut};
 use crate::clone::TrivialClone;
 use crate::cmp::Ordering;
-use crate::convert::Infallible;
 use crate::error::Error;
 use crate::hash::{self, Hash};
 use crate::intrinsics::transmute_unchecked;
@@ -195,8 +194,8 @@ impl Error for TryFromSliceError {}
 
 #[stable(feature = "try_from_slice_error", since = "1.36.0")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
-const impl From<Infallible> for TryFromSliceError {
-    fn from(x: Infallible) -> TryFromSliceError {
+const impl From<!> for TryFromSliceError {
+    fn from(x: !) -> TryFromSliceError {
         match x {}
     }
 }

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -815,10 +815,10 @@ const impl<T, U> TryFrom<U> for T
 where
     U: [const] Into<T>,
 {
-    type Error = Infallible;
+    type Error = !;
 
     #[inline]
-    fn try_from(value: U) -> Result<Self, Self::Error> {
+    fn try_from(value: U) -> Result<Self, !> {
         Ok(U::into(value))
     }
 }

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -1,5 +1,5 @@
 use crate::marker::Destruct;
-use crate::{convert, ops};
+use crate::ops;
 
 /// Used to tell an operation whether it should exit early or go on as usual.
 ///
@@ -104,7 +104,7 @@ pub enum ControlFlow<B, C = ()> {
 #[rustc_const_unstable(feature = "const_try", issue = "74935")]
 const impl<B, C> ops::Try for ControlFlow<B, C> {
     type Output = C;
-    type Residual = ControlFlow<B, convert::Infallible>;
+    type Residual = ControlFlow<B, !>;
 
     #[inline]
     fn from_output(output: Self::Output) -> Self {
@@ -124,9 +124,9 @@ const impl<B, C> ops::Try for ControlFlow<B, C> {
 #[rustc_const_unstable(feature = "const_try", issue = "74935")]
 // Note: manually specifying the residual type instead of using the default to work around
 // https://github.com/rust-lang/rust/issues/99940
-const impl<B, C> ops::FromResidual<ControlFlow<B, convert::Infallible>> for ControlFlow<B, C> {
+const impl<B, C> ops::FromResidual<ControlFlow<B, !>> for ControlFlow<B, C> {
     #[inline]
-    fn from_residual(residual: ControlFlow<B, convert::Infallible>) -> Self {
+    fn from_residual(residual: ControlFlow<B, !>) -> Self {
         match residual {
             ControlFlow::Break(b) => ControlFlow::Break(b),
         }
@@ -135,7 +135,7 @@ const impl<B, C> ops::FromResidual<ControlFlow<B, convert::Infallible>> for Cont
 
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
 #[rustc_const_unstable(feature = "const_try_residual", issue = "91285")]
-const impl<B, C> ops::Residual<C> for ControlFlow<B, convert::Infallible> {
+const impl<B, C> ops::Residual<C> for ControlFlow<B, !> {
     type TryType = ControlFlow<B, C>;
 }
 

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -148,12 +148,12 @@ pub const trait Try: [const] FromResidual {
     /// this type is typically a newtype of some sort to "color" the type
     /// so that it's distinguishable from the residuals of other types.
     ///
-    /// This is why `Result<T, E>::Residual` is not `E`, but `Result<Infallible, E>`.
+    /// This is why `Result<T, E>::Residual` is not `E`, but `Result<!, E>`.
     /// That way it's distinct from `ControlFlow<E>::Residual`, for example,
     /// and thus `?` on `ControlFlow` cannot be used in a method returning `Result`.
     ///
     /// If you're making a generic type `Foo<T>` that implements `Try<Output = T>`,
-    /// then typically you can use `Foo<std::convert::Infallible>` as its `Residual`
+    /// then typically you can use `Foo<!>` as its `Residual`
     /// type: that type will have a "hole" in the correct place, and will maintain the
     /// "foo-ness" of the residual so other types need to opt-in to interconversion.
     #[unstable(feature = "try_trait_v2", issue = "84277", old_name = "try_trait")]
@@ -356,9 +356,9 @@ where
 /// and [`Try::Residual`] components, this allows putting them back together.
 ///
 /// For example,
-/// `Result<T, E>: Try<Output = T, Residual = Result<Infallible, E>>`,
+/// `Result<T, E>: Try<Output = T, Residual = Result<!, E>>`,
 /// and in the other direction,
-/// `<Result<Infallible, E> as Residual<T>>::TryType = Result<T, E>`.
+/// `<Result<!, E> as Residual<T>>::TryType = Result<T, E>`.
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
 #[rustc_const_unstable(feature = "const_try_residual", issue = "91285")]
 pub const trait Residual<O>: Sized {

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -585,7 +585,7 @@ use crate::num::NonZero;
 use crate::ops::{self, ControlFlow, Deref, DerefMut, Residual, Try};
 use crate::panicking::{panic, panic_display};
 use crate::pin::Pin;
-use crate::{cmp, convert, hint, mem, slice};
+use crate::{cmp, hint, mem, slice};
 
 /// The `Option` type. See [the module level documentation](self) for more.
 #[doc(search_unbox)]
@@ -2864,7 +2864,7 @@ impl<T, V: FromIterator<T>> FromIterator<Option<T>> for Option<V> {
 #[rustc_const_unstable(feature = "const_try", issue = "74935")]
 const impl<T> ops::Try for Option<T> {
     type Output = T;
-    type Residual = Option<convert::Infallible>;
+    type Residual = Option<!>;
 
     #[inline]
     fn from_output(output: Self::Output) -> Self {
@@ -2884,9 +2884,9 @@ const impl<T> ops::Try for Option<T> {
 #[rustc_const_unstable(feature = "const_try", issue = "74935")]
 // Note: manually specifying the residual type instead of using the default to work around
 // https://github.com/rust-lang/rust/issues/99940
-const impl<T> ops::FromResidual<Option<convert::Infallible>> for Option<T> {
+const impl<T> ops::FromResidual<Option<!>> for Option<T> {
     #[inline]
-    fn from_residual(residual: Option<convert::Infallible>) -> Self {
+    fn from_residual(residual: Option<!>) -> Self {
         match residual {
             None => None,
         }
@@ -2905,7 +2905,7 @@ const impl<T> ops::FromResidual<ops::Yeet<()>> for Option<T> {
 
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
 #[rustc_const_unstable(feature = "const_try", issue = "74935")]
-const impl<T> ops::Residual<T> for Option<convert::Infallible> {
+const impl<T> ops::Residual<T> for Option<!> {
     type TryType = Option<T>;
 }
 

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -544,7 +544,7 @@
 use crate::iter::{self, FusedIterator, TrustedLen};
 use crate::marker::Destruct;
 use crate::ops::{self, ControlFlow, Deref, DerefMut};
-use crate::{convert, fmt, hint};
+use crate::{fmt, hint};
 
 /// `Result` is a type that represents either success ([`Ok`]) or failure ([`Err`]).
 ///
@@ -2164,7 +2164,7 @@ impl<T, E, V: FromIterator<T>> FromIterator<Result<T, E>> for Result<V, E> {
 #[rustc_const_unstable(feature = "const_try", issue = "74935")]
 const impl<T, E> ops::Try for Result<T, E> {
     type Output = T;
-    type Residual = Result<convert::Infallible, E>;
+    type Residual = Result<!, E>;
 
     #[inline]
     fn from_output(output: Self::Output) -> Self {
@@ -2182,12 +2182,10 @@ const impl<T, E> ops::Try for Result<T, E> {
 
 #[unstable(feature = "try_trait_v2", issue = "84277", old_name = "try_trait")]
 #[rustc_const_unstable(feature = "const_try", issue = "74935")]
-const impl<T, E, F: [const] From<E>> ops::FromResidual<Result<convert::Infallible, E>>
-    for Result<T, F>
-{
+const impl<T, E, F: [const] From<E>> ops::FromResidual<Result<!, E>> for Result<T, F> {
     #[inline]
     #[track_caller]
-    fn from_residual(residual: Result<convert::Infallible, E>) -> Self {
+    fn from_residual(residual: Result<!, E>) -> Self {
         match residual {
             Err(e) => Err(From::from(e)),
         }
@@ -2205,6 +2203,6 @@ const impl<T, E, F: [const] From<E>> ops::FromResidual<ops::Yeet<E>> for Result<
 
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
 #[rustc_const_unstable(feature = "const_try", issue = "74935")]
-const impl<T, E> ops::Residual<T> for Result<convert::Infallible, E> {
+const impl<T, E> ops::Residual<T> for Result<!, E> {
     type TryType = Result<T, E>;
 }

--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -176,7 +176,7 @@ const trait SliceChain: Sized {
     fn chaining_ge(left: &[Self], right: &[Self]) -> ControlFlow<bool>;
 }
 
-type AlwaysBreak<B> = ControlFlow<B, crate::convert::Infallible>;
+type AlwaysBreak<B> = ControlFlow<B, !>;
 
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
 const impl<A: [const] PartialOrd> SlicePartialOrd for A {

--- a/library/core/src/task/poll.rs
+++ b/library/core/src/task/poll.rs
@@ -1,6 +1,5 @@
 #![stable(feature = "futures_api", since = "1.36.0")]
 
-use crate::convert;
 use crate::ops::{self, ControlFlow};
 
 /// Indicates whether a value is available or if the current task has been
@@ -233,7 +232,7 @@ const impl<T> From<T> for Poll<T> {
 #[unstable(feature = "try_trait_v2", issue = "84277", old_name = "try_trait")]
 impl<T, E> ops::Try for Poll<Result<T, E>> {
     type Output = Poll<T>;
-    type Residual = Result<convert::Infallible, E>;
+    type Residual = Result<!, E>;
 
     #[inline]
     fn from_output(c: Self::Output) -> Self {
@@ -251,9 +250,9 @@ impl<T, E> ops::Try for Poll<Result<T, E>> {
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277", old_name = "try_trait")]
-impl<T, E, F: From<E>> ops::FromResidual<Result<convert::Infallible, E>> for Poll<Result<T, F>> {
+impl<T, E, F: From<E>> ops::FromResidual<Result<!, E>> for Poll<Result<T, F>> {
     #[inline]
-    fn from_residual(x: Result<convert::Infallible, E>) -> Self {
+    fn from_residual(x: Result<!, E>) -> Self {
         match x {
             Err(e) => Poll::Ready(Err(From::from(e))),
         }
@@ -263,7 +262,7 @@ impl<T, E, F: From<E>> ops::FromResidual<Result<convert::Infallible, E>> for Pol
 #[unstable(feature = "try_trait_v2", issue = "84277", old_name = "try_trait")]
 impl<T, E> ops::Try for Poll<Option<Result<T, E>>> {
     type Output = Poll<Option<T>>;
-    type Residual = Result<convert::Infallible, E>;
+    type Residual = Result<!, E>;
 
     #[inline]
     fn from_output(c: Self::Output) -> Self {
@@ -282,11 +281,9 @@ impl<T, E> ops::Try for Poll<Option<Result<T, E>>> {
 }
 
 #[unstable(feature = "try_trait_v2", issue = "84277", old_name = "try_trait")]
-impl<T, E, F: From<E>> ops::FromResidual<Result<convert::Infallible, E>>
-    for Poll<Option<Result<T, F>>>
-{
+impl<T, E, F: From<E>> ops::FromResidual<Result<!, E>> for Poll<Option<Result<T, F>>> {
     #[inline]
-    fn from_residual(x: Result<convert::Infallible, E>) -> Self {
+    fn from_residual(x: Result<!, E>) -> Self {
         match x {
             Err(e) => Poll::Ready(Some(Err(From::from(e)))),
         }

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1804,10 +1804,10 @@ impl AsInner<Slice> for OsStr {
 
 #[stable(feature = "osstring_from_str", since = "1.45.0")]
 impl FromStr for OsString {
-    type Err = core::convert::Infallible;
+    type Err = !;
 
     #[inline]
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, !> {
         Ok(OsString::from(s))
     }
 }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2025,10 +2025,10 @@ impl From<String> for PathBuf {
 
 #[stable(feature = "path_from_str", since = "1.32.0")]
 impl FromStr for PathBuf {
-    type Err = core::convert::Infallible;
+    type Err = !;
 
     #[inline]
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, !> {
         Ok(PathBuf::from(s))
     }
 }

--- a/tests/rustdoc-js/never-search.js
+++ b/tests/rustdoc-js/never-search.js
@@ -12,6 +12,7 @@ const EXPECTED = [
         'query': '-> !',
         'others': [
             { 'path': 'never_search', 'name': 'loops' },
+            { 'path': 'never_search::never', 'name': 'try_from' },
         ],
     },
     {
@@ -19,6 +20,7 @@ const EXPECTED = [
         'others': [
             { 'path': 'never_search', 'name': 'loops' },
             { 'path': 'never_search', 'name': 'returns' },
+            { 'path': 'never_search::never', 'name': 'try_from' },
         ],
     },
     {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162073)*
<!-- homu-ignore:end -->

I believe this desirable since we recommend `!` over `Infallible`, so std follows its own advice. Most changes are to unstable features, but not all. Similar changes in compiler have to wait for a bootstrap update.