### PR TITLE
perf: Do not reevaluate goals on the changes on the very opaques registered by them

### DIFF
--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -340,6 +340,9 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
     fn opaque_types_storage_num_entries(&self) -> OpaqueTypeStorageEntries {
         self.inner.borrow_mut().opaque_types().num_entries()
     }
+    fn num_opaques_in_storage(&self) -> usize {
+        self.inner.borrow_mut().opaque_types().num_opaques()
+    }
     fn clone_opaque_types_lookup_table(&self) -> Vec<(ty::OpaqueTypeKey<'tcx>, Ty<'tcx>)> {
         self.inner.borrow_mut().opaque_types().iter_lookup_table().map(|(k, h)| (k, h.ty)).collect()
     }

--- a/compiler/rustc_infer/src/infer/opaque_types/table.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/table.rs
@@ -72,6 +72,10 @@ impl<'tcx> OpaqueTypeStorage<'tcx> {
         }
     }
 
+    pub fn num_opaques(&self) -> usize {
+        self.opaque_types.len()
+    }
+
     pub fn opaque_types_added_since(
         &self,
         prev_entries: OpaqueTypeStorageEntries,

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -24,7 +24,7 @@ use rustc_type_ir::{
 use thin_vec::ThinVec;
 use tracing::{Level, debug, instrument, trace, warn};
 
-use super::has_only_region_constraints;
+use super::has_only_region_constraints_or_opaques;
 use crate::canonical::{
     canonicalize_goal, canonicalize_response, instantiate_and_apply_query_response,
     response_no_constraints_raw,
@@ -671,7 +671,7 @@ where
         )
         .entered();
 
-        let (result, orig_values, canonical_goal, succeeded_in_erased) = 'retry_canonicalize: {
+        let (result, orig_values, succeeded_in_erased) = 'retry_canonicalize: {
             let skip_erased_attempt = match typing_mode {
                 TypingMode::Reflection | TypingMode::Coherence => true,
                 TypingMode::Typeck { .. }
@@ -737,7 +737,6 @@ where
                         break 'retry_canonicalize (
                             canonical_result,
                             orig_values,
-                            canonical_goal,
                             SucceededInErased::Yes { accessed_opaques },
                         );
                     }
@@ -746,7 +745,6 @@ where
                         break 'retry_canonicalize (
                             canonical_result,
                             orig_values,
-                            canonical_goal,
                             // If we're propagating up, we should never retry the goal.
                             // That means `No` is fine to return, it doesn't really matter.
                             SucceededInErased::No,
@@ -770,7 +768,7 @@ where
                 "we run without TypingMode::ErasedNotCoherence, so opaques are available, and we don't retry if the outer typing mode is ErasedNotCoherence: {accessed_opaques:?} after {goal:?}"
             );
 
-            (canonical_result, orig_values, canonical_goal, SucceededInErased::No)
+            (canonical_result, orig_values, SucceededInErased::No)
         };
 
         debug!(?result);
@@ -787,8 +785,11 @@ where
 
         drop(tracing_span);
 
-        let has_changed =
-            if !has_only_region_constraints(response) { HasChanged::Yes } else { HasChanged::No };
+        let has_changed = if !has_only_region_constraints_or_opaques(response) {
+            HasChanged::Yes
+        } else {
+            HasChanged::No
+        };
 
         let (normalization_nested_goals, certainty) = instantiate_and_apply_query_response(
             self.delegate,
@@ -816,12 +817,9 @@ where
                 // that is not resolved. Only when *these* have changed is it meaningful
                 // to recompute this goal.
                 HasChanged::Yes => None,
-                HasChanged::No => Some(self.build_stalled_on(
-                    canonical_goal,
-                    maybe_info,
-                    orig_values,
-                    succeeded_in_erased,
-                )),
+                HasChanged::No => {
+                    Some(self.build_stalled_on(maybe_info, orig_values, succeeded_in_erased))
+                }
             },
         };
 
