### PR TITLE
keep fake borrows alive until exiting their scopes

### DIFF
--- a/compiler/rustc_middle/src/middle/region.rs
+++ b/compiler/rustc_middle/src/middle/region.rs
@@ -97,6 +97,7 @@ impl fmt::Debug for Scope {
             ScopeData::IfThen => write!(fmt, "IfThen({:?})", self.local_id),
             ScopeData::IfThenRescope => write!(fmt, "IfThen[edition2024]({:?})", self.local_id),
             ScopeData::MatchGuard => write!(fmt, "MatchGuard({:?})", self.local_id),
+            ScopeData::MatchFakeBorrows => write!(fmt, "MatchFakeBorrows({:?})", self.local_id),
             ScopeData::Remainder(fsi) => write!(
                 fmt,
                 "Remainder {{ block: {:?}, first_statement_index: {}}}",
@@ -136,6 +137,9 @@ pub enum ScopeData {
     /// Used for variables introduced in an if-let guard,
     /// whose lifetimes do not cross beyond this scope.
     MatchGuard,
+
+    /// Dummy scope used for matches' fake borrow temporaries.
+    MatchFakeBorrows,
 
     /// Scope following a `let id = expr;` binding in a block.
     Remainder(FirstStatementIndex),
@@ -323,6 +327,7 @@ impl ScopeTree {
                 | ScopeData::CallSite
                 | ScopeData::Arguments
                 | ScopeData::IfThen
+                | ScopeData::MatchFakeBorrows
                 | ScopeData::Remainder(_) => {
                     // If we haven't already passed through a backwards-incompatible node,
                     // then check if we are passing through one now and record it if so.

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -503,7 +503,7 @@ impl WithRetag {
 }
 
 /// The `FakeReadCause` describes the type of pattern why a FakeRead statement exists.
-#[derive(Copy, Clone, TyEncodable, TyDecodable, Debug, StableHash, PartialEq)]
+#[derive(Copy, Clone, TyEncodable, TyDecodable, Debug, StableHash, PartialEq, Eq, Hash)]
 pub enum FakeReadCause {
     /// A fake read injected into a match guard to ensure that the discriminants
     /// that are being matched on aren't modified while the match guard is being

--- a/compiler/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_place.rs
@@ -5,6 +5,7 @@ use std::{assert_matches, iter};
 use rustc_abi::{FIRST_VARIANT, FieldIdx, VariantIdx};
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::hir::place::{Projection as HirProjection, ProjectionKind as HirProjectionKind};
+use rustc_middle::middle::region;
 use rustc_middle::mir::AssertKind::BoundsCheck;
 use rustc_middle::mir::*;
 use rustc_middle::thir::*;
@@ -419,7 +420,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         mut block: BasicBlock,
         expr_id: ExprId,
         mutability: Mutability,
-        fake_borrow_temps: Option<&mut Vec<Local>>,
+        fake_borrow_scope: Option<region::Scope>,
     ) -> BlockAnd<PlaceBuilder<'tcx>> {
         let expr = &self.thir[expr_id];
         debug!("expr_as_place(block={:?}, expr={:?}, mutability={:?})", block, expr, mutability);
@@ -431,13 +432,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::Scope { region_scope, hir_id, value } => {
                 this.in_scope((region_scope, source_info), LintLevel::Explicit(hir_id), |this| {
                     this.push_coverage_point_for_expr(block, source_info, hir_id);
-                    this.expr_as_place(block, value, mutability, fake_borrow_temps)
+                    this.expr_as_place(block, value, mutability, fake_borrow_scope)
                 })
             }
             ExprKind::Field { lhs, variant_index, name } => {
                 let lhs_expr = &this.thir[lhs];
                 let mut place_builder =
-                    unpack!(block = this.expr_as_place(block, lhs, mutability, fake_borrow_temps,));
+                    unpack!(block = this.expr_as_place(block, lhs, mutability, fake_borrow_scope,));
                 if let ty::Adt(adt_def, _) = lhs_expr.ty.kind() {
                     if adt_def.is_enum() {
                         place_builder = place_builder.downcast(*adt_def, variant_index);
@@ -447,7 +448,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
             ExprKind::Deref { arg } => {
                 let place_builder =
-                    unpack!(block = this.expr_as_place(block, arg, mutability, fake_borrow_temps,));
+                    unpack!(block = this.expr_as_place(block, arg, mutability, fake_borrow_scope,));
                 block.and(place_builder.deref())
             }
             ExprKind::Index { lhs, index } => this.lower_index_expression(
@@ -455,7 +456,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 lhs,
                 index,
                 mutability,
-                fake_borrow_temps,
+                fake_borrow_scope,
                 expr_span,
                 source_info,
             ),
@@ -476,7 +477,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             ExprKind::PlaceTypeAscription { source, ref user_ty, user_ty_span } => {
                 let place_builder = unpack!(
-                    block = this.expr_as_place(block, source, mutability, fake_borrow_temps,)
+                    block = this.expr_as_place(block, source, mutability, fake_borrow_scope,)
                 );
                 if let Some(user_ty) = user_ty {
                     let ty_source_info = this.source_info(user_ty_span);
@@ -535,7 +536,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             ExprKind::PlaceUnwrapUnsafeBinder { source } => {
                 let place_builder = unpack!(
-                    block = this.expr_as_place(block, source, mutability, fake_borrow_temps,)
+                    block = this.expr_as_place(block, source, mutability, fake_borrow_scope,)
                 );
                 block.and(place_builder.project(PlaceElem::UnwrapUnsafeBinder(expr.ty)))
             }
@@ -625,16 +626,15 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         base: ExprId,
         index: ExprId,
         mutability: Mutability,
-        fake_borrow_temps: Option<&mut Vec<Local>>,
+        fake_borrow_scope: Option<region::Scope>,
         expr_span: Span,
         source_info: SourceInfo,
     ) -> BlockAnd<PlaceBuilder<'tcx>> {
-        let base_fake_borrow_temps = &mut Vec::new();
-        let is_outermost_index = fake_borrow_temps.is_none();
-        let fake_borrow_temps = fake_borrow_temps.unwrap_or(base_fake_borrow_temps);
+        let is_outermost_index = fake_borrow_scope.is_none();
+        let fake_borrow_scope = fake_borrow_scope.unwrap_or_else(|| self.local_scope());
 
         let base_place =
-            unpack!(block = self.expr_as_place(block, base, mutability, Some(fake_borrow_temps),));
+            unpack!(block = self.expr_as_place(block, base, mutability, Some(fake_borrow_scope),));
 
         // Making this a *fresh* temporary means we do not have to worry about
         // the index changing later: Nothing will ever change this temporary.
@@ -647,13 +647,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
         block = self.bounds_check(block, &base_place, idx, expr_span, source_info);
 
-        if is_outermost_index {
-            self.read_fake_borrows(block, fake_borrow_temps, source_info)
-        } else {
+        if !is_outermost_index {
             self.add_fake_borrows_of_base(
                 base_place.to_place(self),
                 block,
-                fake_borrow_temps,
+                fake_borrow_scope,
                 expr_span,
                 source_info,
             );
@@ -760,7 +758,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         &mut self,
         base_place: Place<'tcx>,
         block: BasicBlock,
-        fake_borrow_temps: &mut Vec<Local>,
+        fake_borrow_scope: region::Scope,
         expr_span: Span,
         source_info: SourceInfo,
     ) {
@@ -791,7 +789,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 Place { local: base_place.local, projection },
                             ),
                         );
-                        fake_borrow_temps.push(fake_borrow_temp);
+                        // Schedule a fake read to keep the fake borrow alive until exiting
+                        // `fake_borrow_scope`.
+                        self.schedule_drop_fake_read(
+                            expr_span,
+                            fake_borrow_scope,
+                            fake_borrow_temp,
+                            FakeReadCause::ForIndex,
+                        );
                     }
                     ProjectionElem::Index(_) => {
                         let index_ty = base_place.ty(&self.local_decls, tcx);
@@ -812,20 +817,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     | ProjectionElem::UnwrapUnsafeBinder(_) => (),
                 }
             }
-        }
-    }
-
-    fn read_fake_borrows(
-        &mut self,
-        bb: BasicBlock,
-        fake_borrow_temps: &mut Vec<Local>,
-        source_info: SourceInfo,
-    ) {
-        // All indexes have been evaluated now, read all of the
-        // fake borrows so that they are live across those index
-        // expressions.
-        for temp in fake_borrow_temps {
-            self.cfg.push_fake_read(bb, source_info, FakeReadCause::ForIndex, Place::from(*temp));
         }
     }
 }

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -14,7 +14,7 @@ use rustc_abi::{FIRST_VARIANT, FieldIdx, VariantIdx};
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::{BindingMode, ByRef, LetStmt, LocalSource, Node};
-use rustc_middle::middle::region::{self, TempLifetime};
+use rustc_middle::middle::region::{self, ScopeData, TempLifetime};
 use rustc_middle::mir::*;
 use rustc_middle::thir::{self, *};
 use rustc_middle::ty::{self, CanonicalUserTypeAnnotation, Ty, ValTree, ValTreeKind};
@@ -2432,21 +2432,35 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.cfg.push_assign(block, scrutinee_source_info, Place::from(temp), borrow);
             }
 
-            let mut guard_span = rustc_span::DUMMY_SP;
+            let guard_span = self.thir[guard].span;
+            let source_info = self.source_info(guard_span);
 
-            let (guard_true_block, guard_false_block) =
-                self.in_if_then_scope(match_scope, guard_span, |this| {
-                    guard_span = this.thir[guard].span;
-                    this.lower_if_condition(
-                        block,
-                        guard,
-                        LowerIfCondArgs {
-                            temp_scope_override: None, // Use `this.local_scope()`.
-                            variable_source_info: this.source_info(arm.span),
-                            // For guards, `let` bindings are declared separately.
-                            declare_let_bindings: DeclareLetBindings::No,
-                        },
-                    )
+            let fake_borrow_scope = region::Scope {
+                data: ScopeData::MatchFakeBorrows,
+                local_id: self.thir[guard].temp_scope_id,
+            };
+            let BlockAnd(guard_true_block, guard_false_block) =
+                self.in_scope((fake_borrow_scope, source_info), LintLevel::Inherited, |this| {
+                    // Schedule fake reads on guard exit to keep fake borrows alive on every path.
+                    let cause = FakeReadCause::ForMatchGuard;
+                    for &(_, temp, _) in fake_borrows {
+                        this.schedule_drop_fake_read(guard_span, fake_borrow_scope, temp, cause);
+                    }
+
+                    let (guard_true_block, guard_false_block) =
+                        this.in_if_then_scope(match_scope, guard_span, |this| {
+                            this.lower_if_condition(
+                                block,
+                                guard,
+                                LowerIfCondArgs {
+                                    temp_scope_override: None, // Use `this.local_scope()`.
+                                    variable_source_info: this.source_info(arm.span),
+                                    // For guards, `let` bindings are declared separately.
+                                    declare_let_bindings: DeclareLetBindings::No,
+                                },
+                            )
+                        });
+                    guard_true_block.and(guard_false_block)
                 });
 
             // If this isn't the final sub-branch being lowered, we need to unschedule drops of
@@ -2456,15 +2470,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.clear_match_arm_and_guard_scopes(arm.scope);
             }
 
-            let source_info = self.source_info(guard_span);
             let guard_end = self.source_info(tcx.sess.source_map().end_point(guard_span));
             let guard_frame = self.guard_context.pop().unwrap();
             debug!("Exiting guard building context with locals: {:?}", guard_frame);
-
-            for &(_, temp, _) in fake_borrows {
-                let cause = FakeReadCause::ForMatchGuard;
-                self.cfg.push_fake_read(guard_true_block, guard_end, cause, Place::from(temp));
-            }
 
             self.cfg.goto(guard_false_block, source_info, sub_branch.otherwise_block);
 

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -431,47 +431,41 @@ impl DropTree {
                     cfg.terminate(block, drop_node.data.source_info, terminator);
                 }
                 DropKind::ForLint => {
-                    let stmt = Statement::new(
-                        drop_node.data.source_info,
-                        StatementKind::BackwardIncompatibleDropHint {
-                            place: Box::new(drop_node.data.local.into()),
-                            reason: BackwardIncompatibleDropReason::Edition2024,
-                        },
-                    );
-                    cfg.push(block, stmt);
-                    let target = blocks[drop_node.next].unwrap();
-                    if target != block {
-                        // Diagnostics don't use this `Span` but debuginfo
-                        // might. Since we don't want breakpoints to be placed
-                        // here, especially when this is on an unwind path, we
-                        // use `DUMMY_SP`.
-                        let source_info =
-                            SourceInfo { span: DUMMY_SP, ..drop_node.data.source_info };
-                        let terminator = TerminatorKind::Goto { target };
-                        cfg.terminate(block, source_info, terminator);
-                    }
+                    let kind = StatementKind::BackwardIncompatibleDropHint {
+                        place: Box::new(drop_node.data.local.into()),
+                        reason: BackwardIncompatibleDropReason::Edition2024,
+                    };
+                    self.link_statement(cfg, blocks, block, drop_node, kind);
                 }
                 // Root nodes don't correspond to a drop.
                 DropKind::Storage if drop_idx == ROOT_NODE => {}
                 DropKind::Storage => {
-                    let stmt = Statement::new(
-                        drop_node.data.source_info,
-                        StatementKind::StorageDead(drop_node.data.local),
-                    );
-                    cfg.push(block, stmt);
-                    let target = blocks[drop_node.next].unwrap();
-                    if target != block {
-                        // Diagnostics don't use this `Span` but debuginfo
-                        // might. Since we don't want breakpoints to be placed
-                        // here, especially when this is on an unwind path, we
-                        // use `DUMMY_SP`.
-                        let source_info =
-                            SourceInfo { span: DUMMY_SP, ..drop_node.data.source_info };
-                        let terminator = TerminatorKind::Goto { target };
-                        cfg.terminate(block, source_info, terminator);
-                    }
+                    let kind = StatementKind::StorageDead(drop_node.data.local);
+                    self.link_statement(cfg, blocks, block, drop_node, kind);
                 }
             }
+        }
+    }
+
+    /// For drops that lower to a statement, adds a goto if the next drop is in a different block.
+    fn link_statement<'tcx>(
+        &self,
+        cfg: &mut CFG<'tcx>,
+        blocks: &IndexSlice<DropIdx, Option<BasicBlock>>,
+        block: BasicBlock,
+        drop_node: &DropNode,
+        kind: StatementKind<'tcx>,
+    ) {
+        cfg.push(block, Statement::new(drop_node.data.source_info, kind));
+        let target = blocks[drop_node.next].unwrap();
+        if target != block {
+            // Diagnostics don't use this `Span` but debuginfo
+            // might. Since we don't want breakpoints to be placed
+            // here, especially when this is on an unwind path, we
+            // use `DUMMY_SP`.
+            let source_info = SourceInfo { span: DUMMY_SP, ..drop_node.data.source_info };
+            let terminator = TerminatorKind::Goto { target };
+            cfg.terminate(block, source_info, terminator);
         }
     }
 }

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -166,6 +166,12 @@ enum DropKind {
     Value,
     Storage,
     ForLint,
+    /// We fake-read fake borrow temporaries when leaving their scopes, as if dropping them, to keep
+    /// fake borrows alive through their entire scopes (#161578, #161852).
+    #[expect(unused)]
+    FakeRead {
+        cause: FakeReadCause,
+    },
 }
 
 #[derive(Debug)]
