### PR TITLE
Record `NormalizesTo` goal for proof tree

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1044,6 +1044,11 @@ where
         Ok(())
     }
 
+    // FIXME: this only exists to walk around `delegate` field privacy.
+    pub(super) fn add_inspect_goal(&mut self, goal: Goal<I, I::Predicate>) {
+        self.inspect.add_goal(self.delegate, self.max_input_universe, GoalSource::Misc, goal);
+    }
+
     pub(super) fn next_region_var(&mut self) -> Region<I> {
         let region = self.delegate.next_region_infer();
         self.inspect.add_var_value(region);

--- a/compiler/rustc_next_trait_solver/src/solve/project_goals/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/project_goals/mod.rs
@@ -48,6 +48,7 @@ where
         let unconstrained_term = self.next_term_infer_of_alias_kind(alias);
         let normalizes_to =
             goal.with(self.cx(), ty::NormalizesTo { alias, term: unconstrained_term });
+        self.add_inspect_goal(normalizes_to);
 
         // We don't want candidate selection when normalizing associated terms to be impacted by
         // the expected term. Normalization should behave like a function of just the alias being

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -104,17 +104,18 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
         let mut instantiated_goals = vec![];
         for step in &self.steps {
             match **step {
-                inspect::ProbeStep::AddGoal(source, goal) => instantiated_goals.push((
-                    source,
-                    instantiate_canonical_state(
+                inspect::ProbeStep::AddGoal(source, goal) => {
+                    let goal = instantiate_canonical_state(
                         infcx,
                         span,
                         param_env,
                         self.goal.prev_universe,
                         &mut orig_values,
                         goal,
-                    ),
-                )),
+                    );
+                    let evaluated = self.instantiate_proof_tree_for_nested_goal(source, goal, span);
+                    instantiated_goals.push(evaluated);
+                }
                 inspect::ProbeStep::RecordImplArgs { .. } => {}
                 inspect::ProbeStep::MakeCanonicalResponse { .. }
                 | inspect::ProbeStep::NestedProbe(_) => unreachable!(),
@@ -131,9 +132,6 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
         );
 
         instantiated_goals
-            .into_iter()
-            .map(|(source, goal)| self.instantiate_proof_tree_for_nested_goal(source, goal, span))
-            .collect()
     }
 
     /// Instantiate the args of an impl if this candidate came from a

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -188,22 +188,13 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
         span: Span,
     ) -> InspectGoal<'a, 'tcx> {
         let infcx = self.goal.infcx;
-        match goal.predicate.kind().no_bound_vars() {
-            Some(ty::PredicateKind::NormalizesTo(ty::NormalizesTo { .. })) => {
-                // We don't handle `NormalizesTo` as a nested goal
-                unreachable!()
-            }
-            _ => {
-                // We're using a probe here as evaluating a goal could constrain
-                // inference variables by choosing one candidate. If we then recurse
-                // into another candidate who ends up with different inference
-                // constraints, we get an ICE if we already applied the constraints
-                // from the chosen candidate.
-                let proof_tree =
-                    infcx.probe(|_| infcx.evaluate_root_goal_for_proof_tree(goal, span).1);
-                InspectGoal::new(infcx, self.goal.depth + 1, proof_tree, source)
-            }
-        }
+        // We're using a probe here as evaluating a goal could constrain
+        // inference variables by choosing one candidate. If we then recurse
+        // into another candidate who ends up with different inference
+        // constraints, we get an ICE if we already applied the constraints
+        // from the chosen candidate.
+        let proof_tree = infcx.probe(|_| infcx.evaluate_root_goal_for_proof_tree(goal, span).1);
+        InspectGoal::new(infcx, self.goal.depth + 1, proof_tree, source)
     }
 
     /// Visit all nested goals of this candidate, rolling back


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
It should be doable.
Only one notable regression in `AmbiguityVisitor` - `tests/ui/specialization/specialization-overlap-projection.rs`. Will look into it tmrw.
Done for the day and open this to start perf.

r? lcnr