### PR TITLE
Make comptime functions ineligible for coverage

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/query.rs
+++ b/compiler/rustc_mir_transform/src/coverage/query.rs
@@ -1,5 +1,6 @@
 use rustc_hir::attrs::CoverageAttrKind;
-use rustc_hir::find_attr;
+use rustc_hir::def::DefKind;
+use rustc_hir::{self as hir, find_attr};
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::mir::coverage::{
@@ -30,8 +31,20 @@ fn is_eligible_for_coverage(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     // expressions from coverage spans in enclosing MIR's, like we do for closures. (That might
     // be tricky if const expressions have no corresponding statements in the enclosing MIR.
     // Closures are carved out by their initial `Assign` statement.)
-    if !tcx.def_kind(def_id).is_fn_like() {
+    let def_kind = tcx.def_kind(def_id);
+    if !def_kind.is_fn_like() {
         trace!("InstrumentCoverage skipped for {def_id:?} (not an fn-like)");
+        return false;
+    }
+
+    // Comptime functions can't exist at runtime, so instrumenting them is useless.
+    // This also avoids an ICE when getting the symbol name for an unused-function record
+    // (due to <https://github.com/rust-lang/rust/pull/159777>).
+    // We check `def_kind` first to avoid any unexpected panics from merely asking for constness.
+    if matches!(def_kind, DefKind::Fn | DefKind::AssocFn)
+        && matches!(tcx.constness(def_id), hir::Constness::Const { always: true })
+    {
+        trace!("InstrumentCoverage skipped for {def_id:?} (comptime)");
         return false;
     }
 

--- a/tests/coverage/comptime.cov-map
+++ b/tests/coverage/comptime.cov-map
@@ -1,0 +1,10 @@
+Function name: comptime::main
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 0b, 01, 00, 0a, 01, 00, 0c, 00, 0d]
+Number of files: 1
+- file 0 => $DIR/comptime.rs
+Number of expressions: 0
+Number of file 0 mappings: 2
+- Code(Counter(0)) at (prev + 11, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 0, 12) to (start + 0, 13)
+Highest counter ID seen: c0
+

--- a/tests/coverage/comptime.coverage
+++ b/tests/coverage/comptime.coverage
@@ -1,0 +1,12 @@
+   LL|       |#![feature(rustc_attrs)]
+   LL|       |//@ edition: 2024
+   LL|       |
+   LL|       |// Check that instrumenting a crate with a comptime function doesn't ICE.
+   LL|       |// (The function itself doesn't need to be instrumented, and probably shouldn't be.)
+   LL|       |// Regression test for <https://github.com/rust-lang/rust/pull/161808>.
+   LL|       |
+   LL|       |#[rustc_comptime]
+   LL|       |fn comptime_fn() {}
+   LL|       |
+   LL|      1|fn main() {}
+

--- a/tests/coverage/comptime.rs
+++ b/tests/coverage/comptime.rs
@@ -1,7 +1,5 @@
 #![feature(rustc_attrs)]
 //@ edition: 2024
-//@ compile-flags: -Cinstrument-coverage
-//@ needs-profiler-runtime
 
 // Check that instrumenting a crate with a comptime function doesn't ICE.
 // (The function itself doesn't need to be instrumented, and probably shouldn't be.)

--- a/tests/crashes/comptime.rs
+++ b/tests/crashes/comptime.rs
@@ -1,0 +1,13 @@
+#![feature(rustc_attrs)]
+//@ edition: 2024
+//@ compile-flags: -Cinstrument-coverage
+//@ needs-profiler-runtime
+
+// Check that instrumenting a crate with a comptime function doesn't ICE.
+// (The function itself doesn't need to be instrumented, and probably shouldn't be.)
+// Regression test for <https://github.com/rust-lang/rust/pull/161808>.
+
+#[rustc_comptime]
+fn comptime_fn() {}
+
+fn main() {}


### PR DESCRIPTION
- https://github.com/rust-lang/rust/pull/159777
- https://github.com/rust-lang/rust/pull/161808
---

As reported in https://github.com/rust-lang/rust/pull/161808, the assertion in https://github.com/rust-lang/rust/pull/159777 causes the compiler to ICE when it tries to generate an unused-function record for comptime functions, because comptime functions aren't allowed to have a symbol name. This can occur when trying to instrument `core`, for example.

Compile-time-only functions don't generate code, so instrumenting them for coverage is useless anyway. This PR therefore makes them ineligible for coverage, which avoids the problem.

<!-- homu-ignore:start -->
---
This PR is essentially a rewrite of https://github.com/rust-lang/rust/pull/161808. I wanted to request several modifications to that PR, and the overall change is small enough that it was easier for me to just recreate it from scratch.

The main differences are:
- Adds a coverage test instead of a ui test
- Comments focus more on the fact that instrumenting comptime functions isn't useful, with avoiding the ICE being a secondary motivation

cc @fmease @oli-obk as I'm not familiar with comptime
<!-- homu-ignore:end -->