### PR TITLE
Use `lldb.eTypeOptionHideChildren` for msvc tuples

### DIFF
--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -357,6 +357,7 @@ def register_providers_compatibility():
         MSVCTupleSyntheticProvider,
         TupleSummaryProvider,
         r"^tuple\$<.+>$",
+        type_options=DEFAULT_TYPE_OPTIONS | lldb.eTypeOptionHideChildren,
     )
 
 


### PR DESCRIPTION
Changes output from e.g. `(8, 5.5) { 0:8, 1:5.5 }` to just `(8, 5.5)` to match non-msvc handling.

Fixes the following tests on `windows-msvc` (see https://github.com/rust-lang/rust/issues/161657):

* `tests\debuginfo\borrowed-tuple.rs`
* `tests\debuginfo\box.rs`
* `tests\debuginfo\cross-crate-spans.rs`
* `tests\debuginfo\destructured-local.rs`
* `tests\debuginfo\pretty-std-collections.rs`
* `tests\debuginfo\simple-tuple.rs`
* `tests\debuginfo\tuple-in-tuple.rs`

Also partially fixes `tests\debuginfo\associated-types.rs`

r? @Kobzol, @jieyouxu 

---

try-job: x86_64-msvc-1
try-job: aarch64-msvc-1