### PR TITLE
fix bare urls split text

### DIFF
--- a/src/librustdoc/passes/lint/bare_urls.rs
+++ b/src/librustdoc/passes/lint/bare_urls.rs
@@ -2,13 +2,14 @@
 //! Suggests wrapping the link with angle brackets: `Go to <https://example.com/>.` to linkify it.
 
 use core::ops::Range;
-use std::mem;
 use std::sync::LazyLock;
 
 use regex::Regex;
 use rustc_errors::{Applicability, DiagDecorator};
 use rustc_hir::HirId;
-use rustc_resolve::rustdoc::pulldown_cmark::{Event, Parser, Tag};
+use rustc_resolve::rustdoc::pulldown_cmark::{
+    DefaultBrokenLinkCallback, Event, Tag, TextMergeWithOffset,
+};
 use rustc_resolve::rustdoc::source_span_for_markdown_range;
 use tracing::trace;
 
@@ -55,21 +56,20 @@ pub(super) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
         );
     };
 
-    let mut p = Parser::new_ext(dox, main_body_opts()).into_offset_iter();
+    // pulldown-cmark can split a URL into multiple `Text` events while processing
+    // characters such as `_` according to CommonMark's emphasis rules.
+    // `TextMergeWithOffset` merges these events so we can check the complete URL.
+    let mut p = TextMergeWithOffset::<DefaultBrokenLinkCallback>::new_ext(dox, main_body_opts());
 
     while let Some((event, range)) = p.next() {
         match event {
             Event::Text(s) => find_raw_urls(cx, dox, &s, range, &report_diag),
             // We don't want to check the text inside code blocks or links.
             Event::Start(tag @ (Tag::CodeBlock(_) | Tag::Link { .. })) => {
+                let end = tag.to_end();
                 for (event, _) in p.by_ref() {
-                    match event {
-                        Event::End(end)
-                            if mem::discriminant(&end) == mem::discriminant(&tag.to_end()) =>
-                        {
-                            break;
-                        }
-                        _ => {}
+                    if matches!(event, Event::End(tag) if tag == end) {
+                        break;
                     }
                 }
             }
@@ -83,7 +83,12 @@ static URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         r"https?://",                          // url scheme
         r"([-a-zA-Z0-9@:%._\+~#=]{2,256}\.)+", // one or more subdomains
         r"[a-zA-Z]{2,63}",                     // root domain
-        r"\b([-a-zA-Z0-9@:%_\+.~#?&/=]*)",     // optional query or url fragments
+        // Match URL characters and balanced parenthesized segments, without
+        // consuming a trailing `)` that belongs to the surrounding prose.
+        r"\b(?:",
+        r"[-a-zA-Z0-9@:%_\+.~#?&/=]",
+        r"|\([-a-zA-Z0-9@:%_\+.~#?&/=]*\)",
+        r")*",
     ))
     .expect("failed to build regex")
 });

--- a/tests/rustdoc-ui/lints/bare-urls.fixed
+++ b/tests/rustdoc-ui/lints/bare-urls.fixed
@@ -92,3 +92,7 @@ pub fn trailing_period() {}
 /// <https://bloob.blob>]
 //~^ ERROR this URL is not a hyperlink
 pub fn lint_with_brackets() {}
+
+/// See <https://en.wikipedia.org/wiki/Rust_(programming_language)>
+//~^ ERROR this URL is not a hyperlink
+pub fn hippo() {}

--- a/tests/rustdoc-ui/lints/bare-urls.rs
+++ b/tests/rustdoc-ui/lints/bare-urls.rs
@@ -92,3 +92,7 @@ pub fn trailing_period() {}
 /// https://bloob.blob]
 //~^ ERROR this URL is not a hyperlink
 pub fn lint_with_brackets() {}
+
+/// See https://en.wikipedia.org/wiki/Rust_(programming_language)
+//~^ ERROR this URL is not a hyperlink
+pub fn hippo() {}

--- a/tests/rustdoc-ui/lints/bare-urls.stderr
+++ b/tests/rustdoc-ui/lints/bare-urls.stderr
@@ -364,5 +364,17 @@ help: use an automatic link instead
 LL | /// <https://bloob.blob>]
    |     +                  +
 
-error: aborting due to 30 previous errors
+error: this URL is not a hyperlink
+  --> $DIR/bare-urls.rs:96:9
+   |
+LL | /// See https://en.wikipedia.org/wiki/Rust_(programming_language)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// See <https://en.wikipedia.org/wiki/Rust_(programming_language)>
+   |         +                                                         +
+
+error: aborting due to 31 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#162345.

The whole fix is explained in the comment in the diff.

<!-- homu-ignore:start -->
LLM disclosure: Only used LLM to fix the URL regex.
<!-- homu-ignore:end -->