### PR TITLE
Do not increase recursion depth for coroutine witness and rigid opaques when proving auto traits

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -636,10 +636,113 @@ where
         source: GoalSource,
         goal: Goal<I, I::Predicate>,
     ) -> Result<GoalEvaluation<I>, NoSolutionOrRerunNonErased> {
-        let (normalization_nested_goals, goal_evaluation) =
-            self.evaluate_goal_raw(source, goal, LowerAvailableDepth::Yes)?;
+        let (normalization_nested_goals, goal_evaluation) = self.evaluate_goal_raw(source, goal)?;
         assert!(normalization_nested_goals.is_empty());
         Ok(goal_evaluation)
+    }
+
+    fn evaluate_in_search_graph(
+        &mut self,
+        canonical_goal: I::CanonicalInput,
+        step_kind: PathKind,
+    ) -> (Result<CanonicalResponse<I>, NoSolution>, AccessedOpaques<I>) {
+        let increase_depth_for_nested =
+            match canonical_goal.canonical.value.goal.predicate.kind().skip_binder() {
+                // We don't lower the available depth for the `NormalizesTo` goal, as evaluating
+                // it is an extra step only exists in the new solver that behaves like a function
+                // call rather than an independent nested goal evaluation. So, decreasing the
+                // available depth may end up regressions which hit the recursion limits for crates
+                // compiled well with the old solver.
+                ty::PredicateKind::NormalizesTo(_) => LowerAvailableDepth::No,
+                // We also don't lower depth for witness and rigid opaque when proving auto traits.
+                // This is to mitigate the overflow FCW warnings in deeply nested async calls.
+                // See #159228.
+                //
+                // We're eventually going to remove the witness type so it's okay to ignore the
+                // depth.
+                // For rigid opaques, revealing hidden types can be viewed as normalization so it's
+                // consistent with the `NormalizesTo` reasoning above.
+                ty::PredicateKind::Clause(ty::ClauseKind::Trait(pred)) => {
+                    if self.cx().trait_is_auto(pred.trait_ref.def_id) {
+                        match pred.self_ty().kind() {
+                            ty::CoroutineWitness(..) => LowerAvailableDepth::No,
+                            ty::Alias(
+                                ty::IsRigid::Yes,
+                                ty::AliasTy { kind: ty::Opaque { def_id, .. }, .. },
+                            ) => {
+                                // We only want to skip lowering depth when the proving is done via auto
+                                // trait leakage. If the goal can be proved via item bounds, we
+                                // should lower depth faithfully.
+                                if self
+                                    .cx()
+                                    .item_self_bounds(def_id.into())
+                                    .skip_binder()
+                                    .into_iter()
+                                    .any(|bound| {
+                                        bound
+                                            .as_trait_clause()
+                                            .is_some_and(|b| b.def_id() == pred.def_id())
+                                    })
+                                {
+                                    LowerAvailableDepth::Yes
+                                } else {
+                                    LowerAvailableDepth::No
+                                }
+                            }
+                            ty::Bool
+                            | ty::Char
+                            | ty::Int(..)
+                            | ty::Uint(..)
+                            | ty::Float(..)
+                            | ty::Str
+                            | ty::Pat(..)
+                            | ty::FnPtr(..)
+                            | ty::Array(..)
+                            | ty::Slice(..)
+                            | ty::RawPtr(..)
+                            | ty::Never
+                            | ty::Tuple(..)
+                            | ty::UnsafeBinder(_)
+                            | ty::Param(..)
+                            | ty::Placeholder(..)
+                            | ty::Bound(..)
+                            | ty::Infer(..)
+                            | ty::Alias(_, _)
+                            | ty::Ref(_, _, _)
+                            | ty::Adt(_, _)
+                            | ty::Foreign(_)
+                            | ty::Dynamic(..)
+                            | ty::Error(_)
+                            | ty::FnDef(..)
+                            | ty::Closure(..)
+                            | ty::CoroutineClosure(..)
+                            | ty::Coroutine(..) => LowerAvailableDepth::Yes,
+                        }
+                    } else {
+                        LowerAvailableDepth::Yes
+                    }
+                }
+                ty::PredicateKind::Clause(ty::ClauseKind::HostEffect(_))
+                | ty::PredicateKind::Clause(ty::ClauseKind::Projection(_))
+                | ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(_))
+                | ty::PredicateKind::Clause(ty::ClauseKind::RegionOutlives(_))
+                | ty::PredicateKind::Clause(ty::ClauseKind::ConstArgHasType(_, _))
+                | ty::PredicateKind::Clause(ty::ClauseKind::UnstableFeature(_))
+                | ty::PredicateKind::Subtype(_)
+                | ty::PredicateKind::Coerce(_)
+                | ty::PredicateKind::DynCompatible(_)
+                | ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(_))
+                | ty::PredicateKind::Clause(ty::ClauseKind::ConstEvaluatable(_))
+                | ty::PredicateKind::ConstEquate(_, _)
+                | ty::PredicateKind::Ambiguous => LowerAvailableDepth::Yes,
+            };
+        self.search_graph.evaluate_goal(
+            self.cx(),
+            canonical_goal,
+            step_kind,
+            increase_depth_for_nested,
+            &mut inspect::ProofTreeBuilder::new_noop(),
+        )
     }
 
     /// Recursively evaluates `goal`, returning the nested goals in case
