### PR TITLE
Improve documentation for `int::from_str*` and `int::from_ascii_bytes*`

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1770,10 +1770,7 @@ macro_rules! from_str_int_impl {
             /// # See also
             ///
             /// If the characters to be parsed is in base 10 (decimal),
-            /// [`from_ascii_bytes`] can also be used.
-            ///
-            // FIXME(#122566): This HTML link work around a rustdoc-json test failure.
-            /// [`from_ascii_bytes`]: #method.from_ascii_bytes
+            /// [`from_ascii_bytes`][Self::from_ascii_bytes] can also be used.
             ///
             /// # Examples
             ///

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1612,6 +1612,7 @@ macro_rules! from_str_int_impl {
             /// also represent an error.
             ///
             /// # See also
+            ///
             /// For parsing numbers in other bases, such as binary or hexadecimal,
             /// see [`from_str_radix`][Self::from_str_radix].
             ///
@@ -1661,6 +1662,7 @@ macro_rules! from_str_int_impl {
             /// This function panics if `radix` is not in the range from 2 to 36.
             ///
             /// # See also
+            ///
             /// If the string to be parsed is in base 10 (decimal),
             /// [`from_str`] or [`str::parse`] can also be used.
             ///
@@ -1699,6 +1701,11 @@ macro_rules! from_str_int_impl {
             /// sign followed by only digits. Leading and trailing non-digit characters (including
             /// whitespace) represent an error. Underscores (which are accepted in Rust literals)
             /// also represent an error.
+            ///
+            /// # See also
+            ///
+            /// For parsing numbers in other bases, such as binary or hexadecimal,
+            /// see [`from_ascii_bytes_radix`][Self::from_ascii_bytes_radix].
             ///
             /// # Examples
             ///
@@ -1747,6 +1754,14 @@ macro_rules! from_str_int_impl {
             /// # Panics
             ///
             /// This function panics if `radix` is not in the range from 2 to 36.
+            ///
+            /// # See also
+            ///
+            /// If the characters to be parsed is in base 10 (decimal),
+            /// [`from_ascii_bytes`] can also be used.
+            ///
+            // FIXME(#122566): This HTML link work around a rustdoc-json test failure.
+            /// [`from_ascii_bytes`]: #method.from_ascii_bytes
             ///
             /// # Examples
             ///

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1607,9 +1607,12 @@ macro_rules! from_str_int_impl {
                     " `+` "
                 }
             }]
-            /// sign followed by only digits. Leading and trailing non-digit characters (including
-            /// whitespace) represent an error. Underscores (which are accepted in Rust literals)
-            /// also represent an error.
+            /// sign followed by only digits.
+            ///
+            /// # Errors
+            ///
+            /// Leading and trailing non-digit characters (including whitespace) represent an error.
+            /// Underscores (which are accepted in Rust literals) also represent an error.
             ///
             /// # See also
             ///
@@ -1648,14 +1651,17 @@ macro_rules! from_str_int_impl {
                     " `+` "
                 }
             }]
-            /// sign followed by only digits. Leading and trailing non-digit characters (including
-            /// whitespace) represent an error. Underscores (which are accepted in Rust literals)
-            /// also represent an error.
+            /// sign followed by only digits.
             ///
             /// Digits are a subset of these characters, depending on `radix`:
             /// * `0-9`
             /// * `a-z`
             /// * `A-Z`
+            ///
+            /// # Errors
+            ///
+            /// Leading and trailing non-digit characters (including whitespace) represent an error.
+            /// Underscores (which are accepted in Rust literals) also represent an error.
             ///
             /// # Panics
             ///
@@ -1698,9 +1704,12 @@ macro_rules! from_str_int_impl {
                     " `+` "
                 }
             }]
