### PR TITLE
Avoid manually instantiating some binders in error reporting with `-Znext-solver`

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -890,9 +890,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
 
         if let Ok(Some(ImplSource::UserDefined(impl_data))) =
-            self.enter_forall(trait_ref, |trait_ref_for_select| {
-                SelectionContext::new(self).select(&obligation.with(self.tcx, trait_ref_for_select))
-            })
+            SelectionContext::new(self).poly_select(&obligation.with(self.tcx, trait_ref))
         {
             let impl_did = impl_data.impl_def_id;
             let trait_did = trait_ref.def_id();

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -6022,19 +6022,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         {
             self.probe(|_| {
                 let ocx = ObligationCtxt::new(self);
-                self.enter_forall(pred, |pred| {
-                    let pred = ocx.normalize(
-                        &ObligationCause::dummy(),
-                        param_env,
-                        Unnormalized::new_wip(pred),
-                    );
-                    ocx.register_obligation(Obligation::new(
-                        self.tcx,
-                        ObligationCause::dummy(),
-                        param_env,
-                        pred,
-                    ));
-                });
+                ocx.register_obligation(Obligation::new(
+                    self.tcx,
+                    ObligationCause::dummy(),
+                    param_env,
+                    pred,
+                ));
                 if !ocx.try_evaluate_obligations().no_errors() {
                     // encountered errors.
                     return;

--- a/compiler/rustc_trait_selection/src/solve/select.rs
+++ b/compiler/rustc_trait_selection/src/solve/select.rs
@@ -5,7 +5,7 @@ use rustc_infer::traits::solve::inspect::ProbeKind;
 use rustc_infer::traits::solve::{CandidateSource, Certainty, Goal};
 use rustc_infer::traits::{
     BuiltinImplSource, ImplSource, ImplSourceUserDefinedData, Obligation, ObligationCause,
-    Selection, SelectionError, SelectionResult, TraitObligation,
+    PolyTraitObligation, Selection, SelectionError, SelectionResult,
 };
 use rustc_macros::extension;
 use rustc_middle::{bug, span_bug};
@@ -16,10 +16,10 @@ use crate::solve::inspect::{self, InferCtxtProofTreeExt};
 
 #[extension(pub trait InferCtxtSelectExt<'tcx>)]
 impl<'tcx> InferCtxt<'tcx> {
-    /// Do not use this directly. This is called from [`crate::traits::SelectionContext::select`].
+    /// Do not use this directly. This is called from [`crate::traits::SelectionContext::poly_select`].
     fn select_in_new_trait_solver(
         &self,
-        obligation: &TraitObligation<'tcx>,
+        obligation: &PolyTraitObligation<'tcx>,
     ) -> SelectionResult<'tcx, Selection<'tcx>> {
         assert!(self.next_trait_solver());
 

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -255,7 +255,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         &mut self,
         obligation: &PolyTraitObligation<'tcx>,
     ) -> SelectionResult<'tcx, Selection<'tcx>> {
-        assert!(!self.infcx.next_trait_solver());
+        if self.infcx.next_trait_solver() {
+            return self.infcx.select_in_new_trait_solver(obligation);
+        }
 
         let candidate = match self.select_from_obligation(obligation) {
             Err(SelectionError::Overflow(OverflowError::Canonical)) => {
@@ -292,10 +294,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         &mut self,
         obligation: &TraitObligation<'tcx>,
     ) -> SelectionResult<'tcx, Selection<'tcx>> {
-        if self.infcx.next_trait_solver() {
-            return self.infcx.select_in_new_trait_solver(obligation);
-        }
-
         self.poly_select(&Obligation {
             cause: obligation.cause.clone(),
             param_env: obligation.param_env,

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-3.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-3.stderr
@@ -8,14 +8,6 @@ LL |         call(f, ());
    |
    = note: expected a closure with signature `for<'a> fn(<_ as ATC<'a>>::Type)`
               found a closure with signature `fn(())`
-note: this is a known limitation of the trait solver that will be lifted in the future
-  --> $DIR/issue-62529-3.rs:25:14
-   |
-LL |         call(f, ());
-   |         -----^-----
-   |         |    |
-   |         |    the trait solver is unable to infer the generic types that should be inferred from this argument
-   |         add turbofish arguments to this call to specify the types manually, even if it's redundant
 note: required by a bound in `call`
   --> $DIR/issue-62529-3.rs:9:36
    |

--- a/tests/ui/mismatched_types/closure-mismatch.next.stderr
+++ b/tests/ui/mismatched_types/closure-mismatch.next.stderr
@@ -9,14 +9,6 @@ LL |     baz(|_| ());
    = help: the trait `for<'a> FnOnce(&'a ())` is not implemented for closure `{closure@$DIR/closure-mismatch.rs:12:9: 12:12}`
    = note: expected a closure with signature `for<'a> fn(&'a ())`
               found a closure with signature `fn(&())`
-note: this is a known limitation of the trait solver that will be lifted in the future
-  --> $DIR/closure-mismatch.rs:12:9
-   |
-LL |     baz(|_| ());
-   |     ----^^^----
-   |     |   |
-   |     |   the trait solver is unable to infer the generic types that should be inferred from this argument
-   |     add turbofish arguments to this call to specify the types manually, even if it's redundant
 note: required for `{closure@$DIR/closure-mismatch.rs:12:9: 12:12}` to implement `Foo`
   --> $DIR/closure-mismatch.rs:7:18
    |
@@ -41,14 +33,6 @@ LL |     baz(|x| ());
    = help: the trait `for<'a> FnOnce(&'a ())` is not implemented for closure `{closure@$DIR/closure-mismatch.rs:16:9: 16:12}`
    = note: expected a closure with signature `for<'a> fn(&'a ())`
               found a closure with signature `fn(&())`
-note: this is a known limitation of the trait solver that will be lifted in the future
-  --> $DIR/closure-mismatch.rs:16:9
-   |
-LL |     baz(|x| ());
-   |     ----^^^----
-   |     |   |
-   |     |   the trait solver is unable to infer the generic types that should be inferred from this argument
-   |     add turbofish arguments to this call to specify the types manually, even if it's redundant
 note: required for `{closure@$DIR/closure-mismatch.rs:16:9: 16:12}` to implement `Foo`
   --> $DIR/closure-mismatch.rs:7:18
    |

--- a/tests/ui/traits/non_lifetime_binders/universe-error-host-effect.rs
+++ b/tests/ui/traits/non_lifetime_binders/universe-error-host-effect.rs
@@ -1,0 +1,28 @@
+//@ compile-flags: -Znext-solver
+
+#![feature(const_trait_impl, non_lifetime_binders, sized_hierarchy)]
+#![allow(incomplete_features)]
+
+use std::marker::PointeeSized;
+
+const trait Other<U: PointeeSized, V: PointeeSized>: PointeeSized {}
+
+trait Guard {}
+
+const impl<X: PointeeSized> Other<X, i32> for X {}
+
+impl<X: PointeeSized> Other<u8, u32> for X where u8: Guard {}
+//~^ ERROR the trait bound `u8: Guard` is not satisfied
+
+fn foo<U: PointeeSized, V: PointeeSized>()
+where
+    for<T> T: const Other<U, V>,
+{
+}
+
+fn bar() {
+    foo::<_, _>();
+    //~^ ERROR the trait bound `u8: Guard` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/traits/non_lifetime_binders/universe-error-host-effect.stderr
+++ b/tests/ui/traits/non_lifetime_binders/universe-error-host-effect.stderr
@@ -1,0 +1,44 @@
+error[E0277]: the trait bound `u8: Guard` is not satisfied
+  --> $DIR/universe-error-host-effect.rs:14:50
+   |
+LL | impl<X: PointeeSized> Other<u8, u32> for X where u8: Guard {}
+   |                                                  ^^^^^^^^^ the trait `Guard` is not implemented for `u8`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/universe-error-host-effect.rs:10:1
+   |
+LL | trait Guard {}
+   | ^^^^^^^^^^^
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+   |
+LL + #![feature(trivial_bounds)]
+   |
+
+error[E0277]: the trait bound `u8: Guard` is not satisfied
+  --> $DIR/universe-error-host-effect.rs:24:11
+   |
+LL |     foo::<_, _>();
+   |           ^ the trait `Guard` is not implemented for `u8`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/universe-error-host-effect.rs:10:1
+   |
+LL | trait Guard {}
+   | ^^^^^^^^^^^
+note: required for `T` to implement `Other<u8, u32>`
+  --> $DIR/universe-error-host-effect.rs:14:23
+   |
+LL | impl<X: PointeeSized> Other<u8, u32> for X where u8: Guard {}
+   |                       ^^^^^^^^^^^^^^     ^           ----- unsatisfied trait bound introduced here
+note: required by a bound in `foo`
+  --> $DIR/universe-error-host-effect.rs:19:15
+   |
+LL | fn foo<U: PointeeSized, V: PointeeSized>()
+   |    --- required by a bound in this function
+LL | where
+LL |     for<T> T: const Other<U, V>,
+   |               ^^^^^^^^^^^^^^^^^ required by this bound in `foo`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/non_lifetime_binders/universe-error1.current.stderr
+++ b/tests/ui/traits/non_lifetime_binders/universe-error1.current.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `T: Other<_>` is not satisfied
-  --> $DIR/universe-error1.rs:16:11
+  --> $DIR/universe-error1.rs:20:11
    |
 LL |     foo::<_>();
    |           ^ the trait `Other<_>` is not implemented for `T`
    |
 note: required by a bound in `foo`
-  --> $DIR/universe-error1.rs:13:15
+  --> $DIR/universe-error1.rs:17:15
    |
 LL | fn foo<U: PointeeSized>()
    |    --- required by a bound in this function

--- a/tests/ui/traits/non_lifetime_binders/universe-error1.next.stderr
+++ b/tests/ui/traits/non_lifetime_binders/universe-error1.next.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `T: Other<_>` is not satisfied
+  --> $DIR/universe-error1.rs:20:11
+   |
+LL |     foo::<_>();
+   |           ^ the trait `Other<_>` is not implemented for `T`
+   |
+note: required by a bound in `foo`
+  --> $DIR/universe-error1.rs:17:15
+   |
+LL | fn foo<U: PointeeSized>()
+   |    --- required by a bound in this function
+LL | where
+LL |     for<T> T: Other<U> {}
+   |               ^^^^^^^^ required by this bound in `foo`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/non_lifetime_binders/universe-error1.rs
+++ b/tests/ui/traits/non_lifetime_binders/universe-error1.rs
@@ -1,3 +1,7 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
 #![feature(sized_hierarchy)]
 #![feature(non_lifetime_binders)]
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

If we call `enter_forall` on a binder before passing it to the new solver, the placeholders that come from instantiation get canonicalized before solving happens. This can be a problem if we end up equating one variable whose universe can't name another variable's, since the equate will succeed in the solver since canonicalization sets all universe indices to the root universe but fail when we actually construct the response with fresh vars at the correct universes, which causes an ICE. We now just hand the unopened binder to the trait solver directly, since (I believe) both solvers are able to handle that just fine.

This came up while I was looking at https://rust-lang.zulipchat.com/#narrow/channel/618216-t-types.2Fcall-for-participation/topic/next-solver.20UI.20test.20triage/with/612965995, and the `universe-error-host-effect.rs`/`poly_select` change was basically the same type of ICE that I found while investigating the first one.