### PR TITLE
fix typo in feature documentation

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -679,7 +679,7 @@ declare_features! (
     (unstable, non_exhaustive_omitted_patterns_lint, "1.57.0", Some(89554)),
     /// Allows `for<T>` binders in where-clauses
     (incomplete, non_lifetime_binders, "1.69.0", Some(108185)),
-    /// Target feaures on nvptx.
+    /// Target features on nvptx.
     (unstable, nvptx_target_feature, "1.91.0", Some(150254)),
     /// Allows using enums in offset_of!
     (unstable, offset_of_enum, "1.75.0", Some(120141)),

--- a/src/tools/rust-analyzer/crates/ide-db/src/generated/lints.rs
+++ b/src/tools/rust-analyzer/crates/ide-db/src/generated/lints.rs
@@ -11773,7 +11773,7 @@ This feature has no tracking issue, and is therefore likely internal to the comp
         label: "nvptx_target_feature",
         description: r##"# `nvptx_target_feature`
 
-Target feaures on nvptx.
+Target features on nvptx.
 
 The tracking issue for this feature is: [#150254]
 


### PR DESCRIPTION
This is causing failing local executions of `typos-cli` (used in CI) in rust-analyzer. rust-analyzer uses the feature documentation to produce generated code.