### PR TITLE
bootstrap: Fix broken path for `./x doc compiler/rustc --open`

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -1153,7 +1153,7 @@ impl CommandLineStep for Rustc {
                 target_doc_dir.join("rustc_middle").join("index.html")
             } else if let Some(krate) = self.crates.first() {
                 // Let's open the first crate documentation page:
-                target_doc_dir.join(krate).join("index.html")
+                target_doc_dir.join(normalize_doc_crate_name(krate)).join("index.html")
             } else {
                 target_doc_dir.clone()
             };


### PR DESCRIPTION
Currently this fails because the correct path contains `rustc_main`, but bootstrap tries to use a path containing `rustc-main` instead.

The existing bug is amplified by the fact that currently doing `./x doc rustc_middle --open` for *any* compiler crate will instead document the entire compiler, and then try to open the docs for `rustc-main`, since it's the first crate in the crate list.

With this fix, it is at least possible to view the resulting whole-compiler docs.

r? Kobzol (or bootstrap)