### PR TITLE
function_item_references: don't ICE when not emitted

### DIFF
--- a/compiler/rustc_mir_transform/src/diagnostics.rs
+++ b/compiler/rustc_mir_transform/src/diagnostics.rs
@@ -159,42 +159,34 @@ pub(crate) struct FfiUnwindCall {
     pub foreign: bool,
 }
 
-pub(crate) struct FnItemRef<'tcx> {
-    pub span: Span,
-    pub fn_sig: Binder<'tcx, FnSig<'tcx>>,
-    pub fn_args: GenericArgsRef<'tcx>,
-    pub ident: Ident,
+pub(crate) struct GenericArgsPrinter<'tcx>(pub GenericArgsRef<'tcx>);
+
+impl core::fmt::Display for GenericArgsPrinter<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let Self(args) = self;
+        if args.is_empty() {
+            return Ok(());
+        }
+        f.write_str("::<")?;
+        for (i, arg) in args.terms().enumerate() {
+            write!(f, "{}{arg}", if i == 0 { "" } else { ", " })?
+        }
+        f.write_str(">")
+    }
 }
 
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for FnItemRef<'_> {
-    #[track_caller]
-    fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
-        use itertools::Itertools;
-
-        let Self { span, fn_sig, fn_args, ident } = self;
-
-        let suggestion = format!(
-            "{ident}{params} as {fn_sig}",
-            params = if fn_args.is_empty() {
-                String::from("")
-            } else {
-                format!("::<{}>", fn_args.terms().join(", "))
-            },
-        );
-
-        let mut diag = Diag::new(
-            dcx,
-            level,
-            msg!("taking a reference to a function item does not give a function pointer"),
-        );
-        diag.arg("ident", ident).span_suggestion(
-            span,
-            msg!("cast `{$ident}` to obtain a function pointer"),
-            suggestion,
-            Applicability::Unspecified,
-        );
-        diag
-    }
+#[derive(Diagnostic)]
+#[diag("taking a reference to a function item does not give a function pointer")]
+pub(crate) struct FnItemRef<'tcx> {
+    #[suggestion(
+        "cast `{$ident}` to obtain a function pointer",
+        code = "{ident}{fn_args} as {fn_sig}",
+        applicability = "unspecified"
+    )]
+    pub span: Span,
+    pub fn_sig: Binder<'tcx, FnSig<'tcx>>,
+    pub fn_args: GenericArgsPrinter<'tcx>,
+    pub ident: Ident,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_mir_transform/src/diagnostics.rs
+++ b/compiler/rustc_mir_transform/src/diagnostics.rs
@@ -173,22 +173,13 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for FnItemRef<'_> {
 
         let Self { span, fn_sig, fn_args, ident } = self;
 
-        // FIXME: use existing printing routines to print the function signature
         let suggestion = format!(
-            "{ident}{params} as {unsafety}{abi}fn({args}{variadic}){ret}",
+            "{ident}{params} as {fn_sig}",
             params = if fn_args.is_empty() {
                 String::from("")
             } else {
                 format!("::<{}>", fn_args.terms().join(", "))
             },
-            unsafety = fn_sig.safety().prefix_str(),
-            abi = match fn_sig.abi() {
-                rustc_abi::ExternAbi::Rust => String::from(""),
-                other_abi => format!("extern {other_abi} "),
-            },
-            args = core::iter::repeat_n("_", fn_sig.inputs().skip_binder().len()).join(", "),
-            variadic = if fn_sig.c_variadic() { ", ..." } else { "" },
-            ret = if fn_sig.output().skip_binder().is_unit() { "" } else { " -> _" }
         );
 
         let mut diag = Diag::new(

--- a/compiler/rustc_mir_transform/src/diagnostics.rs
+++ b/compiler/rustc_mir_transform/src/diagnostics.rs
@@ -7,7 +7,7 @@ use rustc_lint_defs::Lint;
 use rustc_lint_defs::builtin::{ARITHMETIC_OVERFLOW, UNCONDITIONAL_PANIC};
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_middle::mir::AssertKind;
-use rustc_middle::ty::{Ty, TyCtxt};
+use rustc_middle::ty::{Binder, FnSig, GenericArgsRef, Ty, TyCtxt};
 use rustc_span::def_id::DefId;
 use rustc_span::{Ident, Span, Symbol};
 
@@ -159,17 +159,51 @@ pub(crate) struct FfiUnwindCall {
     pub foreign: bool,
 }
 
-#[derive(Diagnostic)]
-#[diag("taking a reference to a function item does not give a function pointer")]
-pub(crate) struct FnItemRef {
-    #[suggestion(
-        "cast `{$ident}` to obtain a function pointer",
-        code = "{sugg}",
-        applicability = "unspecified"
-    )]
+pub(crate) struct FnItemRef<'tcx> {
     pub span: Span,
