### PR TITLE
abby test DSL: AliasTyOutlivesViaEnv

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -4081,6 +4081,8 @@ pub struct TestBinderBody {
     pub foralls: ThinVec<TestBinderForall>,
     pub exists: ThinVec<TestBinderExists>,
     pub constraints: Vec<TestBinderConstraint>,
+    /// These are not where clauses, but rather predicates within the body to be proven
+    pub predicates: Vec<WhereClause>,
 }
 
 #[derive(Clone, Encodable, Decodable, Debug, Walkable)]
@@ -4114,11 +4116,24 @@ pub enum TestBinderConstraint {
         #[visitable(extra = LifetimeCtxt::Bound)]
         rhs: Lifetime,
     },
-    Type {
+    PlaceholderOutlives {
         lhs: Box<Ty>,
         #[visitable(extra = LifetimeCtxt::Bound)]
         rhs: Lifetime,
     },
+    AliasOutlives {
+        bound_type_constraint: TestBinderBoundTypeConstraint,
+    },
+}
+
+#[derive(Clone, Encodable, Decodable, Debug, Walkable)]
+pub struct TestBinderBoundTypeConstraint {
+    pub span: Span,
+    pub node_id: NodeId,
+    pub params: ThinVec<GenericParam>,
+    pub lhs: Box<Ty>,
+    #[visitable(extra = LifetimeCtxt::Bound)]
+    pub rhs: Lifetime,
 }
 
 // Adding a new variant? Please update `test_item` in `tests/ui/macros/stringify.rs`.

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -610,6 +610,7 @@ macro_rules! common_visitor_and_walkers {
                 fn visit_qself(QSelf);
                 fn visit_test_binder_body(TestBinderBody);
                 fn visit_test_binder_constraint(TestBinderConstraint);
+                fn visit_test_binder_bound_type_constraint(TestBinderBoundTypeConstraint);
                 fn visit_test_binder_constraints(TestBinderConstraints);
                 fn visit_test_binder_exists(TestBinderExists);
                 fn visit_test_binder_forall(TestBinderForall);
@@ -1145,6 +1146,7 @@ macro_rules! common_visitor_and_walkers {
             pub fn walk_qself(QSelf);
             pub fn walk_test_binder_body(TestBinderBody);
             pub fn walk_test_binder_constraint(TestBinderConstraint);
+            pub fn walk_test_binder_bound_type_constraint(TestBinderBoundTypeConstraint);
             pub fn walk_test_binder_exists(TestBinderExists);
             pub fn walk_test_binder_forall(TestBinderForall);
             pub fn walk_trait_ref(TraitRef);

--- a/compiler/rustc_ast_lowering/src/index.rs
+++ b/compiler/rustc_ast_lowering/src/index.rs
@@ -432,13 +432,27 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
         intravisit::walk_precise_capturing_arg(self, arg);
     }
 
-    fn visit_test_binder_forall(&mut self, forall: &'hir TestBinderForall<'hir>) -> Self::Result {
+    fn visit_test_binder_forall(&mut self, forall: &'hir TestBinderForall<'hir>) {
         self.insert(forall.span, forall.hir_id, Node::TestBinderForall(forall));
         self.with_parent(forall.hir_id, |this| intravisit::walk_test_binder_forall(this, forall))
     }
 
-    fn visit_test_binder_exists(&mut self, exists: &'hir TestBinderExists<'hir>) -> Self::Result {
+    fn visit_test_binder_exists(&mut self, exists: &'hir TestBinderExists<'hir>) {
         self.insert(exists.span, exists.hir_id, Node::TestBinderExists(exists));
         self.with_parent(exists.hir_id, |this| intravisit::walk_test_binder_exists(this, exists))
+    }
+
+    fn visit_test_binder_bound_type_constraint(
+        &mut self,
+        bound_type: &'hir TestBinderBoundTypeConstraint<'hir>,
+    ) {
+        self.insert(
+            bound_type.span,
+            bound_type.hir_id,
+            Node::TestBinderBoundTypeConstraint(bound_type),
+        );
+        self.with_parent(bound_type.hir_id, |this| {
+            intravisit::walk_test_binder_bound_type_constraint(this, bound_type)
+        })
     }
 }

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -2111,7 +2111,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
             body.exists.iter().map(|exists| self.lower_test_binder_exists(exists)),
         );
         let constraints = self.lower_test_binder_constraints_as_and(&body.constraints);
-        hir::TestBinderBody { foralls, exists, constraints }
+        let mut dedup_map = Default::default();
+        let predicates = self.arena.alloc_from_iter(
+            body.predicates
+                .iter()
+                .flat_map(|w| &w.predicates)
+                .map(|predicate| self.lower_where_predicate(predicate, &[], &mut dedup_map)),
+        );
+        hir::TestBinderBody { foralls, exists, constraints, predicates }
     }
 
     fn lower_test_binder_forall(
@@ -2193,12 +2200,45 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let rhs = self.lower_lifetime(rhs, LifetimeSource::OutlivesBound, rhs.ident.into());
                 hir::TestBinderConstraint::Lifetime { lhs, rhs }
             }
