### PR TITLE
rustdoc: Fix rendering of cross-crate target_features

### DIFF
--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -15,6 +15,7 @@ use rustc_hir::Attribute;
 use rustc_hir::attrs::{
     AttributeKind, CfgEntry, CfgHideShow, DocCfgHideShow, DocCfgHideShowValue, HideOrShow,
 };
+use rustc_hir::def_id::DefId;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::symbol::{Symbol, sym};
 use rustc_span::{DUMMY_SP, Span};
@@ -838,6 +839,7 @@ pub(crate) fn extract_cfg_from_attrs<'a, I: Iterator<Item = &'a hir::Attribute> 
     attrs: I,
     tcx: TyCtxt<'_>,
     cfg_info: &mut CfgInfo,
+    item_def_id: Option<DefId>,
 ) -> Option<Arc<Cfg>> {
     fn check_changed_auto_active_status(
         changed_auto_active_status: &mut Option<rustc_span::Span>,
@@ -933,6 +935,22 @@ pub(crate) fn extract_cfg_from_attrs<'a, I: Iterator<Item = &'a hir::Attribute> 
         {
             for (new_cfg, _) in cfgs {
                 cfg_info.current_cfg &= Cfg(new_cfg.clone());
+            }
+        }
+    }
+    if let Some(def_id) = item_def_id {
+        if !def_id.is_local() && tcx.def_kind(def_id).is_fn_like() {
+            let codegen_fn_attrs = tcx.codegen_fn_attrs(def_id);
+            for feature in &codegen_fn_attrs.target_features {
+                if feature.kind
+                    == rustc_middle::middle::codegen_fn_attrs::TargetFeatureKind::Enabled
+                {
+                    cfg_info.current_cfg &= Cfg(CfgEntry::NameValue {
+                        name: sym::target_feature,
+                        value: Some(feature.name),
+                        span: DUMMY_SP,
+                    });
+                }
             }
         }
     }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -435,6 +435,7 @@ pub(crate) fn merge_attrs(
     old_attrs: &[hir::Attribute],
     new_attrs: Option<(&[hir::Attribute], Option<LocalDefId>)>,
     cfg_info: &mut CfgInfo,
+    item_def_id: Option<DefId>,
 ) -> (clean::Attributes, Option<Arc<clean::cfg::Cfg>>) {
     // NOTE: If we have additional attributes (from a re-export),
     // always insert them first. This ensure that re-export
@@ -449,10 +450,13 @@ pub(crate) fn merge_attrs(
             } else {
                 Attributes::from_hir(&both)
             },
-            extract_cfg_from_attrs(both.iter(), tcx, cfg_info),
+            extract_cfg_from_attrs(both.iter(), tcx, cfg_info, item_def_id),
         )
     } else {
-        (Attributes::from_hir(old_attrs), extract_cfg_from_attrs(old_attrs.iter(), tcx, cfg_info))
+        (
+            Attributes::from_hir(old_attrs),
+            extract_cfg_from_attrs(old_attrs.iter(), tcx, cfg_info, item_def_id),
+        )
     }
 }
 
@@ -639,7 +643,7 @@ pub(crate) fn build_impl(
     //
     // We need to pass this empty `CfgInfo` because `merge_attrs` is used when computing the `cfg`.
     let (merged_attrs, cfg) =
-        merge_attrs(cx.tcx, load_attrs(cx.tcx, did), attrs, &mut CfgInfo::default());
+        merge_attrs(cx.tcx, load_attrs(cx.tcx, did), attrs, &mut CfgInfo::default(), Some(did));
     trace!("merged_attrs={merged_attrs:?}");
 
     trace!(

--- a/src/librustdoc/passes/propagate_doc_cfg.rs
+++ b/src/librustdoc/passes/propagate_doc_cfg.rs
@@ -104,7 +104,13 @@ impl CfgPropagator<'_, '_> {
                     &mut parent_attrs,
                     load_attrs(self.cx.tcx, parent_def_id.to_def_id()),
                 );
-                merge_attrs(self.cx.tcx, &[], Some((&parent_attrs, None)), &mut self.cfg_info);
+                merge_attrs(
+                    self.cx.tcx,
+                    &[],
+                    Some((&parent_attrs, None)),
+                    &mut self.cfg_info,
+                    None,
+                );
             }
         }
 
@@ -113,6 +119,7 @@ impl CfgPropagator<'_, '_> {
             item.attrs.other_attrs.as_slice(),
             Some((&attrs, None)),
             &mut self.cfg_info,
+            item.item_id.as_def_id(),
         );
         item.inner.cfg = cfg;
     }
@@ -160,6 +167,7 @@ impl DocFolder for CfgPropagator<'_, '_> {
                         std::iter::once(&attrs_iter),
                         tcx,
                         &mut self.cfg_info,
+                        None,
                     );
                 }
             }

--- a/tests/rustdoc-html/auxiliary/inline-target-feature.rs
+++ b/tests/rustdoc-html/auxiliary/inline-target-feature.rs
@@ -1,0 +1,4 @@
+
+
+#[target_feature(enable = "avx")]
+pub unsafe fn foo() {}

--- a/tests/rustdoc-html/inline-target-feature.rs
+++ b/tests/rustdoc-html/inline-target-feature.rs
@@ -1,0 +1,12 @@
+//@ only-x86_64
+//@ aux-build:inline-target-feature.rs
+//@ build-aux-docs
+
+#![feature(doc_cfg)]
+#![crate_name = "foo"]
+
+extern crate inline_target_feature;
+
+//@ has foo/fn.foo.html
+//@ has - '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' 'Available with target feature avx only.'
+pub use inline_target_feature::foo;


### PR DESCRIPTION
Fixes rust-lang/rust#162207

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
