### PR TITLE
make it clear that Range cannot represent arbitrary ranges

### DIFF
--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -56,6 +56,10 @@ impl fmt::Debug for RangeFull {
 /// The range `start..end` contains all values with `start <= x < end`.
 /// It is empty if `start >= end`.
 ///
+/// Note that this type is not suited to represent all possible ranges. For example, `Range<u8>`
+/// cannot represent the range that covers all of `u8`. Use [`(Bound<T>, Bound<T>)`][Bound] if you
+/// need a type that can store an arbitrary range.
+///
 /// # Examples
 ///
 /// The `start..end` syntax is a `Range`:

--- a/library/core/src/range.rs
+++ b/library/core/src/range.rs
@@ -48,6 +48,10 @@ pub use crate::ops::{RangeFull, RangeTo};
 /// The `Range` contains all values with `start <= x < end`.
 /// It is empty if `start >= end`.
 ///
+/// Note that this type is not suited to represent all possible ranges. For example, `Range<u8>`
+/// cannot represent the range that covers all of `u8`. Use [`(Bound<T>, Bound<T>)`][Bound] if you
+/// need a type that can store an arbitrary range.
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
This seems like a useful clarification, though it is already heavily implied by the first sentence in the docs.

What is less clear to me is what type one *should* use to represent arbitrary ranges. Should we recommend `(Bound<T>, Bound<T>)` for that purpose? It seems best-stuied, and is already used for that purpose by the btree collections and in https://github.com/rust-lang/rust/issues/136903. However, I suspect it is also common that one wants to represent an arbitrary range that's bounded on both sides. `RangeInclusive` can represent all those (though representing the empty range is a bit awkward), `Range` cannot.

Nominating for t-libs to get their general vibe on what we want to recommend here, if anything.