### PR TITLE
Fix msvc-specific differences in debuginfo tests

### DIFF
--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -545,6 +545,9 @@ def f16SummaryProvider(valobj: SBValue, _dict: LLDBOpaque) -> str:
 def sequence_formatter(output: str, valobj: SBValue, _dict: LLDBOpaque):
     length: int = valobj.GetNumChildren()
 
+    if length == 0:
+        return output
+
     long: bool = False
     for i in range(0, length):
         if len(output) > 32:

--- a/tests/debuginfo/basic-types-globals.rs
+++ b/tests/debuginfo/basic-types-globals.rs
@@ -1,6 +1,6 @@
 //@ revisions: lto no-lto
 
-//@ compile-flags:-g
+//@ compile-flags:-g --crate-name=basic_types_globals
 //@ disable-gdb-pretty-printers
 
 //@ [lto] compile-flags:-C lto
@@ -8,36 +8,36 @@
 //@ ignore-backends: gcc
 
 //@ lldb-command:run
-//@ lldb-command:v B
-//@ lldb-check: ::B = false
-//@ lldb-command:v I
-//@ lldb-check: ::I = -1
-//@ lldb-command:v --format=d C
-//@ lldb-check: ::C = 97 U+0x00000061 U'a'
-//@ lldb-command:v --format=d I8
-//@ lldb-check: ::I8 = 68
-//@ lldb-command:v I16
-//@ lldb-check: ::I16 = -16
-//@ lldb-command:v I32
-//@ lldb-check: ::I32 = -32
-//@ lldb-command:v I64
-//@ lldb-check: ::I64 = -64
-//@ lldb-command:v U
-//@ lldb-check: ::U = 1
-//@ lldb-command:v --format=d U8
-//@ lldb-check: ::U8 = 100
-//@ lldb-command:v U16
-//@ lldb-check: ::U16 = 16
-//@ lldb-command:v U32
-//@ lldb-check: ::U32 = 32
-//@ lldb-command:v U64
-//@ lldb-check: ::U64 = 64
-//@ lldb-command:v F16
-//@ lldb-check: ::F16 = 1.5
-//@ lldb-command:v F32
-//@ lldb-check: ::F32 = 2.5
-//@ lldb-command:v F64
-//@ lldb-check: ::F64 = 3.5
+//@ lldb-command:v basic_types_globals::B
+//@ lldb-check:[...]basic_types_globals::B = false
+//@ lldb-command:v basic_types_globals::I
+//@ lldb-check:[...]basic_types_globals::I = -1
+//@ lldb-command:v basic_types_globals::C
+//@ lldb-check:[...]basic_types_globals::C = U+0x00000061 U'a'
+//@ lldb-command:v basic_types_globals::I8
+//@ lldb-check:[...]basic_types_globals::I8 = 68
+//@ lldb-command:v basic_types_globals::I16
+//@ lldb-check:[...]basic_types_globals::I16 = -16
+//@ lldb-command:v basic_types_globals::I32
+//@ lldb-check:[...]basic_types_globals::I32 = -32
+//@ lldb-command:v basic_types_globals::I64
+//@ lldb-check:[...]basic_types_globals::I64 = -64
+//@ lldb-command:v basic_types_globals::U
+//@ lldb-check:[...]basic_types_globals::U = 1
+//@ lldb-command:v basic_types_globals::U8
+//@ lldb-check:[...]basic_types_globals::U8 = 100
+//@ lldb-command:v basic_types_globals::U16
+//@ lldb-check:[...]basic_types_globals::U16 = 16
+//@ lldb-command:v basic_types_globals::U32
+//@ lldb-check:[...]basic_types_globals::U32 = 32
+//@ lldb-command:v basic_types_globals::U64
+//@ lldb-check:[...]basic_types_globals::U64 = 64
+//@ lldb-command:v basic_types_globals::F16
+//@ lldb-check:[...]basic_types_globals::F16 = 1.5
+//@ lldb-command:v basic_types_globals::F32
+//@ lldb-check:[...]basic_types_globals::F32 = 2.5
+//@ lldb-command:v basic_types_globals::F64
+//@ lldb-check:[...]basic_types_globals::F64 = 3.5
 
 //@ gdb-command:run
 //@ gdb-command:print B

--- a/tests/debuginfo/borrowed-unique-basic.rs
+++ b/tests/debuginfo/borrowed-unique-basic.rs
@@ -55,6 +55,7 @@
 // === LLDB TESTS ==================================================================================
 
 //@ lldb-command:type format add -f decimal char
