### PR TITLE
Clean up some small things related to lint `ambiguous_glob_imported_traits`

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -347,7 +347,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                 })
             }
 
-            probe::TraitPick(_) => {
+            probe::TraitPick { .. } => {
                 let trait_def_id = pick.item.container_id(self.tcx);
 
                 // Make a trait reference `$0 : Trait<$1...$n>`
@@ -756,7 +756,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         pick: &probe::Pick<'_>,
         segment: &hir::PathSegment<'tcx>,
     ) {
-        if pick.kind != probe::PickKind::TraitPick(true) {
+        if pick.kind != (probe::PickKind::TraitPick { is_ambiguously_imported: true }) {
             return;
         }
         let trait_name = self.tcx.item_name(pick.item.container_id(self.tcx));

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -767,11 +767,11 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
             segment.hir_id,
             rustc_errors::DiagDecorator(|diag| {
                 diag.primary_message(format!(
-                    "Use of ambiguously glob imported trait `{trait_name}`"
+                    "use of ambiguously glob imported trait `{trait_name}`"
                 ))
                 .span(segment.ident.span)
                 .span_label(import_span, format!("`{trait_name}` imported ambiguously here"))
-                .help(format!("Import `{trait_name}` explicitly"));
+                .help(format!("import `{trait_name}` explicitly"));
             }),
         );
     }

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -118,7 +118,7 @@ pub(crate) struct Candidate<'tcx> {
 pub(crate) enum CandidateKind<'tcx> {
     InherentImplCandidate { impl_def_id: DefId, receiver_steps: usize },
     ObjectCandidate(ty::PolyTraitRef<'tcx>),
-    TraitCandidate(ty::PolyTraitRef<'tcx>, bool /* lint_ambiguous */),
+    TraitCandidate { trait_ref: ty::PolyTraitRef<'tcx>, is_ambiguously_imported: bool },
     WhereClauseCandidate(ty::PolyTraitRef<'tcx>),
 }
 
@@ -239,7 +239,7 @@ pub(crate) struct Pick<'tcx> {
     /// Only applies for inherent impls.
     pub receiver_steps: Option<usize>,
 
-    /// Candidates that were shadowed by supertraits.
+    /// Candidates that were shadowed by subtraits.
     pub shadowed_candidates: Vec<ty::AssocItem>,
 }
 
@@ -247,10 +247,9 @@ pub(crate) struct Pick<'tcx> {
 pub(crate) enum PickKind<'tcx> {
     InherentImplPick,
     ObjectPick,
-    TraitPick(
-        // Is Ambiguously Imported
-        bool,
-    ),
+    TraitPick {
+        is_ambiguously_imported: bool,
+    },
     WhereClausePick(
         // Trait
         ty::PolyTraitRef<'tcx>,
@@ -611,10 +610,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         Candidate {
                             item,
                             kind: match item.container {
-                                AssocContainer::Trait => CandidateKind::TraitCandidate(
-                                    ty::Binder::dummy(trait_ref),
-                                    false,
-                                ),
+                                AssocContainer::Trait => CandidateKind::TraitCandidate {
+                                    trait_ref: ty::Binder::dummy(trait_ref),
+                                    is_ambiguously_imported: false,
+                                },
                                 AssocContainer::InherentImpl => {
                                     CandidateKind::InherentImplCandidate {
                                         impl_def_id: self.tcx.parent(def_id),
@@ -1143,7 +1142,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         &mut self,
         import_ids: &'tcx [LocalDefId],
         trait_def_id: DefId,
-        lint_ambiguous: bool,
+        is_ambiguously_imported: bool,
     ) {
         let trait_args = self.fresh_args_for_item(self.span, trait_def_id);
         let trait_ref = ty::TraitRef::new_from_args(self.tcx, trait_def_id, trait_args);
@@ -1165,7 +1164,10 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                             Candidate {
                                 item,
                                 import_ids,
-                                kind: TraitCandidate(bound_trait_ref, lint_ambiguous),
+                                kind: TraitCandidate {
+                                    trait_ref: bound_trait_ref,
+                                    is_ambiguously_imported,
+                                },
                             },
                             false,
                         );
@@ -1188,7 +1190,10 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     Candidate {
                         item,
                         import_ids,
-                        kind: TraitCandidate(ty::Binder::dummy(trait_ref), lint_ambiguous),
+                        kind: TraitCandidate {
+                            trait_ref: ty::Binder::dummy(trait_ref),
+                            is_ambiguously_imported,
+                        },
                     },
                     false,
                 );
@@ -1958,7 +1963,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             ObjectCandidate(_) | WhereClauseCandidate(_) => {
                 CandidateSource::Trait(candidate.item.container_id(self.tcx))
             }
-            TraitCandidate(trait_ref, _) => self.probe(|_| {
+            TraitCandidate { trait_ref, is_ambiguously_imported: _ } => self.probe(|_| {
                 let trait_ref = self.instantiate_binder_with_fresh_vars(
                     self.span,
                     BoundRegionConversionTime::FnCall,
@@ -1988,7 +1993,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     fn candidate_source_from_pick(&self, pick: &Pick<'tcx>) -> CandidateSource {
         match pick.kind {
             InherentImplPick => CandidateSource::Impl(pick.item.container_id(self.tcx)),
-            ObjectPick | WhereClausePick(_) | TraitPick(_) => {
+            ObjectPick | WhereClausePick(_) | TraitPick { .. } => {
                 CandidateSource::Trait(pick.item.container_id(self.tcx))
             }
         }
@@ -2069,7 +2074,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                         impl_bounds,
                     ));
                 }
-                TraitCandidate(poly_trait_ref, _) => {
+                TraitCandidate { trait_ref: poly_trait_ref, is_ambiguously_imported: _ } => {
                     // Some trait methods are excluded for arrays before 2021.
                     // (`array.into_iter()` wants a slice iterator for compatibility.)
                     if let Some(method_name) = self.method_name {
@@ -2373,8 +2378,8 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         }
 
         // They are all the same, so if any of them is ambiguous, we report the pick as ambiguous.
-        let lint_ambiguous = probes.iter().any(|(p, _)| match p.kind {
-            TraitCandidate(_, lint) => lint,
+        let is_ambiguously_imported = probes.iter().any(|(p, _)| match p.kind {
+            TraitCandidate { is_ambiguously_imported, .. } => is_ambiguously_imported,
             _ => false,
         });
 
@@ -2382,7 +2387,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         // If so, just use this trait and call it a day.
         Some(Pick {
             item: probes[0].0.item,
-            kind: TraitPick(lint_ambiguous),
+            kind: TraitPick { is_ambiguously_imported },
             import_ids: probes[0].0.import_ids,
             autoderefs: 0,
             autoref_or_ptr_adjustment: None,
@@ -2457,14 +2462,14 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             }
         }
 
-        let lint_ambiguous = match child_candidate.kind {
-            TraitCandidate(_, lint) => lint,
+        let is_ambiguously_imported = match child_candidate.kind {
+            TraitCandidate { is_ambiguously_imported, .. } => is_ambiguously_imported,
             _ => false,
         };
 
         Some(Pick {
             item: child_candidate.item,
-            kind: TraitPick(lint_ambiguous),
+            kind: TraitPick { is_ambiguously_imported },
             import_ids: child_candidate.import_ids,
             autoderefs: 0,
             autoref_or_ptr_adjustment: None,
@@ -2712,7 +2717,9 @@ impl<'tcx> Candidate<'tcx> {
             kind: match self.kind {
                 InherentImplCandidate { .. } => InherentImplPick,
                 ObjectCandidate(_) => ObjectPick,
-                TraitCandidate(_, lint_ambiguous) => TraitPick(lint_ambiguous),
+                TraitCandidate { is_ambiguously_imported, .. } => {
+                    TraitPick { is_ambiguously_imported }
+                }
                 WhereClauseCandidate(trait_ref) => {
                     // Only trait derived from where-clauses should
                     // appear here, so they should not contain any

--- a/tests/ui/imports/ambiguous-trait-and-struct-in-scope.rs
+++ b/tests/ui/imports/ambiguous-trait-and-struct-in-scope.rs
@@ -28,7 +28,7 @@ mod module_3 {
         use super::*;
         use crate::module_2::*;
         fn weird() {
-            1_i32.method(); //~ WARNING Use of ambiguously glob imported trait `Foo` [ambiguous_glob_imported_traits]
+            1_i32.method(); //~ WARNING use of ambiguously glob imported trait `Foo` [ambiguous_glob_imported_traits]
                             //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
         }
     }

--- a/tests/ui/imports/ambiguous-trait-and-struct-in-scope.stderr
+++ b/tests/ui/imports/ambiguous-trait-and-struct-in-scope.stderr
@@ -1,4 +1,4 @@
-warning: Use of ambiguously glob imported trait `Foo`
+warning: use of ambiguously glob imported trait `Foo`
   --> $DIR/ambiguous-trait-and-struct-in-scope.rs:31:19
    |
 LL |         use crate::module_2::*;
@@ -7,7 +7,7 @@ LL |         fn weird() {
 LL |             1_i32.method();
    |                   ^^^^^^
    |
-   = help: Import `Foo` explicitly
+   = help: import `Foo` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
    = note: `#[warn(ambiguous_glob_imported_traits)]` (part of `#[warn(future_incompatible)]`) on by default

--- a/tests/ui/imports/ambiguous-trait-in-scope-and-underscore.first.stderr
+++ b/tests/ui/imports/ambiguous-trait-in-scope-and-underscore.first.stderr
@@ -1,4 +1,4 @@
-warning: Use of ambiguously glob imported trait `Foo`
+warning: use of ambiguously glob imported trait `Foo`
   --> $DIR/ambiguous-trait-in-scope-and-underscore.rs:40:10
    |
 LL | use export::*;
@@ -7,7 +7,7 @@ LL | use export::*;
 LL |     1i32.method();
    |          ^^^^^^
    |
-   = help: Import `Foo` explicitly
+   = help: import `Foo` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
    = note: `#[warn(ambiguous_glob_imported_traits)]` (part of `#[warn(future_incompatible)]`) on by default

--- a/tests/ui/imports/ambiguous-trait-in-scope-and-underscore.last.stderr
+++ b/tests/ui/imports/ambiguous-trait-in-scope-and-underscore.last.stderr
@@ -1,4 +1,4 @@
-warning: Use of ambiguously glob imported trait `Foo`
+warning: use of ambiguously glob imported trait `Foo`
   --> $DIR/ambiguous-trait-in-scope-and-underscore.rs:40:10
    |
 LL | use export::*;
@@ -7,7 +7,7 @@ LL | use export::*;
 LL |     1i32.method();
    |          ^^^^^^
    |
-   = help: Import `Foo` explicitly
+   = help: import `Foo` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
    = note: `#[warn(ambiguous_glob_imported_traits)]` (part of `#[warn(future_incompatible)]`) on by default

--- a/tests/ui/imports/ambiguous-trait-in-scope-and-underscore.rs
+++ b/tests/ui/imports/ambiguous-trait-in-scope-and-underscore.rs
@@ -38,6 +38,6 @@ use export::*;
 
 fn main() {
     1i32.method();
-    //~^ WARNING Use of ambiguously glob imported trait `Foo` [ambiguous_glob_imported_traits]
+    //~^ WARNING use of ambiguously glob imported trait `Foo` [ambiguous_glob_imported_traits]
     //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }

--- a/tests/ui/imports/ambiguous-trait-in-scope.rs
+++ b/tests/ui/imports/ambiguous-trait-in-scope.rs
@@ -29,7 +29,7 @@ fn test1() {
     // Create an ambiguous import for `Trait` in one order
     use m1::*;
     use m2::*;
-    0u8.method1(); //~ WARNING Use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
+    0u8.method1(); //~ WARNING use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
                    //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     0u8.method2(); //~ ERROR: no method named `method2` found for type `u8` in the current scope
 }
@@ -39,21 +39,21 @@ fn test2() {
     use m2::*;
     use m1::*;
     0u8.method1(); //~ ERROR: no method named `method1` found for type `u8` in the current scope
-    0u8.method2(); //~ WARNING Use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
+    0u8.method2(); //~ WARNING use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
                    //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 }
 
 fn test_indirect_reexport() {
     use m1_reexport::*;
     use m2_reexport::*;
-    0u8.method1(); //~ WARNING Use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
+    0u8.method1(); //~ WARNING use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
                    //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     0u8.method2(); //~ ERROR: no method named `method2` found for type `u8` in the current scope
 }
 
 fn test_ambig_reexport() {
     use ambig_reexport::*;
-    0u8.method1(); //~ WARNING Use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
+    0u8.method1(); //~ WARNING use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
                    //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     0u8.method2(); //~ ERROR: no method named `method2` found for type `u8` in the current scope
 }
@@ -61,7 +61,7 @@ fn test_ambig_reexport() {
 fn test_external() {
     use external::m1::*;
     use external::m2::*;
-    0u8.method1(); //~ WARNING Use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
+    0u8.method1(); //~ WARNING use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
                    //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     0u8.method2(); //~ ERROR: no method named `method2` found for type `u8` in the current scope
 }
@@ -69,14 +69,14 @@ fn test_external() {
 fn test_external_indirect_reexport() {
     use external::m1_reexport::*;
     use external::m2_reexport::*;
-    0u8.method1(); //~ WARNING Use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
+    0u8.method1(); //~ WARNING use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
                    //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     0u8.method2(); //~ ERROR: no method named `method2` found for type `u8` in the current scope
 }
 
 fn test_external_ambig_reexport() {
     use external::ambig_reexport::*;
-    0u8.method1(); //~ WARNING Use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
+    0u8.method1(); //~ WARNING use of ambiguously glob imported trait `Trait` [ambiguous_glob_imported_traits]
                    //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
     0u8.method2(); //~ ERROR: no method named `method2` found for type `u8` in the current scope
 }

--- a/tests/ui/imports/ambiguous-trait-in-scope.stderr
+++ b/tests/ui/imports/ambiguous-trait-in-scope.stderr
@@ -1,4 +1,4 @@
-warning: Use of ambiguously glob imported trait `Trait`
+warning: use of ambiguously glob imported trait `Trait`
   --> $DIR/ambiguous-trait-in-scope.rs:32:9
    |
 LL |     use m1::*;
@@ -7,7 +7,7 @@ LL |     use m2::*;
 LL |     0u8.method1();
    |         ^^^^^^^
    |
-   = help: Import `Trait` explicitly
+   = help: import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
    = note: `#[warn(ambiguous_glob_imported_traits)]` (part of `#[warn(future_incompatible)]`) on by default
@@ -40,7 +40,7 @@ LL + use ambiguous_trait_reexport::m1::Trait;
 LL + use crate::m1::Trait;
    |
 
-warning: Use of ambiguously glob imported trait `Trait`
+warning: use of ambiguously glob imported trait `Trait`
   --> $DIR/ambiguous-trait-in-scope.rs:42:9
    |
 LL |     use m2::*;
@@ -49,11 +49,11 @@ LL |     use m2::*;
 LL |     0u8.method2();
    |         ^^^^^^^
    |
-   = help: Import `Trait` explicitly
+   = help: import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
 
-warning: Use of ambiguously glob imported trait `Trait`
+warning: use of ambiguously glob imported trait `Trait`
   --> $DIR/ambiguous-trait-in-scope.rs:49:9
    |
 LL |     use m1_reexport::*;
@@ -62,7 +62,7 @@ LL |     use m2_reexport::*;
 LL |     0u8.method1();
    |         ^^^^^^^
    |
-   = help: Import `Trait` explicitly
+   = help: import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
 
@@ -80,7 +80,7 @@ LL + use ambiguous_trait_reexport::m2::Trait;
 LL + use crate::m2::Trait;
    |
 
-warning: Use of ambiguously glob imported trait `Trait`
+warning: use of ambiguously glob imported trait `Trait`
   --> $DIR/ambiguous-trait-in-scope.rs:56:9
    |
 LL |     use ambig_reexport::*;
@@ -88,7 +88,7 @@ LL |     use ambig_reexport::*;
 LL |     0u8.method1();
    |         ^^^^^^^
    |
-   = help: Import `Trait` explicitly
+   = help: import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
 
@@ -106,7 +106,7 @@ LL + use ambiguous_trait_reexport::m2::Trait;
 LL + use crate::m2::Trait;
    |
 
-warning: Use of ambiguously glob imported trait `Trait`
+warning: use of ambiguously glob imported trait `Trait`
   --> $DIR/ambiguous-trait-in-scope.rs:64:9
    |
 LL |     use external::m1::*;
@@ -115,7 +115,7 @@ LL |     use external::m2::*;
 LL |     0u8.method1();
    |         ^^^^^^^
    |
-   = help: Import `Trait` explicitly
+   = help: import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
 
@@ -133,7 +133,7 @@ LL + use ambiguous_trait_reexport::m2::Trait;
 LL + use crate::m2::Trait;
    |
 
-warning: Use of ambiguously glob imported trait `Trait`
+warning: use of ambiguously glob imported trait `Trait`
   --> $DIR/ambiguous-trait-in-scope.rs:72:9
    |
 LL |     use external::m1_reexport::*;
@@ -142,7 +142,7 @@ LL |     use external::m2_reexport::*;
 LL |     0u8.method1();
    |         ^^^^^^^
    |
-   = help: Import `Trait` explicitly
+   = help: import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
 
@@ -160,7 +160,7 @@ LL + use ambiguous_trait_reexport::m2::Trait;
 LL + use crate::m2::Trait;
    |
 
-warning: Use of ambiguously glob imported trait `Trait`
+warning: use of ambiguously glob imported trait `Trait`
   --> $DIR/ambiguous-trait-in-scope.rs:79:9
    |
 LL |     use external::ambig_reexport::*;
@@ -168,7 +168,7 @@ LL |     use external::ambig_reexport::*;
 LL |     0u8.method1();
    |         ^^^^^^^
    |
-   = help: Import `Trait` explicitly
+   = help: import `Trait` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
 

--- a/tests/ui/supertrait-shadowing/ambiguous-glob-imported-subtrait.rs
+++ b/tests/ui/supertrait-shadowing/ambiguous-glob-imported-subtrait.rs
@@ -31,6 +31,6 @@ use second_policy::*;
 
 fn main() {
     assert!(0u8.allow_action());
-    //~^ ERROR Use of ambiguously glob imported trait `Role`
+    //~^ ERROR use of ambiguously glob imported trait `Role`
     //~| WARN this was previously accepted by the compiler but is being phased out
 }

--- a/tests/ui/supertrait-shadowing/ambiguous-glob-imported-subtrait.stderr
+++ b/tests/ui/supertrait-shadowing/ambiguous-glob-imported-subtrait.stderr
@@ -1,4 +1,4 @@
-error: Use of ambiguously glob imported trait `Role`
+error: use of ambiguously glob imported trait `Role`
   --> $DIR/ambiguous-glob-imported-subtrait.rs:33:17
    |
 LL | use first_policy::*;
@@ -7,7 +7,7 @@ LL | use first_policy::*;
 LL |     assert!(0u8.allow_action());
    |                 ^^^^^^^^^^^^
    |
-   = help: Import `Role` explicitly
+   = help: import `Role` explicitly
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #152822 <https://github.com/rust-lang/rust/issues/152822>
 note: the lint level is defined here


### PR DESCRIPTION
Cleaning up things I noticed in the vicinity while reviewing PR https://github.com/rust-lang/rust/pull/157968 (which concerns lint `ambiguous_glob_imported_traits` and feature `supertrait_item_shadowing`).

Namely,

1. turning two tuple struct variants into named ones to avoid "anonymous `bool`s"
2. fixing an inaccurate `supertrait_item_shadowing`-specific doc comment
3. applying the rules listed in our [Diagnostic output style guide](https://rustc-dev-guide.rust-lang.org/diagnostics.html#diagnostic-output-style-guide) to the diagnostic of lint `ambiguous_glob_imported_traits`

<sub>(No LLM was or will be used by me during the entire creation process of this PR)</sub>