### PR TITLE
Fix hashing of span end columns in incremental compilation

### DIFF
--- a/compiler/rustc_middle/src/ich.rs
+++ b/compiler/rustc_middle/src/ich.rs
@@ -8,7 +8,7 @@ use rustc_data_structures::stable_hash::{
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_session::Session;
 use rustc_span::source_map::SourceMap;
-use rustc_span::{CachingSourceMapView, DUMMY_SP, Pos, Span};
+use rustc_span::{BytePos, CachingSourceMapView, DUMMY_SP, Pos, Span};
 
 // Very often, we are hashing something that does not need the `CachingSourceMapView`, so we
 // initialize it lazily.
@@ -91,6 +91,20 @@ impl<'a> StableHashCtxt for StableHashState<'a> {
         const TAG_INVALID_SPAN: u8 = 1;
         const TAG_RELATIVE_SPAN: u8 = 2;
 
+        #[inline]
+        fn pack_span_location(
+            line_lo: usize,
+            col_lo: BytePos,
+            line_hi: usize,
+            col_hi: BytePos,
+        ) -> u64 {
+            let col_lo_trunc = (col_lo.0 as u64) & 0xFF;
+            let line_lo_trunc = ((line_lo as u64) & 0xFF_FF_FF) << 8;
+            let col_hi_trunc = ((col_hi.0 as u64) & 0xFF) << 32;
+            let line_hi_trunc = ((line_hi as u64) & 0xFF_FF_FF) << 40;
+            col_lo_trunc | line_lo_trunc | col_hi_trunc | line_hi_trunc
+        }
+
         if !self.stable_hash_controls().hash_spans {
             return;
         }
@@ -149,11 +163,7 @@ impl<'a> StableHashCtxt for StableHashState<'a> {
         // issue #74890). A similar analysis applies if some query depends specifically on the
         // length of the span, but we only hash the end location. So hash both.
 
-        let col_lo_trunc = (col_lo.0 as u64) & 0xFF;
-        let line_lo_trunc = ((line_lo as u64) & 0xFF_FF_FF) << 8;
-        let col_hi_trunc = (col_hi.0 as u64) & 0xFF << 32;
-        let line_hi_trunc = ((line_hi as u64) & 0xFF_FF_FF) << 40;
-        let col_line = col_lo_trunc | line_lo_trunc | col_hi_trunc | line_hi_trunc;
+        let col_line = pack_span_location(line_lo, col_lo, line_hi, col_hi);
         let len = (span.hi - span.lo).0;
         Hash::hash(&col_line, hasher);
         Hash::hash(&len, hasher);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->



`stable_hash_span` packs the span start/end line and column together with its length, but the `col_hi` mask was shifted before being applied, so the end column was effectively omitted from the hash. 

Parenthesize the mask operation so `col_hi` is masked with `0xFF` before being shifted into bits 32..39.


