### PR TITLE
Update internal docs & tests to use `!` rather than `Infallible` in relation to `Try`

### DIFF
--- a/compiler/rustc_attr_ir/src/diagnostic.rs
+++ b/compiler/rustc_attr_ir/src/diagnostic.rs
@@ -204,9 +204,9 @@ impl FormatString {
 /// ```rust,ignore (just an example)
 /// FormatArgs {
 ///     this: "FromResidual",
-///     this_resolved: "FromResidual<Option<Infallible>>",
+///     this_resolved: "FromResidual<Option<!>>",
 ///     item_context: "an async function",
-///     generic_args: [("Self", "u32"), ("R", "Option<Infallible>")],
+///     generic_args: [("Self", "u32"), ("R", "Option<!>")],
 /// }
 /// ```
 #[derive(Debug)]
@@ -444,7 +444,7 @@ pub enum LitOrArg {
 ///     crate_local: false,
 ///     direct: true,
 ///     generic_args: [("Self","u32"),
-///         ("R", "core::option::Option<core::convert::Infallible>"),
+///         ("R", "core::option::Option<!>"),
 ///         ("R", "core::option::Option<T>" ),
 ///     ],
 /// }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -396,7 +396,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                                 // `std::marker::Sized` is not implemented for `T`" as we will point
                                 // at the type param with a label to suggest constraining it.
                                 && !self.tcx.is_diagnostic_item(sym::FromResidual, leaf_trait_predicate.def_id())
-                            // Don't say "the trait `FromResidual<Option<Infallible>>` is
+                            // Don't say "the trait `FromResidual<Option<!>>` is
                             // not implemented for `Result<T, E>`".
                             {
                                 // We do this just so that the JSON output's `help` position is the

--- a/src/tools/clippy/clippy_lints/src/methods/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/mod.rs
@@ -4193,7 +4193,7 @@ declare_clippy_lint! {
     /// ### Why is this bad?
     /// In those cases, the `TryInto` and `TryFrom` trait implementation is a blanket impl that forwards
     /// to `Into` or `From`, which always succeeds.
-    /// The returned `Result<_, Infallible>` requires error handling to get the contained value
+    /// The returned `Result<_, !>` requires error handling to get the contained value
     /// even though the conversion can never fail.
     ///
     /// ### Example

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_fallible_conversions.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_fallible_conversions.rs
@@ -95,7 +95,7 @@ fn check<'tcx>(
         // If `T: TryFrom<U>` and `T: From<U>` both exist, then that means that the `TryFrom`
         // _must_ be from the blanket impl and cannot have been manually implemented
         // (else there would be conflicting impls, even with #![feature(spec)]), so we don't even need to check
-        // what `<T as TryFrom<U>>::Error` is: it's always `Infallible`
+        // what `<T as TryFrom<U>>::Error` is: it's always `!`
         && implements_trait(cx, self_ty, from_into_trait, &[other_ty])
         && let Some(other_ty) = other_ty.as_type()
     {

--- a/src/tools/clippy/tests/ui/drop_non_drop.rs
+++ b/src/tools/clippy/tests/ui/drop_non_drop.rs
@@ -7,7 +7,7 @@ fn make_result<T>(t: T) -> Result<T, ()> {
 }
 
 // The return type should behave as `T` as the `Err` variant is uninhabited
-fn make_result_uninhabited_err<T>(t: T) -> Result<T, std::convert::Infallible> {
+fn make_result_uninhabited_err<T>(t: T) -> Result<T, !> {
     Ok(t)
 }
 

--- a/src/tools/clippy/tests/ui/infallible_try_from.rs
+++ b/src/tools/clippy/tests/ui/infallible_try_from.rs
@@ -1,7 +1,5 @@
 #![warn(clippy::infallible_try_from)]
 
-use std::convert::Infallible;
-
 struct MyStruct(i32);
 
 impl TryFrom<i8> for MyStruct {
@@ -14,8 +12,8 @@ impl TryFrom<i8> for MyStruct {
 
 impl TryFrom<i16> for MyStruct {
     //~^ infallible_try_from
-    type Error = Infallible;
-    fn try_from(other: i16) -> Result<Self, Infallible> {
+    type Error = !;
+    fn try_from(other: i16) -> Result<Self, !> {
         Ok(Self(other.into()))
     }
 }

--- a/src/tools/clippy/tests/ui/infallible_try_from.stderr
+++ b/src/tools/clippy/tests/ui/infallible_try_from.stderr
@@ -1,5 +1,5 @@
 error: infallible TryFrom impl; consider implementing From instead
-  --> tests/ui/infallible_try_from.rs:7:1
+  --> tests/ui/infallible_try_from.rs:5:1
    |
 LL | impl TryFrom<i8> for MyStruct {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,13 +11,13 @@ LL |     type Error = !;
    = help: to override `-D warnings` add `#[allow(clippy::infallible_try_from)]`
 
 error: infallible TryFrom impl; consider implementing From instead
-  --> tests/ui/infallible_try_from.rs:15:1
+  --> tests/ui/infallible_try_from.rs:13:1
    |
 LL | impl TryFrom<i16> for MyStruct {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
-LL |     type Error = Infallible;
-   |                  ---------- infallible error type
+LL |     type Error = !;
+   |                  - infallible error type
 
 error: aborting due to 2 previous errors
 

--- a/src/tools/clippy/tests/ui/let_underscore_must_use.rs
+++ b/src/tools/clippy/tests/ui/let_underscore_must_use.rs
@@ -110,16 +110,24 @@ fn main() {
     let _ = a;
     //~^ let_underscore_must_use
 
+    enum Uninhabited {}
+
     #[allow(clippy::let_underscore_must_use)]
     let _ = a;
 
     // No lint because this type should behave as `()`
-    let _ = Result::<_, std::convert::Infallible>::Ok(());
+    let _ = Result::<_, !>::Ok(());
 
+    // No lint because this type should behave as `()`
+    let _ = Result::<_, Uninhabited>::Ok(());
     #[must_use]
     struct T;
 
     // Lint because this type should behave as `T`
-    let _ = Result::<_, std::convert::Infallible>::Ok(T);
+    let _ = Result::<_, !>::Ok(T);
+    //~^ let_underscore_must_use
+
+    // Lint because this type should behave as `T`
+    let _ = Result::<_, Uninhabited>::Ok(T);
     //~^ let_underscore_must_use
 }

--- a/src/tools/clippy/tests/ui/let_underscore_must_use.stderr
+++ b/src/tools/clippy/tests/ui/let_underscore_must_use.stderr
@@ -140,17 +140,30 @@ LL |     let _ = a;
    |             ^
 
 error: non-binding `let` on an expression with `#[must_use]` type
-  --> tests/ui/let_underscore_must_use.rs:123:5
+  --> tests/ui/let_underscore_must_use.rs:127:5
    |
-LL |     let _ = Result::<_, std::convert::Infallible>::Ok(T);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = Result::<_, !>::Ok(T);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider explicitly using expression value
 note: type is `main::T` in a `Result` with an uninhabited error
-  --> tests/ui/let_underscore_must_use.rs:123:13
+  --> tests/ui/let_underscore_must_use.rs:127:13
    |
-LL |     let _ = Result::<_, std::convert::Infallible>::Ok(T);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = Result::<_, !>::Ok(T);
+   |             ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 14 previous errors
+error: non-binding `let` on an expression with `#[must_use]` type
+  --> tests/ui/let_underscore_must_use.rs:131:5
+   |
+LL |     let _ = Result::<_, Uninhabited>::Ok(T);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider explicitly using expression value
+note: type is `main::T` in a `Result` with an uninhabited error
+  --> tests/ui/let_underscore_must_use.rs:131:13
+   |
+LL |     let _ = Result::<_, Uninhabited>::Ok(T);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 15 previous errors
 

--- a/src/tools/clippy/tests/ui/manual_ok_err.fixed
+++ b/src/tools/clippy/tests/ui/manual_ok_err.fixed
@@ -76,7 +76,7 @@ fn no_lint() {
         Ok(v) => Some(v),
     };
 
-    let _ = match Ok::<_, std::convert::Infallible>(1) {
+    let _ = match Ok::<_, !>(1) {
         Ok(3) => None,
         Ok(v) => Some(v),
     };

--- a/src/tools/clippy/tests/ui/manual_ok_err.rs
+++ b/src/tools/clippy/tests/ui/manual_ok_err.rs
@@ -112,7 +112,7 @@ fn no_lint() {
         Ok(v) => Some(v),
     };
 
-    let _ = match Ok::<_, std::convert::Infallible>(1) {
+    let _ = match Ok::<_, !>(1) {
         Ok(3) => None,
         Ok(v) => Some(v),
     };

--- a/src/tools/clippy/tests/ui/must_use_candidates.fixed
+++ b/src/tools/clippy/tests/ui/must_use_candidates.fixed
@@ -102,9 +102,17 @@ pub fn main() -> std::process::ExitCode {
     std::process::ExitCode::SUCCESS
 }
 
+pub enum Uninhabited {}
+
 //~v must_use_candidate
 #[must_use]
-pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
+pub fn result_uninhabited_1() -> Result<i32, Uninhabited> {
+    todo!()
+}
+
+//~v must_use_candidate
+#[must_use]
+pub fn result_never_1() -> Result<i32, !> {
     todo!()
 }
 
@@ -112,7 +120,12 @@ pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
 pub struct T;
 
 // Do not lint, `T` is `#[must_use]`, so the `Result<T, uninhabited>` also is.
-pub fn result_uninhabited_2() -> Result<T, std::convert::Infallible> {
+pub fn result_uninhabited_2() -> Result<T, Uninhabited> {
+    todo!()
+}
+
+// Do not lint, `T` is `#[must_use]`, so the `Result<T, uninhabited>` also is.
+pub fn result_never_2() -> Result<T, !> {
     todo!()
 }
 

--- a/src/tools/clippy/tests/ui/must_use_candidates.rs
+++ b/src/tools/clippy/tests/ui/must_use_candidates.rs
@@ -97,8 +97,15 @@ pub fn main() -> std::process::ExitCode {
     std::process::ExitCode::SUCCESS
 }
 
+pub enum Uninhabited {}
+
 //~v must_use_candidate
-pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
+pub fn result_uninhabited_1() -> Result<i32, Uninhabited> {
+    todo!()
+}
+
+//~v must_use_candidate
+pub fn result_never_1() -> Result<i32, !> {
     todo!()
 }
 
@@ -106,7 +113,12 @@ pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
 pub struct T;
 
 // Do not lint, `T` is `#[must_use]`, so the `Result<T, uninhabited>` also is.
-pub fn result_uninhabited_2() -> Result<T, std::convert::Infallible> {
+pub fn result_uninhabited_2() -> Result<T, Uninhabited> {
+    todo!()
+}
+
+// Do not lint, `T` is `#[must_use]`, so the `Result<T, uninhabited>` also is.
+pub fn result_never_2() -> Result<T, !> {
     todo!()
 }
 

--- a/src/tools/clippy/tests/ui/must_use_candidates.stderr
+++ b/src/tools/clippy/tests/ui/must_use_candidates.stderr
@@ -61,16 +61,28 @@ LL | pub fn arcd(_x: Arc<u32>) -> bool {
    |
 
 error: this function could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:101:8
+  --> tests/ui/must_use_candidates.rs:103:8
    |
-LL | pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
+LL | pub fn result_uninhabited_1() -> Result<i32, Uninhabited> {
    |        ^^^^^^^^^^^^^^^^^^^^
    |
 help: add the attribute
    |
 LL + #[must_use]
-LL | pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
+LL | pub fn result_uninhabited_1() -> Result<i32, Uninhabited> {
    |
 
-error: aborting due to 6 previous errors
+error: this function could have a `#[must_use]` attribute
+  --> tests/ui/must_use_candidates.rs:108:8
+   |
+LL | pub fn result_never_1() -> Result<i32, !> {
+   |        ^^^^^^^^^^^^^^
+   |
+help: add the attribute
+   |
+LL + #[must_use]
+LL | pub fn result_never_1() -> Result<i32, !> {
+   |
+
+error: aborting due to 7 previous errors
 

--- a/src/tools/clippy/tests/ui/single_match_else.fixed
+++ b/src/tools/clippy/tests/ui/single_match_else.fixed
@@ -99,8 +99,16 @@ fn main() {
     //~| NOTE: you might want to preserve the comments from inside the `match`
 
     // lint here
-    use std::convert::Infallible;
-    if let Ok(a) = Result::<i32, &Infallible>::Ok(1) { println!("${:?}", a) } else {
+    if let Ok(a) = Result::<i32, &!>::Ok(1) { println!("${:?}", a) } else {
+        println!("else block");
+        return;
+    }
+    //~^^^^^^^ single_match_else
+
+    enum Uninhabited {}
+
+    // lint here
+    if let Ok(a) = Result::<i32, &Uninhabited>::Ok(1) { println!("${:?}", a) } else {
         println!("else block");
         return;
     }

--- a/src/tools/clippy/tests/ui/single_match_else.rs
+++ b/src/tools/clippy/tests/ui/single_match_else.rs
@@ -112,8 +112,19 @@ fn main() {
     //~| NOTE: you might want to preserve the comments from inside the `match`
 
     // lint here
-    use std::convert::Infallible;
-    match Result::<i32, &Infallible>::Ok(1) {
+    match Result::<i32, &!>::Ok(1) {
+        Ok(a) => println!("${:?}", a),
+        Err(_) => {
+            println!("else block");
+            return;
+        }
+    }
+    //~^^^^^^^ single_match_else
+
+    enum Uninhabited {}
+
+    // lint here
+    match Result::<i32, &Uninhabited>::Ok(1) {
         Ok(a) => println!("${:?}", a),
         Err(_) => {
             println!("else block");

--- a/src/tools/clippy/tests/ui/single_match_else.stderr
+++ b/src/tools/clippy/tests/ui/single_match_else.stderr
@@ -83,9 +83,9 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:116:5
+  --> tests/ui/single_match_else.rs:115:5
    |
-LL | /     match Result::<i32, &Infallible>::Ok(1) {
+LL | /     match Result::<i32, &!>::Ok(1) {
 LL | |         Ok(a) => println!("${:?}", a),
 LL | |         Err(_) => {
 LL | |             println!("else block");
@@ -95,14 +95,33 @@ LL | |     }
    |
 help: try
    |
-LL ~     if let Ok(a) = Result::<i32, &Infallible>::Ok(1) { println!("${:?}", a) } else {
+LL ~     if let Ok(a) = Result::<i32, &!>::Ok(1) { println!("${:?}", a) } else {
 LL +         println!("else block");
 LL +         return;
 LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:126:5
+  --> tests/ui/single_match_else.rs:127:5
+   |
+LL | /     match Result::<i32, &Uninhabited>::Ok(1) {
+LL | |         Ok(a) => println!("${:?}", a),
+LL | |         Err(_) => {
+LL | |             println!("else block");
+...  |
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if let Ok(a) = Result::<i32, &Uninhabited>::Ok(1) { println!("${:?}", a) } else {
+LL +         println!("else block");
+LL +         return;
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> tests/ui/single_match_else.rs:137:5
    |
 LL | /     match Cow::from("moo") {
 LL | |         Cow::Owned(a) => println!("${:?}", a),
@@ -121,7 +140,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:137:5
+  --> tests/ui/single_match_else.rs:148:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -144,7 +163,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:149:5
+  --> tests/ui/single_match_else.rs:160:5
    |
 LL | /     match bar {
 LL | |         Some(v) => {
@@ -168,7 +187,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:162:5
+  --> tests/ui/single_match_else.rs:173:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -192,7 +211,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:175:5
+  --> tests/ui/single_match_else.rs:186:5
    |
 LL | /     match bar {
 LL | |         #[rustfmt::skip]
@@ -217,7 +236,7 @@ LL +     }
    |
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match_else.rs:225:5
+  --> tests/ui/single_match_else.rs:236:5
    |
 LL | /     match ExprNode::Butterflies {
 LL | |         ExprNode::Butterflies => Some(&NODE),
@@ -228,5 +247,5 @@ LL | |         },
 LL | |     }
    | |_____^ help: try: `Some(&NODE)`
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 

--- a/tests/ui/inference/cannot-infer-partial-try-return.rs
+++ b/tests/ui/inference/cannot-infer-partial-try-return.rs
@@ -10,7 +10,7 @@ where
     }
 }
 
-fn infallible() -> Result<(), std::convert::Infallible> {
+fn infallible() -> Result<(), !> {
     Ok(())
 }
 

--- a/tests/ui/try-trait/try-operator-custom.rs
+++ b/tests/ui/try-trait/try-operator-custom.rs
@@ -43,7 +43,7 @@ impl<U, V> Residual<U> for MyResult<Never, V> {
     type TryType = MyResult<U, V>;
 }
 
-type ResultResidual<E> = Result<std::convert::Infallible, E>;
+type ResultResidual<E> = Result<!, E>;
 
 impl<U, V, W> FromResidual<ResultResidual<V>> for MyResult<U, W>
 where


### PR DESCRIPTION
- Update docs, internal comments and tests to use `!` rather than `Infallible` in `Try` situations.
- Add a custom `enum Uninhabited {}` to specific clippy tests where unintentional future divergence in handling `!` vs other uninhabited types may be a possible concern

Refs:
- Never is ~~meow~~ now rust-lang/rust#155499
- Try: rust-lang/rust#84277 & rust-lang/goals#654

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
