### PR TITLE
normalize CoerceShared field types before relating

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -2597,8 +2597,11 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 let Some(src_field) = src_fields.iter().find(|f| f.name == dst_field.name) else {
                     continue;
                 };
-                let dst_ty = dst_field.ty(tcx, dst_args).skip_norm_wip();
-                let src_ty = src_field.ty(tcx, src_args).skip_norm_wip();
+                // These field types can still contain projections from the source or target type
+                // and normalize them before handing them to `NllTypeRelating`
+                let dst_ty = self.normalize(dst_field.ty(tcx, dst_args), location.to_locations());
+                let src_ty = self.normalize(src_field.ty(tcx, src_args), location.to_locations());
+
                 if let (
                     ty::Ref(src_region, _, Mutability::Mut),
                     ty::Ref(dst_region, _, Mutability::Not),

--- a/tests/ui/reborrow/coerce-shared-normalizes-field-tys-issue-162144.rs
+++ b/tests/ui/reborrow/coerce-shared-normalizes-field-tys-issue-162144.rs
@@ -1,0 +1,29 @@
+//@ check-pass
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, PhantomData, Reborrow};
+
+#[derive(Reborrow, CoerceShared)]
+#[coerce_shared(CustomMarkerRef<'a>)]
+struct CustomMarker<'a>(PhantomData<&'a ()>);
+
+#[derive(Clone, Copy)]
+struct CustomMarkerRef<'a>(PhantomData<&'a <Self as Iterator>::Item>);
+
+impl<'a> Iterator for CustomMarkerRef<'a> {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+fn method<'a>(_a: CustomMarkerRef<'a>) -> &'a () {
+    &()
+}
+
+fn main() {
+    let a = CustomMarker(PhantomData);
+    let _b = method(a);
+}


### PR DESCRIPTION
fixes rust-lang/rust#162144

we need to normalize the field types before passing them to NllTypeRelating since they may still contain projections from the source or target type