-    pub sugg: String,
+    pub fn_sig: Binder<'tcx, FnSig<'tcx>>,
+    pub fn_args: GenericArgsRef<'tcx>,
     pub ident: Ident,
+}
+
+impl<G: EmissionGuarantee> Diagnostic<'_, G> for FnItemRef<'_> {
+    #[track_caller]
+    fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
+        use itertools::Itertools;
+
+        let Self { span, fn_sig, fn_args, ident } = self;
+
+        // FIXME: use existing printing routines to print the function signature
+        let suggestion = format!(
+            "{ident}{params} as {unsafety}{abi}fn({args}{variadic}){ret}",
+            params = if fn_args.is_empty() {
+                String::from("")
+            } else {
+                format!("::<{}>", fn_args.terms().join(", "))
+            },
+            unsafety = fn_sig.safety().prefix_str(),
+            abi = match fn_sig.abi() {
+                rustc_abi::ExternAbi::Rust => String::from(""),
+                other_abi => format!("extern {other_abi} "),
+            },
+            args = core::iter::repeat_n("_", fn_sig.inputs().skip_binder().len()).join(", "),
+            variadic = if fn_sig.c_variadic() { ", ..." } else { "" },
+            ret = if fn_sig.output().skip_binder().is_unit() { "" } else { " -> _" }
+        );
+
+        let mut diag = Diag::new(
+            dcx,
+            level,
+            msg!("taking a reference to a function item does not give a function pointer"),
+        );
+        diag.arg("ident", ident).span_suggestion(
+            span,
+            msg!("cast `{$ident}` to obtain a function pointer"),
+            suggestion,
+            Applicability::Unspecified,
+        );
+        diag
+    }
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_mir_transform/src/function_item_references.rs
+++ b/compiler/rustc_mir_transform/src/function_item_references.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-use rustc_abi::ExternAbi;
 use rustc_hir::def_id::DefId;
 use rustc_lint_defs::builtin::FUNCTION_ITEM_REFERENCES;
 use rustc_middle::mir::visit::Visitor;
@@ -156,33 +154,16 @@ impl<'tcx> FunctionItemRefChecker<'_, 'tcx> {
             .as_ref()
             .unwrap_crate_local()
             .lint_root;
-        // FIXME: use existing printing routines to print the function signature
+
         let fn_sig = self.tcx.fn_sig(fn_id).instantiate(self.tcx, fn_args).skip_norm_wip();
-        let unsafety = fn_sig.safety().prefix_str();
-        let abi = match fn_sig.abi() {
-            ExternAbi::Rust => String::from(""),
-            other_abi => format!("extern {other_abi} "),
-        };
+
         let ident = self.tcx.item_ident(fn_id);
-        let params = fn_args.terms().map(|term| format!("{term}")).join(", ");
-        let num_args = fn_sig.inputs().map_bound(|inputs| inputs.len()).skip_binder();
-        let variadic = if fn_sig.c_variadic() { ", ..." } else { "" };
-        let ret = if fn_sig.output().skip_binder().is_unit() { "" } else { " -> _" };
-        let sugg = format!(
-            "{} as {}{}fn({}{}){}",
-            if params.is_empty() { ident.to_string() } else { format!("{ident}::<{params}>") },
-            unsafety,
-            abi,
-            vec!["_"; num_args].join(", "),
-            variadic,
-            ret,
-        );
 
         self.tcx.emit_node_span_lint(
             FUNCTION_ITEM_REFERENCES,
             lint_root,
             span,
-            diagnostics::FnItemRef { span, sugg, ident },
+            diagnostics::FnItemRef { span, fn_sig, fn_args, ident },
         );
     }
 }

