### PR TITLE
Forward CfgTrace attributes on EII items

### DIFF
--- a/compiler/rustc_builtin_macros/src/eii.rs
+++ b/compiler/rustc_builtin_macros/src/eii.rs
@@ -1,8 +1,8 @@
 use rustc_ast::token::{Delimiter, TokenKind};
 use rustc_ast::tokenstream::{DelimSpacing, DelimSpan, Spacing, TokenStream, TokenTree};
 use rustc_ast::{
-    Attribute, DUMMY_NODE_ID, EiiDecl, EiiImpl, ItemKind, MetaItem, Mutability, Path, StmtKind,
-    Visibility, ast,
+    AttrKind, Attribute, DUMMY_NODE_ID, EiiDecl, EiiImpl, ItemKind, MetaItem, Mutability, Path,
+    StmtKind, SyntheticAttr, Visibility, ast,
 };
 use rustc_ast_pretty::pprust::path_to_string;
 use rustc_expand::base::{Annotatable, ExtCtxt};
@@ -200,37 +200,47 @@ fn split_attrs(
     let mut foreign_item_attributes = ThinVec::new();
 
     for attr in attrs {
-        match attr.name() {
-            // If an eii is marked a lang item, that's because we want to call its declaration, so
-            // mark the foreign item as the lang item
-            Some(sym::lang) => foreign_item_attributes.push(attr),
-            // Deprecating an eii means deprecating the macro and the foreign item
-            Some(sym::deprecated) => {
+        match &attr.kind {
+            // Forward synthetic CfgTrace and CfgAttrTrace, these are applicable to both foreign item and macro.
+            AttrKind::Synthetic(SyntheticAttr::CfgTrace(_) | SyntheticAttr::CfgAttrTrace(_)) => {
                 foreign_item_attributes.push(attr.clone());
                 macro_attributes.push(attr);
-            }
-            // The stability of an EII affects the usage of the macro and calling the foreign item
-            Some(sym::stable) | Some(sym::unstable) => {
-                foreign_item_attributes.push(attr.clone());
-                macro_attributes.push(attr);
-            }
-            // `#[track_caller]` goes on the foreign item only: it's the symbol callers link
-            // against, so it must carry the flag for call sites to pass the caller location.
-            // Implementations derive it during codegen (see `EiiImpls` in `codegen_attrs.rs`),
-            // so it must not be routed onto the default impl here.
-            Some(sym::track_caller) => {
-                foreign_item_attributes.push(attr);
             }
             // Doc attributes should be forwarded to the macro and the foreign item, since those are
             // the two items you interact with as a user.
             // FIXME: idk yet how EIIs show up in docs, might want to customize
-            _ if attr.is_doc_comment() => {
+            AttrKind::DocComment(_, _) => {
                 foreign_item_attributes.push(attr.clone());
                 macro_attributes.push(attr);
             }
-            Some(sym::eii) => unreachable!("should already be filtered out"),
-            _ => {
-                ecx.dcx().emit_err(EiiAttributeNotSupported { span, attr_span: attr.span() });
+            AttrKind::Normal(normal) => {
+                match normal.item.name() {
+                    // If an eii is marked a lang item, that's because we want to call its declaration, so
+                    // mark the foreign item as the lang item
+                    Some(sym::lang) => foreign_item_attributes.push(attr),
+                    // Deprecating an eii means deprecating the macro and the foreign item
+                    Some(sym::deprecated) => {
+                        foreign_item_attributes.push(attr.clone());
+                        macro_attributes.push(attr);
+                    }
+                    // The stability of an EII affects the usage of the macro and calling the foreign item
+                    Some(sym::stable) | Some(sym::unstable) => {
+                        foreign_item_attributes.push(attr.clone());
+                        macro_attributes.push(attr);
+                    }
+                    // `#[track_caller]` goes on the foreign item only: it's the symbol callers link
+                    // against, so it must carry the flag for call sites to pass the caller location.
+                    // Implementations derive it during codegen (see `EiiImpls` in `codegen_attrs.rs`),
+                    // so it must not be routed onto the default impl here.
+                    Some(sym::track_caller) => {
+                        foreign_item_attributes.push(attr);
+                    }
+                    Some(sym::eii) => unreachable!("should already be filtered out"),
+                    _ => {
+                        ecx.dcx()
+                            .emit_err(EiiAttributeNotSupported { span, attr_span: attr.span() });
+                    }
+                }
             }
         }
     }

--- a/tests/ui/eii/cfg_on_eii.rs
+++ b/tests/ui/eii/cfg_on_eii.rs
@@ -1,0 +1,20 @@
+//@ compile-flags: -Z unpretty=hir,typed
+
+#![feature(extern_item_impls)]
+#![deny(deprecated)] //~ NOTE:
+
+#[cfg(true)]
+#[eii]
+fn cfg_on_eii() {}
+
+#[cfg_attr(true, eii)]
+fn conditional_eii() {}
+
+#[cfg_attr(true, deprecated = "bar")]
+#[eii]
+fn cfg_attr_on_eii() {}
+
+fn main() {
+    cfg_attr_on_eii();
+    //~^ ERROR use of deprecated function
+}

--- a/tests/ui/eii/cfg_on_eii.stderr
+++ b/tests/ui/eii/cfg_on_eii.stderr
@@ -1,0 +1,14 @@
+error: use of deprecated function `cfg_attr_on_eii`: bar
+  --> $DIR/cfg_on_eii.rs:18:5
+   |
+LL |     cfg_attr_on_eii();
+   |     ^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/cfg_on_eii.rs:4:9
+   |
+LL | #![deny(deprecated)]
+   |         ^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/eii/cfg_on_eii.stdout
+++ b/tests/ui/eii/cfg_on_eii.stdout
@@ -1,0 +1,72 @@
+//@ compile-flags: -Z unpretty=hir,typed
+
+#![deny(deprecated)]
+#![attr = Feature([extern_item_impls#0])]
+extern crate std;
+#[attr = PreludeImport]
+use ::std::prelude::rust_2015::*;
+
+const _: () =
+    ({
+        #[attr = EiiImpl(EiiImpl {resolution: Known(DefId(0:7 ~ cfg_on_eii[fec6]::{extern#0}::cfg_on_eii)),
+        is_default: true})]
+        fn cfg_on_eii() ({ } as ())
+    } as ());
+extern "Rust" {
+    #[attr = CfgTrace([Bool(true, $DIR/cfg_on_eii.rs:6:7: 6:11 (#0))])]
+    #[attr = RustcEiiForeignItem]
+    fn cfg_on_eii();
+}
+#[attr = CfgTrace([Bool(true, $DIR/cfg_on_eii.rs:6:7: 6:11 (#0))])]
+#[attr = RustcMacroTransparency(SemiOpaque)]
+#[attr = RustcBuiltinMacro {builtin_name: "eii_shared_macro",
+helper_attrs: []}]
+#[attr = EiiDeclaration(EiiDecl {foreign_item: DefId(0:7 ~ cfg_on_eii[fec6]::{extern#0}::cfg_on_eii),
+impl_unsafe: false, name: cfg_on_eii#0})]
+macro cfg_on_eii { () => {} }
+
+const _: () =
+    ({
+        #[attr = EiiImpl(EiiImpl {resolution: Known(DefId(0:12 ~ cfg_on_eii[fec6]::{extern#1}::conditional_eii)),
+        is_default: true})]
+        fn conditional_eii() ({ } as ())
+    } as ());
+extern "Rust" {
+    #[attr = CfgAttrTrace([Bool(true, $DIR/cfg_on_eii.rs:10:12: 10:16 (#0))])]
+    #[attr = RustcEiiForeignItem]
+    fn conditional_eii();
+}
+#[attr = CfgAttrTrace([Bool(true, $DIR/cfg_on_eii.rs:10:12: 10:16 (#0))])]
+#[attr = RustcMacroTransparency(SemiOpaque)]
+#[attr = RustcBuiltinMacro {builtin_name: "eii_shared_macro",
+helper_attrs: []}]
+#[attr = EiiDeclaration(EiiDecl {foreign_item: DefId(0:12 ~ cfg_on_eii[fec6]::{extern#1}::conditional_eii),
+impl_unsafe: false, name: conditional_eii#0})]
+macro conditional_eii { () => {} }
+
+const _: () =
+    ({
+        #[attr = EiiImpl(EiiImpl {resolution: Known(DefId(0:17 ~ cfg_on_eii[fec6]::{extern#2}::cfg_attr_on_eii)),
+        is_default: true})]
+        fn cfg_attr_on_eii() ({ } as ())
+    } as ());
+extern "Rust" {
+    #[attr = CfgAttrTrace([Bool(true, $DIR/cfg_on_eii.rs:13:12: 13:16 (#0))])]
+    #[attr = Deprecated {deprecation: Deprecation {since: Unspecified,
+    note: bar#0}}]
+    #[attr = RustcEiiForeignItem]
+    fn cfg_attr_on_eii();
+}
+#[attr = CfgAttrTrace([Bool(true, $DIR/cfg_on_eii.rs:13:12: 13:16 (#0))])]
+#[attr = Deprecated {deprecation: Deprecation {since: Unspecified,
+note: bar#0}}]
+#[attr = RustcMacroTransparency(SemiOpaque)]
+#[attr = RustcBuiltinMacro {builtin_name: "eii_shared_macro",
+helper_attrs: []}]
+#[attr = EiiDeclaration(EiiDecl {foreign_item: DefId(0:17 ~ cfg_on_eii[fec6]::{extern#2}::cfg_attr_on_eii),
+impl_unsafe: false, name: cfg_attr_on_eii#0})]
+macro cfg_attr_on_eii { () => {} }
+
+fn main() ({
+    ((cfg_attr_on_eii as fn() {cfg_attr_on_eii})() as ());
+} as ())


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Forwards compiler's synthetic CfgTrace and CfgAttrTrace to EII foreign item and macro. This enables the usage of `#[cfg(..)]`, `#[cfg_attr(..)]` and `cfg_select!` on EII.

Fixes rust-lang/rust#162378.

No LLM was used in the creation of this PR.