### PR TITLE
Prefer `LLVMGetVersion` for runtime info

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2172,9 +2172,13 @@ unsafe extern "C" {
 
     pub(crate) safe fn LLVMRustCoverageMappingVersion() -> u32;
     pub(crate) fn LLVMRustDebugMetadataVersion() -> u32;
+
+    /// Returns the LLVM major version that the compiler was built with.
+    ///
+    /// Note that this is hard-coded as `LLVM_VERSION_MAJOR` when `RustWrapper.cpp` is built. This
+    /// could be different than what the runtime LLVM library reports in `LLVMGetVersion`, so we
+    /// assert their equality in `configure_llvm`.
     pub(crate) fn LLVMRustVersionMajor() -> u32;
-    pub(crate) fn LLVMRustVersionMinor() -> u32;
-    pub(crate) fn LLVMRustVersionPatch() -> u32;
 
     /// Add LLVM module flags.
     ///

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -50,10 +50,7 @@ unsafe fn configure_llvm(sess: &Session) {
 
     // Check to ensure we're running against the correct LLVM version.
     unsafe {
-        let mut llvm_major = 0;
-        let mut llvm_minor = 0;
-        let mut llvm_patch = 0;
-        llvm::LLVMGetVersion(&mut llvm_major, &mut llvm_minor, &mut llvm_patch);
+        let (llvm_major, llvm_minor, llvm_patch) = get_version();
         let expected_version = llvm::LLVMRustVersionMajor();
         if llvm_major != expected_version {
             sess.dcx().emit_fatal(diagnostics::LlvmVersionMismatch {
@@ -465,7 +462,11 @@ pub(crate) fn print_version() {
 pub(crate) fn get_version() -> (u32, u32, u32) {
     // Can be called without initializing LLVM
     unsafe {
-        (llvm::LLVMRustVersionMajor(), llvm::LLVMRustVersionMinor(), llvm::LLVMRustVersionPatch())
+        let mut llvm_major = 0;
+        let mut llvm_minor = 0;
+        let mut llvm_patch = 0;
+        llvm::LLVMGetVersion(&mut llvm_major, &mut llvm_minor, &mut llvm_patch);
+        (llvm_major, llvm_minor, llvm_patch)
     }
 }
 

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -885,10 +885,6 @@ extern "C" uint32_t LLVMRustDebugMetadataVersion() {
   return DEBUG_METADATA_VERSION;
 }
 
-extern "C" uint32_t LLVMRustVersionPatch() { return LLVM_VERSION_PATCH; }
-
-extern "C" uint32_t LLVMRustVersionMinor() { return LLVM_VERSION_MINOR; }
-
 extern "C" uint32_t LLVMRustVersionMajor() { return LLVM_VERSION_MAJOR; }
 
 // FFI equivalent of LLVM's `llvm::Module::ModFlagBehavior`.


### PR DESCRIPTION
Our `LLVMRustVersion*` functions get hard-coded `LLVM_VERSION_*` values
when we build `RustWrapper.cpp`, but this could be different than the
actual LLVM library at runtime. This should never happen with toolchains
from `rustup`, but with external LLVM in a distro build, for example,
`rustc` and `LLVM` can be upgraded independently.

Most of the time when we check the LLVM version, we're only looking at
the major version anyway, and we already assert that these are equal in
`configure_llvm`. However, for anything that does check the minor or
patch version too, the runtime version is probably more relevant.
