### PR TITLE
Pass -Z merge-functions=disabled in tests/codegen-llvm/intrinsics/unchecked_math.rs

### DIFF
--- a/tests/codegen-llvm/intrinsics/unchecked_math.rs
+++ b/tests/codegen-llvm/intrinsics/unchecked_math.rs
@@ -1,3 +1,4 @@
+//@ compile-flags: -Z merge-functions=disabled
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]
 


### PR DESCRIPTION
Otherwise e.g. `@unchecked_add_unsigned` and `@unchecked_add_signed` get merged after https://github.com/llvm/llvm-project/pull/220015, breaking the test's expectations.