-            TestBinderConstraint::Type { lhs, rhs } => {
+            TestBinderConstraint::PlaceholderOutlives { lhs, rhs } => {
                 let lhs = self
                     .lower_ty_alloc(lhs, ImplTraitContext::Disallowed(ImplTraitPosition::Bound));
                 let rhs = self.lower_lifetime(rhs, LifetimeSource::OutlivesBound, rhs.ident.into());
-                hir::TestBinderConstraint::Type { lhs, rhs }
+                hir::TestBinderConstraint::PlaceholderOutlives { lhs, rhs }
             }
+            TestBinderConstraint::AliasOutlives { bound_type_constraint } => {
+                hir::TestBinderConstraint::AliasOutlives {
+                    bound_type_constraint: self
+                        .arena
+                        .alloc(self.lower_test_binder_bound_type_constraint(bound_type_constraint)),
+                }
+            }
+        }
+    }
+
+    fn lower_test_binder_bound_type_constraint(
+        &mut self,
+        bound_type: &TestBinderBoundTypeConstraint,
+    ) -> hir::TestBinderBoundTypeConstraint<'hir> {
+        let TestBinderBoundTypeConstraint { span, node_id, params, lhs, rhs } = bound_type;
+
+        let (generics, (lhs, rhs)) = self.lower_generics(
+            &Generics { params: params.clone(), where_clause: Default::default(), span: *span },
+            ImplTraitContext::Disallowed(ImplTraitPosition::Bound),
+            |this| {
+                let lhs = this
+                    .lower_ty_alloc(lhs, ImplTraitContext::Disallowed(ImplTraitPosition::Bound));
+                let rhs = this.lower_lifetime(rhs, LifetimeSource::OutlivesBound, rhs.ident.into());
+                (lhs, rhs)
+            },
+        );
+
+        hir::TestBinderBoundTypeConstraint {
+            span: *span,
+            hir_id: self.lower_node_id(*node_id),
+            params: generics.params,
+            lhs,
+            rhs,
         }
     }
 }

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -395,6 +395,14 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
         self.check_late_bound_lifetime_defs(&exists.params);
         visit::walk_test_binder_exists(self, exists)
     }
+
+    fn visit_test_binder_bound_type_constraint(
+        &mut self,
+        bound_type: &'a ast::TestBinderBoundTypeConstraint,
+    ) -> Self::Result {
+        self.check_late_bound_lifetime_defs(&bound_type.params);
+        visit::walk_test_binder_bound_type_constraint(self, bound_type)
+    }
 }
 
 // -----------------------------------------------------------------------------

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4467,7 +4467,10 @@ impl FnHeader {
 pub struct TestBinderBody<'hir> {
     pub foralls: &'hir [TestBinderForall<'hir>],
     pub exists: &'hir [TestBinderExists<'hir>],
+    /// Constraints to be inserted directly into constraint storage to be proven
     pub constraints: TestBinderConstraint<'hir>,
+    /// Constraints declared using `where` syntax, used via `register_obligation`
+    pub predicates: &'hir [WherePredicate<'hir>],
 }
 
 #[derive(Debug, Clone, Copy, StableHash)]
@@ -4492,7 +4495,17 @@ pub enum TestBinderConstraint<'hir> {
     And { items: &'hir [TestBinderConstraint<'hir>] },
     Or { items: &'hir [TestBinderConstraint<'hir>] },
     Lifetime { lhs: &'hir Lifetime, rhs: &'hir Lifetime },
-    Type { lhs: &'hir Ty<'hir>, rhs: &'hir Lifetime },
+    PlaceholderOutlives { lhs: &'hir Ty<'hir>, rhs: &'hir Lifetime },
+    AliasOutlives { bound_type_constraint: &'hir TestBinderBoundTypeConstraint<'hir> },
+}
+
+#[derive(Debug, Clone, Copy, StableHash)]
+pub struct TestBinderBoundTypeConstraint<'hir> {
+    pub span: Span,
+    pub hir_id: HirId,
+    pub params: &'hir [GenericParam<'hir>],
+    pub lhs: &'hir Ty<'hir>,
+    pub rhs: &'hir Lifetime,
 }
 
 #[derive(Debug, Clone, Copy, StableHash)]
@@ -4910,6 +4923,7 @@ pub enum Node<'hir> {
     PreciseCapturingNonLifetimeArg(&'hir PreciseCapturingNonLifetimeArg),
     TestBinderForall(&'hir TestBinderForall<'hir>),
     TestBinderExists(&'hir TestBinderExists<'hir>),
+    TestBinderBoundTypeConstraint(&'hir TestBinderBoundTypeConstraint<'hir>),
     // Created by query feeding
     Synthetic,
     Err(Span),
@@ -4967,6 +4981,7 @@ impl<'hir> Node<'hir> {
             | Node::WherePredicate(..)
             | Node::TestBinderForall(..)
             | Node::TestBinderExists(..)
+            | Node::TestBinderBoundTypeConstraint(..)
             | Node::Synthetic
             | Node::Err(..) => None,
         }

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -512,6 +512,12 @@ pub trait Visitor<'v>: Sized {
     ) -> Self::Result {
         walk_test_binder_constraint(self, constraint)
     }
