### PR TITLE
Use IndexVec instead of BTreeMap for polonius variances

### DIFF
--- a/compiler/rustc_borrowck/src/polonius/constraints.rs
+++ b/compiler/rustc_borrowck/src/polonius/constraints.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexSet};
 use rustc_index::interval::SparseIntervalMatrix;
 use rustc_middle::mir::{Body, Location};
@@ -9,7 +7,7 @@ use rustc_mir_dataflow::points::PointIndex;
 use crate::BorrowSet;
 use crate::constraints::OutlivesConstraint;
 use crate::dataflow::BorrowIndex;
-use crate::polonius::ConstraintDirection;
+use crate::polonius::{ConstraintDirection, LiveRegionVariances};
 use crate::region_infer::values::LivenessValues;
 use crate::type_check::Locations;
 use crate::universal_regions::UniversalRegions;
@@ -99,7 +97,7 @@ impl LocalizedConstraintGraph {
         &self,
         body: &Body<'tcx>,
         liveness: &LivenessValues,
-        live_region_variances: &BTreeMap<RegionVid, ConstraintDirection>,
+        live_region_variances: &LiveRegionVariances,
         universal_regions: &UniversalRegions<'tcx>,
         borrow_set: &BorrowSet<'tcx>,
         visitor: &mut impl LocalizedConstraintGraphVisitor,
@@ -244,7 +242,7 @@ fn compute_forward_successor(
     region: RegionVid,
     next_point: PointIndex,
     live_regions: &SparseIntervalMatrix<RegionVid, PointIndex>,
-    live_region_variances: &BTreeMap<RegionVid, ConstraintDirection>,
+    live_region_variances: &LiveRegionVariances,
     is_universal_region: bool,
 ) -> Option<LocalizedNode> {
     // 1. Universal regions are semantically live at all points.
@@ -268,8 +266,11 @@ fn compute_forward_successor(
     // propagate liveness when needed.
     //
     // FIXME: add the missing variance information and remove this fallback bidirectional edge.
-    let direction =
-        live_region_variances.get(&region).unwrap_or(&ConstraintDirection::Bidirectional);
+    let direction = live_region_variances
+        .get(region)
+        .copied()
+        .flatten()
+        .unwrap_or(ConstraintDirection::Bidirectional);
 
     match direction {
         ConstraintDirection::Backward => {
@@ -294,7 +295,7 @@ fn compute_backward_successor(
     current_point: PointIndex,
     previous_point: PointIndex,
     live_regions: &SparseIntervalMatrix<RegionVid, PointIndex>,
-    live_region_variances: &BTreeMap<RegionVid, ConstraintDirection>,
+    live_region_variances: &LiveRegionVariances,
 ) -> Option<LocalizedNode> {
     // Liveness flows into the regions live at the next point. So, in a backwards view, we'll link
     // the region from the current point, if it's live there, to the previous point.
@@ -304,8 +305,11 @@ fn compute_backward_successor(
 
     // FIXME: add the missing variance information and remove this fallback bidirectional edge. See
     // the same comment in `compute_forward_successor`.
-    let direction =
-        live_region_variances.get(&region).unwrap_or(&ConstraintDirection::Bidirectional);
+    let direction = live_region_variances
+        .get(region)
+        .copied()
+        .flatten()
+        .unwrap_or(ConstraintDirection::Bidirectional);
 
     match direction {
         ConstraintDirection::Forward => {

--- a/compiler/rustc_borrowck/src/polonius/liveness_constraints.rs
+++ b/compiler/rustc_borrowck/src/polonius/liveness_constraints.rs
@@ -1,18 +1,17 @@
-use std::collections::BTreeMap;
-
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::relate::{
     self, Relate, RelateResult, TypeRelation, relate_args_with_variances,
 };
-use rustc_middle::ty::{self, RegionVid, Ty, TyCtxt, TypeVisitable};
+use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitable};
 
 use super::ConstraintDirection;
+use crate::polonius::LiveRegionVariances;
 use crate::universal_regions::UniversalRegions;
 
 /// Record the variance of each region contained within the given value.
 pub(crate) fn record_live_region_variance<'tcx>(
     tcx: TyCtxt<'tcx>,
-    live_region_variances: &mut BTreeMap<RegionVid, ConstraintDirection>,
+    live_region_variances: &mut LiveRegionVariances,
     universal_regions: &UniversalRegions<'tcx>,
     value: impl TypeVisitable<TyCtxt<'tcx>> + Relate<TyCtxt<'tcx>>,
 ) {
@@ -31,7 +30,7 @@ pub(crate) fn record_live_region_variance<'tcx>(
 struct VarianceExtractor<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     ambient_variance: ty::Variance,
-    directions: &'a mut BTreeMap<RegionVid, ConstraintDirection>,
+    directions: &'a mut LiveRegionVariances,
     universal_regions: &'a UniversalRegions<'tcx>,
 }
 
@@ -72,17 +71,14 @@ impl<'tcx> VarianceExtractor<'_, 'tcx> {
         };
 
         let region = self.universal_regions.to_region_vid(region);
-        self.directions
-            .entry(region)
-            .and_modify(|entry| {
-                // If there's already a recorded direction for this region, we combine the two:
-                // - combining the same direction is idempotent
-                // - combining different directions is trivially bidirectional
-                if entry != &direction {
-                    *entry = ConstraintDirection::Bidirectional;
-                }
-            })
-            .or_insert(direction);
+        let entry = self.directions.ensure_contains_elem(region, || None);
+        *entry = match *entry {
+            // If there's already a recorded direction for this region, we combine the two:
+            // - combining the same direction is idempotent
+            // - combining different directions is trivially bidirectional
+            Some(existing) if existing != direction => Some(ConstraintDirection::Bidirectional),
+            _ => Some(direction),
+        };
     }
 }
 

--- a/compiler/rustc_borrowck/src/polonius/mod.rs
+++ b/compiler/rustc_borrowck/src/polonius/mod.rs
@@ -38,9 +38,8 @@ mod dump;
 pub(crate) mod legacy;
 mod liveness_constraints;
 
-use std::collections::BTreeMap;
-
 use rustc_data_structures::fx::FxHashSet;
+use rustc_index::IndexVec;
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::{Body, Local};
 use rustc_middle::ty::RegionVid;
@@ -54,6 +53,8 @@ use crate::constraints::OutlivesConstraint;
 use crate::dataflow::BorrowIndex;
 use crate::region_infer::values::LivenessValues;
 use crate::universal_regions::UniversalRegions;
+
+pub(crate) type LiveRegionVariances = IndexVec<RegionVid, Option<ConstraintDirection>>;
 
 #[derive(Clone)]
 pub(crate) struct LiveLoans {
@@ -89,7 +90,7 @@ pub(crate) struct PoloniusContext {
 
     /// The expected edge direction per live region: the kind of directed edge we'll create as
     /// liveness constraints depends on the variance of types with respect to each contained region.
-    pub(crate) live_region_variances: BTreeMap<RegionVid, ConstraintDirection>,
+    pub(crate) live_region_variances: LiveRegionVariances,
 
     /// The regions that outlive free regions are used to distinguish relevant live locals from
     /// boring locals. A boring local is one whose type contains only such regions. Polonius


### PR DESCRIPTION
This results in wins, ranging from negligible to significant, for Polonius Alpha. 

r? lqd

<!-- homu-ignore:start -->
<details>
  <summary>LLM-generated perf summary table</summary>
  <img width="623" height="207" alt="image" src="https://github.com/user-attachments/assets/9cb686f1-c3a0-4df2-9870-f4bce32afc0e" />
</details>
<!-- homu-ignore:end -->