### PR TITLE
FileCheck uninhabited_fallthrough_elimination

### DIFF
--- a/tests/mir-opt/uninhabited_fallthrough_elimination.rs
+++ b/tests/mir-opt/uninhabited_fallthrough_elimination.rs
@@ -1,4 +1,5 @@
-//@ skip-filecheck
+//@ test-mir-pass: UnreachableEnumBranching
+
 enum Empty {}
 
 enum S {
@@ -11,6 +12,20 @@ use S::*;
 
 // EMIT_MIR uninhabited_fallthrough_elimination.keep_fallthrough.UnreachableEnumBranching.diff
 fn keep_fallthrough(s: S) -> u32 {
+    // CHECK-LABEL: fn keep_fallthrough(
+    // CHECK: debug s => [[s:_.*]];
+    // CHECK: [[DISCR:_.*]] = discriminant([[s]]);
+    // CHECK: switchInt({{.*}} [[DISCR]]) -> [
+    //
+    // CHECK-SAME: 0: [[UNREACH:bb[0-9]+]],
+    // CHECK-SAME: 1: [[BB_B:bb[0-9]+]],
+    // CHECK-SAME: 2: [[BB_ANY:bb[0-9]+]],
+    // CHECK-SAME: otherwise: [[UNREACH]]
+    // CHECK-SAME: ];
+    //
+    // CHECK-DAG: [[BB_B]]: {{{[[:space:]]}} _0 = const 2_u32;
+    // CHECK-DAG: [[BB_ANY]]: {{{[[:space:]]}} _0 = const 3_u32;
+    // CHECK-DAG: [[UNREACH]]: {{{[[:space:]]}} unreachable;
     match s {
         A(_) => 1,
         B => 2,
@@ -20,6 +35,19 @@ fn keep_fallthrough(s: S) -> u32 {
 
 // EMIT_MIR uninhabited_fallthrough_elimination.eliminate_fallthrough.UnreachableEnumBranching.diff
 fn eliminate_fallthrough(s: S) -> u32 {
+    // CHECK-LABEL: fn eliminate_fallthrough(
+    // CHECK debug s => [[s:_.*]];
+    // CHECK: [[DISCR:_.*]] = discriminant([[s]]);
+    //
+    // CHECK: switchInt({{.*}} [[DISCR]]) -> [
+    // CHECK-SAME: 1: [[BB_B:bb[0-9]+]],
+    // CHECK-SAME: 2: [[BB_C:bb[0-9]+]],
+    // CHECK-SAME: otherwise: [[UNREACH:bb[0-9]+]]
+    // CHECK-SAME: ];
+    //
+    // CHECK-DAG: [[BB_B]]: {{{[[:space:]]}} _0 = const 2_u32;
+    // CHECK-DAG: [[BB_C]]: {{{[[:space:]]}} _0 = const 1_u32;
+    // CHECK-DAG: [[UNREACH]]: {{{[[:space:]]}} unreachable;
     match s {
         C => 1,
         B => 2,


### PR DESCRIPTION
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? cjgillot

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->

FileCheck `uninhabited_fallthrough_elimination` seems to be missing `test-mir-pass: UnreachableEnumBranching` so it was added.

The check assert that only the basic blocks expected are in the `switchInt` and for each BB that the return value is assigned in that bb.

r? cjgillot

part of https://github.com/rust-lang/rust/issues/116971