@@ -265,9 +271,12 @@ impl Scope {
     ///  * freeing up stack space has no effect during unwinding
     /// Note that for coroutines we do emit StorageDeads, for the
     /// use of optimizations in the MIR coroutine transform.
+    ///
+    /// We add fake reads of fake borrow temporaries on cleanup paths to keep fake borrows alive on
+    /// paths that unconditionally panic. These are removed after borrowck.
     fn needs_cleanup(&self) -> bool {
         self.drops.iter().any(|drop| match drop.kind {
-            DropKind::Value | DropKind::ForLint => true,
+            DropKind::Value | DropKind::ForLint | DropKind::FakeRead { .. } => true,
             DropKind::Storage => false,
         })
     }
@@ -435,6 +444,11 @@ impl DropTree {
                         place: Box::new(drop_node.data.local.into()),
                         reason: BackwardIncompatibleDropReason::Edition2024,
                     };
+                    self.link_statement(cfg, blocks, block, drop_node, kind);
+                }
+                DropKind::FakeRead { cause } => {
+                    let kind =
+                        StatementKind::FakeRead(Box::new((cause, drop_node.data.local.into())));
                     self.link_statement(cfg, blocks, block, drop_node, kind);
                 }
                 // Root nodes don't correspond to a drop.
@@ -1122,7 +1136,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let source_info = drop_data.source_info;
                 let local = drop_data.local;
 
