### PR TITLE
Suggest keyword order for `extern "C" const unsafe fn`

### DIFF
--- a/compiler/rustc_parse/src/parser/function.rs
+++ b/compiler/rustc_parse/src/parser/function.rs
@@ -362,6 +362,8 @@ impl<'a> Parser<'a> {
                 }) == Some(true) ||
                     // This branch is only for better diagnostics; `pub`, `unsafe`, etc. are not
                     // allowed here.
+                    // This branch also follows `$qual fn` or `$qual $qual` rule
+                    // above since a valid `fn` can be after `extern`.
                     (self.may_recover()
                         && self.tree_look_ahead(2, |tt| {
                             match tt {
@@ -374,7 +376,12 @@ impl<'a> Parser<'a> {
                         }) == Some(true)
                         && self.tree_look_ahead(3, |tt| {
                             match tt {
-                                TokenTree::Token(t, _) => t.is_keyword_case(kw::Fn, case),
+                                TokenTree::Token(t, _) => {
+                                    t.is_keyword_case(kw::Fn, case) ||
+                                    ALL_QUALS.iter().any(|exp| {
+                                        t.is_keyword(exp.kw)
+                                    })
+                                },
                                 TokenTree::Delimited(..) => false,
                             }
                         }) == Some(true)

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const-async-unsafe-abi.rs
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const-async-unsafe-abi.rs
@@ -1,0 +1,15 @@
+// Test for issue https://github.com/rust-lang/rust/issues/140171
+// There is an order to respect for keywords before a function:
+// `<visibility>, const, async, unsafe, extern, "<ABI>"`
+//
+// This test ensures the compiler is helpful about them being misplaced.
+//@ edition:2018
+
+extern "C" const async unsafe fn b() {}
+//~^ ERROR expected `fn`, found keyword `const`
+//~| NOTE expected `fn`
+//~| HELP `const` must come before `extern "C"`
+//~| SUGGESTION const extern "C"
+//~| NOTE keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+
+fn main() {}

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const-async-unsafe-abi.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const-async-unsafe-abi.stderr
@@ -1,5 +1,5 @@
 error: expected `fn`, found keyword `const`
-  --> $DIR/wrong-const-async-unsafe-abi.rs:7:12
+  --> $DIR/wrong-const-async-unsafe-abi.rs:8:12
    |
 LL | extern "C" const async unsafe fn b() {}
    |            ^^^^^ expected `fn`

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const-async-unsafe-abi.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const-async-unsafe-abi.stderr
@@ -1,0 +1,15 @@
+error: expected `fn`, found keyword `const`
+  --> $DIR/wrong-const-async-unsafe-abi.rs:7:12
+   |
+LL | extern "C" const async unsafe fn b() {}
+   |            ^^^^^ expected `fn`
+   |
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+help: `const` must come before `extern "C"`
+   |
+LL - extern "C" const async unsafe fn b() {}
+LL + const extern "C" async unsafe fn b() {}
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const-unsafe-abi.rs
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const-unsafe-abi.rs
@@ -1,0 +1,15 @@
+// Test for issue https://github.com/rust-lang/rust/issues/140171
+// There is an order to respect for keywords before a function:
+// `<visibility>, const, async, unsafe, extern, "<ABI>"`
+//
+// This test ensures the compiler is helpful about them being misplaced.
+//@ edition:2018
+
+extern "C" const unsafe fn a() {}
+//~^ ERROR expected `fn`, found keyword `const`
+//~| NOTE expected `fn`
+//~| HELP `const` must come before `extern "C"`
+//~| SUGGESTION const extern "C"
+//~| NOTE keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+
+fn main() {}

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const-unsafe-abi.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const-unsafe-abi.stderr
@@ -1,5 +1,5 @@
 error: expected `fn`, found keyword `const`
-  --> $DIR/wrong-const-unsafe-abi.rs:7:12
+  --> $DIR/wrong-const-unsafe-abi.rs:8:12
    |
 LL | extern "C" const unsafe fn a() {}
    |            ^^^^^ expected `fn`

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const-unsafe-abi.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-const-unsafe-abi.stderr
@@ -1,0 +1,15 @@
+error: expected `fn`, found keyword `const`
+  --> $DIR/wrong-const-unsafe-abi.rs:7:12
+   |
+LL | extern "C" const unsafe fn a() {}
+   |            ^^^^^ expected `fn`
+   |
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
+help: `const` must come before `extern "C"`
+   |
+LL - extern "C" const unsafe fn a() {}
+LL + const extern "C" unsafe fn a() {}
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-pub-const-unsafe-abi.rs
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-pub-const-unsafe-abi.rs
@@ -1,0 +1,16 @@
+// Test for issue https://github.com/rust-lang/rust/issues/140171
+// There is an order to respect for keywords before a function:
+// `<visibility>, const, async, unsafe, extern, "<ABI>"`
+//
+// This test ensures the compiler is helpful about them being misplaced.
+//@ edition:2018
+
+unsafe extern "C" { static errno: i32; }
+
+extern "C" pub const unsafe fn c() {}
+//~^ ERROR expected `fn`, found keyword `pub`
+//~| NOTE expected `fn`
+//~| HELP visibility `pub` must come before `extern "C"`
+//~| SUGGESTION pub extern "C"
+
+fn main() {}

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-pub-const-unsafe-abi.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-pub-const-unsafe-abi.stderr
@@ -1,0 +1,14 @@
+error: expected `fn`, found keyword `pub`
+  --> $DIR/wrong-pub-const-unsafe-abi.rs:9:12
+   |
+LL | extern "C" pub const unsafe fn c() {}
+   |            ^^^ expected `fn`
+   |
+help: visibility `pub` must come before `extern "C"`
+   |
+LL - extern "C" pub const unsafe fn c() {}
+LL + pub extern "C" const unsafe fn c() {}
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-pub-const-unsafe-abi.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-pub-const-unsafe-abi.stderr
@@ -1,5 +1,5 @@
 error: expected `fn`, found keyword `pub`
-  --> $DIR/wrong-pub-const-unsafe-abi.rs:9:12
+  --> $DIR/wrong-pub-const-unsafe-abi.rs:10:12
    |
 LL | extern "C" pub const unsafe fn c() {}
    |            ^^^ expected `fn`


### PR DESCRIPTION
closes rust-lang/rust#140171

This implementation does not accurately follow the desired output in the issue as it could introduces a much bigger change, where as the one item suggestion approach is also decently helpful and sufficient already.