+    fn visit_test_binder_bound_type_constraint(
+        &mut self,
+        bound_type: &'v TestBinderBoundTypeConstraint<'v>,
+    ) -> Self::Result {
+        walk_test_binder_bound_type_constraint(self, bound_type)
+    }
 }
 
 pub trait VisitorExt<'v>: Visitor<'v> {
@@ -1581,9 +1587,11 @@ pub fn walk_test_binder_body<'v, V: Visitor<'v>>(
     visitor: &mut V,
     body: &'v TestBinderBody<'v>,
 ) -> V::Result {
-    walk_list!(visitor, visit_test_binder_forall, body.foralls);
-    walk_list!(visitor, visit_test_binder_exists, body.exists);
-    try_visit!(visitor.visit_test_binder_constraint(&body.constraints));
+    let TestBinderBody { foralls, exists, constraints, predicates } = body;
+    walk_list!(visitor, visit_test_binder_forall, *foralls);
+    walk_list!(visitor, visit_test_binder_exists, *exists);
+    try_visit!(visitor.visit_test_binder_constraint(&constraints));
+    walk_list!(visitor, visit_where_predicate, *predicates);
     V::Result::output()
 }
 
@@ -1591,10 +1599,11 @@ pub fn walk_test_binder_forall<'v, V: Visitor<'v>>(
     visitor: &mut V,
     forall: &'v TestBinderForall<'v>,
 ) -> V::Result {
-    try_visit!(visitor.visit_id(forall.hir_id));
-    try_visit!(visitor.visit_generics(forall.generics));
-    try_visit!(visitor.visit_test_binder_body(forall.body));
-    if let Some(assert_on_exit) = &forall.assert_on_exit {
+    let TestBinderForall { span: _, hir_id, generics, body, assert_on_exit } = forall;
+    try_visit!(visitor.visit_id(*hir_id));
+    try_visit!(visitor.visit_generics(generics));
+    try_visit!(visitor.visit_test_binder_body(body));
+    if let Some(assert_on_exit) = &assert_on_exit {
         try_visit!(visitor.visit_test_binder_constraint(assert_on_exit));
     }
     V::Result::output()
@@ -1604,9 +1613,10 @@ pub fn walk_test_binder_exists<'v, V: Visitor<'v>>(
     visitor: &mut V,
     exists: &'v TestBinderExists<'v>,
 ) -> V::Result {
-    try_visit!(visitor.visit_id(exists.hir_id));
-    walk_list!(visitor, visit_generic_param, exists.params);
-    try_visit!(visitor.visit_test_binder_body(exists.body));
+    let TestBinderExists { span: _, hir_id, params, body } = exists;
+    try_visit!(visitor.visit_id(*hir_id));
+    walk_list!(visitor, visit_generic_param, *params);
+    try_visit!(visitor.visit_test_binder_body(body));
     V::Result::output()
 }
 
@@ -1625,10 +1635,25 @@ pub fn walk_test_binder_constraint<'v, V: Visitor<'v>>(
             try_visit!(visitor.visit_lifetime(lhs));
             try_visit!(visitor.visit_lifetime(rhs));
         }
-        TestBinderConstraint::Type { lhs, rhs } => {
+        TestBinderConstraint::PlaceholderOutlives { lhs, rhs } => {
             try_visit!(visitor.visit_ty_unambig(lhs));
             try_visit!(visitor.visit_lifetime(rhs));
         }
+        TestBinderConstraint::AliasOutlives { bound_type_constraint } => {
+            try_visit!(visitor.visit_test_binder_bound_type_constraint(bound_type_constraint));
+        }
     }
+    V::Result::output()
+}
+
+pub fn walk_test_binder_bound_type_constraint<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    constraint: &'v TestBinderBoundTypeConstraint<'v>,
+) -> V::Result {
+    let TestBinderBoundTypeConstraint { span: _, hir_id, params, lhs, rhs } = constraint;
+    try_visit!(visitor.visit_id(*hir_id));
+    walk_list!(visitor, visit_generic_param, *params);
+    try_visit!(visitor.visit_ty_unambig(lhs));
+    try_visit!(visitor.visit_lifetime(rhs));
     V::Result::output()
 }

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -2333,17 +2333,33 @@ impl<'tcx> WfCheckingCtxt<'_, 'tcx> {
 
     #[instrument(level = "debug", skip(self))]
     pub(super) fn check_test_binder_body(&self, body: TestBinderBody<'tcx>) {
-        let constraints = match validate(self.tcx(), &body.constraints) {
-            Ok(()) => body.constraints,
+        let TestBinderBody { foralls, exists, constraints, predicates } = body;
+        if !predicates.is_empty() {
+            for (predicate, span) in predicates {
+                let cause = traits::ObligationCause::misc(span, self.body_def_id);
+                let obligation = Obligation::new(self.tcx(), cause, self.param_env, predicate);
+                self.register_obligation(obligation);
+            }
+            match self.ocx.evaluate_obligations_error_on_ambiguity() {
+                TraitErrors::NoErrors => (),
+                TraitErrors::HasErrors(errors) => {
+                    self.infcx.err_ctxt().report_fulfillment_errors(errors);
+                    return;
+                }
+            }
+        }
+
+        let constraints = match validate(self.tcx(), &constraints) {
+            Ok(()) => constraints,
             Err(_guar) => ty::region_constraint::RegionConstraint::new_true(),
         };
 
         self.infcx.register_solver_region_constraint(constraints);
 
-        for forall in body.foralls {
+        for forall in foralls {
             self.check_test_binder_forall(forall);
         }
-        for exists in body.exists {
+        for exists in exists {
             self.check_test_binder_exists(exists);
         }
 
@@ -2431,8 +2447,8 @@ impl<'tcx> WfCheckingCtxt<'_, 'tcx> {
             if let Some(actual_span) = actual_span {
                 err.span_note(actual_span, "constraint from here");
             }
-            err.note(format!("expected: {expected:?}"));
-            err.note(format!("actual: {actual:?}"));
+            err.note(format!("expected: {expected:#?}"));
+            err.note(format!("actual: {actual:#?}"));
             err.emit();
         }
 
@@ -2446,7 +2462,25 @@ impl<'tcx> WfCheckingCtxt<'_, 'tcx> {
 
         let check_leaf_constraint =
             |expected: LeafRegionConstraint<_, _>, actual: LeafRegionConstraint<_, _>| {
-                if expected.clone().without_span() != actual.clone().without_span() {
+                if let LeafRegionConstraint::AliasTyOutlivesViaEnv(expected, expected_span) =
+                    expected
+                    && let LeafRegionConstraint::AliasTyOutlivesViaEnv(actual, actual_span) = actual
+                {
+                    let expected_anon = self.tcx().anonymize_bound_vars(expected);
+                    let actual_anon = self.tcx().anonymize_bound_vars(actual);
+                    if expected_anon != actual_anon {
+                        let mut err = self
+                            .tcx()
+                            .dcx()
+                            .struct_span_err(expected_span, "forall expect clause failed");
+                        err.span_note(actual_span, "constraint from here");
+                        err.note(format!("expected: {expected:#?}"));
+                        err.note(format!("actual: {actual:#?}"));
+                        err.note(format!("expected_anon: {expected_anon:#?}"));
+                        err.note(format!("actual_anon: {actual_anon:#?}"));
+                        err.emit();
+                    }
+                } else if expected.clone().without_span() != actual.clone().without_span() {
                     err(self.tcx(), expected.span(), expected, Some(actual.span()), actual);
                 }
             };
@@ -2663,7 +2697,10 @@ struct RedundantLifetimeArgsLint<'tcx> {
 pub(crate) struct TestBinderBody<'tcx> {
     pub foralls: Vec<TestBinderForall<'tcx>>,
     pub exists: Vec<TestBinderExists<'tcx>>,
+    /// Constraints to be inserted directly into constraint storage to be proven
     pub constraints: SolverRegionConstraint<'tcx>,
+    /// Constraints declared using `where` syntax, used via `register_obligation`
+    pub predicates: Vec<(ty::Binder<'tcx, ty::ClauseKind<'tcx>>, Span)>,
 }
 
 #[derive(Clone, Debug, TypeFoldable, TypeVisitable)]

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -327,12 +327,16 @@ impl<'tcx> ItemCtxt<'tcx> {
         &self,
         item: &hir::TestBinderBody<'tcx>,
     ) -> TestBinderBody<'tcx> {
-        let foralls =
-            item.foralls.iter().map(|forall| self.lower_test_binder_forall(forall)).collect();
-        let exists =
-            item.exists.iter().map(|exists| self.lower_test_binder_exists(exists)).collect();
-        let constraints = self.lower_test_binder_constraint(&item.constraints);
-        TestBinderBody { foralls, exists, constraints }
+        let hir::TestBinderBody { foralls, exists, constraints, predicates } = item;
+        let foralls = foralls.iter().map(|forall| self.lower_test_binder_forall(forall)).collect();
+        let exists = exists.iter().map(|exists| self.lower_test_binder_exists(exists)).collect();
+        let constraints = self.lower_test_binder_constraint(&constraints);
+        let mut clauses = Default::default();
+        for predicate in *predicates {
+            clauses_of::where_predicate_clauses(self, predicate, &mut clauses);
+        }
+        let predicates = clauses.into_iter().map(|(c, span)| (c.kind(), span)).collect();
+        TestBinderBody { foralls, exists, constraints, predicates }
     }
 
     #[instrument(level = "debug", skip(self), ret)]
@@ -451,7 +455,7 @@ impl<'tcx> ItemCtxt<'tcx> {
                     lhs, rhs, span,
                 ))
             }
-            hir::TestBinderConstraint::Type { lhs, rhs } => {
+            hir::TestBinderConstraint::PlaceholderOutlives { lhs, rhs } => {
                 let span = lhs.span.to(rhs.ident.span);
                 let lhs = self.lower_ty(lhs);
                 let rhs = self.lowerer().lower_lifetime(rhs, RegionInferReason::RegionPredicate);
@@ -460,6 +464,21 @@ impl<'tcx> ItemCtxt<'tcx> {
                 // instead, we check it when we emit the region constraint.
                 SolverRegionConstraint::new_leaf(LeafRegionConstraint::PlaceholderTyOutlives(
                     lhs, rhs, span,
+                ))
+            }
+            hir::TestBinderConstraint::AliasOutlives {
+                bound_type_constraint:
+                    hir::TestBinderBoundTypeConstraint { span, hir_id, params: _, lhs, rhs },
+            } => {
+                let bound_vars = self.tcx.late_bound_vars(*hir_id);
+                let &ty::Alias(_, lhs) = self.lower_ty(lhs).kind() else {
+                    self.dcx().span_err(lhs.span, "bound type test binder constraint must be alias (it's a AliasTyOutlivesViaEnv)");
+                    return SolverRegionConstraint::new_true();
+                };
+                let rhs = self.lowerer().lower_lifetime(rhs, RegionInferReason::RegionPredicate);
+                SolverRegionConstraint::new_leaf(LeafRegionConstraint::AliasTyOutlivesViaEnv(
+                    ty::Binder::bind_with_vars((lhs, rhs), bound_vars),
+                    *span,
                 ))
             }
         }

--- a/compiler/rustc_hir_analysis/src/collect/clauses_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/clauses_of.rs
@@ -267,63 +267,7 @@ fn gather_explicit_clauses_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generi
     trace!(?clauses);
     // Add inline `<T: Foo>` bounds and bounds in the where clause.
     for predicate in hir_generics.predicates {
-        match predicate.kind {
-            hir::WherePredicateKind::BoundPredicate(bound_pred) => {
-                let ty = icx.lowerer().lower_ty_maybe_return_type_notation(bound_pred.bounded_ty);
-                let bound_vars = tcx.late_bound_vars(predicate.hir_id);
-
-                // This is a `where Ty:` (sic!).
-                if bound_pred.bounds.is_empty() {
-                    if let ty::Param(_) = ty.kind() {
-                        // We can skip the predicate because type parameters are trivially WF.
-                    } else {
-                        // Keep the type around in a dummy predicate. That way, it's not a complete
-                        // noop (see #53696) and `Ty` is still checked for WF.
-
-                        let span = bound_pred.bounded_ty.span;
-                        let clause = ty::Binder::bind_with_vars(
-                            ty::ClauseKind::WellFormed(ty.into()),
-                            bound_vars,
-                        );
-                        clauses.insert((clause.upcast(tcx), span));
-                    }
-                }
-
-                let mut bounds = Vec::new();
-                icx.lowerer().lower_bounds(
-                    ty,
-                    bound_pred.bounds,
-                    &mut bounds,
-                    bound_vars,
-                    PredicateFilter::All,
-                    OverlappingAsssocItemConstraints::Allowed,
-                );
-                clauses.extend(bounds);
-            }
-
-            hir::WherePredicateKind::RegionPredicate(region_pred) => {
-                let r1 = icx
-                    .lowerer()
-                    .lower_lifetime(region_pred.lifetime, RegionInferReason::RegionPredicate);
-                clauses.extend(region_pred.bounds.iter().map(|bound| {
-                    let (r2, span) = match bound {
-                        hir::GenericBound::Outlives(lt) => (
-                            icx.lowerer().lower_lifetime(lt, RegionInferReason::RegionPredicate),
-                            lt.ident.span,
-                        ),
-                        bound => {
-                            span_bug!(
-                                bound.span(),
-                                "lifetime param bounds must be outlives, but found {bound:?}"
-                            )
-                        }
-                    };
-                    let clause =
-                        ty::ClauseKind::RegionOutlives(ty::OutlivesClause(r1, r2)).upcast(tcx);
-                    (clause, span)
-                }))
-            }
-        }
+        where_predicate_clauses(&icx, predicate, &mut clauses);
     }
 
     if tcx.features().generic_const_exprs() {
@@ -371,6 +315,70 @@ fn gather_explicit_clauses_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generi
     }
 
     ty::GenericClauses { parent: generics.parent, clauses: tcx.arena.alloc_from_iter(clauses) }
+}
+
+pub(super) fn where_predicate_clauses<'tcx>(
+    icx: &ItemCtxt<'tcx>,
+    predicate: &hir::WherePredicate<'_>,
+    clauses: &mut FxIndexSet<(ty::Clause<'tcx>, Span)>,
+) {
+    let tcx = icx.tcx;
+    match predicate.kind {
+        hir::WherePredicateKind::BoundPredicate(bound_pred) => {
+            let ty = icx.lowerer().lower_ty_maybe_return_type_notation(bound_pred.bounded_ty);
+            let bound_vars = tcx.late_bound_vars(predicate.hir_id);
+
+            // This is a `where Ty:` (sic!).
+            if bound_pred.bounds.is_empty() {
+                if let ty::Param(_) = ty.kind() {
+                    // We can skip the predicate because type parameters are trivially WF.
+                } else {
+                    // Keep the type around in a dummy predicate. That way, it's not a complete
+                    // noop (see #53696) and `Ty` is still checked for WF.
+
+                    let span = bound_pred.bounded_ty.span;
+                    let clause = ty::Binder::bind_with_vars(
+                        ty::ClauseKind::WellFormed(ty.into()),
+                        bound_vars,
+                    );
+                    clauses.insert((clause.upcast(tcx), span));
+                }
+            }
+
+            let mut bounds = Vec::new();
+            icx.lowerer().lower_bounds(
+                ty,
+                bound_pred.bounds,
+                &mut bounds,
+                bound_vars,
+                PredicateFilter::All,
+                OverlappingAsssocItemConstraints::Allowed,
+            );
+            clauses.extend(bounds);
+        }
+
+        hir::WherePredicateKind::RegionPredicate(region_pred) => {
+            let r1 = icx
+                .lowerer()
+                .lower_lifetime(region_pred.lifetime, RegionInferReason::RegionPredicate);
+            clauses.extend(region_pred.bounds.iter().map(|bound| {
+                let (r2, span) = match bound {
+                    hir::GenericBound::Outlives(lt) => (
+                        icx.lowerer().lower_lifetime(lt, RegionInferReason::RegionPredicate),
+                        lt.ident.span,
+                    ),
+                    bound => {
+                        span_bug!(
+                            bound.span(),
+                            "lifetime param bounds must be outlives, but found {bound:?}"
+                        )
+                    }
+                };
+                let clause = ty::ClauseKind::RegionOutlives(ty::OutlivesClause(r1, r2)).upcast(tcx);
+                (clause, span)
+            }))
+        }
+    }
 }
 
 /// Opaques have duplicated lifetimes and we need to compute bidirectional outlives clauses to

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -1087,7 +1087,7 @@ impl<'a, 'tcx> Visitor<'tcx> for BoundVarContext<'a, 'tcx> {
 
     fn visit_test_binder_forall(
         &mut self,
-        forall: &'tcx rustc_hir::TestBinderForall<'tcx>,
+        forall: &'tcx hir::TestBinderForall<'tcx>,
     ) -> Self::Result {
         let (bound_vars, binders): (FxIndexMap<LocalDefId, ResolvedArg>, Vec<_>) = forall
             .generics
@@ -1121,7 +1121,7 @@ impl<'a, 'tcx> Visitor<'tcx> for BoundVarContext<'a, 'tcx> {
 
     fn visit_test_binder_exists(
         &mut self,
-        exists: &'tcx rustc_hir::TestBinderExists<'tcx>,
+        exists: &'tcx hir::TestBinderExists<'tcx>,
     ) -> Self::Result {
         let (bound_vars, binders): (FxIndexMap<LocalDefId, ResolvedArg>, Vec<_>) = exists
             .params
@@ -1147,6 +1147,34 @@ impl<'a, 'tcx> Visitor<'tcx> for BoundVarContext<'a, 'tcx> {
                 this.visit_generic_param(param);
             }
             this.visit_test_binder_body(exists.body);
+        });
+    }
+
+    fn visit_test_binder_bound_type_constraint(
+        &mut self,
+        bound_type: &'tcx hir::TestBinderBoundTypeConstraint<'tcx>,
+    ) -> Self::Result {
+        let (bound_vars, binders): (FxIndexMap<LocalDefId, ResolvedArg>, Vec<_>) = bound_type
+            .params
+            .iter()
+            .enumerate()
+            .map(|(late_bound_idx, param)| {
+                (
+                    (param.def_id, ResolvedArg::late(late_bound_idx as u32, param)),
+                    late_arg_as_bound_arg(param),
+                )
+            })
+            .unzip();
+        self.record_late_bound_vars(bound_type.hir_id, binders);
+        let scope = Scope::Binder {
+            hir_id: bound_type.hir_id,
+            bound_vars,
+            s: self.scope,
+            scope_type: BinderScopeType::Normal,
+            where_bound_origin: None,
+        };
+        self.with(scope, |this| {
+            intravisit::walk_test_binder_bound_type_constraint(this, bound_type);
         });
     }
 }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -218,6 +218,9 @@ impl<'a> State<'a> {
             Node::WherePredicate(pred) => self.print_where_predicate(pred),
             Node::TestBinderForall(_) => panic!("cannot print Node::TestBinderForall"),
             Node::TestBinderExists(_) => panic!("cannot print Node::TestBinderExists"),
+            Node::TestBinderBoundTypeConstraint(_) => {
+                panic!("cannot print Node::TestBinderBoundTypeConstraint")
+            }
             Node::Synthetic => unreachable!(),
             Node::Err(_) => self.word("/*ERROR*/"),
         }

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -798,6 +798,7 @@ impl<'tcx> TyCtxt<'tcx> {
             Node::PreciseCapturingNonLifetimeArg(_param) => node_str("parameter"),
             Node::TestBinderForall(_) => node_str("forall"),
             Node::TestBinderExists(_) => node_str("exists"),
+            Node::TestBinderBoundTypeConstraint(_) => node_str("test bound type constraint"),
             Node::Synthetic => unreachable!(),
             Node::Err(_) => node_str("error"),
         }
