### PR TITLE
Add counter to self profiler path generation.

### DIFF
--- a/compiler/rustc_data_structures/src/profiling.rs
+++ b/compiler/rustc_data_structures/src/profiling.rs
@@ -87,7 +87,7 @@ use std::error::Error;
 use std::fmt::Display;
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use std::{fs, hint, process};
 
@@ -623,6 +623,8 @@ impl SelfProfiler {
         event_filters: Option<&[String]>,
         counter_name: &str,
     ) -> Result<SelfProfiler, Box<dyn Error + Send + Sync>> {
+        static PROFILER_COUNT: AtomicUsize = AtomicUsize::new(0);
+
         fs::create_dir_all(output_directory)?;
 
         let crate_name = crate_name.unwrap_or("unknown-crate");
@@ -630,7 +632,20 @@ impl SelfProfiler {
         // length can behave as a source of entropy for heap addresses, when
         // ASLR is disabled and the heap is otherwise deterministic.
         let pid: u32 = process::id();
-        let filename = format!("{crate_name}-{pid:07}.rustc_profile");
+        // We count how many profilers have been made to ensure unique names
+        // for profiles when invoking the compiler multiple times from the same
+        // process, as in those cases the combination cratename + pid might
+        // not be unique.
+        //
+        // These are not added to the default name in order
+        // to not change the existing names when the compiler is run through
+        // the rustc binary.
+        let count = PROFILER_COUNT.fetch_add(1, Ordering::Relaxed);
+        let filename = if count != 0 {
+            format!("{crate_name}-{pid:07}-{count:022}.rustc_profile")
+        } else {
+            format!("{crate_name}-{pid:07}.rustc_profile")
+        };
         let path = output_directory.join(filename);
         let profiler =
             Profiler::with_counter(&path, measureme::counters::Counter::by_name(counter_name)?)?;


### PR DESCRIPTION
This allows multiple invocations of the compiler within the same process, without running into potential issues when self-profiling with the name of the profiles not being unique.

To keep current names consistent, the first profiler created will still use the old naming convention.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
