### PR TITLE
docs(num): clarify conditions under which error occurs in `impl TryFrom<int> for int`

### DIFF
--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -336,8 +336,7 @@ macro_rules! impl_try_from_unbounded {
             type Error = TryFromIntError;
 
             /// Tries to create the target number type from a source
-            /// number type. This returns an error if the source value
-            /// is outside of the range of the target type.
+            /// number type. This never returns an error.
             #[inline]
             fn try_from(value: $source) -> Result<Self, Self::Error> {
                 Ok(value as Self)
@@ -356,7 +355,7 @@ macro_rules! impl_try_from_lower_bounded {
 
             /// Tries to create the target number type from a source
             /// number type. This returns an error if the source value
-            /// is outside of the range of the target type.
+            #[doc = concat!("is less than [`", stringify!($target), "::MIN`].")]
             #[inline]
             fn try_from(u: $source) -> Result<Self, Self::Error> {
                 if u >= 0 {
@@ -379,7 +378,7 @@ macro_rules! impl_try_from_upper_bounded {
 
             /// Tries to create the target number type from a source
             /// number type. This returns an error if the source value
-            /// is outside of the range of the target type.
+            #[doc = concat!("is greater than [`", stringify!($target), "::MAX`].")]
             #[inline]
             fn try_from(u: $source) -> Result<Self, Self::Error> {
                 if u > (Self::MAX as $source) {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

`impl_try_from_unbounded` always returns `Ok(T)`, but the documentation is written as if it may return an error, so I fixed this.

I also clarified that `impl_try_from_lower_bounded` returns an error only when the source value is less than `T::MIN`, and `impl_try_from_upper_bounded` returns an error only when the source value is greater than `T::MAX`.

While the original text

> This returns an error if the source value is outside of the range of the target type.

is fine for both cases, but I think the revised text makes it clearer that the error occurs at either the lower bound or the upper bound.

As for `impl_try_from_both_bounded`, I think the current text is fine, so I have not made any changes to it.