### PR TITLE
mir_build: Don't pass a redundant `scrutinee_span` to some MIR-build methods

### DIFF
--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -55,14 +55,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::Block { block: ast_block } => {
                 this.ast_block(destination, block, ast_block, source_info)
             }
-            ExprKind::Match { scrutinee, ref arms, .. } => this.match_expr(
-                destination,
-                block,
-                scrutinee,
-                arms,
-                expr_span,
-                this.thir[scrutinee].span,
-            ),
+            ExprKind::Match { scrutinee, ref arms, .. } => {
+                this.match_expr(destination, block, scrutinee, arms, expr_span)
+            }
             ExprKind::If { cond, then, else_opt, if_then_scope } => {
                 let then_span = this.thir[then].span;
                 let then_source_info = this.source_info(then_span);
@@ -303,9 +298,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                     // Logic for `match`.
                     let scrutinee_span = this.thir.exprs[scrutinee].span;
-                    let scrutinee_place_builder = unpack!(
-                        body_block = this.lower_scrutinee(body_block, scrutinee, scrutinee_span)
-                    );
+                    let scrutinee_place_builder =
+                        unpack!(body_block = this.lower_scrutinee(body_block, scrutinee));
 
                     let match_start_span = match_span.shrink_to_lo().to(scrutinee_span);
 

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -339,10 +339,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         scrutinee_id: ExprId,
         arms: &[ArmId],
         span: Span,
-        scrutinee_span: Span,
     ) -> BlockAnd<()> {
-        let scrutinee_place =
-            unpack!(block = self.lower_scrutinee(block, scrutinee_id, scrutinee_span));
+        let scrutinee_span = self.thir[scrutinee_id].span;
+        let scrutinee_place = unpack!(block = self.lower_scrutinee(block, scrutinee_id));
 
         let match_start_span = span.shrink_to_lo().to(scrutinee_span);
         let patterns = arms
@@ -378,11 +377,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         &mut self,
         mut block: BasicBlock,
         scrutinee_id: ExprId,
-        scrutinee_span: Span,
     ) -> BlockAnd<PlaceBuilder<'tcx>> {
         let scrutinee_place_builder = unpack!(block = self.as_place_builder(block, scrutinee_id));
         if let Some(scrutinee_place) = scrutinee_place_builder.try_to_place(self) {
-            let source_info = self.source_info(scrutinee_span);
+            let source_info = self.source_info(self.thir[scrutinee_id].span);
             self.cfg.push_place_mention(block, source_info, scrutinee_place);
         }
 
@@ -612,9 +610,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
 
             _ => {
-                let initializer = &self.thir[initializer_id];
-                let place_builder =
-                    unpack!(block = self.lower_scrutinee(block, initializer_id, initializer.span));
+                let place_builder = unpack!(block = self.lower_scrutinee(block, initializer_id));
                 self.place_into_pattern(block, irrefutable_pat, place_builder, true)
             }
         }
@@ -2334,7 +2330,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         declare_let_bindings: DeclareLetBindings,
     ) -> BlockAnd<()> {
         let expr_span = self.thir[expr_id].span;
-        let scrutinee = unpack!(block = self.lower_scrutinee(block, expr_id, expr_span));
+        let scrutinee = unpack!(block = self.lower_scrutinee(block, expr_id));
         let built_tree = self.lower_match_tree(
             block,
             expr_span,


### PR DESCRIPTION
In all cases, the caller was passing `&self.thir[scrutinee_id].span`, which can just as easily be done by the callee. There's no need to add confusion by passing a separate span.

(The current situation is probably the result of gradual changes over time.)

There should be no change to compiler output.