### PR TITLE
Revert "retrieve supported GCC targets from the sysroot"

### DIFF
--- a/src/tools/compiletest/src/cli.rs
+++ b/src/tools/compiletest/src/cli.rs
@@ -401,13 +401,6 @@ pub(crate) fn parse_config(args: Vec<String>) -> Config {
     let iteration_count = args.iteration_count.unwrap_or(Config::DEFAULT_ITERATION_COUNT);
     assert!(iteration_count > 0, "`--iteration-count` must be a positive integer");
 
-    let gcc_supported_target_tuples = match default_codegen_backend {
-        CodegenBackend::Gcc => {
-            directives::find_gcc_supported_targets(&args.sysroot_base, &args.host)
-        }
-        CodegenBackend::Llvm | CodegenBackend::Cranelift => vec![],
-    };
-
     // FIXME: this run scheme is... confusing.
     let run = args.run.and_then(|mode| match mode.as_str() {
         "auto" => None,
@@ -454,8 +447,6 @@ pub(crate) fn parse_config(args: Vec<String>) -> Config {
         filters,
         force_pass_mode: args.pass,
         force_rerun: args.force_rerun,
-
-        gcc_supported_target_tuples,
 
         gdb: args.gdb,
         gdb_version,

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -770,9 +770,6 @@ pub(crate) struct Config {
     /// Whether to ignore `//@ ignore-backends`.
     pub(crate) bypass_ignore_backends: bool,
 
-    /// Target tuples for which we've found libgccjit.so.
-    pub(crate) gcc_supported_target_tuples: Vec<String>,
-
     /// Number of parallel jobs configured for the build.
     ///
     /// This is forwarded from bootstrap's `jobs` configuration.

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -851,30 +851,6 @@ pub(crate) fn extract_llvm_version_from_binary(binary_path: &str) -> Option<Vers
     None
 }
 
-pub(crate) fn find_gcc_supported_targets(sysroot_base: &Utf8Path, host: &str) -> Vec<String> {
-    // E.g. `lib/rustlib/x86_64-unknown-linux-gnu/codegen-backends/lib`.
-    let backends_dir =
-        sysroot_base.join("lib").join("rustlib").join(host).join("codegen-backends").join("lib");
-
-    match std::fs::read_dir(&backends_dir) {
-        Ok(entries) => {
-            // Search for `aarch64-unknown-linux-gnu/libgccjit.so` et cetera.
-            let target_tuples: Vec<_> = entries
-                .filter_map(|entry| entry.ok())
-                .filter(|entry| entry.path().join("libgccjit.so").exists())
-                .filter_map(|entry| entry.file_name().into_string().ok())
-                .collect();
-
-            if target_tuples.is_empty() {
-                panic!("did not find `libgccjit.so` for any target in {backends_dir}");
-            }
-
-            target_tuples
-        }
-        Err(e) => panic!("unable to find `libgccjit.so` for any target in {backends_dir}: {e:?}",),
-    }
-}
-
 /// Takes a directive of the form `"<version1> [- <version2>]"`, returns the numeric representation
 /// of `<version1>` and `<version2>` as tuple: `(<version1>, <version2>)`.
 ///
@@ -1255,7 +1231,7 @@ fn ignore_unsupported_backend_target(config: &Config, line: &DirectiveLine<'_>) 
         return IgnoreDecision::Continue;
     };
 
-    if !config.gcc_supported_target_tuples.iter().any(|t| t == target) {
+    if target != "x86_64-unknown-linux-gnu" {
         IgnoreDecision::Ignore {
             reason: format!(
                 "backend `{}` cannot build for target `{target}`",

--- a/src/tools/compiletest/src/rustdoc_gui_test.rs
+++ b/src/tools/compiletest/src/rustdoc_gui_test.rs
@@ -143,7 +143,6 @@ fn incomplete_config_for_rustdoc_gui_test() -> Config {
         default_codegen_backend: CodegenBackend::Llvm,
         override_codegen_backend: None,
         bypass_ignore_backends: Default::default(),
-        gcc_supported_target_tuples: vec![],
         jobs: Default::default(),
         parallel_frontend_threads: Config::DEFAULT_PARALLEL_FRONTEND_THREADS,
         iteration_count: Config::DEFAULT_ITERATION_COUNT,


### PR DESCRIPTION
see [#t-infra/bootstrap > cg_gcc sysroot?](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/cg_gcc.20sysroot.3F/with/620307625)