### PR TITLE
Better diagnostic for relative paths in visibilities

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0807.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0807.md
@@ -1,0 +1,31 @@
+Since edition 2018, paths for visibilities must start with `crate`, `self`,
+or `super`.
+
+Erroneous code example:
+
+```rust,edition2018,compile_fail,E0807
+mod a{
+    mod b{
+        pub(in a)struct foo;
+            //~^ ERROR E0807
+    }
+}
+fn main(){}
+```
+
+`pub(in some::path)` in edition 2015 is equivalent to
+`pub(in crate::some::path)` in edition 2018.
+So, to fix this, try adding a `crate` prefix:
+
+```rust,edition2018
+mod a{
+    mod b{
+        pub(in crate::a)struct foo;
+        //     ^^^^^^^ add a `crate` prefix here
+    }
+}
+fn main(){}
+```
+
+For more information about visibility, visit:
+https://doc.rust-lang.org/reference/visibility-and-privacy.html

--- a/compiler/rustc_error_codes/src/lib.rs
+++ b/compiler/rustc_error_codes/src/lib.rs
@@ -545,6 +545,7 @@ macro_rules! error_codes {
 0804,
 0805,
 0806,
+0807,
         );
     )
 }

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -258,21 +258,41 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 let ident = path.segments.get(0).expect("empty path in visibility").ident;
                 let crate_root = if ident.is_path_segment_keyword() {
                     None
-                } else if ident.span.is_rust_2015() {
+                } else {
                     Some(Segment::from_ident(Ident::new(
-                        kw::PathRoot,
+                        // Although relative paths are banned in edition 2018, we still
+                        // need the path for diagnostic so we use `Crate` in this case.
+                        // We don't use `Crate` in edition 2015 is to keep the diagnostic accurate.
+                        if path.span.is_rust_2015() { kw::PathRoot } else { kw::Crate },
                         path.span.shrink_to_lo().with_ctxt(ident.span.ctxt()),
                     )))
-                } else {
-                    return Err(VisResolutionError::Relative2018(
-                        ident.span,
-                        path.as_ref().clone(),
-                    ));
                 };
                 let segments = crate_root
                     .into_iter()
                     .chain(path.segments.iter().map(|seg| seg.into()))
                     .collect::<Vec<_>>();
