### PR TITLE
Add a hint for using `nolimit` to the limiting error message

### DIFF
--- a/src/ci/citool/src/jobs.rs
+++ b/src/ci/citool/src/jobs.rs
@@ -317,7 +317,7 @@ fn calculate_jobs(
                 }
                 if jobs.len() > MAX_TRY_JOBS_COUNT && !nolimit {
                     return Err(anyhow::anyhow!(
-                        "It is only possible to schedule up to {MAX_TRY_JOBS_COUNT} custom jobs, received {} custom jobs expanded from {} pattern(s)",
+                        "It is only possible to schedule up to {MAX_TRY_JOBS_COUNT} custom jobs, received {} custom jobs expanded from {} pattern(s). Use `@bors try jobs=... nolimit` to allow running an arbitrary number of try jobs.",
                         jobs.len(),
                         patterns.len()
                     ));


### PR DESCRIPTION
So people know they can get around it :)
I think the current wording is fine, if you'd like the message to be a bit scarier by adding "If really needed, ", lmk