### PR TITLE
Force u8/i8 numeric formatting on LLDB

### DIFF
--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -126,6 +126,38 @@ def register_providers_compatibility():
 
     global RUST_CATEGORY
 
+    # Don't format 8-bit builtins as chars
+    unsigned_format = lldb.SBTypeFormat(
+        lldb.eFormatUnsigned,
+        lldb.eTypeOptionCascade
+        | lldb.eTypeOptionSkipPointers
+        | lldb.eTypeOptionSkipReferences,
+    )
+
+    RUST_CATEGORY.AddTypeFormat(lldb.SBTypeNameSpecifier("u8", False), unsigned_format)
+    RUST_CATEGORY.AddTypeFormat(
+        lldb.SBTypeNameSpecifier("unsigned char", False),
+        unsigned_format,
+    )
+
+    signed_format = lldb.SBTypeFormat(
+        lldb.eFormatDecimal,
+        lldb.eTypeOptionCascade
+        | lldb.eTypeOptionSkipPointers
+        | lldb.eTypeOptionSkipReferences,
+    )
+    RUST_CATEGORY.AddTypeFormat(
+        lldb.SBTypeNameSpecifier("i8", False), lldb.SBTypeFormat(lldb.eFormatDecimal)
+    )
+
+    # i8 translates to signed char on msvc
+    RUST_CATEGORY.AddTypeFormat(
+        lldb.SBTypeNameSpecifier("signed char", False),
+        signed_format,
+    )
+    # Does not conflict with rust char, which ends up with the type name `char32_t`
+    RUST_CATEGORY.AddTypeFormat(lldb.SBTypeNameSpecifier("char", False), signed_format)
+
     if LLDBFeature.TypeRecognizers in FEATURE_FLAGS:
         # enforce uniform aggregate formatting
         register_summary(

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -680,6 +680,9 @@ class MSVCStrSyntheticProvider:
         element = self.data_ptr.CreateValueFromAddress(
             f"[{index}]", address, self.data_ptr.GetType().GetPointeeType()
         )
+
+        element.SetFormat(eFormatChar)
+
         return element
 
     def get_type_name(self):
@@ -1154,10 +1157,28 @@ class StdVecSyntheticProvider:
 
 
 class StdSliceSyntheticProvider:
-    __slots__ = ["valobj", "length", "data_ptr", "element_type", "element_size"]
+    __slots__ = [
+        "valobj",
+        "length",
+        "data_ptr",
+        "element_type",
+        "element_size",
+        "is_str",
+    ]
 
     def __init__(self, valobj: SBValue, _dict: LLDBOpaque):
         self.valobj = valobj
+        type_name = self.valobj.GetTypeName()
+        self.is_str = type_name.startswith("alloc::boxed::Box<str") or type_name in {
+            "&str",
+            "&mut str",
+            "*const str",
+            "*mut str",
+            "ref$<str>",
+            "ref_mut$<str>",
+            "ptr_const$<str>",
+            "ptr_mut$<str>",
+        }
         self.update()
 
     def num_children(self) -> int:
@@ -1176,6 +1197,9 @@ class StdSliceSyntheticProvider:
         element = self.data_ptr.CreateValueFromAddress(
             "[%s]" % index, address, self.element_type
         )
+
+        if self.is_str:
+            element.SetFormat(eFormatChar)
         return element
 
     def update(self):

--- a/tests/debuginfo/basic-types/lldb_input/non_windows.json
+++ b/tests/debuginfo/basic-types/lldb_input/non_windows.json
@@ -23,8 +23,9 @@
    },
    "i8": {
     "type": "char",
-    "pretty_print": "'D'",
-    "value": 68
+    "pretty_print": "68",
+    "value": 68,
+    "format": 9
    },
    "i16": {
     "type": "short",
@@ -48,8 +49,9 @@
    },
    "u8": {
     "type": "unsigned char",
-    "pretty_print": "'d'",
-    "value": 100
+    "pretty_print": "100",
+    "value": 100,
+    "format": 18
    },
    "u16": {
     "type": "unsigned short",
@@ -77,5 +79,17 @@
     "value": 3.5
    }
   }
- ]
+ ],
+ "types": {
+  "char": {
+   "size": 1,
+   "type_class": 4,
+   "basic_type": 3
+  },
+  "unsigned char": {
+   "size": 1,
+   "type_class": 4,
+   "basic_type": 4
+  }
+ }
 }

--- a/tests/debuginfo/basic-types/lldb_input/windows_gnu.json
+++ b/tests/debuginfo/basic-types/lldb_input/windows_gnu.json
@@ -23,8 +23,9 @@
    },
    "i8": {
     "type": "char",
-    "pretty_print": "'D'",
-    "value": 68
+    "pretty_print": "68",
+    "value": 68,
+    "format": 9
    },
    "i16": {
     "type": "short",
@@ -48,8 +49,9 @@
    },
    "u8": {
     "type": "unsigned char",
-    "pretty_print": "'d'",
-    "value": 100
+    "pretty_print": "100",
+    "value": 100,
+    "format": 18
    },
    "u16": {
     "type": "unsigned short",
@@ -77,5 +79,17 @@
     "value": 3.5
    }
   }
- ]
+ ],
+ "types": {
+  "char": {
+   "size": 1,
+   "type_class": 4,
+   "basic_type": 3
+  },
+  "unsigned char": {
+   "size": 1,
+   "type_class": 4,
+   "basic_type": 4
+  }
+ }
 }

