### PR TITLE
Add a regression test for trailing attributes in doctests

### DIFF
--- a/tests/rustdoc-ui/expect-item-after-attribute.rs
+++ b/tests/rustdoc-ui/expect-item-after-attribute.rs
@@ -1,0 +1,26 @@
+//@ compile-flags: --test --test-args=--test-threads=1
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ failure-status: 101
+
+//! ```
+//! #[should_panic]
+//! ```
+
+//! ```
+//! fn main() {
+//!     #[should_panic]
+//! }
+//! ```
+
+//! ```
+//! fn main() { }
+//! #[should_panic]
+//! ```
+
+//! ```
+//! let x = 0; #[should_panic]
+//! ```
+
+//! ```
+//! let x = 0; //! assert!(true);
+//! ```

--- a/tests/rustdoc-ui/expect-item-after-attribute.rs
+++ b/tests/rustdoc-ui/expect-item-after-attribute.rs
@@ -24,3 +24,13 @@
 //! ```
 //! let x = 0; //! assert!(true);
 //! ```
+
+/// ```
+/// /// doc comment
+/// ```
+struct Test;
+
+/// ```
+/// #[cfg(true)] {
+/// }    /// ```
+pub fn wtf() {}

--- a/tests/rustdoc-ui/expect-item-after-attribute.stdout
+++ b/tests/rustdoc-ui/expect-item-after-attribute.stdout
@@ -1,0 +1,80 @@
+
+running 5 tests
+test $DIR/expect-item-after-attribute.rs - (line 13) ... FAILED
+test $DIR/expect-item-after-attribute.rs - (line 17) ... FAILED
+test $DIR/expect-item-after-attribute.rs - (line 20) ... FAILED
+test $DIR/expect-item-after-attribute.rs - (line 5) ... FAILED
+test $DIR/expect-item-after-attribute.rs - (line 8) ... FAILED
+
+failures:
+
+---- $DIR/expect-item-after-attribute.rs - (line 13) stdout ----
+error: expected item after attributes
+  --> $DIR/expect-item-after-attribute.rs:15:1
+   |
+LL | #[should_panic]
+   | ^^^^^^^^^^^^^^^ expected an item after this
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
+---- $DIR/expect-item-after-attribute.rs - (line 17) stdout ----
+error: expected item, found keyword `let`
+  --> $DIR/expect-item-after-attribute.rs:18:1
+   |
+LL | let x = 0; #[should_panic]
+   | ^^^
+   | |
+   | `let` cannot be used for global variables
+   | help: consider using `static` or `const` instead of `let`
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
+---- $DIR/expect-item-after-attribute.rs - (line 20) stdout ----
+error: expected item, found keyword `let`
+  --> $DIR/expect-item-after-attribute.rs:21:1
+   |
+LL | let x = 0; //! assert!(true);
+   | ^^^
+   | |
+   | `let` cannot be used for global variables
+   | help: consider using `static` or `const` instead of `let`
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
+---- $DIR/expect-item-after-attribute.rs - (line 5) stdout ----
+error: expected item after attributes
+  --> $DIR/expect-item-after-attribute.rs:6:1
+   |
+LL | #[should_panic]
+   | ^^^^^^^^^^^^^^^ expected an item after this
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
+---- $DIR/expect-item-after-attribute.rs - (line 8) stdout ----
+error: expected statement after outer attribute
+  --> $DIR/expect-item-after-attribute.rs:10:5
+   |
+LL |     #[should_panic]
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
+
+failures:
+    $DIR/expect-item-after-attribute.rs - (line 13)
+    $DIR/expect-item-after-attribute.rs - (line 17)
+    $DIR/expect-item-after-attribute.rs - (line 20)
+    $DIR/expect-item-after-attribute.rs - (line 5)
+    $DIR/expect-item-after-attribute.rs - (line 8)
+
+test result: FAILED. 0 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/expect-item-after-attribute.stdout
+++ b/tests/rustdoc-ui/expect-item-after-attribute.stdout
@@ -1,10 +1,12 @@
 
-running 5 tests
+running 7 tests
 test $DIR/expect-item-after-attribute.rs - (line 13) ... FAILED
 test $DIR/expect-item-after-attribute.rs - (line 17) ... FAILED
 test $DIR/expect-item-after-attribute.rs - (line 20) ... FAILED
 test $DIR/expect-item-after-attribute.rs - (line 5) ... FAILED
 test $DIR/expect-item-after-attribute.rs - (line 8) ... FAILED
+test $DIR/expect-item-after-attribute.rs - Test (line 28) ... FAILED
+test $DIR/expect-item-after-attribute.rs - wtf (line 33) ... FAILED
 
 failures:
 
@@ -68,6 +70,26 @@ LL |     #[should_panic]
 error: aborting due to 1 previous error
 
 Couldn't compile the test.
+---- $DIR/expect-item-after-attribute.rs - Test (line 28) stdout ----
+error: expected item after doc comment
+  --> $DIR/expect-item-after-attribute.rs:29:1
+   |
+LL | /// doc comment
+   | ^^^^^^^^^^^^^^^ this doc comment doesn't document anything
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
+---- $DIR/expect-item-after-attribute.rs - wtf (line 33) stdout ----
+error: expected item after attributes
+  --> $DIR/expect-item-after-attribute.rs:34:1
+   |
+LL | #[cfg(true)] {
+   | ^^^^^^^^^^^^ expected an item after this
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
 
 failures:
     $DIR/expect-item-after-attribute.rs - (line 13)
@@ -75,6 +97,8 @@ failures:
     $DIR/expect-item-after-attribute.rs - (line 20)
     $DIR/expect-item-after-attribute.rs - (line 5)
     $DIR/expect-item-after-attribute.rs - (line 8)
+    $DIR/expect-item-after-attribute.rs - Test (line 28)
+    $DIR/expect-item-after-attribute.rs - wtf (line 33)
 
-test result: FAILED. 0 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+test result: FAILED. 0 passed; 7 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 


### PR DESCRIPTION
Adds a regression test for https://github.com/rust-lang/rust/issues/162131, https://github.com/rust-lang/rust/issues/162129, https://github.com/rust-lang/rust/issues/162349, and https://github.com/rust-lang/rust/issues/162352

It seems likely this breakage is going to be accepted, so let's add a test in nightly so we can at least track this behavior in the feature