### PR TITLE
Fix incorrect meta span

### DIFF
--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -442,7 +442,7 @@ impl<'a> Parser<'a> {
                     })
                     .unwrap()
                     .node;
-                Ok(attr_item.meta(attr_item.path.span).unwrap())
+                Ok(attr_item.meta(attr_item.span).unwrap())
             } else {
                 self.unexpected_any()
             };

--- a/tests/ui/macros/correct-meta-item-span.rs
+++ b/tests/ui/macros/correct-meta-item-span.rs
@@ -1,0 +1,8 @@
+// The span of the suggestion should be correct and not ICE on this code (#161472)
+macro_rules! m { ($m:meta) => { #[derive($m)] pub struct S; }; }
+
+m!(a(::b::c));
+//~^ ERROR traits in `#[derive(...)]` don't accept arguments
+//~| ERROR cannot find derive macro `a` in this scope
+//~| ERROR cannot find derive macro `a` in this scope
+fn main(){}

--- a/tests/ui/macros/correct-meta-item-span.stderr
+++ b/tests/ui/macros/correct-meta-item-span.stderr
@@ -1,0 +1,22 @@
+error: traits in `#[derive(...)]` don't accept arguments
+  --> $DIR/correct-meta-item-span.rs:4:5
+   |
+LL | m!(a(::b::c));
+   |     ^^^^^^^^ help: remove the arguments
+
+error: cannot find derive macro `a` in this scope
+  --> $DIR/correct-meta-item-span.rs:4:4
+   |
+LL | m!(a(::b::c));
+   |    ^
+
+error: cannot find derive macro `a` in this scope
+  --> $DIR/correct-meta-item-span.rs:4:4
+   |
+LL | m!(a(::b::c));
+   |    ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust#161472
We should use `attr_item.span` which covers the entire `MetaItem`. 