+//@ lldb-command:type format add -f decimal 'signed char'
 //@ lldb-command:type format add -f decimal 'unsigned char'
 //@ lldb-command:run
 

--- a/tests/debuginfo/captured-fields-1.rs
+++ b/tests/debuginfo/captured-fields-1.rs
@@ -30,22 +30,22 @@
 
 //@ lldb-command:run
 //@ lldb-command:v test
-//@ lldb-check:(captured_fields_1::main::{closure_env#0}) test = {_ref__my_ref__my_field1:0x[...]}
+//@ lldb-check:(captured_fields_1::main::[...]closure_env[...]0[...]) test = {_ref__my_ref__my_field1:0x[...]}
 //@ lldb-command:continue
 //@ lldb-command:v test
-//@ lldb-check:(captured_fields_1::main::{closure_env#1}) test = {_ref__my_ref__my_field2:0x[...]}
+//@ lldb-check:(captured_fields_1::main::[...]closure_env[...]1[...]) test = {_ref__my_ref__my_field2:0x[...]}
 //@ lldb-command:continue
 //@ lldb-command:v test
-//@ lldb-check:(captured_fields_1::main::{closure_env#2}) test = {_ref__my_ref:0x[...]}
+//@ lldb-check:(captured_fields_1::main::[...]closure_env[...]2[...]) test = {_ref__my_ref:0x[...]}
 //@ lldb-command:continue
 //@ lldb-command:v test
-//@ lldb-check:(captured_fields_1::main::{closure_env#3}) test = {my_ref:{my_field1:11, my_field2:22}}
+//@ lldb-check:(captured_fields_1::main::[...]closure_env[...]3[...]) test = {my_ref:{my_field1:11, my_field2:22}}
 //@ lldb-command:continue
 //@ lldb-command:v test
-//@ lldb-check:(captured_fields_1::main::{closure_env#4}) test = {my_var__my_field2:22}
+//@ lldb-check:(captured_fields_1::main::[...]closure_env[...]4[...]) test = {my_var__my_field2:22}
 //@ lldb-command:continue
 //@ lldb-command:v test
-//@ lldb-check:(captured_fields_1::main::{closure_env#5}) test = {my_var:{my_field1:11, my_field2:22}}
+//@ lldb-check:(captured_fields_1::main::[...]closure_env[...]5[...]) test = {my_var:{my_field1:11, my_field2:22}}
 //@ lldb-command:continue
 
 #![allow(unused)]

--- a/tests/debuginfo/generic-struct.rs
+++ b/tests/debuginfo/generic-struct.rs
@@ -1,3 +1,7 @@
+//@ revisions: msvc non-msvc
+
+//@ [msvc] only-msvc
+//@ [non-msvc] ignore-msvc
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc
@@ -20,14 +24,20 @@
 //@ lldb-command:run
 
 //@ lldb-command:v int_int
-//@ lldb-check:[...]AGenericStruct<int, int>) int_int = {key:0, value:1}
+//@ [non-msvc] lldb-check:[...]AGenericStruct<int, int>) int_int = {key:0, value:1}
+//@ [msvc] lldb-check:[...]AGenericStruct<i32,i32>) int_int = {key:0, value:1}
 //@ lldb-command:v int_float
-//@ lldb-check:[...]AGenericStruct<int, double>) int_float = {key:2, value:3.5}
+//@ [non-msvc] lldb-check:[...]AGenericStruct<int, double>) int_float = {key:2, value:3.5}
+//@ [msvc] lldb-check:[...]AGenericStruct<i32,f64>) int_float = {value:3.5, key:2}
 //@ lldb-command:v float_int
-//@ lldb-check:[...]AGenericStruct<double, int>) float_int = {key:4.5, value:5}
+//@ [non-msvc] lldb-check:[...]AGenericStruct<double, int>) float_int = {key:4.5, value:5}
+//@ [msvc] lldb-check:[...]AGenericStruct<f64,i32>) float_int = {key:4.5, value:5}
 
 //@ lldb-command:v float_int_float
-//@ lldb-check:[...]AGenericStruct<double, generic_struct::AGenericStruct<int, double> >) float_int_float = {key:6.5, value:{key:7, value:8.5}}
+// ignore-tidy-linelength
+//@ [non-msvc]lldb-check:[...]AGenericStruct<double, generic_struct::AGenericStruct<int, double> >) float_int_float = {key:6.5, value:{key:7, value:8.5}}
+// ignore-tidy-linelength
+//@ [msvc] lldb-check:[...]AGenericStruct<f64,generic_struct::AGenericStruct<i32,f64> >) float_int_float = {value:{value:8.5, key:7}, key:6.5}
 
 // === CDB TESTS ===================================================================================
 

