### PR TITLE
Use correct `dir_path` when parsing module from path

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1382,7 +1382,11 @@ impl InvocationCollectorNode for Box<ast::Item> {
                 // This lets `parse_external_mod` catch cycles if it's self-referential.
                 let file_path = match inline {
                     Inline::Yes => None,
-                    Inline::No { .. } => mod_file_path_from_attr(ecx.sess, &node.attrs, &dir_path),
+                    Inline::No { .. } => mod_file_path_from_attr(
+                        ecx.sess,
+                        &node.attrs,
+                        &ecx.current_expansion.module.dir_path,
+                    ),
                 };
                 (file_path, dir_path, dir_ownership)
             }

--- a/tests/ui/modules/path-attr-inner-attr-nested-mod-rs/name/mod.rs
+++ b/tests/ui/modules/path-attr-inner-attr-nested-mod-rs/name/mod.rs
@@ -1,0 +1,7 @@
+//@ ignore-auxiliary
+
+// DON'T remove this attribute, it is used to trigger re-collection
+// See more info: <https://github.com/rust-lang/rust/issues/162080>
+#![deny(unsafe_code)]
+
+mod name;

--- a/tests/ui/modules/path-attr-inner-attr-nested-mod-rs/name/name/mod.rs
+++ b/tests/ui/modules/path-attr-inner-attr-nested-mod-rs/name/name/mod.rs
@@ -1,0 +1,1 @@
+//@ ignore-auxiliary

--- a/tests/ui/modules/path-attr-inner-attr-nested-mod-rs/path-attr-inner-attr-nested-mod-rs.rs
+++ b/tests/ui/modules/path-attr-inner-attr-nested-mod-rs/path-attr-inner-attr-nested-mod-rs.rs
@@ -1,0 +1,7 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/162080>
+//@ check-pass
+
+#[path = "name/mod.rs"]
+mod name;
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/162080

We previously used the incorrect `dir_path` (which was `name`, the parent of `name/mod.rs`, in this case), and then joined it with `name/mod.rs` again, resulting in `name/name/mod.rs`.

The first commit adds the regression test and snapshot of current behavior, the second commit fixes it.

r? petrochenkov