@@ -653,7 +756,6 @@ where
         &mut self,
         source: GoalSource,
         goal: Goal<I, I::Predicate>,
-        increase_depth_for_nested: LowerAvailableDepth,
     ) -> Result<(NestedNormalizationGoals<I>, GoalEvaluation<I>), NoSolutionOrRerunNonErased> {
         // We only care about one entry per `OpaqueTypeKey` here,
         // so we only canonicalize the lookup table and ignore
@@ -719,13 +821,8 @@ where
                     TypingMode::ErasedNotCoherence(MayBeErased),
                 );
 
-                let (canonical_result, accessed_opaques) = self.search_graph.evaluate_goal(
-                    self.cx(),
-                    canonical_goal,
-                    step_kind,
-                    increase_depth_for_nested,
-                    &mut inspect::ProofTreeBuilder::new_noop(),
-                );
+                let (canonical_result, accessed_opaques) =
+                    self.evaluate_in_search_graph(canonical_goal, step_kind);
 
                 let should_rerun = should_rerun_after_erased_canonicalization(
                     accessed_opaques,
@@ -759,13 +856,8 @@ where
             let (orig_values, canonical_goal) =
                 canonicalize_goal(self.delegate, goal, &opaque_types, typing_mode);
 
-            let (canonical_result, accessed_opaques) = self.search_graph.evaluate_goal(
-                self.cx(),
-                canonical_goal,
-                step_kind,
-                increase_depth_for_nested,
-                &mut inspect::ProofTreeBuilder::new_noop(),
-            );
+            let (canonical_result, accessed_opaques) =
+                self.evaluate_in_search_graph(canonical_goal, step_kind);
             assert!(
                 !accessed_opaques.might_rerun(),
                 "we run without TypingMode::ErasedNotCoherence, so opaques are available, and we don't retry if the outer typing mode is ErasedNotCoherence: {accessed_opaques:?} after {goal:?}"

--- a/compiler/rustc_next_trait_solver/src/solve/project_goals/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/project_goals/mod.rs
@@ -3,7 +3,6 @@ mod free_alias;
 mod inherent;
 mod opaque_types;
 
-use rustc_type_ir::search_graph::LowerAvailableDepth;
 use rustc_type_ir::solve::QueryResultOrRerunNonErased;
 use rustc_type_ir::{self as ty, Interner, ProjectionClause};
 use tracing::{instrument, trace};
@@ -70,16 +69,7 @@ where
         let (
             NestedNormalizationGoals(nested_goals),
             GoalEvaluation { goal: _, certainty, stalled_on: _, has_changed: _ },
-        ) = self.evaluate_goal_raw(
-            GoalSource::TypeRelating,
-            normalizes_to,
-            // We don't lower thr available depth for this `NormalizesTo` goal, as evaluating
-            // it is an extra step only exists in the new solver that behaves like a function
-            // call rather than an independent nested goal evaluation. So, decreasing the
-            // available depth may end up regressions which hit the recursion limits for crates
-            // compiled well with the old solver.
-            LowerAvailableDepth::No,
-        )?;
+        ) = self.evaluate_goal_raw(GoalSource::TypeRelating, normalizes_to)?;
 
         trace!(?nested_goals);
 

--- a/tests/ui/traits/next-solver/overflow/dont-lower-depth-for-witness-and-rigid-opaque.rs
+++ b/tests/ui/traits/next-solver/overflow/dont-lower-depth-for-witness-and-rigid-opaque.rs
@@ -1,0 +1,31 @@
+//@ compile-flags: -Znext-solver
+//@ edition: 2024
+//@ check-pass
+
+// We don't increase recursion depth when proving auto traits for witness
+// and rigid opaques. This is to mitigate the FCW warnings in deeply nested
+// async calls. See #159228.
+
+#![recursion_limit = "6"]
+
+async fn foo1() {}
+
+async fn foo2() {
+    foo1().await
+}
+async fn foo3() {
+    foo2().await
+}
+async fn foo4() {
+    foo3().await
+}
+
+async fn foo5() {
+    foo4().await
+}
+
+fn assert_send<T: Send>(_: T) {}
+
+fn main() {
+    assert_send(foo5());
+}


### PR DESCRIPTION

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
With deeply nested async calls, we can easily overflow evaluating auto trait goals as shown in rust-lang/rust#159228.
Users have no choice but increase the per-crate `recursion_limit` which is bad for compilation time/RSS. And downstream users may encounter the same warnings when calling library async functions.

We mitigate that by no longer increasing recursion depth for coroutine witness and rigid opaques when proving auto traits. See the comments for why it's okay to do so.
This fix actually makes the required depth a third of what it was before for async calls.

I've checked locally that `bors` and `triagebot` no longer have FCWs.

r? lcnr