--- a/tests/debuginfo/method-on-generic-struct.rs
+++ b/tests/debuginfo/method-on-generic-struct.rs
@@ -1,3 +1,7 @@
+//@ revisions: msvc non-msvc
+
+//@ [msvc] only-msvc
+//@ [non-msvc] ignore-msvc
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc
@@ -58,7 +62,8 @@
 
 // STACK BY REF
 //@ lldb-command:v *self
-//@ lldb-check:[...]Struct<(u32, i32)>) *self = {x:(8888, -8888)}
+//@ [non-msvc] lldb-check:[...]Struct<(u32, i32)>) *self = {x:(8888, -8888)}
+//@ [msvc] lldb-check:[...]Struct<tuple$<u32,i32> >) *self = {x:(8888, -8888)}
 //@ lldb-command:v arg1
 //@ lldb-check:[...] -1
 //@ lldb-command:v arg2
@@ -67,7 +72,8 @@
 
 // STACK BY VAL
 //@ lldb-command:v self
-//@ lldb-check:[...]Struct<(u32, i32)>) self = {x:(8888, -8888)}
+//@ [non-msvc] lldb-check:[...]Struct<(u32, i32)>) self = {x:(8888, -8888)}
+//@ [msvc] lldb-check:[...]Struct<tuple$<u32,i32> >) self = {x:(8888, -8888)}
 //@ lldb-command:v arg1
 //@ lldb-check:[...] -3
 //@ lldb-command:v arg2
@@ -76,7 +82,8 @@
 
 // OWNED BY REF
 //@ lldb-command:v *self
-//@ lldb-check:[...]Struct<double>) *self = {x:1234.5}
+//@ [non-msvc] lldb-check:[...]Struct<double>) *self = {x:1234.5}
+//@ [msvc] lldb-check:[...]Struct<f64>) *self = {x:1234.5}
 //@ lldb-command:v arg1
 //@ lldb-check:[...] -5
 //@ lldb-command:v arg2
@@ -85,7 +92,8 @@
 
 // OWNED BY VAL
 //@ lldb-command:v self
-//@ lldb-check:[...]Struct<double>) self = {x:1234.5}
+//@ [non-msvc] lldb-check:[...]Struct<double>) self = {x:1234.5}
+//@ [msvc] lldb-check:[...]Struct<f64>) self = {x:1234.5}
 //@ lldb-command:v arg1
 //@ lldb-check:[...] -7
 //@ lldb-command:v arg2
@@ -94,7 +102,8 @@
 
 // OWNED MOVED
 //@ lldb-command:v *self
-//@ lldb-check:[...]Struct<double>) *self = {x:1234.5}
+//@ [non-msvc] lldb-check:[...]Struct<double>) *self = {x:1234.5}
+//@ [msvc] lldb-check:[...]Struct<f64>) *self = {x:1234.5}
 //@ lldb-command:v arg1
 //@ lldb-check:[...] -9
 //@ lldb-command:v arg2

--- a/tests/debuginfo/no_mangle-info.rs
+++ b/tests/debuginfo/no_mangle-info.rs
@@ -1,4 +1,9 @@
-//@ compile-flags:-g
+//@ revisions: msvc non-msvc
+
+//@ [msvc] only-msvc
+//@ [non-msvc] ignore-msvc
+
+//@ compile-flags:-g --crate-name=no_mangle_info
 //@ min-gdb-version: 10.1
 //@ ignore-backends: gcc
 
@@ -11,10 +16,13 @@
 
 // === LLDB TESTS ==================================================================================
 //@ lldb-command:run
-//@ lldb-command:v TEST
-//@ lldb-check:(unsigned long) TEST = 3735928559
-//@ lldb-command:v OTHER_TEST
-//@ lldb-check:(unsigned long) no_mangle_info::namespace::OTHER_TEST = 42
+//@ [msvc] lldb-command:v no_mangle_info::TEST
+//@ [msvc] lldb-check:[...]no_mangle_info::TEST = 3735928559
+
+//@ [non-msvc] lldb-command:v TEST
+//@ [non-msvc] lldb-check:[...]TEST = 3735928559
+//@ lldb-command:v no_mangle_info::namespace::OTHER_TEST
+//@ lldb-check:[...]no_mangle_info::namespace::OTHER_TEST = 42
 
 // === CDB TESTS ==================================================================================
 //@ cdb-command: g
@@ -36,6 +44,6 @@ pub mod namespace {
 }
 
 pub fn main() {
-    println!("TEST: {}", TEST);
+    println!("TEST: {}", unsafe { TEST} );
     println!("OTHER TEST: {}", namespace::OTHER_TEST); // #break
 }

