### PR TITLE
Add regression tests for issues marked fixed-by-next-solver (3/N)

### DIFF
--- a/tests/ui/traits/hir-wfcheck-gat-issue-157800.rs
+++ b/tests/ui/traits/hir-wfcheck-gat-issue-157800.rs
@@ -1,0 +1,32 @@
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/157800>.
+// Used to ICE
+
+trait Dbg {}
+
+struct Foo<I, E> {
+    input: I,
+    errors: E,
+}
+
+trait Bar: Offset<<Self as Bar>::Checkpoint> {
+    type Checkpoint;
+}
+
+impl<I: Bar, E: Dbg> Bar for Foo<I, E> {
+    type Checkpoint = I::Checkpoint;
+}
+
+trait Offset<Start = Self> {}
+
+impl<I: Bar, E: Dbg> Offset<<Foo<I, E> as Bar>::Checkpoint> for Foo<I, E> {}
+
+impl<I: Bar, E: Dbg> Foo<I, E> {
+    fn record_err(self, _: <Self as Bar>::Checkpoint) {}
+}
+
+fn main() {}

--- a/tests/ui/traits/mir-inlining-geoarrow-issue-131960.rs
+++ b/tests/ui/traits/mir-inlining-geoarrow-issue-131960.rs
@@ -1,0 +1,45 @@
+//@ revisions: current next
+//@ compile-flags: -Copt-level=3
+//@ [next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/131960>.
+// Used to overflow
+
+pub trait One: Sized {
+    type ItemOne;
+    type ToTwo: Two<ItemTwo = Self::ItemOne>;
+}
+pub trait Two {
+    type ItemTwo;
+    type ToOne: One<ItemOne = Self::ItemTwo>;
+}
+
+trait OneExt {
+    fn one_ext() {}
+}
+impl<T, C: One<ItemOne = T>> OneExt for C {}
+// Using this instead makes it compile
+// impl<C: One> OneExt for C {}
+
+#[allow(unconditional_recursion)]
+fn recurse<C: One>() {
+    C::one_ext();
+    recurse::<<C::ToTwo as Two>::ToOne>();
+}
+
+// This works fine
+// #[allow(unconditional_recursion)]
+// fn recurse<C: One>() {
+//     fn require_one_ext<C: OneExt>() {}
+//     require_one_ext::<C>();
+//     recurse::<<C::ToTwo as Two>::ToOne>();
+// }
+
+// This function is necessary to reproduce the bug.
+pub fn call_recurse<C: One>() {
+    recurse::<C>();
+}
+
+fn main() {}

--- a/tests/ui/traits/nested-assoc-implied-bound-issue-149120.rs
+++ b/tests/ui/traits/nested-assoc-implied-bound-issue-149120.rs
@@ -1,0 +1,17 @@
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/149120>.
+// Used to result in delayed bug
+
+fn f<T: WithAssoc<Assoc = ()>>(_ptr: &Wrapper<T>) {}
+
+struct Wrapper<T: WithAssoc>(<T::Assoc as WithAssoc>::Assoc);
+
+trait WithAssoc {
+    type Assoc: WithAssoc;
+}
+
+fn main() {}

--- a/tests/ui/traits/nested-struct-exponential-issue-105900.rs
+++ b/tests/ui/traits/nested-struct-exponential-issue-105900.rs
@@ -1,0 +1,47 @@
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/105900>.
+// Used to take exponentially long
+
+use std::marker::PhantomData;
+
+pub trait Wrappable<I>: Sized {
+    type Type;
+    fn wrap(self) -> Wrapper<Self, Self::Type> {
+        Wrapper(self, PhantomData)
+    }
+}
+
+pub struct Wrapper<A, E>(A, PhantomData<E>);
+impl<I, E, A: Wrappable<I, Type = E>> Wrappable<I> for Wrapper<A, E> {
+    type Type = E;
+}
+
+impl Wrappable<u8> for u8 {
+    type Type = u8;
+}
+
+pub fn function() {
+    0u8
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap()
+        .wrap();
+}
+fn main() {}

--- a/tests/ui/traits/recursive-assoc-const-resolution-issue-126296.rs
+++ b/tests/ui/traits/recursive-assoc-const-resolution-issue-126296.rs
@@ -1,0 +1,19 @@
+//@ edition: 2021
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/126296>.
+// Used to overflow
+
+trait Unimplemented {}
+
+struct Special<U>(U);
+struct Wrapper<T>(T);
+
+trait A {}
+impl<T> A for Special<Wrapper<T>> where Special<T>: A {}
+impl<T: Unimplemented> A for Special<T> {}
+
+fn main() {}

--- a/tests/ui/traits/sized-param-env-guidance-issue-137812.rs
+++ b/tests/ui/traits/sized-param-env-guidance-issue-137812.rs
@@ -1,0 +1,20 @@
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/137812>.
+// Used to say the trait bound `T: Foo<(U,)>` is not satisfied
+trait Foo<T> {
+    fn method();
+}
+
+fn test<T, U>()
+where
+    T: Foo<(i32,)>,
+    (U,): Sized,
+{
+    <T as Foo<(_,)>>::method();
+}
+
+fn main() {}

--- a/tests/ui/traits/stack-dependent-cache-issue-123403.rs
+++ b/tests/ui/traits/stack-dependent-cache-issue-123403.rs
@@ -1,0 +1,42 @@
+//@ edition: 2021
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/123403>.
+// Used to say the trait bound is not satisfied
+struct W<T: ?Sized>(*const T);
+trait Foo {}
+trait Bar {}
+
+impl<T: Bar + NotImplemented> Foo for T {}
+impl Foo for W<u32> {}
+
+impl<T: Foo + AssertInferenceConstraintsApplied> Bar for T {}
+trait AssertInferenceConstraintsApplied {}
+trait GuideFromEnv {}
+trait ErrOnGuidance {}
+impl<T: GuideFromEnv + ErrOnGuidance> AssertInferenceConstraintsApplied for T {}
+impl<T> GuideFromEnv for T {}
+impl ErrOnGuidance for W<u32> {}
+
+impl<T> Bar for T
+where
+    W<T>: NotImplemented {}
+trait NotImplemented {}
+
+fn impls_foo<T: Foo>() {}
+fn impls_bar<T: Bar>() {}
+
+fn with_bound()
+where
+    W<u64>: GuideFromEnv,
+{
+    impls_foo::<W<_>>(); // commenting this line changes the next one to OK
+    impls_bar::<W<_>>();
+}
+
+fn main() {
+    with_bound();
+}


### PR DESCRIPTION
Note that while these issues are marked `fixed-by-next-solver`, they also pass with the old solver now.
<!-- homu-ignore:start -->
LLM disclosure: I used LLM to collect and classify the issues. After that, I manually extracted the MCE from each issue and checked how it failed on older Rust versions.
<!-- homu-ignore:end -->
