### PR TITLE
Put manual calls of Enzyme intrinsics behind a feature gate

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -207,14 +207,28 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     fn visit_foreign_item(&mut self, i: &'a ast::ForeignItem) {
         match i.kind {
             ast::ForeignItemKind::Fn(..) | ast::ForeignItemKind::Static(..) => {
-                let link_name = attr::first_attr_value_str_by_name(&i.attrs, sym::link_name);
-                let links_to_llvm = link_name.is_some_and(|val| val.as_str().starts_with("llvm."));
-                if links_to_llvm {
+                let symbol_name = if let Some(link_name) =
+                    attr::first_attr_value_str_by_name(&i.attrs, sym::link_name)
+                {
+                    link_name
+                } else {
+                    i.kind.ident().unwrap().name
+                };
+
+                let name = symbol_name.as_str();
+                if name.starts_with("llvm.") {
                     gate!(
                         self,
                         link_llvm_intrinsics,
                         i.span,
                         "linking to LLVM intrinsics is experimental"
+                    );
+                } else if name.starts_with("__enzyme_") {
+                    gate!(
+                        self,
+                        link_enzyme_intrinsics,
+                        i.span,
+                        "linking to Enzyme intrinsics is experimental"
                     );
                 }
             }

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -272,6 +272,8 @@ declare_features! (
     (internal, lang_items, "1.0.0", None),
     /// Allows `#[link(..., cfg(..))]`; perma-unstable per #37406
     (internal, link_cfg, "1.14.0", None),
+    /// Allows using `#[link_name="__enzyme_*"]`.
+    (internal, link_enzyme_intrinsics, "CURRENT_RUSTC_VERSION", None),
     /// Allows using `?Trait` trait bounds in more contexts.
     (internal, more_maybe_bounds, "1.82.0", None),
     /// Allow negative trait bounds. This is an internal-only feature for testing the trait solver!

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1212,6 +1212,7 @@ symbols! {
         link_args,
         link_cfg,
         link_dash_arg: "link-arg",
+        link_enzyme_intrinsics,
         link_llvm_intrinsics,
         link_name,
         link_ordinal,

--- a/tests/ui/feature-gates/feature-gate-link-enzyme-intrinsics-enabled.rs
+++ b/tests/ui/feature-gates/feature-gate-link-enzyme-intrinsics-enabled.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+// gate-test-link_enzyme_intrinsics
+#![feature(link_enzyme_intrinsics)]
+
+unsafe extern "C" {
+    fn __enzyme_autodiff();
+    fn __enzyme_fwddiff();
+    fn __enzyme_augmentfwd();
+    fn __enzyme_reverse();
+    #[link_name = "__enzyme_autodiff"]
+    fn autodiff();
+
+    static __enzyme_dup: i32;
+    #[link_name = "__enzyme_dup"]
+    static ENZYME_DUP: i32;
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-link-enzyme-intrinsics-no-gate.rs
+++ b/tests/ui/feature-gates/feature-gate-link-enzyme-intrinsics-no-gate.rs
@@ -1,0 +1,30 @@
+// gate-test-link_enzyme_intrinsics
+
+unsafe extern "C" {
+    fn __enzyme_autodiff();
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    fn __enzyme_fwddiff();
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    fn __enzyme_augmentfwd();
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    fn __enzyme_reverse();
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    #[link_name = "__enzyme_autodiff"]
+    fn autodiff();
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    static __enzyme_dup: i32;
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    #[link_name = "__enzyme_dup"]
+    static ENZYME_DUP: i32;
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    static enzyme_dup: i32;
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-link-enzyme-intrinsics-no-gate.stderr
+++ b/tests/ui/feature-gates/feature-gate-link-enzyme-intrinsics-no-gate.stderr
@@ -1,0 +1,66 @@
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:4:5
+   |
+LL |     fn __enzyme_autodiff();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:7:5
+   |
+LL |     fn __enzyme_fwddiff();
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:10:5
+   |
+LL |     fn __enzyme_augmentfwd();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:13:5
+   |
+LL |     fn __enzyme_reverse();
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:17:5
+   |
+LL |     fn autodiff();
+   |     ^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:20:5
+   |
+LL |     static __enzyme_dup: i32;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:24:5
+   |
+LL |     static ENZYME_DUP: i32;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

r? bjorn3

fixes rust-lang/rust#161820

I created the internal feature gate without a tracking issue. `autodiff` didn’t seem like it was the right one. 