### PR TITLE
core: mark float `ClampBounds` methods as `#[inline]`

### DIFF
--- a/library/core/src/cmp/clamp.rs
+++ b/library/core/src/cmp/clamp.rs
@@ -66,6 +66,7 @@ macro impl_for_float($t:ty) {
     #[unstable(feature = "clamp_bounds", issue = "147781")]
     #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
     const impl ClampBounds<$t> for RangeFrom<$t> {
+        #[inline]
         fn clamp(self, value: $t) -> $t {
             assert!(!self.start.is_nan(), "start was NaN");
             value.max(self.start)
@@ -75,6 +76,7 @@ macro impl_for_float($t:ty) {
     #[unstable(feature = "clamp_bounds", issue = "147781")]
     #[rustc_const_unstable(feature = "clamp_bounds", issue = "147781")]
     const impl ClampBounds<$t> for RangeToInclusive<$t> {
+        #[inline]
         fn clamp(self, value: $t) -> $t {
             assert!(!self.end.is_nan(), "end was NaN");
             value.min(self.end)
@@ -88,6 +90,7 @@ macro impl_for_float($t:ty) {
             clippy::neg_cmp_op_on_partial_ord,
             reason = "NaN check is intentionally included in comparison"
         )]
+        #[inline]
         fn clamp(self, value: $t) -> $t {
             let (start, end) = self.into_inner();
             assert!(start <= end, "start > end, or either was NaN");


### PR DESCRIPTION
Commit bd174e1b20a8 ("Implement clamp_to") added a few float methods that are not marked `#[inline]`. This causes `core` to require new symbols in soft-float builds, even if the methods are unused, e.g. from the Linux kernel:

    ld.lld: error: undefined symbol: fmaximum_numf
    >>> referenced by core.1f440ee8661e09f9-cgu.0
    >>>               rust/core.o:(<core::ops::range::RangeFrom<f32> as core::cmp::clamp::ClampBounds<f32>>::clamp) in archive vmlinux.a

(and similar for `f{min,max}imum_num{f,}` and `__gt{s,d}f2`).

It is possible to work around this in the Linux side, but these methods should probably be `#[inline]` to begin with, like many other similar methods are.

Thus mark them as inline.