### PR TITLE
Make `VaArgSafe` dyn-incompatible

### DIFF
--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -309,6 +309,7 @@ const impl<'f> Drop for VaList<'f> {
 // meantime.
 #[lang = "va_arg_safe"]
 #[stable(feature = "c_variadic", since = "1.99.0")]
+#[rustc_dyn_incompatible_trait]
 pub impl(self) unsafe trait VaArgSafe {}
 
 crate::cfg_select! {

--- a/src/bootstrap/stdlib-semver-check-stamp
+++ b/src/bootstrap/stdlib-semver-check-stamp
@@ -2,4 +2,4 @@ Change this file to explicitly acknowledge making a breaking change to the Rust 
 If this file is modified in the same PR as the breaking change, then CI will not fail due to the
 breaking change being detected by cargo-semver-checks.
 
-Last change is for: https://github.com/rust-lang/rust/pull/155499
+Last change is for: https://github.com/rust-lang/rust/pull/162374


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162374)*
<!-- homu-ignore:end -->

This is done just in case we want to later do stuff like adding a `Sized` supertrait.

See discussion at [#t-libs > Should &#96;VaArgSafe&#96; require &#96;Sized&#96;?](https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/Should.20.60VaArgSafe.60.20require.20.60Sized.60.3F/with/622074620)

r? @clarfonthey