### PR TITLE
Remove `gate_check` from `AttributeStability::Unstable`

### DIFF
--- a/compiler/rustc_attr_parsing/src/stability.rs
+++ b/compiler/rustc_attr_parsing/src/stability.rs
@@ -7,13 +7,15 @@ use crate::{AttributeParser, ShouldEmit};
 
 #[macro_export]
 macro_rules! unstable {
-    ($feat: ident $(, $notes:expr)*) => {
+    ($feat: ident $(, $notes:expr)*) => {{
+        // Check that the feature exists
+        _ = rustc_feature::Features::$feat;
+
         AttributeStability::Unstable {
             gate_name: rustc_span::sym::$feat,
-            gate_check: rustc_feature::Features::$feat,
             notes: &[$($notes),*],
         }
-    };
+    }};
 }
 
 impl<'sess> AttributeParser<'sess> {
@@ -27,12 +29,11 @@ impl<'sess> AttributeParser<'sess> {
             return;
         }
 
-        let AttributeStability::Unstable { gate_check, gate_name, notes } = expected_stability
-        else {
+        let AttributeStability::Unstable { gate_name, notes } = expected_stability else {
             return;
         };
 
-        if gate_check(self.features()) || attr_span.allows_unstable(gate_name) {
+        if self.features().enabled(gate_name) || attr_span.allows_unstable(gate_name) {
             return;
         }
 

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -65,9 +65,6 @@ pub enum AttributeStability {
     Unstable {
         /// The feature gate, for example `rustc_attrs` for rustc_* attributes.
         gate_name: Symbol,
-        /// Check function to be called during the `PostExpansionVisitor` pass, which will be one
-        /// of the `Features::*` functions
-        gate_check: GateFn,
         /// Notes to be displayed when an attempt is made to use the attribute without its feature
         /// gate.
         notes: &'static [&'static str],


### PR DESCRIPTION
Based on the idea from https://github.com/rust-lang/rust/pull/162051#discussion_r3894434669

r? @mejrs