### PR TITLE
rustdoc: format arrays differently than slices in search results

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2433,7 +2433,8 @@ class DocSearch {
                     fnType.id === typeNameIds.typeNameIdOfUnit
                 ) {
                     const [ob, sb] =
-                        fnType.id === typeNameIds.typeNameIdOfArray ||
+                        fnType.id === typeNameIds.typeNameIdOfArray ?
+                          ["[", "; _]"] :
                             fnType.id === typeNameIds.typeNameIdOfSlice ?
                         ["[", "]"] :
                         ["(", ")"];


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
before:
<img width="1194" height="450" alt="image" src="https://github.com/user-attachments/assets/aa8bf060-8ea0-4287-af81-cbf70c502a2f" />

after:
<img width="1564" height="651" alt="image" src="https://github.com/user-attachments/assets/824e35ca-870d-4f28-a211-d294955da107" />

i want to improve this further, but that would require storing const generics in rustdoc somehow.

r? @GuillaumeGomez 