### PR TITLE
mention the opaque when its hidden type cannot be inferred

### DIFF
--- a/compiler/rustc_hir_typeck/src/opaque_types.rs
+++ b/compiler/rustc_hir_typeck/src/opaque_types.rs
@@ -198,6 +198,10 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
                                 TypeAnnotationNeeded::E0282,
                                 false,
                             )
+                            // The shared E0282 label only says "cannot infer type", which gives no
+                            // hint that the ambiguity is in an opaque's hidden type rather than an
+                            // ordinary local inference failure.
+                            .with_note("cannot infer type of hidden type of opaque")
                             .emit()
                     }
                 }

--- a/tests/ui/generic-associated-types/ambig-hr-projection-issue-93340.next.stderr
+++ b/tests/ui/generic-associated-types/ambig-hr-projection-issue-93340.next.stderr
@@ -4,6 +4,7 @@ error[E0282]: type annotations needed
 LL |     cmp_eq
    |     ^^^^^^ cannot infer type of the type parameter `A` declared on the function `cmp_eq`
    |
+   = note: cannot infer type of hidden type of opaque
 help: consider specifying the generic arguments
    |
 LL |     cmp_eq::<A, B, O>

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.next.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.next.stderr
@@ -4,6 +4,7 @@ error[E0282]: type annotations needed for `<X as Trait<'static>>::Out<_>`
 LL |     let x = *x;
    |         ^
    |
+   = note: cannot infer type of hidden type of opaque
 help: consider giving `x` an explicit type, where the placeholders `_` are specified
    |
 LL |     let x: <_ as Trait<'static>>::Out<_> = *x;

--- a/tests/ui/impl-trait/auto-trait-selection-freeze.next.stderr
+++ b/tests/ui/impl-trait/auto-trait-selection-freeze.next.stderr
@@ -4,6 +4,7 @@ error[E0282]: type annotations needed
 LL |     if false { is_trait(foo()) } else { Default::default() }
    |                ^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `is_trait`
    |
+   = note: cannot infer type of hidden type of opaque
 help: consider specifying the generic arguments
    |
 LL |     if false { is_trait::<T, U>(foo()) } else { Default::default() }

--- a/tests/ui/impl-trait/auto-trait-selection.next.stderr
+++ b/tests/ui/impl-trait/auto-trait-selection.next.stderr
@@ -4,6 +4,7 @@ error[E0282]: type annotations needed
 LL |     if false { is_trait(foo()) } else { Default::default() }
    |                ^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `is_trait`
    |
+   = note: cannot infer type of hidden type of opaque
 help: consider specifying the generic arguments
    |
 LL |     if false { is_trait::<T, U>(foo()) } else { Default::default() }

