### PR TITLE
Improve diagnostics for non-well-formed associated items

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -171,6 +171,31 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         if let Err(guar) = leaf_trait_predicate.error_reported() {
                             return guar;
                         }
+                        let impl_assoc_type_self_trait_bound_param =
+                            if self.is_explicit_self_trait_bound_on_impl_assoc_type(
+                                obligation.cause.body_def_id,
+                                obligation.cause.code(),
+                                leaf_trait_predicate.def_id(),
+                            ) && let ty::Param(param_ty) =
+                                *leaf_trait_predicate.skip_binder().self_ty().kind()
+                            {
+                                Some(param_ty)
+                            } else {
+                                None
+                            };
+
+                        let is_explicit_self_sized_bound_on_impl_assoc_type =
+                            impl_assoc_type_self_trait_bound_param.is_some()
+                                && self
+                                    .tcx
+                                    .is_lang_item(leaf_trait_predicate.def_id(), LangItem::Sized);
+
+                        if let Some(param_ty) = impl_assoc_type_self_trait_bound_param {
+                            span = param_ty.span_from_generics(
+                                self.tcx,
+                                obligation.cause.body_def_id.to_def_id(),
+                            );
+                        }
                         // Silence redundant errors on binding access that are already
                         // reported on the binding definition (#56607).
                         if let Err(guar) = self.fn_arg_obligation(&obligation) {
@@ -388,9 +413,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             _ => DUMMY_SP,
                         };
                         if let Some(s) = label {
-                            // If it has a custom `#[rustc_on_unimplemented]`
-                            // error message, let's display it as the label!
-                            err.span_label(span, s);
+                            // Preserve custom `#[rustc_on_unimplemented]` labels for other traits;
+                            // the explicit `Self: Sized` associated-type case has targeted labeling.
+                            if !is_explicit_self_sized_bound_on_impl_assoc_type {
+                                err.span_label(span, s);
+                            }
                             if !matches!(leaf_trait_predicate.skip_binder().self_ty().kind(), ty::Param(_))
                                 // When the self type is a type param We don't need to "the trait
                                 // `std::marker::Sized` is not implemented for `T`" as we will point

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3802,6 +3802,38 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         );
         true
     }
+    /// Checks for an explicit `Self: Trait` bound on an associated type impl.
+    pub(super) fn is_explicit_self_trait_bound_on_impl_assoc_type(
+        &self,
+        body_def_id: LocalDefId,
+        cause_code: &ObligationCauseCode<'tcx>,
+        trait_def_id: DefId,
+    ) -> bool {
+        let ObligationCauseCode::WhereClause(item_def_id, span) = *cause_code.peel_derives() else {
+            return false;
+        };
+        let is_impl_trait_assoc_type = if let Some(assoc_item) =
+            self.tcx.opt_associated_item(body_def_id.to_def_id())
+            && let Some(trait_item_def_id) = assoc_item.trait_item_def_id()
+        {
+            trait_item_def_id == item_def_id
+                && matches!(assoc_item.kind, ty::AssocKind::Type { .. })
+        } else {
+            false
+        };
+
+        if !is_impl_trait_assoc_type {
+            return false;
+        }
+
+        self.tcx.clauses_of(item_def_id).instantiate_own_identity().any(|(clause, clause_span)| {
+            clause_span == span
+                && clause.skip_norm_wip().as_trait_clause().is_some_and(|trait_pred| {
+                    trait_pred.def_id() == trait_def_id
+                        && trait_pred.skip_binder().self_ty().is_self_param()
+                })
+        })
+    }
 
     pub(super) fn note_obligation_cause_code<G: EmissionGuarantee, T>(
         &self,
@@ -3998,6 +4030,32 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                                     this =
                                         "the implicit `Sized` requirement on this type parameter";
                                 }