+                if !path.span.is_rust_2015() && !ident.is_path_segment_keyword() {
+                    // If there isn't a module called `parent`, the user is
+                    // likely referring to "the parent module" of the current item.
+                    let suggest_super = ident.name.as_str() == "parent"
+                        && matches!(
+                            self.cm_mut().resolve_path(
+                                &segments,
+                                None,
+                                parent_scope,
+                                finalize.then(|| Finalize::new(id, path.span)),
+                                None,
+                                None,
+                            ),
+                            PathResult::Failed { .. }
+                        );
+                    return Err(VisResolutionError::Relative2018(
+                        ident.span,
+                        path.as_ref().clone(),
+                        suggest_super,
+                    ));
+                }
+
                 let expected_found_error = |res| {
                     Err(VisResolutionError::ExpectedFound(
                         path.span,

--- a/compiler/rustc_resolve/src/diagnostics/impls.rs
+++ b/compiler/rustc_resolve/src/diagnostics/impls.rs
@@ -1408,13 +1408,14 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         vis_resolution_error: VisResolutionError,
     ) -> ErrorGuaranteed {
         match vis_resolution_error {
-            VisResolutionError::Relative2018(span, path) => {
+            VisResolutionError::Relative2018(span, path, suggest_super) => {
                 self.dcx().create_err(diagnostics::Relative2018 {
                     span,
                     path_span: path.span,
                     // intentionally converting to String, as the text would also be used as
                     // in suggestion context
                     path_str: pprust::path_to_string(&path),
+                    suggest_super: if suggest_super { Some(path.span) } else { None },
                 })
             }
             VisResolutionError::AncestorOnly(span) => {

--- a/compiler/rustc_resolve/src/diagnostics/mod.rs
+++ b/compiler/rustc_resolve/src/diagnostics/mod.rs
@@ -524,13 +524,27 @@ pub(crate) struct TraitImplDuplicate {
 }
 
 #[derive(Diagnostic)]
-#[diag("relative paths are not supported in visibilities in 2018 edition or later")]
+#[diag("relative paths are not supported in visibilities in 2018 edition or later",code=E0807)]
+#[note_once(
+    "for more information about visibility, visit:
+    https://doc.rust-lang.org/reference/visibility-and-privacy.html"
+)]
 pub(crate) struct Relative2018 {
     #[primary_span]
     pub(crate) span: Span,
-    #[suggestion("try", code = "crate::{path_str}", applicability = "maybe-incorrect")]
+    #[suggestion(
+        "try adding a `crate` prefix",
+        code = "crate::{path_str}",
+        applicability = "maybe-incorrect"
+    )]
     pub(crate) path_span: Span,
     pub(crate) path_str: String,
+    #[suggestion(
+        "use `super` if you want this item to be visible in the parent module",
+        code = "super",
+        applicability = "maybe-incorrect"
+    )]
+    pub(crate) suggest_super: Option<Span>,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -338,7 +338,7 @@ enum ResolutionError<'ra> {
 
 #[derive(Debug)]
 enum VisResolutionError {
-    Relative2018(Span, ast::Path),
+    Relative2018(Span, ast::Path, bool),
     AncestorOnly(Span),
     FailedToResolve {
         span: Span,

--- a/tests/ui/error-codes/E0807.rs
+++ b/tests/ui/error-codes/E0807.rs
@@ -1,0 +1,12 @@
+//@edition:2018
+mod a{
+    pub(in a) struct Foo;
+    //~^ ERROR E0807
+    //~| SUGGESTION crate::a
+    pub(in parent) struct Baz;
+    //~^ ERROR E0807
+    //~| SUGGESTION super
+    //~| SUGGESTION crate::parent
+}
+
+fn main(){}

--- a/tests/ui/error-codes/E0807.stderr
+++ b/tests/ui/error-codes/E0807.stderr
@@ -1,0 +1,28 @@
+error[E0807]: relative paths are not supported in visibilities in 2018 edition or later
+  --> $DIR/E0807.rs:3:12
+   |
+LL |     pub(in a) struct Foo;
+   |            ^ help: try adding a `crate` prefix: `crate::a`
+   |
+   = note: for more information about visibility, visit:
+           https://doc.rust-lang.org/reference/visibility-and-privacy.html
+
+error[E0807]: relative paths are not supported in visibilities in 2018 edition or later
+  --> $DIR/E0807.rs:6:12
+   |
+LL |     pub(in parent) struct Baz;
+   |            ^^^^^^
+   |
+help: try adding a `crate` prefix
+   |
+LL |     pub(in crate::parent) struct Baz;
+   |            +++++++
+help: use `super` if you want this item to be visible in the parent module
+   |
+LL -     pub(in parent) struct Baz;
+LL +     pub(in super) struct Baz;
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0807`.

--- a/tests/ui/error-codes/ex-E0807.rs
+++ b/tests/ui/error-codes/ex-E0807.rs
@@ -1,0 +1,7 @@
+//@edition:2018
+mod parent{
+    pub(in parent) struct Foo;
+    //~^ ERROR E0807
+    //~| SUGGESTION crate::parent
+}
+fn main(){}

--- a/tests/ui/error-codes/ex-E0807.stderr
+++ b/tests/ui/error-codes/ex-E0807.stderr
@@ -1,0 +1,12 @@
+error[E0807]: relative paths are not supported in visibilities in 2018 edition or later
+  --> $DIR/ex-E0807.rs:3:12
+   |
+LL |     pub(in parent) struct Foo;
+   |            ^^^^^^ help: try adding a `crate` prefix: `crate::parent`
+   |
+   = note: for more information about visibility, visit:
+           https://doc.rust-lang.org/reference/visibility-and-privacy.html
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0807`.

--- a/tests/ui/privacy/restricted/relative-2018.stderr
+++ b/tests/ui/privacy/restricted/relative-2018.stderr
@@ -4,14 +4,18 @@ error[E0742]: visibilities can only be restricted to ancestor modules
 LL |     pub(in ::core) struct S4;
    |            ^^^^^^
 
-error: relative paths are not supported in visibilities in 2018 edition or later
+error[E0807]: relative paths are not supported in visibilities in 2018 edition or later
   --> $DIR/relative-2018.rs:9:12
    |
 LL |     pub(in a::b) struct S5;
    |            ^---
    |            |
-   |            help: try: `crate::a::b`
+   |            help: try adding a `crate` prefix: `crate::a::b`
+   |
+   = note: for more information about visibility, visit:
+           https://doc.rust-lang.org/reference/visibility-and-privacy.html
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0742`.
+Some errors have detailed explanations: E0742, E0807.
+For more information about an error, try `rustc --explain E0742`.


### PR DESCRIPTION
Fixes rust-lang/rust#118878

Note that the compiler suggest `pub(in super)` instead of `pub(super)`, because we can only get the span of the path. `in super` is valid but tell me if there are better ways to do this :)

I also change the original message from `try` to ``try adding a `crate` prefix`` because rustc stops inlining the suggestion when there are multiple, and a single word looks weird:
```rust
error[E0807]: relative paths are not supported in visibilities in 2018 edition or later
  --> $DIR/E0807.rs:6:5
   |
LL |     pub(in parent) struct Baz;
   |     ^^^^^^^^^^^^^^
   |
help: try
   |
LL |     pub(in crate::parent) struct Baz;
   |            +++++++
help: use `super` if you want this item to be visible in the parent module
   |
LL -     pub(in parent) struct Baz;
LL +     pub(in super) struct Baz;
   |
`