-            /// sign followed by only digits. Leading and trailing non-digit characters (including
-            /// whitespace) represent an error. Underscores (which are accepted in Rust literals)
-            /// also represent an error.
+            /// sign followed by only digits.
+            ///
+            /// # Errors
+            ///
+            /// Leading and trailing non-digit characters (including whitespace) represent an error.
+            /// Underscores (which are accepted in Rust literals) also represent an error.
             ///
             /// # See also
             ///
@@ -1742,14 +1751,17 @@ macro_rules! from_str_int_impl {
                     " `+` "
                 }
             }]
-            /// sign followed by only digits. Leading and trailing non-digit characters (including
-            /// whitespace) represent an error. Underscores (which are accepted in Rust literals)
-            /// also represent an error.
+            /// sign followed by only digits.
             ///
             /// Digits are a subset of these characters, depending on `radix`:
             /// * `0-9`
             /// * `a-z`
             /// * `A-Z`
+            ///
+            /// # Errors
+            ///
+            /// Leading and trailing non-digit characters (including whitespace) represent an error.
+            /// Underscores (which are accepted in Rust literals) also represent an error.
             ///
             /// # Panics
             ///

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1326,10 +1326,7 @@ macro_rules! nonzero_integer {
             /// # See also
             ///
             /// If the characters to be parsed is in base 10 (decimal),
-            /// [`from_ascii_bytes`] can also be used.
-            ///
-            // FIXME(#122566): This HTML link work around a rustdoc-json test failure.
-            /// [`from_ascii_bytes`]: #method.from_ascii_bytes
+            /// [`from_ascii_bytes`][Self::from_ascii_bytes] can also be used.
             ///
             /// # Examples
             ///
@@ -1409,11 +1406,7 @@ macro_rules! nonzero_integer {
             /// # See also
             ///
             /// If the string to be parsed is in base 10 (decimal),
-            /// [`from_str`] or [`str::parse`] can also be used.
-            ///
-            // FIXME(#122566): These HTML links work around a rustdoc-json test failure.
-            /// [`from_str`]: #method.from_str
-            /// [`str::parse`]: primitive.str.html#method.parse
+            /// [`from_str`][Self::from_str] or [`str::parse`] can also be used.
             ///
             /// # Examples
             ///

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1249,9 +1249,12 @@ macro_rules! nonzero_integer {
                     " `+` "
                 }
             }]
-            /// sign followed by only digits. Leading and trailing non-digit characters (including
-            /// whitespace) represent an error. Underscores (which are accepted in Rust literals)
-            /// also represent an error.
+            /// sign followed by only digits.
+            ///
+            /// # Errors
+            ///
+            /// Leading and trailing non-digit characters (including whitespace) represent an error.
+            /// Underscores (which are accepted in Rust literals) also represent an error.
             ///
             /// # See also
             ///
@@ -1303,15 +1306,18 @@ macro_rules! nonzero_integer {
                     " `+` "
                 }
             }]
-            /// sign followed by only digits. Leading and trailing non-digit characters (including
-            /// whitespace) represent an error. Underscores (which are accepted in Rust literals)
-            /// also represent an error.
+            /// sign followed by only digits.
             ///
             /// Digits are a subset of these characters, depending on `radix`:
             ///
             /// - `0-9`
             /// - `a-z`
             /// - `A-Z`
+            ///
+            /// # Errors
+            ///
+            /// Leading and trailing non-digit characters (including whitespace) represent an error.
+            /// Underscores (which are accepted in Rust literals) also represent an error.
             ///
             /// # Panics
             ///
@@ -1383,15 +1389,18 @@ macro_rules! nonzero_integer {
                     " `+` "
                 }
             }]
-            /// sign followed by only digits. Leading and trailing non-digit characters (including
-            /// whitespace) represent an error. Underscores (which are accepted in Rust literals)
-            /// also represent an error.
+            /// sign followed by only digits.
             ///
             /// Digits are a subset of these characters, depending on `radix`:
             ///
             /// - `0-9`
             /// - `a-z`
             /// - `A-Z`
