### PR TITLE
add test ensuring we refuse to const-eval the body of a rustc_do_not_const_check function

### DIFF
--- a/tests/ui/consts/const-eval/do_not_const_check.rs
+++ b/tests/ui/consts/const-eval/do_not_const_check.rs
@@ -1,0 +1,25 @@
+//! Ensure that we refuse to run a do_not_const_check function, even if the body *would* const-check
+//! at the moment.
+#![feature(rustc_attrs, intrinsics)]
+
+#[rustc_do_not_const_check]
+const fn mostly_harmless() {}
+
+const _: () = {
+    mostly_harmless(); //~ERROR: calling non-const function
+};
+
+// Also ensure the same happens with intrinsics.
+// Here we need some intrinsic that the interpreter does *not* have a native implementation for.
+// Let's hope nobody adds one...
+#[rustc_intrinsic]
+#[rustc_do_not_const_check]
+pub const fn integer_min<T: Copy>(a: T, b: T) -> T {
+    a
+}
+
+const _: () = {
+    integer_min(0, 1); //~ERROR: calling non-const function
+};
+
+fn main() {}

--- a/tests/ui/consts/const-eval/do_not_const_check.stderr
+++ b/tests/ui/consts/const-eval/do_not_const_check.stderr
@@ -1,0 +1,15 @@
+error[E0080]: calling non-const function `mostly_harmless`
+  --> $DIR/do_not_const_check.rs:9:5
+   |
+LL |     mostly_harmless();
+   |     ^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
+
+error[E0080]: calling non-const function `integer_min::<i32>`
+  --> $DIR/do_not_const_check.rs:22:5
+   |
+LL |     integer_min(0, 1);
+   |     ^^^^^^^^^^^^^^^^^ evaluation of `_` failed here
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
IMO this is crucial, to ensure that we cannot break users by changing the body of such a function to something no-longer-const-compatible.

r? @oli-obk 