### PR TITLE
Don't special-case `!` in stability checks anymore

### DIFF
--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -932,27 +932,12 @@ impl<'tcx> Visitor<'tcx> for CheckTraitImplStable<'tcx> {
     }
 
     fn visit_ty(&mut self, t: &'tcx Ty<'tcx, AmbigArg>) {
-        if let TyKind::Never = t.kind {
-            self.fully_stable = false;
-        }
         if let TyKind::FnPtr(function) = t.kind {
             if extern_abi_stability(function.abi).is_err() {
                 self.fully_stable = false;
             }
         }
         intravisit::walk_ty(self, t)
-    }
-
-    fn visit_fn_decl(&mut self, fd: &'tcx hir::FnDecl<'tcx>) {
-        for ty in fd.inputs {
-            self.visit_ty_unambig(ty)
-        }
-        if let hir::FnRetTy::Return(output_ty) = fd.output {
-            match output_ty.kind {
-                TyKind::Never => {} // `-> !` is stable
-                _ => self.visit_ty_unambig(output_ty),
-            }
-        }
     }
 }
 

--- a/tests/ui/stability-attribute/stability-attribute-trait-impl.rs
+++ b/tests/ui/stability-attribute/stability-attribute-trait-impl.rs
@@ -40,4 +40,10 @@ impl StableTrait for fn() -> ! {}
 #[unstable(feature = "l", issue = "none")]
 impl StableTrait for fn() -> UnstableType {}
 
+#[unstable(feature = "m", issue = "none")]
+impl StableTrait for fn(!) {}
+
+#[unstable(feature = "n", issue = "none")]
+impl StableTrait for fn(UnstableType) {}
+
 fn main() {}

--- a/tests/ui/stability-attribute/stability-attribute-trait-impl.rs
+++ b/tests/ui/stability-attribute/stability-attribute-trait-impl.rs
@@ -23,6 +23,7 @@ impl StableTrait for UnstableType {}
 impl UnstableTrait for StableType {}
 
 #[unstable(feature = "h", issue = "none")]
+//~^ ERROR an `#[unstable]` annotation here has no effect [ineffective_unstable_trait_impl]
 impl StableTrait for ! {}
 
 // Note: If rust_cold_cc is stabilized, switch this to another (unstable) ABI.
@@ -41,6 +42,7 @@ impl StableTrait for fn() -> ! {}
 impl StableTrait for fn() -> UnstableType {}
 
 #[unstable(feature = "m", issue = "none")]
+//~^ ERROR an `#[unstable]` annotation here has no effect [ineffective_unstable_trait_impl]
 impl StableTrait for fn(!) {}
 
 #[unstable(feature = "n", issue = "none")]

--- a/tests/ui/stability-attribute/stability-attribute-trait-impl.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-trait-impl.stderr
@@ -1,16 +1,32 @@
 error: an `#[unstable]` annotation here has no effect
-  --> $DIR/stability-attribute-trait-impl.rs:32:1
+  --> $DIR/stability-attribute-trait-impl.rs:25:1
    |
-LL | #[unstable(feature = "j", issue = "none")]
+LL | #[unstable(feature = "h", issue = "none")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information
    = note: `#[deny(ineffective_unstable_trait_impl)]` on by default
 
 error: an `#[unstable]` annotation here has no effect
-  --> $DIR/stability-attribute-trait-impl.rs:36:1
+  --> $DIR/stability-attribute-trait-impl.rs:33:1
+   |
+LL | #[unstable(feature = "j", issue = "none")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information
+
+error: an `#[unstable]` annotation here has no effect
+  --> $DIR/stability-attribute-trait-impl.rs:37:1
    |
 LL | #[unstable(feature = "k", issue = "none")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information
+
+error: an `#[unstable]` annotation here has no effect
+  --> $DIR/stability-attribute-trait-impl.rs:44:1
+   |
+LL | #[unstable(feature = "m", issue = "none")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information
@@ -26,5 +42,5 @@ LL | | #[stable(feature = "a", since = "3.3.3")]
 LL | | fn main() {}
    | |____________^
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Two instances of special-casing:
- one for `!`, added in rust-lang/rust#76538 (nearly 6 years ago, Rust v1.48), back when `!` was unstable,
- one for `fn() -> !` in rust-lang/rust#103239 (nearly 4 years ago, Rust v1.66), because `-> !` was allowed on stable even with `!` being unstable.

Since then, in rust-lang/rust#103239 (just a week ago, on track to be part of Rust v1.100), `!` was stabilized, so the first check became wrong and the second became redundant. Let's remove them.

Fixes rust-lang/rust#162116.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
