### PR TITLE
make -Ctarget-feature warnings more explicitly FCWs

### DIFF
--- a/compiler/rustc_codegen_ssa/src/diagnostics.rs
+++ b/compiler/rustc_codegen_ssa/src/diagnostics.rs
@@ -1219,6 +1219,10 @@ pub(crate) enum PossibleFeature<'a> {
 #[note(
     "it is still passed through to the codegen backend, but use of this feature might be unsound and the behavior of this feature can change in the future"
 )]
+#[note(
+    "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
+)]
+#[note("for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>")]
 pub(crate) struct UnknownCTargetFeature<'a> {
     pub feature: &'a str,
     #[subdiagnostic]
@@ -1228,6 +1232,10 @@ pub(crate) struct UnknownCTargetFeature<'a> {
 #[derive(Diagnostic)]
 #[diag("unstable feature specified for `-Ctarget-feature`: `{$feature}`")]
 #[note("{$note}; its behavior can change in the future")]
+#[note(
+    "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
+)]
+#[note("for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>")]
 pub(crate) struct UnstableCTargetFeature<'a> {
     pub feature: &'a str,
     pub note: &'a str,
@@ -1243,7 +1251,7 @@ pub(crate) struct InternalOnlyCTargetFeature<'a> {
         "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
     )]
     #[note(
-        "for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>"
+        "for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>"
     )]
     pub future_compat_note: bool,
 }

--- a/compiler/rustc_interface/src/diagnostics.rs
+++ b/compiler/rustc_interface/src/diagnostics.rs
@@ -129,7 +129,7 @@ pub(crate) struct AbiRequiredTargetFeature<'a> {
         "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
     )]
     #[note(
-        "for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>"
+        "for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>"
     )]
     pub fcw: bool,
 }

--- a/src/tools/miri/tests/pass/shims/x86/intrinsics-x86-pause-without-sse2.stderr
+++ b/src/tools/miri/tests/pass/shims/x86/intrinsics-x86-pause-without-sse2.stderr
@@ -1,7 +1,7 @@
 warning: target feature `sse2` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/abi/avr-sram.disable_sram.stderr
+++ b/tests/ui/abi/avr-sram.disable_sram.stderr
@@ -1,12 +1,12 @@
 warning: target feature `sram` cannot be disabled with `-Ctarget-feature`: devices that have no SRAM are unsupported
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `sram` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/abi/avr-sram.no_sram.stderr
+++ b/tests/ui/abi/avr-sram.no_sram.stderr
@@ -1,7 +1,7 @@
 warning: target feature `sram` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/abi/riscv-discoverability-guidance.riscv32.stderr
+++ b/tests/ui/abi/riscv-discoverability-guidance.riscv32.stderr
@@ -1,9 +1,11 @@
 warning: unstable feature specified for `-Ctarget-feature`: `unaligned-scalar-mem`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error[E0703]: invalid ABI: found `riscv-interrupt`
-  --> $DIR/riscv-discoverability-guidance.rs:19:8
+  --> $DIR/riscv-discoverability-guidance.rs:21:8
    |
 LL | extern "riscv-interrupt" fn isr() {}
    |        ^^^^^^^^^^^^^^^^^ invalid ABI
@@ -15,7 +17,7 @@ LL | extern "riscv-interrupt-m" fn isr() {}
    |                        ++
 
 error[E0703]: invalid ABI: found `riscv-interrupt-u`
-  --> $DIR/riscv-discoverability-guidance.rs:24:8
+  --> $DIR/riscv-discoverability-guidance.rs:26:8
    |
 LL | extern "riscv-interrupt-u" fn isr_U() {}
    |        ^^^^^^^^^^^^^^^^^^^ invalid ABI

--- a/tests/ui/abi/riscv-discoverability-guidance.riscv64.stderr
+++ b/tests/ui/abi/riscv-discoverability-guidance.riscv64.stderr
@@ -1,9 +1,11 @@
 warning: unstable feature specified for `-Ctarget-feature`: `unaligned-scalar-mem`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error[E0703]: invalid ABI: found `riscv-interrupt`
-  --> $DIR/riscv-discoverability-guidance.rs:19:8
+  --> $DIR/riscv-discoverability-guidance.rs:21:8
    |
 LL | extern "riscv-interrupt" fn isr() {}
    |        ^^^^^^^^^^^^^^^^^ invalid ABI
@@ -15,7 +17,7 @@ LL | extern "riscv-interrupt-m" fn isr() {}
    |                        ++
 
 error[E0703]: invalid ABI: found `riscv-interrupt-u`
-  --> $DIR/riscv-discoverability-guidance.rs:24:8
+  --> $DIR/riscv-discoverability-guidance.rs:26:8
    |
 LL | extern "riscv-interrupt-u" fn isr_U() {}
    |        ^^^^^^^^^^^^^^^^^^^ invalid ABI

