### PR TITLE
docs(time): clarify exact seconds for hour and minute

### DIFF
--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -401,6 +401,8 @@ impl Duration {
 
     /// Creates a new `Duration` from the specified number of hours.
     ///
+    /// For this method, one hour is defined as 60 minutes, or 3,600 seconds.
+    ///
     /// # Panics
     ///
     /// Panics if the given number of hours overflows the `Duration` size.
@@ -428,6 +430,8 @@ impl Duration {
     }
 
     /// Creates a new `Duration` from the specified number of minutes.
+    ///
+    /// For this method, one minute is defined as 60 seconds.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Documented that `Duration::from_hours` defines one hour as 3,600 seconds (60 minutes), and `Duration::from_mins` defines one minute as 60 seconds.

Doctests for these methods also appear to be based on these definitions.

The purpose of this is to clarify that `Duration` is a fixed length value that ignores factors such as a leap second.

This is inspired by <https://github.com/rust-lang/libs-team/issues/869#issuecomment-5500049965>.

It seems that no library in Rust handle leap seconds, so there isn't much point in documenting this. However, I don't think it would hurt to include it for the sake of consistency with rust-lang/rust#162195.

See also rust-lang/rust#120301

@rustbot label +A-docs