### PR TITLE
Pin the number of frontend threads while gathering PGO to 1

### DIFF
--- a/src/tools/opt-dist/src/training.rs
+++ b/src/tools/opt-dist/src/training.rs
@@ -38,6 +38,8 @@ fn init_compiler_benchmarks(
         scenarios.join(",").as_str(),
         "--exact-match",
         crates.join(",").as_str(),
+        "--frontend-threads",
+        "1",
         "--jobs",
         "4",
     ])


### PR DESCRIPTION
This will be important after https://github.com/rust-lang/rustc-perf/pull/2574 is synced here, to avoid running some benchmarks multiple times unexpectedly.

But we can do it proactively, the CLI argument should already be in the in-tree `rustc-perf` version (hopefully, let's see).
