### PR TITLE
Add regression test from 1.98.1

### DIFF
--- a/tests/ui/traits/object/rerun-impossible-predicates-post-analysis.rs
+++ b/tests/ui/traits/object/rerun-impossible-predicates-post-analysis.rs
@@ -1,0 +1,43 @@
+//@ run-pass
+
+// Regression test for #161441. This is a next-solver bug fixed by #158993
+// which affected stable due to `impossible_predicates` already using the next-solver
+// by default.
+
+use std::marker::PhantomData;
+
+struct MyError;
+
+trait StreamingBody {
+    type BodyError;
+}
+struct Body;
+impl StreamingBody for Body {
+    type BodyError = MyError;
+}
+
+trait Service {
+    type Output;
+}
+struct HttpClientService;
+impl Service for HttpClientService {
+    type Output = Body;
+}
+
+trait Trait {
+    fn method(&self);
+}
+impl<F, R, ResBody> Trait for (F, PhantomData<R>)
+where
+    F: Fn() -> R,
+    HttpClientService: Service<Output = ResBody>,
+    ResBody: StreamingBody<BodyError: Sized>,
+{
+    fn method(&self) {}
+}
+
+fn inspect_websocket_message() -> impl Sized {}
+
+fn main() {
+    (&(inspect_websocket_message, PhantomData) as &dyn Trait).method();
+}


### PR DESCRIPTION
Regression test for https://github.com/rust-lang/rust/issues/161441. The file contents are taken directly from [`41c7a25` (#161555)](https://github.com/rust-lang/rust/pull/161555/changes/41c7a25d863176cddf1e7a56f583fcc7ec7b3626), which was previously committed directly to the 1.98.1 stable release, but not to the main branch.