### PR TITLE
Add regression tests for issues marked fixed-by-next-solver (1/N)

### DIFF
--- a/tests/ui/async-await/async-closures/dyn-coercion-asyncfn-issue-160355.rs
+++ b/tests/ui/async-await/async-closures/dyn-coercion-asyncfn-issue-160355.rs
@@ -1,0 +1,21 @@
+//@ edition: 2024
+//@ compile-flags: -Znext-solver
+//@ build-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/160355>.
+// Used to ICE
+
+struct Wrap<F>(F);
+
+impl<F> Service for Wrap<F> where F: AsyncFn() {}
+
+trait Service {}
+
+impl<F> Service for F where F: AsyncFn() {}
+
+async fn ice<P>() {}
+
+fn main() {
+    let service = Wrap(ice::<&'static ()>);
+    let _ = Box::new(service) as Box<dyn Service>;
+}

--- a/tests/ui/generic-associated-types/gat-derive-clone-overflow-issue-102580.rs
+++ b/tests/ui/generic-associated-types/gat-derive-clone-overflow-issue-102580.rs
@@ -1,0 +1,17 @@
+//@ edition: 2021
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/102580>.
+// Used to overflow
+
+trait Trait: Clone {
+    type Type<T: Clone>: Clone;
+}
+
+#[derive(Clone)]
+struct Struct<T: Trait>(Option<T::Type<Self>>);
+
+fn main() {}

--- a/tests/ui/generic-associated-types/gat-where-clause-hang-issue-134370.rs
+++ b/tests/ui/generic-associated-types/gat-where-clause-hang-issue-134370.rs
@@ -1,0 +1,23 @@
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/134370>.
+// Used to get stuck in trait solver
+
+trait Assoc {
+    type Ty;
+}
+
+trait Foo {
+    type Gat<'a>;
+}
+
+trait Bar {
+    type Ty: Foo
+    where
+        for<'a> <Self::Ty as Foo>::Gat<'a>: Assoc<Ty = ()>;
+}
+
+fn main() {}

--- a/tests/ui/generic-associated-types/hrtb-bounds-not-resolving-issue-90950.rs
+++ b/tests/ui/generic-associated-types/hrtb-bounds-not-resolving-issue-90950.rs
@@ -1,0 +1,44 @@
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/90950>.
+// Used to say bound not satisfied
+
+trait Yokeable<'a>: 'static {
+    type Output: 'a;
+}
+
+
+trait IsCovariant<'a> {}
+
+struct Yoke<Y: for<'a> Yokeable<'a>> {
+    data: Y,
+}
+
+fn upcast<Y>(x: Yoke<Y>) -> Yoke<Box<dyn IsCovariant<'static> + 'static>>
+where
+    Y: for<'a> Yokeable<'a>,
+    for<'a> <Y as Yokeable<'a>>::Output: IsCovariant<'a>,
+{
+    unimplemented!()
+}
+
+
+impl<'a> Yokeable<'a> for Box<dyn IsCovariant<'static> + 'static> {
+    type Output = Box<dyn IsCovariant<'a> + 'a>;
+}
+
+use std::borrow::*;
+impl<'a, T: ToOwned + ?Sized> Yokeable<'a> for Cow<'static, T> {
+    type Output = Cow<'a, T>;
+}
+impl<'a, T: ToOwned + ?Sized> IsCovariant<'a> for Cow<'a, T> {}
+
+
+fn upcast_yoke(y: Yoke<Cow<'static, str>>) -> Yoke<Box<dyn IsCovariant<'static> + 'static>> {
+    upcast(y)
+}
+
+fn main() {}

--- a/tests/ui/generic-associated-types/hrtb-gat-assoc-hang-issue-134312.rs
+++ b/tests/ui/generic-associated-types/hrtb-gat-assoc-hang-issue-134312.rs
@@ -1,0 +1,23 @@
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/134312>.
+// Used to hang
+
+trait Trait {
+    type Type<'a>;
+}
+
+trait Trait2 {
+    type Type2;
+}
+
+trait Test {
+    type Assoc: Trait
+    where
+        for<'a> <Self::Assoc as Trait>::Type<'a>: Trait2<Type2 = ()>;
+}
+
+fn main() {}

--- a/tests/ui/generic-associated-types/mundane-hrtb-constraint-issue-97487.rs
+++ b/tests/ui/generic-associated-types/mundane-hrtb-constraint-issue-97487.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/97487>.
+// Used to ask for type annotations
+trait A {
+    type X;
+}
+
+trait B: for<'a> A<X = u32> {
+}
+
+impl<T> A for T where T: B {
+    type X = u32;
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/canonical-query-ambiguity-issue-141478.rs
+++ b/tests/ui/impl-trait/canonical-query-ambiguity-issue-141478.rs
@@ -1,0 +1,42 @@
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/141478>.
+// Used to ICE
+
+fn pretty_print<'r, T: ToProviderRef<'r>>() {
+    request::<T::ProviderRef, u8>()
+}
+fn request<T, R: RequestWithArg<PeanoSucc<T>>>() -> R::Output {
+    unimplemented!()
+}
+trait RequestWithArg<P> {
+    type Output;
+}
+impl<P, T> RequestWithArg<P> for T
+where
+    P: Tagged,
+{
+    type Output = ();
+}
+trait ToProviderRef<'r> {
+    type ProviderRef: Tagged<Tag: Sized>;
+}
+trait Tagged {
+    type Tag;
+}
+trait Unimplemented {}
+impl<T: Unimplemented> Tagged for T {
+    type Tag = ();
+}
+struct PeanoSucc<N>(N);
+impl<P, U> Tagged for PeanoSucc<P>
+where
+    P: Tagged<Tag = U>,
+{
+    type Tag = ();
+}
+
+fn main() {}


### PR DESCRIPTION
Note that while these issues are marked `fixed-by-next-solver`, some of them also pass with the old solver now.

Fixes rust-lang/rust#90950 
Fixes rust-lang/rust#102580 
Fixes rust-lang/rust#134312 
Fixes rust-lang/rust#134370 
Fixes rust-lang/rust#141478 

<!-- homu-ignore:start -->
LLM disclosure: I used LLM to collect and classify the issues. After that, I manually extracted the MCE from each issue and checked how it failed on older Rust versions.
<!-- homu-ignore:end -->