@@ -1075,6 +1076,7 @@ impl<'tcx> TyCtxt<'tcx> {
             Node::PreciseCapturingNonLifetimeArg(param) => param.ident.span,
             Node::TestBinderForall(forall) => forall.span,
             Node::TestBinderExists(exists) => exists.span,
+            Node::TestBinderBoundTypeConstraint(bound_type) => bound_type.span,
             Node::Synthetic => unreachable!(),
             Node::Err(span) => span,
         }

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -352,7 +352,8 @@ impl<'tcx> TyCtxt<'tcx> {
             | Node::ConstArgExprField(_)
             | Node::OpaqueTy(_)
             | Node::TestBinderForall(_)
-            | Node::TestBinderExists(_) => {
+            | Node::TestBinderExists(_)
+            | Node::TestBinderBoundTypeConstraint(_) => {
                 unreachable!("no sub-expr expected for {parent_node:?}")
             }
         }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2702,7 +2702,12 @@ impl<'a> Parser<'a> {
         let mut foralls = ThinVec::new();
         let mut exists = ThinVec::new();
         let mut constraints = Vec::new();
+        let mut predicates = Vec::new();
         self.parse_delim_comma_seq(exp!(OpenBrace), exp!(CloseBrace), |this| {
+            if this.check_keyword(exp!(Where)) {
+                predicates.push(this.parse_where_clause()?);
+                return Ok(());
+            }
             match this.token.ident() {
                 Some((Ident { name: sym::forall, .. }, IdentIsRaw::No)) => {
                     foralls.push(this.parse_test_binder_forall()?)
@@ -2710,11 +2715,12 @@ impl<'a> Parser<'a> {
                 Some((Ident { name: sym::exists, .. }, IdentIsRaw::No)) => {
                     exists.push(this.parse_test_binder_exists()?)
                 }
+
                 _ => constraints.push(this.parse_test_binder_constraint()?),
             }
             Ok(())
         })?;
-        Ok(TestBinderBody { foralls, exists, constraints })
+        Ok(TestBinderBody { foralls, exists, constraints, predicates })
     }
 
     pub fn parse_test_binder_forall(&mut self) -> PResult<'a, TestBinderForall> {
@@ -2771,6 +2777,10 @@ impl<'a> Parser<'a> {
                     .0;
                 Ok(TestBinderConstraint::Or { items })
             }
+            _ if self.check_keyword(exp!(For)) => {
+                let bound_type_constraint = self.parse_test_binder_bound_type_constraint()?;
+                Ok(TestBinderConstraint::AliasOutlives { bound_type_constraint })
+            }
             _ if self.token.lifetime().is_some() => {
                 let lhs = self.expect_lifetime();
                 self.expect(exp!(Colon))?;
@@ -2787,9 +2797,51 @@ impl<'a> Parser<'a> {
                     self.unexpected()?;
                 }
                 let rhs = self.expect_lifetime();
-                Ok(TestBinderConstraint::Type { lhs, rhs })
+                Ok(TestBinderConstraint::PlaceholderOutlives { lhs, rhs })
             }
             _ => Err(self.dcx().struct_span_err(self.token.span, "unexpected token")),
+        }
+    }
+
+    fn parse_test_binder_bound_type_constraint(
+        &mut self,
+    ) -> PResult<'a, TestBinderBoundTypeConstraint> {
+        let lo = self.token.span;
+        let ast::WhereBoundPredicate { bound_generic_params, bounded_ty, bounds } =
+            self.parse_ty_where_predicate_kind()?;
+        let mut rhs = None;
+        for bound in bounds {
+            match bound {
+                GenericBound::Trait(poly_trait_ref) => {
+                    self.dcx().span_err(poly_trait_ref.span, "trait bounds aren't supported here");
+                }
+                GenericBound::Use(_, span) => {
+                    self.dcx().span_err(span, "use bounds aren't supported here");
+                }
+                GenericBound::Outlives(lifetime) => {
+                    if rhs.is_some() {
+                        self.dcx().span_err(
+                            lifetime.ident.span,
+                            "only one lifetime on the rhs supported",
+                        );
+                    } else {
+                        rhs = Some(lifetime);
+                    }
+                }
+            }
+        }
+        match rhs {
+            Some(rhs) => Ok(TestBinderBoundTypeConstraint {
+                span: lo.to(self.prev_token.span),
+                node_id: DUMMY_NODE_ID,
+                params: bound_generic_params,
+                lhs: bounded_ty,
+                rhs,
+            }),
+            None => Err(self.dcx().struct_span_err(
+                bounded_ty.span,
+                "expected a single lifetime on the rhs of this constraint",
+            )),
         }
     }
 

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1521,6 +1521,20 @@ impl<'ast, 'ra, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'ra, 'tc
             |this| visit::walk_test_binder_exists(this, exists),
         );
     }
