### PR TITLE
Fix an edge for certain platforms that views trailing cur dir components as a separate missing directory components

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3742,6 +3742,11 @@ impl DirBuilder {
             return Ok(());
         }
 
+        // For certain platforms, a path like "/tmp/foo/.", while the "/tmp" directory exists,
+        // the mkdir function may produce a `NotFound` error on that path instead of succeeding
+        // due to viewing the "foo" and "." as two separate missing components.
+        // See https://github.com/rust-lang/rust/issues/162243
+        let path = path.components().as_path();
         let ancestors = path.ancestors();
         let mut uncreated_dirs = 0;
 

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -944,6 +944,14 @@ fn recursive_mkdir() {
 }
 
 #[test]
+fn recursive_mkdir_with_trailing_cur_dir() {
+    let tmpdir = tmpdir();
+    let dir = tmpdir.join("foo").join(".");
+    check!(fs::create_dir_all(&dir));
+    assert!(dir.is_dir())
+}
+
+#[test]
 fn recursive_mkdir_failure() {
     let tmpdir = tmpdir();
     let dir = tmpdir.join("d1");


### PR DESCRIPTION
This PR fixes rust-lang/rust#162243.

I talk about what the problem is in more details within the issue, but essentially when you have trailing cur dir components, e.g. `"/tmp/foo/."`, some platforms may fail with `mkdir` on this path because it could consider "foo" and the "." as two separate missing path components to create instead of normalizing the given path and seeing that "foo" is the only missing directory here (in which case `mkdir` should succeed).

What this PR does is it normalizes the provided path, so we don't experience this issue on certain platforms whose `mkdir` function do not normalize the cur dir component away (as all platforms should succeed with `"/tmp/foo/."`). There's Rust Playground link that @Raniz85 made that demonstrates the `NotFound` error occurring on "/tmp/foo/.".

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
