### PR TITLE
Suggest wrapping in a closure instead of call parens when a method is passed where an Fn callable is expected

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -3095,20 +3095,24 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 Applicability::MachineApplicable,
             );
         } else if !self.expr_in_place(expr.hir_id) {
-            // Suggest call parentheses inside the wrapping parentheses
+            // land the suggestion inside the user's own wrapping parentheses, not around them.
             let span = if is_wrapped {
                 expr.span.with_lo(after_open).with_hi(before_close)
             } else {
                 expr.span
             };
-            self.suggest_method_call(
-                &mut err,
-                "use parentheses to call the method",
-                field,
-                expr_t,
-                expr,
-                Some(span),
-            );
+            // prefer the closure wrapping: it only fires when the parameter's `Fn` bound tells
+            // us the wanted arity, in which case bare call parentheses would be a worse fix.
+            if !self.suggest_wrap_method_in_closure(&mut err, expr, span) {
+                self.suggest_method_call(
+                    &mut err,
+                    "use parentheses to call the method",
+                    field,
+                    expr_t,
+                    expr,
+                    Some(span),
+                );
+            }
         } else if let ty::RawPtr(ptr_ty, _) = expr_t.kind()
             && let ty::Adt(adt_def, _) = ptr_ty.kind()
             && let ExprKind::Field(base_expr, _) = expr.kind
@@ -3129,6 +3133,72 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // See `StashKey::GenericInFieldExpr` for more info
         self.dcx().try_steal_replace_and_emit_err(field.span, StashKey::GenericInFieldExpr, err)
+    }
+
+    /// If `ty` is a type parameter of `owner` bounded by one of the `Fn` traits, return the
+    /// number of arguments that callable takes.
+    fn fn_trait_arity(&self, owner: DefId, ty: Ty<'tcx>) -> Option<usize> {
+        // Only a type parameter can appear as the self type of one of `owner`'s own clauses.
+        let ty::Param(_) = ty.kind() else { return None };
+        let preds = self.tcx.explicit_clauses_of(owner).instantiate_identity(self.tcx);
+        for (clause, _) in preds {
+            let ty::ClauseKind::Trait(pred) = clause.kind().skip_binder() else { continue };
+            if pred.self_ty() != ty || !self.tcx.is_fn_trait(pred.def_id()) {
+                continue;
+            }
+            // `C: Fn(A, B)` is sugar for `C: Fn<(A, B)>`.
+            if let ty::Tuple(tys) = pred.trait_ref.args.type_at(1).kind() {
+                return Some(tys.len());
+            }
+        }
+        None
+    }
+
+    /// When `expr` is being passed as an argument, the arity of the callable that the
+    /// corresponding parameter wants, if it wants one at all.
+    #[instrument(level = "debug", skip(self), ret)]
+    fn expected_callable_arity(&self, expr: &hir::Expr<'tcx>) -> Option<usize> {
+        let hir::Node::Expr(parent) = self.tcx.parent_hir_node(expr.hir_id) else { return None };
+        let (def_id, idx) = match parent.kind {
+            ExprKind::Call(callee, args) => {
+                let idx = args.iter().position(|arg| arg.hir_id == expr.hir_id)?;
+                let callee_ty = self.typeck_results.borrow().node_type_opt(callee.hir_id)?;
+                let ty::FnDef(def_id, _) = *self.resolve_vars_if_possible(callee_ty).kind() else {
+                    // Through a fn pointer or a closure there are no where-clauses to read.
+                    return None;
+                };
+                (def_id, idx)
+            }
+            // The receiver is absent from `args` but present in `inputs()`.
+            ExprKind::MethodCall(_, _, args, _) => {
+                let idx = args.iter().position(|arg| arg.hir_id == expr.hir_id)?;
+                let def_id = self.typeck_results.borrow().type_dependent_def_id(parent.hir_id)?;
+                (def_id, idx + 1)
+            }
+            _ => return None,
+        };
+
+        let sig = self.tcx.fn_sig(def_id).instantiate_identity().skip_binder();
+        self.fn_trait_arity(def_id, *sig.inputs().get(idx)?)
+    }
+
+    fn suggest_wrap_method_in_closure(
+        &self,
+        err: &mut Diag<'_>,
+        expr: &hir::Expr<'tcx>,
+        span: Span,
+    ) -> bool {
+        let Some(arity) = self.expected_callable_arity(expr) else { return false };
+        let args = (0..arity).map(|i| format!("arg{i}")).collect::<Vec<_>>().join(", ");
+        err.multipart_suggestion(
+            "consider wrapping the method call in a closure",
+            vec![
+                (span.shrink_to_lo(), format!("|{args}| ")),
+                (span.shrink_to_hi(), format!("({args})")),
+            ],
+            Applicability::MaybeIncorrect,
+        );
+        true
     }
 
     fn point_at_param_definition(&self, err: &mut Diag<'_>, param: ty::ParamTy) {

--- a/tests/ui/typeck/method-value-expected-fn-arg.rs
+++ b/tests/ui/typeck/method-value-expected-fn-arg.rs
@@ -1,0 +1,21 @@
+fn call<C>(f: C)
+where
+    C: Fn(),
+{
+    f()
+}
+
+struct FooPrinter {}
+
+impl FooPrinter {
+    fn print(&self) {
+        println!("foo");
+    }
+    fn new() -> Self {
+        FooPrinter {}
+    }
+}
+
+fn main() {
+    call(FooPrinter::new().print); //~ ERROR attempted to take value of method
+}

--- a/tests/ui/typeck/method-value-expected-fn-arg.stderr
+++ b/tests/ui/typeck/method-value-expected-fn-arg.stderr
@@ -1,0 +1,14 @@
+error[E0615]: attempted to take value of method `print` on type `FooPrinter`
+  --> $DIR/method-value-expected-fn-arg.rs:20:28
+   |
+LL |     call(FooPrinter::new().print);
+   |                            ^^^^^ method, not a field
+   |
+help: consider wrapping the method call in a closure
+   |
+LL |     call(|| FooPrinter::new().print());
+   |          ++                        ++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0615`.


### PR DESCRIPTION
Fixes rust-lang/rust#162033
When an uncalled method is passed where an `Fn` callable is expected, E0615's "use parentheses to call the method" help leads into a second error — this instead suggests wrapping it in a closure (`call(|| foo.print())`)  falling through to the old suggestion everywhere else. 

Before:
```
error[E0615]: attempted to take value of method `print` on type `FooPrinter`
  --> src/main.rs:21:28
   |
21 |     call(FooPrinter::new().print);
   |                            ^^^^^ method, not a field
   |
help: use parentheses to call the method
   |
21 |     call(FooPrinter::new().print());
   |                                 ++

For more information about this error, try `rustc --explain E0615`.
```

After:
```
error[E0615]: attempted to take value of method `print` on type `FooPrinter`
  --> $DIR/method-value-expected-fn-arg.rs:20:28
   |
LL |     call(FooPrinter::new().print);
   |                            ^^^^^ method, not a field
   |
help: consider wrapping the method call in a closure
   |
LL |     call(|| FooPrinter::new().print());
   |          ++                        ++

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0615`.
```
