### PR TITLE
fix(parser): emit targeted diagnostic for fields inside traits

### DIFF
--- a/compiler/rustc_parse/src/diagnostics.rs
+++ b/compiler/rustc_parse/src/diagnostics.rs
@@ -2495,6 +2495,23 @@ pub(crate) struct AssociatedStaticItemNotAllowed {
     pub span: Span,
 }
 
+#[derive(Subdiagnostic)]
+pub(crate) enum FieldNotAllowedInTraitSugg {
+    #[help("consider using a method instead: `fn {$ident}(&self) -> {$ty};`")]
+    Method { ident: String, ty: String },
+    #[note("`self` can only appear as a method receiver; consider `fn method(self: {$ty})`")]
+    SelfReceiver { ty: String },
+}
+
+#[derive(Diagnostic)]
+#[diag("fields are not allowed in trait definitions")]
+pub(crate) struct FieldNotAllowedInTrait {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: FieldNotAllowedInTraitSugg,
+}
+
 #[derive(Diagnostic)]
 #[diag("crate name using dashes are not valid in `extern crate` statements")]
 pub(crate) struct ExternCrateNameWithDashes {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -404,6 +404,14 @@ impl<'a> Parser<'a> {
                 Case::Insensitive,
             );
         } else if macros_allowed && self.check_path() {
+            // Detect `field_name: Type` or `self: Type` inside a trait body and emit
+            // a clearer diagnostic before falling through to the macro invocation path.
+            let is_field_in_trait = fn_parse_mode.context == FnContext::Trait
+                && self.token.is_path_start()
+                && self.look_ahead(1, |t| t.kind == token::Colon);
+            if is_field_in_trait {
+                return self.recover_field_in_trait();
+            }
             if self.isnt_macro_invocation() {
                 self.recover_missing_kw_before_item()?;
             }
@@ -431,6 +439,35 @@ impl<'a> Parser<'a> {
                 Ok(None)
             }
         }
+    }
+
+    fn recover_field_in_trait(&mut self) -> PResult<'a, Option<ItemKind>> {
+        let ident_span = self.token.span;
+        let ident_str = pprust::token_to_string(&self.token).into_owned();
+        let is_self = self.token.is_keyword(kw::SelfLower);
+
+        self.bump(); // identifier or `self`
+        self.bump(); // `:`
+
+        let ty_str = match self.parse_ty() {
+            Ok(ty) => pprust::ty_to_string(&ty),
+            Err(e) => {
+                e.cancel();
+                String::from("Type")
+            }
+        };
+        // Eat the trailing separator so the parser doesn't trip over it.
+        let _ = self.eat(exp!(Comma));
+        let _ = self.eat(exp!(Semi));
+
+        let span = ident_span.to(self.prev_token.span);
+        let sugg = if is_self {
+            diagnostics::FieldNotAllowedInTraitSugg::SelfReceiver { ty: ty_str }
+        } else {
+            diagnostics::FieldNotAllowedInTraitSugg::Method { ident: ident_str, ty: ty_str }
+        };
+        let err = self.dcx().create_err(diagnostics::FieldNotAllowedInTrait { span, sugg });
+        Err(err)
     }
 
     fn parse_use_item(&mut self) -> PResult<'a, ItemKind> {

--- a/tests/ui/parser/trait-item-field-colon-syntax.rs
+++ b/tests/ui/parser/trait-item-field-colon-syntax.rs
@@ -1,0 +1,9 @@
+fn main() {}
+
+trait Trait1 {
+    field_name: String, //~ ERROR expected one of `!` or `::`, found `:`
+}
+
+trait Trait2 {
+    self: String, //~ ERROR expected one of `!` or `::`, found `:`
+}

--- a/tests/ui/parser/trait-item-field-colon-syntax.rs
+++ b/tests/ui/parser/trait-item-field-colon-syntax.rs
@@ -1,9 +1,17 @@
 fn main() {}
 
 trait Trait1 {
-    field_name: String, //~ ERROR expected one of `!` or `::`, found `:`
+    field_name: String, //~ ERROR fields are not allowed in trait definitions
 }
 
 trait Trait2 {
-    self: String, //~ ERROR expected one of `!` or `::`, found `:`
+    self: String, //~ ERROR fields are not allowed in trait definitions
+}
+
+trait Trait3 {
+    field_name: String //~ ERROR fields are not allowed in trait definitions
+}
+
+trait Trait4 {
+    self: String //~ ERROR fields are not allowed in trait definitions
 }

--- a/tests/ui/parser/trait-item-field-colon-syntax.stderr
+++ b/tests/ui/parser/trait-item-field-colon-syntax.stderr
@@ -1,0 +1,22 @@
+error: expected one of `!` or `::`, found `:`
+  --> $DIR/trait-item-field-colon-syntax.rs:4:15
+   |
+LL | trait Trait1 {
+   |              - while parsing this item list starting here
+LL |     field_name: String,
+   |               ^ expected one of `!` or `::`
+LL | }
+   | - the item list ends here
+
+error: expected one of `!` or `::`, found `:`
+  --> $DIR/trait-item-field-colon-syntax.rs:8:9
+   |
+LL | trait Trait2 {
+   |              - while parsing this item list starting here
+LL |     self: String,
+   |         ^ expected one of `!` or `::`
+LL | }
+   | - the item list ends here
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/parser/trait-item-field-colon-syntax.stderr
+++ b/tests/ui/parser/trait-item-field-colon-syntax.stderr
@@ -1,22 +1,50 @@
-error: expected one of `!` or `::`, found `:`
-  --> $DIR/trait-item-field-colon-syntax.rs:4:15
+error: fields are not allowed in trait definitions
+  --> $DIR/trait-item-field-colon-syntax.rs:4:5
    |
 LL | trait Trait1 {
    |              - while parsing this item list starting here
 LL |     field_name: String,
-   |               ^ expected one of `!` or `::`
+   |     ^^^^^^^^^^^^^^^^^^^
 LL | }
    | - the item list ends here
+   |
+   = help: consider using a method instead: `fn field_name(&self) -> String;`
 
-error: expected one of `!` or `::`, found `:`
-  --> $DIR/trait-item-field-colon-syntax.rs:8:9
+error: fields are not allowed in trait definitions
+  --> $DIR/trait-item-field-colon-syntax.rs:8:5
    |
 LL | trait Trait2 {
    |              - while parsing this item list starting here
 LL |     self: String,
-   |         ^ expected one of `!` or `::`
+   |     ^^^^^^^^^^^^^
 LL | }
    | - the item list ends here
+   |
+   = note: `self` can only appear as a method receiver; consider `fn method(self: String)`
 
-error: aborting due to 2 previous errors
+error: fields are not allowed in trait definitions
+  --> $DIR/trait-item-field-colon-syntax.rs:12:5
+   |
+LL | trait Trait3 {
+   |              - while parsing this item list starting here
+LL |     field_name: String
+   |     ^^^^^^^^^^^^^^^^^^
+LL | }
+   | - the item list ends here
+   |
+   = help: consider using a method instead: `fn field_name(&self) -> String;`
+
+error: fields are not allowed in trait definitions
+  --> $DIR/trait-item-field-colon-syntax.rs:16:5
+   |
+LL | trait Trait4 {
+   |              - while parsing this item list starting here
+LL |     self: String
+   |     ^^^^^^^^^^^^
+LL | }
+   | - the item list ends here
+   |
+   = note: `self` can only appear as a method receiver; consider `fn method(self: String)`
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust#161815

Detect `ident: Type` or `self: Type` inside trait bodies to emit a clearer diagnostic.