### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1911,6 +1911,7 @@ pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
         use crate::fs::{OpenOptions, Permissions};
 
         let mut options = OpenOptions::new();
+        options.read(true);
 
         // ESP-IDF and Horizon do not support O_NOFOLLOW, so we skip setting it.
         // Their filesystems do not have symbolic links, so no special handling is required.
@@ -1920,7 +1921,7 @@ pub fn set_perm_nofollow(p: &CStr, perm: FilePermissions) -> io::Result<()> {
             use crate::os::unix::fs::OpenOptionsExt;
             #[cfg(target_os = "wasi")]
             use crate::os::wasi::fs::OpenOptionsExt;
-            options.read(true).custom_flags(libc::O_NOFOLLOW);
+            options.custom_flags(libc::O_NOFOLLOW);
         }
 
         // SAFETY: Since this function is called with `with_native_path`

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -2231,30 +2231,37 @@ impl Step for FileCheck {
         };
 
         // There is a LLVM config set, take filecheck from it
-        // Note: because `download-ci-llvm` currently overrides `llvm-config`, when the LLVM is
-        // downloaded, we go through this branch. Ideally, this should be changed so that
-        // `download-ci-llvm` doesn't override the config.
-        if let Some(s) = target_config.and_then(|c| c.llvm_config.as_ref()) {
-            let llvm_bindir = command(s).arg("--bindir").run_capture_stdout(builder).stdout();
-            let filecheck = Path::new(llvm_bindir.trim()).join(exe("FileCheck", self.target));
-            let filecheck = if filecheck.exists() {
+        if let Some(llvm_config) = target_config.and_then(|c| c.llvm_config.as_ref()) {
+            // We can only execute llvm-config if we're on the same host target
+            return if builder.is_host_target(self.target) {
+                let llvm_bindir =
+                    command(llvm_config).arg("--bindir").run_capture_stdout(builder).stdout();
+                let filecheck = Path::new(llvm_bindir.trim()).join(exe("FileCheck", self.target));
+                let filecheck = if filecheck.exists() {
+                    filecheck
+                } else {
+                    // On Fedora the system LLVM installs FileCheck in the
+                    // llvm subdirectory of the libdir.
+                    let llvm_libdir =
+                        command(llvm_config).arg("--libdir").run_capture_stdout(builder).stdout();
+                    let lib_filecheck = Path::new(llvm_libdir.trim())
+                        .join("llvm")
+                        .join(exe("FileCheck", self.target));
+                    if lib_filecheck.exists() {
+                        lib_filecheck
+                    } else {
+                        // Return the most normal file name, even though
+                        // it doesn't exist, so that any error message
+                        // refers to that.
+                        filecheck
+                    }
+                };
                 filecheck
             } else {
-                // On Fedora the system LLVM installs FileCheck in the
-                // llvm subdirectory of the libdir.
-                let llvm_libdir = command(s).arg("--libdir").run_capture_stdout(builder).stdout();
-                let lib_filecheck =
-                    Path::new(llvm_libdir.trim()).join("llvm").join(exe("FileCheck", self.target));
-                if lib_filecheck.exists() {
-                    lib_filecheck
-                } else {
-                    // Return the most normal file name, even though
-                    // it doesn't exist, so that any error message
-                    // refers to that.
-                    filecheck
-                }
+                // In other cases, just guess that Filecheck is available in the same directory
+                // as the llvm-config
+                llvm_config.parent().unwrap().join(exe("FileCheck", self.target))
             };
-            return filecheck;
         }
         // Here we take the filecheck from LLVM directly
         let llvm_output = builder.ensure(Llvm { target: self.target });

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -2237,7 +2237,8 @@ impl Step for FileCheck {
                 let llvm_bindir =
                     command(llvm_config).arg("--bindir").run_capture_stdout(builder).stdout();
                 let filecheck = Path::new(llvm_bindir.trim()).join(exe("FileCheck", self.target));
-                let filecheck = if filecheck.exists() {
+
+                if filecheck.exists() {
                     filecheck
                 } else {
                     // On Fedora the system LLVM installs FileCheck in the
@@ -2255,8 +2256,7 @@ impl Step for FileCheck {
                         // refers to that.
                         filecheck
                     }
-                };
-                filecheck
+                }
             } else {
                 // In other cases, just guess that Filecheck is available in the same directory
                 // as the llvm-config

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1008,11 +1008,6 @@ impl Config {
                     target.llvm_has_rust_patches = Some(patches);
                 }
                 if let Some(ref s) = target_llvm_filecheck {
-                    if target_llvm_config.is_none() {
-                        panic!(
-                            "You must also configure `llvm-config` when setting `llvm-filecheck` for target {triple}",
-                        );
-                    }
                     target.llvm_filecheck = Some(src.join(s));
                 }
                 target.llvm_libunwind = target_llvm_libunwind.as_ref().map(|v| {

--- a/src/librustdoc/passes/lint/bare_urls.rs
+++ b/src/librustdoc/passes/lint/bare_urls.rs
@@ -2,13 +2,14 @@
 //! Suggests wrapping the link with angle brackets: `Go to <https://example.com/>.` to linkify it.
 
 use core::ops::Range;
-use std::mem;
 use std::sync::LazyLock;
 
 use regex::Regex;
 use rustc_errors::{Applicability, DiagDecorator};
 use rustc_hir::HirId;
-use rustc_resolve::rustdoc::pulldown_cmark::{Event, Parser, Tag};
+use rustc_resolve::rustdoc::pulldown_cmark::{
+    DefaultBrokenLinkCallback, Event, Tag, TextMergeWithOffset,
+};
 use rustc_resolve::rustdoc::source_span_for_markdown_range;
 use tracing::trace;
 
@@ -55,21 +56,20 @@ pub(super) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
         );
     };
 
-    let mut p = Parser::new_ext(dox, main_body_opts()).into_offset_iter();
+    // pulldown-cmark can split a URL into multiple `Text` events while processing
+    // characters such as `_` according to CommonMark's emphasis rules.
+    // `TextMergeWithOffset` merges these events so we can check the complete URL.
+    let mut p = TextMergeWithOffset::<DefaultBrokenLinkCallback>::new_ext(dox, main_body_opts());
 
     while let Some((event, range)) = p.next() {
         match event {
             Event::Text(s) => find_raw_urls(cx, dox, &s, range, &report_diag),
             // We don't want to check the text inside code blocks or links.
             Event::Start(tag @ (Tag::CodeBlock(_) | Tag::Link { .. })) => {
+                let end = tag.to_end();
                 for (event, _) in p.by_ref() {
-                    match event {
-                        Event::End(end)
-                            if mem::discriminant(&end) == mem::discriminant(&tag.to_end()) =>
-                        {
-                            break;
-                        }
-                        _ => {}
+                    if matches!(event, Event::End(tag) if tag == end) {
+                        break;
                     }
                 }
             }
@@ -83,7 +83,12 @@ static URL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         r"https?://",                          // url scheme
         r"([-a-zA-Z0-9@:%._\+~#=]{2,256}\.)+", // one or more subdomains
         r"[a-zA-Z]{2,63}",                     // root domain
-        r"\b([-a-zA-Z0-9@:%_\+.~#?&/=]*)",     // optional query or url fragments
+        // Match URL characters and balanced parenthesized segments, without
+        // consuming a trailing `)` that belongs to the surrounding prose.
+        r"\b(?:",
+        r"[-a-zA-Z0-9@:%_\+.~#?&/=]",
+        r"|\([-a-zA-Z0-9@:%_\+.~#?&/=]*\)",
+        r")*",
     ))
     .expect("failed to build regex")
 });

--- a/tests/rustdoc-ui/lints/bare-urls.fixed
+++ b/tests/rustdoc-ui/lints/bare-urls.fixed
@@ -92,3 +92,7 @@ pub fn trailing_period() {}
 /// <https://bloob.blob>]
 //~^ ERROR this URL is not a hyperlink
 pub fn lint_with_brackets() {}
+
+/// See <https://en.wikipedia.org/wiki/Rust_(programming_language)>
+//~^ ERROR this URL is not a hyperlink
+pub fn hippo() {}

--- a/tests/rustdoc-ui/lints/bare-urls.rs
+++ b/tests/rustdoc-ui/lints/bare-urls.rs
@@ -92,3 +92,7 @@ pub fn trailing_period() {}
 /// https://bloob.blob]
 //~^ ERROR this URL is not a hyperlink
 pub fn lint_with_brackets() {}
+
+/// See https://en.wikipedia.org/wiki/Rust_(programming_language)
+//~^ ERROR this URL is not a hyperlink
+pub fn hippo() {}

--- a/tests/rustdoc-ui/lints/bare-urls.stderr
+++ b/tests/rustdoc-ui/lints/bare-urls.stderr
@@ -364,5 +364,17 @@ help: use an automatic link instead
 LL | /// <https://bloob.blob>]
    |     +                  +
 
-error: aborting due to 30 previous errors
+error: this URL is not a hyperlink
+  --> $DIR/bare-urls.rs:96:9
+   |
+LL | /// See https://en.wikipedia.org/wiki/Rust_(programming_language)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: bare URLs are not automatically turned into clickable links
+help: use an automatic link instead
+   |
+LL | /// See <https://en.wikipedia.org/wiki/Rust_(programming_language)>
+   |         +                                                         +
+
+error: aborting due to 31 previous errors
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#162328 (Allow overriding filecheck even if LLVM is built or downloaded)
 - rust-lang/rust#162381 (fix bare urls split text)
 - rust-lang/rust#162388 (std: fix set_permissions_nofollow on espidf and horizon)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=162328,162381,162388)
<!-- homu-ignore:end -->