--- a/tests/debuginfo/pretty-slices.rs
+++ b/tests/debuginfo/pretty-slices.rs
@@ -1,3 +1,7 @@
+//@ revisions: msvc non-msvc
+
+//@ [msvc] only-msvc
+//@ [non-msvc] ignore-msvc
 //@ ignore-android: FIXME(#10381)
 //@ ignore-windows-gnu: #128981
 //@ compile-flags:-g
@@ -20,10 +24,12 @@
 //@ lldb-command:run
 
 //@ lldb-command:v slice
-//@ lldb-check:(&[i32]) slice = size=3 { [0] = 0 [1] = 1 [2] = 2 }
+//@ [non-msvc] lldb-check:(&[i32]) slice = size=3 { [0] = 0 [1] = 1 [2] = 2 }
+//@ [msvc] lldb-check:(&[i32]) slice = [0, 1, 2] { [0] = 0 [1] = 1 [2] = 2 }
 
 //@ lldb-command:v mut_slice
-//@ lldb-check:(&mut [i32]) mut_slice = size=4 { [0] = 2 [1] = 3 [2] = 5 [3] = 7 }
+//@ [non-msvc] lldb-check:(&mut [i32]) mut_slice = size=4 { [0] = 2 [1] = 3 [2] = 5 [3] = 7 }
+//@ [msvc] lldb-check:(&mut [i32]) mut_slice = [2, 3, 5, 7] { [0] = 2 [1] = 3 [2] = 5 [3] = 7 }
 
 //@ lldb-command:v str_slice
 //@ lldb-check:(&str) str_slice = "string slice" { [0] = 's' [1] = 't' [2] = 'r' [3] = 'i' [4] = 'n' [5] = 'g' [6] = ' ' [7] = 's' [8] = 'l' [9] = 'i' [10] = 'c' [11] = 'e' }

--- a/tests/debuginfo/strings-and-strs.rs
+++ b/tests/debuginfo/strings-and-strs.rs
@@ -40,13 +40,13 @@
 //@ lldb-check:(strings_and_strs::Foo) str_in_struct = {inner:"Hello"}
 
 //@ lldb-command:v str_in_tuple
-//@ lldb-check:((&str, &str)) str_in_tuple = ("Hello", "World")
+//@ lldb-check:[...] str_in_tuple = ("Hello", "World")
 
 //@ lldb-command:v str_in_rc
-//@ lldb-check:(alloc::rc::Rc<&str, alloc::alloc::Global>) str_in_rc = strong=1, weak=0 { value = "Hello" { [0] = 'H' [1] = 'e' [2] = 'l' [3] = 'l' [4] = 'o' } }
+//@ lldb-check:[...] str_in_rc = strong=1, weak=0 { value = "Hello" { [0] = 'H' [1] = 'e' [2] = 'l' [3] = 'l' [4] = 'o' } }
 
 //@ lldb-command:v box_str
-//@ lldb-check:(alloc::boxed::Box<str, alloc::alloc::Global>) box_str = "World" { [0] = 'W' [1] = 'o' [2] = 'r' [3] = 'l' [4] = 'd' }
+//@ lldb-check:[...] box_str = "World" { [0] = 'W' [1] = 'o' [2] = 'r' [3] = 'l' [4] = 'd' }
 
 // Disabled temporarily since it only "works" by accident
 // `value` is a wide pointer, whose `data_ptr` type, according to LLDB, is `unsigned char[]`. LLDB

--- a/tests/debuginfo/thread-names.rs
+++ b/tests/debuginfo/thread-names.rs
@@ -17,11 +17,14 @@
 // === LLDB TESTS =================================================================================
 //
 //@ lldb-command:run
-//
-//@ lldb-command:thread info 1
-//@ lldb-check:thread #1:[...]name = 'main'[...]
-//@ lldb-command:thread info 2
-//@ lldb-check:thread #2:[...]name = 'my new thread'[...]
+
+// We list all threads and check the full results because we're not guaranteed to have only 2
+// threads, nor are we guaranteed to have `my new thread` be thread 2.
+// We use the python API to do this because `thread list` refuses to print anything inside the test
+// harness for some reason.
+//@ lldb-command:script print(lldb.debugger.GetTargetAtIndex(0).GetProcess().threads)
+//@ lldb-check:[...]name = 'main'[...]
+//@ lldb-check:[...]name = 'my new thread'[...]
 
 // === CDB TESTS ==================================================================================
 //

