### PR TITLE
Handle higher-ranked trait bounds in `suggest_impl_fn_for_fn_ptr_ret`.

### DIFF
--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -378,7 +378,7 @@ impl<'a> State<'a> {
     }
 
     fn print_opt_lifetime(&mut self, lifetime: &hir::Lifetime) {
-        if !lifetime.is_elided() {
+        if !lifetime.is_implicit() {
             self.print_lifetime(lifetime);
             self.nbsp();
         }
@@ -440,7 +440,7 @@ impl<'a> State<'a> {
                     }
                     self.print_poly_trait_ref(bound);
                 }
-                if !lifetime.is_elided() {
+                if !lifetime.is_implicit() {
                     self.nbsp();
                     self.word_space("+");
                     self.print_lifetime(lifetime.pointer());

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -12,8 +12,9 @@ use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::intravisit::Visitor;
 use rustc_hir::{
     self as hir, Arm, CoroutineDesugaring, CoroutineKind, CoroutineSource, Expr, ExprKind,
-    GenericBound, HirId, LoopSource, Node, PatExpr, PatExprKind, Path, QPath, Stmt, StmtKind,
-    TyKind, WherePredicateKind, expr_needs_parens, is_range_literal,
+    GenericBound, GenericParam, GenericParamKind, GenericParamSource, HirId, LifetimeParamKind,
+    LoopSource, Node, ParamName, PatExpr, PatExprKind, Path, QPath, Stmt, StmtKind, TyKind,
+    WherePredicateKind, expr_needs_parens, is_range_literal,
 };
 use rustc_hir_analysis::hir_ty_lowering::HirTyLowerer;
 use rustc_hir_analysis::suggest_impl_trait;
@@ -731,10 +732,36 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         };
 
-        let suggestion = format!("impl Fn({inputs_str}){output_str}");
+        // collect all higher-ranked lifetimes
+        let hr_lifetimes = fn_ptr_ty
+            .generic_params
+            .iter()
+            .filter_map(|param| {
+                if let GenericParam {
+                    kind: GenericParamKind::Lifetime { kind: LifetimeParamKind::Explicit },
+                    source: GenericParamSource::Binder,
+                    name: ParamName::Plain(name),
+                    ..
+                } = param
+                {
+                    Some(name.as_str())
+                } else {
+                    None
+                }
+            })
+            .format(", ")
+            .to_string();
+
+        let for_clause = if !hr_lifetimes.is_empty() {
+            format!(" for<{}>", hr_lifetimes)
+        } else {
+            String::new()
+        };
+
+        let suggestion = format!("impl{for_clause} Fn({inputs_str}){output_str}");
         err.span_suggestion(
             ret_ty.span,
-            "change the return type to return a type-erased closure instead",
+            "consider changing the return type to a type-erased closure instead",
             suggestion,
             Applicability::MaybeIncorrect,
         );

--- a/tests/pretty/delegation/generics.pp
+++ b/tests/pretty/delegation/generics.pp
@@ -10,8 +10,8 @@ use ::std::prelude::rust_2015::*;
 
 mod free_to_trait {
     trait Trait<'a, XX, Y, T = (), const N: usize = 2> {
-        fn method<A, B>(&self, t: (T, A, B), slice: &'_ [usize; N]) { }
-        fn r#static<A, B>(t: (T, A, B), slice: &'_ [usize; N]) { }
+        fn method<A, B>(&self, t: (T, A, B), slice: &[usize; N]) { }
+        fn r#static<A, B>(t: (T, A, B), slice: &[usize; N]) { }
     }
 
     struct X;
@@ -108,8 +108,8 @@ mod free_to_trait {
 
 mod trait_impl_to_trait {
     trait Trait<'a, X, Y, T = (), const N: usize = 2> {
-        fn foo(&self, t: (T, T, T), slice: &'_ [usize; N]) { }
-        fn bar(&self, t: (T, T, T), slice: &'_ [usize; N]) { }
+        fn foo(&self, t: (T, T, T), slice: &[usize; N]) { }
+        fn bar(&self, t: (T, T, T), slice: &[usize; N]) { }
     }
 
     struct S;

--- a/tests/pretty/delegation/inline-attribute.pp
+++ b/tests/pretty/delegation/inline-attribute.pp
@@ -29,7 +29,7 @@ impl Trait for u8 { }
 struct S(u8);
 
 mod to_import {
-    fn check(arg: &'_ u8) -> &'_ u8 { arg }
+    fn check(arg: &u8) -> &u8 { arg }
 }
 
 impl Trait for S {

--- a/tests/pretty/hir-lifetimes.pp
+++ b/tests/pretty/hir-lifetimes.pp
@@ -18,7 +18,7 @@ impl <'a> Foo<'a> {
 }
 
 impl  Foo<'_> {
-    fn a(x: &'_ u32) { }
+    fn a(x: &u32) { }
 
     fn b(x: &'_ u32) { }
 
@@ -55,7 +55,7 @@ impl <'a, 'b, 'c, T> MyTrait<'a, 'b> for Bar<'a, 'b, 'c, T> {
     fn f(&self, x: Foo<'a>, y: Foo<'b>) { }
 }
 
-fn g(x: &'_ dyn for<'a, 'b> MyTrait<'a, 'b>) { }
+fn g(x: &dyn for<'a, 'b> MyTrait<'a, 'b>) { }
 
 trait Blah { }
 
@@ -84,7 +84,7 @@ fn f() { { let _ = St { x: &0 }; }; { let _ = St { x: &0 }; }; }
 struct Name<'a>(&'a str);
 
 const A: Name<'_> = Name("a");
-const B: &'_ str = "";
+const B: &str = "";
 static C: &'_ str = "";
 static D: &'static str = "";
 

--- a/tests/pretty/pin-ergonomics-hir.pp
+++ b/tests/pretty/pin-ergonomics-hir.pp
@@ -40,7 +40,7 @@ fn bar() {
     foo_const(x);
 }
 
-fn patterns<'a>(&pin mut x: Pin<&'_ mut i32>, &pin const y: Pin<&'a i32>,
+fn patterns<'a>(&pin mut x: Pin<&mut i32>, &pin const y: Pin<&'a i32>,
     ref pin mut z: i32, ref pin const w: i32) { }
 
 fn main() { }

--- a/tests/ui/closures/suggest-impl-fn-return-for-capturing-closure.rs
+++ b/tests/ui/closures/suggest-impl-fn-return-for-capturing-closure.rs
@@ -51,3 +51,13 @@ fn multi_args(a: i32, b: i32) -> fn(i32, i32) -> i32 {
     |x, y| x + y + a + b
     //~^ ERROR mismatched types
 }
+
+fn hrtb(x: i32) -> for<'a> fn(&'a i32) -> &'a i32 {
+    |y| &(x + y)
+    //~^ ERROR mismatched types
+}
+
+fn hrtb_out_of_order(x: i32) -> for<'b, 'a> fn(&'a i32, &'b i32) -> (&'b i32, &'a i32) {
+    |y, z| (&(x + y + z), unimplemented!())
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/closures/suggest-impl-fn-return-for-capturing-closure.stderr
+++ b/tests/ui/closures/suggest-impl-fn-return-for-capturing-closure.stderr
@@ -13,7 +13,7 @@ note: closures can only be coerced to `fn` types if they do not capture any vari
    |
 LL |     || a
    |        ^ `a` captured here
-help: change the return type to return a type-erased closure instead
+help: consider changing the return type to a type-erased closure instead
    |
 LL - fn no_args(a: i32) -> fn() -> i32 {
 LL + fn no_args(a: i32) -> impl Fn() -> i32 {
@@ -34,7 +34,7 @@ note: closures can only be coerced to `fn` types if they do not capture any vari
    |
 LL |     || println!("{}", a)
    |                       ^ `a` captured here
-help: change the return type to return a type-erased closure instead
+help: consider changing the return type to a type-erased closure instead
    |
 LL - fn no_args_no_return(a: i32) -> fn() {
 LL + fn no_args_no_return(a: i32) -> impl Fn() {
@@ -55,7 +55,7 @@ note: closures can only be coerced to `fn` types if they do not capture any vari
    |
 LL |     |x| x + a
    |             ^ `a` captured here
-help: change the return type to return a type-erased closure instead
+help: consider changing the return type to a type-erased closure instead
    |
 LL - fn one_arg(a: i32) -> fn(i32) -> i32 {
 LL + fn one_arg(a: i32) -> impl Fn(i32) -> i32 {
@@ -76,7 +76,7 @@ note: closures can only be coerced to `fn` types if they do not capture any vari
    |
 LL |     |x| x + a
    |             ^ `a` captured here
-help: change the return type to return a type-erased closure instead
+help: consider changing the return type to a type-erased closure instead
    |
 LL - fn one_arg_unsafe(a: i32) -> unsafe fn(i32) -> i32 {
 LL + fn one_arg_unsafe(a: i32) -> impl Fn(i32) -> i32 {
@@ -97,7 +97,7 @@ note: closures can only be coerced to `fn` types if they do not capture any vari
    |
 LL |     |x| x + a
    |             ^ `a` captured here
-help: change the return type to return a type-erased closure instead
+help: consider changing the return type to a type-erased closure instead
    |
 LL - fn one_arg_extern(a: i32) -> extern "C" fn(i32) -> i32 {
 LL + fn one_arg_extern(a: i32) -> impl Fn(i32) -> i32 {
@@ -118,7 +118,7 @@ note: closures can only be coerced to `fn` types if they do not capture any vari
    |
 LL |     |x| println!("{}", x + a)
    |                            ^ `a` captured here
-help: change the return type to return a type-erased closure instead
+help: consider changing the return type to a type-erased closure instead
    |
 LL - fn one_arg_no_return(a: i32) -> fn(i32) {
 LL + fn one_arg_no_return(a: i32) -> impl Fn(i32) {
@@ -139,7 +139,7 @@ note: closures can only be coerced to `fn` types if they do not capture any vari
    |
 LL |     |x| println!("{}", x + a)
    |                            ^ `a` captured here
-help: change the return type to return a type-erased closure instead
+help: consider changing the return type to a type-erased closure instead
    |
 LL - fn one_arg_return_unit(a: i32) -> fn(i32) -> () {
 LL + fn one_arg_return_unit(a: i32) -> impl Fn(i32) -> () {
@@ -164,10 +164,10 @@ note: closures can only be coerced to `fn` types if they do not capture any vari
    |
 LL |         println!("{}", a);
    |                        ^ `a` captured here
-help: change the return type to return a type-erased closure instead
+help: consider changing the return type to a type-erased closure instead
    |
 LL - fn one_arg_ref(a: i32) -> fn(&i32) -> &i32 {
-LL + fn one_arg_ref(a: i32) -> impl Fn(&'_ i32) -> &'_ i32 {
+LL + fn one_arg_ref(a: i32) -> impl Fn(&i32) -> &i32 {
    |
 
 error[E0308]: mismatched types
@@ -187,12 +187,54 @@ LL |     |x, y| x + y + a + b
    |                    ^   ^ `b` captured here
    |                    |
    |                    `a` captured here
-help: change the return type to return a type-erased closure instead
+help: consider changing the return type to a type-erased closure instead
    |
 LL - fn multi_args(a: i32, b: i32) -> fn(i32, i32) -> i32 {
 LL + fn multi_args(a: i32, b: i32) -> impl Fn(i32, i32) -> i32 {
    |
 
-error: aborting due to 9 previous errors
+error[E0308]: mismatched types
+  --> $DIR/suggest-impl-fn-return-for-capturing-closure.rs:56:5
+   |
+LL | fn hrtb(x: i32) -> for<'a> fn(&'a i32) -> &'a i32 {
+   |                    ------------------------------ expected `for<'a> fn(&'a i32) -> &'a i32` because of return type
+LL |     |y| &(x + y)
+   |     ^^^^^^^^^^^^ expected fn pointer, found closure
+   |
+   = note: expected fn pointer `for<'a> fn(&'a i32) -> &'a i32`
+                 found closure `{closure@$DIR/suggest-impl-fn-return-for-capturing-closure.rs:56:5: 56:8}`
+note: closures can only be coerced to `fn` types if they do not capture any variables
+  --> $DIR/suggest-impl-fn-return-for-capturing-closure.rs:56:11
+   |
+LL |     |y| &(x + y)
+   |           ^ `x` captured here
+help: consider changing the return type to a type-erased closure instead
+   |
+LL - fn hrtb(x: i32) -> for<'a> fn(&'a i32) -> &'a i32 {
+LL + fn hrtb(x: i32) -> impl for<'a> Fn(&'a i32) -> &'a i32 {
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-impl-fn-return-for-capturing-closure.rs:61:5
+   |
+LL | fn hrtb_out_of_order(x: i32) -> for<'b, 'a> fn(&'a i32, &'b i32) -> (&'b i32, &'a i32) {
+   |                                 ------------------------------------------------------ expected `for<'a, 'b> fn(&'a i32, &'b i32) -> (&'b i32, &'a i32)` because of return type
+LL |     |y, z| (&(x + y + z), unimplemented!())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected fn pointer, found closure
+   |
+   = note: expected fn pointer `for<'a, 'b> fn(&'a i32, &'b i32) -> (&'b i32, &'a i32)`
+                 found closure `{closure@$DIR/suggest-impl-fn-return-for-capturing-closure.rs:61:5: 61:11}`
+note: closures can only be coerced to `fn` types if they do not capture any variables
+  --> $DIR/suggest-impl-fn-return-for-capturing-closure.rs:61:15
+   |
+LL |     |y, z| (&(x + y + z), unimplemented!())
+   |               ^ `x` captured here
+help: consider changing the return type to a type-erased closure instead
+   |
+LL - fn hrtb_out_of_order(x: i32) -> for<'b, 'a> fn(&'a i32, &'b i32) -> (&'b i32, &'a i32) {
+LL + fn hrtb_out_of_order(x: i32) -> impl for<'b, 'a> Fn(&'a i32, &'b i32) -> (&'b i32, &'a i32) {
+   |
+
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/unpretty/debug-fmt-hir.stdout
+++ b/tests/ui/unpretty/debug-fmt-hir.stdout
@@ -13,13 +13,13 @@ struct Bar {
 }
 
 impl fmt::Debug for Bar {
-    fn fmt(&self, f: &'_ mut fmt::Formatter<'_>)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>)
         ->
             fmt::Result {
         debug_struct_field2_finish(f, "Bar", "a", &self.a, "b", &&self.b)
     }
 }
 
-fn debug_struct_field2_finish<'a>(name: &'_ str, name1: &'_ str,
-    value1: &'a dyn fmt::Debug, name2: &'_ str, value2: &'a dyn fmt::Debug)
+fn debug_struct_field2_finish<'a>(name: &str, name1: &str,
+    value1: &'a dyn fmt::Debug, name2: &str, value2: &'a dyn fmt::Debug)
     -> fmt::Result { loop { } }

--- a/tests/ui/unpretty/exhaustive.hir.stdout
+++ b/tests/ui/unpretty/exhaustive.hir.stdout
@@ -519,7 +519,7 @@ mod items {
 }
 mod patterns {
     /// PatKind::Missing
-    fn pat_missing() { let _: for fn(u32, T, &'_ str); }
+    fn pat_missing() { let _: for fn(u32, T, &str); }
     /// PatKind::Wild
     fn pat_wild() { let _; }
     /// PatKind::Ident


### PR DESCRIPTION
Adresses rust-lang/rust#159481. 
Builds on rust-lang/rust#159594.

### Summery

Handle higher-ranked trait bounds in `suggest_impl_fn_for_fn_ptr_ret`. If the `fn` type had higher-ranked trait bounds, the suggested `impl Fn` replacement will now have the same higher-ranked trait bounds.

Changed how rustc_hir_pretty handles lifetimes, it know only prints *explicit* lifetimes, i.e. lifetimes that exist in the source code. Previously it would print implicit lifetimes as `'_`. This change was made to make code suggestions less verbose and make prints of the HIR match the source code more closely. Without this change, `suggest_impl_fn_for_fn_ptr_ret` would suggest replacing `fn(&()) -> &()` with `impl Fn(&'_ ()) -> &'_ ()`, now it will suggest the more intuitive `impl Fn(&()) -> &()`.