### PR TITLE
Avoid an intermediate vec when ref-decoding to `&'tcx [T]`

### DIFF
--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -162,8 +162,10 @@ where
     D: TyDecoder<'tcx>,
     T: ArenaAllocatable<'tcx, C> + Decodable<D>,
 {
-    let values: Vec<T> = Decodable::decode(decoder);
-    decoder.interner().arena.alloc_from_iter(values)
+    // This decoder must agree with the format of `impl Decodable for Vec<T>`,
+    // which is simply a `usize` length followed by that many `T`.
+    let len = decoder.read_usize();
+    decoder.interner().arena.alloc_from_iter((0..len).map(|_| T::decode(decoder)))
 }
 
 macro_rules! impl_ref_decodable_into_arena {


### PR DESCRIPTION
For !needs_drop types, this should allow decoding directly into the arena-allocated slice.

For needs_drop types, the arena already collects into a SmallVec<T>, so this avoids an intermediate conversion from Vec<T> to SmallVec<T>.

---

I was planning some cleanups to `RefDecodable` impls (https://github.com/rust-lang/rust/pull/162287), and along the way I noticed that some hand-written impls for slices manage to avoid the overhead of decoding to an intermediate Vec<T>, by instead reading a `usize` length and then decoding that many items directly. This matches the format that encoding a vec/slice or decoding to Vec<T> would use.

This PR therefore applies that same optimization to the impls generated by `impl_ref_decodable_into_arena!`.

I extracted this change into its own small PR since it has perf effects.

r? nnethercote (or compiler)