-                if !self.local_decls[local].ty.needs_drop(self.tcx, typing_env) {
+                if !self.local_decls[local].ty.needs_drop(self.tcx, typing_env)
+                    && !matches!(drop_data.kind, DropKind::FakeRead { .. })
+                {
                     continue;
                 }
 
@@ -1175,6 +1191,18 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 },
                             ),
                         );
+                    }
+                    DropKind::FakeRead { cause } => {
+                        debug_assert_eq!(
+                            unwind_drops.drop_nodes[unwind_to].data.local,
+                            drop_data.local
+                        );
+                        debug_assert_eq!(
+                            unwind_drops.drop_nodes[unwind_to].data.kind,
+                            drop_data.kind
+                        );
+                        unwind_to = unwind_drops.drop_nodes[unwind_to].next;
+                        self.cfg.push_fake_read(block, source_info, cause, local.into());
                     }
                     DropKind::Storage => {
                         // Only temps and vars need their storage dead.
@@ -1439,7 +1467,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // the unwind or coroutine drop paths. This means that for
         // non-coroutines we don't need to invalidate caches for `DropKind::Storage`.
         let invalidate_caches = match drop_kind {
-            DropKind::Value | DropKind::ForLint => true,
+            DropKind::Value | DropKind::ForLint | DropKind::FakeRead { .. } => true,
             DropKind::Storage => self.coroutine.is_some(),
         };
         for scope in self.scopes.scopes.iter_mut().rev() {
@@ -1510,6 +1538,18 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // Note that we are *not* gating BIDs here on whether they have significant destructor.
         // We need to know all of them so that we can capture potential borrow-checking errors.
         self.schedule_drop(span, region_scope, local, DropKind::ForLint);
+    }
+
+    /// Schedule a fake read. Used to keep fake borrows alive until their scopes end.
+    #[expect(unused)]
+    pub(crate) fn schedule_drop_fake_read(
+        &mut self,
+        span: Span,
+        region_scope: region::Scope,
+        local: Local,
+        cause: FakeReadCause,
+    ) {
+        self.schedule_drop(span, region_scope, local, DropKind::FakeRead { cause });
     }
 
     /// Indicates that the "local operand" stored in `local` is
@@ -1604,7 +1644,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let is_coroutine = self.coroutine.is_some();
         for scope in &mut self.scopes.scopes[uncached_scope..=target] {
             for drop in &scope.drops {
-                if is_coroutine || drop.kind == DropKind::Value {
+                if is_coroutine || matches!(drop.kind, DropKind::Value | DropKind::FakeRead { .. })
+                {
                     cached_drop = self.scopes.unwind_drops.add_drop(*drop, cached_drop);
                 }
             }
@@ -1950,6 +1991,21 @@ where
                 assert!(local.index() > arg_count);
                 cfg.push(block, Statement::new(source_info, StatementKind::StorageDead(local)));
             }
+            DropKind::FakeRead { cause } => {
+                // We always emit fake reads on unwind to keep fake borrows alive on paths that
+                // unconditionally panic.
+                debug_assert_eq!(unwind_drops.drop_nodes[unwind_to].data.local, drop_data.local);
+                debug_assert_eq!(unwind_drops.drop_nodes[unwind_to].data.kind, drop_data.kind);
+                unwind_to = unwind_drops.drop_nodes[unwind_to].next;
+
+                if let Some(idx) = dropline_to {
+                    debug_assert_eq!(coroutine_drops.drop_nodes[idx].data.local, drop_data.local);
+                    debug_assert_eq!(coroutine_drops.drop_nodes[idx].data.kind, drop_data.kind);
+                    dropline_to = Some(coroutine_drops.drop_nodes[idx].next);
+                }
+
+                cfg.push_fake_read(block, source_info, cause, local.into());
+            }
         }
     }
     block.unit()
