### PR TITLE
Update mailmap for Will Crichton and Petr Hosek

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -562,6 +562,7 @@ Paul Faria <paul_faria@ultimatesoftware.com> Paul Faria <Nashenas88@gmail.com>
 Peer Aramillo Irizar <peer.aramillo.irizar@gmail.com> parir <peer.aramillo.irizar@gmail.com>
 Peter Elmers <peter.elmers@yahoo.com> <peter.elmers@rice.edu>
 Peter Liniker <peter.liniker+github@gmail.com>
+Petr Hosek <petrhosek@gmail.com> <phosek@google.com>
 Phil Dawes <phil@phildawes.net> Phil Dawes <pdawes@drw.com>
 Phil Hansch <dev@phansch.net>
 Philipp Brüschweiler <blei42@gmail.com> <blei42@gmail.com>
@@ -720,6 +721,7 @@ Wilfred Hughes <me@wilfred.me.uk>
 Wilfred Hughes <me@wilfred.me.uk> <wilfred@meta.com>
 Will Crichton <crichton.will@gmail.com> <wcrichto@stanford.edu>
 Will Crichton <crichton.will@gmail.com> <wcrichto@cs.stanford.edu>
+Will Crichton <crichton.will@gmail.com> <will_crichton@brown.edu>
 William Ting <io@williamting.com> <william.h.ting@gmail.com>
 Wim Looman <wim@nemo157.com> <rust-lang@nemo157.com>
 Wim Looman <wim@nemo157.com> <git@nemo157.com>


### PR DESCRIPTION
They are now in the team database, so they don't need to be hardcoded in `thanks` anymore. However, when I ran thanks locally, their entries were duplicated. This PR should merge their entries for different e-mails.

CC @willcrichton @petrhosek To confirm that the e-mails look right.