### PR TITLE
Allow overriding filecheck even if LLVM is built or downloaded

### DIFF
--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -2231,30 +2231,37 @@ impl Step for FileCheck {
         };
 
         // There is a LLVM config set, take filecheck from it
-        // Note: because `download-ci-llvm` currently overrides `llvm-config`, when the LLVM is
-        // downloaded, we go through this branch. Ideally, this should be changed so that
-        // `download-ci-llvm` doesn't override the config.
-        if let Some(s) = target_config.and_then(|c| c.llvm_config.as_ref()) {
-            let llvm_bindir = command(s).arg("--bindir").run_capture_stdout(builder).stdout();
-            let filecheck = Path::new(llvm_bindir.trim()).join(exe("FileCheck", self.target));
-            let filecheck = if filecheck.exists() {
+        if let Some(llvm_config) = target_config.and_then(|c| c.llvm_config.as_ref()) {
+            // We can only execute llvm-config if we're on the same host target
+            return if builder.is_host_target(self.target) {
+                let llvm_bindir =
+                    command(llvm_config).arg("--bindir").run_capture_stdout(builder).stdout();
+                let filecheck = Path::new(llvm_bindir.trim()).join(exe("FileCheck", self.target));
+                let filecheck = if filecheck.exists() {
+                    filecheck
+                } else {
+                    // On Fedora the system LLVM installs FileCheck in the
+                    // llvm subdirectory of the libdir.
+                    let llvm_libdir =
+                        command(llvm_config).arg("--libdir").run_capture_stdout(builder).stdout();
+                    let lib_filecheck = Path::new(llvm_libdir.trim())
+                        .join("llvm")
+                        .join(exe("FileCheck", self.target));
+                    if lib_filecheck.exists() {
+                        lib_filecheck
+                    } else {
+                        // Return the most normal file name, even though
+                        // it doesn't exist, so that any error message
+                        // refers to that.
+                        filecheck
+                    }
+                };
                 filecheck
             } else {
-                // On Fedora the system LLVM installs FileCheck in the
-                // llvm subdirectory of the libdir.
-                let llvm_libdir = command(s).arg("--libdir").run_capture_stdout(builder).stdout();
-                let lib_filecheck =
-                    Path::new(llvm_libdir.trim()).join("llvm").join(exe("FileCheck", self.target));
-                if lib_filecheck.exists() {
-                    lib_filecheck
-                } else {
-                    // Return the most normal file name, even though
-                    // it doesn't exist, so that any error message
-                    // refers to that.
-                    filecheck
-                }
+                // In other cases, just guess that Filecheck is available in the same directory
+                // as the llvm-config
+                llvm_config.parent().unwrap().join(exe("FileCheck", self.target))
             };
-            return filecheck;
         }
         // Here we take the filecheck from LLVM directly
         let llvm_output = builder.ensure(Llvm { target: self.target });

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -2237,7 +2237,8 @@ impl Step for FileCheck {
                 let llvm_bindir =
                     command(llvm_config).arg("--bindir").run_capture_stdout(builder).stdout();
                 let filecheck = Path::new(llvm_bindir.trim()).join(exe("FileCheck", self.target));
-                let filecheck = if filecheck.exists() {
+
+                if filecheck.exists() {
                     filecheck
                 } else {
                     // On Fedora the system LLVM installs FileCheck in the
@@ -2255,8 +2256,7 @@ impl Step for FileCheck {
                         // refers to that.
                         filecheck
                     }
-                };
-                filecheck
+                }
             } else {
                 // In other cases, just guess that Filecheck is available in the same directory
                 // as the llvm-config

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1008,11 +1008,6 @@ impl Config {
                     target.llvm_has_rust_patches = Some(patches);
                 }
                 if let Some(ref s) = target_llvm_filecheck {
-                    if target_llvm_config.is_none() {
-                        panic!(
-                            "You must also configure `llvm-config` when setting `llvm-filecheck` for target {triple}",
-                        );
-                    }
                     target.llvm_filecheck = Some(src.join(s));
                 }
                 target.llvm_libunwind = target_llvm_libunwind.as_ref().map(|v| {


### PR DESCRIPTION
@antoyo ran into some issues with this, because he wants to run UI tests using the GCC codegen backend. But the tests still require LLVM FileCheck for checking annotations, so he had to download/build LLVM. But really the thing he wants is just to provide an external FileCheck, and that's it. I don't see why we couldn't allow providing filecheck separately, now that it is an explicit step in bootstrap.

r? jieyouxu