--- a/tests/debuginfo/basic-types/lldb_input/windows_msvc.json
+++ b/tests/debuginfo/basic-types/lldb_input/windows_msvc.json
@@ -23,8 +23,9 @@
    },
    "i8": {
     "type": "signed char",
-    "pretty_print": "'D'",
-    "value": 68
+    "pretty_print": "68",
+    "value": 68,
+    "format": 9
    },
    "i16": {
     "type": "short",
@@ -48,8 +49,9 @@
    },
    "u8": {
     "type": "unsigned char",
-    "pretty_print": "'d'",
-    "value": 100
+    "pretty_print": "100",
+    "value": 100,
+    "format": 18
    },
    "u16": {
     "type": "unsigned short",
@@ -77,5 +79,17 @@
     "value": 3.5
    }
   }
- ]
+ ],
+ "types": {
+  "signed char": {
+   "size": 1,
+   "type_class": 4,
+   "basic_type": 3
+  },
+  "unsigned char": {
+   "size": 1,
+   "type_class": 4,
+   "basic_type": 4
+  }
+ }
 }

--- a/tests/debuginfo/borrowed-basic.rs
+++ b/tests/debuginfo/borrowed-basic.rs
@@ -60,9 +60,11 @@
 //@ lldb-command:v *int_ref
 //@ lldb-check:[...] -1
 
+//@ lldb-command:v *char_ref
+//@ lldb-check: [...] U+0x00000061 U'a'
 
 //@ lldb-command:v *i8_ref
-//@ lldb-check:[...] 'D'
+//@ lldb-check:[...] 68
 
 //@ lldb-command:v *i16_ref
 //@ lldb-check:[...] -16
@@ -77,7 +79,7 @@
 //@ lldb-check:[...] 1
 
 //@ lldb-command:v *u8_ref
-//@ lldb-check:[...] 'd'
+//@ lldb-check:[...] 100
 
 //@ lldb-command:v *u16_ref
 //@ lldb-check:[...] 16

--- a/tests/debuginfo/reference-debuginfo.rs
+++ b/tests/debuginfo/reference-debuginfo.rs
@@ -67,9 +67,11 @@
 //@ lldb-command:v *int_ref
 //@ lldb-check:[...] -1
 
+//@ lldb-command:v *char_ref
+//@ lldb-check: [...] U+0x00000061 U'a'
 
 //@ lldb-command:v *i8_ref
-//@ lldb-check:[...] 'D'
+//@ lldb-check:[...] 68
 
 //@ lldb-command:v *i16_ref
 //@ lldb-check:[...] -16
@@ -84,7 +86,7 @@
 //@ lldb-check:[...] 1
 
 //@ lldb-command:v *u8_ref
-//@ lldb-check:[...] 'd'
+//@ lldb-check:[...] 100
 
 //@ lldb-command:v *u16_ref
 //@ lldb-check:[...] 16

--- a/tests/debuginfo/strings-and-strs.rs
+++ b/tests/debuginfo/strings-and-strs.rs
@@ -48,8 +48,15 @@
 //@ lldb-command:v box_str
 //@ lldb-check:(alloc::boxed::Box<str, alloc::alloc::Global>) box_str = "World" { [0] = 'W' [1] = 'o' [2] = 'r' [3] = 'l' [4] = 'd' }
 
-//@ lldb-command:v rc_str
-//@ lldb-check:(alloc::rc::Rc<unsigned char[], alloc::alloc::Global>) rc_str = strong=1, weak=0 { value = "World" }
+// Disabled temporarily since it only "works" by accident
+// `value` is a wide pointer, whose `data_ptr` type, according to LLDB, is `unsigned char[]`. LLDB
+// reads this as a c-string by default. On Linux this fairly consistenly results in the expected
+// output below. On Windows, the string data is often not followed by a null byte and attempts to
+// read OOB memory. This will be fixed as part of #161657
+// lldb-command:v rc_str
+
+// ignore-tidy-linelength
+// lldb-check:(alloc::rc::Rc<unsigned char[], alloc::alloc::Global>) rc_str = strong=1, weak=0 { value = "World" }
 
 #![allow(unused_variables)]
 

--- a/tests/debuginfo/union-smoke.rs
+++ b/tests/debuginfo/union-smoke.rs
@@ -14,10 +14,10 @@
 
 //@ lldb-command:run
 //@ lldb-command:v u
-//@ lldb-check:[...] {a:('\x02', '\x02'), b:514}
+//@ lldb-check:[...] {a:(2, 2), b:514}
 
 //@ lldb-command:print union_smoke::SU
-//@ lldb-check:[...] {a:('\x01', '\x01'), b:257}
+//@ lldb-check:[...] {a:(1, 1), b:257}
 
 #![allow(unused)]
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Resolves a very common annoyance with the existing visualizers. This doesn't touch the behavior that formats char pointers as c-strings since that's its own can of worms (and likely needs to be handled alongside adding the wide pointer visualizer).

I disabled checking `Rc<str>` in `strings-and-strs.rs`, as this patch caused it to fail on `windows-gnu` and the fix is the wide pointer visualizer. Technically, even on `linux-gnu` the test only works because it's seemingly somewhat reliable for there to be a null byte directly after the `str` data, but that's obviously not something we should be relying on.

Also fixes `tests\debuginfo\borrowed-unique-basic.rs` on `windows-msvc` as part of https://github.com/rust-lang/rust/issues/161657#event-30426783684

r? @Kobzol, @jieyouxu 

---

try-job: aarch64-apple-1
try-job: x86_64-mingw-1