+                                let is_explicit_self_sized_bound_on_impl_assoc_type = self
+                                    .is_explicit_self_trait_bound_on_impl_assoc_type(
+                                        body_def_id,
+                                        cause_code,
+                                        def_id,
+                                    );
+
+                                if is_explicit_self_sized_bound_on_impl_assoc_type
+                                    && let Some(generics) = tcx.hir_get_generics(body_def_id)
+                                    && !generics.where_clause_span.from_expansion()
+                                    && generics.where_clause_span.desugaring_kind().is_none()
+                                {
+                                    let tail_span = generics.tail_span_for_predicate_suggestion();
+                                    if tail_span.can_be_used_for_suggestions() {
+                                        err.span_suggestion_verbose(
+                                            tail_span,
+                                            "consider adding `where Self: Sized`",
+                                            format!(
+                                                "{} Self: Sized",
+                                                generics.add_where_or_trailing_comma()
+                                            ),
+                                            Applicability::MachineApplicable,
+                                        );
+                                    }
+                                }
+
                                 if let Some(hir::Node::TraitItem(hir::TraitItem {
                                     generics,
                                     kind: hir::TraitItemKind::Type(bounds, None),
@@ -4007,6 +4065,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                                     && !bounds.iter()
                                         .filter_map(|bound| bound.trait_ref())
                                         .any(|tr| tr.trait_def_id().is_some_and(|def_id| tcx.is_lang_item(def_id, LangItem::Sized)))
+                                    && !is_explicit_self_sized_bound_on_impl_assoc_type
                                 {
                                     let (span, separator) = if let [.., last] = bounds {
                                         (last.span().shrink_to_hi(), " +")

--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -379,19 +379,42 @@ impl<'tcx> BestObligation<'tcx> {
         alias: ty::AliasTerm<'tcx>,
     ) -> ControlFlow<PredicateObligation<'tcx>> {
         let tcx = goal.infcx().tcx;
-        let obligation = Obligation::new(
-            tcx,
-            self.obligation.cause.clone(),
-            goal.goal().param_env,
-            alias.trait_ref(tcx),
-        );
+
+        let trait_ref = alias.trait_ref(tcx);
+        let obligation =
+            Obligation::new(tcx, self.obligation.cause.clone(), goal.goal().param_env, trait_ref);
+
         self.with_derived_obligation(obligation, |this| {
             goal.infcx().visit_proof_tree_at_depth(
-                goal.goal().with(tcx, alias.trait_ref(tcx)),
+                goal.goal().with(tcx, trait_ref),
                 goal.depth() + 1,
                 this,
             )
-        })
+        })?;
+
+        let def_id = alias.expect_projection_def_id();
+
+        for (clause, span) in tcx.clauses_of(def_id).instantiate_own(tcx, alias.args) {
+            let clause = clause.skip_norm_wip();
+
+            let cause = ObligationCause::new(
+                self.obligation.cause.span,
+                self.obligation.cause.body_def_id,
+                ObligationCauseCode::WhereClause(def_id, span),
+            );
+
+            let obligation = Obligation::new(tcx, cause, goal.goal().param_env, clause);
+
+            self.with_derived_obligation(obligation, |this| {
+                goal.infcx().visit_proof_tree_at_depth(
+                    goal.goal().with(tcx, clause),
+                    goal.depth() + 1,
+                    this,
+                )
+            })?;
+        }
+
+        ControlFlow::Continue(())
     }
 
     /// If we have no candidates, then it's likely that there is a

--- a/tests/ui/traits/next-solver/assoc-item-own-bound-issue-162368.current.stderr
+++ b/tests/ui/traits/next-solver/assoc-item-own-bound-issue-162368.current.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/assoc-item-own-bound-issue-162368.rs:13:18
+   |
+LL | impl<T: ?Sized> Trait for T {
+   |      - this type parameter needs to be `Sized`
+LL |     type Assoc = i32;
+   |                  ^^^ doesn't have a size known at compile-time
+   |
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - impl<T: ?Sized> Trait for T {
+LL + impl<T> Trait for T {
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/next-solver/assoc-item-own-bound-issue-162368.next.stderr
+++ b/tests/ui/traits/next-solver/assoc-item-own-bound-issue-162368.next.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/assoc-item-own-bound-issue-162368.rs:12:6
+   |
+LL | impl<T: ?Sized> Trait for T {
+   |      ^ this type parameter needs to be `Sized`
+   |
+note: required by a bound in `Trait::Assoc`
+  --> $DIR/assoc-item-own-bound-issue-162368.rs:8:15
+   |
+LL |     type Assoc
+   |          ----- required by a bound in this associated type
+LL |     where
+LL |         Self: Sized;
+   |               ^^^^^ required by this bound in `Trait::Assoc`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - impl<T: ?Sized> Trait for T {
+LL + impl<T> Trait for T {
+   |
+help: consider adding `where Self: Sized`
+   |
+LL |     type Assoc = i32 where Self: Sized;
+   |                      +++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/next-solver/assoc-item-own-bound-issue-162368.rs
+++ b/tests/ui/traits/next-solver/assoc-item-own-bound-issue-162368.rs
@@ -1,0 +1,17 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+trait Trait {
+    type Assoc
+    where
+        Self: Sized;
+}
+
+//[next]~v ERROR the size for values of type `T` cannot be known at compilation time
+impl<T: ?Sized> Trait for T {
+    type Assoc = i32;
+    //[current]~^ ERROR the size for values of type `T` cannot be known at compilation time
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/assoc-item-own-bound-where-clause-suggestion.rs
+++ b/tests/ui/traits/next-solver/assoc-item-own-bound-where-clause-suggestion.rs
@@ -1,0 +1,67 @@
+//@ compile-flags: -Znext-solver
+
+// Case B: implementation associated type already has an existing where-clause
+trait TraitWithBound {
+    type Assoc
+    where
+        Self: Sized,
+        Self: 'static;
+}
+
+impl<T: ?Sized> TraitWithBound for T {
+    //~^ ERROR the size for values of type `T` cannot be known at compilation time
+    type Assoc = i32
+    where
+        Self: 'static;
+}
+
+// Case C: normal associated-type implicit-Sized diagnostic (suppression is not global)
+trait NormalAssoc {
+    type Assoc;
+}
+
+impl NormalAssoc for () {
+    type Assoc = [u8];
+    //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time
+}
+
+// Case D: projection/non-impl use-site (targeted suggestion does not leak)
+trait NonImplTrait {
+    type Assoc
+    where
+        Self: Sized;
+}
+
+fn non_impl_use<T: ?Sized>() {
+    let _: <T as NonImplTrait>::Assoc;
+    //~^ ERROR the size for values of type `T` cannot be known at compilation time
+    //~| ERROR the trait bound `T: NonImplTrait` is not satisfied
+}
+
+// Case E: explicit associated-type bound with a trait other than `Sized`
+trait Marker {}
+
+trait TraitWithMarker {
+    type Assoc
+    where
+        Self: Marker;
+}
+
+impl<T> TraitWithMarker for T {
+    //~^ ERROR the trait bound `T: Marker` is not satisfied
+    type Assoc = i32;
+}
+
+// Case F: associated-type bound with a custom on-unimplemented diagnostic
+trait TraitWithSend {
+    type Assoc
+    where
+        Self: Send;
+}
+
+impl<T> TraitWithSend for T {
+    //~^ ERROR `T` cannot be sent between threads safely
+    type Assoc = i32;
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/assoc-item-own-bound-where-clause-suggestion.stderr
+++ b/tests/ui/traits/next-solver/assoc-item-own-bound-where-clause-suggestion.stderr
@@ -1,0 +1,119 @@
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/assoc-item-own-bound-where-clause-suggestion.rs:11:6
+   |
+LL | impl<T: ?Sized> TraitWithBound for T {
+   |      ^ this type parameter needs to be `Sized`
+   |
+note: required by a bound in `TraitWithBound::Assoc`
+  --> $DIR/assoc-item-own-bound-where-clause-suggestion.rs:7:15
+   |
+LL |     type Assoc
+   |          ----- required by a bound in this associated type
+LL |     where
+LL |         Self: Sized,
+   |               ^^^^^ required by this bound in `TraitWithBound::Assoc`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - impl<T: ?Sized> TraitWithBound for T {
+LL + impl<T> TraitWithBound for T {
+   |
+help: consider adding `where Self: Sized`
+   |
+LL |         Self: 'static, Self: Sized;
+   |                      +++++++++++++
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/assoc-item-own-bound-where-clause-suggestion.rs:24:18
+   |
+LL |     type Assoc = [u8];
+   |                  ^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `NormalAssoc::Assoc`
+  --> $DIR/assoc-item-own-bound-where-clause-suggestion.rs:20:5
+   |
+LL |     type Assoc;
+   |     ^^^^^^^^^^^ required by this bound in `NormalAssoc::Assoc`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Assoc: ?Sized;
+   |               ++++++++
+
+error[E0277]: the trait bound `T: Marker` is not satisfied
+  --> $DIR/assoc-item-own-bound-where-clause-suggestion.rs:50:6
+   |
+LL | impl<T> TraitWithMarker for T {
+   |      ^ the trait `Marker` is not implemented for `T`
+   |
+note: required by a bound in `TraitWithMarker::Assoc`
+  --> $DIR/assoc-item-own-bound-where-clause-suggestion.rs:47:15
+   |
+LL |     type Assoc
+   |          ----- required by a bound in this associated type
+LL |     where
+LL |         Self: Marker;
+   |               ^^^^^^ required by this bound in `TraitWithMarker::Assoc`
+help: consider restricting type parameter `T` with trait `Marker`
+   |
+LL | impl<T: Marker> TraitWithMarker for T {
+   |       ++++++++
+
+error[E0277]: `T` cannot be sent between threads safely
+  --> $DIR/assoc-item-own-bound-where-clause-suggestion.rs:62:6
+   |
+LL | impl<T> TraitWithSend for T {
+   |      ^ `T` cannot be sent between threads safely
+   |
+note: required by a bound in `TraitWithSend::Assoc`
+  --> $DIR/assoc-item-own-bound-where-clause-suggestion.rs:59:15
+   |
+LL |     type Assoc
+   |          ----- required by a bound in this associated type
+LL |     where
+LL |         Self: Send;
+   |               ^^^^ required by this bound in `TraitWithSend::Assoc`
+help: consider restricting type parameter `T` with trait `Send`
+   |
+LL | impl<T: std::marker::Send> TraitWithSend for T {
+   |       +++++++++++++++++++
+
+error[E0277]: the trait bound `T: NonImplTrait` is not satisfied
+  --> $DIR/assoc-item-own-bound-where-clause-suggestion.rs:36:13
+   |
+LL |     let _: <T as NonImplTrait>::Assoc;
+   |             ^ the trait `NonImplTrait` is not implemented for `T`
+   |
+help: consider further restricting type parameter `T` with trait `NonImplTrait`
+   |
+LL | fn non_impl_use<T: ?Sized + NonImplTrait>() {
+   |                           ++++++++++++++
+
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/assoc-item-own-bound-where-clause-suggestion.rs:36:13
+   |
+LL | fn non_impl_use<T: ?Sized>() {
+   |                 - this type parameter needs to be `Sized`
+LL |     let _: <T as NonImplTrait>::Assoc;
+   |             ^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `NonImplTrait::Assoc`
+  --> $DIR/assoc-item-own-bound-where-clause-suggestion.rs:32:15
+   |
+LL |     type Assoc
+   |          ----- required by a bound in this associated type
+LL |     where
+LL |         Self: Sized;
+   |               ^^^^^ required by this bound in `NonImplTrait::Assoc`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - fn non_impl_use<T: ?Sized>() {
+LL + fn non_impl_use<T>() {
+   |
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Assoc: ?Sized
+   |               ++++++++
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/trivial-unsized-projection-2.bad_new.stderr
+++ b/tests/ui/traits/trivial-unsized-projection-2.bad_new.stderr
@@ -1,9 +1,3 @@
-error[E0271]: type mismatch resolving `<Tail as Bad>::Assert == _`
-  --> $DIR/trivial-unsized-projection-2.rs:22:12
-   |
-LL | const FOO: <Tail as Bad>::Assert = todo!();
-   |            ^^^^^^^^^^^^^^^^^^^^^ types differ
-
 error[E0277]: the size for values of type `[()]` cannot be known at compilation time
   --> $DIR/trivial-unsized-projection-2.rs:22:12
    |
@@ -29,13 +23,31 @@ help: consider relaxing the implicit `Sized` restriction
 LL |     type Assert: ?Sized
    |                ++++++++
 
-error[E0271]: type mismatch resolving `<Tail as Bad>::Assert == _`
+error[E0277]: the size for values of type `[()]` cannot be known at compilation time
   --> $DIR/trivial-unsized-projection-2.rs:22:36
    |
 LL | const FOO: <Tail as Bad>::Assert = todo!();
-   |                                    ^^^^^^^ types differ
+   |                                    ^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `Tail`, the trait `Sized` is not implemented for `[()]`
+note: required because it appears within the type `Tail`
+  --> $DIR/trivial-unsized-projection-2.rs:17:8
+   |
+LL | struct Tail([()]);
+   |        ^^^^
+note: required by a bound in `Bad::Assert`
+  --> $DIR/trivial-unsized-projection-2.rs:14:15
+   |
+LL |     type Assert
+   |          ------ required by a bound in this associated type
+LL |     where
+LL |         Self: Sized;
+   |               ^^^^^ required by this bound in `Bad::Assert`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Assert: ?Sized
+   |                ++++++++
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0271, E0277.
-For more information about an error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/trivial-unsized-projection-2.rs
+++ b/tests/ui/traits/trivial-unsized-projection-2.rs
@@ -23,8 +23,7 @@ const FOO: <Tail as Bad>::Assert = todo!();
 //[bad]~^ ERROR the size for values of type `[()]` cannot be known at compilation time
 //[bad]~| ERROR the size for values of type `[()]` cannot be known at compilation time
 //[bad_new]~^^^ ERROR the size for values of type `[()]` cannot be known at compilation time
-//[bad_new]~| ERROR: type mismatch resolving `<Tail as Bad>::Assert == _`
-//[bad_new]~| ERROR: type mismatch resolving `<Tail as Bad>::Assert == _`
+//[bad_new]~| ERROR the size for values of type `[()]` cannot be known at compilation time
 
 #[cfg(any(good, good_new))]
 // Well-formed in trivially false param-env

--- a/tests/ui/traits/trivial-unsized-projection.bad_new.stderr
+++ b/tests/ui/traits/trivial-unsized-projection.bad_new.stderr
@@ -1,9 +1,3 @@
-error[E0271]: type mismatch resolving `<[()] as Bad>::Assert == _`
-  --> $DIR/trivial-unsized-projection.rs:20:12
-   |
-LL | const FOO: <[()] as Bad>::Assert = todo!();
-   |            ^^^^^^^^^^^^^^^^^^^^^ types differ
-
 error[E0277]: the size for values of type `[()]` cannot be known at compilation time
   --> $DIR/trivial-unsized-projection.rs:20:12
    |
@@ -24,13 +18,26 @@ help: consider relaxing the implicit `Sized` restriction
 LL |     type Assert: ?Sized
    |                ++++++++
 
-error[E0271]: type mismatch resolving `<[()] as Bad>::Assert == _`
+error[E0277]: the size for values of type `[()]` cannot be known at compilation time
   --> $DIR/trivial-unsized-projection.rs:20:36
    |
 LL | const FOO: <[()] as Bad>::Assert = todo!();
-   |                                    ^^^^^^^ types differ
+   |                                    ^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[()]`
+note: required by a bound in `Bad::Assert`
+  --> $DIR/trivial-unsized-projection.rs:14:15
+   |
+LL |     type Assert
+   |          ------ required by a bound in this associated type
+LL |     where
+LL |         Self: Sized;
+   |               ^^^^^ required by this bound in `Bad::Assert`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Assert: ?Sized
+   |                ++++++++
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0271, E0277.
-For more information about an error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/trivial-unsized-projection.rs
+++ b/tests/ui/traits/trivial-unsized-projection.rs
@@ -21,8 +21,7 @@ const FOO: <[()] as Bad>::Assert = todo!();
 //[bad]~^ ERROR the size for values of type `[()]` cannot be known at compilation time
 //[bad]~| ERROR the size for values of type `[()]` cannot be known at compilation time
 //[bad_new]~^^^ ERROR the size for values of type `[()]` cannot be known at compilation time
-//[bad_new]~| ERROR type mismatch resolving `<[()] as Bad>::Assert == _`
-//[bad_new]~| ERROR type mismatch resolving `<[()] as Bad>::Assert == _`
+//[bad_new]~| ERROR the size for values of type `[()]` cannot be known at compilation time
 
 #[cfg(any(good, good_new))]
 // Well-formed in trivially false param-env


### PR DESCRIPTION
Fixes rust-lang/rust#162368.

With the new solver, this ended up as a projection mismatch instead of reporting the `Sized` requirement from the associated type.

I changed the diagnostic fallback to also check the associated item's own clauses, so it can recover the `Self: Sized` obligation and report E0277 instead.

In this case, the diagnostic now points to the impl type parameter instead of `i32`, keeps the note for the associated type bound, and suggests adding `where Self: Sized`.

I also added regression tests for the original case, an existing where-clause, the normal implicit `Sized` case, and a non-impl projection use site.