### PR TITLE
rustdoc: Add reexport info

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -40,7 +40,7 @@ use crate::html::format::{
 };
 use crate::html::markdown::{HeadingOffset, MarkdownSummaryLine};
 use crate::html::render::sidebar::filters;
-use crate::html::render::{document_full, document_item_info, notable_trait_badges};
+use crate::html::render::{document_full, document_item_info, href, notable_trait_badges};
 use crate::html::url_parts_builder::UrlPartsBuilder;
 
 const ITEM_TABLE_OPEN: &str = "<dl class=\"item-table\">";
@@ -62,6 +62,20 @@ struct NotableTraitBadgeVars {
     color_index: u8,
 }
 
+enum HtmlLinkOrPath {
+    Link { path: String, url: String },
+    Path(String),
+}
+
+impl fmt::Display for HtmlLinkOrPath {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Link { path, url } => write!(fmt, "<a href=\"{url}\">{path}</a>"),
+            Self::Path(path) => write!(fmt, "<code>{path}</code>"),
+        }
+    }
+}
+
 #[derive(Template)]
 #[template(path = "print_item.html")]
 struct ItemVars<'a> {
@@ -72,6 +86,7 @@ struct ItemVars<'a> {
     stability_since_raw: &'a str,
     notable_trait_badges: Vec<NotableTraitBadgeVars>,
     src_href: Option<&'a str>,
+    original_path: Option<HtmlLinkOrPath>,
 }
 
 pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item) -> impl fmt::Display {
@@ -110,8 +125,9 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item) -> impl fmt::Disp
                 unreachable!();
             }
         };
+        let tcx = cx.tcx();
         let stability_since_raw =
-            render_stability_since_raw(item.stable_since(cx.tcx()), item.const_stability(cx.tcx()))
+            render_stability_since_raw(item.stable_since(tcx), item.const_stability(tcx))
                 .maybe_display()
                 .to_string();
 
@@ -143,6 +159,26 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item) -> impl fmt::Disp
             })
             .collect();
 
+        let original_path = item.item_id.as_def_id().and_then(|def_id| {
+            // We only show non-local reexports.
+            if def_id.is_local() {
+                None
+            } else {
+                // To ensure that we go completely through the reexports. If we use
+                // `def_path_debug_str`, we `alloc::vec::Vec`, but if we use `def_path_str`, it's
+                // `std::vec::Vec`. So let's force the right path.
+                let path = format!(
+                    "{}{}",
+                    tcx.crate_name(def_id.krate),
+                    tcx.cstore_untracked().def_path(def_id).to_string_no_crate_verbose(),
+                );
+                Some(match href(def_id, cx) {
+                    Ok(href) => HtmlLinkOrPath::Link { path, url: href.url },
+                    _ => HtmlLinkOrPath::Path(path),
+                })
+            }
+        });
+
         let path_components = if item.is_fake_item() {
             vec![]
         } else {
@@ -168,6 +204,7 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item) -> impl fmt::Disp
             stability_since_raw: &stability_since_raw,
             notable_trait_badges,
             src_href: src_href.as_deref(),
+            original_path,
         };
 
         item_vars.render_into(buf).unwrap();

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -165,8 +165,8 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item) -> impl fmt::Disp
                 None
             } else {
                 // To ensure that we go completely through the reexports. If we use
-                // `def_path_debug_str`, we `alloc::vec::Vec`, but if we use `def_path_str`, it's
-                // `std::vec::Vec`. So let's force the right path.
+                // `def_path_debug_str`, we get `alloc::vec::Vec`, but if we use `def_path_str`, we
+                // get `std::vec::Vec`. So let's force the right path.
                 let path = format!(
                     "{}{}",
                     tcx.crate_name(def_id.krate),

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1677,11 +1677,6 @@ so that we can apply CSS-filters to change the arrow color in themes */
 .notable-trait-badge-container > .badge-4 { background: var(--notable-badge-blue); }
 .notable-trait-badge-container > .badge-5 { background: var(--notable-badge-violet); }
 
-.reexport-origin {
-	display: block;
-	margin-top: 0.5em;
-}
-
 .rightside {
 	padding-left: 12px;
 	float: right;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1677,6 +1677,11 @@ so that we can apply CSS-filters to change the arrow color in themes */
 .notable-trait-badge-container > .badge-4 { background: var(--notable-badge-blue); }
 .notable-trait-badge-container > .badge-5 { background: var(--notable-badge-violet); }
 
+.reexport-origin {
+	display: block;
+	margin-top: 0.5em;
+}
+
 .rightside {
 	padding-left: 12px;
 	float: right;

--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -38,5 +38,8 @@
                 <a class="src" href="{{href|safe}}">Source</a> {#+ #}
             {% else %}
         {% endmatch %}
+        {% if let Some(original_path) = original_path %}
+            <span class="reexport-origin">Reexported from {{+ original_path|safe}}</span>
+        {% endif %}
     </span> {# #}
 </div> {# #}

--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -29,16 +29,18 @@
             {% endfor %}
         </div>
         {% endif %}
+        {% let mut heading_items = 0u8 %}
         {% if !stability_since_raw.is_empty() %}
-        {{ stability_since_raw|safe +}}
+            {{ stability_since_raw|safe +}}
+            {% mut heading_items += 1 %}
         {% endif %}
-        {% match src_href %}
-            {% when Some with (href) %}
-                {% if !stability_since_raw.is_empty() +%} · {%+ endif %}
-                <a class="src" href="{{href|safe}}">Source</a> {#+ #}
-            {% else %}
-        {% endmatch %}
+        {% if let Some(href) = src_href %}
+            {% if heading_items != 0 +%} · {%+ endif %}
+            <a class="src" href="{{href|safe}}">Source</a>
+            {% mut heading_items += 1 %}
+        {% endif %}
         {% if let Some(original_path) = original_path %}
+            {% if heading_items != 0 +%} · {%+ endif %}
             <span class="reexport-origin">Reexported from {{+ original_path|safe}}</span>
         {% endif %}
     </span> {# #}


### PR DESCRIPTION
It looks like this (in the `std` page of `Vec`):

<img width="896" height="178" alt="image" src="https://github.com/user-attachments/assets/223c6156-932e-4f64-9829-d3b1cfcfb64c" />

In the `std::vec` module:

<img width="896" height="178" alt="image" src="https://github.com/user-attachments/assets/e6c910cd-e7d9-4f69-ae78-c0f41c802ae2" />

So now come a few questions:

 * Should we do it for local items too?
 * What should we do for reexported `doc(hidden)` items?
 * What should we go for reexported items within a `doc(hidden)` module as ancestor?
 * Should we add an attribute to enable/disable this feature?

As this is likely going to need a lot of discussion, it's a draft for now. Nominating it for discussing it in next rustdoc meeting.

cc @rust-lang/rustdoc 