### PR TITLE
CheckFile GVN array access

### DIFF
--- a/tests/mir-opt/const_prop/large_array_index.rs
+++ b/tests/mir-opt/const_prop/large_array_index.rs
@@ -1,10 +1,13 @@
-//@ skip-filecheck
 //@ test-mir-pass: GVN
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR large_array_index.main.GVN.diff
 fn main() {
-    // check that we don't propagate this, because it's too large
+    // check that gvn access repeat inner.
+    // CHECK-LABEL: fn main(
+    // CHECK: debug x => [[x:_.*]];
+    // CHECK: assert(const true,
+    // CHECK: [[x]] = const 0_u8;
     let x: u8 = [0_u8; 5000][2];
 }


### PR DESCRIPTION
GVN replaced const prop and this can symbolically evaluate `[0_u8; 5000][2] = 0u8`.

This PR asserts this

r? cjgillot