+
+    fn visit_test_binder_bound_type_constraint(
+        &mut self,
+        bound_type: &'ast TestBinderBoundTypeConstraint,
+    ) {
+        self.with_generic_param_rib(
+            &bound_type.params,
+            RibKind::Normal,
+            bound_type.node_id,
+            LifetimeBinderKind::WhereBound,
+            bound_type.lhs.span.to(bound_type.rhs.ident.span),
+            |this| visit::walk_test_binder_bound_type_constraint(this, bound_type),
+        );
+    }
 }
 
 impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -2791,7 +2791,8 @@ pub fn expr_use_sites<'tcx>(
                 | Node::TyPat(_)
                 | Node::WherePredicate(_)
                 | Node::TestBinderForall(_)
-                | Node::TestBinderExists(_) => {
+                | Node::TestBinderExists(_)
+                | Node::TestBinderBoundTypeConstraint(_) => {
                     // This shouldn't be possible to hit; the inner iterator should have
                     // been moved to the end before we hit any of these nodes.
                     debug_assert!(false, "found {parent:?} which is after the final use node");

--- a/tests/ui/assumptions_on_binders/test-infra-fails-properly.rs
+++ b/tests/ui/assumptions_on_binders/test-infra-fails-properly.rs
@@ -67,4 +67,11 @@ core::test_binder_constraints! {
     }
 }
 
+core::test_binder_constraints! {
+    impl<'a, T> {
+        for<> T: 'a
+        //~^ ERROR bound type test binder constraint must be alias (it's a AliasTyOutlivesViaEnv)
+    }
+}
+
 fn main() {}

