### PR TITLE
Fix gap in const stability checks around intrinsics

### DIFF
--- a/compiler/rustc_const_eval/src/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/check_consts/check.rs
@@ -830,20 +830,19 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                         // as well skip the remaining checks.
                         return;
                     }
-                    // We use `intrinsic.const_stable` to determine if this can be safely exposed to
-                    // stable code, rather than `const_stable_indirect`. This is to make
-                    // `#[rustc_const_stable_indirect]` an attribute that is always safe to add.
-                    // We also ask is_safe_to_expose_on_stable_const_fn; this determines whether the intrinsic
-                    // fallback body is safe to expose on stable.
-                    let is_const_stable = intrinsic.const_stable
-                        || (!intrinsic.must_be_overridden
-                            && is_fn_or_trait_safe_to_expose_on_stable(tcx, callee));
+                    // In addition to the usual check, we also require that the intrinsic either has
+                    // a fallback body, or the special `#[rustc_intrinsic_const_stable_indirect]`.
+                    let usable_fallback_body = !intrinsic.must_be_overridden
+                        && !find_attr!(self.tcx, callee, RustcDoNotConstCheck);
+                    let const_stable_indirect =
+                        is_fn_or_trait_safe_to_expose_on_stable(tcx, callee)
+                            && (usable_fallback_body || intrinsic.const_stable_indirect);
                     match tcx.lookup_const_stability(callee) {
                         None => {
                             // This doesn't need a separate const-stability check -- const-stability equals
                             // regular stability, and regular stability is checked separately.
                             // However, we *do* have to worry about *recursive* const stability.
-                            if !is_const_stable && self.enforce_recursive_const_stability() {
+                            if !const_stable_indirect && self.enforce_recursive_const_stability() {
                                 self.dcx().emit_err(diagnostics::UnmarkedIntrinsicExposed {
                                     span: self.span,
                                     def_path: self.tcx.def_path_str(callee),
@@ -860,14 +859,14 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                             // This is not ideal since it means the user sees an error, not the macro
                             // author, but that's also the case if one forgets to set
                             // `#[allow_internal_unstable]` in the first place.
-                            if self.span.allows_unstable(feature) && is_const_stable {
+                            if self.span.allows_unstable(feature) && const_stable_indirect {
                                 return;
                             }
 
                             self.check_op(ops::IntrinsicUnstable {
                                 name: intrinsic.name,
                                 feature,
-                                const_stable_indirect: is_const_stable,
+                                const_stable_indirect,
                             });
                         }
                         Some(hir::ConstStability {

--- a/compiler/rustc_const_eval/src/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/check_consts/check.rs
@@ -247,7 +247,17 @@ impl<'mir, 'tcx> Checker<'mir, 'tcx> {
                     && self.enforce_recursive_const_stability()
                     && !super::rustc_allow_const_fn_unstable(self.tcx, self.def_id(), gate)
                 {
-                    emit_unstable_in_stable_exposed_error(self.ccx, span, gate, is_function_call);
+                    // Avoid suggesting to add `rustc_const_unstable` if the attribute is already
+                    // present. Need to directly check raw attributes as
+                    // `tcx.lookup_const_stability` also includes inherited stability.
+                    let already_unstable = find_attr!(self.tcx, self.def_id(), RustcConstStability { stability, .. } if stability.is_const_unstable());
+                    emit_unstable_in_stable_exposed_error(
+                        self.ccx,
+                        span,
+                        gate,
+                        is_function_call,
+                        already_unstable,
+                    );
                 }
 
                 return;
@@ -954,13 +964,14 @@ fn emit_unstable_in_stable_exposed_error(
     span: Span,
     gate: Symbol,
     is_function_call: bool,
+    already_unstable: bool,
 ) -> ErrorGuaranteed {
     let attr_span = ccx.tcx.def_span(ccx.def_id()).shrink_to_lo();
 
     ccx.dcx().emit_err(diagnostics::UnstableInStableExposed {
         gate: gate.to_string(),
         span,
-        attr_span,
+        suggest_const_unstable: (!already_unstable).then_some(attr_span),
         is_function_call,
         is_function_call2: is_function_call,
     })

--- a/compiler/rustc_const_eval/src/check_consts/mod.rs
+++ b/compiler/rustc_const_eval/src/check_consts/mod.rs
@@ -107,8 +107,10 @@ pub fn is_fn_or_trait_safe_to_expose_on_stable(tcx: TyCtxt<'_>, def_id: DefId) -
         }
         Some(stab) => {
             // We consider things safe-to-expose if they are stable or if they are marked as
-            // `const_stable_indirect`.
-            stab.is_const_stable() || stab.const_stable_indirect
+            // `const_stable_indirect`. Intrinsics are special so we need to check for those too.
+            stab.is_const_stable()
+                || stab.const_stable_indirect
+                || tcx.intrinsic(def_id).is_some_and(|i| i.const_stable_indirect)
         }
     }
 }

--- a/compiler/rustc_const_eval/src/diagnostics.rs
+++ b/compiler/rustc_const_eval/src/diagnostics.rs
@@ -102,7 +102,7 @@ pub(crate) struct UnstableInStableExposed {
         code = "#[rustc_const_unstable(feature = \"...\", issue = \"...\")]\n",
         applicability = "has-placeholders"
     )]
-    pub attr_span: Span,
+    pub suggest_const_unstable: Option<Span>,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_middle/src/ty/intrinsic.rs
+++ b/compiler/rustc_middle/src/ty/intrinsic.rs
@@ -9,8 +9,8 @@ pub struct IntrinsicDef {
     pub name: Symbol,
     /// Whether the intrinsic has no meaningful body and all backends need to shim all calls to it.
     pub must_be_overridden: bool,
-    /// Whether the intrinsic can be invoked from stable const fn
-    pub const_stable: bool,
+    /// Whether the intrinsic can be invoked from stable const fn (`#[rustc_intrinsic_const_stable_indirect]`).
+    pub const_stable_indirect: bool,
 }
 
 impl TyCtxt<'_> {

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1720,7 +1720,7 @@ pub fn intrinsic_raw(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<ty::Intrinsi
         Some(ty::IntrinsicDef {
             name: tcx.item_name(def_id),
             must_be_overridden,
-            const_stable: find_attr!(tcx, def_id, RustcIntrinsicConstStableIndirect),
+            const_stable_indirect: find_attr!(tcx, def_id, RustcIntrinsicConstStableIndirect),
         })
     } else {
         None

--- a/library/core/src/intrinsics/bounds.rs
+++ b/library/core/src/intrinsics/bounds.rs
@@ -44,8 +44,7 @@ impl<T: PointeeSized, U: PointeeSized> ChangePointee<U> for *const T {
 ///
 /// # Safety
 /// Must actually *be* such a type.
-#[rustc_const_unstable(feature = "core_intrinsics", issue = "none")]
-pub const unsafe trait FloatPrimitive: Sized + Copy {
+pub unsafe trait FloatPrimitive: Sized + Copy {
     type UInt: const core::ops::BitOr<Output = Self::UInt>
         + const core::ops::BitAnd<Output = Self::UInt>
         + const core::ops::Not<Output = Self::UInt>;
@@ -54,8 +53,7 @@ pub const unsafe trait FloatPrimitive: Sized + Copy {
     fn from_bits(bits: Self::UInt) -> Self;
 }
 
-#[rustc_const_unstable(feature = "core_intrinsics", issue = "none")]
-const unsafe impl FloatPrimitive for f16 {
+unsafe impl FloatPrimitive for f16 {
     type UInt = u16;
     const SIGN_MASK: Self::UInt = f16::SIGN_MASK;
     #[inline]
@@ -68,8 +66,7 @@ const unsafe impl FloatPrimitive for f16 {
     }
 }
 
-#[rustc_const_unstable(feature = "core_intrinsics", issue = "none")]
-const unsafe impl FloatPrimitive for f32 {
+unsafe impl FloatPrimitive for f32 {
     type UInt = u32;
     const SIGN_MASK: Self::UInt = f32::SIGN_MASK;
     #[inline]
@@ -82,8 +79,7 @@ const unsafe impl FloatPrimitive for f32 {
     }
 }
 
-#[rustc_const_unstable(feature = "core_intrinsics", issue = "none")]
-const unsafe impl FloatPrimitive for f64 {
+unsafe impl FloatPrimitive for f64 {
     type UInt = u64;
     const SIGN_MASK: Self::UInt = f64::SIGN_MASK;
     #[inline]
@@ -96,8 +92,7 @@ const unsafe impl FloatPrimitive for f64 {
     }
 }
 
-#[rustc_const_unstable(feature = "core_intrinsics", issue = "none")]
-const unsafe impl FloatPrimitive for f128 {
+unsafe impl FloatPrimitive for f128 {
     type UInt = u128;
     const SIGN_MASK: Self::UInt = f128::SIGN_MASK;
     #[inline]

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3587,6 +3587,7 @@ pub const fn maximumf128(x: f128, y: f128) -> f128 {
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[miri::intrinsic_fallback_is_spec]
+#[rustc_do_not_const_check] // interpreter has built-in impl
 pub const fn fabs<T: const bounds::FloatPrimitive>(x: T) -> T {
     T::from_bits(x.to_bits() & !T::SIGN_MASK)
 }

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3587,8 +3587,8 @@ pub const fn maximumf128(x: f128, y: f128) -> f128 {
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[miri::intrinsic_fallback_is_spec]
-#[rustc_do_not_const_check] // interpreter has built-in impl
-pub const fn fabs<T: const bounds::FloatPrimitive>(x: T) -> T {
+#[rustc_do_not_const_check] // use built-in impl to avoid const-checks in the fallback body.
+pub const fn fabs<T: bounds::FloatPrimitive>(x: T) -> T {
     T::from_bits(x.to_bits() & !T::SIGN_MASK)
 }
 

--- a/tests/ui/consts/const-unstable-intrinsic.rs
+++ b/tests/ui/consts/const-unstable-intrinsic.rs
@@ -39,7 +39,6 @@ pub const unsafe fn align_of_val<T>(x: *const T) -> usize;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
-#[inline]
 pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
     // Const stability attributes are not inherited from parent items.
     #[rustc_intrinsic]
@@ -55,5 +54,34 @@ mod fallback {
     const unsafe fn copy<T>(src: *const T, _dst: *mut T, _count: usize) {
         super::size_of_val(src);
         //~^ ERROR cannot use `#[feature(local)]`
+    }
+
+    // Even unstable intrinsics must be const-checked if we add
+    // `rustc_intrinsic_const_stable_indirect`.
+    #[rustc_intrinsic]
+    #[rustc_const_unstable(feature = "core_intrinsics", issue = "none")]
+    #[rustc_intrinsic_const_stable_indirect]
+    pub const unsafe fn align_of_val<T>(x: *const T) -> usize {
+        super::align_of_val(x)
+        //~^ ERROR cannot use `#[feature(local)]`
+    }
+}
+
+// `rustc_const_stable_indirect` does not actually make this intrinsic callable
+// if the fallback body is non-const. That would require `rustc_intrinsic_const_stable_indirect`
+// which in turns requires t-lang approval.
+mod non_const_fallback {
+    #[rustc_intrinsic]
+    #[rustc_const_stable_indirect]
+    #[rustc_do_not_const_check]
+    pub const unsafe fn size_of_val<T>(_x: *const T) -> usize {
+        0
+    }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_stable(feature = "rust1", since = "1.0.0")]
+    pub const fn something_stable<T>(x: *const T) -> usize {
+        unsafe { size_of_val(x) }
+        //~^ERROR: cannot be (indirectly) exposed to stable
     }
 }

--- a/tests/ui/consts/const-unstable-intrinsic.stderr
+++ b/tests/ui/consts/const-unstable-intrinsic.stderr
@@ -89,12 +89,6 @@ error: const function that might be (indirectly) exposed to stable cannot use `#
    |
 LL |         super::align_of_val(x)
    |         ^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: if the function is not (yet) meant to be exposed to stable const contexts, add `#[rustc_const_unstable]`
-   |
-LL +     #[rustc_const_unstable(feature = "...", issue = "...")]
-LL |     pub const unsafe fn align_of_val<T>(x: *const T) -> usize {
-   |
 
 error: intrinsic `non_const_fallback::size_of_val` cannot be (indirectly) exposed to stable
   --> $DIR/const-unstable-intrinsic.rs:84:18

--- a/tests/ui/consts/const-unstable-intrinsic.stderr
+++ b/tests/ui/consts/const-unstable-intrinsic.stderr
@@ -65,7 +65,7 @@ LL | const fn const_main() {
    |
 
 error: intrinsic `copy::copy` cannot be (indirectly) exposed to stable
-  --> $DIR/const-unstable-intrinsic.rs:48:14
+  --> $DIR/const-unstable-intrinsic.rs:47:14
    |
 LL |     unsafe { copy(src, dst, count) }
    |              ^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL |     unsafe { copy(src, dst, count) }
    = help: mark the caller as `#[rustc_const_unstable]`, or mark the intrinsic `#[rustc_intrinsic_const_stable_indirect]` (but this requires team approval)
 
 error: const function that might be (indirectly) exposed to stable cannot use `#[feature(local)]`
-  --> $DIR/const-unstable-intrinsic.rs:56:9
+  --> $DIR/const-unstable-intrinsic.rs:55:9
    |
 LL |         super::size_of_val(src);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,6 +84,26 @@ LL +     #[rustc_const_unstable(feature = "...", issue = "...")]
 LL |     const unsafe fn copy<T>(src: *const T, _dst: *mut T, _count: usize) {
    |
 
-error: aborting due to 8 previous errors
+error: const function that might be (indirectly) exposed to stable cannot use `#[feature(local)]`
+  --> $DIR/const-unstable-intrinsic.rs:65:9
+   |
+LL |         super::align_of_val(x)
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: if the function is not (yet) meant to be exposed to stable const contexts, add `#[rustc_const_unstable]`
+   |
+LL +     #[rustc_const_unstable(feature = "...", issue = "...")]
+LL |     pub const unsafe fn align_of_val<T>(x: *const T) -> usize {
+   |
+
+error: intrinsic `non_const_fallback::size_of_val` cannot be (indirectly) exposed to stable
+  --> $DIR/const-unstable-intrinsic.rs:84:18
+   |
+LL |         unsafe { size_of_val(x) }
+   |                  ^^^^^^^^^^^^^^
+   |
+   = help: mark the caller as `#[rustc_const_unstable]`, or mark the intrinsic `#[rustc_intrinsic_const_stable_indirect]` (but this requires team approval)
+
+error: aborting due to 10 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
+++ b/tests/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
@@ -82,11 +82,6 @@ LL | const fn stable_indirect() -> u32 { foo2_gated() }
    |                                     ^^^^^^^^^^^^
    |
    = help: mark the callee as `#[rustc_const_stable_indirect]` if it does not itself require any unstable features
-help: if the caller is not (yet) meant to be exposed to stable const contexts, add `#[rustc_const_unstable]`
-   |
-LL + #[rustc_const_unstable(feature = "...", issue = "...")]
-LL | const fn stable_indirect() -> u32 { foo2_gated() }
-   |
 
 error: aborting due to 7 previous errors
 


### PR DESCRIPTION
@N1ark managed to find a gap in our const stability checks around intrinsics. This PR fixes that gap.

Sadly the standard library already relies on the gap, so for now I added a `rustc_allow_const_fn_unstable` but that attribute usually needs some process to be approved.

Also fixes https://github.com/rust-lang/rust/issues/150961 by properly supporting & testing `rustc_do_not_const_check` on intrinsics.