### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4745,6 +4745,7 @@ name = "rustc_sanitizers"
 version = "0.0.0"
 dependencies = [
  "bitflags",
+ "libc",
  "rustc_abi",
  "rustc_data_structures",
  "rustc_hir",

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -170,10 +170,10 @@ macro_rules! impl_visitable {
 }
 
 macro_rules! impl_walkable {
-    ($(<$K:ident: $Kb:ident>)? |&mut $self:ident: $self_ty:ty,
+    (|&mut $self:ident: $self_ty:ty,
       $vis:ident: &mut $vis_ty:ident| $block:block) => {
         #[allow(unused_parens, non_local_definitions)]
-        impl<$($K: $Kb,)? $vis_ty: MutVisitor> MutWalkable<$vis_ty> for $self_ty {
+        impl<$vis_ty: MutVisitor> MutWalkable<$vis_ty> for $self_ty {
             fn walk_mut(&mut $self, $vis: &mut $vis_ty) -> V::Result {
                 $block
             }

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -285,7 +285,11 @@ pub fn walk_flat_map_pat_field<T: MutVisitor>(
 
 macro_rules! generate_walk_flat_map_fns {
     ($($fn_name:ident($Ty:ty$(,$extra_name:ident: $ExtraTy:ty)*) => $visit_fn_name:ident;)+) => {$(
-        pub fn $fn_name<V: MutVisitor>(vis: &mut V, mut value: $Ty$(,$extra_name: $ExtraTy)*) -> SmallVec<[$Ty; 1]> {
+        pub fn $fn_name<V: MutVisitor>(
+            vis: &mut V,
+            mut value: $Ty
+            $(,$extra_name: $ExtraTy)*
+        ) -> SmallVec<[$Ty; 1]> {
             vis.$visit_fn_name(&mut value$(,$extra_name)*);
             smallvec![value]
         }

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -244,49 +244,35 @@ macro_rules! define_named_walk {
 super::common_visitor_and_walkers!((mut) MutVisitor);
 
 macro_rules! generate_flat_map_visitor_fns {
-    ($($name:ident, $Ty:ty, $flat_map_fn:ident$(, $param:ident: $ParamTy:ty)*;)+) => {
+    ($($flat_map_fn:ident, $Ty:ty $(, $param:ident: $ParamTy:ty)?;)+) => {
         $(
             #[allow(unused_parens)]
             impl<V: MutVisitor> MutVisitable<V> for ThinVec<$Ty> {
-                type Extra = ($($ParamTy),*);
+                type Extra = ($($ParamTy)?);
 
                 #[inline]
-                fn visit_mut(
-                    &mut self,
-                    visitor: &mut V,
-                    ($($param),*): Self::Extra,
-                ) -> V::Result {
-                    $name(visitor, self $(, $param)*)
+                fn visit_mut(&mut self, visitor: &mut V, ($($param)?): Self::Extra) -> V::Result {
+                    self.flat_map_in_place(|value| visitor.$flat_map_fn(value $(, $param)?));
                 }
-            }
-
-            fn $name<V: MutVisitor>(
-                vis: &mut V,
-                values: &mut ThinVec<$Ty>,
-                $(
-                    $param: $ParamTy,
-                )*
-            ) {
-                values.flat_map_in_place(|value| vis.$flat_map_fn(value$(,$param)*));
             }
         )+
     }
 }
 
 generate_flat_map_visitor_fns! {
-    visit_items, Box<Item>, flat_map_item;
-    visit_foreign_items, Box<ForeignItem>, flat_map_foreign_item;
-    visit_generic_params, GenericParam, flat_map_generic_param;
-    visit_stmts, Stmt, flat_map_stmt;
-    visit_exprs, Box<Expr>, filter_map_expr;
-    visit_expr_fields, ExprField, flat_map_expr_field;
-    visit_pat_fields, PatField, flat_map_pat_field;
-    visit_variants, Variant, flat_map_variant;
-    visit_assoc_items, Box<AssocItem>, flat_map_assoc_item, ctxt: AssocCtxt;
-    visit_where_predicates, WherePredicate, flat_map_where_predicate;
-    visit_params, Param, flat_map_param;
-    visit_field_defs, FieldDef, flat_map_field_def;
-    visit_arms, Arm, flat_map_arm;
+    flat_map_item, Box<Item>;
+    flat_map_foreign_item, Box<ForeignItem>;
+    flat_map_generic_param, GenericParam;
+    flat_map_stmt, Stmt;
+    filter_map_expr, Box<Expr>; // the odd one out; it works because `Option` impls `IntoIterator`
+    flat_map_expr_field, ExprField;
+    flat_map_pat_field, PatField;
+    flat_map_variant, Variant;
+    flat_map_assoc_item, Box<AssocItem>, ctxt: AssocCtxt;
+    flat_map_where_predicate, WherePredicate;
+    flat_map_param, Param;
+    flat_map_field_def, FieldDef;
+    flat_map_arm, Arm;
 }
 
 pub fn walk_flat_map_pat_field<T: MutVisitor>(

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -144,13 +144,13 @@ pub trait MutWalkable<V: MutVisitor> {
 }
 
 macro_rules! visit_visitable {
-    (mut $visitor:expr, $($expr:expr),* $(,)?) => {{
+    ($visitor:expr, $($expr:expr),* $(,)?) => {{
         $(MutVisitable::visit_mut($expr, $visitor, ());)*
     }};
 }
 
 macro_rules! visit_visitable_with {
-    (mut $visitor:expr, $expr:expr, $extra:expr $(,)?) => {
+    ($visitor:expr, $expr:expr, $extra:expr $(,)?) => {
         MutVisitable::visit_mut($expr, $visitor, $extra)
     };
 }
@@ -232,7 +232,7 @@ macro_rules! impl_visitable_calling_walkable {
 }
 
 macro_rules! define_named_walk {
-    ((mut) $Visitor:ident
+    ($Visitor:ident
         $( pub fn $method:ident($ty:ty); )*
     ) => {
         $(pub fn $method<V: $Visitor>(visitor: &mut V, node: &mut $ty) {

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -97,16 +97,6 @@ where
     }
 }
 
-impl<V: MutVisitor, T> MutVisitable<V> for (T,)
-where
-    T: MutVisitable<V>,
-{
-    type Extra = T::Extra;
-    fn visit_mut(&mut self, visitor: &mut V, extra: Self::Extra) {
-        self.0.visit_mut(visitor, extra);
-    }
-}
-
 impl<V: MutVisitor, T1, T2> MutVisitable<V> for (T1, T2)
 where
     T1: MutVisitable<V, Extra = ()>,

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -155,12 +155,6 @@ macro_rules! visit_visitable_with {
     };
 }
 
-macro_rules! walk_walkable {
-    ($visitor:expr, $expr:expr, mut) => {
-        MutWalkable::walk_mut($expr, $visitor)
-    };
-}
-
 macro_rules! impl_visitable {
     (|&mut $self:ident: $self_ty:ty,
       $vis:ident: &mut $vis_ty:ident,
@@ -233,7 +227,7 @@ macro_rules! impl_visitable_calling_walkable {
                 let ($($extra_name)?) = extra;
                 visitor.$method(self $(, $extra_name)?);
             });
-            walk_walkable!(self, node, mut)
+            MutWalkable::walk_mut(node, self)
         })*
     }
 }
@@ -243,7 +237,7 @@ macro_rules! define_named_walk {
         $( pub fn $method:ident($ty:ty); )*
     ) => {
         $(pub fn $method<V: $Visitor>(visitor: &mut V, node: &mut $ty) {
-            walk_walkable!(visitor, node, mut)
+            MutWalkable::walk_mut(node, visitor)
         })*
     };
 }

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -172,7 +172,6 @@ macro_rules! impl_visitable {
 macro_rules! impl_walkable {
     (|&mut $self:ident: $self_ty:ty,
       $vis:ident: &mut $vis_ty:ident| $block:block) => {
-        #[allow(unused_parens, non_local_definitions)]
         impl<$vis_ty: MutVisitor> MutWalkable<$vis_ty> for $self_ty {
             fn walk_mut(&mut $self, $vis: &mut $vis_ty) -> V::Result {
                 $block

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -181,7 +181,7 @@ macro_rules! impl_walkable {
 }
 
 macro_rules! impl_visitable_noop {
-    (<mut> $($ty:ty,)*) => {
+    ($($ty:ty,)*) => {
         $(
             impl_visitable!(|&mut self: $ty, _vis: &mut V, _extra: ()| {});
         )*
@@ -189,7 +189,7 @@ macro_rules! impl_visitable_noop {
 }
 
 macro_rules! impl_visitable_list {
-    (<mut> $($ty:ty,)*) => {
+    ($($ty:ty,)*) => {
         $(impl<V: MutVisitor, T> MutVisitable<V> for $ty
         where
             for<'a> &'a mut $ty: IntoIterator<Item = &'a mut T>,
@@ -208,7 +208,7 @@ macro_rules! impl_visitable_list {
 }
 
 macro_rules! impl_visitable_direct {
-    (<mut> $($ty:ty,)*) => {
+    ($($ty:ty,)*) => {
         $(impl_visitable!(
             |&mut self: $ty, visitor: &mut V, _extra: ()| {
                 MutWalkable::walk_mut(self, visitor)
@@ -218,7 +218,7 @@ macro_rules! impl_visitable_direct {
 }
 
 macro_rules! impl_visitable_calling_walkable {
-    (<mut>
+    (
         $( fn $method:ident($ty:ty $(, $extra_name:ident: $extra_ty:ty)?); )*
     ) => {
         $(fn $method(&mut self, node: &mut $ty $(, $extra_name:$extra_ty)?) {

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -343,7 +343,7 @@ macro_rules! common_visitor_and_walkers {
         }
 
         // This macro generates `impl Visitable` and `impl MutVisitable` that do nothing.
-        impl_visitable_noop!(<$($lt)? $($mut)?>
+        impl_visitable_noop!($(<$lt>)?
             AttrId,
             bool,
             rustc_span::ByteSymbol,
@@ -372,7 +372,7 @@ macro_rules! common_visitor_and_walkers {
         // This macro generates `impl Visitable` and `impl MutVisitable` that simply iterate over
         // their contents. We do not use a generic impl for `ThinVec` because we want to allow
         // custom visits for the `MutVisitor`.
-        impl_visitable_list!(<$($lt)? $($mut)?>
+        impl_visitable_list!($(<$lt>)?
             ThinVec<AngleBracketedArg>,
             ThinVec<Attribute>,
             ThinVec<GenericBound>,
@@ -393,7 +393,7 @@ macro_rules! common_visitor_and_walkers {
         // This macro generates `impl Visitable` and `impl MutVisitable` that forward to `Walkable`
         // or `MutWalkable`. By default, all types that do not have a custom visit method in the
         // visitor should appear here.
-        impl_visitable_direct!(<$($lt)? $($mut)?>
+        impl_visitable_direct!($(<$lt>)?
             AngleBracketedArg,
             AngleBracketedArgs,
             AsmMacro,
@@ -546,7 +546,7 @@ macro_rules! common_visitor_and_walkers {
             // This macro defines a custom visit method for each listed type.
             // It implements `impl Visitable` and `impl MutVisitable` to call those methods on the
             // visitor.
-            impl_visitable_calling_walkable!(<$($lt)? $($mut)?>
+            impl_visitable_calling_walkable!($(<$lt>)?
                 fn visit_anon_const(AnonConst);
                 fn visit_arm(Arm);
                 //fn visit_assoc_item(AssocItem, _ctxt: AssocCtxt);
@@ -765,7 +765,7 @@ macro_rules! common_visitor_and_walkers {
             }
             V::Result::output()
         });)?
-        $(impl_visitable_list!(<$mut> ThinVec<(UseTree, NodeId)>,);)?
+        $(${ignore($mut)} impl_visitable_list!(ThinVec<(UseTree, NodeId)>,);)?
 
         fn walk_item_inner<$($lt,)? K: WalkItemKind, V: $Visitor$(<$lt>)?>(
             visitor: &mut V,

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -220,7 +220,6 @@ macro_rules! impl_visitable {
 macro_rules! impl_walkable {
     (|&$lt:lifetime $self:ident: $self_ty:ty,
       $vis:ident: &mut $vis_ty:ident| $block:block) => {
-        #[allow(unused_parens, non_local_definitions)]
         impl<$lt, $vis_ty: Visitor<$lt>> Walkable<$lt, $vis_ty> for $self_ty {
             fn walk_ref(&$lt $self, $vis: &mut $vis_ty) -> V::Result {
                 $block

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -539,7 +539,7 @@ macro_rules! common_visitor_and_walkers {
                 impl_visitable!(|&$($lt)? $($mut)? self: Ident, visitor: &mut V, _extra: ()| {
                     visitor.visit_ident(self)
                 });
-                visit_visitable!($($mut)? self, span);
+                visit_visitable!(self, span);
                 Self::Result::output()
             }
 
@@ -773,9 +773,9 @@ macro_rules! common_visitor_and_walkers {
             ctxt: K::Ctxt,
         ) -> V::Result {
             let Item { attrs, id, kind, vis, span, tokens: _ } = item;
-            visit_visitable!($($mut)? visitor, id, attrs, vis);
+            visit_visitable!(visitor, id, attrs, vis);
             try_visit!(kind.walk(attrs, *span, *id, vis, ctxt, visitor));
-            visit_visitable!($($mut)? visitor, span);
+            visit_visitable!(visitor, span);
             V::Result::output()
         }
 
@@ -813,46 +813,46 @@ macro_rules! common_visitor_and_walkers {
                         try_visit!(vis.visit_fn(kind, attrs, span, id));
                     }
                     ItemKind::ExternCrate(orig_name, ident) =>
-                        visit_visitable!($($mut)? vis, orig_name, ident),
+                        visit_visitable!(vis, orig_name, ident),
                     ItemKind::Use(use_tree) =>
-                        visit_visitable!($($mut)? vis, use_tree),
+                        visit_visitable!(vis, use_tree),
                     ItemKind::Static(item) =>
-                        visit_visitable!($($mut)? vis, item),
+                        visit_visitable!(vis, item),
                     ItemKind::ConstBlock(item) =>
-                        visit_visitable!($($mut)? vis, item),
+                        visit_visitable!(vis, item),
                     ItemKind::Const(item) =>
-                        visit_visitable!($($mut)? vis, item),
+                        visit_visitable!(vis, item),
                     ItemKind::Mod(safety, ident, mod_kind) =>
-                        visit_visitable!($($mut)? vis, safety, ident, mod_kind),
+                        visit_visitable!(vis, safety, ident, mod_kind),
                     ItemKind::ForeignMod(nm) =>
-                        visit_visitable!($($mut)? vis, nm),
+                        visit_visitable!(vis, nm),
                     ItemKind::GlobalAsm(asm) =>
-                        visit_visitable!($($mut)? vis, asm),
+                        visit_visitable!(vis, asm),
                     ItemKind::TyAlias(ty_alias) =>
-                        visit_visitable!($($mut)? vis, ty_alias),
+                        visit_visitable!(vis, ty_alias),
                     ItemKind::Enum(ident, generics, enum_definition) =>
-                        visit_visitable!($($mut)? vis, ident, generics, enum_definition),
+                        visit_visitable!(vis, ident, generics, enum_definition),
                     ItemKind::Struct(ident, generics, variant_data)
                     | ItemKind::Union(ident, generics, variant_data) =>
-                        visit_visitable!($($mut)? vis, ident, generics, variant_data),
+                        visit_visitable!(vis, ident, generics, variant_data),
                     ItemKind::Impl(impl_) =>
-                        visit_visitable!($($mut)? vis, impl_),
+                        visit_visitable!(vis, impl_),
                     ItemKind::Trait(trait_) =>
-                        visit_visitable!($($mut)? vis, trait_),
+                        visit_visitable!(vis, trait_),
                     ItemKind::TraitAlias(TraitAlias { constness, ident, generics, bounds}) => {
-                        visit_visitable!($($mut)? vis, constness, ident, generics);
-                        visit_visitable_with!($($mut)? vis, bounds, BoundKind::Bound)
+                        visit_visitable!(vis, constness, ident, generics);
+                        visit_visitable_with!(vis, bounds, BoundKind::Bound)
                     }
                     ItemKind::MacCall(m) =>
-                        visit_visitable!($($mut)? vis, m),
+                        visit_visitable!(vis, m),
                     ItemKind::MacroDef(ident, def) =>
-                        visit_visitable!($($mut)? vis, ident, def),
+                        visit_visitable!(vis, ident, def),
                     ItemKind::Delegation(delegation) =>
-                        visit_visitable!($($mut)? vis, delegation),
+                        visit_visitable!(vis, delegation),
                     ItemKind::DelegationMac(dm) =>
-                        visit_visitable!($($mut)? vis, dm),
+                        visit_visitable!(vis, dm),
                     ItemKind::TestBinderConstraints(item) =>
-                        visit_visitable!($($mut)? vis, item),
+                        visit_visitable!(vis, item),
                 }
                 V::Result::output()
             }
@@ -871,19 +871,19 @@ macro_rules! common_visitor_and_walkers {
             ) -> V::Result {
                 match self {
                     AssocItemKind::Const(item) =>
-                        visit_visitable!($($mut)? vis, item),
+                        visit_visitable!(vis, item),
                     AssocItemKind::Fn(func) => {
                         let kind = FnKind::Fn(FnCtxt::Assoc(ctxt), visibility, &$($mut)? *func);
                         try_visit!(vis.visit_fn(kind, attrs, span, id))
                     }
                     AssocItemKind::Type(alias) =>
-                        visit_visitable!($($mut)? vis, alias),
+                        visit_visitable!(vis, alias),
                     AssocItemKind::MacCall(mac) =>
-                        visit_visitable!($($mut)? vis, mac),
+                        visit_visitable!(vis, mac),
                     AssocItemKind::Delegation(delegation) =>
-                        visit_visitable!($($mut)? vis, delegation),
+                        visit_visitable!(vis, delegation),
                     AssocItemKind::DelegationMac(dm) =>
-                        visit_visitable!($($mut)? vis, dm),
+                        visit_visitable!(vis, dm),
                 }
                 V::Result::output()
             }
@@ -902,15 +902,15 @@ macro_rules! common_visitor_and_walkers {
             ) -> V::Result {
                 match self {
                     ForeignItemKind::Static(item) =>
-                        visit_visitable!($($mut)? vis, item),
+                        visit_visitable!(vis, item),
                     ForeignItemKind::Fn(func) => {
                         let kind = FnKind::Fn(FnCtxt::Foreign, visibility, &$($mut)?*func);
                         try_visit!(vis.visit_fn(kind, attrs, span, id))
                     }
                     ForeignItemKind::TyAlias(alias) =>
-                        visit_visitable!($($mut)? vis, alias),
+                        visit_visitable!(vis, alias),
                     ForeignItemKind::MacCall(mac) =>
-                        visit_visitable!($($mut)? vis, mac),
+                        visit_visitable!(vis, mac),
                 }
                 V::Result::output()
             }
@@ -925,13 +925,13 @@ macro_rules! common_visitor_and_walkers {
                     Fn { defaultness, ident, sig, generics, contract, body, define_opaque, eii_impl },
                 ) => {
                     let FnSig { header, decl, span } = sig;
-                    visit_visitable!($($mut)? vis,
+                    visit_visitable!(vis,
                         defaultness, ident, header, generics, decl,
                         contract, body, span, define_opaque, eii_impl
                     );
                 }
                 FnKind::Closure(binder, coroutine_marker, decl, body) =>
-                    visit_visitable!($($mut)? vis, binder, coroutine_marker, decl, body),
+                    visit_visitable!(vis, binder, coroutine_marker, decl, body),
             }
             V::Result::output()
         }
@@ -941,10 +941,10 @@ macro_rules! common_visitor_and_walkers {
             try_visit!(vis.visit_generics(generics));
             if let Some(of_trait) = of_trait {
                 let TraitImplHeader { defaultness, safety, polarity, trait_ref } = of_trait;
-                visit_visitable!($($mut)? vis, defaultness, safety, polarity, trait_ref);
+                visit_visitable!(vis, defaultness, safety, polarity, trait_ref);
             }
             try_visit!(vis.visit_ty(self_ty));
-            visit_visitable_with!($($mut)? vis, items, AssocCtxt::Impl { of_trait: of_trait.is_some() });
+            visit_visitable_with!(vis, items, AssocCtxt::Impl { of_trait: of_trait.is_some() });
             V::Result::output()
         });
 
@@ -952,48 +952,48 @@ macro_rules! common_visitor_and_walkers {
         impl_walkable!(|&$($mut)? $($lt)? self: MethodCall, vis: &mut V| {
             let MethodCall { seg, receiver, args, span } = self;
             try_visit!(vis.visit_method_receiver_expr(receiver));
-            visit_visitable!($($mut)? vis, seg, args, span);
+            visit_visitable!(vis, seg, args, span);
             V::Result::output()
         });
 
         impl_walkable!(|&$($mut)? $($lt)? self: Expr, vis: &mut V| {
             let Expr { id, kind, span, attrs, tokens: _ } = self;
-            visit_visitable!($($mut)? vis, id, attrs);
+            visit_visitable!(vis, id, attrs);
             match kind {
                 ExprKind::Array(exprs) =>
-                    visit_visitable!($($mut)? vis, exprs),
+                    visit_visitable!(vis, exprs),
                 ExprKind::ConstBlock(anon_const) =>
-                    visit_visitable!($($mut)? vis, anon_const),
+                    visit_visitable!(vis, anon_const),
                 ExprKind::Repeat(element, count) =>
-                    visit_visitable!($($mut)? vis, element, count),
+                    visit_visitable!(vis, element, count),
                 ExprKind::Struct(se) =>
-                    visit_visitable!($($mut)? vis, se),
+                    visit_visitable!(vis, se),
                 ExprKind::Tup(exprs) =>
-                    visit_visitable!($($mut)? vis, exprs),
+                    visit_visitable!(vis, exprs),
                 ExprKind::Call(callee_expression, arguments) =>
-                    visit_visitable!($($mut)? vis, callee_expression, arguments),
+                    visit_visitable!(vis, callee_expression, arguments),
                 ExprKind::MethodCall(mc) =>
-                    visit_visitable!($($mut)? vis, mc),
+                    visit_visitable!(vis, mc),
                 ExprKind::Binary(op, lhs, rhs) =>
-                    visit_visitable!($($mut)? vis, op, lhs, rhs),
+                    visit_visitable!(vis, op, lhs, rhs),
                 ExprKind::AddrOf(kind, mutbl, subexpression) =>
-                    visit_visitable!($($mut)? vis, kind, mutbl, subexpression),
+                    visit_visitable!(vis, kind, mutbl, subexpression),
                 ExprKind::Unary(op, subexpression) =>
-                    visit_visitable!($($mut)? vis, op, subexpression),
+                    visit_visitable!(vis, op, subexpression),
                 ExprKind::Cast(subexpression, typ) | ExprKind::Type(subexpression, typ) =>
-                    visit_visitable!($($mut)? vis, subexpression, typ),
+                    visit_visitable!(vis, subexpression, typ),
                 ExprKind::Let(pat, expr, span, _recovered) =>
-                    visit_visitable!($($mut)? vis, pat, expr, span),
+                    visit_visitable!(vis, pat, expr, span),
                 ExprKind::If(head_expression, if_block, optional_else) =>
-                    visit_visitable!($($mut)? vis, head_expression, if_block, optional_else),
+                    visit_visitable!(vis, head_expression, if_block, optional_else),
                 ExprKind::While(subexpression, block, opt_label) =>
-                    visit_visitable!($($mut)? vis, subexpression, block, opt_label),
+                    visit_visitable!(vis, subexpression, block, opt_label),
                 ExprKind::ForLoop(ForLoop { pat, iter, body, label, kind }) =>
-                    visit_visitable!($($mut)? vis, pat, iter, body, label, kind),
+                    visit_visitable!(vis, pat, iter, body, label, kind),
                 ExprKind::Loop(block, opt_label, span) =>
-                    visit_visitable!($($mut)? vis, block, opt_label, span),
+                    visit_visitable!(vis, block, opt_label, span),
                 ExprKind::Match(subexpression, arms, kind) =>
-                    visit_visitable!($($mut)? vis, subexpression, arms, kind),
+                    visit_visitable!(vis, subexpression, arms, kind),
                 ExprKind::Closure(Closure {
                     binder,
                     capture_clause,
@@ -1005,73 +1005,73 @@ macro_rules! common_visitor_and_walkers {
                     fn_decl_span,
                     fn_arg_span,
                 }) => {
-                    visit_visitable!($($mut)? vis, constness, movability, capture_clause);
+                    visit_visitable!(vis, constness, movability, capture_clause);
                     let kind = FnKind::Closure(binder, coroutine_marker, fn_decl, body);
                     try_visit!(vis.visit_fn(kind, attrs, *span, *id));
-                    visit_visitable!($($mut)? vis, fn_decl_span, fn_arg_span);
+                    visit_visitable!(vis, fn_decl_span, fn_arg_span);
                 }
                 ExprKind::Block(block, opt_label) =>
-                    visit_visitable!($($mut)? vis, block, opt_label),
+                    visit_visitable!(vis, block, opt_label),
                 ExprKind::Gen(capt, body, kind, decl_span) =>
-                    visit_visitable!($($mut)? vis, capt, body, kind, decl_span),
+                    visit_visitable!(vis, capt, body, kind, decl_span),
                 ExprKind::Await(expr, span)
                 | ExprKind::Move(expr, span)
                 | ExprKind::Use(expr, span) =>
-                    visit_visitable!($($mut)? vis, expr, span),
+                    visit_visitable!(vis, expr, span),
                 ExprKind::Assign(lhs, rhs, span) =>
-                    visit_visitable!($($mut)? vis, lhs, rhs, span),
+                    visit_visitable!(vis, lhs, rhs, span),
                 ExprKind::AssignOp(op, lhs, rhs) =>
-                    visit_visitable!($($mut)? vis, op, lhs, rhs),
+                    visit_visitable!(vis, op, lhs, rhs),
                 ExprKind::Field(subexpression, ident) =>
-                    visit_visitable!($($mut)? vis, subexpression, ident),
+                    visit_visitable!(vis, subexpression, ident),
                 ExprKind::Index(main_expression, index_expression, span) =>
-                    visit_visitable!($($mut)? vis, main_expression, index_expression, span),
+                    visit_visitable!(vis, main_expression, index_expression, span),
                 ExprKind::Range(start, end, limit) =>
-                    visit_visitable!($($mut)? vis, start, end, limit),
+                    visit_visitable!(vis, start, end, limit),
                 ExprKind::Underscore => {}
                 ExprKind::Path(maybe_qself, path) =>
-                    visit_visitable!($($mut)? vis, maybe_qself, path),
+                    visit_visitable!(vis, maybe_qself, path),
                 ExprKind::Break(opt_label, opt_expr) =>
-                    visit_visitable!($($mut)? vis, opt_label, opt_expr),
+                    visit_visitable!(vis, opt_label, opt_expr),
                 ExprKind::Continue(opt_label) =>
-                    visit_visitable!($($mut)? vis, opt_label),
+                    visit_visitable!(vis, opt_label),
                 ExprKind::Ret(optional_expression) | ExprKind::Yeet(optional_expression) =>
-                    visit_visitable!($($mut)? vis, optional_expression),
+                    visit_visitable!(vis, optional_expression),
                 ExprKind::Become(expr) =>
-                    visit_visitable!($($mut)? vis, expr),
+                    visit_visitable!(vis, expr),
                 ExprKind::MacCall(mac) =>
-                    visit_visitable!($($mut)? vis, mac),
+                    visit_visitable!(vis, mac),
                 ExprKind::Paren(subexpression) =>
-                    visit_visitable!($($mut)? vis, subexpression),
+                    visit_visitable!(vis, subexpression),
                 ExprKind::InlineAsm(asm) =>
-                    visit_visitable!($($mut)? vis, asm),
+                    visit_visitable!(vis, asm),
                 ExprKind::FormatArgs(f) =>
-                    visit_visitable!($($mut)? vis, f),
+                    visit_visitable!(vis, f),
                 ExprKind::OffsetOf(container, fields) =>
-                    visit_visitable!($($mut)? vis, container, fields),
+                    visit_visitable!(vis, container, fields),
                 ExprKind::Yield(kind) =>
-                    visit_visitable!($($mut)? vis, kind),
+                    visit_visitable!(vis, kind),
                 ExprKind::Try(subexpression) =>
-                    visit_visitable!($($mut)? vis, subexpression),
+                    visit_visitable!(vis, subexpression),
                 ExprKind::TryBlock(body, optional_type) =>
-                    visit_visitable!($($mut)? vis, body, optional_type),
+                    visit_visitable!(vis, body, optional_type),
                 ExprKind::Lit(token) =>
-                    visit_visitable!($($mut)? vis, token),
+                    visit_visitable!(vis, token),
                 ExprKind::IncludedBytes(bytes) =>
-                    visit_visitable!($($mut)? vis, bytes),
+                    visit_visitable!(vis, bytes),
                 ExprKind::UnsafeBinderCast(kind, expr, ty) =>
-                    visit_visitable!($($mut)? vis, kind, expr, ty),
+                    visit_visitable!(vis, kind, expr, ty),
                 ExprKind::DirectConstArg(expr) =>
-                    visit_visitable!($($mut)? vis, expr),
+                    visit_visitable!(vis, expr),
                 ExprKind::Err(_guar) => {}
                 ExprKind::Dummy => {}
             }
 
-            visit_visitable!($($mut)? vis, span);
+            visit_visitable!(vis, span);
             V::Result::output()
         });
 
-        define_named_walk!($(($mut))? $Visitor$(<$lt>)?
+        define_named_walk!($Visitor$(<$lt>)?
             pub fn walk_anon_const(AnonConst);
             pub fn walk_arm(Arm);
             //pub fn walk_assoc_item(AssocItem, _ctxt: AssocCtxt);

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -141,16 +141,6 @@ where
     }
 }
 
-impl<'a, V: Visitor<'a>, T> Visitable<'a, V> for (T,)
-where
-    T: Visitable<'a, V>,
-{
-    type Extra = T::Extra;
-    fn visit(&'a self, visitor: &mut V, extra: Self::Extra) -> V::Result {
-        self.0.visit(visitor, extra)
-    }
-}
-
 impl<'a, V: Visitor<'a>, T1, T2> Visitable<'a, V> for (T1, T2)
 where
     T1: Visitable<'a, V, Extra = ()>,

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -1137,50 +1137,36 @@ macro_rules! common_visitor_and_walkers {
 common_visitor_and_walkers!(Visitor<'a>);
 
 macro_rules! generate_list_visit_fns {
-    ($($name:ident, $Ty:ty, $visit_fn:ident$(, $param:ident: $ParamTy:ty)*;)+) => {
+    ($($visit_fn:ident, $Ty:ty $(, $param:ident: $ParamTy:ty)?;)+) => {
         $(
             #[allow(unused_parens)]
             impl<'a, V: Visitor<'a>> Visitable<'a, V> for ThinVec<$Ty> {
-                type Extra = ($($ParamTy),*);
+                type Extra = ($($ParamTy)?);
 
                 #[inline]
-                fn visit(
-                    &'a self,
-                    visitor: &mut V,
-                    ($($param),*): Self::Extra,
-                ) -> V::Result {
-                    $name(visitor, self $(, $param)*)
+                fn visit(&'a self, visitor: &mut V, ($($param)?): Self::Extra) -> V::Result {
+                    walk_list!(visitor, $visit_fn, self $(, $param)?);
+                    V::Result::output()
                 }
-            }
-
-            fn $name<'a, V: Visitor<'a>>(
-                vis: &mut V,
-                values: &'a ThinVec<$Ty>,
-                $(
-                    $param: $ParamTy,
-                )*
-            ) -> V::Result {
-                walk_list!(vis, $visit_fn, values$(,$param)*);
-                V::Result::output()
             }
         )+
     }
 }
 
 generate_list_visit_fns! {
-    visit_items, Box<Item>, visit_item;
-    visit_foreign_items, Box<ForeignItem>, visit_foreign_item;
-    visit_generic_params, GenericParam, visit_generic_param;
-    visit_stmts, Stmt, visit_stmt;
-    visit_exprs, Box<Expr>, visit_expr;
-    visit_expr_fields, ExprField, visit_expr_field;
-    visit_pat_fields, PatField, visit_pat_field;
-    visit_variants, Variant, visit_variant;
-    visit_assoc_items, Box<AssocItem>, visit_assoc_item, ctxt: AssocCtxt;
-    visit_where_predicates, WherePredicate, visit_where_predicate;
-    visit_params, Param, visit_param;
-    visit_field_defs, FieldDef, visit_field_def;
-    visit_arms, Arm, visit_arm;
+    visit_item, Box<Item>;
+    visit_foreign_item, Box<ForeignItem>;
+    visit_generic_param, GenericParam;
+    visit_stmt, Stmt;
+    visit_expr, Box<Expr>;
+    visit_expr_field, ExprField;
+    visit_pat_field, PatField;
+    visit_variant, Variant;
+    visit_assoc_item, Box<AssocItem>, ctxt: AssocCtxt;
+    visit_where_predicate, WherePredicate;
+    visit_param, Param;
+    visit_field_def, FieldDef;
+    visit_arm, Arm;
 }
 
 pub fn walk_stmt<'a, V: Visitor<'a>>(visitor: &mut V, statement: &'a Stmt) -> V::Result {

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -540,7 +540,8 @@ macro_rules! common_visitor_and_walkers {
                 impl_visitable!(|&$($lt)? $($mut)? self: Ident, visitor: &mut V, _extra: ()| {
                     visitor.visit_ident(self)
                 });
-                visit_span(self, span)
+                visit_visitable!($($mut)? self, span);
+                Self::Result::output()
             }
 
             // This macro defines a custom visit method for each listed type.
@@ -757,17 +758,6 @@ macro_rules! common_visitor_and_walkers {
                 ctxt: Self::Ctxt,
                 vis: &mut V,
             ) -> V::Result;
-        }
-
-        // This is only used by the MutVisitor. We include this symmetry here to make writing other
-        // functions easier.
-        $(${ignore($lt)}
-            #[expect(unused, rustc::disallowed_pass_by_ref)]
-            #[inline]
-        )?
-        fn visit_span<$($lt,)? V: $Visitor$(<$lt>)?>(vis: &mut V, span: &$($lt)? $($mut)? Span) -> V::Result {
-            $(${ignore($mut)} vis.visit_span(span))?;
-            V::Result::output()
         }
 
         $(impl_visitable!(|&$lt self: ThinVec<(UseTree, NodeId)>, vis: &mut V, _extra: ()| {
@@ -1078,7 +1068,8 @@ macro_rules! common_visitor_and_walkers {
                 ExprKind::Dummy => {}
             }
 
-            visit_span(vis, span)
+            visit_visitable!($($mut)? vis, span);
+            V::Result::output()
         });
 
         define_named_walk!($(($mut))? $Visitor$(<$lt>)?

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -308,7 +308,7 @@ macro_rules! common_visitor_and_walkers {
                 &'a $($mut)? ClosureBinder,
                 &'a $($mut)? Option<CoroutineMarker>,
                 &'a $($mut)? Box<FnDecl>,
-                &'a $($mut)? Box<Expr>
+                &'a $($mut)? Box<Expr>,
             ),
         }
 
@@ -490,7 +490,11 @@ macro_rules! common_visitor_and_walkers {
         /// Each method of this trait is a hook to be potentially
         /// overridden. Each method's default implementation recursively visits
         /// the substructure of the input via the corresponding `walk` method;
-        #[doc = concat!(" e.g., the `visit_item` method by default calls `visit"$(, "_", stringify!($mut))?, "::walk_item`.")]
+        #[doc = concat!(
+            " e.g., the `visit_item` method by default calls `visit"
+            $(, "_", stringify!($mut))?,
+            "::walk_item`."
+        )]
         ///
         /// If you want to ensure that your code handles every variant
         /// explicitly, you need to override each method. (And you also need
@@ -500,7 +504,7 @@ macro_rules! common_visitor_and_walkers {
         /// Every `walk_*` method uses deconstruction to access fields of structs and
         /// enums. This will result in a compile error if a field is added, which makes
         /// it more likely the appropriate visit call will be added for it.
-        pub trait $Visitor<$($lt)?> : Sized $(${ignore($mut)} + MutVisitorResult<Result = ()>)? {
+        pub trait $Visitor<$($lt)?>: Sized $(${ignore($mut)} + MutVisitorResult<Result = ()>)? {
             $(
                 ${ignore($lt)}
                 /// The result type of the `visit_*` methods. Can be either `()`,
@@ -535,7 +539,9 @@ macro_rules! common_visitor_and_walkers {
             // version will cause a compile error, which is good. In comparison, the
             // field access version will continue working and it would be easy to
             // forget to add handling for it.
-            fn visit_ident(&mut self, Ident { name: _, span }: &$($lt)? $($mut)? Ident) -> Self::Result {
+            fn visit_ident(&mut self, Ident { name: _, span }: &$($lt)? $($mut)? Ident)
+                -> Self::Result
+            {
                 impl_visitable!(|&$($lt)? $($mut)? self: Ident, visitor: &mut V, _extra: ()| {
                     visitor.visit_ident(self)
                 });
@@ -643,7 +649,9 @@ macro_rules! common_visitor_and_walkers {
                 walk_item(self, item)
             }
 
-            fn visit_assoc_item(&mut self, item: &$($lt)? $($mut)? AssocItem, ctxt: AssocCtxt) -> Self::Result {
+            fn visit_assoc_item(&mut self, item: &$($lt)? $($mut)? AssocItem, ctxt: AssocCtxt)
+                -> Self::Result
+            {
                 impl_visitable!(|&$($lt)? $($mut)? self: AssocItem, vis: &mut V, ctxt: AssocCtxt| {
                     vis.visit_assoc_item(self, ctxt)
                 });
@@ -667,7 +675,9 @@ macro_rules! common_visitor_and_walkers {
                     walk_stmt(self, s)
                 }
 
-                fn visit_nested_use_tree(&mut self, use_tree: &$lt UseTree, id: NodeId) -> Self::Result {
+                fn visit_nested_use_tree(&mut self, use_tree: &$lt UseTree, id: NodeId)
+                    -> Self::Result
+                {
                     try_visit!(self.visit_id(id));
                     self.visit_use_tree(use_tree)
                 }
@@ -685,7 +695,9 @@ macro_rules! common_visitor_and_walkers {
                     // Do nothing.
                 }
 
-                fn flat_map_foreign_item(&mut self, ni: Box<ForeignItem>) -> SmallVec<[Box<ForeignItem>; 1]> {
+                fn flat_map_foreign_item(&mut self, ni: Box<ForeignItem>)
+                    -> SmallVec<[Box<ForeignItem>; 1]>
+                {
                     walk_flat_map_foreign_item(self, ni)
                 }
 
@@ -725,7 +737,9 @@ macro_rules! common_visitor_and_walkers {
                     walk_flat_map_param(self, param)
                 }
 
-                fn flat_map_generic_param(&mut self, param: GenericParam) -> SmallVec<[GenericParam; 1]> {
+                fn flat_map_generic_param(&mut self, param: GenericParam)
+                    -> SmallVec<[GenericParam; 1]>
+                {
                     walk_flat_map_generic_param(self, param)
                 }
 
@@ -769,7 +783,7 @@ macro_rules! common_visitor_and_walkers {
 
         fn walk_item_inner<$($lt,)? K: WalkItemKind, V: $Visitor$(<$lt>)?>(
             visitor: &mut V,
-            item: &$($mut)? $($lt)? Item<K>,
+            item: &$($lt)? $($mut)? Item<K>,
             ctxt: K::Ctxt,
         ) -> V::Result {
             let Item { attrs, id, kind, vis, span, tokens: _ } = item;
@@ -782,7 +796,7 @@ macro_rules! common_visitor_and_walkers {
         // Do not implement `Walkable`/`MutWalkable` for *Item to avoid confusion.
         pub fn walk_item<$($lt,)? K: WalkItemKind<Ctxt = ()>, V: $Visitor$(<$lt>)?>(
             visitor: &mut V,
-            item: &$($mut)? $($lt)? Item<K>,
+            item: &$($lt)? $($mut)? Item<K>,
         ) -> V::Result {
             walk_item_inner(visitor, item, ())
         }
@@ -790,7 +804,7 @@ macro_rules! common_visitor_and_walkers {
         // Do not implement `Walkable`/`MutWalkable` for *Item to avoid confusion.
         pub fn walk_assoc_item<$($lt,)? K: WalkItemKind<Ctxt = AssocCtxt>, V: $Visitor$(<$lt>)?>(
             visitor: &mut V,
-            item: &$($mut)? $($lt)? Item<K>,
+            item: &$($lt)? $($mut)? Item<K>,
             ctxt: AssocCtxt,
         ) -> V::Result {
             walk_item_inner(visitor, item, ctxt)
@@ -839,7 +853,7 @@ macro_rules! common_visitor_and_walkers {
                         visit_visitable!(vis, impl_),
                     ItemKind::Trait(trait_) =>
                         visit_visitable!(vis, trait_),
-                    ItemKind::TraitAlias(TraitAlias { constness, ident, generics, bounds}) => {
+                    ItemKind::TraitAlias(TraitAlias { constness, ident, generics, bounds }) => {
                         visit_visitable!(vis, constness, ident, generics);
                         visit_visitable_with!(vis, bounds, BoundKind::Bound)
                     }
@@ -904,7 +918,7 @@ macro_rules! common_visitor_and_walkers {
                     ForeignItemKind::Static(item) =>
                         visit_visitable!(vis, item),
                     ForeignItemKind::Fn(func) => {
-                        let kind = FnKind::Fn(FnCtxt::Foreign, visibility, &$($mut)?*func);
+                        let kind = FnKind::Fn(FnCtxt::Foreign, visibility, &$($mut)? *func);
                         try_visit!(vis.visit_fn(kind, attrs, span, id))
                     }
                     ForeignItemKind::TyAlias(alias) =>
@@ -916,13 +930,25 @@ macro_rules! common_visitor_and_walkers {
             }
         }
 
-        pub fn walk_fn<$($lt,)? V: $Visitor$(<$lt>)?>(vis: &mut V, kind: FnKind<$($lt)? $(${ignore($mut)} '_)?>) -> V::Result {
+        pub fn walk_fn<$($lt,)? V: $Visitor$(<$lt>)?>(
+            vis: &mut V,
+            kind: FnKind<$($lt)? $(${ignore($mut)} '_)?>,
+        ) -> V::Result {
             match kind {
                 FnKind::Fn(
                     _ctxt,
                     // Visibility is visited as a part of the item.
                     _vis,
-                    Fn { defaultness, ident, sig, generics, contract, body, define_opaque, eii_impl },
+                    Fn {
+                        defaultness,
+                        ident,
+                        sig,
+                        generics,
+                        contract,
+                        body,
+                        define_opaque,
+                        eii_impl,
+                    },
                 ) => {
                     let FnSig { header, decl, span } = sig;
                     visit_visitable!(vis,
@@ -936,7 +962,7 @@ macro_rules! common_visitor_and_walkers {
             V::Result::output()
         }
 
-        impl_walkable!(|&$($mut)? $($lt)? self: Impl, vis: &mut V| {
+        impl_walkable!(|&$($lt)? $($mut)? self: Impl, vis: &mut V| {
             let Impl { generics, of_trait, self_ty, items, constness: _ } = self;
             try_visit!(vis.visit_generics(generics));
             if let Some(of_trait) = of_trait {
@@ -949,14 +975,14 @@ macro_rules! common_visitor_and_walkers {
         });
 
         // Special case to call `visit_method_receiver_expr`.
-        impl_walkable!(|&$($mut)? $($lt)? self: MethodCall, vis: &mut V| {
+        impl_walkable!(|&$($lt)? $($mut)? self: MethodCall, vis: &mut V| {
             let MethodCall { seg, receiver, args, span } = self;
             try_visit!(vis.visit_method_receiver_expr(receiver));
             visit_visitable!(vis, seg, args, span);
             V::Result::output()
         });
 
-        impl_walkable!(|&$($mut)? $($lt)? self: Expr, vis: &mut V| {
+        impl_walkable!(|&$($lt)? $($mut)? self: Expr, vis: &mut V| {
             let Expr { id, kind, span, attrs, tokens: _ } = self;
             visit_visitable!(vis, id, attrs);
             match kind {

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -203,12 +203,6 @@ macro_rules! visit_visitable_with {
     };
 }
 
-macro_rules! walk_walkable {
-    ($visitor:expr, $expr:expr, ) => {
-        Walkable::walk_ref($expr, $visitor)
-    };
-}
-
 macro_rules! impl_visitable {
     (|&$lt:lifetime $self:ident: $self_ty:ty,
       $vis:ident: &mut $vis_ty:ident,
@@ -284,7 +278,7 @@ macro_rules! impl_visitable_calling_walkable {
                 let ($($extra_name)?) = extra;
                 visitor.$method(self $(, $extra_name)?)
             });
-            walk_walkable!(self, node, )
+            Walkable::walk_ref(node, self)
         })*
     };
 }
@@ -294,7 +288,7 @@ macro_rules! define_named_walk {
         $( pub fn $method:ident($ty:ty); )*
     ) => {
         $(pub fn $method<$lt, V: $Visitor<$lt>>(visitor: &mut V, node: &$lt $ty) -> V::Result {
-            walk_walkable!(visitor, node,)
+            Walkable::walk_ref(node, visitor)
         })*
     };
 }

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -218,10 +218,10 @@ macro_rules! impl_visitable {
 }
 
 macro_rules! impl_walkable {
-    ($(<$K:ident: $Kb:ident>)? |&$lt:lifetime $self:ident: $self_ty:ty,
+    (|&$lt:lifetime $self:ident: $self_ty:ty,
       $vis:ident: &mut $vis_ty:ident| $block:block) => {
         #[allow(unused_parens, non_local_definitions)]
-        impl<$($K: $Kb,)? $lt, $vis_ty: Visitor<$lt>> Walkable<$lt, $vis_ty> for $self_ty {
+        impl<$lt, $vis_ty: Visitor<$lt>> Walkable<$lt, $vis_ty> for $self_ty {
             fn walk_ref(&$lt $self, $vis: &mut $vis_ty) -> V::Result {
                 $block
             }

--- a/compiler/rustc_attr_ir/src/diagnostic.rs
+++ b/compiler/rustc_attr_ir/src/diagnostic.rs
@@ -204,9 +204,9 @@ impl FormatString {
 /// ```rust,ignore (just an example)
 /// FormatArgs {
 ///     this: "FromResidual",
-///     this_resolved: "FromResidual<Option<Infallible>>",
+///     this_resolved: "FromResidual<Option<!>>",
 ///     item_context: "an async function",
-///     generic_args: [("Self", "u32"), ("R", "Option<Infallible>")],
+///     generic_args: [("Self", "u32"), ("R", "Option<!>")],
 /// }
 /// ```
 #[derive(Debug)]
@@ -444,7 +444,7 @@ pub enum LitOrArg {
 ///     crate_local: false,
 ///     direct: true,
 ///     generic_args: [("Self","u32"),
-///         ("R", "core::option::Option<core::convert::Infallible>"),
+///         ("R", "core::option::Option<!>"),
 ///         ("R", "core::option::Option<T>" ),
 ///     ],
 /// }

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -599,6 +599,7 @@ impl<'ll, 'tcx> FnAbiLlvmExt<'ll, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
                 llfn,
                 &cx.tcx.codegen_instance_attrs(instance.def),
                 Some(instance),
+                cx.sanitizer_ignorelist.as_ref(),
             );
         }
     }

--- a/compiler/rustc_codegen_llvm/src/allocator.rs
+++ b/compiler/rustc_codegen_llvm/src/allocator.rs
@@ -125,7 +125,7 @@ fn create_wrapper_function(
         ty,
     );
 
-    llfn_attrs_from_instance(cx, tcx, llfn, attrs, None);
+    llfn_attrs_from_instance(cx, tcx, llfn, attrs, None, None);
 
     let no_return = if no_return {
         // -> ! DIFlagNoReturn

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -7,6 +7,7 @@ use rustc_middle::middle::codegen_fn_attrs::{
     TargetFeature,
 };
 use rustc_middle::ty::{self, Instance, TyCtxt};
+use rustc_sanitizers::ignorelist::SanitizerIgnoreList;
 use rustc_session::config::{
     BranchProtection, FunctionReturn, InstrumentMcount, InstrumentMcountOpts, OptLevel, PAuthKey,
     PacRet,
@@ -137,9 +138,24 @@ pub(crate) fn sanitize_attrs<'ll, 'tcx>(
     cx: &SimpleCx<'ll>,
     tcx: TyCtxt<'tcx>,
     sanitizer_fn_attr: SanitizerFnAttrs,
+    instance: Option<ty::Instance<'tcx>>,
+    sanitizer_ignorelist: Option<&SanitizerIgnoreList>,
 ) -> SmallVec<[&'ll Attribute; 4]> {
     let mut attrs = SmallVec::new();
-    let enabled = tcx.sess.sanitizers() - sanitizer_fn_attr.disabled;
+    let mut enabled = tcx.sess.sanitizers() - sanitizer_fn_attr.disabled;
+    if let Some(ignorelist) = sanitizer_ignorelist {
+        if let Some(instance) = instance {
+            let result = ignorelist.filter_instance_sanitizers(tcx, instance, enabled);
+            enabled = result.enabled;
+            if result.ignore_cfi {
+                attrs.push(llvm::CreateAttrString(cx.llcx, "no-sanitize-cfi"));
+            }
+            if result.ignore_kcfi {
+                attrs.push(llvm::CreateAttrString(cx.llcx, "no-sanitize-kcfi"));
+            }
+        }
+    }
+
     if enabled.contains(SanitizerSet::ADDRESS) || enabled.contains(SanitizerSet::KERNELADDRESS) {
         attrs.push(llvm::AttributeKind::SanitizeAddress.create_attr(cx.llcx));
     }
@@ -476,6 +492,7 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
     llfn: &'ll Value,
     codegen_fn_attrs: &CodegenFnAttrs,
     instance: Option<ty::Instance<'tcx>>,
+    sanitizer_ignorelist: Option<&SanitizerIgnoreList>,
 ) {
     let sess = tcx.sess;
     let mut to_add = SmallVec::<[_; 16]>::new();
@@ -537,7 +554,13 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
         // not used.
     } else {
         // Do not set sanitizer attributes for naked functions.
-        to_add.extend(sanitize_attrs(cx, tcx, codegen_fn_attrs.sanitizers));
+        to_add.extend(sanitize_attrs(
+            cx,
+            tcx,
+            codegen_fn_attrs.sanitizers,
+            instance,
+            sanitizer_ignorelist,
+        ));
 
         // For non-naked functions, set branch protection attributes on aarch64.
         if let Some(BranchProtection { bti, pac_ret, gcs }) = sess.branch_protection() {

--- a/compiler/rustc_codegen_llvm/src/base.rs
+++ b/compiler/rustc_codegen_llvm/src/base.rs
@@ -129,7 +129,8 @@ pub(crate) fn compile_codegen_unit(
             if let Some(entry) =
                 maybe_create_entry_wrapper::<Builder<'_, '_, '_>>(&cx, cx.codegen_unit)
             {
-                let mut attrs = attributes::sanitize_attrs(&cx, tcx, SanitizerFnAttrs::default());
+                let mut attrs =
+                    attributes::sanitize_attrs(&cx, tcx, SanitizerFnAttrs::default(), None, None);
                 // When pointer authentication is enabled, ensure that the ptrauth-* attributes are
                 // also attached to the entry wrapper.
                 //

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -1961,7 +1961,7 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
 
         // Emit KCFI operand bundle
         let kcfi_bundle = self.kcfi_operand_bundle(fn_attrs, fn_abi, instance, llfn);
-        if let Some(kcfi_bundle) = kcfi_bundle.as_ref().map(|b| b.as_ref()) {
+        if let Some(kcfi_bundle) = kcfi_bundle.as_ref().map(|bundle| bundle.as_ref()) {
             bundles.push(kcfi_bundle);
         }
 
@@ -2009,6 +2009,9 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
             {
                 return;
             }
+            if crate::llvm::HasStringAttribute(self.llfn(), "no-sanitize-cfi") {
+                return;
+            }
 
             let mut options = cfi::TypeIdOptions::empty();
             if self.tcx.sess.is_sanitizer_cfi_generalize_pointers_enabled() {
@@ -2016,6 +2019,10 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
             }
             if self.tcx.sess.is_sanitizer_cfi_normalize_integers_enabled() {
                 options.insert(cfi::TypeIdOptions::NORMALIZE_INTEGERS);
+            }
+
+            if self.cx.is_sanitizer_type_ignored(c"cfi", fn_abi) {
+                return;
             }
 
             let typeid = if let Some(instance) = instance {
@@ -2123,6 +2130,9 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
             {
                 return None;
             }
+            if crate::llvm::HasStringAttribute(self.llfn(), "no-sanitize-kcfi") {
+                return None;
+            }
 
             let mut options = kcfi::TypeIdOptions::empty();
             if self.tcx.sess.is_sanitizer_cfi_generalize_pointers_enabled() {
@@ -2130,6 +2140,10 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
             }
             if self.tcx.sess.is_sanitizer_cfi_normalize_integers_enabled() {
                 options.insert(kcfi::TypeIdOptions::NORMALIZE_INTEGERS);
+            }
+
+            if self.cx.is_sanitizer_type_ignored(c"kcfi", fn_abi) {
+                return None;
             }
 
             let kcfi_typeid = if let Some(instance) = instance {

--- a/compiler/rustc_codegen_llvm/src/consts.rs
+++ b/compiler/rustc_codegen_llvm/src/consts.rs
@@ -570,6 +570,81 @@ impl<'ll> CodegenCx<'ll, '_> {
         base::set_link_section(g, attrs);
         base::set_variable_sanitizer_attrs(g, attrs);
 
+        if let Some(ignorelist) = &self.sanitizer_ignorelist {
+            let instance = ty::Instance::mono(self.tcx, def_id);
+            let sym_name = self.tcx.symbol_name(instance).name;
+            let span = self.tcx.def_span(def_id);
+            let source_map = self.tcx.sess.source_map();
+            let filename =
+                source_map.span_to_filename(span).prefer_local_unconditionally().to_string();
+            let ty_name = rustc_middle::ty::print::with_no_trimmed_paths!(
+                self.tcx.type_of(def_id).skip_binder().to_string()
+            );
+            let mainfile = self
+                .tcx
+                .sess
+                .local_crate_source_file()
+                .and_then(|path| path.local_path().map(|p| p.display().to_string()))
+                .unwrap_or_default();
+
+            let demangled =
+                rustc_middle::ty::print::with_no_trimmed_paths!(self.tcx.def_path_str(def_id));
+
+            let global_blame = |section| -> (
+                rustc_sanitizers::ignorelist::Blame,
+                rustc_sanitizers::ignorelist::Blame,
+            ) {
+                let mut no_san = rustc_sanitizers::ignorelist::Blame::NONE;
+                let mut san = rustc_sanitizers::ignorelist::Blame::NONE;
+                let mut update = |prefix, query| {
+                    let (ns, s) = ignorelist.in_section_blame(section, prefix, query);
+                    no_san = no_san.max(ns);
+                    san = san.max(s);
+                };
+                update(c"global", sym_name);
+                update(c"global", &demangled);
+                update(c"src", &filename);
+                if !mainfile.is_empty() {
+                    update(c"mainfile", &mainfile);
+                }
+                update(c"type", &ty_name);
+                (no_san, san)
+            };
+
+            let sanitizers = self.tcx.sess.sanitizers();
+            let (address_nosan, address_san) = global_blame(c"address");
+            let (kaddress_nosan, kaddress_san) = global_blame(c"kernel-address");
+            let (hwaddress_nosan, hwaddress_san) = global_blame(c"hwaddress");
+            let (khwaddress_nosan, khwaddress_san) = global_blame(c"kernel-hwaddress");
+
+            let ignore_address =
+                rustc_sanitizers::ignorelist::is_blame_ignored(address_nosan, address_san);
+            let ignore_kernel_address = rustc_sanitizers::ignorelist::is_blame_ignored(
+                address_nosan.max(kaddress_nosan),
+                address_san.max(kaddress_san),
+            );
+            let ignore_hwaddress =
+                rustc_sanitizers::ignorelist::is_blame_ignored(hwaddress_nosan, hwaddress_san);
+            let ignore_kernel_hwaddress = rustc_sanitizers::ignorelist::is_blame_ignored(
+                hwaddress_nosan.max(khwaddress_nosan),
+                hwaddress_san.max(khwaddress_san),
+            );
+
+            if (sanitizers.contains(rustc_target::spec::SanitizerSet::ADDRESS) && ignore_address)
+                || (sanitizers.contains(rustc_target::spec::SanitizerSet::KERNELADDRESS)
+                    && ignore_kernel_address)
+            {
+                unsafe { llvm::LLVMRustSetNoSanitizeAddress(g) };
+            }
+            if (sanitizers.contains(rustc_target::spec::SanitizerSet::HWADDRESS)
+                && ignore_hwaddress)
+                || (sanitizers.contains(rustc_target::spec::SanitizerSet::KERNELHWADDRESS)
+                    && ignore_kernel_hwaddress)
+            {
+                unsafe { llvm::LLVMRustSetNoSanitizeHWAddress(g) };
+            }
+        }
+
         if attrs.flags.contains(CodegenFnAttrFlags::USED_COMPILER) {
             // `USED` and `USED_LINKER` can't be used together.
             assert!(!attrs.flags.contains(CodegenFnAttrFlags::USED_LINKER));

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -20,6 +20,7 @@ use rustc_middle::ty::layout::{
 };
 use rustc_middle::ty::{self, Instance, Ty, TyCtxt};
 use rustc_middle::{bug, span_bug};
+use rustc_sanitizers::ignorelist::{SanitizerIgnoreList, typename_for_ignore_list};
 use rustc_session::config::{
     BranchProtection, CFGuard, CFProtection, DebugInfo, FunctionReturn, PAuthKey, PacRet,
 };
@@ -133,6 +134,7 @@ pub(crate) struct FullCx<'ll, 'tcx> {
     /// Extra per-CGU codegen state needed when coverage instrumentation is enabled.
     pub coverage_cx: Option<coverageinfo::CguCoverageContext<'ll, 'tcx>>,
     pub dbg_cx: Option<debuginfo::CodegenUnitDebugContext<'ll, 'tcx>>,
+    pub sanitizer_ignorelist: Option<SanitizerIgnoreList>,
 
     eh_personality: Cell<Option<&'ll Value>>,
     pub rust_try_fn: Cell<Option<(&'ll Type, &'ll Value)>>,
@@ -680,6 +682,24 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
             None
         };
 
+        // FIXME: This parses the ignorelist files for each CGU, which adds a performance overhead.
+        // Clang parses it once per frontend invocation. LLVM's `SpecialCaseList::inSection`
+        // mutates an internal `LazyInit` cache and is not thread-safe. We either need to wrap
+        // the queries in a lock or wait for LLVM to expose a thread-safe way to query it.
+        let sanitizer_ignorelist = if !tcx.sess.opts.unstable_opts.sanitizer_ignorelist.is_empty() {
+            for path in &tcx.sess.opts.unstable_opts.sanitizer_ignorelist {
+                let _ = tcx.sess.source_map().load_file(std::path::Path::new(path));
+            }
+            match SanitizerIgnoreList::new(&tcx.sess.opts.unstable_opts.sanitizer_ignorelist) {
+                Ok(list) => Some(list),
+                Err(err) => {
+                    tcx.dcx().fatal(format!("failed to parse sanitizer ignorelist: {}", err));
+                }
+            }
+        } else {
+            None
+        };
+
         GenericCx(
             FullCx {
                 tcx,
@@ -699,6 +719,7 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
                 scalar_lltypes: Default::default(),
                 coverage_cx,
                 dbg_cx,
+                sanitizer_ignorelist,
                 eh_personality: Cell::new(None),
                 rust_try_fn: Cell::new(None),
                 intrinsics: Default::default(),
@@ -837,6 +858,17 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
             "Objective-C Class Properties",
             1 << 6,
         );
+    }
+
+    pub(crate) fn is_sanitizer_type_ignored(
+        &self,
+        sanitizer: &std::ffi::CStr,
+        fn_abi: &rustc_target::callconv::FnAbi<'tcx, Ty<'tcx>>,
+    ) -> bool {
+        self.sanitizer_ignorelist.as_ref().is_some_and(|ignorelist| {
+            let type_name = typename_for_ignore_list(self.tcx, fn_abi);
+            ignorelist.contains_prefix(sanitizer, c"type", &type_name)
+        })
     }
 }
 impl<'ll> SimpleCx<'ll> {

--- a/compiler/rustc_codegen_llvm/src/declare.rs
+++ b/compiler/rustc_codegen_llvm/src/declare.rs
@@ -232,13 +232,12 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
                 options.insert(kcfi::TypeIdOptions::NORMALIZE_INTEGERS);
             }
 
-            if let Some(instance) = instance {
-                let kcfi_typeid = kcfi::typeid_for_instance(self.tcx, instance, options);
-                self.set_kcfi_type_metadata(llfn, kcfi_typeid);
+            let kcfi_typeid = if let Some(instance) = instance {
+                kcfi::typeid_for_instance(self.tcx, instance, options)
             } else {
-                let kcfi_typeid = kcfi::typeid_for_fnabi(self.tcx, fn_abi, options);
-                self.set_kcfi_type_metadata(llfn, kcfi_typeid);
-            }
+                kcfi::typeid_for_fnabi(self.tcx, fn_abi, options)
+            };
+            self.set_kcfi_type_metadata(llfn, kcfi_typeid);
         }
 
         llfn

--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -1233,6 +1233,28 @@ pub(super) fn emit_va_arg<'ll, 'tcx>(
             // sparc64 is a big-endian target and stores variable arguments right-adjusted.
             ForceRightAdjust::Yes,
         ),
+        Arch::Sparc => {
+            std::assert_matches!(stability, CVariadicStatus::Unstable { .. });
+
+            // f128 is passed indirectly.
+            let pass_mode = match layout.layout.backend_repr() {
+                BackendRepr::Scalar(scalar) => match scalar.primitive() {
+                    Primitive::Float(Float::F128) => PassMode::Indirect,
+                    _ => PassMode::Direct,
+                },
+                _ => PassMode::Direct,
+            };
+
+            emit_ptr_va_arg(
+                bx,
+                addr,
+                target_ty,
+                pass_mode,
+                SlotSize::Bytes4,
+                AllowHigherAlign::No,
+                ForceRightAdjust::Yes,
+            )
+        }
         Arch::Mips | Arch::Mips32r6 | Arch::Mips64 | Arch::Mips64r6 => emit_ptr_va_arg(
             bx,
             addr,
@@ -1256,7 +1278,7 @@ pub(super) fn emit_va_arg<'ll, 'tcx>(
         Arch::Bpf => bug!("bpf does not support c-variadic functions"),
         Arch::SpirV => bug!("spirv does not support c-variadic functions"),
 
-        Arch::Sparc | Arch::Avr | Arch::M68k | Arch::Msp430 => {
+        Arch::Avr | Arch::M68k | Arch::Msp430 => {
             std::assert_matches!(stability, CVariadicStatus::Unstable { .. });
 
             // Clang uses the LLVM implementation for these architectures.

--- a/compiler/rustc_codegen_ssa/src/diagnostics.rs
+++ b/compiler/rustc_codegen_ssa/src/diagnostics.rs
@@ -1219,6 +1219,10 @@ pub(crate) enum PossibleFeature<'a> {
 #[note(
     "it is still passed through to the codegen backend, but use of this feature might be unsound and the behavior of this feature can change in the future"
 )]
+#[note(
+    "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
+)]
+#[note("for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>")]
 pub(crate) struct UnknownCTargetFeature<'a> {
     pub feature: &'a str,
     #[subdiagnostic]
@@ -1228,6 +1232,10 @@ pub(crate) struct UnknownCTargetFeature<'a> {
 #[derive(Diagnostic)]
 #[diag("unstable feature specified for `-Ctarget-feature`: `{$feature}`")]
 #[note("{$note}; its behavior can change in the future")]
+#[note(
+    "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
+)]
+#[note("for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>")]
 pub(crate) struct UnstableCTargetFeature<'a> {
     pub feature: &'a str,
     pub note: &'a str,
@@ -1243,7 +1251,7 @@ pub(crate) struct InternalOnlyCTargetFeature<'a> {
         "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
     )]
     #[note(
-        "for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>"
+        "for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>"
     )]
     pub future_compat_note: bool,
 }

--- a/compiler/rustc_interface/src/diagnostics.rs
+++ b/compiler/rustc_interface/src/diagnostics.rs
@@ -129,7 +129,7 @@ pub(crate) struct AbiRequiredTargetFeature<'a> {
         "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
     )]
     #[note(
-        "for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>"
+        "for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>"
     )]
     pub fcw: bool,
 }

--- a/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
+++ b/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
@@ -19,6 +19,9 @@ extern "C" void LLVMRustSetLastError(const char *);
 enum class LLVMRustResult { Success, Failure };
 
 typedef struct OpaqueRustString *RustStringRef;
+typedef struct LLVMOpaqueTwine *LLVMTwineRef;
+typedef struct LLVMOpaqueSMDiagnostic *LLVMSMDiagnosticRef;
+typedef struct LLVMOpaqueSpecialCaseList *LLVMSpecialCaseListRef;
 
 extern "C" void LLVMRustStringWriteImpl(RustStringRef buf,
                                         const char *slice_ptr,

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -34,8 +34,10 @@
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/ModRef.h"
 #include "llvm/Support/Signals.h"
+#include "llvm/Support/SpecialCaseList.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/ToolOutputFile.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
 #include <iostream>
@@ -1837,3 +1839,176 @@ FIXED_MD_KIND(MD_noalias_addrspace, 41)
 // LLVM versions, it's fine to omit them from this list; in that case Rust-side
 // code cannot declare them as fixed IDs and must look them up by name instead.
 #undef FIXED_MD_KIND
+
+class RustSanitizerSpecialCaseList : public llvm::SpecialCaseList {
+public:
+  static std::unique_ptr<RustSanitizerSpecialCaseList>
+  create(const std::vector<std::string> &Paths, llvm::vfs::FileSystem &VFS,
+         std::string &Error) {
+    std::unique_ptr<RustSanitizerSpecialCaseList> SSCL(
+        new RustSanitizerSpecialCaseList());
+    if (SSCL->createInternal(Paths, VFS, Error)) {
+      SSCL->createSanitizerSections();
+      return SSCL;
+    }
+    return nullptr;
+  }
+
+  std::pair<unsigned, unsigned>
+  inSectionBlame(uint32_t Mask, llvm::StringRef SectionName,
+                 llvm::StringRef Prefix, llvm::StringRef Query,
+                 llvm::StringRef Category = llvm::StringRef()) const {
+    for (auto It = SanitizerSections.rbegin(); It != SanitizerSections.rend();
+         ++It) {
+      bool Matches = false;
+      if (Mask != 0 && (It->Mask & Mask) != 0) {
+        Matches = true;
+      } else if (!SectionName.empty() && matchSection(It->S, SectionName)) {
+        Matches = true;
+      }
+      if (Matches) {
+        unsigned LineNum = getLastMatch(It->S, Prefix, Query, Category);
+        if (LineNum > 0)
+          return {getFileIndex(It->S), LineNum};
+      }
+    }
+    return NotFound;
+  }
+
+private:
+  struct SanitizerSection {
+    uint32_t Mask;
+    const Section &S;
+    SanitizerSection(uint32_t Mask, const Section &S) : Mask(Mask), S(S) {}
+  };
+
+  std::vector<SanitizerSection> SanitizerSections;
+
+#if LLVM_VERSION_GE(22, 0)
+  static bool matchSection(const Section &S, llvm::StringRef Name) {
+    return S.matchName(Name);
+  }
+  unsigned getLastMatch(const Section &S, llvm::StringRef Prefix,
+                        llvm::StringRef Query, llvm::StringRef Category) const {
+    return S.getLastMatch(Prefix, Query, Category);
+  }
+  static unsigned getFileIndex(const Section &S) { return S.fileIndex(); }
+#else
+  static bool matchSection(const Section &S, llvm::StringRef Name) {
+    return S.SectionMatcher && S.SectionMatcher->match(Name) != 0;
+  }
+  unsigned getLastMatch(const Section &S, llvm::StringRef Prefix,
+                        llvm::StringRef Query, llvm::StringRef Category) const {
+    return llvm::SpecialCaseList::inSectionBlame(S.Entries, Prefix, Query,
+                                                 Category);
+  }
+  static unsigned getFileIndex(const Section &S) { return S.FileIdx; }
+#endif
+
+  void createSanitizerSections() {
+#if LLVM_VERSION_GE(22, 0)
+    const auto &SecList = sections();
+#else
+    const auto &SecList = Sections;
+#endif
+    for (const auto &S : SecList) {
+      uint32_t Mask = 0;
+
+      // All sanitizers: [all]
+      if (matchSection(S, "all"))
+        Mask |= ~0u;
+
+      // Address: [address]
+      if (matchSection(S, "address"))
+        Mask |= (1 << 0);
+      // Leak: [leak]
+      if (matchSection(S, "leak"))
+        Mask |= (1 << 1);
+      // Memory: [memory]
+      if (matchSection(S, "memory"))
+        Mask |= (1 << 2);
+      // Thread: [thread]
+      if (matchSection(S, "thread"))
+        Mask |= (1 << 3);
+      // HWAddress: [hwaddress]
+      if (matchSection(S, "hwaddress"))
+        Mask |= (1 << 4);
+
+      // CFI (indirect call checking): [cfi], [cfi-icall]
+      if (matchSection(S, "cfi") || matchSection(S, "cfi-icall"))
+        Mask |= (1 << 5);
+
+      // MemTag: [memtag], [memtag-stack], [memtag-heap], [memtag-globals]
+      if (matchSection(S, "memtag") || matchSection(S, "memtag-stack") ||
+          matchSection(S, "memtag-heap") || matchSection(S, "memtag-globals"))
+        Mask |= (1 << 6);
+      // ShadowCallStack: [shadow-call-stack], [shadowcallstack]
+      if (matchSection(S, "shadow-call-stack") ||
+          matchSection(S, "shadowcallstack"))
+        Mask |= (1 << 7);
+      // KCFI: [kcfi]
+      if (matchSection(S, "kcfi"))
+        Mask |= (1 << 8);
+      // KernelAddress: [kernel-address], [kasan]
+      if (matchSection(S, "kernel-address") || matchSection(S, "kasan"))
+        Mask |= (1 << 9);
+      // KernelHWAddress: [kernel-hwaddress], [khwasan]
+      if (matchSection(S, "kernel-hwaddress") || matchSection(S, "khwasan"))
+        Mask |= (1 << 10);
+      // SafeStack: [safe-stack] (Clang standard), [safestack]
+      if (matchSection(S, "safe-stack") || matchSection(S, "safestack"))
+        Mask |= (1 << 11);
+      // DataFlow: [dataflow]
+      if (matchSection(S, "dataflow"))
+        Mask |= (1 << 12);
+      // Realtime: [realtime]
+      if (matchSection(S, "realtime"))
+        Mask |= (1 << 13);
+
+      SanitizerSections.emplace_back(Mask, S);
+    }
+  }
+};
+
+extern "C" LLVMSpecialCaseListRef
+LLVMRustSpecialCaseListCreate(const char **Paths, size_t NumPaths,
+                              RustStringRef ErrorMsg) {
+  std::string Error;
+  std::vector<std::string> PathsVec(Paths, Paths + NumPaths);
+  std::unique_ptr<RustSanitizerSpecialCaseList> SCL =
+      RustSanitizerSpecialCaseList::create(
+          PathsVec, *llvm::vfs::getRealFileSystem(), Error);
+  if (!SCL) {
+    LLVMRustStringWriteImpl(ErrorMsg, Error.data(), Error.size());
+    return nullptr;
+  }
+  return reinterpret_cast<LLVMSpecialCaseListRef>(SCL.release());
+}
+
+extern "C" void LLVMRustSpecialCaseListDestroy(LLVMSpecialCaseListRef List) {
+  delete reinterpret_cast<RustSanitizerSpecialCaseList *>(List);
+}
+
+struct LLVMRustSpecialCaseListBlame {
+  uint32_t FileIdx;
+  uint32_t LineNo;
+};
+
+extern "C" void
+LLVMRustSpecialCaseListInSectionBlame(LLVMSpecialCaseListRef List,
+                                      uint32_t Mask, const char *Section,
+                                      const char *Prefix, const char *Query,
+                                      LLVMRustSpecialCaseListBlame *OutNoSan,
+                                      LLVMRustSpecialCaseListBlame *OutSan) {
+  auto *SSCL = reinterpret_cast<RustSanitizerSpecialCaseList *>(List);
+  llvm::StringRef SectionStr = Section ? Section : "";
+  std::pair<unsigned, unsigned> NoSan =
+      SSCL->inSectionBlame(Mask, SectionStr, Prefix, Query);
+  OutNoSan->FileIdx = NoSan.first;
+  OutNoSan->LineNo = NoSan.second;
+
+  std::pair<unsigned, unsigned> San =
+      SSCL->inSectionBlame(Mask, SectionStr, Prefix, Query, "sanitize");
+  OutSan->FileIdx = San.first;
+  OutSan->LineNo = San.second;
+}

--- a/compiler/rustc_sanitizers/Cargo.toml
+++ b/compiler/rustc_sanitizers/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 # tidy-alphabetical-start
 bitflags = "2.5.0"
+libc = "0.2"
 rustc_abi = { path = "../rustc_abi" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_hir = { path = "../rustc_hir" }

--- a/compiler/rustc_sanitizers/src/ignorelist/ffi.rs
+++ b/compiler/rustc_sanitizers/src/ignorelist/ffi.rs
@@ -1,0 +1,91 @@
+use std::cell::RefCell;
+use std::ffi::c_char;
+use std::ptr;
+use std::string::FromUtf8Error;
+
+use libc::size_t;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Blame {
+    pub file_idx: u32,
+    pub line_no: u32,
+}
+
+impl Blame {
+    pub const NONE: Self = Self { file_idx: 0, line_no: 0 };
+
+    #[inline]
+    pub fn is_none(self) -> bool {
+        self.line_no == 0
+    }
+
+    #[inline]
+    pub fn is_some(self) -> bool {
+        self.line_no != 0
+    }
+}
+
+unsafe extern "C" {
+    pub(crate) type Opaque;
+    /// Opaque type that allows C++ code to write bytes to a Rust-side buffer,
+    /// in conjunction with `RawRustStringOstream`. Use this as `&RustString`
+    /// (Rust) and `RustStringRef` (C++) in FFI signatures.
+    pub(crate) type RustString;
+
+    pub(crate) fn LLVMRustSpecialCaseListCreate(
+        Paths: *const *const c_char,
+        NumPaths: size_t,
+        ErrorMsg: &RustString,
+    ) -> *mut Opaque;
+
+    pub(crate) fn LLVMRustSpecialCaseListDestroy(List: *mut Opaque);
+    pub(crate) fn LLVMRustSpecialCaseListInSectionBlame(
+        List: *const Opaque,
+        Mask: u32,
+        Section: *const c_char,
+        Prefix: *const c_char,
+        Query: *const c_char,
+        OutNoSan: *mut Blame,
+        OutSan: *mut Blame,
+    );
+}
+
+/// Underlying implementation of [`RustString`].
+///
+/// Having two separate types makes it possible to use the opaque [`RustString`]
+/// in FFI signatures without `improper_ctypes` warnings. This is a workaround
+/// for the fact that there is no way to opt out of `improper_ctypes` when
+/// _declaring_ a type (as opposed to using that type).
+#[derive(Default)]
+struct RustStringInner {
+    bytes: RefCell<Vec<u8>>,
+}
+
+impl RustStringInner {
+    fn as_opaque(&self) -> &RustString {
+        let ptr: *const RustStringInner = ptr::from_ref(self);
+        // We can't use `ptr::cast` here because extern types are `!Sized`.
+        let ptr = ptr as *const RustString;
+        unsafe {
+            // Safety: `self` outlives returned `&RustString` and it is originated from `rustc`
+            &*ptr
+        }
+    }
+
+    fn into_inner(self) -> Vec<u8> {
+        self.bytes.into_inner()
+    }
+}
+
+impl RustString {
+    pub(crate) fn build_byte_buffer(closure: impl FnOnce(&Self)) -> Vec<u8> {
+        let buf = RustStringInner::default();
+        closure(buf.as_opaque());
+        buf.into_inner()
+    }
+}
+
+pub(crate) fn build_string(f: impl FnOnce(&RustString)) -> Result<String, FromUtf8Error> {
+    String::from_utf8(RustString::build_byte_buffer(f))
+}

--- a/compiler/rustc_sanitizers/src/ignorelist/mod.rs
+++ b/compiler/rustc_sanitizers/src/ignorelist/mod.rs
@@ -1,0 +1,212 @@
+pub use ffi::Blame;
+use rustc_middle::ty::{self, Instance, Ty, TyCtxt};
+use rustc_target::spec::SanitizerSet;
+
+pub(crate) mod ffi;
+
+#[inline]
+pub fn is_blame_ignored(no_san: Blame, san: Blame) -> bool {
+    no_san.is_some() && (san.is_none() || no_san > san)
+}
+
+pub struct SanitizerIgnoreList {
+    inner: *mut ffi::Opaque,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct InstanceSanitizers {
+    pub enabled: SanitizerSet,
+    pub ignore_cfi: bool,
+    pub ignore_kcfi: bool,
+}
+
+impl SanitizerIgnoreList {
+    pub fn new(paths: &[String]) -> Result<Self, String> {
+        use std::ffi::CString;
+        let c_paths: Vec<CString> =
+            paths.iter().map(|p| CString::new(p.as_str()).unwrap()).collect();
+        let c_ptrs: Vec<*const libc::c_char> = c_paths.iter().map(|c| c.as_ptr()).collect();
+
+        let mut inner = std::ptr::null_mut();
+        let err = ffi::build_string(|err| unsafe {
+            inner = ffi::LLVMRustSpecialCaseListCreate(c_ptrs.as_ptr(), c_ptrs.len(), err);
+        });
+
+        let err = err.unwrap_or_else(|e| format!("utf8 error: {}", e));
+        if inner.is_null() { Err(err) } else { Ok(Self { inner }) }
+    }
+
+    pub fn in_section_blame(
+        &self,
+        section: &std::ffi::CStr,
+        prefix: &std::ffi::CStr,
+        query: &str,
+    ) -> (Blame, Blame) {
+        let mask = section_to_sanitizer_set(section);
+        let mut no_san = Blame::NONE;
+        let mut san = Blame::NONE;
+        let Ok(query) = std::ffi::CString::new(query) else {
+            return (Blame::NONE, Blame::NONE);
+        };
+        unsafe {
+            ffi::LLVMRustSpecialCaseListInSectionBlame(
+                self.inner,
+                mask.map(|s| s.bits() as u32).unwrap_or(0),
+                section.as_ptr(),
+                prefix.as_ptr(),
+                query.as_ptr(),
+                &mut no_san,
+                &mut san,
+            );
+        }
+        (no_san, san)
+    }
+
+    pub fn instance_blame<'tcx>(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        instance: Instance<'tcx>,
+        section: &std::ffi::CStr,
+    ) -> (Blame, Blame) {
+        let sym_name = tcx.symbol_name(instance).name;
+        let span = tcx.def_span(instance.def_id());
+        let filename =
+            tcx.sess.source_map().span_to_filename(span).prefer_local_unconditionally().to_string();
+        let mainfile = tcx
+            .sess
+            .local_crate_source_file()
+            .and_then(|path| path.local_path().map(|p| p.display().to_string()))
+            .unwrap_or_default();
+        let demangled =
+            rustc_middle::ty::print::with_no_trimmed_paths!(tcx.def_path_str(instance.def_id()));
+
+        let mut no_san = Blame::NONE;
+        let mut san = Blame::NONE;
+        let mut update = |prefix: &std::ffi::CStr, query: &str| {
+            let (ns, s) = self.in_section_blame(section, prefix, query);
+            no_san = no_san.max(ns);
+            san = san.max(s);
+        };
+
+        update(c"fun", sym_name);
+        update(c"fun", &demangled);
+        update(c"src", &filename);
+        if !mainfile.is_empty() {
+            update(c"mainfile", &mainfile);
+        }
+
+        (no_san, san)
+    }
+
+    pub fn is_instance_ignored<'tcx>(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        instance: Instance<'tcx>,
+        section: &std::ffi::CStr,
+    ) -> bool {
+        let (no_san, san) = self.instance_blame(tcx, instance, section);
+        is_blame_ignored(no_san, san)
+    }
+
+    pub fn filter_instance_sanitizers<'tcx>(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        instance: Instance<'tcx>,
+        mut enabled: SanitizerSet,
+    ) -> InstanceSanitizers {
+        let (address_nosan, address_san) = self.instance_blame(tcx, instance, c"address");
+        let (kaddress_nosan, kaddress_san) = self.instance_blame(tcx, instance, c"kernel-address");
+        let (hwaddress_nosan, hwaddress_san) = self.instance_blame(tcx, instance, c"hwaddress");
+        let (khwaddress_nosan, khwaddress_san) =
+            self.instance_blame(tcx, instance, c"kernel-hwaddress");
+
+        let ignore_address = is_blame_ignored(address_nosan, address_san);
+        let ignore_kernel_address = is_blame_ignored(kaddress_nosan, kaddress_san);
+
+        let ignore_hwaddress = is_blame_ignored(hwaddress_nosan, hwaddress_san);
+        let ignore_kernel_hwaddress = is_blame_ignored(khwaddress_nosan, khwaddress_san);
+
+        if enabled.contains(SanitizerSet::ADDRESS) && ignore_address {
+            enabled.remove(SanitizerSet::ADDRESS);
+        }
+        if enabled.contains(SanitizerSet::KERNELADDRESS) && ignore_kernel_address {
+            enabled.remove(SanitizerSet::KERNELADDRESS);
+        }
+        if enabled.contains(SanitizerSet::MEMORY)
+            && self.is_instance_ignored(tcx, instance, c"memory")
+        {
+            enabled.remove(SanitizerSet::MEMORY);
+        }
+        if enabled.contains(SanitizerSet::THREAD)
+            && self.is_instance_ignored(tcx, instance, c"thread")
+        {
+            enabled.remove(SanitizerSet::THREAD);
+        }
+        if enabled.contains(SanitizerSet::HWADDRESS) && ignore_hwaddress {
+            enabled.remove(SanitizerSet::HWADDRESS);
+        }
+        if enabled.contains(SanitizerSet::KERNELHWADDRESS) && ignore_kernel_hwaddress {
+            enabled.remove(SanitizerSet::KERNELHWADDRESS);
+        }
+        // FIXME: Add support for filtering SAFESTACK, SHADOWCALLSTACK, MEMTAG, and REALTIME.
+        // Note: For REALTIME, `rustc_codegen_llvm::attributes::sanitize_attrs` will also
+        // need to check the filtered `enabled` set rather than `tcx.sess.sanitizers()`.
+
+        let ignore_cfi = self.is_instance_ignored(tcx, instance, c"cfi");
+        let ignore_kcfi = self.is_instance_ignored(tcx, instance, c"kcfi");
+
+        InstanceSanitizers { enabled, ignore_cfi, ignore_kcfi }
+    }
+
+    pub fn contains_prefix(
+        &self,
+        section: &std::ffi::CStr,
+        prefix: &std::ffi::CStr,
+        query: &str,
+    ) -> bool {
+        let (no_san, san) = self.in_section_blame(section, prefix, query);
+        is_blame_ignored(no_san, san)
+    }
+}
+
+impl Drop for SanitizerIgnoreList {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::LLVMRustSpecialCaseListDestroy(self.inner);
+        }
+    }
+}
+
+pub fn typename_for_ignore_list<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    fn_abi: &rustc_target::callconv::FnAbi<'tcx, Ty<'tcx>>,
+) -> String {
+    let inputs: Vec<_> = fn_abi.args.iter().map(|arg| arg.layout.ty).collect();
+    let output = fn_abi.ret.layout.ty;
+    let mut fn_sig_kind = ty::FnSigKind::default();
+    fn_sig_kind = fn_sig_kind.set_safety(rustc_hir::Safety::Safe);
+    fn_sig_kind = fn_sig_kind.set_c_variadic(fn_abi.c_variadic);
+    let fn_sig = tcx.mk_fn_sig(inputs, output, fn_sig_kind);
+    let fn_ptr = Ty::new_fn_ptr(tcx, ty::Binder::dummy(fn_sig));
+    ty::print::with_no_trimmed_paths!(fn_ptr.to_string())
+}
+
+fn section_to_sanitizer_set(section: &std::ffi::CStr) -> Option<SanitizerSet> {
+    match section.to_bytes() {
+        b"address" => Some(SanitizerSet::ADDRESS),
+        b"kernel-address" | b"kasan" => Some(SanitizerSet::KERNELADDRESS),
+        b"memory" => Some(SanitizerSet::MEMORY),
+        b"thread" => Some(SanitizerSet::THREAD),
+        b"hwaddress" => Some(SanitizerSet::HWADDRESS),
+        b"kernel-hwaddress" | b"khwasan" => Some(SanitizerSet::KERNELHWADDRESS),
+        b"safestack" | b"safe-stack" => Some(SanitizerSet::SAFESTACK),
+        b"shadow-call-stack" | b"shadowcallstack" => Some(SanitizerSet::SHADOWCALLSTACK),
+        b"cfi" | b"cfi-icall" => Some(SanitizerSet::CFI),
+        b"kcfi" => Some(SanitizerSet::KCFI),
+        b"memtag" => Some(SanitizerSet::MEMTAG),
+        b"realtime" => Some(SanitizerSet::REALTIME),
+        b"leak" => Some(SanitizerSet::LEAK),
+        b"dataflow" => Some(SanitizerSet::DATAFLOW),
+        _ => None,
+    }
+}

--- a/compiler/rustc_sanitizers/src/lib.rs
+++ b/compiler/rustc_sanitizers/src/lib.rs
@@ -3,8 +3,11 @@
 //! This crate contains the source code for providing support for the sanitizers to the Rust
 //! compiler.
 
+#![feature(extern_types)]
+
 // tidy-alphabetical-start
 // tidy-alphabetical-end
 
 pub mod cfi;
+pub mod ignorelist;
 pub mod kcfi;

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -336,15 +336,11 @@ impl<S: Encoder, T: Encodable<S>, const N: usize> Encodable<S> for [T; N] {
     }
 }
 
-impl<D: Decoder, const N: usize> Decodable<D> for [u8; N] {
-    fn decode(d: &mut D) -> [u8; N] {
+impl<D: Decoder, T: Decodable<D>, const N: usize> Decodable<D> for [T; N] {
+    fn decode(d: &mut D) -> [T; N] {
         let len = d.read_usize();
         assert!(len == N);
-        let mut v = [0u8; N];
-        for i in 0..len {
-            v[i] = Decodable::decode(d);
-        }
-        v
+        std::array::from_fn(move |_| Decodable::decode(d))
     }
 }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2811,6 +2811,8 @@ written to standard error output)"),
     #[rustc_lint_opt_deny_field_access("use `Session::sanitizers()` instead of this field")]
     sanitizer: SanitizerSet = (SanitizerSet::empty(), parse_sanitizers, [TRACKED] { TARGET_MODIFIER: Sanitizer },
         "use a sanitizer"),
+    sanitizer_ignorelist: Vec<String> = (vec![], parse_list, [TRACKED],
+        "list of files providing ignorelists for sanitizers"),
     sanitizer_cfi_canonical_jump_tables: Option<bool> = (Some(true), parse_opt_bool, [TRACKED],
         "enable canonical jump tables (default: yes)"),
     sanitizer_cfi_generalize_pointers: Option<bool> = (None, parse_opt_bool, [TRACKED],

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -396,7 +396,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                                 // `std::marker::Sized` is not implemented for `T`" as we will point
                                 // at the type param with a label to suggest constraining it.
                                 && !self.tcx.is_diagnostic_item(sym::FromResidual, leaf_trait_predicate.def_id())
-                            // Don't say "the trait `FromResidual<Option<Infallible>>` is
+                            // Don't say "the trait `FromResidual<Option<!>>` is
                             // not implemented for `Result<T, E>`".
                             {
                                 // We do this just so that the JSON output's `help` position is the

--- a/src/tools/clippy/clippy_lints/src/methods/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/mod.rs
@@ -4193,7 +4193,7 @@ declare_clippy_lint! {
     /// ### Why is this bad?
     /// In those cases, the `TryInto` and `TryFrom` trait implementation is a blanket impl that forwards
     /// to `Into` or `From`, which always succeeds.
-    /// The returned `Result<_, Infallible>` requires error handling to get the contained value
+    /// The returned `Result<_, !>` requires error handling to get the contained value
     /// even though the conversion can never fail.
     ///
     /// ### Example

--- a/src/tools/clippy/clippy_lints/src/methods/unnecessary_fallible_conversions.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/unnecessary_fallible_conversions.rs
@@ -95,7 +95,7 @@ fn check<'tcx>(
         // If `T: TryFrom<U>` and `T: From<U>` both exist, then that means that the `TryFrom`
         // _must_ be from the blanket impl and cannot have been manually implemented
         // (else there would be conflicting impls, even with #![feature(spec)]), so we don't even need to check
-        // what `<T as TryFrom<U>>::Error` is: it's always `Infallible`
+        // what `<T as TryFrom<U>>::Error` is: it's always `!`
         && implements_trait(cx, self_ty, from_into_trait, &[other_ty])
         && let Some(other_ty) = other_ty.as_type()
     {

--- a/src/tools/clippy/tests/ui/drop_non_drop.rs
+++ b/src/tools/clippy/tests/ui/drop_non_drop.rs
@@ -7,7 +7,7 @@ fn make_result<T>(t: T) -> Result<T, ()> {
 }
 
 // The return type should behave as `T` as the `Err` variant is uninhabited
-fn make_result_uninhabited_err<T>(t: T) -> Result<T, std::convert::Infallible> {
+fn make_result_uninhabited_err<T>(t: T) -> Result<T, !> {
     Ok(t)
 }
 

--- a/src/tools/clippy/tests/ui/infallible_try_from.rs
+++ b/src/tools/clippy/tests/ui/infallible_try_from.rs
@@ -1,7 +1,5 @@
 #![warn(clippy::infallible_try_from)]
 
-use std::convert::Infallible;
-
 struct MyStruct(i32);
 
 impl TryFrom<i8> for MyStruct {
@@ -14,8 +12,8 @@ impl TryFrom<i8> for MyStruct {
 
 impl TryFrom<i16> for MyStruct {
     //~^ infallible_try_from
-    type Error = Infallible;
-    fn try_from(other: i16) -> Result<Self, Infallible> {
+    type Error = !;
+    fn try_from(other: i16) -> Result<Self, !> {
         Ok(Self(other.into()))
     }
 }

--- a/src/tools/clippy/tests/ui/infallible_try_from.stderr
+++ b/src/tools/clippy/tests/ui/infallible_try_from.stderr
@@ -1,5 +1,5 @@
 error: infallible TryFrom impl; consider implementing From instead
-  --> tests/ui/infallible_try_from.rs:7:1
+  --> tests/ui/infallible_try_from.rs:5:1
    |
 LL | impl TryFrom<i8> for MyStruct {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,13 +11,13 @@ LL |     type Error = !;
    = help: to override `-D warnings` add `#[allow(clippy::infallible_try_from)]`
 
 error: infallible TryFrom impl; consider implementing From instead
-  --> tests/ui/infallible_try_from.rs:15:1
+  --> tests/ui/infallible_try_from.rs:13:1
    |
 LL | impl TryFrom<i16> for MyStruct {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
-LL |     type Error = Infallible;
-   |                  ---------- infallible error type
+LL |     type Error = !;
+   |                  - infallible error type
 
 error: aborting due to 2 previous errors
 

--- a/src/tools/clippy/tests/ui/let_underscore_must_use.rs
+++ b/src/tools/clippy/tests/ui/let_underscore_must_use.rs
@@ -110,16 +110,24 @@ fn main() {
     let _ = a;
     //~^ let_underscore_must_use
 
+    enum Uninhabited {}
+
     #[allow(clippy::let_underscore_must_use)]
     let _ = a;
 
     // No lint because this type should behave as `()`
-    let _ = Result::<_, std::convert::Infallible>::Ok(());
+    let _ = Result::<_, !>::Ok(());
 
+    // No lint because this type should behave as `()`
+    let _ = Result::<_, Uninhabited>::Ok(());
     #[must_use]
     struct T;
 
     // Lint because this type should behave as `T`
-    let _ = Result::<_, std::convert::Infallible>::Ok(T);
+    let _ = Result::<_, !>::Ok(T);
+    //~^ let_underscore_must_use
+
+    // Lint because this type should behave as `T`
+    let _ = Result::<_, Uninhabited>::Ok(T);
     //~^ let_underscore_must_use
 }

--- a/src/tools/clippy/tests/ui/let_underscore_must_use.stderr
+++ b/src/tools/clippy/tests/ui/let_underscore_must_use.stderr
@@ -140,17 +140,30 @@ LL |     let _ = a;
    |             ^
 
 error: non-binding `let` on an expression with `#[must_use]` type
-  --> tests/ui/let_underscore_must_use.rs:123:5
+  --> tests/ui/let_underscore_must_use.rs:127:5
    |
-LL |     let _ = Result::<_, std::convert::Infallible>::Ok(T);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = Result::<_, !>::Ok(T);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider explicitly using expression value
 note: type is `main::T` in a `Result` with an uninhabited error
-  --> tests/ui/let_underscore_must_use.rs:123:13
+  --> tests/ui/let_underscore_must_use.rs:127:13
    |
-LL |     let _ = Result::<_, std::convert::Infallible>::Ok(T);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = Result::<_, !>::Ok(T);
+   |             ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 14 previous errors
+error: non-binding `let` on an expression with `#[must_use]` type
+  --> tests/ui/let_underscore_must_use.rs:131:5
+   |
+LL |     let _ = Result::<_, Uninhabited>::Ok(T);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider explicitly using expression value
+note: type is `main::T` in a `Result` with an uninhabited error
+  --> tests/ui/let_underscore_must_use.rs:131:13
+   |
+LL |     let _ = Result::<_, Uninhabited>::Ok(T);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 15 previous errors
 

--- a/src/tools/clippy/tests/ui/manual_ok_err.fixed
+++ b/src/tools/clippy/tests/ui/manual_ok_err.fixed
@@ -76,7 +76,7 @@ fn no_lint() {
         Ok(v) => Some(v),
     };
 
-    let _ = match Ok::<_, std::convert::Infallible>(1) {
+    let _ = match Ok::<_, !>(1) {
         Ok(3) => None,
         Ok(v) => Some(v),
     };

--- a/src/tools/clippy/tests/ui/manual_ok_err.rs
+++ b/src/tools/clippy/tests/ui/manual_ok_err.rs
@@ -112,7 +112,7 @@ fn no_lint() {
         Ok(v) => Some(v),
     };
 
-    let _ = match Ok::<_, std::convert::Infallible>(1) {
+    let _ = match Ok::<_, !>(1) {
         Ok(3) => None,
         Ok(v) => Some(v),
     };

--- a/src/tools/clippy/tests/ui/must_use_candidates.fixed
+++ b/src/tools/clippy/tests/ui/must_use_candidates.fixed
@@ -102,9 +102,17 @@ pub fn main() -> std::process::ExitCode {
     std::process::ExitCode::SUCCESS
 }
 
+pub enum Uninhabited {}
+
 //~v must_use_candidate
 #[must_use]
-pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
+pub fn result_uninhabited_1() -> Result<i32, Uninhabited> {
+    todo!()
+}
+
+//~v must_use_candidate
+#[must_use]
+pub fn result_never_1() -> Result<i32, !> {
     todo!()
 }
 
@@ -112,7 +120,12 @@ pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
 pub struct T;
 
 // Do not lint, `T` is `#[must_use]`, so the `Result<T, uninhabited>` also is.
-pub fn result_uninhabited_2() -> Result<T, std::convert::Infallible> {
+pub fn result_uninhabited_2() -> Result<T, Uninhabited> {
+    todo!()
+}
+
+// Do not lint, `T` is `#[must_use]`, so the `Result<T, uninhabited>` also is.
+pub fn result_never_2() -> Result<T, !> {
     todo!()
 }
 

--- a/src/tools/clippy/tests/ui/must_use_candidates.rs
+++ b/src/tools/clippy/tests/ui/must_use_candidates.rs
@@ -97,8 +97,15 @@ pub fn main() -> std::process::ExitCode {
     std::process::ExitCode::SUCCESS
 }
 
+pub enum Uninhabited {}
+
 //~v must_use_candidate
-pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
+pub fn result_uninhabited_1() -> Result<i32, Uninhabited> {
+    todo!()
+}
+
+//~v must_use_candidate
+pub fn result_never_1() -> Result<i32, !> {
     todo!()
 }
 
@@ -106,7 +113,12 @@ pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
 pub struct T;
 
 // Do not lint, `T` is `#[must_use]`, so the `Result<T, uninhabited>` also is.
-pub fn result_uninhabited_2() -> Result<T, std::convert::Infallible> {
+pub fn result_uninhabited_2() -> Result<T, Uninhabited> {
+    todo!()
+}
+
+// Do not lint, `T` is `#[must_use]`, so the `Result<T, uninhabited>` also is.
+pub fn result_never_2() -> Result<T, !> {
     todo!()
 }
 

--- a/src/tools/clippy/tests/ui/must_use_candidates.stderr
+++ b/src/tools/clippy/tests/ui/must_use_candidates.stderr
@@ -61,16 +61,28 @@ LL | pub fn arcd(_x: Arc<u32>) -> bool {
    |
 
 error: this function could have a `#[must_use]` attribute
-  --> tests/ui/must_use_candidates.rs:101:8
+  --> tests/ui/must_use_candidates.rs:103:8
    |
-LL | pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
+LL | pub fn result_uninhabited_1() -> Result<i32, Uninhabited> {
    |        ^^^^^^^^^^^^^^^^^^^^
    |
 help: add the attribute
    |
 LL + #[must_use]
-LL | pub fn result_uninhabited_1() -> Result<i32, std::convert::Infallible> {
+LL | pub fn result_uninhabited_1() -> Result<i32, Uninhabited> {
    |
 
-error: aborting due to 6 previous errors
+error: this function could have a `#[must_use]` attribute
+  --> tests/ui/must_use_candidates.rs:108:8
+   |
+LL | pub fn result_never_1() -> Result<i32, !> {
+   |        ^^^^^^^^^^^^^^
+   |
+help: add the attribute
+   |
+LL + #[must_use]
+LL | pub fn result_never_1() -> Result<i32, !> {
+   |
+
+error: aborting due to 7 previous errors
 

--- a/src/tools/clippy/tests/ui/single_match_else.fixed
+++ b/src/tools/clippy/tests/ui/single_match_else.fixed
@@ -99,8 +99,16 @@ fn main() {
     //~| NOTE: you might want to preserve the comments from inside the `match`
 
     // lint here
-    use std::convert::Infallible;
-    if let Ok(a) = Result::<i32, &Infallible>::Ok(1) { println!("${:?}", a) } else {
+    if let Ok(a) = Result::<i32, &!>::Ok(1) { println!("${:?}", a) } else {
+        println!("else block");
+        return;
+    }
+    //~^^^^^^^ single_match_else
+
+    enum Uninhabited {}
+
+    // lint here
+    if let Ok(a) = Result::<i32, &Uninhabited>::Ok(1) { println!("${:?}", a) } else {
         println!("else block");
         return;
     }

--- a/src/tools/clippy/tests/ui/single_match_else.rs
+++ b/src/tools/clippy/tests/ui/single_match_else.rs
@@ -112,8 +112,19 @@ fn main() {
     //~| NOTE: you might want to preserve the comments from inside the `match`
 
     // lint here
-    use std::convert::Infallible;
-    match Result::<i32, &Infallible>::Ok(1) {
+    match Result::<i32, &!>::Ok(1) {
+        Ok(a) => println!("${:?}", a),
+        Err(_) => {
+            println!("else block");
+            return;
+        }
+    }
+    //~^^^^^^^ single_match_else
+
+    enum Uninhabited {}
+
+    // lint here
+    match Result::<i32, &Uninhabited>::Ok(1) {
         Ok(a) => println!("${:?}", a),
         Err(_) => {
             println!("else block");

--- a/src/tools/clippy/tests/ui/single_match_else.stderr
+++ b/src/tools/clippy/tests/ui/single_match_else.stderr
@@ -83,9 +83,9 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:116:5
+  --> tests/ui/single_match_else.rs:115:5
    |
-LL | /     match Result::<i32, &Infallible>::Ok(1) {
+LL | /     match Result::<i32, &!>::Ok(1) {
 LL | |         Ok(a) => println!("${:?}", a),
 LL | |         Err(_) => {
 LL | |             println!("else block");
@@ -95,14 +95,33 @@ LL | |     }
    |
 help: try
    |
-LL ~     if let Ok(a) = Result::<i32, &Infallible>::Ok(1) { println!("${:?}", a) } else {
+LL ~     if let Ok(a) = Result::<i32, &!>::Ok(1) { println!("${:?}", a) } else {
 LL +         println!("else block");
 LL +         return;
 LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:126:5
+  --> tests/ui/single_match_else.rs:127:5
+   |
+LL | /     match Result::<i32, &Uninhabited>::Ok(1) {
+LL | |         Ok(a) => println!("${:?}", a),
+LL | |         Err(_) => {
+LL | |             println!("else block");
+...  |
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     if let Ok(a) = Result::<i32, &Uninhabited>::Ok(1) { println!("${:?}", a) } else {
+LL +         println!("else block");
+LL +         return;
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> tests/ui/single_match_else.rs:137:5
    |
 LL | /     match Cow::from("moo") {
 LL | |         Cow::Owned(a) => println!("${:?}", a),
@@ -121,7 +140,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:137:5
+  --> tests/ui/single_match_else.rs:148:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -144,7 +163,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:149:5
+  --> tests/ui/single_match_else.rs:160:5
    |
 LL | /     match bar {
 LL | |         Some(v) => {
@@ -168,7 +187,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:162:5
+  --> tests/ui/single_match_else.rs:173:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -192,7 +211,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> tests/ui/single_match_else.rs:175:5
+  --> tests/ui/single_match_else.rs:186:5
    |
 LL | /     match bar {
 LL | |         #[rustfmt::skip]
@@ -217,7 +236,7 @@ LL +     }
    |
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match_else.rs:225:5
+  --> tests/ui/single_match_else.rs:236:5
    |
 LL | /     match ExprNode::Butterflies {
 LL | |         ExprNode::Butterflies => Some(&NODE),
@@ -228,5 +247,5 @@ LL | |         },
 LL | |     }
    | |_____^ help: try: `Some(&NODE)`
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 

--- a/src/tools/miri/tests/pass/shims/x86/intrinsics-x86-pause-without-sse2.stderr
+++ b/src/tools/miri/tests/pass/shims/x86/intrinsics-x86-pause-without-sse2.stderr
@@ -1,7 +1,7 @@
 warning: target feature `sse2` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/assembly-llvm/c-variadic/sparc.rs
+++ b/tests/assembly-llvm/c-variadic/sparc.rs
@@ -90,14 +90,17 @@ unsafe extern "C" fn read_i64(ap: &mut VaList<'_>) -> i64 {
     // CHECK-LABEL: read_i64
     //
     // SPARC: ld [%o0], %o1
-    // SPARC-NEXT: add %o1, 4, %o2
+    // SPARC-NEXT: add %o1, 8, %o2
     // SPARC-NEXT: st %o2, [%o0]
-    // SPARC-NEXT: ld [%o1], %o2
-    // SPARC-NEXT: add %o1, 8, %o3
-    // SPARC-NEXT: st %o3, [%o0]
-    // SPARC-NEXT: ld [%o1+4], %o1
+    // SPARC-NEXT: ld [%o1+4], %o0
+    // SPARC-NEXT: add %sp, 96, %o2
+    // SPARC-NEXT: or %o2, 4, %o2
+    // SPARC-NEXT: st %o0, [%o2]
+    // SPARC-NEXT: ld [%o1], %o0
+    // SPARC-NEXT: st %o0, [%sp+96]
+    // SPARC-NEXT: ldd [%sp+96], %o0
     // SPARC-NEXT: retl
-    // SPARC-NEXT: mov %o2, %o0
+    // SPARC-NEXT: add %sp, 104, %sp
     //
     // SPARC64: ldx [%o0], %o1
     // SPARC64-NEXT: add %o1, 8, %o2

--- a/tests/codegen-llvm/sanitizer/ignorelist/cfi-ignorelist.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/cfi-ignorelist.rs
@@ -1,0 +1,43 @@
+//@ needs-sanitizer-cfi
+//@ compile-flags: -Zsanitizer=cfi -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitizer -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/cfi-ignorelist.txt
+
+#![crate_type = "lib"]
+
+// CHECK: define void @test_cfi
+// CHECK-SAME: !type
+// CHECK-NOT: trap
+// CHECK: call void %f()
+#[no_mangle]
+pub fn test_cfi(f: fn(), x: &mut i32) {
+    *x = 1;
+    f();
+}
+
+// CHECK: define void @test_memory
+// CHECK-SAME: !type
+// CHECK: trap
+#[no_mangle]
+pub fn test_memory(f: fn(i32), x: &mut i32) {
+    *x = 2;
+    f(1);
+}
+
+// CHECK: define void @test_all
+// CHECK-SAME: !type
+// CHECK-NOT: trap
+// CHECK: call void %f()
+#[no_mangle]
+pub fn test_all(f: fn(), x: &mut i32) {
+    *x = 3;
+    f();
+}
+
+// CHECK: define void @test_cfi_icall
+// CHECK-SAME: !type
+// CHECK-NOT: trap
+// CHECK: call void %f()
+#[no_mangle]
+pub fn test_cfi_icall(f: fn(), x: &mut i32) {
+    *x = 4;
+    f();
+}

--- a/tests/codegen-llvm/sanitizer/ignorelist/cfi-ignorelist.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/cfi-ignorelist.txt
@@ -1,0 +1,11 @@
+[cfi]
+fun:*test_cfi*
+
+[memory]
+fun:*test_memory*
+
+[cfi-icall]
+fun:*test_cfi_icall*
+
+[all]
+fun:*test_all*

--- a/tests/codegen-llvm/sanitizer/ignorelist/global-ignorelist.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/global-ignorelist.rs
@@ -1,0 +1,13 @@
+//@ needs-sanitizer-address
+//@ compile-flags: -Zsanitizer=address -Ctarget-feature=-crt-static -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/global-ignorelist.txt
+
+#![crate_type = "lib"]
+
+// CHECK: @IGNORED_GLOBAL = {{.*}} no_sanitize_address
+#[no_mangle]
+pub static IGNORED_GLOBAL: i64 = 42;
+
+// CHECK: @CHECKED_GLOBAL = {{.*}} no_sanitize_address
+// (because of src:*global-ignorelist.rs)
+#[no_mangle]
+pub static CHECKED_GLOBAL: i64 = 42;

--- a/tests/codegen-llvm/sanitizer/ignorelist/global-ignorelist.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/global-ignorelist.txt
@@ -1,0 +1,3 @@
+[address]
+global:*IGNORED_GLOBAL*
+src:*global-ignorelist.rs

--- a/tests/codegen-llvm/sanitizer/ignorelist/ignorelist.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/ignorelist.rs
@@ -1,0 +1,67 @@
+//@ revisions: ASAN MSAN TSAN HWASAN
+//@[ASAN] needs-sanitizer-address
+//@[MSAN] needs-sanitizer-memory
+//@[TSAN] needs-sanitizer-thread
+//@[HWASAN] needs-sanitizer-hwaddress
+//@ compile-flags: -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/ignorelist.txt -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitizer
+//@ [ASAN] compile-flags: -Zsanitizer=address
+//@ [MSAN] compile-flags: -Zsanitizer=memory
+//@ [TSAN] compile-flags: -Zsanitizer=thread
+//@ [HWASAN] compile-flags: -Zsanitizer=hwaddress -C target-feature=+tagged-globals
+
+#![crate_type = "lib"]
+
+// CHECK: ; Function Attrs:
+// ASAN-NOT: sanitize_address
+// MSAN-SAME: sanitize_memory
+// TSAN-SAME: sanitize_thread
+// HWASAN-SAME: sanitize_hwaddress
+// CHECK-NEXT: define void @test_address
+#[no_mangle]
+pub fn test_address(x: &mut i32) {
+    *x = 1;
+}
+
+// CHECK: ; Function Attrs:
+// ASAN-SAME: sanitize_address
+// MSAN-NOT: sanitize_memory
+// TSAN-SAME: sanitize_thread
+// HWASAN-SAME: sanitize_hwaddress
+// CHECK-NEXT: define void @test_memory
+#[no_mangle]
+pub fn test_memory(x: &mut i32) {
+    *x = 2;
+}
+
+// CHECK: ; Function Attrs:
+// ASAN-SAME: sanitize_address
+// MSAN-SAME: sanitize_memory
+// TSAN-NOT: sanitize_thread
+// HWASAN-SAME: sanitize_hwaddress
+// CHECK-NEXT: define void @test_thread
+#[no_mangle]
+pub fn test_thread(x: &mut i32) {
+    *x = 3;
+}
+
+// CHECK: ; Function Attrs:
+// ASAN-SAME: sanitize_address
+// MSAN-SAME: sanitize_memory
+// TSAN-SAME: sanitize_thread
+// HWASAN-NOT: sanitize_hwaddress
+// CHECK-NEXT: define void @test_hwaddress
+#[no_mangle]
+pub fn test_hwaddress(x: &mut i32) {
+    *x = 4;
+}
+
+// CHECK: ; Function Attrs:
+// ASAN-NOT: sanitize_address
+// MSAN-NOT: sanitize_memory
+// TSAN-NOT: sanitize_thread
+// HWASAN-NOT: sanitize_hwaddress
+// CHECK-NEXT: define void @test_all
+#[no_mangle]
+pub fn test_all(x: &mut i32) {
+    *x = 6;
+}

--- a/tests/codegen-llvm/sanitizer/ignorelist/ignorelist.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/ignorelist.txt
@@ -1,0 +1,14 @@
+[address]
+fun:*test_address*
+
+[memory]
+fun:*test_memory*
+
+[thread]
+fun:*test_thread*
+
+[hwaddress]
+fun:*test_hwaddress*
+
+[all]
+fun:*test_all*

--- a/tests/codegen-llvm/sanitizer/ignorelist/kcfi-ignorelist.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/kcfi-ignorelist.rs
@@ -1,0 +1,23 @@
+//@ needs-sanitizer-kcfi
+//@ compile-flags: -Zsanitizer=kcfi -C panic=abort -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitizer -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/kcfi-ignorelist.txt
+
+#![crate_type = "lib"]
+
+// CHECK: define void @test_kcfi
+// CHECK-SAME: !kcfi_type
+// CHECK-NOT: [ "kcfi"
+// CHECK: call void %f()
+#[no_mangle]
+pub fn test_kcfi(f: fn(), x: &mut i32) {
+    *x = 1;
+    f();
+}
+
+// CHECK: define void @test_memory
+// CHECK-SAME: !kcfi_type
+// CHECK: call void %f(i32 {{.*}}1){{.*}}[ "kcfi"
+#[no_mangle]
+pub fn test_memory(f: fn(i32), x: &mut i32) {
+    *x = 2;
+    f(1);
+}

--- a/tests/codegen-llvm/sanitizer/ignorelist/kcfi-ignorelist.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/kcfi-ignorelist.txt
@@ -1,0 +1,5 @@
+[kcfi]
+fun:*test_kcfi*
+
+[memory]
+fun:*test_memory*

--- a/tests/codegen-llvm/sanitizer/ignorelist/kernel-address-ignorelist.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/kernel-address-ignorelist.rs
@@ -1,0 +1,20 @@
+//@ needs-sanitizer-address
+//@ compile-flags: -Zsanitizer=address -Ctarget-feature=-crt-static -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/kernel-address-ignorelist.txt
+
+#![crate_type = "lib"]
+
+// CHECK: ; Function Attrs:
+// CHECK-SAME: sanitize_address
+// CHECK-NEXT: define void @test_kernel_address_ignored
+#[no_mangle]
+pub fn test_kernel_address_ignored(x: &mut i32) {
+    *x = 1;
+}
+
+// CHECK: ; Function Attrs:
+// CHECK-NOT: sanitize_address
+// CHECK-NEXT: define void @test_address_ignored
+#[no_mangle]
+pub fn test_address_ignored(x: &mut i32) {
+    *x = 2;
+}

--- a/tests/codegen-llvm/sanitizer/ignorelist/kernel-address-ignorelist.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/kernel-address-ignorelist.txt
@@ -1,0 +1,5 @@
+[kernel-address]
+fun:test_kernel_address_ignored
+
+[address]
+fun:test_address_ignored

--- a/tests/codegen-llvm/sanitizer/ignorelist/mainfile-ignore.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/mainfile-ignore.rs
@@ -1,0 +1,12 @@
+//@ needs-sanitizer-address
+//@ compile-flags: -Zsanitizer=address -Ctarget-feature=-crt-static -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/mainfile-ignorelist.txt
+
+#![crate_type = "lib"]
+
+// CHECK: ; Function Attrs:
+// CHECK-NOT: sanitize_address
+// CHECK-NEXT: define void @test_mainfile
+#[no_mangle]
+pub fn test_mainfile(x: &mut i32) {
+    *x = 1;
+}

--- a/tests/codegen-llvm/sanitizer/ignorelist/mainfile-ignorelist.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/mainfile-ignorelist.txt
@@ -1,0 +1,2 @@
+[address]
+mainfile:*mainfile-ignore.rs

--- a/tests/codegen-llvm/sanitizer/ignorelist/override-ignorelist.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/override-ignorelist.rs
@@ -1,0 +1,30 @@
+//@ needs-sanitizer-address
+//@ compile-flags: -Zsanitizer=address -Ctarget-feature=-crt-static -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/override-ignorelist.txt
+
+#![crate_type = "lib"]
+
+// CHECK: ; Function Attrs:
+// CHECK-NOT: sanitize_address
+// CHECK-NEXT: define void @test_ignored
+#[no_mangle]
+pub fn test_ignored(x: &mut i32) {
+    *x = 1;
+}
+
+// CHECK: ; Function Attrs:
+// CHECK-SAME: sanitize_address
+// CHECK-NEXT: define void @test_re_enabled
+#[no_mangle]
+pub fn test_re_enabled(x: &mut i32) {
+    *x = 2;
+}
+
+pub static RE_ENABLED_REF: fn(&mut i32) = test_mangled_re_enabled;
+
+// CHECK: ; Function Attrs:
+// CHECK-SAME: sanitize_address
+// CHECK-LABEL: define {{.*}}test_mangled_re_enabled
+#[inline(never)]
+pub fn test_mangled_re_enabled(x: &mut i32) {
+    *x = 3;
+}

--- a/tests/codegen-llvm/sanitizer/ignorelist/override-ignorelist.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/override-ignorelist.txt
@@ -1,0 +1,4 @@
+[address]
+fun:*
+fun:test_re_enabled=sanitize
+fun:*test_mangled_re_enabled*=sanitize

--- a/tests/codegen-llvm/sanitizer/ignorelist/override-kernel-address.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/override-kernel-address.rs
@@ -1,0 +1,31 @@
+//@ needs-sanitizer-kasan
+//@ compile-flags: -Zsanitizer=kernel-address -Ctarget-feature=-crt-static -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/override-kernel-address.txt
+
+#![crate_type = "lib"]
+
+// [address] does not ignore functions under -Zsanitizer=kernel-address (matches Clang):
+// CHECK: ; Function Attrs:
+// CHECK-SAME: sanitize_address
+// CHECK-NEXT: define void @test_address_not_ignored
+#[no_mangle]
+pub fn test_address_not_ignored(x: &mut i32) {
+    *x = 1;
+}
+
+// Ignored via [kernel-address]:
+// CHECK: ; Function Attrs:
+// CHECK-NOT: sanitize_address
+// CHECK-NEXT: define void @test_kernel_ignored
+#[no_mangle]
+pub fn test_kernel_ignored(x: &mut i32) {
+    *x = 2;
+}
+
+// Re-enabled via [kernel-address] =sanitize:
+// CHECK: ; Function Attrs:
+// CHECK-SAME: sanitize_address
+// CHECK-NEXT: define void @test_kernel_override
+#[no_mangle]
+pub fn test_kernel_override(x: &mut i32) {
+    *x = 3;
+}

--- a/tests/codegen-llvm/sanitizer/ignorelist/override-kernel-address.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/override-kernel-address.txt
@@ -1,0 +1,6 @@
+[address]
+fun:test_address_not_ignored
+
+[kernel-address]
+fun:test_kernel_ignored
+fun:test_kernel_override=sanitize

--- a/tests/codegen-llvm/sanitizer/ignorelist/src-ignore-memory.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/src-ignore-memory.rs
@@ -1,0 +1,56 @@
+//@ revisions: ASAN MSAN TSAN HWASAN
+//@[ASAN] needs-sanitizer-address
+//@[MSAN] needs-sanitizer-memory
+//@[TSAN] needs-sanitizer-thread
+//@[HWASAN] needs-sanitizer-hwaddress
+//@ compile-flags: -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/src-ignore-memory.txt -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitizer
+//@ [ASAN] compile-flags: -Zsanitizer=address
+//@ [MSAN] compile-flags: -Zsanitizer=memory
+//@ [TSAN] compile-flags: -Zsanitizer=thread
+//@ [HWASAN] compile-flags: -Zsanitizer=hwaddress -C target-feature=+tagged-globals
+
+#![crate_type = "lib"]
+
+// CHECK: ; Function Attrs:
+// ASAN-NOT: sanitize_address
+// MSAN-NOT: sanitize_memory
+// TSAN-NOT: sanitize_thread
+// HWASAN-NOT: sanitize_hwaddress
+// CHECK-NEXT: define void @test_file_address
+#[no_mangle]
+pub fn test_file_address(x: &mut i32) {
+    *x = 1;
+}
+
+// CHECK: ; Function Attrs:
+// ASAN-NOT: sanitize_address
+// MSAN-NOT: sanitize_memory
+// TSAN-NOT: sanitize_thread
+// HWASAN-NOT: sanitize_hwaddress
+// CHECK-NEXT: define void @test_file_memory
+#[no_mangle]
+pub fn test_file_memory(x: &mut i32) {
+    *x = 2;
+}
+
+// CHECK: ; Function Attrs:
+// ASAN-NOT: sanitize_address
+// MSAN-NOT: sanitize_memory
+// TSAN-NOT: sanitize_thread
+// HWASAN-NOT: sanitize_hwaddress
+// CHECK-NEXT: define void @test_file_thread
+#[no_mangle]
+pub fn test_file_thread(x: &mut i32) {
+    *x = 3;
+}
+
+// CHECK: ; Function Attrs:
+// ASAN-NOT: sanitize_address
+// MSAN-NOT: sanitize_memory
+// TSAN-NOT: sanitize_thread
+// HWASAN-NOT: sanitize_hwaddress
+// CHECK-NEXT: define void @test_file_hwaddress
+#[no_mangle]
+pub fn test_file_hwaddress(x: &mut i32) {
+    *x = 4;
+}

--- a/tests/codegen-llvm/sanitizer/ignorelist/src-ignore-memory.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/src-ignore-memory.txt
@@ -1,0 +1,11 @@
+[address]
+src:*src-ignore-memory.rs
+
+[memory]
+src:*src-ignore-memory.rs
+
+[thread]
+src:*src-ignore-memory.rs
+
+[hwaddress]
+src:*src-ignore-memory.rs

--- a/tests/codegen-llvm/sanitizer/ignorelist/src-ignore.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/src-ignore.rs
@@ -1,0 +1,15 @@
+//@ needs-sanitizer-cfi
+//@ compile-flags: -Zsanitizer=cfi -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitizer -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/src-ignore.txt
+
+#![crate_type = "lib"]
+
+// CHECK: define void @test_file
+// CHECK-SAME: !type
+// CHECK-NOT: llvm.type.test
+// CHECK-NOT: trap
+// CHECK: call void %f()
+#[no_mangle]
+pub fn test_file(f: fn(), x: &mut i32) {
+    *x = 1;
+    f();
+}

--- a/tests/codegen-llvm/sanitizer/ignorelist/src-ignore.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/src-ignore.txt
@@ -1,0 +1,2 @@
+[cfi]
+src:*src-ignore*

--- a/tests/codegen-llvm/sanitizer/ignorelist/type-ignorelist-asan.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/type-ignorelist-asan.rs
@@ -1,0 +1,22 @@
+//@ needs-sanitizer-address
+//@ compile-flags: -Zsanitizer=address -Ctarget-feature=-crt-static -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/type-ignorelist-asan.txt
+
+#![crate_type = "lib"]
+
+// CHECK: @IGNORED_GLOBAL = {{.*}} no_sanitize_address
+#[no_mangle]
+pub static IGNORED_GLOBAL: i32 = 42;
+
+// CHECK: @CHECKED_GLOBAL =
+// CHECK-NOT: no_sanitize_address
+#[no_mangle]
+pub static CHECKED_GLOBAL: i64 = 42;
+
+pub struct MyStruct {
+    #[allow(dead_code)]
+    x: i32,
+}
+
+// CHECK: @MY_STRUCT = {{.*}} no_sanitize_address
+#[no_mangle]
+pub static MY_STRUCT: MyStruct = MyStruct { x: 42 };

--- a/tests/codegen-llvm/sanitizer/ignorelist/type-ignorelist-asan.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/type-ignorelist-asan.txt
@@ -1,0 +1,3 @@
+[address]
+type:i32
+type:MyStruct

--- a/tests/codegen-llvm/sanitizer/ignorelist/type-ignorelist-kcfi.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/type-ignorelist-kcfi.rs
@@ -1,0 +1,21 @@
+//@ needs-sanitizer-kcfi
+//@ compile-flags: -Zsanitizer=kcfi -Cpanic=abort -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitizer -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/type-ignorelist-kcfi.txt
+
+#![crate_type = "lib"]
+
+// CHECK: define void @test_type
+// CHECK-SAME: !kcfi_type
+// CHECK-NOT: [ "kcfi"
+// CHECK: call void %f()
+// CHECK: call void %g(i32 {{.*}}1){{.*}}[ "kcfi"
+#[no_mangle]
+pub fn test_type(f: fn(), g: fn(i32), x: &mut i32) {
+    *x = 1;
+    f();
+    g(1);
+}
+
+// CHECK: define void @test_type_2()
+// CHECK-SAME: !kcfi_type
+#[no_mangle]
+pub fn test_type_2() {}

--- a/tests/codegen-llvm/sanitizer/ignorelist/type-ignorelist-kcfi.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/type-ignorelist-kcfi.txt
@@ -1,0 +1,2 @@
+[kcfi]
+type:fn()

--- a/tests/codegen-llvm/sanitizer/ignorelist/type-ignorelist.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/type-ignorelist.rs
@@ -1,0 +1,21 @@
+//@ needs-sanitizer-cfi
+//@ compile-flags: -Zsanitizer=cfi -Clto -Ctarget-feature=-crt-static -Cunsafe-allow-abi-mismatch=sanitizer -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/type-ignorelist.txt
+
+#![crate_type = "lib"]
+
+// CHECK: define void @test_type
+// CHECK-SAME: !type
+// CHECK-NOT: trap
+// CHECK: call void %f()
+// CHECK: trap
+#[no_mangle]
+pub fn test_type(f: fn(), g: fn(i32), x: &mut i32) {
+    *x = 1;
+    f();
+    g(1);
+}
+
+// CHECK: define void @test_type_2()
+// CHECK-SAME: !type
+#[no_mangle]
+pub fn test_type_2() {}

--- a/tests/codegen-llvm/sanitizer/ignorelist/type-ignorelist.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/type-ignorelist.txt
@@ -1,0 +1,2 @@
+[cfi]
+type:fn()

--- a/tests/codegen-llvm/sanitizer/ignorelist/type-string-unsafe-ignorelist.txt
+++ b/tests/codegen-llvm/sanitizer/ignorelist/type-string-unsafe-ignorelist.txt
@@ -1,0 +1,2 @@
+[address]
+type:*unsafe*extern*fn*

--- a/tests/codegen-llvm/sanitizer/ignorelist/type-string-unsafe.rs
+++ b/tests/codegen-llvm/sanitizer/ignorelist/type-string-unsafe.rs
@@ -1,0 +1,10 @@
+//@ needs-sanitizer-address
+//@ compile-flags: -Zsanitizer=address -Ctarget-feature=-crt-static -Zsanitizer-ignorelist={{src-base}}/sanitizer/ignorelist/type-string-unsafe-ignorelist.txt
+
+#![crate_type = "lib"]
+
+pub static MY_FN: unsafe extern "C" fn() = my_fn_impl;
+
+// CHECK: MY_FN = {{.*}} no_sanitize_address
+
+unsafe extern "C" fn my_fn_impl() {}

--- a/tests/run-make/c-link-to-rust-va-list-fn/checkrust.rs
+++ b/tests/run-make/c-link-to-rust-va-list-fn/checkrust.rs
@@ -1,5 +1,5 @@
 #![crate_type = "staticlib"]
-#![feature(c_variadic_int128)]
+#![feature(c_variadic_int128, c_variadic_experimental_arch)]
 
 use core::ffi::{CStr, VaList, c_char, c_double, c_int, c_long, c_longlong};
 

--- a/tests/ui/abi/avr-sram.disable_sram.stderr
+++ b/tests/ui/abi/avr-sram.disable_sram.stderr
@@ -1,12 +1,12 @@
 warning: target feature `sram` cannot be disabled with `-Ctarget-feature`: devices that have no SRAM are unsupported
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `sram` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/abi/avr-sram.no_sram.stderr
+++ b/tests/ui/abi/avr-sram.no_sram.stderr
@@ -1,7 +1,7 @@
 warning: target feature `sram` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/abi/riscv-discoverability-guidance.riscv32.stderr
+++ b/tests/ui/abi/riscv-discoverability-guidance.riscv32.stderr
@@ -1,9 +1,11 @@
 warning: unstable feature specified for `-Ctarget-feature`: `unaligned-scalar-mem`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error[E0703]: invalid ABI: found `riscv-interrupt`
-  --> $DIR/riscv-discoverability-guidance.rs:19:8
+  --> $DIR/riscv-discoverability-guidance.rs:21:8
    |
 LL | extern "riscv-interrupt" fn isr() {}
    |        ^^^^^^^^^^^^^^^^^ invalid ABI
@@ -15,7 +17,7 @@ LL | extern "riscv-interrupt-m" fn isr() {}
    |                        ++
 
 error[E0703]: invalid ABI: found `riscv-interrupt-u`
-  --> $DIR/riscv-discoverability-guidance.rs:24:8
+  --> $DIR/riscv-discoverability-guidance.rs:26:8
    |
 LL | extern "riscv-interrupt-u" fn isr_U() {}
    |        ^^^^^^^^^^^^^^^^^^^ invalid ABI

--- a/tests/ui/abi/riscv-discoverability-guidance.riscv64.stderr
+++ b/tests/ui/abi/riscv-discoverability-guidance.riscv64.stderr
@@ -1,9 +1,11 @@
 warning: unstable feature specified for `-Ctarget-feature`: `unaligned-scalar-mem`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error[E0703]: invalid ABI: found `riscv-interrupt`
-  --> $DIR/riscv-discoverability-guidance.rs:19:8
+  --> $DIR/riscv-discoverability-guidance.rs:21:8
    |
 LL | extern "riscv-interrupt" fn isr() {}
    |        ^^^^^^^^^^^^^^^^^ invalid ABI
@@ -15,7 +17,7 @@ LL | extern "riscv-interrupt-m" fn isr() {}
    |                        ++
 
 error[E0703]: invalid ABI: found `riscv-interrupt-u`
-  --> $DIR/riscv-discoverability-guidance.rs:24:8
+  --> $DIR/riscv-discoverability-guidance.rs:26:8
    |
 LL | extern "riscv-interrupt-u" fn isr_U() {}
    |        ^^^^^^^^^^^^^^^^^^^ invalid ABI

--- a/tests/ui/abi/riscv-discoverability-guidance.rs
+++ b/tests/ui/abi/riscv-discoverability-guidance.rs
@@ -12,6 +12,8 @@
 
 //~? WARN unstable feature specified for `-Ctarget-feature`
 //~? NOTE this feature is not stably supported; its behavior can change in the future
+//~? NOTE previously accepted
+//~? NOTE for more information, see issue
 
 extern crate minicore;
 use minicore::*;

--- a/tests/ui/abi/s390x-softfloat-gate.disable-softfloat.stderr
+++ b/tests/ui/abi/s390x-softfloat-gate.disable-softfloat.stderr
@@ -1,12 +1,12 @@
 warning: target feature `soft-float` cannot be enabled with `-Ctarget-feature`: unsupported ABI-configuration feature
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `soft-float` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/abi/s390x-softfloat-gate.enable-softfloat.stderr
+++ b/tests/ui/abi/s390x-softfloat-gate.enable-softfloat.stderr
@@ -1,7 +1,7 @@
 warning: target feature `vector` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/abi/simd-abi-checks-s390x.z13_soft_float.stderr
+++ b/tests/ui/abi/simd-abi-checks-s390x.z13_soft_float.stderr
@@ -1,12 +1,12 @@
 warning: target feature `soft-float` cannot be enabled with `-Ctarget-feature`: unsupported ABI-configuration feature
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `soft-float` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: this function definition requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:33:1

--- a/tests/ui/abi/sparcv8plus.sparc_cpu_v9_feature_v8plus.stderr
+++ b/tests/ui/abi/sparcv8plus.sparc_cpu_v9_feature_v8plus.stderr
@@ -1,11 +1,13 @@
 warning: unstable feature specified for `-Ctarget-feature`: `v8plus`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `v8plus` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: +v8plus,+v9
   --> $DIR/sparcv8plus.rs:35:1

--- a/tests/ui/abi/sparcv8plus.sparc_feature_v8plus.stderr
+++ b/tests/ui/abi/sparcv8plus.sparc_feature_v8plus.stderr
@@ -1,11 +1,13 @@
 warning: unstable feature specified for `-Ctarget-feature`: `v8plus`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `v8plus` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: +v8plus,-v9 (FIXME)
   --> $DIR/sparcv8plus.rs:40:1

--- a/tests/ui/asm/hexagon-register-pairs.stderr
+++ b/tests/ui/asm/hexagon-register-pairs.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `hvx-length128b`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: avoid using named labels in inline assembly
   --> $DIR/hexagon-register-pairs.rs:32:15

--- a/tests/ui/asm/hexagon/bad-reg.stderr
+++ b/tests/ui/asm/hexagon/bad-reg.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `hvx-length128b`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: invalid register `r19`: r19 is used internally by LLVM and cannot be used as an operand for inline asm
   --> $DIR/bad-reg.rs:20:18

--- a/tests/ui/asm/mips/reg-conflict.mips32.stderr
+++ b/tests/ui/asm/mips/reg-conflict.mips32.stderr
@@ -1,15 +1,21 @@
 warning: unknown and unstable feature specified for `-Ctarget-feature`: `mips32r5`
    |
    = note: it is still passed through to the codegen backend, but use of this feature might be unsound and the behavior of this feature can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
    = help: consider filing a feature request
 
 warning: unstable feature specified for `-Ctarget-feature`: `fp64`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: unstable feature specified for `-Ctarget-feature`: `msa`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: register `$f4` conflicts with register `$w4`
   --> $DIR/reg-conflict.rs:28:33

--- a/tests/ui/asm/mips/reg-conflict.mips32r6.stderr
+++ b/tests/ui/asm/mips/reg-conflict.mips32r6.stderr
@@ -1,10 +1,14 @@
 warning: unstable feature specified for `-Ctarget-feature`: `fp64`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: unstable feature specified for `-Ctarget-feature`: `msa`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: register `$f4` conflicts with register `$w4`
   --> $DIR/reg-conflict.rs:28:33

--- a/tests/ui/asm/mips/reg-conflict.mips64.stderr
+++ b/tests/ui/asm/mips/reg-conflict.mips64.stderr
@@ -1,15 +1,21 @@
 warning: unknown and unstable feature specified for `-Ctarget-feature`: `mips64r5`
    |
    = note: it is still passed through to the codegen backend, but use of this feature might be unsound and the behavior of this feature can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
    = help: consider filing a feature request
 
 warning: unstable feature specified for `-Ctarget-feature`: `fp64`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: unstable feature specified for `-Ctarget-feature`: `msa`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: register `$f4` conflicts with register `$w4`
   --> $DIR/reg-conflict.rs:28:33

--- a/tests/ui/asm/mips/reg-conflict.mips64r6.stderr
+++ b/tests/ui/asm/mips/reg-conflict.mips64r6.stderr
@@ -1,10 +1,14 @@
 warning: unstable feature specified for `-Ctarget-feature`: `fp64`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: unstable feature specified for `-Ctarget-feature`: `msa`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 error: register `$f4` conflicts with register `$w4`
   --> $DIR/reg-conflict.rs:28:33

--- a/tests/ui/inference/cannot-infer-partial-try-return.rs
+++ b/tests/ui/inference/cannot-infer-partial-try-return.rs
@@ -10,7 +10,7 @@ where
     }
 }
 
-fn infallible() -> Result<(), std::convert::Infallible> {
+fn infallible() -> Result<(), !> {
     Ok(())
 }
 

--- a/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.riscv.stderr
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.riscv.stderr
@@ -1,11 +1,13 @@
 warning: unstable feature specified for `-Ctarget-feature`: `d`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `d` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.x86.stderr
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.x86.stderr
@@ -1,12 +1,12 @@
 warning: target feature `soft-float` cannot be enabled with `-Ctarget-feature`: use a soft-float target instead
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `soft-float` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/target-feature/abi-irrelevant-target-feature-flag-disable.stderr
+++ b/tests/ui/target-feature/abi-irrelevant-target-feature-flag-disable.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `x87`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/abi-required-target-feature-flag-disable.aarch64.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-flag-disable.aarch64.stderr
@@ -1,7 +1,7 @@
 warning: target feature `neon` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/abi-required-target-feature-flag-disable.loongarch.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-flag-disable.loongarch.stderr
@@ -1,7 +1,7 @@
 warning: target feature `d` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/abi-required-target-feature-flag-disable.riscv.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-flag-disable.riscv.stderr
@@ -1,11 +1,13 @@
 warning: unstable feature specified for `-Ctarget-feature`: `d`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `d` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/target-feature/abi-required-target-feature-flag-disable.x86-implied.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-flag-disable.x86-implied.stderr
@@ -1,7 +1,7 @@
 warning: target feature `sse2` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/abi-required-target-feature-flag-disable.x86.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-flag-disable.x86.stderr
@@ -1,11 +1,13 @@
 warning: unstable feature specified for `-Ctarget-feature`: `x87`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: target feature `x87` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/target-feature/abi-required-target-feature-missing-in-target-cpu.x86.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-missing-in-target-cpu.x86.stderr
@@ -1,7 +1,7 @@
 warning: target feature `sse2` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/feature-hierarchy.hexagon-hvxv66.stderr
+++ b/tests/ui/target-feature/feature-hierarchy.hexagon-hvxv66.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `hvxv66`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/feature-hierarchy.hexagon-v60.stderr
+++ b/tests/ui/target-feature/feature-hierarchy.hexagon-v60.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `v60`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/feature-hierarchy.hexagon-v68.stderr
+++ b/tests/ui/target-feature/feature-hierarchy.hexagon-v68.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `v68`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/forbidden-target-feature-flag-disable.stderr
+++ b/tests/ui/target-feature/forbidden-target-feature-flag-disable.stderr
@@ -1,7 +1,7 @@
 warning: target feature `forced-atomics` cannot be disabled with `-Ctarget-feature`: unsound because it changes the ABI of atomic operations
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/forbidden-target-feature-flag.stderr
+++ b/tests/ui/target-feature/forbidden-target-feature-flag.stderr
@@ -1,7 +1,7 @@
 warning: target feature `forced-atomics` cannot be enabled with `-Ctarget-feature`: unsound because it changes the ABI of atomic operations
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/packedstack-combinations.with_softfloat.stderr
+++ b/tests/ui/target-feature/packedstack-combinations.with_softfloat.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `backchain`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/retpoline-target-feature-flag.by_feature1.stderr
+++ b/tests/ui/target-feature/retpoline-target-feature-flag.by_feature1.stderr
@@ -1,7 +1,7 @@
 warning: target feature `retpoline-external-thunk` cannot be enabled with `-Ctarget-feature`: use `-Zretpoline-external-thunk` compiler flag instead
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/retpoline-target-feature-flag.by_feature2.stderr
+++ b/tests/ui/target-feature/retpoline-target-feature-flag.by_feature2.stderr
@@ -1,7 +1,7 @@
 warning: target feature `retpoline-indirect-branches` cannot be enabled with `-Ctarget-feature`: use `-Zretpoline` compiler flag instead
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/retpoline-target-feature-flag.by_feature3.stderr
+++ b/tests/ui/target-feature/retpoline-target-feature-flag.by_feature3.stderr
@@ -1,7 +1,7 @@
 warning: target feature `retpoline-indirect-calls` cannot be enabled with `-Ctarget-feature`: use `-Zretpoline` compiler flag instead
    |
    = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116344 <https://github.com/rust-lang/rust/issues/116344>
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/target-feature/similar-feature-suggestion.stderr
+++ b/tests/ui/target-feature/similar-feature-suggestion.stderr
@@ -1,6 +1,8 @@
 warning: unknown and unstable feature specified for `-Ctarget-feature`: `rdrnd`
    |
    = note: it is still passed through to the codegen backend, but use of this feature might be unsound and the behavior of this feature can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
    = help: you might have meant: `rdrand`
 
 warning: 1 warning emitted

--- a/tests/ui/target-feature/unstable-feature.stderr
+++ b/tests/ui/target-feature/unstable-feature.stderr
@@ -1,6 +1,8 @@
 warning: unstable feature specified for `-Ctarget-feature`: `x87`
    |
    = note: this feature is not stably supported; its behavior can change in the future
+   = note: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #162235 <https://github.com/rust-lang/rust/issues/162235>
 
 warning: 1 warning emitted
 

--- a/tests/ui/try-trait/try-operator-custom.rs
+++ b/tests/ui/try-trait/try-operator-custom.rs
@@ -43,7 +43,7 @@ impl<U, V> Residual<U> for MyResult<Never, V> {
     type TryType = MyResult<U, V>;
 }
 
-type ResultResidual<E> = Result<std::convert::Infallible, E>;
+type ResultResidual<E> = Result<!, E>;
 
 impl<U, V, W> FromResidual<ResultResidual<V>> for MyResult<U, W>
 where


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#157808 (sanitizers: Implement support for the sanitize ignorelist)
 - rust-lang/rust#160660 (c-variadic: use `emit_ptr_va_arg` for `va_arg` on `sparc`)
 - rust-lang/rust#162237 (make -Ctarget-feature warnings more explicitly FCWs)
 - rust-lang/rust#160111 (Generalize Decodable impl for arrays to all types)
 - rust-lang/rust#162174 (Update internal docs & tests to use `!` rather than `Infallible` in relation to `Try`)
 - rust-lang/rust#162226 (Clean up the AST visitor)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=157808,160660,162237,160111,162174,162226)
<!-- homu-ignore:end -->

