### PR TITLE
remove outdated comment in `UnsafeCell::raw_get` source

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -2494,8 +2494,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     #[rustc_diagnostic_item = "unsafe_cell_raw_get"]
     pub const fn raw_get(this: *const Self) -> *mut T {
         // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
-        // #[repr(transparent)]. This exploits std's special status, there is
-        // no guarantee for user code that this will work in future versions of the compiler!
+        // #[repr(transparent)].
         this as *const T as *mut T
     }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

It was decided that UnsafeCell can be accessed mutably without going through `get` (https://github.com/rust-lang/unsafe-code-guidelines/issues/281) and a comment stating that std has special privileges was removed in rust-lang/rust#159730, but that PR missed `raw_get`. This comment actively contradicted `CovariantUnsafeCell`:
https://github.com/rust-lang/rust/blob/5a2be9f5f075d31e3ca5526b5b029881ce441253/library/core/src/cell/covariant_unsafe_cell.rs#L154-L161