### PR TITLE
Add several new LLDB feature flags

### DIFF
--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -79,6 +79,29 @@ class LLDBFeature(Flag):
     Float128 = auto()
     """Added in LLDB 22.1. Adds builtin support for Float 128's, including an `eBasicTypeFloat128`,
     a formatter, and handlers in `TypeSystemClang`"""
+    GetParent = auto()
+    """Added in LLDB 23.1. Adds `SBValue.GetParent`, which retrieves the `SBValue` that the caller
+    originates from. Useful when a child object must be modified/styled based on information only
+    available to is parent e.g. unsized array types that must determine their length via the parent
+    wide pointer value."""
+    ProviderDecorator = auto()
+    """Added in LLDB 23.1. Adds `@lldb.summary` and `@lldb.synthetic`, which can automatically
+    register decorated providers. At time of writing, we do not use this feature for the following
+    reasons:
+
+    1. backwards compatibility
+    2. to maintain more strict control over the order in which providers are loaded"""
+    PerObjectSynthetics = auto()
+    """Currently only available in prerelease. Adds:
+
+    * `SBValue.SetTypeSynthetic` - allows synthetic providers to override their children's synthetic
+    provider without overriding the synthetic provider of all objects with that share a type name.
+    * `SBValue.GetTypeSyntheticImplementation` - retrieves the *instance* of the synthetic provider
+    associated with that variable. This allows us to easily inspect the state of a parent/child
+    and use it to make decisions about the current object without needing to redo work. It is worth
+    noting that this can be achieved backwards-compatibly (though less elegantly) by using a global
+    `weakref.WeakValueDictionary`, with the keys being `SBValue.GetID()` (which are unique per
+    session) and the values being the provider instance."""
 
 
 def detect_features() -> LLDBFeature:
@@ -93,6 +116,12 @@ def detect_features() -> LLDBFeature:
         features |= LLDBFeature.TypeRecognizers
     if getattr(lldb, "eBasicTypeFloat128", None) is not None:
         features |= LLDBFeature.Float128
+    if getattr(lldb.SBValue, "GetParent", None) is not None:
+        features |= LLDBFeature.GetParent
+    if getattr(lldb, "summary", None) is not None:
+        features |= LLDBFeature.ProviderDecorator
+    if getattr(lldb.SBValue, "SetTypeSynthetic", None) is not None:
+        features |= LLDBFeature.PerObjectSynthetics
 
     return features
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

These flags aren't currently used anywhere, but the features they describe are *incredibly* useful (particularly for a wide pointer visualizer that I have in the works). This patch serves both to document them (especially a feature we *shouldn't* use), and to prep for future visualizers.