--- a/tests/ui/abi/riscv-discoverability-guidance.rs
+++ b/tests/ui/abi/riscv-discoverability-guidance.rs
@@ -12,6 +12,8 @@
 
 //~? WARN unstable feature specified for `-Ctarget-feature`
 //~? NOTE this feature is not stably supported; its behavior can change in the future
+//~? NOTE previously accepted
+//~? NOTE for more information, see issue
 
 extern crate minicore;
 use minicore::*;

--- a/tests/ui/abi/s390x-softfloat-gate.disable-softfloat.stderr
+++ b/tests/ui/abi/s390x-softfloat-gate.disable-softfloat.stderr
@@ -1,12 +1,12 @@
 warning: target feature `soft-float` cannot be enabled with `-Ctarget-feature`: unsupported ABI-configuration feature
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `soft-float` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/abi/s390x-softfloat-gate.enable-softfloat.stderr
+++ b/tests/ui/abi/s390x-softfloat-gate.enable-softfloat.stderr
@@ -1,7 +1,7 @@
 warning: target feature `vector` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/abi/simd-abi-checks-s390x.z13_soft_float.stderr
+++ b/tests/ui/abi/simd-abi-checks-s390x.z13_soft_float.stderr
@@ -1,12 +1,12 @@
 warning: target feature `soft-float` cannot be enabled with `-Ctarget-feature`: unsupported ABI-configuration feature
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `soft-float` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:33:1

--- a/tests/ui/abi/sparcv8plus.sparc_cpu_v9_feature_v8plus.stderr
+++ b/tests/ui/abi/sparcv8plus.sparc_cpu_v9_feature_v8plus.stderr
@@ -1,11 +1,13 @@
 warning: unstable feature specified for `-Ctarget-feature`: `v8plus`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `v8plus` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: +v8plus,+v9
   --> $DIR/sparcv8plus.rs:35:1

--- a/tests/ui/abi/sparcv8plus.sparc_feature_v8plus.stderr
+++ b/tests/ui/abi/sparcv8plus.sparc_feature_v8plus.stderr
@@ -1,11 +1,13 @@
 warning: unstable feature specified for `-Ctarget-feature`: `v8plus`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `v8plus` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: +v8plus,-v9 (FIXME)
   --> $DIR/sparcv8plus.rs:40:1

--- a/tests/ui/asm/hexagon-register-pairs.stderr
+++ b/tests/ui/asm/hexagon-register-pairs.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `hvx-length128b`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: avoid using named labels in inline assembly
   --> $DIR/hexagon-register-pairs.rs:32:15

--- a/tests/ui/asm/hexagon/bad-reg.stderr
+++ b/tests/ui/asm/hexagon/bad-reg.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `hvx-length128b`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: invalid register `r19`: r19 is used internally by LLVM and cannot be used as an operand for inline asm
   --> $DIR/bad-reg.rs:20:18

--- a/tests/ui/asm/mips/reg-conflict.mips32.stderr
+++ b/tests/ui/asm/mips/reg-conflict.mips32.stderr
@@ -1,15 +1,21 @@
 warning: unknown and unstable feature specified for `-Ctarget-feature`: `mips32r5`
    |
    = note: it is still passed through to the codegen backend, but use of this feature might be unsound and the behavior of this feature can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
    = help: consider filing a feature request
 
 warning: unstable feature specified for `-Ctarget-feature`: `fp64`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: unstable feature specified for `-Ctarget-feature`: `msa`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: register `$f4` conflicts with register `$w4`
   --> $DIR/reg-conflict.rs:28:33

--- a/tests/ui/asm/mips/reg-conflict.mips32r6.stderr
+++ b/tests/ui/asm/mips/reg-conflict.mips32r6.stderr
@@ -1,10 +1,14 @@
 warning: unstable feature specified for `-Ctarget-feature`: `fp64`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: unstable feature specified for `-Ctarget-feature`: `msa`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: register `$f4` conflicts with register `$w4`
   --> $DIR/reg-conflict.rs:28:33

--- a/tests/ui/asm/mips/reg-conflict.mips64.stderr
+++ b/tests/ui/asm/mips/reg-conflict.mips64.stderr
@@ -1,15 +1,21 @@
 warning: unknown and unstable feature specified for `-Ctarget-feature`: `mips64r5`
    |
    = note: it is still passed through to the codegen backend, but use of this feature might be unsound and the behavior of this feature can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
    = help: consider filing a feature request
 
 warning: unstable feature specified for `-Ctarget-feature`: `fp64`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: unstable feature specified for `-Ctarget-feature`: `msa`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: register `$f4` conflicts with register `$w4`
   --> $DIR/reg-conflict.rs:28:33

--- a/tests/ui/asm/mips/reg-conflict.mips64r6.stderr
+++ b/tests/ui/asm/mips/reg-conflict.mips64r6.stderr
@@ -1,10 +1,14 @@
 warning: unstable feature specified for `-Ctarget-feature`: `fp64`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: unstable feature specified for `-Ctarget-feature`: `msa`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: register `$f4` conflicts with register `$w4`
   --> $DIR/reg-conflict.rs:28:33

