### PR TITLE
Revise documentation of `NumBuffer` and `format_into()`.

### DIFF
--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -254,8 +254,12 @@ macro_rules! impl_Display {
         }
 
         impl $Signed {
-            /// Allows users to write an integer (in signed decimal format) into a variable `buf` of
-            /// type [`NumBuffer`] that is passed by the caller by mutable reference.
+            /// Formats this integer as a signed decimal number, using the memory pointed to by
+            /// `buf` as storage for the returned string slice.
+            ///
+            /// This method can be used to convert integers to strings without involving the
+            /// dynamic dispatch that using [`Display`][fmt::Display] would.
+            /// This may be more efficient in situations where [`fmt`] is not otherwise used.
             ///
             /// # Examples
             ///
@@ -298,8 +302,12 @@ macro_rules! impl_Display {
         }
 
         impl $Unsigned {
-            /// Allows users to write an integer (in unsigned decimal format) into a variable `buf`
-            /// of type [`NumBuffer`] that is passed by the caller by mutable reference.
+            /// Formats this integer as an unsigned decimal number, using the memory pointed to by
+            /// `buf` as storage for the returned string slice.
+            ///
+            /// This method can be used to convert integers to strings without involving the
+            /// dynamic dispatch that using [`Display`][fmt::Display] would.
+            /// This may be more efficient in situations where [`fmt`] is not otherwise used.
             ///
             /// # Examples
             ///
@@ -740,8 +748,12 @@ impl u128 {
         offset
     }
 
-    /// Allows users to write an integer (in unsigned decimal format) into a variable `buf` of
-    /// type [`NumBuffer`] that is passed by the caller by mutable reference.
+    /// Formats this integer as an unsigned decimal number, using the memory pointed to by
+    /// `buf` as storage for the returned string slice.
+    ///
+    /// This method can be used to convert integers to strings without involving the
+    /// dynamic dispatch that using [`Display`][fmt::Display] would.
+    /// This may be more efficient in situations where [`fmt`] is not otherwise used.
     ///
     /// # Examples
     ///
@@ -774,8 +786,12 @@ impl u128 {
 }
 
 impl i128 {
-    /// Allows users to write an integer (in signed decimal format) into a variable `buf` of
-    /// type [`NumBuffer`] that is passed by the caller by mutable reference.
+    /// Formats this integer as a signed decimal number, using the memory pointed to by
+    /// `buf` as storage for the returned string slice.
+    ///
+    /// This method can be used to convert integers to strings without involving the
+    /// dynamic dispatch that using [`Display`][fmt::Display] would.
+    /// This may be more efficient in situations where [`fmt`] is not otherwise used.
     ///
     /// # Examples
     ///

--- a/library/core/src/fmt/num_buffer.rs
+++ b/library/core/src/fmt/num_buffer.rs
@@ -38,8 +38,15 @@ impl_NumBufferTrait! {
     i128, u128,
 }
 
-/// A buffer wrapper of which the internal size is based on the maximum
-/// number of digits the associated integer can have.
+/// Memory for formatting numbers using [`T::format_into()`][u8::format_into].
+///
+/// This type consists of enough memory to hold the longest decimal string representation
+/// a number of type `T` could have.
+/// It is used only by calling `format_into()`; there is no other way to access its contents.
+/// Its purpose is to allow formatting numbers without involving the dynamic dispatch of the
+/// [`fmt`] system, which may be more efficient when [`fmt`] is not otherwise used.
+///
+/// [`fmt`]: crate::fmt
 ///
 /// # Examples
 ///


### PR DESCRIPTION
The previous documentation was, in my opinion, overly focused on the implementation of these items, rather than how and when to use them. In particular, this new documentation:

* Begins the `format_into()` documentation with what it does when called.
* Specifies that `format_into()` is a specialized alternative to the more commonly used `Display`.
* Specifies that `NumBuffer` cannot be read or otherwise used by itself.

@rustbot label +A-docs