--- a/compiler/rustc_mir_transform/src/function_item_references.rs
+++ b/compiler/rustc_mir_transform/src/function_item_references.rs
@@ -163,7 +163,12 @@ impl<'tcx> FunctionItemRefChecker<'_, 'tcx> {
             FUNCTION_ITEM_REFERENCES,
             lint_root,
             span,
-            diagnostics::FnItemRef { span, fn_sig, fn_args, ident },
+            diagnostics::FnItemRef {
+                span,
+                fn_sig,
+                fn_args: diagnostics::GenericArgsPrinter(fn_args),
+                ident,
+            },
         );
     }
 }

--- a/tests/ui/lint/function-item-references-allow.rs
+++ b/tests/ui/lint/function-item-references-allow.rs
@@ -1,0 +1,7 @@
+//@ check-pass
+// regression test for https://github.com/rust-lang/rust/issues/162107
+
+#[allow(function_item_references)]
+fn main() {
+    println!("{:p}", &std::env::var::<String>);
+}

--- a/tests/ui/lint/function-item-references.stderr
+++ b/tests/ui/lint/function-item-references.stderr
@@ -2,7 +2,7 @@ warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:45:18
    |
 LL |     Pointer::fmt(&zst_ref, f)
-   |                  ^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                  ^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
    |
 note: the lint level is defined here
   --> $DIR/function-item-references.rs:4:9
@@ -14,55 +14,55 @@ warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:82:22
    |
 LL |     println!("{:p}", &foo);
-   |                      ^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                      ^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:84:20
    |
 LL |     print!("{:p}", &foo);
-   |                    ^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                    ^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:86:21
    |
 LL |     format!("{:p}", &foo);
-   |                     ^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                     ^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:89:22
    |
 LL |     println!("{:p}", &foo as *const _);
-   |                      ^^^^^^^^^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                      ^^^^^^^^^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:91:22
    |
 LL |     println!("{:p}", zst_ref);
-   |                      ^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                      ^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:93:22
    |
 LL |     println!("{:p}", cast_zst_ptr);
-   |                      ^^^^^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                      ^^^^^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:95:22
    |
 LL |     println!("{:p}", coerced_zst_ptr);
-   |                      ^^^^^^^^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                      ^^^^^^^^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:98:22
    |
 LL |     println!("{:p}", &fn_item);
-   |                      ^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                      ^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:100:22
    |
 LL |     println!("{:p}", indirect_ref);
-   |                      ^^^^^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                      ^^^^^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:103:22
@@ -74,13 +74,13 @@ warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:105:22
    |
 LL |     println!("{:p}", &bar);
-   |                      ^^^^ help: cast `bar` to obtain a function pointer: `bar as fn(_) -> _`
+   |                      ^^^^ help: cast `bar` to obtain a function pointer: `bar as fn(u32) -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:107:22
    |
 LL |     println!("{:p}", &baz);
-   |                      ^^^^ help: cast `baz` to obtain a function pointer: `baz as fn(_, _) -> _`
+   |                      ^^^^ help: cast `baz` to obtain a function pointer: `baz as fn(u32, u32) -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:109:22
@@ -104,37 +104,37 @@ warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:115:22
    |
 LL |     println!("{:p}", &variadic);
