### PR TITLE
Unconditionally invalidate the library when the compiler changes

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1018,9 +1018,9 @@ impl Builder<'_> {
         // Avoid doing this during dry run as that usually means the relevant
         // compiler is not yet linked/copied properly.
         //
-        // Only clear out the directory if we're compiling std; otherwise, we
+        // Only clear out the directory if we're running Cargo on std; otherwise, we
         // should let Cargo take care of things for us (via depdep info)
-        if !self.config.dry_run() && mode == Mode::Std && cmd_kind == Kind::Build {
+        if !self.config.dry_run() && mode == Mode::Std {
             build_stamp::clear_if_dirty(self, &out_dir, &self.rustc(compiler));
         }
 

--- a/src/bootstrap/src/utils/build_stamp.rs
+++ b/src/bootstrap/src/utils/build_stamp.rs
@@ -114,7 +114,13 @@ pub fn clear_if_dirty(builder: &Builder<'_>, dir: &Path, input: &Path) -> bool {
     let stamp = BuildStamp::new(dir);
     let mut cleared = false;
     if mtime(stamp.path()) < mtime(input) {
-        builder.do_if_verbose(|| println!("Dirty - {}", dir.display()));
+        builder.do_if_verbose(|| {
+            println!(
+                "Removing dirty directory `{}` because `{}` changed",
+                dir.display(),
+                input.display(),
+            )
+        });
         let _ = fs::remove_dir_all(dir);
         cleared = true;
     } else if stamp.path().exists() {


### PR DESCRIPTION
Note that `x doc` is invalidated elsewhere, when `rustdoc` changes.

Fixes: https://github.com/rust-lang/rust/issues/162407

r? jieyouxu
