### PR TITLE
let people change rustc-dev-guide in-tree

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1493,12 +1493,7 @@ https://github.com/rust-lang/reference/blob/HEAD/src/identifiers.md.
 cc = ["@rust-lang/lang-docs"]
 
 [mentions."src/doc/rustc-dev-guide"]
-message = """
-`rustc-dev-guide` is developed in its own repository. If possible, consider \
-making this change to \
-[rust-lang/rustc-dev-guide](https://github.com/rust-lang/rustc-dev-guide) \
-instead.
-"""
+message = "The rustc-dev-guide subtree was changed. If your future PRs *only* touch the subtree, consider submitting them directly to [rust-lang/rustc-dev-guide](https://github.com/rust-lang/rustc-dev-guide/pulls), which is where the document is primarily maintained (and has faster CI)."
 cc = ["@BoxyUwU", "@tshepang"]
 
 [mentions."compiler/rustc_passes/src/check_attr.rs"]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162255)*
<!-- homu-ignore:end -->

am happy for people to edit the document in this repo... let's not scare them away, or waste their time

[example message](https://github.com/rust-lang/rust/pull/160100#issuecomment-5116721172) that resulted in [reverting a positive change](https://github.com/rust-lang/rust/compare/ff6dcf461b4f15551d54cdc0e92a576e48357cc3..76bb5f07890ba6b455b7b75b73975f749b8e3fc3)

r? @BoxyUwU