-   |                      ^^^^^^^^^ help: cast `variadic` to obtain a function pointer: `variadic as unsafe extern "C" fn(_, ...)`
+   |                      ^^^^^^^^^ help: cast `variadic` to obtain a function pointer: `variadic as unsafe extern "C" fn(u32, ...)`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:117:22
    |
 LL |     println!("{:p}", &take_generic_ref::<u32>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `take_generic_ref` to obtain a function pointer: `take_generic_ref::<u32> as fn(_)`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `take_generic_ref` to obtain a function pointer: `take_generic_ref::<u32> as for<'a> fn(&'a u32)`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:119:22
    |
 LL |     println!("{:p}", &take_generic_array::<u32, 4>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `take_generic_array` to obtain a function pointer: `take_generic_array::<u32, 4> as fn(_)`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `take_generic_array` to obtain a function pointer: `take_generic_array::<u32, 4> as fn([u32; 4])`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:121:22
    |
 LL |     println!("{:p}", &multiple_generic::<u32, f32>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `multiple_generic` to obtain a function pointer: `multiple_generic::<u32, f32> as fn(_, _)`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `multiple_generic` to obtain a function pointer: `multiple_generic::<u32, f32> as fn(u32, f32)`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:123:22
    |
 LL |     println!("{:p}", &multiple_generic_arrays::<u32, 4, f32, 8>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `multiple_generic_arrays` to obtain a function pointer: `multiple_generic_arrays::<u32, 4, f32, 8> as fn(_, _)`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `multiple_generic_arrays` to obtain a function pointer: `multiple_generic_arrays::<u32, 4, f32, 8> as fn([u32; 4], [f32; 8])`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:125:22
    |
 LL |     println!("{:p}", &std::env::var::<String>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `var` to obtain a function pointer: `var::<String> as fn(_) -> _`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `var` to obtain a function pointer: `var::<String> as fn(String) -> Result<String, VarError>`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:128:32
@@ -146,61 +146,61 @@ warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:128:38
    |
 LL |     println!("{:p} {:p} {:p}", &nop, &foo, &bar);
-   |                                      ^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                                      ^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:128:44
    |
 LL |     println!("{:p} {:p} {:p}", &nop, &foo, &bar);
-   |                                            ^^^^ help: cast `bar` to obtain a function pointer: `bar as fn(_) -> _`
+   |                                            ^^^^ help: cast `bar` to obtain a function pointer: `bar as fn(u32) -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:143:41
    |
 LL |         std::mem::transmute::<_, usize>(&foo);
-   |                                         ^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                                         ^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:145:50
    |
 LL |         std::mem::transmute::<_, (usize, usize)>((&foo, &bar));
-   |                                                  ^^^^^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                                                  ^^^^^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:145:50
    |
 LL |         std::mem::transmute::<_, (usize, usize)>((&foo, &bar));
-   |                                                  ^^^^^^^^^^^^ help: cast `bar` to obtain a function pointer: `bar as fn(_) -> _`
+   |                                                  ^^^^^^^^^^^^ help: cast `bar` to obtain a function pointer: `bar as fn(u32) -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:148:41
    |
 LL |         std::mem::transmute::<_, usize>(&take_generic_ref::<u32>);
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `take_generic_ref` to obtain a function pointer: `take_generic_ref::<u32> as fn(_)`
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^ help: cast `take_generic_ref` to obtain a function pointer: `take_generic_ref::<u32> as for<'a> fn(&'a u32)`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:157:15
    |
 LL |     print_ptr(&bar);
-   |               ^^^^ help: cast `bar` to obtain a function pointer: `bar as fn(_) -> _`
+   |               ^^^^ help: cast `bar` to obtain a function pointer: `bar as fn(u32) -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:159:24
    |
 LL |     bound_by_ptr_trait(&bar);
-   |                        ^^^^ help: cast `bar` to obtain a function pointer: `bar as fn(_) -> _`
+   |                        ^^^^ help: cast `bar` to obtain a function pointer: `bar as fn(u32) -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:161:30
    |
 LL |     bound_by_ptr_trait_tuple((&foo, &bar));
-   |                              ^^^^^^^^^^^^ help: cast `bar` to obtain a function pointer: `bar as fn(_) -> _`
+   |                              ^^^^^^^^^^^^ help: cast `bar` to obtain a function pointer: `bar as fn(u32) -> u32`
 
 warning: taking a reference to a function item does not give a function pointer
   --> $DIR/function-item-references.rs:161:30
    |
 LL |     bound_by_ptr_trait_tuple((&foo, &bar));
-   |                              ^^^^^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> _`
+   |                              ^^^^^^^^^^^^ help: cast `foo` to obtain a function pointer: `foo as fn() -> u32`
 
 warning: 33 warnings emitted
 


### PR DESCRIPTION
The classical case of formatting stuff too early. I wonder how many other lints like that we currently have.

Fixes rust-lang/rust#162107

No LLMs used

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