--- a/tests/debuginfo/vec-slices.rs
+++ b/tests/debuginfo/vec-slices.rs
@@ -1,3 +1,7 @@
+//@ revisions: msvc non-msvc
+
+//@ [msvc] only-msvc
+//@ [non-msvc] ignore-msvc
 //@ ignore-gdb-version: 15.0 - 99.0
 // ^ test temporarily disabled as it fails under gdb 15
 
@@ -55,22 +59,29 @@
 //@ lldb-command:run
 
 //@ lldb-command:v empty
-//@ lldb-check:[...] size=0
+//@ [non-msvc] lldb-check:[...] size=0
+//@ [msvc] lldb-check: []
 
 //@ lldb-command:v singleton
-//@ lldb-check:[...] size=1 { [0] = 1 }
+//@ [non-msvc] lldb-check:[...] size=1 { [0] = 1 }
+//@ [msvc] lldb-check:[...] [1] { [0] = 1 }
 
 //@ lldb-command:v multiple
-//@ lldb-check:[...] size=4 { [0] = 2 [1] = 3 [2] = 4 [3] = 5 }
+//@ [non-msvc] lldb-check:[...] size=4 { [0] = 2 [1] = 3 [2] = 4 [3] = 5 }
+//@ [msvc] lldb-check:[...] [2, 3, 4, 5] { [0] = 2 [1] = 3 [2] = 4 [3] = 5 }
 
 //@ lldb-command:v slice_of_slice
-//@ lldb-check:[...] size=2 { [0] = 3 [1] = 4 }
+//@ [non-msvc] lldb-check:[...] size=2 { [0] = 3 [1] = 4 }
+//@ [msvc] lldb-check:[...] [3, 4] { [0] = 3 [1] = 4 }
 
 //@ lldb-command:v padded_tuple
-//@ lldb-check:[...] size=2 { [0] = (6, 7) [1] = (8, 9) }
+//@ [non-msvc] lldb-check:[...] size=2 { [0] = (6, 7) [1] = (8, 9) }
+//@ [msvc] lldb-check:[...] [(6, 7), (8, 9)] { [0] = (6, 7) [1] = (8, 9) }
 
 //@ lldb-command:v padded_struct
-//@ lldb-check:[...] size=2 { [0] = {x:10, y:11, z:12} [1] = {x:13, y:14, z:15} }
+//@ [non-msvc] lldb-check:[...] size=2 { [0] = {x:10, y:11, z:12} [1] = {x:13, y:14, z:15} }
+// ignore-tidy-linelength
+//@ [msvc] lldb-check:[...] [{x:10, y:11, z:12}, {x:13, y:14, z:15}] { [0] = {x:10, y:11, z:12} [1] = {x:13, y:14, z:15} }
 
 #![allow(dead_code, unused_variables)]
 


### PR DESCRIPTION
As part of https://github.com/rust-lang/rust/issues/161657

Fixes ~every test that fails due to an msvc-specific problem. I tried to modify the `lldb-check` commands in-place where possible. If I couldn't, I used revisions. 

There is 1 very tiny visualizer bug fix that I lumped in here that affects summaries of empty arrays on msvc (`]` -> `[]`)

`basic-types-globals.rs`- msvc stores globals under the `statics` category, and LLDB-with-PDB-debug-info requires that those be access by a fully qualified name (which shouldn't pose any issue for dwarf debug info, which IIRC can access via the qualified or unqualified name). I enforced the crate name through compiler flags, so even if this file moves around or is renamed, it shouldn't break. 

The above also applies to `no_mangle-info.rs` except, for some reason, non-msvc targets are *only* able to access the top level static through the unqualified path. I'm not 100% sure if this is an LLDB bug or not, but it's not a huge deal for us since we can just use revisions.

The only test that changed behaviorally is `thread-names.rs`, which now uses a `script` command to print all threads, and then `compiletest` can pick the 2 it cares about out of that list. On windows, the spawned thread isn't thread 2, since there's typically a bunch of `ntdll.dll` threads. Even for non-windows, relying on exact thread numbers seems pretty fragile so this should help all around. 

After this patch, the remainder of the 22 test failures on `windows-msvc` are the `<variable has been optimized out>` issue and the variable shadowing issue. The variable shadowing is a bug on their end, but we can work around it. I need to look into the `<variable has been optimized out>` issue a bit more to see what's going on there.

r? @Kobzol , @jieyouxu 

---

try-job: test-aarch64-msvc-1
try-job: test-x86_64-msvc-1
try-job: test-aarch64-gnu-debug
try-job: test-x86_64-mingw-1
try-job: test-aarch64-apple-1