### PR TITLE
Rename `thir::ExprKind::Use` to `ValueExpr`

### DIFF
--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -344,7 +344,7 @@ pub enum ExprKind<'tcx> {
     /// expression. This is inserted in some places where an operation would
     /// otherwise be erased completely (e.g. some no-op casts), but we still
     /// need to ensure that its operand is treated as a value and not a place.
-    Use {
+    ValueExpr {
         source: ExprId,
     },
     /// A coercion from `!` to any type.

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -71,7 +71,7 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         }
         Unary { arg, op: _ } => visitor.visit_expr(&visitor.thir()[arg]),
         Cast { source } => visitor.visit_expr(&visitor.thir()[source]),
-        Use { source } => visitor.visit_expr(&visitor.thir()[source]),
+        ValueExpr { source } => visitor.visit_expr(&visitor.thir()[source]),
         NeverToAny { source } => visitor.visit_expr(&visitor.thir()[source]),
         PointerCoercion { source, cast: _, is_from_as_cast: _ } => {
             visitor.visit_expr(&visitor.thir()[source])

--- a/compiler/rustc_middle/src/ty/abstract_const.rs
+++ b/compiler/rustc_middle/src/ty/abstract_const.rs
@@ -11,9 +11,9 @@ use crate::ty::{
 #[derive(Hash, Debug, Clone, Copy, Ord, PartialOrd, PartialEq, Eq)]
 #[derive(TyDecodable, TyEncodable, StableHash, TypeVisitable, TypeFoldable)]
 pub enum CastKind {
-    /// thir::ExprKind::As
+    /// `thir::ExprKind::As`
     As,
-    /// thir::ExprKind::Use
+    /// `thir::ExprKind::ValueExpr`
     Use,
 }
 

--- a/compiler/rustc_mir_build/src/builder/coverageinfo.rs
+++ b/compiler/rustc_mir_build/src/builder/coverageinfo.rs
@@ -120,7 +120,7 @@ impl CoverageInfoBuilder {
                 self.visit_with_not_info(thir, arg, not_info);
             }
             ExprKind::Scope { value, .. } => self.visit_with_not_info(thir, value, not_info),
-            ExprKind::Use { source } => self.visit_with_not_info(thir, source, not_info),
+            ExprKind::ValueExpr { source } => self.visit_with_not_info(thir, source, not_info),
             // All other expressions (including `&&` and `||`) don't need any
             // special handling of their contents, so stop visiting.
             _ => {}
@@ -190,7 +190,7 @@ impl<'tcx> Builder<'_, 'tcx> {
         };
 
         // Remove any wrappers, so that we can inspect the real underlying expression.
-        while let ExprKind::Use { source: inner } | ExprKind::Scope { value: inner, .. } =
+        while let ExprKind::ValueExpr { source: inner } | ExprKind::Scope { value: inner, .. } =
             self.thir[expr_id].kind
         {
             expr_id = inner;

--- a/compiler/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_place.rs
@@ -553,7 +553,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::Binary { .. }
             | ExprKind::LogicalOp { .. }
             | ExprKind::Cast { .. }
-            | ExprKind::Use { .. }
+            | ExprKind::ValueExpr { .. }
             | ExprKind::NeverToAny { .. }
             | ExprKind::PointerCoercion { .. }
             | ExprKind::Repeat { .. }

--- a/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -385,7 +385,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::Match { .. }
             | ExprKind::If { .. }
             | ExprKind::NeverToAny { .. }
-            | ExprKind::Use { .. }
+            | ExprKind::ValueExpr { .. }
             | ExprKind::Borrow { .. }
             | ExprKind::RawBorrow { .. }
             | ExprKind::Adt { .. }
@@ -600,7 +600,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             debug!(?kind, "check_constness");
             match kind {
                 &ExprKind::ValueTypeAscription { source: eid, user_ty: _, user_ty_span: _ }
-                | &ExprKind::Use { source: eid }
+                | &ExprKind::ValueExpr { source: eid }
                 | &ExprKind::PointerCoercion {
                     cast: PointerCoercion::Unsize,
                     source: eid,

--- a/compiler/rustc_mir_build/src/builder/expr/category.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/category.rs
@@ -50,7 +50,7 @@ impl Category {
             | ExprKind::If { .. }
             | ExprKind::Let { .. }
             | ExprKind::NeverToAny { .. }
-            | ExprKind::Use { .. }
+            | ExprKind::ValueExpr { .. }
             | ExprKind::Adt { .. }
             | ExprKind::Borrow { .. }
             | ExprKind::RawBorrow { .. }

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -569,7 +569,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     block.unit()
                 }
             }
-            ExprKind::Use { source } => this.expr_into_dest(destination, block, source),
+            ExprKind::ValueExpr { source } => this.expr_into_dest(destination, block, source),
             ExprKind::Borrow { arg, borrow_kind } => {
                 // We don't do this in `as_rvalue` because we use `as_place`
                 // for borrow expressions, so we cannot create an `RValue` that

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -172,7 +172,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     this.lower_if_condition(block, value, args)
                 })
             }
-            ExprKind::Use { source } => this.lower_if_condition(block, source, args),
+            ExprKind::ValueExpr { source } => this.lower_if_condition(block, source, args),
             ExprKind::Let { expr, ref pat } => this.lower_let_expr(
                 block,
                 expr,
@@ -749,7 +749,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::Scope { value, .. } => {
                 self.declare_guard_bindings(value, scope_span, visibility_scope);
             }
-            ExprKind::Use { source } => {
+            ExprKind::ValueExpr { source } => {
                 self.declare_guard_bindings(source, scope_span, visibility_scope);
             }
             ExprKind::LogicalOp { op: LogicalOp::And, lhs, rhs } => {

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -393,7 +393,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
             | ExprKind::If { .. }
             | ExprKind::InlineAsm { .. }
             | ExprKind::LogicalOp { .. }
-            | ExprKind::Use { .. }
+            | ExprKind::ValueExpr { .. }
             | ExprKind::Reborrow { .. } => {
                 // We don't need to save the old value and restore it
                 // because all the place expressions can't have more

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -312,7 +312,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
         // using a coercion (or is a no-op).
         if self.typeck_results.is_coercion_cast(source.hir_id) {
             // Convert the lexpr to a vexpr.
-            ExprKind::Use { source: self.mirror_expr(source) }
+            ExprKind::ValueExpr { source: self.mirror_expr(source) }
         } else if self.typeck_results.expr_ty(source).is_ref() {
             // Special cased so that we can type check that the element
             // type of the source matches the pointed to type of the
@@ -1178,7 +1178,9 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 ExprKind::WrapUnsafeBinder { source: mirrored }
             }
 
-            hir::ExprKind::DropTemps(source) => ExprKind::Use { source: self.mirror_expr(source) },
+            hir::ExprKind::DropTemps(source) => {
+                ExprKind::ValueExpr { source: self.mirror_expr(source) }
+            }
             hir::ExprKind::Array(fields) => ExprKind::Array { fields: self.mirror_exprs(fields) },
             hir::ExprKind::Tup(fields) => ExprKind::Tuple { fields: self.mirror_exprs(fields) },
 
@@ -1605,7 +1607,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                     name: field,
                 },
                 HirProjectionKind::OpaqueCast => {
-                    ExprKind::Use { source: self.thir.exprs.push(captured_place_expr) }
+                    ExprKind::ValueExpr { source: self.thir.exprs.push(captured_place_expr) }
                 }
                 HirProjectionKind::UnwrapUnsafeBinder => ExprKind::PlaceUnwrapUnsafeBinder {
                     source: self.thir.exprs.push(captured_place_expr),

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -314,7 +314,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
             // Casts don't cause a load.
             NeverToAny { source }
             | Cast { source }
-            | Use { source }
+            | ValueExpr { source }
             | PointerCoercion { source, .. }
             | PlaceTypeAscription { source, .. }
             | ValueTypeAscription { source, .. }

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -301,8 +301,8 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
                 self.print_expr(*source, depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl);
             }
-            Use { source } => {
-                print_indented!(self, "Use {", depth_lvl);
+            ValueExpr { source } => {
+                print_indented!(self, "ValueExpr {", depth_lvl);
                 print_indented!(self, "source:", depth_lvl + 1);
                 self.print_expr(*source, depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl);

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -119,10 +119,10 @@ fn recurse_build<'tcx>(
                 maybe_supported_error(GenericConstantTooComplexSub::BlockNotSupported(node.span))?
             }
         }
-        // `ExprKind::Use` happens when a `hir::ExprKind::Cast` is a
+        // `ExprKind::ValueExpr` happens when a `hir::ExprKind::Cast` is a
         // "coercion cast" i.e. using a coercion or is a no-op.
         // This is important so that `N as usize as usize` doesn't unify with `N as usize`. (untested)
-        &ExprKind::Use { source } => {
+        &ExprKind::ValueExpr { source } => {
             let value_ty = body.exprs[source].ty;
             let value = recurse_build(tcx, body, source, root_span)?;
             ty::Const::new_expr(tcx, Expr::new_cast(tcx, CastKind::Use, value_ty, value, node.ty))
@@ -279,7 +279,7 @@ impl<'a, 'tcx> IsThirPolymorphic<'a, 'tcx> {
             | thir::ExprKind::LogicalOp { .. }
             | thir::ExprKind::Unary { .. }
             | thir::ExprKind::Cast { .. }
-            | thir::ExprKind::Use { .. }
+            | thir::ExprKind::ValueExpr { .. }
             | thir::ExprKind::NeverToAny { .. }
             | thir::ExprKind::PointerCoercion { .. }
             | thir::ExprKind::Loop { .. }

--- a/tests/ui/thir-print/thir-tree-match-for.stdout
+++ b/tests/ui/thir-print/thir-tree-match-for.stdout
@@ -345,7 +345,7 @@ body:
                                                         temp_scope_id: 44
                                                         span: $DIR/thir-tree-match-for.rs:16:3: 18:4 (#7)
                                                         kind: 
-                                                            Use {
+                                                            ValueExpr {
                                                                 source:
                                                                     Expr {
                                                                         ty: ()


### PR DESCRIPTION
The current name is very confusing, because this node kind has nothing to do with `use` imports or unstable `.use` expressions. It is therefore also unrelated to `ast::ExprKind::Use` and `hir::ExprKind::Use`.

It actually represents an expression that must be lowered as a value, even if it would otherwise be a place-expression in place context.