@@ -833,7 +831,6 @@ where
 
     fn build_stalled_on(
         &self,
-        canonical_goal: I::CanonicalInput,
         maybe_info: MaybeInfo,
         stalled_vars: ThinVec<I::GenericArg>,
         previously_succeeded_in_erased: SucceededInErased<I>,
@@ -870,11 +867,7 @@ where
             sub_roots,
             stalled_maybe_info: maybe_info,
             opaques: GoalStalledOnOpaques::Yes {
-                num_opaques_in_storage: canonical_goal
-                    .canonical
-                    .value
-                    .predefined_opaques_in_body
-                    .len(),
+                num_opaques_in_storage: self.delegate.num_opaques_in_storage(),
                 previously_succeeded_in_erased,
             },
         }

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -79,6 +79,17 @@ fn has_only_region_constraints<I: Interner>(response: ty::Canonical<I, Response<
         && normalization_nested_goals.is_empty()
 }
 
+fn has_only_region_constraints_or_opaques<I: Interner>(
+    response: ty::Canonical<I, Response<I>>,
+) -> bool {
+    let ExternalConstraintsData {
+        region_constraints: _,
+        opaque_types: _,
+        ref normalization_nested_goals,
+    } = *response.value.external_constraints;
+    response.value.var_values.is_identity_modulo_regions() && normalization_nested_goals.is_empty()
+}
+
 impl<'a, D, I> EvalCtxt<'a, D>
 where
     D: SolverDelegate<Interner = I>,

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -549,6 +549,7 @@ pub trait InferCtxtLike: Sized {
 
     type OpaqueTypeStorageEntries: OpaqueTypeStorageEntries;
     fn opaque_types_storage_num_entries(&self) -> Self::OpaqueTypeStorageEntries;
+    fn num_opaques_in_storage(&self) -> usize;
     fn clone_opaque_types_lookup_table(
         &self,
     ) -> Vec<(ty::OpaqueTypeKey<Self::Interner>, <Self::Interner as Interner>::Ty)>;

--- a/tests/ui/assumptions_on_binders/canonical-response-placeholder-assumptions-issue-159889.rs
+++ b/tests/ui/assumptions_on_binders/canonical-response-placeholder-assumptions-issue-159889.rs
@@ -19,6 +19,6 @@ impl Trait for () {
 
 #[define_opaque(Foo)]
 fn foo() -> Foo {}
-//~^ ERROR item does not constrain `Foo::{opaque#0}`
+//~^ ERROR type annotations needed
 
 fn main() {}

--- a/tests/ui/assumptions_on_binders/canonical-response-placeholder-assumptions-issue-159889.stderr
+++ b/tests/ui/assumptions_on_binders/canonical-response-placeholder-assumptions-issue-159889.stderr
@@ -1,15 +1,9 @@
-error: item does not constrain `Foo::{opaque#0}`
-  --> $DIR/canonical-response-placeholder-assumptions-issue-159889.rs:21:4
+error[E0282]: type annotations needed
+  --> $DIR/canonical-response-placeholder-assumptions-issue-159889.rs:21:13
    |
 LL | fn foo() -> Foo {}
-   |    ^^^
-   |
-   = note: consider removing `#[define_opaque]` or adding an empty `#[define_opaque()]`
-note: this opaque type is supposed to be constrained
-  --> $DIR/canonical-response-placeholder-assumptions-issue-159889.rs:13:12
-   |
-LL | type Foo = impl for<'a> Trait<Assoc<'a> = FooAssoc<'a>>;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^ cannot infer type
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
Originally written by @cynecx in https://github.com/rust-lang/rust-analyzer/issues/23217#issuecomment-5502762028

Currently we track `StalledOnOpaques` with the number of opaques when we started to evaluate the goal.
This is correct and safe, but it makes the goals normalizes opaques, either by their own or their nested goals, to be evaluated once again b/c the `num_opaques_in_storage` is changed by themselves.

I think tracking the `num_opaques_in_storage` from the point we finished to evaluate the goal make sense, because..

- The only places we directly register opaques is when we evaluate `Projection` goals for opaques, and they are surely unaffected by skipping reevaluation.
- For the goals who have the above goals as nested goals are also unaffected, as registering some opaques from some nested goals still makes the other goals to be reevaluated in the fixed-point iteration. 