--- a/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.riscv.stderr
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.riscv.stderr
@@ -1,11 +1,13 @@
 warning: unstable feature specified for `-Ctarget-feature`: `d`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `d` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.x86.stderr
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.x86.stderr
@@ -1,12 +1,12 @@
 warning: target feature `soft-float` cannot be enabled with `-Ctarget-feature`: use a soft-float target instead
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `soft-float` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/target-feature/abi-irrelevant-target-feature-flag-disable.stderr
+++ b/tests/ui/target-feature/abi-irrelevant-target-feature-flag-disable.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `x87`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/abi-required-target-feature-flag-disable.aarch64.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-flag-disable.aarch64.stderr
@@ -1,7 +1,7 @@
 warning: target feature `neon` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/abi-required-target-feature-flag-disable.loongarch.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-flag-disable.loongarch.stderr
@@ -1,7 +1,7 @@
 warning: target feature `d` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/abi-required-target-feature-flag-disable.riscv.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-flag-disable.riscv.stderr
@@ -1,11 +1,13 @@
 warning: unstable feature specified for `-Ctarget-feature`: `d`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `d` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/target-feature/abi-required-target-feature-flag-disable.x86-implied.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-flag-disable.x86-implied.stderr
@@ -1,7 +1,7 @@
 warning: target feature `sse2` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/abi-required-target-feature-flag-disable.x86.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-flag-disable.x86.stderr
@@ -1,11 +1,13 @@
 warning: unstable feature specified for `-Ctarget-feature`: `x87`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `x87` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/target-feature/abi-required-target-feature-missing-in-target-cpu.x86.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-missing-in-target-cpu.x86.stderr
@@ -1,7 +1,7 @@
 warning: target feature `sse2` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/feature-hierarchy.hexagon-hvxv66.stderr
+++ b/tests/ui/target-feature/feature-hierarchy.hexagon-hvxv66.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `hvxv66`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/feature-hierarchy.hexagon-v60.stderr
+++ b/tests/ui/target-feature/feature-hierarchy.hexagon-v60.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `v60`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/feature-hierarchy.hexagon-v68.stderr
+++ b/tests/ui/target-feature/feature-hierarchy.hexagon-v68.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `v68`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/forbidden-target-feature-flag-disable.stderr
+++ b/tests/ui/target-feature/forbidden-target-feature-flag-disable.stderr
@@ -1,7 +1,7 @@
 warning: target feature `forced-atomics` cannot be disabled with `-Ctarget-feature`: unsound because it changes the ABI of atomic operations
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/forbidden-target-feature-flag.stderr
+++ b/tests/ui/target-feature/forbidden-target-feature-flag.stderr
@@ -1,7 +1,7 @@
 warning: target feature `forced-atomics` cannot be enabled with `-Ctarget-feature`: unsound because it changes the ABI of atomic operations
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/packedstack-combinations.with_softfloat.stderr
+++ b/tests/ui/target-feature/packedstack-combinations.with_softfloat.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `backchain`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/retpoline-target-feature-flag.by_feature1.stderr
+++ b/tests/ui/target-feature/retpoline-target-feature-flag.by_feature1.stderr
@@ -1,7 +1,7 @@
 warning: target feature `retpoline-external-thunk` cannot be enabled with `-Ctarget-feature`: use `-Zretpoline-external-thunk` compiler flag instead
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/retpoline-target-feature-flag.by_feature2.stderr
+++ b/tests/ui/target-feature/retpoline-target-feature-flag.by_feature2.stderr
@@ -1,7 +1,7 @@
 warning: target feature `retpoline-indirect-branches` cannot be enabled with `-Ctarget-feature`: use `-Zretpoline` compiler flag instead
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/retpoline-target-feature-flag.by_feature3.stderr
+++ b/tests/ui/target-feature/retpoline-target-feature-flag.by_feature3.stderr
@@ -1,7 +1,7 @@
 warning: target feature `retpoline-indirect-calls` cannot be enabled with `-Ctarget-feature`: use `-Zretpoline` compiler flag instead
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/similar-feature-suggestion.stderr
+++ b/tests/ui/target-feature/similar-feature-suggestion.stderr
@@ -1,6 +1,8 @@
 warning: unknown and unstable feature specified for `-Ctarget-feature`: `rdrnd`
    |
    = note: it is still passed through to the codegen backend, but use of this feature might be unsound and the behavior of this feature can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
    = help: you might have meant: `rdrand`
 
 warning: 1 warning emitted

--- a/tests/ui/target-feature/unstable-feature.stderr
+++ b/tests/ui/target-feature/unstable-feature.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `x87`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 


### PR DESCRIPTION
In https://github.com/rust-lang/compiler-team/issues/994 we agreed that 

> We also change the warning emitted for unknown features in -Ctarget-feature to be explicitly a future-compat warning, and eventually we make unknown features in -Ctarget-feature a hard error.

This PR implements that.
I also created a new tracking issue specifically for this FCW as the old one has all sorts of discussion about us even figuring out the problem in the first place: https://github.com/rust-lang/rust/issues/162235.