### PR TITLE
perf experiment: give noalias back to refs in closures

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2195,7 +2195,6 @@ impl<'tcx> Ty<'tcx> {
                 def.flags().contains(AdtFlags::IS_MAYBE_DANGLING)
                     || def.flags().contains(AdtFlags::IS_MANUALLY_DROP)
             }
-            ty::Closure(..) | ty::Coroutine(..) | ty::CoroutineClosure(..) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
More https://github.com/rust-lang/rust/pull/160745 perf experiments.