### PR TITLE
docs(time): clarify exact seconds for week and day

### DIFF
--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -345,6 +345,8 @@ impl Duration {
 
     /// Creates a new `Duration` from the specified number of weeks.
     ///
+    /// For this method, one week is defined as 7 days, or 604,800 seconds.
+    ///
     /// # Panics
     ///
     /// Panics if the given number of weeks overflows the `Duration` size.
@@ -372,6 +374,8 @@ impl Duration {
     }
 
     /// Creates a new `Duration` from the specified number of days.
+    ///
+    /// For this method, one day is defined as 24 hours, or 86,400 seconds.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Documented that `Duration::from_weeks` defines one week as 604,800 seconds (7 days), and `Duration::from_days` defines one day as 86,400 seconds (24 hours).

Doctests for these methods also appear to be based on these definitions.

The purpose of this is to clarify that `Duration` is a fixed length value that ignores factors such as DST or a leap second.

This is inspired by <https://github.com/rust-lang/libs-team/issues/869#issuecomment-5500049965>.

See also rust-lang/rust#120301

@rustbot label +A-docs