### PR TITLE
add test for direct-const-arg

### DIFF
--- a/tests/ui/const-generics/mgca/direct-const-arg-placeholder.rs
+++ b/tests/ui/const-generics/mgca/direct-const-arg-placeholder.rs
@@ -1,0 +1,10 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/159558>
+#![feature(min_generic_const_args)]
+struct S<const N: usize>;
+
+fn foo() -> S<core::direct_const_arg!(_)> {
+    //~^ ERROR: type annotations needed
+    //~| ERROR: the placeholder `_` is not allowed
+    todo!()
+}
+fn main() {}

--- a/tests/ui/const-generics/mgca/direct-const-arg-placeholder.stderr
+++ b/tests/ui/const-generics/mgca/direct-const-arg-placeholder.stderr
@@ -1,0 +1,21 @@
+error[E0282]: type annotations needed
+  --> $DIR/direct-const-arg-placeholder.rs:5:43
+   |
+LL |   fn foo() -> S<core::direct_const_arg!(_)> {
+   |  ___________________________________________^
+LL | |
+LL | |
+LL | |     todo!()
+LL | | }
+   | |_^ cannot infer type for struct `S<_>`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/direct-const-arg-placeholder.rs:5:39
+   |
+LL | fn foo() -> S<core::direct_const_arg!(_)> {
+   |                                       ^ not allowed in type signatures
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0121, E0282.
+For more information about an error, try `rustc --explain E0121`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

close: rust-lang/rust#159558

The generic argument count was unrelated to the ICE, so I added a const argument.

cc: @khyperia 
