### PR TITLE
Move track_caller on closures gating to attribute parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3634,6 +3634,7 @@ version = "0.0.0"
 dependencies = [
  "rustc_abi",
  "rustc_ast",
+ "rustc_attr_ir",
  "rustc_attr_parsing",
  "rustc_data_structures",
  "rustc_errors",

--- a/compiler/rustc_ast_lowering/Cargo.toml
+++ b/compiler/rustc_ast_lowering/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 # tidy-alphabetical-start
 rustc_abi = { path = "../rustc_abi" }
 rustc_ast = { path = "../rustc_ast" }
+rustc_attr_ir = { path = "../rustc_attr_ir" }
 rustc_attr_parsing = { path = "../rustc_attr_parsing" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -3,19 +3,19 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use rustc_ast::node_id::NodeMap;
+use rustc_ast::visit::{Visitor, walk_expr};
 use rustc_ast::*;
+use rustc_attr_ir::lang_items::LangItem;
+use rustc_attr_ir::target::Target;
 use rustc_errors::msg;
 use rustc_hir as hir;
-use rustc_hir::attrs::lang_items::LangItem;
+use rustc_hir::HirId;
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::{HirId, Target, find_attr};
 use rustc_middle::span_bug;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::diagnostics::report_lit_error;
 use rustc_span::{ByteSymbol, DUMMY_SP, DesugaringKind, Ident, Span, Spanned, Symbol, respan, sym};
 use thin_vec::{ThinVec, thin_vec};
-use visit::{Visitor, walk_expr};
-
 mod closure;
 
 use crate::diagnostics::{
@@ -882,35 +882,17 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
     /// Forwards a possible `#[track_caller]` annotation from `outer_hir_id` to
     /// `inner_hir_id` in case the `async_fn_track_caller` feature is enabled.
-    pub(super) fn maybe_forward_track_caller(
-        &mut self,
-        span: Span,
-        outer_hir_id: HirId,
-        inner_hir_id: HirId,
-    ) {
+    pub(super) fn maybe_forward_track_caller(&mut self, outer_hir_id: HirId, inner_hir_id: HirId) {
         if self.tcx.features().async_fn_track_caller()
             && let Some(attrs) = self.attrs.get(&outer_hir_id.local_id)
-            && find_attr!(*attrs, TrackCaller(_))
+            && let Some(t) = attrs.iter().find(|a| {
+                matches!(
+                    a,
+                    rustc_attr_ir::Attribute::Parsed(rustc_attr_ir::AttributeKind::TrackCaller(_))
+                )
+            })
         {
-            let unstable_span = self.mark_span_with_reason(
-                DesugaringKind::Async,
-                span,
-                Some(Arc::clone(&self.allow_gen_future)),
-            );
-            self.lower_attrs(
-                inner_hir_id,
-                &[Attribute {
-                    kind: AttrKind::Normal(Box::new(NormalAttr::from_ident(Ident::new(
-                        sym::track_caller,
-                        span,
-                    )))),
-                    id: self.tcx.sess.psess.attr_id_generator.mk_attr_id(),
-                    style: AttrStyle::Outer,
-                    span: unstable_span,
-                }],
-                span,
-                Target::Fn,
-            );
+            self.attrs.insert(inner_hir_id.local_id, std::slice::from_ref(t));
         }
     }
 

--- a/compiler/rustc_ast_lowering/src/expr/closure.rs
+++ b/compiler/rustc_ast_lowering/src/expr/closure.rs
@@ -343,7 +343,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     )
                 });
 
-                this.maybe_forward_track_caller(body.span, closure_hir_id, expr.hir_id);
+                this.maybe_forward_track_caller(closure_hir_id, expr.hir_id);
 
                 (parameters, expr)
             });

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1462,7 +1462,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
             // FIXME(async_fn_track_caller): Can this be moved above?
             let hir_id = expr.hir_id;
-            this.maybe_forward_track_caller(body.span, fn_id, hir_id);
+            this.maybe_forward_track_caller(fn_id, hir_id);
 
             (parameters, expr)
         })

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -364,6 +364,15 @@ impl NoArgsAttributeParser for TrackCallerParser {
                     });
                 }
             }
+            Target::Closure if !cx.features().closure_track_caller() => {
+                feature_err(
+                    cx.sess(),
+                    sym::closure_track_caller,
+                    attr_span,
+                    "`#[track_caller]` on closures is currently unstable",
+                )
+                .emit();
+            }
             _ => {}
         }
     }

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -15,8 +15,7 @@ use rustc_middle::middle::codegen_fn_attrs::{
 use rustc_middle::mono::Visibility;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::{self as ty, TyCtxt};
-use rustc_session::diagnostics::feature_err;
-use rustc_span::{Span, sym};
+use rustc_span::Span;
 use rustc_target::spec::Os;
 
 use crate::diagnostics;
@@ -154,18 +153,6 @@ fn process_builtin_attrs(
                 {
                     // This error is already reported in `rustc_ast_passes/src/ast_validation.rs`.
                     tcx.dcx().delayed_bug("`#[track_caller]` requires the Rust ABI");
-                }
-                if is_closure
-                    && !tcx.features().closure_track_caller()
-                    && !attr_span.allows_unstable(sym::closure_track_caller)
-                {
-                    feature_err(
-                        &tcx.sess,
-                        sym::closure_track_caller,
-                        *attr_span,
-                        "`#[track_caller]` on closures is currently unstable",
-                    )
-                    .emit();
                 }
                 codegen_fn_attrs.flags |= CodegenFnAttrFlags::TRACK_CALLER
             }


### PR DESCRIPTION
I noticed this while reviewing rust-lang/rust#161958