### PR TITLE
bootstrap: use target's LLVM libdir when cross-compiling

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -5,6 +5,7 @@ use std::{env, fs};
 
 use super::{Builder, Kind};
 use crate::core::build_steps::compile::is_lto_stage;
+use crate::core::build_steps::llvm::Llvm;
 use crate::core::build_steps::test;
 use crate::core::build_steps::tool::SourceType;
 use crate::core::compiler::Compiler;
@@ -1243,12 +1244,18 @@ impl Builder<'_> {
         if (mode == Mode::ToolRustcPrivate || mode == Mode::Codegen)
             && self.is_llvm_enabled_for(target)
         {
-            let llvm_libdir_raw = command(self.host_llvm_config())
-                .cached()
-                .arg("--libdir")
-                .run_capture_stdout(self)
-                .stdout();
-            let llvm_libdir = llvm_libdir_raw.trim();
+            let llvm_libdir = if self.config.is_host_target(target) {
+                command(self.host_llvm_config())
+                    .cached()
+                    .arg("--libdir")
+                    .run_capture_stdout(self)
+                    .stdout()
+                    .trim()
+                    .to_owned()
+            } else {
+                let llvm_output = self.ensure(Llvm { target });
+                llvm_output.root_dir().join("lib").to_string_lossy().into_owned()
+            };
             if target.is_msvc() {
                 rustflags.arg(&format!("-Clink-arg=-LIBPATH:{llvm_libdir}"));
             } else {


### PR DESCRIPTION
`Cargo::cargo` adds LLVM's library search path to `rustflags` for `ToolRustcPrivate`/`Codegen` so that tools linking against compiler libraries can find `libLLVM`. However, it always queried `host_llvm_config()`, which resolves to the *host*'s `llvm-config` regardless of the requested `target`. When cross-compiling, this appends the host's LLVM libdir to the target's link flags, which can cause linking to fail.

Only use `llvm-config --libdir` when `target` is the host. Otherwise, ensure the `Llvm` step for `target` and derive the libdir from its `root_dir()` instead of invoking `llvm-config`, since the resulting binary may not be executable on the host if it was built for a different target.
