### PR TITLE
Use `#[repr(C)]` on debuginfo test structs

### DIFF
--- a/tests/debuginfo/associated-types.rs
+++ b/tests/debuginfo/associated-types.rs
@@ -82,6 +82,7 @@ impl TraitWithAssocType for i32 {
     fn get_value(&self) -> i64 { *self as i64 }
 }
 
+#[repr(C)]
 struct Struct<T: TraitWithAssocType> {
     b: T,
     b1: T::Type,

--- a/tests/debuginfo/boxed-struct.rs
+++ b/tests/debuginfo/boxed-struct.rs
@@ -25,6 +25,7 @@
 
 #![allow(unused_variables)]
 
+#[repr(C)]
 struct StructWithSomePadding {
     x: i16,
     y: i32,
@@ -32,6 +33,7 @@ struct StructWithSomePadding {
     w: i64
 }
 
+#[repr(C)]
 struct StructWithDestructor {
     x: i16,
     y: i32,

--- a/tests/debuginfo/c-style-enum-in-composite.rs
+++ b/tests/debuginfo/c-style-enum-in-composite.rs
@@ -57,18 +57,21 @@
 use self::AnEnum::{OneHundred, OneThousand, OneMillion};
 use self::AnotherEnum::{MountainView, Toronto, Vienna};
 
+#[repr(u32)]
 enum AnEnum {
     OneHundred = 100,
     OneThousand = 1000,
     OneMillion = 1000000
 }
 
+#[repr(u8)]
 enum AnotherEnum {
     MountainView,
     Toronto,
     Vienna
 }
 
+#[repr(C)]
 struct PaddedStruct {
     a: i16,
     b: AnEnum,
@@ -77,7 +80,7 @@ struct PaddedStruct {
     e: i16
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct PackedStruct {
     a: i16,
     b: AnEnum,
@@ -86,6 +89,7 @@ struct PackedStruct {
     e: i16
 }
 
+#[repr(C)]
 struct NonPaddedStruct {
     a: AnEnum,
     b: AnotherEnum,

--- a/tests/debuginfo/destructured-for-loop-variable.rs
+++ b/tests/debuginfo/destructured-for-loop-variable.rs
@@ -73,6 +73,8 @@
 // === LLDB TESTS ==================================================================================
 
 //@ lldb-command:type format add --format hex char
+// MSVC uses signed char
+//@ lldb-command:type format add --format hex 'signed char'
 //@ lldb-command:type format add --format hex 'unsigned char'
 
 //@ lldb-command:run
@@ -144,6 +146,7 @@
 #![allow(unused_variables)]
 #![feature(deref_patterns)]
 
+#[repr(C)]
 struct Struct {
     x: i16,
     y: f32,

--- a/tests/debuginfo/evec-in-struct.rs
+++ b/tests/debuginfo/evec-in-struct.rs
@@ -41,17 +41,20 @@
 
 #![allow(unused_variables)]
 
+#[repr(C)]
 struct NoPadding1 {
     x: [u32; 3],
     y: i32,
     z: [f32; 2]
 }
 
+#[repr(C)]
 struct NoPadding2 {
     x: [u32; 3],
     y: [[u32; 2]; 2]
 }
 
+#[repr(C)]
 struct StructInternalPadding {
     x: [i16; 2],
     y: [i64; 2]
@@ -61,6 +64,7 @@ struct SingleVec {
     x: [i16; 5]
 }
 
+#[repr(C)]
 struct StructPaddedAtEnd {
     x: [i64; 2],
     y: [i16; 2]

--- a/tests/debuginfo/packed-struct-with-destructor.rs
+++ b/tests/debuginfo/packed-struct-with-destructor.rs
@@ -63,7 +63,7 @@
 
 #![allow(unused_variables)]
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct Packed {
     x: i16,
     y: i32,
@@ -74,7 +74,7 @@ impl Drop for Packed {
     fn drop(&mut self) {}
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct PackedInPacked {
     a: i32,
     b: Packed,
@@ -82,6 +82,7 @@ struct PackedInPacked {
     d: Packed
 }
 
+#[repr(C)]
 struct PackedInUnpacked {
     a: i32,
     b: Packed,
@@ -89,6 +90,7 @@ struct PackedInUnpacked {
     d: Packed
 }
 
+#[repr(C)]
 struct Unpacked {
     x: i64,
     y: i32,
@@ -99,7 +101,7 @@ impl Drop for Unpacked {
     fn drop(&mut self) {}
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct UnpackedInPacked {
     a: i16,
     b: Unpacked,
@@ -107,7 +109,7 @@ struct UnpackedInPacked {
     d: i64
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct PackedInPackedWithDrop {
     a: i32,
     b: Packed,
@@ -119,6 +121,7 @@ impl Drop for PackedInPackedWithDrop {
     fn drop(&mut self) {}
 }
 
+#[repr(C)]
 struct PackedInUnpackedWithDrop {
     a: i32,
     b: Packed,
@@ -130,7 +133,7 @@ impl Drop for PackedInUnpackedWithDrop {
     fn drop(&mut self) {}
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct UnpackedInPackedWithDrop {
     a: i16,
     b: Unpacked,
@@ -142,6 +145,7 @@ impl Drop for UnpackedInPackedWithDrop {
     fn drop(&mut self) {}
 }
 
+#[repr(C)]
 struct DeeplyNested {
     a: PackedInPacked,
     b: UnpackedInPackedWithDrop,

--- a/tests/debuginfo/packed-struct.rs
+++ b/tests/debuginfo/packed-struct.rs
@@ -49,14 +49,14 @@
 
 #![allow(unused_variables)]
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct Packed {
     x: i16,
     y: i32,
     z: i64
 }
 
-#[repr(packed)]
+#[repr(C, packed)]
 struct PackedInPacked {
     a: i32,
     b: Packed,
@@ -64,6 +64,7 @@ struct PackedInPacked {
     d: Packed
 }
 
+#[repr(C)]
 // layout (64 bit): aaaa bbbb bbbb bbbb bb.. .... cccc cccc dddd dddd dddd dd..
 struct PackedInUnpacked {
     a: i32,
@@ -72,6 +73,7 @@ struct PackedInUnpacked {
     d: Packed
 }
 
+#[repr(C)]
 // layout (64 bit): xx.. yyyy zz.. .... wwww wwww
 struct Unpacked {
     x: i16,
@@ -81,7 +83,7 @@ struct Unpacked {
 }
 
 // layout (64 bit): aabb bbbb bbbb bbbb bbbb bbbb bbcc cccc cccc cccc cccc cccc ccdd dddd dd
-#[repr(packed)]
+#[repr(C, packed)]
 struct UnpackedInPacked {
     a: i16,
     b: Unpacked,

--- a/tests/debuginfo/simple-struct.rs
+++ b/tests/debuginfo/simple-struct.rs
@@ -87,23 +87,27 @@
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
+#[repr(C)]
 struct NoPadding16 {
     x: u16,
     y: i16
 }
 
+#[repr(C)]
 struct NoPadding32 {
     x: i32,
     y: f32,
     z: u32
 }
 
+#[repr(C)]
 struct NoPadding64 {
     x: f64,
     y: i64,
     z: u64
 }
 
+#[repr(C)]
 struct NoPadding163264 {
     a: i16,
     b: u16,
@@ -111,11 +115,13 @@ struct NoPadding163264 {
     d: u64
 }
 
+#[repr(C)]
 struct InternalPadding {
     x: u16,
     y: i64
 }
 
+#[repr(C)]
 struct PaddingAtEnd {
     x: i64,
     y: u16

--- a/tests/debuginfo/struct-in-struct.rs
+++ b/tests/debuginfo/struct-in-struct.rs
@@ -50,34 +50,40 @@ struct Simple {
     x: i32
 }
 
+#[repr(C)]
 struct InternalPadding {
     x: i32,
     y: i64
 }
 
+#[repr(C)]
 struct PaddingAtEnd {
     x: i64,
     y: i32
 }
 
+#[repr(C)]
 struct ThreeSimpleStructs {
     x: Simple,
     y: Simple,
     z: Simple
 }
 
+#[repr(C)]
 struct InternalPaddingParent {
     x: InternalPadding,
     y: InternalPadding,
     z: InternalPadding
 }
 
+#[repr(C)]
 struct PaddingAtEndParent {
     x: PaddingAtEnd,
     y: PaddingAtEnd,
     z: PaddingAtEnd
 }
 
+#[repr(C)]
 struct Mixed {
     x: PaddingAtEnd,
     y: InternalPadding,
@@ -97,6 +103,7 @@ struct ThatsJustOverkill {
     x: BagInBag
 }
 
+#[repr(C)]
 struct Tree {
     x: Simple,
     y: InternalPaddingParent,

--- a/tests/debuginfo/struct-with-destructor.rs
+++ b/tests/debuginfo/struct-with-destructor.rs
@@ -35,11 +35,13 @@
 
 #![allow(unused_variables)]
 
+#[repr(C)]
 struct NoDestructor {
     x: i32,
     y: i64
 }
 
+#[repr(C)]
 struct WithDestructor {
     x: i32,
     y: i64
@@ -49,11 +51,13 @@ impl Drop for WithDestructor {
     fn drop(&mut self) {}
 }
 
+#[repr(C)]
 struct NoDestructorGuarded {
     a: NoDestructor,
     guard: i64
 }
 
+#[repr(C)]
 struct WithDestructorGuarded {
     a: WithDestructor,
     guard: i64

--- a/tests/debuginfo/vec-slices.rs
+++ b/tests/debuginfo/vec-slices.rs
@@ -74,6 +74,7 @@
 
 #![allow(dead_code, unused_variables)]
 
+#[repr(C)]
 struct AStruct {
     x: i16,
     y: i32,


### PR DESCRIPTION
This fixes a couple of issues.

* LLDB reading PDB debug info re-orders fields and displays them in offset order instead of source-order like DWARF. While this has been [fixed upstream](https://github.com/llvm/llvm-project/pull/218731), it'll be quite a while before it's reflected in CI runners and such
* For all targets, the structs were often written (and named) under the assumption that they would have specific layouts. Nothing was actually enforcing those assumed layouts, so very often a type would be named e.g. `HasInternalPadding` but rust would reorder it such that no internal padding existed.

`struct-with-destructor.rs` is still iffy. I'll test it when I get home and can update my main PC's LLDB. 

On my remote PC (lldb 22.1.2) it didn't fix the test, and it looked like the variable was straight up being read incorrectly:

 ```
// expected:
 (struct_with_destructor::NestedOuter) nested = {a:{a:{x:7890, y:9870}}}
// got:
 (struct_with_destructor::NestedOuter) nested = {a:{a:{y:1378684509906, x:9870}}
 ```
On my laptop when manually inspecting it (CodeLLDB which uses 22.1.8 under the hood) everything looked fine, so it might have been a bug that LLDB patched. 

Part of the MSVC test fixes for https://github.com/rust-lang/rust/issues/161657

r? @Kobzol, @jieyouxu 

---

test-jobs: aarch64-apple-1
test-jobs: aarch64-msvc-1
test-jobs: x86_64-msvc-1
test-jobs: x86_64-mingw-1