--- a/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.next.stderr
+++ b/tests/ui/impl-trait/non-defining-uses/ice-issue-146191.next.stderr
@@ -3,6 +3,8 @@ error[E0282]: type annotations needed
    |
 LL | fn create_complex_future() -> impl Future<Output = impl ReturnsSend> {
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: cannot infer type of hidden type of opaque
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/non-defining-uses/unconstrained-hidden-type-issue-146231.next.stderr
+++ b/tests/ui/impl-trait/non-defining-uses/unconstrained-hidden-type-issue-146231.next.stderr
@@ -1,8 +1,8 @@
 error[E0282]: type annotations needed
-  --> $DIR/constrain_in_projection2.rs:28:27
+  --> $DIR/unconstrained-hidden-type-issue-146231.rs:15:24
    |
-LL |     let x = <Foo as Trait<Bar>>::Assoc::default();
-   |                           ^^^ cannot infer type
+LL | fn recursive_rpit() -> impl Sized {
+   |                        ^^^^^^^^^^ cannot infer type
    |
    = note: cannot infer type of hidden type of opaque
 

--- a/tests/ui/impl-trait/non-defining-uses/unconstrained-hidden-type-issue-146231.rs
+++ b/tests/ui/impl-trait/non-defining-uses/unconstrained-hidden-type-issue-146231.rs
@@ -1,0 +1,20 @@
+//@ revisions: current next
+//@[current] check-pass
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+
+// The only use of the opaque below is the recursive call, so nothing ever
+// constrains its hidden type. The error has to say that the ambiguity is in
+// the opaque's hidden type, otherwise it reads as an ordinary inference
+// failure and gives no hint that an opaque is involved at all.
+//
+// Only the next solver reports this; the old solver accepts the item.
+
+#![allow(unconditional_recursion)]
+
+fn recursive_rpit() -> impl Sized {
+    //[next]~^ ERROR type annotations needed
+    recursive_rpit()
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/recursive-in-exhaustiveness.next.stderr
+++ b/tests/ui/impl-trait/recursive-in-exhaustiveness.next.stderr
@@ -4,6 +4,7 @@ error[E0282]: type annotations needed for `(_,)`
 LL |     let (x,) = (build(x),);
    |         ^^^^
    |
+   = note: cannot infer type of hidden type of opaque
 help: consider giving this pattern a type, where the placeholder `_` is specified
    |
 LL |     let (x,): (_,) = (build(x),);
@@ -15,6 +16,7 @@ error[E0282]: type annotations needed for `((_,),)`
 LL |     let (x,) = (build2(x),);
    |         ^^^^
    |
+   = note: cannot infer type of hidden type of opaque
 help: consider giving this pattern a type, where the placeholder `_` is specified
    |
 LL |     let (x,): ((_,),) = (build2(x),);
@@ -25,6 +27,8 @@ error[E0282]: type annotations needed
    |
 LL | fn build3<T>(x: T) -> impl Sized {
    |                       ^^^^^^^^^^ cannot infer type
+   |
+   = note: cannot infer type of hidden type of opaque
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/impl-trait/two_tait_defining_each_other2.next.stderr
+++ b/tests/ui/impl-trait/two_tait_defining_each_other2.next.stderr
@@ -3,6 +3,8 @@ error[E0282]: type annotations needed
    |
 LL | fn muh(x: A) -> B {
    |           ^ cannot infer type
+   |
+   = note: cannot infer type of hidden type of opaque
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/next-solver/opaques/dont-type_of-tait-in-defining-scope.is_send.stderr
+++ b/tests/ui/traits/next-solver/opaques/dont-type_of-tait-in-defining-scope.is_send.stderr
@@ -3,6 +3,8 @@ error[E0282]: type annotations needed
    |
 LL |     needs_send::<Foo>();
    |     ^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `needs_send`
+   |
+   = note: cannot infer type of hidden type of opaque
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/next-solver/opaques/dont-type_of-tait-in-defining-scope.not_send.stderr
+++ b/tests/ui/traits/next-solver/opaques/dont-type_of-tait-in-defining-scope.not_send.stderr
@@ -3,6 +3,8 @@ error[E0282]: type annotations needed
    |
 LL |     needs_send::<Foo>();
    |     ^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `needs_send`
+   |
+   = note: cannot infer type of hidden type of opaque
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/next-solver/opaques/recursive-hidden-type-canonicalization.stderr
+++ b/tests/ui/traits/next-solver/opaques/recursive-hidden-type-canonicalization.stderr
@@ -4,6 +4,7 @@ error[E0282]: type annotations needed for `*mut _`
 LL |         let r = random_paulis().unwrap();
    |             ^
    |
+   = note: cannot infer type of hidden type of opaque
 help: consider giving `r` an explicit type, where the placeholder `_` is specified
    |
 LL |         let r: *mut _ = random_paulis().unwrap();

--- a/tests/ui/type-alias-impl-trait/issue-84660-unsoundness.next.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-84660-unsoundness.next.stderr
@@ -12,6 +12,8 @@ error[E0282]: type annotations needed
    |
 LL |     fn convert(_i: In) -> Self::Out {
    |                           ^^^^^^^^^ cannot infer type
+   |
+   = note: cannot infer type of hidden type of opaque
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-impl-trait/method_resolution_trait_method_from_opaque.next.stderr
+++ b/tests/ui/type-alias-impl-trait/method_resolution_trait_method_from_opaque.next.stderr
@@ -4,6 +4,7 @@ error[E0282]: type annotations needed
 LL |         self.bar.next().unwrap();
    |                  ^^^^
    |
+   = note: cannot infer type of hidden type of opaque
 help: try using a fully qualified path to specify the expected types
    |
 LL -         self.bar.next().unwrap();

--- a/tests/ui/type-alias-impl-trait/nested-tait-inference2.next.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-tait-inference2.next.stderr
@@ -3,6 +3,8 @@ error[E0282]: type annotations needed
    |
 LL | fn foo() -> impl Foo<FooX> {
    |             ^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: cannot infer type of hidden type of opaque
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
when the hidden type of an opaque was never constrained, typeck reported `E0282` with only the shared cannot infer type label. nothing in the output said an opaque was involved, so the error read like an ordinary local inference failure.

the unconstrained hidden type arm now adds a note naming the opaque as the source of the ambiguity.

fixes https://github.com/rust-lang/rust/issues/146231

r? @lcnr