### PR TITLE
std: implement `File::fsync` for Hermit

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -74,7 +74,7 @@ fortanix-sgx-abi = { version = "0.6.1", features = [
 moto-rt = { version = "0.17", features = ['rustc-dep-of-std'], public = true }
 
 [target.'cfg(target_os = "hermit")'.dependencies]
-hermit-abi = { version = "0.5.0", features = [
+hermit-abi = { version = "0.5.3", features = [
     'rustc-dep-of-std',
 ], public = true }
 

--- a/library/std/src/sys/fs/hermit.rs
+++ b/library/std/src/sys/fs/hermit.rs
@@ -411,7 +411,8 @@ impl File {
     }
 
     pub fn fsync(&self) -> io::Result<()> {
-        unsupported()
+        unsafe { cvt(hermit_abi::fsync(self.as_raw_fd()))? };
+        Ok(())
     }
 
     pub fn datasync(&self) -> io::Result<()> {


### PR DESCRIPTION
- hermit-abi 0.5.3 exposes `fsync`, so the operation no longer has to return `Unsupported`.

cc: @mkroening 