+            ///
+            /// # Errors
+            ///
+            /// Leading and trailing non-digit characters (including whitespace) represent an error.
+            /// Underscores (which are accepted in Rust literals) also represent an error.
             ///
             /// # Panics
             ///

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1445,6 +1445,52 @@ macro_rules! nonzero_integer {
         #[stable(feature = "nonzero_parse", since = "1.35.0")]
         impl FromStr for NonZero<$Int> {
             type Err = ParseIntError;
+
+            /// Parses a non-zero integer from a string slice with decimal digits.
+            ///
+            /// The characters are expected to be an optional
+            #[doc = sign_dependent_expr!{
+                $signedness ?
+                if signed {
+                    " `+` or `-` "
+                }
+                if unsigned {
+                    " `+` "
+                }
+            }]
+            /// sign followed by only digits.
+            ///
+            /// # Errors
+            ///
+            /// Leading and trailing non-digit characters (including whitespace) represent an error.
+            /// Underscores (which are accepted in Rust literals) also represent an error.
+            ///
+            /// # See also
+            ///
+            /// For parsing numbers in other bases, such as binary or hexadecimal,
+            /// see [`from_str_radix`][Self::from_str_radix].
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// # use std::num::NonZero;
+            /// use std::str::FromStr;
+            /// #
+            /// # fn main() { test().unwrap(); }
+            /// # fn test() -> Option<()> {
+            #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::from_str(\"+10\"), Ok(NonZero::new(10)?));")]
+            /// # Some(())
+            /// # }
+            /// ```
+            ///
+            /// Trailing space returns error:
+            ///
+            /// ```
+            /// # use std::num::NonZero;
+            /// # use std::str::FromStr;
+            /// #
+            #[doc = concat!("assert!(NonZero::<", stringify!($Int), ">::from_str(\"1 \").is_err());")]
+            /// ```
             fn from_str(src: &str) -> Result<Self, Self::Err> {
                 Self::from_str_radix(src, 10)
             }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1253,6 +1253,11 @@ macro_rules! nonzero_integer {
             /// whitespace) represent an error. Underscores (which are accepted in Rust literals)
             /// also represent an error.
             ///
+            /// # See also
+            ///
+            /// For parsing numbers in other bases, such as binary or hexadecimal,
+            /// see [`from_ascii_bytes_radix`][Self::from_ascii_bytes_radix].
+            ///
             /// # Examples
             ///
             /// ```
@@ -1311,6 +1316,14 @@ macro_rules! nonzero_integer {
             /// # Panics
             ///
             /// This method panics if `radix` is not in the range from 2 to 36.
+            ///
+            /// # See also
+            ///
+            /// If the characters to be parsed is in base 10 (decimal),
+            /// [`from_ascii_bytes`] can also be used.
+            ///
+            // FIXME(#122566): This HTML link work around a rustdoc-json test failure.
+            /// [`from_ascii_bytes`]: #method.from_ascii_bytes
             ///
             /// # Examples
             ///
@@ -1383,6 +1396,15 @@ macro_rules! nonzero_integer {
             /// # Panics
             ///
             /// This method panics if `radix` is not in the range from 2 to 36.
+            ///
+            /// # See also
+            ///
+            /// If the string to be parsed is in base 10 (decimal),
+            /// [`from_str`] or [`str::parse`] can also be used.
+            ///
+            // FIXME(#122566): These HTML links work around a rustdoc-json test failure.
+            /// [`from_str`]: #method.from_str
+            /// [`str::parse`]: primitive.str.html#method.parse
             ///
             /// # Examples
             ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

1. Added "See also" section to `int::from_ascii_bytes*`, `NonZero::from_str*` and `NonZero::from_ascii_bytes*`. These originate from the section of the same name in `int::from_str*`.
2. Added "Errors" section and moved the existing error-related descriptions to this section. I think it would be easier to find the description of the errors if there are a dedicated section.
3. Add documentation for `NonZero::from_str`. This was the only one lacking its own documentation, so I added it based on the documentation for `int::from_str`.