### PR TITLE
add regression test for packus_epi16 issue

### DIFF
--- a/tests/assembly-llvm/x86-vendor-intrinsics.rs
+++ b/tests/assembly-llvm/x86-vendor-intrinsics.rs
@@ -1,0 +1,21 @@
+// Output differs depending on ABI so we need to match the full target.
+//@ only-x86_64-unknown-linux-gnu
+//@ assembly-output: emit-asm
+//@ compile-flags: -Ctarget-feature=-sse3 -C opt-level=3
+
+// Regression test for various cases where we used to compile x86 vendor intrinsics in a suboptimal
+// way.
+
+#![crate_type = "lib"]
+
+use std::arch::x86_64::*;
+
+// CHECK-LABEL: test_packus_epi16:
+#[unsafe(no_mangle)]
+#[target_feature(enable = "sse2")]
+extern "C" fn test_packus_epi16(a: __m128i, b: __m128i) -> __m128i {
+    // CHECK: .cfi_startproc
+    // CHECK-NEXT: packuswb
+    // CHECK-NEXT: ret
+    _mm_packus_epi16(a, b)
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162341)*
<!-- homu-ignore:end -->

https://github.com/rust-lang/rust/issues/159464 got fixed without a test. This adds the missing test.

Ideally this would be tested in stdarch, but we don't have enough infrastructure for that. Testing it here is better than not testing it at all.

Cc @folkertdev 