--- a/tests/ui/assumptions_on_binders/test-infra-fails-properly.stderr
+++ b/tests/ui/assumptions_on_binders/test-infra-fails-properly.stderr
@@ -61,9 +61,23 @@ note: constraint from here
    |
 LL |         forall<'a> where 'b: 'a {
    |         ^^^^^^
-   = note: expected: RegionOutlives('c/#1, 'c/#1, $DIR/test-infra-fails-properly.rs:63:17: 63:23 (#0))
-   = note: actual: RegionOutlives('c/#1, 'static, $DIR/test-infra-fails-properly.rs:58:9: 58:15 (#0))
+   = note: expected: RegionOutlives(
+               'c/#1,
+               'c/#1,
+               $DIR/test-infra-fails-properly.rs:63:17: 63:23 (#0),
+           )
+   = note: actual: RegionOutlives(
+               'c/#1,
+               'static,
+               $DIR/test-infra-fails-properly.rs:58:9: 58:15 (#0),
+           )
 
-error: aborting due to 8 previous errors
+error: bound type test binder constraint must be alias (it's a AliasTyOutlivesViaEnv)
+  --> $DIR/test-infra-fails-properly.rs:72:15
+   |
+LL |         for<> T: 'a
+   |               ^
+
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/assumptions_on_binders/test-infra-works.rs
+++ b/tests/ui/assumptions_on_binders/test-infra-works.rs
@@ -41,4 +41,45 @@ core::test_binder_constraints! {
     }
 }
 
+trait Trait {
+    type Assoc;
+}
+
+// FIXME(-Zassumptions-on-binders): this probably shouldn't compile, the exit for the top-level
+// `impl` should fail because the constraints asserted in `expect` should fail to prove true. Might
+// be https://github.com/rust-lang/project-assumptions-on-binders/issues/26
+//
+// for<> syntax does direct insert into constraint storage
+core::test_binder_constraints! {
+    impl<T: Trait> {
+        forall<'a> {
+            for<> T::Assoc: 'a
+        } expect {
+            or {
+                for<'b> T::Assoc: 'b,
+                for<> T::Assoc: 'static
+            }
+        }
+    }
+}
+
+// FIXME(-Zassumptions-on-binders): this probably shouldn't compile, the exit for the top-level
+// `impl` should fail because the constraints asserted in `expect` should fail to prove true. Might
+// be https://github.com/rust-lang/project-assumptions-on-binders/issues/26
+//
+// `where` syntax goes through the full clause destructuring and register_obligation pipeline
+core::test_binder_constraints! {
+    impl<T: Trait> {
+        forall<'a> {
+            where T::Assoc: 'a
+        } expect {
+            or {
+                for<'b> T::Assoc: 'b,
+                for<> T::Assoc: 'static,
+                T: 'static
+            }
+        }
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
fixes https://github.com/rust-lang/project-assumptions-on-binders/issues/32

adds two new features to the testing DSL:

- in test bodies, add `where` syntax. This is parsed as a standard where clause (reusing the parser's `parse_where_clause`) and goes through the full lowering machinery for various destructurings and whatnot, and goes through the `register_obligation` pipeline, rather than being directly inserted into constraint storage.
  - `where` syntax inside of `or {}` is not supported, nor is it supported inside of `expect {}`
- in test bodies (including inside `or {}`) as well as inside `expect {}`, parse `AliasTyOutlivesViaEnv` constraints via the syntax `for<> Some::Alias: 'a`.

The second one is particularly boilerplate-y, due to needing to hook up a `Binder`, which needs a `HirId` and whatnot (this is `TestBinderBoundTypeConstraint`). Oh well.

r? @BoxyUwU