@@ -1987,6 +2043,13 @@ impl<'a, 'tcx: 'a> Builder<'a, 'tcx> {
                             unwind_indices.push(unwind_indices[drop_node.next]);
                         }
                     }
+                    DropKind::FakeRead { .. } => {
+                        let unwind_drop = self
+                            .scopes
+                            .unwind_drops
+                            .add_drop(drop_node.data, unwind_indices[drop_node.next]);
+                        unwind_indices.push(unwind_drop);
+                    }
                     DropKind::Value => {
                         let unwind_drop = self
                             .scopes
@@ -2015,7 +2078,7 @@ impl<'a, 'tcx: 'a> Builder<'a, 'tcx> {
                     .coroutine_drops
                     .add_drop(drop_data.data, dropline_indices[drop_data.next]);
                 match drop_data.data.kind {
-                    DropKind::Storage | DropKind::ForLint => {}
+                    DropKind::Storage | DropKind::ForLint | DropKind::FakeRead { .. } => {}
                     DropKind::Value => {
                         if self.is_async_drop(drop_data.data.local) {
                             self.scopes.coroutine_drops.add_entry_point(

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -168,7 +168,6 @@ enum DropKind {
     ForLint,
     /// We fake-read fake borrow temporaries when leaving their scopes, as if dropping them, to keep
     /// fake borrows alive through their entire scopes (#161578, #161852).
-    #[expect(unused)]
     FakeRead {
         cause: FakeReadCause,
     },
@@ -1541,7 +1540,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     /// Schedule a fake read. Used to keep fake borrows alive until their scopes end.
-    #[expect(unused)]
     pub(crate) fn schedule_drop_fake_read(
         &mut self,
         span: Span,

--- a/tests/mir-opt/building/match/match_false_edges.full_tested_match.built.after.mir
+++ b/tests/mir-opt/building/match/match_false_edges.full_tested_match.built.after.mir
@@ -105,6 +105,7 @@ fn full_tested_match() -> () {
 
     bb13: {
         StorageDead(_7);
+        FakeRead(ForMatchGuard, _3);
         StorageDead(_6);
         goto -> bb9;
     }
@@ -123,6 +124,7 @@ fn full_tested_match() -> () {
     }
 
     bb16 (cleanup): {
+        FakeRead(ForMatchGuard, _3);
         resume;
     }
 }

--- a/tests/mir-opt/building/match/match_false_edges.full_tested_match2.built.after.mir
+++ b/tests/mir-opt/building/match/match_false_edges.full_tested_match2.built.after.mir
@@ -105,6 +105,7 @@ fn full_tested_match2() -> () {
 
     bb13: {
         StorageDead(_7);
+        FakeRead(ForMatchGuard, _3);
         StorageDead(_6);
         goto -> bb9;
     }
@@ -123,6 +124,7 @@ fn full_tested_match2() -> () {
     }
 
     bb16 (cleanup): {
+        FakeRead(ForMatchGuard, _3);
         resume;
     }
 }

--- a/tests/mir-opt/building/match/match_false_edges.main.built.after.mir
+++ b/tests/mir-opt/building/match/match_false_edges.main.built.after.mir
@@ -136,6 +136,7 @@ fn main() -> () {
 
     bb17: {
         StorageDead(_8);
+        FakeRead(ForMatchGuard, _3);
         StorageDead(_7);
         goto -> bb13;
     }
@@ -164,6 +165,7 @@ fn main() -> () {
     bb21: {
         StorageDead(_13);
         StorageDead(_12);
+        FakeRead(ForMatchGuard, _3);
         StorageDead(_11);
         goto -> bb10;
     }
@@ -182,6 +184,7 @@ fn main() -> () {
     }
 
     bb24 (cleanup): {
+        FakeRead(ForMatchGuard, _3);
         resume;
     }
 }

--- a/tests/mir-opt/building/match/sort_candidates.constant_eq.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/building/match/sort_candidates.constant_eq.SimplifyCfg-initial.after.mir
@@ -102,15 +102,18 @@ fn constant_eq(_1: &str, _2: bool) -> u32 {
 
     bb16: {
         StorageDead(_13);
-        FakeRead(ForMatchGuard, _6);
-        FakeRead(ForMatchGuard, _7);
         FakeRead(ForMatchGuard, _8);
+        FakeRead(ForMatchGuard, _7);
+        FakeRead(ForMatchGuard, _6);
         _0 = const 1_u32;
         goto -> bb18;
     }
 
     bb17: {
         StorageDead(_13);
+        FakeRead(ForMatchGuard, _8);
+        FakeRead(ForMatchGuard, _7);
+        FakeRead(ForMatchGuard, _6);
         falseEdge -> [real: bb3, imaginary: bb5];
     }
 

--- a/tests/mir-opt/building/match/sort_candidates.disjoint_ranges.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/building/match/sort_candidates.disjoint_ranges.SimplifyCfg-initial.after.mir
@@ -79,6 +79,7 @@ fn disjoint_ranges(_1: i32, _2: bool) -> u32 {
 
     bb13: {
         StorageDead(_8);
+        FakeRead(ForMatchGuard, _3);
         falseEdge -> [real: bb1, imaginary: bb3];
     }
 

--- a/tests/mir-opt/coroutine/async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#0}.built.after.mir
+++ b/tests/mir-opt/coroutine/async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#0}.built.after.mir
@@ -47,8 +47,8 @@ yields ()
 
     bb7: {
         StorageDead(_6);
-        FakeRead(ForMatchGuard, _3);
         FakeRead(ForMatchGuard, _4);
+        FakeRead(ForMatchGuard, _3);
         _0 = const ();
         goto -> bb10;
     }
@@ -59,6 +59,8 @@ yields ()
 
     bb9: {
         StorageDead(_6);
+        FakeRead(ForMatchGuard, _4);
+        FakeRead(ForMatchGuard, _3);
         goto -> bb6;
     }
 

--- a/tests/mir-opt/coroutine/async_closure_fake_read_for_by_move.foo-{closure#0}-{synthetic#0}.built.after.mir
+++ b/tests/mir-opt/coroutine/async_closure_fake_read_for_by_move.foo-{closure#0}-{synthetic#0}.built.after.mir
@@ -35,14 +35,16 @@ yields ()
 
     bb4: {
         StorageDead(_6);
-        FakeRead(ForMatchGuard, _3);
         FakeRead(ForMatchGuard, _4);
+        FakeRead(ForMatchGuard, _3);
         _0 = const ();
         goto -> bb6;
     }
 
     bb5: {
         StorageDead(_6);
+        FakeRead(ForMatchGuard, _4);
+        FakeRead(ForMatchGuard, _3);
         falseEdge -> [real: bb1, imaginary: bb1];
     }
 

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -134,8 +134,8 @@
 +     bb10: {
           StorageDead(_10);
           StorageDead(_9);
--         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForGuardBinding, _6);
 -         FakeRead(ForGuardBinding, _8);
           StorageLive(_5);
@@ -150,6 +150,8 @@
 +     bb11: {
           StorageDead(_10);
           StorageDead(_9);
+-         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
           StorageDead(_8);
           StorageDead(_6);
 -         falseEdge -> [real: bb3, imaginary: bb3];
@@ -176,8 +178,8 @@
 +     bb14: {
           StorageDead(_13);
           StorageDead(_12);
--         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForGuardBinding, _6);
 -         FakeRead(ForGuardBinding, _8);
           StorageLive(_5);
@@ -192,6 +194,8 @@
 +     bb15: {
           StorageDead(_13);
           StorageDead(_12);
+-         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
           StorageDead(_8);
           StorageDead(_6);
 -         falseEdge -> [real: bb1, imaginary: bb1];
@@ -230,6 +234,8 @@
       }
   
 -     bb23: {
+-         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
 +     bb20: {
           StorageDead(_8);
           StorageDead(_6);

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -134,8 +134,8 @@
 +     bb10: {
           StorageDead(_10);
           StorageDead(_9);
--         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForGuardBinding, _6);
 -         FakeRead(ForGuardBinding, _8);
           StorageLive(_5);
@@ -150,6 +150,8 @@
 +     bb11: {
           StorageDead(_10);
           StorageDead(_9);
+-         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
           StorageDead(_8);
           StorageDead(_6);
 -         falseEdge -> [real: bb3, imaginary: bb3];
@@ -176,8 +178,8 @@
 +     bb14: {
           StorageDead(_13);
           StorageDead(_12);
--         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
 -         FakeRead(ForGuardBinding, _6);
 -         FakeRead(ForGuardBinding, _8);
           StorageLive(_5);
@@ -192,6 +194,8 @@
 +     bb15: {
           StorageDead(_13);
           StorageDead(_12);
+-         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
           StorageDead(_8);
           StorageDead(_6);
 -         falseEdge -> [real: bb1, imaginary: bb1];
@@ -230,6 +234,8 @@
       }
   
 -     bb23: {
+-         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
 +     bb20: {
           StorageDead(_8);
           StorageDead(_6);

--- a/tests/mir-opt/remove_fake_borrows.match_guard.CleanupPostBorrowck.panic-abort.diff
+++ b/tests/mir-opt/remove_fake_borrows.match_guard.CleanupPostBorrowck.panic-abort.diff
@@ -48,10 +48,10 @@
   
       bb5: {
           StorageDead(_8);
--         FakeRead(ForMatchGuard, _3);
--         FakeRead(ForMatchGuard, _4);
--         FakeRead(ForMatchGuard, _5);
 -         FakeRead(ForMatchGuard, _6);
+-         FakeRead(ForMatchGuard, _5);
+-         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
 +         nop;
 +         nop;
 +         nop;
@@ -62,7 +62,15 @@
   
       bb6: {
           StorageDead(_8);
+-         FakeRead(ForMatchGuard, _6);
+-         FakeRead(ForMatchGuard, _5);
+-         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
 -         falseEdge -> [real: bb1, imaginary: bb1];
++         nop;
++         nop;
++         nop;
++         nop;
 +         goto -> bb1;
       }
   

--- a/tests/mir-opt/remove_fake_borrows.match_guard.CleanupPostBorrowck.panic-unwind.diff
+++ b/tests/mir-opt/remove_fake_borrows.match_guard.CleanupPostBorrowck.panic-unwind.diff
@@ -48,10 +48,10 @@
   
       bb5: {
           StorageDead(_8);
--         FakeRead(ForMatchGuard, _3);
--         FakeRead(ForMatchGuard, _4);
--         FakeRead(ForMatchGuard, _5);
 -         FakeRead(ForMatchGuard, _6);
+-         FakeRead(ForMatchGuard, _5);
+-         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
 +         nop;
 +         nop;
 +         nop;
@@ -62,7 +62,15 @@
   
       bb6: {
           StorageDead(_8);
+-         FakeRead(ForMatchGuard, _6);
+-         FakeRead(ForMatchGuard, _5);
+-         FakeRead(ForMatchGuard, _4);
+-         FakeRead(ForMatchGuard, _3);
 -         falseEdge -> [real: bb1, imaginary: bb1];
++         nop;
++         nop;
++         nop;
++         nop;
 +         goto -> bb1;
       }
   

--- a/tests/ui/indexing/fake-borrow-in-divergent-indexing-chain.rs
+++ b/tests/ui/indexing/fake-borrow-in-divergent-indexing-chain.rs
@@ -1,8 +1,6 @@
 //! Regression test for <https://github.com/rust-lang/rust/issues/161852>: we need to keep fake
 //! borrows on indexed-into slice pointers alive for bounds-checks even if the end of the indexing
 //! chain is unreachable. This prevents bounds-checks from performing out-of-bounds accesses.
-//@ check-pass
-// TODO: this should be check-fail
 
 #![feature(explicit_tail_calls)]
 
@@ -10,7 +8,7 @@ fn main() {
     let mut x: &[&[&[u32]]] = &[&[&[0]]];
     let y: &[&[&[u32]]] = &[];
     x[0][{ x = y; 0 }][{ return; 0 }];
-    // TODO: ERROR: cannot assign `x` in indexing expression
+    //~^ ERROR: cannot assign `x` in indexing expression
 }
 
 // In the following tests, no bounds-checks are reachable after mutating `x`. We keep the fake
@@ -20,14 +18,14 @@ fn always_return_after_mutation() {
     let mut x: &[&[&[u32]]] = &[&[&[0]]];
     let y: &[&[&[u32]]] = &[];
     x[0][{ x = y; return; 0 }];
-    // TODO: ERROR: cannot assign `x` in indexing expression
+    //~^ ERROR: cannot assign `x` in indexing expression
 }
 
 fn always_panic_after_mutation() {
     let mut x: &[&[&[u32]]] = &[&[&[0]]];
     let y: &[&[&[u32]]] = &[];
     x[0][{ x = y; panic!(); 0 }];
-    // TODO: ERROR: cannot assign `x` in indexing expression
+    //~^ ERROR: cannot assign `x` in indexing expression
 }
 
 fn always_break_after_mutation() {
@@ -35,7 +33,7 @@ fn always_break_after_mutation() {
     let y: &[&[&[u32]]] = &[];
     'b: {
         x[0][{ x = y; break 'b; 0 }];
-        // TODO: ERROR: cannot assign `x` in indexing expression
+        //~^ ERROR: cannot assign `x` in indexing expression
     }
 }
 
@@ -44,7 +42,7 @@ fn always_continue_after_mutation() {
     let y: &[&[&[u32]]] = &[];
     loop {
         x[0][{ x = y; continue; 0 }];
-        // TODO: ERROR: cannot assign `x` in indexing expression
+        //~^ ERROR: cannot assign `x` in indexing expression
     }
 }
 
@@ -52,5 +50,5 @@ fn always_become_after_mutation() {
     let mut x: &[&[&[u32]]] = &[&[&[0]]];
     let y: &[&[&[u32]]] = &[];
     x[0][{ x = y; become always_become_after_mutation(); 0 }];
-    // TODO: ERROR: cannot assign `x` in indexing expression
+    //~^ ERROR: cannot assign `x` in indexing expression
 }

--- a/tests/ui/indexing/fake-borrow-in-divergent-indexing-chain.rs
+++ b/tests/ui/indexing/fake-borrow-in-divergent-indexing-chain.rs
@@ -1,0 +1,56 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/161852>: we need to keep fake
+//! borrows on indexed-into slice pointers alive for bounds-checks even if the end of the indexing
+//! chain is unreachable. This prevents bounds-checks from performing out-of-bounds accesses.
+//@ check-pass
+// TODO: this should be check-fail
+
+#![feature(explicit_tail_calls)]
+
+fn main() {
+    let mut x: &[&[&[u32]]] = &[&[&[0]]];
+    let y: &[&[&[u32]]] = &[];
+    x[0][{ x = y; 0 }][{ return; 0 }];
+    // TODO: ERROR: cannot assign `x` in indexing expression
+}
+
+// In the following tests, no bounds-checks are reachable after mutating `x`. We keep the fake
+// borrow on it alive for consistency, though it isn't necessary for soundness.
+
+fn always_return_after_mutation() {
+    let mut x: &[&[&[u32]]] = &[&[&[0]]];
+    let y: &[&[&[u32]]] = &[];
+    x[0][{ x = y; return; 0 }];
+    // TODO: ERROR: cannot assign `x` in indexing expression
+}
+
+fn always_panic_after_mutation() {
+    let mut x: &[&[&[u32]]] = &[&[&[0]]];
+    let y: &[&[&[u32]]] = &[];
+    x[0][{ x = y; panic!(); 0 }];
+    // TODO: ERROR: cannot assign `x` in indexing expression
+}
+
+fn always_break_after_mutation() {
+    let mut x: &[&[&[u32]]] = &[&[&[0]]];
+    let y: &[&[&[u32]]] = &[];
+    'b: {
+        x[0][{ x = y; break 'b; 0 }];
+        // TODO: ERROR: cannot assign `x` in indexing expression
+    }
+}
+
+fn always_continue_after_mutation() {
+    let mut x: &[&[&[u32]]] = &[&[&[0]]];
+    let y: &[&[&[u32]]] = &[];
+    loop {
+        x[0][{ x = y; continue; 0 }];
+        // TODO: ERROR: cannot assign `x` in indexing expression
+    }
+}
+
+fn always_become_after_mutation() {
+    let mut x: &[&[&[u32]]] = &[&[&[0]]];
+    let y: &[&[&[u32]]] = &[];
+    x[0][{ x = y; become always_become_after_mutation(); 0 }];
+    // TODO: ERROR: cannot assign `x` in indexing expression
+}

--- a/tests/ui/indexing/fake-borrow-in-divergent-indexing-chain.stderr
+++ b/tests/ui/indexing/fake-borrow-in-divergent-indexing-chain.stderr
@@ -1,0 +1,51 @@
+error[E0510]: cannot assign `x` in indexing expression
+  --> $DIR/fake-borrow-in-divergent-indexing-chain.rs:10:12
+   |
+LL |     x[0][{ x = y; 0 }][{ return; 0 }];
+   |     ----   ^^^^^ cannot assign
+   |     |
+   |     value is immutable in indexing expression
+
+error[E0510]: cannot assign `x` in indexing expression
+  --> $DIR/fake-borrow-in-divergent-indexing-chain.rs:20:12
+   |
+LL |     x[0][{ x = y; return; 0 }];
+   |     ----   ^^^^^ cannot assign
+   |     |
+   |     value is immutable in indexing expression
+
+error[E0510]: cannot assign `x` in indexing expression
+  --> $DIR/fake-borrow-in-divergent-indexing-chain.rs:27:12
+   |
+LL |     x[0][{ x = y; panic!(); 0 }];
+   |     ----   ^^^^^ cannot assign
+   |     |
+   |     value is immutable in indexing expression
+
+error[E0510]: cannot assign `x` in indexing expression
+  --> $DIR/fake-borrow-in-divergent-indexing-chain.rs:35:16
+   |
+LL |         x[0][{ x = y; break 'b; 0 }];
+   |         ----   ^^^^^ cannot assign
+   |         |
+   |         value is immutable in indexing expression
+
+error[E0510]: cannot assign `x` in indexing expression
+  --> $DIR/fake-borrow-in-divergent-indexing-chain.rs:44:16
+   |
+LL |         x[0][{ x = y; continue; 0 }];
+   |         ----   ^^^^^ cannot assign
+   |         |
+   |         value is immutable in indexing expression
+
+error[E0510]: cannot assign `x` in indexing expression
+  --> $DIR/fake-borrow-in-divergent-indexing-chain.rs:52:12
+   |
+LL |     x[0][{ x = y; become always_become_after_mutation(); 0 }];
+   |     ----   ^^^^^ cannot assign
+   |     |
+   |     value is immutable in indexing expression
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0510`.

--- a/tests/ui/match/fake-borrow-in-divergent-guard.rs
+++ b/tests/ui/match/fake-borrow-in-divergent-guard.rs
@@ -1,0 +1,74 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/161578>: the fake borrow on `x`
+//! below was ignored previously because the fake read keeping it live was unreachable.
+//@ check-pass
+// TODO: this should be check-fail
+
+#![feature(explicit_tail_calls)]
+
+// In this first test, it's possible for the guard to fail. We need the fake borrow for soundness.
+
+fn main() {
+    let mut x: Option<Box<u64>> = Some(Box::new(7));
+    match x {
+        Some(_) if { x = None; false } && return => {}
+        // TODO: ERROR: cannot assign `x` in match guard
+        Some(b) => println!("{b}"),
+        None => println!("none"),
+    }
+}
+
+// In the following tests, the guard can't fail, but we keep the fake borrow alive for consistency.
+
+fn always_return_after_mutation() {
+    let mut x: Option<Box<u64>> = Some(Box::new(7));
+    match x {
+        Some(_) if { x = None; return } => {}
+        // TODO: ERROR: cannot assign `x` in match guard
+        Some(b) => println!("{b}"),
+        None => println!("none"),
+    }
+}
+
+fn always_panic_after_mutation() {
+    let mut x: Option<Box<u64>> = Some(Box::new(7));
+    match x {
+        Some(_) if { x = None; panic!() } => {}
+        // TODO: ERROR: cannot assign `x` in match guard
+        Some(b) => println!("{b}"),
+        None => println!("none"),
+    }
+}
+
+fn always_break_after_mutation() {
+    let mut x: Option<Box<u64>> = Some(Box::new(7));
+    'b: {
+        match x {
+            Some(_) if { x = None; break 'b } => {}
+            // TODO: ERROR: cannot assign `x` in match guard
+            Some(b) => println!("{b}"),
+            None => println!("none"),
+        }
+    }
+}
+
+fn always_continue_after_mutation() {
+    let mut x: Option<Box<u64>> = Some(Box::new(7));
+    loop {
+        match x {
+            Some(_) if { x = None; continue } => {}
+            // TODO: ERROR: cannot assign `x` in match guard
+            Some(ref b) => println!("{b}"),
+            None => println!("none"),
+        }
+    }
+}
+
+fn always_become_after_mutation() {
+    let mut x: Option<Box<u64>> = Some(Box::new(7));
+    match x {
+        Some(_) if { x = None; become always_become_after_mutation() } => {}
+        // TODO: ERROR: cannot assign `x` in match guard
+        Some(b) => println!("{b}"),
+        None => println!("none"),
+    }
+}

--- a/tests/ui/match/fake-borrow-in-divergent-guard.rs
+++ b/tests/ui/match/fake-borrow-in-divergent-guard.rs
@@ -1,7 +1,5 @@
 //! Regression test for <https://github.com/rust-lang/rust/issues/161578>: the fake borrow on `x`
 //! below was ignored previously because the fake read keeping it live was unreachable.
-//@ check-pass
-// TODO: this should be check-fail
 
 #![feature(explicit_tail_calls)]
 
@@ -11,7 +9,7 @@ fn main() {
     let mut x: Option<Box<u64>> = Some(Box::new(7));
     match x {
         Some(_) if { x = None; false } && return => {}
-        // TODO: ERROR: cannot assign `x` in match guard
+        //~^ ERROR: cannot assign `x` in match guard
         Some(b) => println!("{b}"),
         None => println!("none"),
     }
@@ -23,7 +21,7 @@ fn always_return_after_mutation() {
     let mut x: Option<Box<u64>> = Some(Box::new(7));
     match x {
         Some(_) if { x = None; return } => {}
-        // TODO: ERROR: cannot assign `x` in match guard
+        //~^ ERROR: cannot assign `x` in match guard
         Some(b) => println!("{b}"),
         None => println!("none"),
     }
@@ -33,7 +31,7 @@ fn always_panic_after_mutation() {
     let mut x: Option<Box<u64>> = Some(Box::new(7));
     match x {
         Some(_) if { x = None; panic!() } => {}
-        // TODO: ERROR: cannot assign `x` in match guard
+        //~^ ERROR: cannot assign `x` in match guard
         Some(b) => println!("{b}"),
         None => println!("none"),
     }
@@ -44,7 +42,7 @@ fn always_break_after_mutation() {
     'b: {
         match x {
             Some(_) if { x = None; break 'b } => {}
-            // TODO: ERROR: cannot assign `x` in match guard
+            //~^ ERROR: cannot assign `x` in match guard
             Some(b) => println!("{b}"),
             None => println!("none"),
         }
@@ -56,7 +54,7 @@ fn always_continue_after_mutation() {
     loop {
         match x {
             Some(_) if { x = None; continue } => {}
-            // TODO: ERROR: cannot assign `x` in match guard
+            //~^ ERROR: cannot assign `x` in match guard
             Some(ref b) => println!("{b}"),
             None => println!("none"),
         }
@@ -67,7 +65,7 @@ fn always_become_after_mutation() {
     let mut x: Option<Box<u64>> = Some(Box::new(7));
     match x {
         Some(_) if { x = None; become always_become_after_mutation() } => {}
-        // TODO: ERROR: cannot assign `x` in match guard
+        //~^ ERROR: cannot assign `x` in match guard
         Some(b) => println!("{b}"),
         None => println!("none"),
     }

--- a/tests/ui/match/fake-borrow-in-divergent-guard.stderr
+++ b/tests/ui/match/fake-borrow-in-divergent-guard.stderr
@@ -1,0 +1,51 @@
+error[E0510]: cannot assign `x` in match guard
+  --> $DIR/fake-borrow-in-divergent-guard.rs:11:22
+   |
+LL |     match x {
+   |           - value is immutable in match guard
+LL |         Some(_) if { x = None; false } && return => {}
+   |                      ^ cannot assign
+
+error[E0510]: cannot assign `x` in match guard
+  --> $DIR/fake-borrow-in-divergent-guard.rs:23:22
+   |
+LL |     match x {
+   |           - value is immutable in match guard
+LL |         Some(_) if { x = None; return } => {}
+   |                      ^ cannot assign
+
+error[E0510]: cannot assign `x` in match guard
+  --> $DIR/fake-borrow-in-divergent-guard.rs:33:22
+   |
+LL |     match x {
+   |           - value is immutable in match guard
+LL |         Some(_) if { x = None; panic!() } => {}
+   |                      ^ cannot assign
+
+error[E0510]: cannot assign `x` in match guard
+  --> $DIR/fake-borrow-in-divergent-guard.rs:44:26
+   |
+LL |         match x {
+   |               - value is immutable in match guard
+LL |             Some(_) if { x = None; break 'b } => {}
+   |                          ^ cannot assign
+
+error[E0510]: cannot assign `x` in match guard
+  --> $DIR/fake-borrow-in-divergent-guard.rs:56:26
+   |
+LL |         match x {
+   |               - value is immutable in match guard
+LL |             Some(_) if { x = None; continue } => {}
+   |                          ^ cannot assign
+
+error[E0510]: cannot assign `x` in match guard
+  --> $DIR/fake-borrow-in-divergent-guard.rs:67:22
+   |
+LL |     match x {
+   |           - value is immutable in match guard
+LL |         Some(_) if { x = None; become always_become_after_mutation() } => {}
+   |                      ^ cannot assign
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0510`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162242)*
<!-- homu-ignore:end -->

This is an alternative to https://github.com/rust-lang/rust/pull/161581 and https://github.com/rust-lang/rust/pull/161857 that implements a more restrictive semantics: fake borrowed places may not be mutated until execution leaves the fake borrow's scope (i.e. a match guard or the outermost indexing expression in a place expression).

Fixes https://github.com/rust-lang/rust/issues/161578
Fixes https://github.com/rust-lang/rust/issues/161852

In contrast to the above PRs, the following are also no longer allowed:

```rust
fn always_return_after_mutation_in_guard() {
    let mut x: Option<Box<u64>> = Some(Box::new(7));
    match x {
        Some(_) if { x = None; return } => {}
        //~^ ERROR: cannot assign `x` in match guard
        Some(b) => println!("{b}"),
        None => println!("none"),
    }
}

fn always_return_after_mutation_in_indexing() {
    let mut x: &[&[&[u32]]] = &[&[&[0]]];
    let y: &[&[&[u32]]] = &[];
    x[0][{ x = y; return; 0 }];
    //~^ ERROR: cannot assign `x` in indexing expression
}
```

Not being sensitive to CFG shape should make this easier to describe at a high-level than https://github.com/rust-lang/rust/pull/161581 and https://github.com/rust-lang/rust/pull/161857 would be. The tradeoff here is implementation complexity: since borrow-checking *is* sensitive to CFG shape, this puts fake reads at every point where execution leaves fake borrows' scopes, as though the fake reads are drops. The resultant MIR might not be quite as nice in some cases as something purpose-built, but I think it's worth being able to reuse the machinery we have for drops.