### PR TITLE
fix ICE in project_goals/inherent

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/project_goals/inherent.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/project_goals/inherent.rs
@@ -50,8 +50,11 @@ where
             }
             ty::AliasTermKind::InherentConstImpl { def_id } if cx.is_type_const(def_id.into()) => {
                 let inherent = cx.const_of_item(def_id.into()).instantiate(cx, inherent_args);
-                let inherent = self.normalize(GoalSource::Misc, goal.param_env, inherent)?;
-                inherent.into()
+                let normalized_ct = self.normalize(GoalSource::Misc, goal.param_env, inherent)?;
+                let normalized = normalized_ct.into();
+                let term = ty::AliasTerm::new_from_args(cx, inherent_kind, inherent_args);
+                self.push_const_arg_has_type_goal(goal.param_env, term, normalized)?;
+                normalized
             }
             ty::AliasTermKind::InherentConstImpl { .. } => {
                 let term = ty::AliasTerm::new_from_args(cx, inherent_kind, inherent_args);
@@ -68,11 +71,6 @@ where
             kind => panic!("expected inherent alias, found {kind:?}"),
         };
 
-        self.push_const_arg_has_type_goal(
-            goal.param_env,
-            goal.predicate.projection_term,
-            normalized,
-        )?;
         self.eq(goal.param_env, goal.predicate.term, normalized)?;
         self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
     }

--- a/tests/ui/const-generics/generic_const_parameter_types/inherent-type-const.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/inherent-type-const.rs
@@ -1,4 +1,7 @@
 //@ check-pass
+//@ revisions: next old
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
 #![feature(
     min_generic_const_args,
     generic_const_parameter_types,


### PR DESCRIPTION
I'm a silly goose. The next solver has the exact same bug as https://github.com/rust-lang/rust/pull/161858 - merely enabling next-solver on the test added in that PR causes an ICE :upside_down_face:

ICE was technically introduced by https://github.com/rust-lang/rust/pull/161929 but this bug has always been present, it's just that PR explicitly tracked things better and ICEd on the bug instead of silently continuing.

fixes https://github.com/rust-lang/rust/issues/162147

explanation: `push_const_arg_has_type_goal` expects its term to have rebased, `impl`-format args, not `Self` format args. See doc comment on `AliasConstKind::InherentSelf` for what "impl format" and "self format" mean: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_type_ir/enum.AliasConstKind.html#variant.InherentSelf

r? @BoxyUwU since we chatted about this yesterday but honestly anyone vaguely t-types and/or const-generics feel free to review as well, should be relatively straightforward!