### PR TITLE
Report unsatisfied opaque item bounds instead of a type mismatch under -Znext-solver

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -381,6 +381,44 @@ impl<'tcx> BestObligation<'tcx> {
         })
     }
 
+    /// A `Projection` goal whose alias is a *free* alias -- e.g. the `Ta` in
+    /// `type Ta = impl Marker;` -- normalizes to the alias' value. If normalizing
+    /// that value fails, `normalize_free_alias` returns before reaching
+    /// `evaluate_added_goals_and_make_canonical_response`, so no
+    /// `MakeCanonicalResponse` step is recorded and the goal ends up with *no*
+    /// candidates at all. We'd then report a bare `Ta == u32` mismatch instead of
+    /// the real reason.
+    ///
+    /// Recurse into the alias' value so the opaque -- and in turn its item bounds --
+    /// get a chance to explain the failure.
+    fn detect_error_in_free_alias_value(
+        &mut self,
+        goal: &inspect::InspectGoal<'_, 'tcx>,
+        alias: ty::AliasTerm<'tcx>,
+        term: ty::Term<'tcx>,
+    ) -> ControlFlow<PredicateObligation<'tcx>> {
+        let tcx = goal.infcx().tcx;
+        let ty::AliasTermKind::FreeTy { def_id } = alias.kind else {
+            return ControlFlow::Continue(());
+        };
+
+        let value = tcx.type_of(def_id).instantiate(tcx, alias.args).skip_norm_wip();
+        let ty::Alias(_, inner) = *value.kind() else {
+            return ControlFlow::Continue(());
+        };
+
+        let pred = ty::ProjectionClause { projection_term: inner.into(), term };
+        let obligation =
+            Obligation::new(tcx, self.obligation.cause.clone(), goal.goal().param_env, pred);
+        self.with_derived_obligation(obligation, |this| {
+            goal.infcx().visit_proof_tree_at_depth(
+                goal.goal().with(tcx, pred),
+                goal.depth() + 1,
+                this,
+            )
+        })
+    }
+
     /// If we have no candidates, then it's likely that there is a
     /// non-well-formed alias in the goal.
     fn detect_error_from_empty_candidates(
@@ -398,6 +436,11 @@ impl<'tcx> BestObligation<'tcx> {
             {
                 self.detect_error_in_self_ty_normalization(goal, pred.projection_term.self_ty())?;
                 self.detect_non_well_formed_assoc_item(goal, pred.projection_term)?;
+            }
+            Some(ty::PredicateKind::Clause(ty::ClauseKind::Projection(pred)))
+                if matches!(pred.projection_term.kind, ty::AliasTermKind::FreeTy { .. }) =>
+            {
+                self.detect_error_in_free_alias_value(goal, pred.projection_term, pred.term)?;
             }
             Some(_) | None => {}
         }

--- a/tests/ui/traits/next-solver/stalled-coroutine-obligations.rs
+++ b/tests/ui/traits/next-solver/stalled-coroutine-obligations.rs
@@ -16,11 +16,11 @@
 fn stalled_copy_clone() {
     type T = impl Copy;
     let foo: T = async {};
-    //~^ ERROR: type mismatch resolving `T == {async block
+    //~^ ERROR: the trait bound `{async block
 
     type U = impl Clone;
     let bar: U = async {};
-    //~^ ERROR: type mismatch resolving `U == {async block
+    //~^ ERROR: the trait bound `{async block
 }
 
 auto trait Valid {}
@@ -31,7 +31,7 @@ fn stalled_auto_traits() {
     type T = impl Valid;
     let a = False;
     let foo: T = async { a };
-    //~^ ERROR: type mismatch resolving `T == {async block
+    //~^ ERROR: the trait bound `False: Valid` is not satisfied
 }
 
 

--- a/tests/ui/traits/next-solver/stalled-coroutine-obligations.stderr
+++ b/tests/ui/traits/next-solver/stalled-coroutine-obligations.stderr
@@ -1,20 +1,33 @@
-error[E0271]: type mismatch resolving `T == {async block@stalled-coroutine-obligations.rs:18:18}`
+error[E0277]: the trait bound `{async block@$DIR/stalled-coroutine-obligations.rs:18:18: 18:23}: Copy` is not satisfied
   --> $DIR/stalled-coroutine-obligations.rs:18:14
    |
 LL |     let foo: T = async {};
-   |              ^ types differ
+   |              ^ the trait `Copy` is not implemented for `{async block@$DIR/stalled-coroutine-obligations.rs:18:18: 18:23}`
 
-error[E0271]: type mismatch resolving `U == {async block@stalled-coroutine-obligations.rs:22:18}`
+error[E0277]: the trait bound `{async block@$DIR/stalled-coroutine-obligations.rs:22:18: 22:23}: Clone` is not satisfied
   --> $DIR/stalled-coroutine-obligations.rs:22:14
    |
 LL |     let bar: U = async {};
-   |              ^ types differ
+   |              ^ the trait `Clone` is not implemented for `{async block@$DIR/stalled-coroutine-obligations.rs:22:18: 22:23}`
 
-error[E0271]: type mismatch resolving `T == {async block@stalled-coroutine-obligations.rs:33:18}`
+error[E0277]: the trait bound `False: Valid` is not satisfied in `{async block@$DIR/stalled-coroutine-obligations.rs:33:18: 33:23}`
   --> $DIR/stalled-coroutine-obligations.rs:33:14
    |
 LL |     let foo: T = async { a };
-   |              ^ types differ
+   |              ^   ----- within this `{async block@$DIR/stalled-coroutine-obligations.rs:33:18: 33:23}`
+   |              |
+   |              unsatisfied trait bound
+   |
+help: within `{async block@$DIR/stalled-coroutine-obligations.rs:33:18: 33:23}`, the trait `Valid` is not implemented for `False`
+  --> $DIR/stalled-coroutine-obligations.rs:27:1
+   |
+LL | struct False;
+   | ^^^^^^^^^^^^
+note: captured value does not implement `Valid`
+  --> $DIR/stalled-coroutine-obligations.rs:33:26
+   |
+LL |     let foo: T = async { a };
+   |                          ^ has type `False` which does not implement `Valid`
 
 error[E0271]: type mismatch resolving `impl Future + Send == {async block@stalled-coroutine-obligations.rs:41:9}`
   --> $DIR/stalled-coroutine-obligations.rs:39:43
@@ -30,4 +43,5 @@ LL |         async move {
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0271`.
+Some errors have detailed explanations: E0271, E0277.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/type-alias-impl-trait/opaque-item-bound-on-unimplemented.current.stderr
+++ b/tests/ui/type-alias-impl-trait/opaque-item-bound-on-unimplemented.current.stderr
@@ -1,0 +1,18 @@
+error[E0277]: my custom message
+  --> $DIR/opaque-item-bound-on-unimplemented.rs:20:19
+   |
+LL | fn construct() -> Ta {
+   |                   ^^ the trait `Marker` is not implemented for `u32`
+LL |
+LL |     5u32
+   |     ---- return type was inferred to be `u32` here
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/opaque-item-bound-on-unimplemented.rs:15:1
+   |
+LL | trait Marker {}
+   | ^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/type-alias-impl-trait/opaque-item-bound-on-unimplemented.next.stderr
+++ b/tests/ui/type-alias-impl-trait/opaque-item-bound-on-unimplemented.next.stderr
@@ -1,0 +1,15 @@
+error[E0277]: my custom message
+  --> $DIR/opaque-item-bound-on-unimplemented.rs:20:19
+   |
+LL | fn construct() -> Ta {
+   |                   ^^ the trait `Marker` is not implemented for `u32`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/opaque-item-bound-on-unimplemented.rs:15:1
+   |
+LL | trait Marker {}
+   | ^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/type-alias-impl-trait/opaque-item-bound-on-unimplemented.rs
+++ b/tests/ui/type-alias-impl-trait/opaque-item-bound-on-unimplemented.rs
@@ -1,0 +1,25 @@
+//! Regression test for #162093.
+//!
+//! When the hidden type of an opaque does not satisfy the opaque's item bounds,
+//! the error should name the unsatisfied bound — and let
+//! `#[diagnostic::on_unimplemented]` apply — rather than reporting an opaque
+//! type mismatch.
+
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+#![feature(type_alias_impl_trait)]
+
+#[diagnostic::on_unimplemented(message = "my custom message")]
+trait Marker {}
+
+type Ta = impl Marker;
+
+#[define_opaque(Ta)]
+fn construct() -> Ta {
+    //~^ ERROR my custom message
+    5u32
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
### LLM disclosure

I used Claude extensively on this PR: to explore the compiler source. The initial diagnosis it produced was wrong twice — the first patch it suggested compiled but was entirely dead code. The actual cause (`FreeTy` rather than `OpaqueTy`) came from debug output I added and ran locally at its suggestion. I have read and understand the final patch, and verified it against a local build and the full `tests/ui` suite.
<!-- homu-ignore:end -->

Fixes rust-lang/rust#162093

Under `-Znext-solver`, a TAIT whose hidden type doesn't satisfy the opaque's item bounds reported a bare type mismatch rather than naming the unsatisfied bound. This also meant `#[diagnostic::on_unimplemented]` on that trait never applied.

### Before

```
error[E0271]: type mismatch resolving `Ta == u32`
 --> src/main.rs:9:19
  |
9 | fn construct() -> Ta {
  |                   ^^ types differ
```

### After

```
error[E0277]: my custom message
 --> src/main.rs:9:19
  |
9 | fn construct() -> Ta {
  |                   ^^ the trait `Marker` is not implemented for `u32`
```

### What was happening

`type Ta = impl Marker;` is a free type alias whose *value* is the opaque, so the failing goal is a projection on a `FreeTy` alias rather than on the opaque directly.

`normalize_free_alias` normalizes the alias' value and propagates failure with `?`, returning before `evaluate_added_goals_and_make_canonical_response`. No `MakeCanonicalResponse` step gets recorded, and `candidates_recur` only builds a candidate when `shallow_certainty` was set — so the goal ends up with no candidates at all. `BestObligation` has nothing to descend into and falls back to the projection obligation, which `fulfillment_error_for_no_solution` turns into `E0271`.

The fix recurses into the alias' value from `detect_error_from_empty_candidates`. That reaches the opaque, which *does* record a candidate and carries its item bounds as nested `GoalSource::AliasWellFormed` goals, so the real `u32: Marker` failure surfaces.

### Test changes

Three errors in `tests/ui/traits/next-solver/stalled-coroutine-obligations.rs` improve from `type mismatch resolving` to naming the unsatisfied trait bound.

### Known gaps

- RPIT (`-> impl Future + Send`) has no free alias in front of the opaque, so it still reports `E0271` — this is the fourth error in `stalled-coroutine-obligations`, left unchanged.
- The `ObligationCauseCode::OpaqueReturnType` cause code isn't attached, so the `return type was inferred to be `u32` here` note the old solver emits is still missing under `next`. Visible as a difference between the `current` and `next` revisions of the new test.

Full `tests/ui` run is clean (20484 passed, 0 failed).

r? lcnr