### PR TITLE
Remove wrong UnusedBraces lint for iterator loop in edition 2024 

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1094,6 +1094,10 @@ impl UnusedDelimLint for UnusedBraces {
                 if let [stmt] = inner.stmts.as_slice()
                     && let ast::StmtKind::Expr(ref expr) = stmt.kind
                     && !Self::is_expr_delims_necessary(expr, ctx, followed_by_block)
+                    // In Rust 2024, this block may drop tail-expression temporaries, such as a
+                    // lock guard, before the loop starts.
+                    && !(ctx == UnusedDelimsCtx::ForIterExpr
+                        && value.span.edition().at_least_rust_2024())
                     && (ctx != UnusedDelimsCtx::AnonConst
                         || (matches!(expr.kind, ast::ExprKind::Lit(_))
                             && !expr.span.from_expansion()))

--- a/tests/ui/lint/unused-braces-for-iterator-temp-scope-issue-160741.e2021.stderr
+++ b/tests/ui/lint/unused-braces-for-iterator-temp-scope-issue-160741.e2021.stderr
@@ -1,11 +1,11 @@
 warning: unnecessary braces around `for` iterator expression
-  --> $DIR/unused-braces-for-iterator-temp-scope-issue-160741.rs:18:18
+  --> $DIR/unused-braces-for-iterator-temp-scope-issue-160741.rs:20:18
    |
 LL |     for value in { data.lock().unwrap().values.clone() } {
    |                  ^^                                   ^^
    |
 note: the lint level is defined here
-  --> $DIR/unused-braces-for-iterator-temp-scope-issue-160741.rs:6:9
+  --> $DIR/unused-braces-for-iterator-temp-scope-issue-160741.rs:8:9
    |
 LL | #![warn(unused_braces)]
    |         ^^^^^^^^^^^^^

--- a/tests/ui/lint/unused-braces-for-iterator-temp-scope-issue-160741.rs
+++ b/tests/ui/lint/unused-braces-for-iterator-temp-scope-issue-160741.rs
@@ -1,6 +1,8 @@
 //! A block around a Rust 2024 `for` iterator expression may shorten the lifetime of temporaries.
 
-//@ edition: 2024
+//@ revisions: e2021 e2024
+//@[e2021] edition: 2021
+//@[e2024] edition: 2024
 //@ check-pass
 
 #![warn(unused_braces)]
@@ -16,7 +18,7 @@ fn main() {
     let data = Arc::new(Mutex::new(State { values: vec![1, 2, 3], total: 0 }));
 
     for value in { data.lock().unwrap().values.clone() } {
-        //~^ WARN unnecessary braces around `for` iterator expression
+        //[e2021]~^ WARN unnecessary braces around `for` iterator expression
         data.lock().unwrap().total += value;
     }
 }

--- a/tests/ui/lint/unused-braces-for-iterator-temp-scope-issue-160741.rs
+++ b/tests/ui/lint/unused-braces-for-iterator-temp-scope-issue-160741.rs
@@ -1,0 +1,22 @@
+//! A block around a Rust 2024 `for` iterator expression may shorten the lifetime of temporaries.
+
+//@ edition: 2024
+//@ check-pass
+
+#![warn(unused_braces)]
+
+use std::sync::{Arc, Mutex};
+
+struct State {
+    values: Vec<u32>,
+    total: u32,
+}
+
+fn main() {
+    let data = Arc::new(Mutex::new(State { values: vec![1, 2, 3], total: 0 }));
+
+    for value in { data.lock().unwrap().values.clone() } {
+        //~^ WARN unnecessary braces around `for` iterator expression
+        data.lock().unwrap().total += value;
+    }
+}

--- a/tests/ui/lint/unused-braces-for-iterator-temp-scope-issue-160741.stderr
+++ b/tests/ui/lint/unused-braces-for-iterator-temp-scope-issue-160741.stderr
@@ -1,0 +1,19 @@
+warning: unnecessary braces around `for` iterator expression
+  --> $DIR/unused-braces-for-iterator-temp-scope-issue-160741.rs:18:18
+   |
+LL |     for value in { data.lock().unwrap().values.clone() } {
+   |                  ^^                                   ^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-braces-for-iterator-temp-scope-issue-160741.rs:6:9
+   |
+LL | #![warn(unused_braces)]
+   |         ^^^^^^^^^^^^^
+help: remove these braces
+   |
+LL -     for value in { data.lock().unwrap().values.clone() } {
+LL +     for value in data.lock().unwrap().values.clone() {
+   |
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes rust-lang/rust#160741 

There are false negative for this fix, but since this is an early lint, seems we don't have a good way for better filter.