### PR TITLE
rustdoc: Use codegen attrs instead of HIR attrs allowing us to encode less in the crate metadata

### DIFF
--- a/compiler/rustc_attr_ir/src/encode_cross_crate.rs
+++ b/compiler/rustc_attr_ir/src/encode_cross_crate.rs
@@ -41,7 +41,7 @@ impl AttributeKind {
             DocComment { .. } => Yes,
             EiiDeclaration(_) => Yes,
             EiiImpl(..) => No,
-            ExportName { .. } => Yes,
+            ExportName { .. } => No,
             ExportStable => No,
             Feature(..) => No,
             FfiConst => No,
@@ -53,9 +53,9 @@ impl AttributeKind {
             InstrumentFn(..) => No,
             Lang(..) => Yes,
             Link(..) => No,
-            LinkName { .. } => Yes, // Needed for rustdoc
+            LinkName { .. } => No,
             LinkOrdinal { .. } => No,
-            LinkSection { .. } => Yes, // Needed for rustdoc
+            LinkSection { .. } => No,
             Linkage(..) => No,
             LoopMatch(..) => No,
             MacroEscape => No,
@@ -74,9 +74,9 @@ impl AttributeKind {
             NoImplicitPrelude => No,
             NoLink => No,
             NoMain => No,
-            NoMangle(..) => Yes, // Needed for rustdoc
+            NoMangle(..) => No,
             NoStd => No,
-            NonExhaustive(..) => Yes, // Needed for rustdoc
+            NonExhaustive(..) => Yes,
             OnConst { .. } => Yes,
             OnMove { .. } => Yes,
             OnTypeError { .. } => Yes,

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -57,6 +57,7 @@ use rustc_hir::attrs::{AttributeKind, DeprecatedSince, Deprecation, RustcVersion
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, DefIdSet};
 use rustc_hir::{ConstStability, Mutability, StabilityLevel, StableSince};
+use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::ty::print::PrintTraitRefExt;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::DUMMY_SP;
@@ -3020,27 +3021,49 @@ pub(super) fn render_attributes_in_code_with_options(
     if render_doc_hidden && item.is_doc_hidden() {
         render_code_attribute(&prefix, "doc(hidden)", w)?;
     }
-    for attr in &item.attrs.other_attrs {
-        let hir::Attribute::Parsed(kind) = attr else { continue };
-        let attr = match kind {
-            AttributeKind::LinkSection { name, .. } => {
-                Cow::Owned(format!("unsafe(link_section = {})", Escape(&format!("{name:?}"))))
-            }
-            AttributeKind::NoMangle(..) => Cow::Borrowed("unsafe(no_mangle)"),
-            AttributeKind::ExportName { name, .. } => {
-                Cow::Owned(format!("unsafe(export_name = {})", Escape(&format!("{name:?}"))))
-            }
-            AttributeKind::NonExhaustive(..) => Cow::Borrowed("non_exhaustive"),
-            _ => continue,
-        };
-        render_code_attribute(&prefix, attr.as_ref(), w)?;
+
+    let Some(def_id) = item.def_id() else { return Ok(()) };
+    let tcx = cx.tcx();
+    let kind = tcx.def_kind(def_id);
+
+    if kind.has_codegen_attrs() {
+        let attrs = tcx.codegen_fn_attrs(def_id);
+
+        if let Some(name) = attrs.link_section {
+            render_code_attribute(
+                &prefix,
+                &format!("unsafe(link_section = {})", Escape(&format!("{name:?}"))),
+                w,
+            )?;
+        }
+
+        if attrs.flags.contains(CodegenFnAttrFlags::NO_MANGLE) {
+            render_code_attribute(&prefix, "unsafe(no_mangle)", w)?;
+        }
+
+        if !attrs.flags.contains(CodegenFnAttrFlags::FOREIGN_ITEM)
+            && let Some(name) = attrs.symbol_name
+        {
+            render_code_attribute(
+                &prefix,
+                &format!("unsafe(export_name = {})", Escape(&format!("{name:?}"))),
+                w,
+            )?;
+        }
     }
 
-    if let Some(def_id) = item.def_id()
-        && let Some(repr) = repr_attribute(cx.tcx(), cx.cache(), def_id)
+    if let DefKind::Enum | DefKind::Struct | DefKind::Variant = kind
+        && item.is_non_exhaustive()
+    {
+        render_code_attribute(&prefix, "non_exhaustive", w)?;
+    }
+
+    if kind.is_adt()
+        && let Some(repr) = repr_attribute(tcx, cx.cache(), def_id)
     {
         render_code_attribute(prefix, &repr, w)?;
     }
+
     Ok(())
 }
 
@@ -3049,7 +3072,9 @@ fn render_repr_attribute_in_code(
     cx: &Context<'_>,
     def_id: DefId,
 ) -> fmt::Result {
-    if let Some(repr) = repr_attribute(cx.tcx(), cx.cache(), def_id) {
+    if cx.tcx().def_kind(def_id).is_adt()
+        && let Some(repr) = repr_attribute(cx.tcx(), cx.cache(), def_id)
+    {
         render_code_attribute("", &repr, w)?;
     }
     Ok(())
@@ -3063,7 +3088,7 @@ fn render_code_attribute(
     write!(w, "<div class=\"code-attribute\">{prefix}#[{attr}]</div>")
 }
 
-/// Compute the *public* `#[repr]` of the item given by `DefId`.
+/// Compute the *public* `#[repr]` of the ADT given by `DefId`.
 ///
 /// Read more about it here:
 /// <https://doc.rust-lang.org/nightly/rustdoc/advanced-features.html#repr-documenting-the-representation-of-a-type>.
@@ -3072,10 +3097,7 @@ fn repr_attribute<'tcx>(
     cache: &Cache,
     def_id: DefId,
 ) -> Option<Cow<'static, str>> {
-    let adt = match tcx.def_kind(def_id) {
-        DefKind::Struct | DefKind::Enum | DefKind::Union => tcx.adt_def(def_id),
-        _ => return None,
-    };
+    let adt = tcx.adt_def(def_id);
     let repr = adt.repr();
 
     let is_visible = |def_id| cache.document_hidden || !tcx.is_doc_hidden(def_id);

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -3018,19 +3018,19 @@ pub(super) fn render_attributes_in_code_with_options(
 ) -> fmt::Result {
     w.write_str(open_tag)?;
     if render_doc_hidden && item.is_doc_hidden() {
-        render_code_attribute(&prefix, "#[doc(hidden)]", w)?;
+        render_code_attribute(&prefix, "doc(hidden)", w)?;
     }
     for attr in &item.attrs.other_attrs {
         let hir::Attribute::Parsed(kind) = attr else { continue };
         let attr = match kind {
             AttributeKind::LinkSection { name, .. } => {
-                Cow::Owned(format!("#[unsafe(link_section = {})]", Escape(&format!("{name:?}"))))
+                Cow::Owned(format!("unsafe(link_section = {})", Escape(&format!("{name:?}"))))
             }
-            AttributeKind::NoMangle(..) => Cow::Borrowed("#[unsafe(no_mangle)]"),
+            AttributeKind::NoMangle(..) => Cow::Borrowed("unsafe(no_mangle)"),
             AttributeKind::ExportName { name, .. } => {
-                Cow::Owned(format!("#[unsafe(export_name = {})]", Escape(&format!("{name:?}"))))
+                Cow::Owned(format!("unsafe(export_name = {})", Escape(&format!("{name:?}"))))
             }
-            AttributeKind::NonExhaustive(..) => Cow::Borrowed("#[non_exhaustive]"),
+            AttributeKind::NonExhaustive(..) => Cow::Borrowed("non_exhaustive"),
             _ => continue,
         };
         render_code_attribute(&prefix, attr.as_ref(), w)?;
@@ -3060,7 +3060,7 @@ fn render_code_attribute(
     attr: impl fmt::Display,
     w: &mut impl fmt::Write,
 ) -> fmt::Result {
-    write!(w, "<div class=\"code-attribute\">{prefix}{attr}</div>")
+    write!(w, "<div class=\"code-attribute\">{prefix}#[{attr}]</div>")
 }
 
 /// Compute the *public* `#[repr]` of the item given by `DefId`.
@@ -3115,7 +3115,7 @@ fn repr_attribute<'tcx>(
 
         // Since the transparent repr can't have any other reprs or
         // repr modifiers beside it, we can safely return early here.
-        return is_public.then(|| "#[repr(transparent)]".into());
+        return is_public.then(|| "repr(transparent)".into());
     }
 
     // The repr is public iff all components are public and visible.
@@ -3154,5 +3154,5 @@ fn repr_attribute<'tcx>(
         result.push(format!("align({})", align.bytes()).into());
     }
 
-    (!result.is_empty()).then(|| format!("#[repr({})]", result.join(", ")).into())
+    (!result.is_empty()).then(|| format!("repr({})", result.join(", ")).into())
 }

--- a/tests/rustdoc-html/attributes.rs
+++ b/tests/rustdoc-html/attributes.rs
@@ -30,65 +30,14 @@ pub extern "C" fn example() {}
 #[repr(C, align(8))]
 pub struct Repr;
 
-//@ has foo/macro.macro_rule.html '//*[@class="code-attribute"]' '#[unsafe(link_section = ".text")]'
-#[unsafe(link_section = ".text")]
-#[macro_export]
-macro_rules! macro_rule {
-    () => {};
-}
-
-//@ has 'foo/enum.Enum.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "enum")]'
-#[unsafe(link_section = "enum")]
-pub enum Enum {
-    //@ has 'foo/enum.Enum.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "a")]'
-    //@ has - '//*[@class="variants"]//*[@class="code-attribute"]' '#[unsafe(link_section = "a")]'
-    #[unsafe(link_section = "a")]
-    A,
-    //@ has 'foo/enum.Enum.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "quz")]'
-    //@ has - '//*[@class="variants"]//*[@class="code-attribute"]' '#[unsafe(link_section = "quz")]'
-    #[unsafe(link_section = "quz")]
-    Quz {
-        //@ has 'foo/enum.Enum.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "b")]'
-        //@ has - '//*[@class="variants"]//*[@class="code-attribute"]' '#[unsafe(link_section = "b")]'
-        #[unsafe(link_section = "b")]
-        b: (),
-    },
-}
-
-//@ has 'foo/trait.Trait.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "trait")]'
-#[unsafe(link_section = "trait")]
 pub trait Trait {
-    //@ has 'foo/trait.Trait.html'
-    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[unsafe(link_section = "bar")]'
-    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' 'const BAR: u32 = 0'
-    #[unsafe(link_section = "bar")]
-    const BAR: u32 = 0;
-
-    //@ has - '//*[@class="code-attribute"]' '#[unsafe(link_section = "foo")]'
-    #[unsafe(link_section = "foo")]
-    fn foo() {}
+    //@ has 'foo/trait.Trait.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "extra")]'
+    #[unsafe(link_section = "extra")]
+    fn func() {}
 }
 
-//@ has 'foo/union.Union.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "union")]'
-#[unsafe(link_section = "union")]
-pub union Union {
-    //@ has 'foo/union.Union.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "x")]'
-    #[unsafe(link_section = "x")]
-    pub x: u32,
-    y: f32,
-}
-
-//@ has 'foo/struct.Struct.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "struct")]'
-#[unsafe(link_section = "struct")]
-pub struct Struct {
-    //@ has 'foo/struct.Struct.html' '//*[@class="code-attribute"]' '#[unsafe(link_section = "x")]'
-    //@ has - '//*[@id="structfield.x"]//*[@class="code-attribute"]' '#[unsafe(link_section = "x")]'
-    #[unsafe(link_section = "x")]
-    pub x: u32,
-    y: f32,
-}
+pub struct Struct;
 
 // Check that the attributes from the trait items show up consistently in the impl.
-//@ has 'foo/struct.Struct.html' '//*[@id="trait-implementations-list"]//*[@class="code-attribute"]' '#[unsafe(link_section = "bar")]'
-//@ has 'foo/struct.Struct.html' '//*[@id="trait-implementations-list"]//*[@class="code-attribute"]' '#[unsafe(link_section = "foo")]'
+//@ has 'foo/struct.Struct.html' '//*[@id="trait-implementations-list"]//*[@class="code-attribute"]' '#[unsafe(link_section = "extra")]'
 impl Trait for Struct {}


### PR DESCRIPTION
Inspired by https://github.com/rust-lang/rust/issues/144004#issuecomment-3077725837.

NB: rustdoc JSON still uses the HIR attrs for `export_name` `link_section` & `no_mangle` but that's fine for now as it doesn't perform cross-crate inlining yet if ever. If that were to change, it's trivial to also migrate it.

<sub>(No LLM was or will be used by me during the entire creation process of this PR)</sub>