### PR TITLE
Allow `:` after `pat_param`

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -1631,7 +1631,8 @@ fn check_matcher_core<'tt>(
 
                             if kind == NonterminalKind::Pat(PatWithOr)
                                 && sess.psess.edition.at_least_rust_2021()
-                                && next_token.is_token(&token::Or)
+                                && (next_token.is_token(&token::Or)
+                                    || next_token.is_token(&token::Colon))
                             {
                                 let suggestion = quoted_tt_to_string(&TokenTree::MetaVarDecl {
                                     span,
@@ -1749,10 +1750,11 @@ fn is_in_follow(tok: &mbe::TokenTree, kind: NonterminalKind) -> IsInFollow {
                 }
             }
             NonterminalKind::Pat(PatParam { .. }) => {
-                const TOKENS: &[&str] = &["`=>`", "`,`", "`=`", "`|`", "`if`", "`if let`", "`in`"];
+                const TOKENS: &[&str] =
+                    &["`=>`", "`,`", "`=`", "`|`", "`:`", "`if`", "`if let`", "`in`"];
                 match tok {
                     TokenTree::Token(token) => match token.kind {
-                        FatArrow | Comma | Eq | Or => IsInFollow::Yes,
+                        FatArrow | Comma | Eq | Or | Colon => IsInFollow::Yes,
                         Ident(name, IdentIsRaw::No) if name == kw::If || name == kw::In => {
                             IsInFollow::Yes
                         }

--- a/tests/ui/macros/macro-follow.rs
+++ b/tests/ui/macros/macro-follow.rs
@@ -12,7 +12,7 @@ macro_rules! follow_pat {
     ($p:pat ()) => {};       //~ERROR  `$p:pat` is followed by `(`
     ($p:pat []) => {};       //~ERROR  `$p:pat` is followed by `[`
     ($p:pat {}) => {};       //~ERROR  `$p:pat` is followed by `{`
-    ($p:pat :) => {};        //~ERROR `$p:pat` is followed by `:`
+    ($p:pat :) => {};        // ok
     ($p:pat >) => {};        //~ERROR `$p:pat` is followed by `>`
     ($p:pat +) => {};        //~ERROR `$p:pat` is followed by `+`
     ($p:pat ident) => {};    //~ERROR `$p:pat` is followed by `ident`

--- a/tests/ui/macros/macro-follow.stderr
+++ b/tests/ui/macros/macro-follow.stderr
@@ -4,7 +4,7 @@ error: `$p:pat` is followed by `(`, which is not allowed for `pat` fragments
 LL |     ($p:pat ()) => {};
    |             ^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `[`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:13:13
@@ -12,7 +12,7 @@ error: `$p:pat` is followed by `[`, which is not allowed for `pat` fragments
 LL |     ($p:pat []) => {};
    |             ^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `{`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:14:13
@@ -20,15 +20,7 @@ error: `$p:pat` is followed by `{`, which is not allowed for `pat` fragments
 LL |     ($p:pat {}) => {};
    |             ^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
-
-error: `$p:pat` is followed by `:`, which is not allowed for `pat` fragments
-  --> $DIR/macro-follow.rs:15:13
-   |
-LL |     ($p:pat :) => {};
-   |             ^ not allowed after `pat` fragments
-   |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `>`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:16:13
@@ -36,7 +28,7 @@ error: `$p:pat` is followed by `>`, which is not allowed for `pat` fragments
 LL |     ($p:pat >) => {};
    |             ^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `+`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:17:13
@@ -44,7 +36,7 @@ error: `$p:pat` is followed by `+`, which is not allowed for `pat` fragments
 LL |     ($p:pat +) => {};
    |             ^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `ident`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:18:13
@@ -52,7 +44,7 @@ error: `$p:pat` is followed by `ident`, which is not allowed for `pat` fragments
 LL |     ($p:pat ident) => {};
    |             ^^^^^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `$q:pat`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:19:13
@@ -60,7 +52,7 @@ error: `$p:pat` is followed by `$q:pat`, which is not allowed for `pat` fragment
 LL |     ($p:pat $q:pat) => {};
    |             ^^^^^^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `$e:expr`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:20:13
@@ -68,7 +60,7 @@ error: `$p:pat` is followed by `$e:expr`, which is not allowed for `pat` fragmen
 LL |     ($p:pat $e:expr) => {};
    |             ^^^^^^^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `$t:ty`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:21:13
@@ -76,7 +68,7 @@ error: `$p:pat` is followed by `$t:ty`, which is not allowed for `pat` fragments
 LL |     ($p:pat $t:ty) => {};
    |             ^^^^^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `$s:stmt`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:22:13
@@ -84,7 +76,7 @@ error: `$p:pat` is followed by `$s:stmt`, which is not allowed for `pat` fragmen
 LL |     ($p:pat $s:stmt) => {};
    |             ^^^^^^^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `$q:path`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:23:13
@@ -92,7 +84,7 @@ error: `$p:pat` is followed by `$q:path`, which is not allowed for `pat` fragmen
 LL |     ($p:pat $q:path) => {};
    |             ^^^^^^^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `$b:block`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:24:13
@@ -100,7 +92,7 @@ error: `$p:pat` is followed by `$b:block`, which is not allowed for `pat` fragme
 LL |     ($p:pat $b:block) => {};
    |             ^^^^^^^^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `$i:ident`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:25:13
@@ -108,7 +100,7 @@ error: `$p:pat` is followed by `$i:ident`, which is not allowed for `pat` fragme
 LL |     ($p:pat $i:ident) => {};
    |             ^^^^^^^^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `$t:tt`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:26:13
@@ -116,7 +108,7 @@ error: `$p:pat` is followed by `$t:tt`, which is not allowed for `pat` fragments
 LL |     ($p:pat $t:tt) => {};
    |             ^^^^^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `$i:item`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:27:13
@@ -124,7 +116,7 @@ error: `$p:pat` is followed by `$i:item`, which is not allowed for `pat` fragmen
 LL |     ($p:pat $i:item) => {};
    |             ^^^^^^^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$p:pat` is followed by `$m:meta`, which is not allowed for `pat` fragments
   --> $DIR/macro-follow.rs:28:13
@@ -132,7 +124,7 @@ error: `$p:pat` is followed by `$m:meta`, which is not allowed for `pat` fragmen
 LL |     ($p:pat $m:meta) => {};
    |             ^^^^^^^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$e:expr` is followed by `(`, which is not allowed for `expr` fragments
   --> $DIR/macro-follow.rs:32:14
@@ -710,5 +702,5 @@ LL |     ($p:path $g:guard) => {};
    |
    = note: allowed there are: `{`, `[`, `=>`, `,`, `>`, `=`, `:`, `;`, `|`, `as` or `where`
 
-error: aborting due to 89 previous errors
+error: aborting due to 88 previous errors
 

--- a/tests/ui/macros/macro-input-future-proofing.stderr
+++ b/tests/ui/macros/macro-input-future-proofing.stderr
@@ -20,7 +20,7 @@ error: `$pa:pat` is followed by `>`, which is not allowed for `pat` fragments
 LL |     ($pa:pat >) => ();
    |              ^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$pa:pat` is followed by `$pb:pat`, which is not allowed for `pat` fragments
   --> $DIR/macro-input-future-proofing.rs:14:14
@@ -28,7 +28,7 @@ error: `$pa:pat` is followed by `$pb:pat`, which is not allowed for `pat` fragme
 LL |     ($pa:pat $pb:pat $ty:ty ,) => ();
    |              ^^^^^^^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$pb:pat` is followed by `$ty:ty`, which is not allowed for `pat` fragments
   --> $DIR/macro-input-future-proofing.rs:14:22
@@ -36,7 +36,7 @@ error: `$pb:pat` is followed by `$ty:ty`, which is not allowed for `pat` fragmen
 LL |     ($pa:pat $pb:pat $ty:ty ,) => ();
    |                      ^^^^^^ not allowed after `pat` fragments
    |
-   = note: allowed there are: `=>`, `,`, `=`, `|`, `if`, `if let` or `in`
+   = note: allowed there are: `=>`, `,`, `=`, `|`, `:`, `if`, `if let` or `in`
 
 error: `$ty:ty` is followed by `-`, which is not allowed for `ty` fragments
   --> $DIR/macro-input-future-proofing.rs:17:17


### PR DESCRIPTION
As on the tin. Perhaps this requires a more formal decision process, but in my view this is something of a bug. Originally, `pat_param` was just the bikeshodden name of `pat2015`, c.f. https://github.com/rust-lang/rust/pull/83386#issuecomment-819719603:

> * `pat_no_or` would be used for closure arguments; can we have something that talks about that (e.g., pat_arg, pat_param -- pattern for a closure argument)
> * `pat_param` is preferred because it is a parameter, not the argument passed to a call

But if it truly is a matcher for "a pattern you can use for a parameter", there shouldn't be a problem allowing it to be followed by a colon, given that that's kind of the definitional constraint for that grammar. And if, in the distant future, the language decides to separate the name and type of a parameter with something other than a colon, well, that'll need an edition change anyway.

In my opinion, this would resolve rust-lang/rust#87724: I'd imagine that most-if-not-all use cases for a `pat` followed by a colon are for matching function signatures or let statements, which don't let you use `|` patterns anyway. But, we get to have our cake and eat it too by still reserving `:` for future extensions to `match` expression (`pat`) patterns. If it ever is desired to make `pat` match the whole `$pat : $ty` syntax, as mentioned in https://github.com/rust-lang/rust/issues/87724#issuecomment-893034652, that's something that can be done over an edition boundary and/or just for `pat` matchers.