### PR TITLE
make Destruct trait coinductive

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
@@ -424,7 +424,7 @@ where
 
         ecx.probe_builtin_trait_candidate(BuiltinImplSource::Misc).enter(|ecx| {
             ecx.add_goals(
-                GoalSource::AliasBoundConstCondition,
+                GoalSource::ImplWhereBound,
                 const_conditions.into_iter().map(|trait_ref| {
                     goal.with(
                         cx,

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -82,13 +82,10 @@ enum CurrentGoalKind {
 impl CurrentGoalKind {
     fn from_query_input<I: Interner>(cx: I, input: QueryInput<I, I::Predicate>) -> CurrentGoalKind {
         match input.goal.predicate.kind().skip_binder() {
-            ty::PredicateKind::Clause(ty::ClauseKind::Trait(pred)) => {
-                if cx.trait_is_coinductive(pred.trait_ref.def_id) {
-                    CurrentGoalKind::CoinductiveTrait
-                } else {
-                    CurrentGoalKind::Misc
-                }
-            }
+            ty::PredicateKind::Clause(
+                ty::ClauseKind::Trait(ty::TraitClause { trait_ref, .. })
+                | ty::ClauseKind::HostEffect(ty::HostEffectClause { trait_ref, .. }),
+            ) if cx.trait_is_coinductive(trait_ref.def_id) => CurrentGoalKind::CoinductiveTrait,
             ty::PredicateKind::NormalizesTo(_) => {
                 CurrentGoalKind::ProjectionComputeAssocTermCandidate
             }

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1060,6 +1060,7 @@ marker_impls! {
 #[diagnostic::on_unimplemented(message = "can't drop `{Self}`")]
 #[rustc_deny_explicit_impl]
 #[rustc_dyn_incompatible_trait]
+#[rustc_coinductive]
 pub const trait Destruct: PointeeSized {}
 
 /// A marker for tuple types.

--- a/tests/ui/consts/const_destruct_coinduction.rs
+++ b/tests/ui/consts/const_destruct_coinduction.rs
@@ -1,0 +1,22 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+#![feature(const_trait_impl)]
+#![feature(const_destruct)]
+
+use std::marker::Destruct;
+
+struct Wrap<T>(*const T);
+
+const impl<T: [const] Destruct> Drop for Wrap<T> {
+    fn drop(&mut self) {}
+}
+
+enum Foo {
+    A,
+    B(Wrap<Self>),
+}
+
+const fn drop_foo(_: Foo) {}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
Makes `Destruct` `#[rustc_coinductive]`, and switches the goal source for the builtin `Destruct` impl conditions to `ImplWhereBound`, which is required for coinduction to apply. This allows recursive types to be `Destruct`. Fixes rust-lang/rust#162217

As a disclaimer, this is my first time contributing to the trait system so my knowledge of the internals is lacking and I may very well have taken the wrong approach/missed implications of the changes I made here. This code was hand-written without the assistance of an LLM.