### PR TITLE
Replace links to `github.com/rust-lang/rfcs` with links to the Rust RFC Book

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0117.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0117.md
@@ -47,4 +47,4 @@ impl Bar for u32 {
 
 For information on the design of the orphan rules, see [RFC 1023].
 
-[RFC 1023]: https://github.com/rust-lang/rfcs/blob/master/text/1023-rebalancing-coherence.md
+[RFC 1023]: https://rust-lang.github.io/rfcs/1023-rebalancing-coherence.html

--- a/compiler/rustc_error_codes/src/error_codes/E0192.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0192.md
@@ -19,4 +19,4 @@ fn main() {}
 Negative impls are only allowed for auto traits. For more
 information see the [opt-in builtin traits RFC][RFC 19].
 
-[RFC 19]: https://github.com/rust-lang/rfcs/blob/master/text/0019-opt-in-builtin-traits.md
+[RFC 19]: https://rust-lang.github.io/rfcs/0019-opt-in-builtin-traits.html

--- a/compiler/rustc_error_codes/src/error_codes/E0207.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0207.md
@@ -223,4 +223,4 @@ impl<'a> Contents for &'a Foo {
 
 For more information, please see [RFC 447].
 
-[RFC 447]: https://github.com/rust-lang/rfcs/blob/master/text/0447-no-unused-impl-parameters.md
+[RFC 447]: https://rust-lang.github.io/rfcs/0447-no-unused-impl-parameters.html

--- a/compiler/rustc_error_codes/src/error_codes/E0210.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0210.md
@@ -77,4 +77,4 @@ For information on the design of the orphan rules,
 see [RFC 2451] and [RFC 1023].
 
 [RFC 2451]: https://rust-lang.github.io/rfcs/2451-re-rebalancing-coherence.html
-[RFC 1023]: https://github.com/rust-lang/rfcs/blob/master/text/1023-rebalancing-coherence.md
+[RFC 1023]: https://rust-lang.github.io/rfcs/1023-rebalancing-coherence.html

--- a/compiler/rustc_error_codes/src/error_codes/E0228.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0228.md
@@ -36,5 +36,5 @@ type Foo<'a, 'b> = TwoBounds<'a, 'b, dyn Trait + 'b>;
 
 For more information, see [RFC 599] and its amendment [RFC 1156].
 
-[RFC 599]: https://github.com/rust-lang/rfcs/blob/master/text/0599-default-object-bound.md
-[RFC 1156]: https://github.com/rust-lang/rfcs/blob/master/text/1156-adjust-default-object-bounds.md
+[RFC 599]: https://rust-lang.github.io/rfcs/0599-default-object-bound.html
+[RFC 1156]: https://rust-lang.github.io/rfcs/1156-adjust-default-object-bounds.html

--- a/compiler/rustc_error_codes/src/error_codes/E0328.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0328.md
@@ -30,5 +30,5 @@ impl<T, U> CoerceUnsized<MyType<U>> for MyType<T>
     where T: CoerceUnsized<U> {}
 ```
 
-[RFC 982]: https://github.com/rust-lang/rfcs/blob/master/text/0982-dst-coercion.md
+[RFC 982]: https://rust-lang.github.io/rfcs/0982-dst-coercion.html
 [`CoerceUnsized`]: https://doc.rust-lang.org/std/ops/trait.CoerceUnsized.html

--- a/compiler/rustc_error_codes/src/error_codes/E0380.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0380.md
@@ -11,4 +11,4 @@ unsafe auto trait Trait {
 Auto traits cannot have methods or associated items. For more information see
 the [opt-in builtin traits RFC][RFC 19].
 
-[RFC 19]: https://github.com/rust-lang/rfcs/blob/master/text/0019-opt-in-builtin-traits.md
+[RFC 19]: https://rust-lang.github.io/rfcs/0019-opt-in-builtin-traits.html

--- a/compiler/rustc_error_codes/src/error_codes/E0398.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0398.md
@@ -32,4 +32,4 @@ fn foo<'a>(arg: &'a Box<SomeTrait+'a>) { /* ... */ }
 This explicitly states that you expect the trait object `SomeTrait` to contain
 references (with a maximum lifetime of `'a`).
 
-[RFC 1156]: https://github.com/rust-lang/rfcs/blob/master/text/1156-adjust-default-object-bounds.md
+[RFC 1156]: https://rust-lang.github.io/rfcs/1156-adjust-default-object-bounds.html

--- a/compiler/rustc_error_codes/src/error_codes/E0517.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0517.md
@@ -50,4 +50,4 @@ types (i.e., `u8`, `i32`, etc) a representation that permits vectorization via
 SIMD. This doesn't make much sense for enums since they don't consist of a
 single list of data.
 
-[rfc2195]: https://github.com/rust-lang/rfcs/blob/master/text/2195-really-tagged-unions.md
+[rfc2195]: https://rust-lang.github.io/rfcs/2195-really-tagged-unions.html

--- a/compiler/rustc_error_codes/src/error_codes/E0591.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0591.md
@@ -78,4 +78,4 @@ alone suffices for that. `*mut fn()` is a pointer to a fn pointer.
 (Since these values are typically just passed to C code, however, this rarely
 makes a difference in practice.)
 
-[rfc401]: https://github.com/rust-lang/rfcs/blob/master/text/0401-coercions.md
+[rfc401]: https://rust-lang.github.io/rfcs/0401-coercions.html

--- a/compiler/rustc_error_codes/src/error_codes/E0737.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0737.md
@@ -9,4 +9,4 @@ Erroneous code example:
 extern "C" fn foo() {}
 ```
 
-[RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
+[RFC 2091]: https://rust-lang.github.io/rfcs/2091-inline-semantic.html

--- a/compiler/rustc_error_codes/src/error_codes/E0739.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0739.md
@@ -11,4 +11,4 @@ struct Bar {
 }
 ```
 
-[RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
+[RFC 2091]: https://rust-lang.github.io/rfcs/2091-inline-semantic.html

--- a/compiler/rustc_error_codes/src/error_codes/E0787.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0787.md
@@ -22,4 +22,4 @@ The asm block must not contain any operands other than `const` and
 
 For more information, please see [RFC 2972].
 
-[RFC 2972]: https://github.com/rust-lang/rfcs/blob/master/text/2972-constrained-naked.md
+[RFC 2972]: https://rust-lang.github.io/rfcs/2972-constrained-naked.html

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2293,7 +2293,7 @@ impl Expr<'_> {
 
             // Type ascription inherits its place expression kind from its
             // operand. See:
-            // https://github.com/rust-lang/rfcs/blob/master/text/0803-type-ascription.md#type-ascription-and-temporaries
+            // https://rust-lang.github.io/rfcs/0803-type-ascription.html#type-ascription-and-temporaries
             ExprKind::Type(ref e, _) => e.is_place_expr(allow_projections_from),
 
             // Unsafe binder cast preserves place-ness of the sub-expression.

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1401,7 +1401,7 @@ declare_lint! {
     /// See [RFC 2056] for more details. This feature is currently only
     /// available on the nightly channel, see [tracking issue #48214].
     ///
-    /// [RFC 2056]: https://github.com/rust-lang/rfcs/blob/master/text/2056-allow-trivial-where-clause-constraints.md
+    /// [RFC 2056]: https://rust-lang.github.io/rfcs/2056-allow-trivial-where-clause-constraints.html
     /// [tracking issue #48214]: https://github.com/rust-lang/rust/issues/48214
     TRIVIAL_BOUNDS,
     Warn,

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -572,7 +572,7 @@ fn register_builtins(store: &mut LintStore) {
     store.register_removed(
         "unsupported_naked_functions",
         "converted into hard error, see RFC 2972 \
-         <https://github.com/rust-lang/rfcs/blob/master/text/2972-constrained-naked.md> for more information",
+         <https://rust-lang.github.io/rfcs/2972-constrained-naked.html> for more information",
     );
     store.register_removed(
         "mutable_borrow_reservation_conflict",

--- a/compiler/rustc_lint/src/non_ascii_idents.rs
+++ b/compiler/rustc_lint/src/non_ascii_idents.rs
@@ -33,7 +33,7 @@ declare_lint! {
     /// collaboration or for security reasons).
     /// See [RFC 2457] for more details.
     ///
-    /// [RFC 2457]: https://github.com/rust-lang/rfcs/blob/master/text/2457-non-ascii-idents.md
+    /// [RFC 2457]: https://rust-lang.github.io/rfcs/2457-non-ascii-idents.html
     pub NON_ASCII_IDENTS,
     Allow,
     "detects non-ASCII identifiers",

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1266,9 +1266,9 @@ declare_lint! {
     /// See [RFC 401 (coercions)][rfc-401], [RFC 803 (type ascription)][rfc-803] and
     /// [RFC 3307 (remove type ascription)][rfc-3307] for historical context.
     ///
-    /// [rfc-401]: https://github.com/rust-lang/rfcs/blob/master/text/0401-coercions.md
-    /// [rfc-803]: https://github.com/rust-lang/rfcs/blob/master/text/0803-type-ascription.md
-    /// [rfc-3307]: https://github.com/rust-lang/rfcs/blob/master/text/3307-de-rfc-type-ascription.md
+    /// [rfc-401]: https://rust-lang.github.io/rfcs/0401-coercions.html
+    /// [rfc-803]: https://rust-lang.github.io/rfcs/0803-type-ascription.html
+    /// [rfc-3307]: https://rust-lang.github.io/rfcs/3307-de-rfc-type-ascription.html
     pub TRIVIAL_CASTS,
     Allow,
     "detects trivial casts which could be removed"
@@ -1301,9 +1301,9 @@ declare_lint! {
     /// See [RFC 401 (coercions)][rfc-401], [RFC 803 (type ascription)][rfc-803] and
     /// [RFC 3307 (remove type ascription)][rfc-3307] for historical context.
     ///
-    /// [rfc-401]: https://github.com/rust-lang/rfcs/blob/master/text/0401-coercions.md
-    /// [rfc-803]: https://github.com/rust-lang/rfcs/blob/master/text/0803-type-ascription.md
-    /// [rfc-3307]: https://github.com/rust-lang/rfcs/blob/master/text/3307-de-rfc-type-ascription.md
+    /// [rfc-401]: https://rust-lang.github.io/rfcs/0401-coercions.html
+    /// [rfc-803]: https://rust-lang.github.io/rfcs/0803-type-ascription.html
+    /// [rfc-3307]: https://rust-lang.github.io/rfcs/3307-de-rfc-type-ascription.html
     pub TRIVIAL_NUMERIC_CASTS,
     Allow,
     "detects trivial casts of numeric types which could be removed"
@@ -1348,7 +1348,7 @@ declare_lint! {
     /// Note that support for this is only available on the nightly channel.
     /// See [RFC 1977] for more details, as well as the [Cargo documentation].
     ///
-    /// [RFC 1977]: https://github.com/rust-lang/rfcs/blob/master/text/1977-public-private-dependencies.md
+    /// [RFC 1977]: https://rust-lang.github.io/rfcs/1977-public-private-dependencies.html
     /// [Cargo documentation]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#public-dependency
     pub EXPORTED_PRIVATE_DEPENDENCIES,
     Warn,
@@ -1791,7 +1791,7 @@ declare_lint! {
     /// that it produces. See [RFC 2115] for historical context, and [issue
     /// #44752] for more details.
     ///
-    /// [RFC 2115]: https://github.com/rust-lang/rfcs/blob/master/text/2115-argument-lifetimes.md
+    /// [RFC 2115]: https://rust-lang.github.io/rfcs/2115-argument-lifetimes.html
     /// [issue #44752]: https://github.com/rust-lang/rust/issues/44752
     pub SINGLE_USE_LIFETIMES,
     Allow,
@@ -2092,7 +2092,7 @@ declare_lint! {
     /// [`while let`]: https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops
     /// [`let`]: https://doc.rust-lang.org/reference/statements.html#let-statements
     /// [`loop`]: https://doc.rust-lang.org/reference/expressions/loop-expr.html#infinite-loops
-    /// [RFC 2086]: https://github.com/rust-lang/rfcs/blob/master/text/2086-allow-if-let-irrefutables.md
+    /// [RFC 2086]: https://rust-lang.github.io/rfcs/2086-allow-if-let-irrefutables.html
     pub IRREFUTABLE_LET_PATTERNS,
     Warn,
     "detects irrefutable patterns in `if let` and `while let` statements"
@@ -2362,7 +2362,7 @@ declare_lint! {
     /// > fn render<'r>(_: Ref<'r, dyn std::fmt::Display + 'static>) {}
     /// > ```
     ///
-    /// [RFC 2093]: https://github.com/rust-lang/rfcs/blob/master/text/2093-infer-outlives.md
+    /// [RFC 2093]: https://rust-lang.github.io/rfcs/2093-infer-outlives.html
     /// [TOLD]: https://doc.rust-lang.org/reference/lifetime-elision.html#default-trait-object-lifetimes
     pub EXPLICIT_OUTLIVES_REQUIREMENTS,
     Allow,
@@ -2432,7 +2432,7 @@ declare_lint! {
     ///
     /// [issue #57644]: https://github.com/rust-lang/rust/issues/57644
     /// [type aliases]: https://doc.rust-lang.org/reference/items/type-aliases.html#type-aliases
-    /// [RFC 2338]: https://github.com/rust-lang/rfcs/blob/master/text/2338-type-alias-enum-variants.md
+    /// [RFC 2338]: https://rust-lang.github.io/rfcs/2338-type-alias-enum-variants.html
     /// [qualified path]: https://doc.rust-lang.org/reference/paths.html#qualified-paths
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub AMBIGUOUS_ASSOCIATED_ITEMS,
@@ -2641,7 +2641,7 @@ declare_lint! {
     /// [`unsafe fn`]: https://doc.rust-lang.org/reference/unsafe-functions.html
     /// [`unsafe` block]: https://doc.rust-lang.org/reference/expressions/block-expr.html#unsafe-blocks
     /// [unsafe]: https://doc.rust-lang.org/reference/unsafety.html
-    /// [RFC #2585]: https://github.com/rust-lang/rfcs/blob/master/text/2585-unsafe-block-in-unsafe-fn.md
+    /// [RFC #2585]: https://rust-lang.github.io/rfcs/2585-unsafe-block-in-unsafe-fn.html
     /// [issue #71668]: https://github.com/rust-lang/rust/issues/71668
     pub UNSAFE_OP_IN_UNSAFE_FN,
     Allow,

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -101,7 +101,7 @@ pub struct TypeckResults<'tcx> {
     /// leads to a `vec![&Box<Option<i32>>, Box<Option<i32>>]`. Empty vectors are not stored.
     ///
     /// See:
-    /// <https://github.com/rust-lang/rfcs/blob/master/text/2005-match-ergonomics.md#definitions>
+    /// <https://rust-lang.github.io/rfcs/2005-match-ergonomics.html#definitions>
     pat_adjustments: ItemLocalMap<Vec<ty::adjustment::PatAdjustment<'tcx>>>,
 
     /// Set of reference patterns that match against a match-ergonomics inserted reference

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -56,7 +56,7 @@ impl<'tcx> fmt::Display for LazyDefPathStr<'tcx> {
 /// Implemented to visit all `DefId`s in a type.
 /// Visiting `DefId`s is useful because visibilities and reachabilities are attached to them.
 /// The idea is to visit "all components of a type", as documented in
-/// <https://github.com/rust-lang/rfcs/blob/master/text/2145-type-privacy.md#how-to-determine-visibility-of-a-type>.
+/// <https://rust-lang.github.io/rfcs/2145-type-privacy.html#how-to-determine-visibility-of-a-type>.
 /// The default type visitor (`TypeVisitor`) does most of the job, but it has some shortcomings.
 /// First, it doesn't have overridable `fn visit_trait_ref`, so we have to catch trait `DefId`s
 /// manually. Second, it doesn't visit some type components like signatures of fn types, or traits

--- a/compiler/rustc_span/src/edition.rs
+++ b/compiler/rustc_span/src/edition.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use rustc_macros::{BlobDecodable, Encodable, StableHash};
 
-/// The edition of the compiler. (See [RFC 2052](https://github.com/rust-lang/rfcs/blob/master/text/2052-epochs.md).)
+/// The edition of the compiler. (See [RFC 2052](https://rust-lang.github.io/rfcs/2052-epochs.html).)
 #[derive(Clone, Copy, Hash, PartialEq, PartialOrd, Debug, Encodable, BlobDecodable, Eq)]
 #[derive(StableHash)]
 pub enum Edition {

--- a/library/core/src/ffi/c_void.md
+++ b/library/core/src/ffi/c_void.md
@@ -13,4 +13,4 @@ compilers down to 1.1.0. After Rust 1.30.0, it was re-exported by
 this definition. For more information, please read [RFC 2521].
 
 [Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
-[RFC 2521]: https://github.com/rust-lang/rfcs/blob/master/text/2521-c_void-reunification.md
+[RFC 2521]: https://rust-lang.github.io/rfcs/2521-c_void-reunification.html

--- a/library/core/src/keyword_docs.rs
+++ b/library/core/src/keyword_docs.rs
@@ -2506,7 +2506,7 @@ const _: () = ();
 /// }
 /// ```
 ///
-/// [RFC]: https://github.com/rust-lang/rfcs/blob/master/text/0135-where.md
+/// [RFC]: https://rust-lang.github.io/rfcs/0135-where.html
 const _: () = ();
 
 #[doc(keyword = "while")]

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -225,7 +225,7 @@ pub trait PointeeSized {
 ///
 /// [`ops::CoerceUnsized`]: crate::ops::CoerceUnsized
 /// [`Rc`]: ../../std/rc/struct.Rc.html
-/// [RFC982]: https://github.com/rust-lang/rfcs/blob/master/text/0982-dst-coercion.md
+/// [RFC982]: https://rust-lang.github.io/rfcs/0982-dst-coercion.html
 /// [nomicon-coerce]: ../../nomicon/coercions.html
 /// [^1]: Formerly known as *object safe*.
 #[unstable(feature = "unsize", issue = "18598")]

--- a/library/core/src/ops/unsize.rs
+++ b/library/core/src/ops/unsize.rs
@@ -28,7 +28,7 @@ use crate::marker::{PointeeSized, Unsize};
 /// [`Unsize`][unsize] is used to mark types which can be coerced to DSTs if behind
 /// pointers. It is implemented automatically by the compiler.
 ///
-/// [dst-coerce]: https://github.com/rust-lang/rfcs/blob/master/text/0982-dst-coercion.md
+/// [dst-coerce]: https://rust-lang.github.io/rfcs/0982-dst-coercion.html
 /// [unsize]: crate::marker::Unsize
 /// [nomicon-coerce]: ../../nomicon/coercions.html
 #[unstable(feature = "coerce_unsized", issue = "18598")]

--- a/library/core/src/panic/unwind_safe.rs
+++ b/library/core/src/panic/unwind_safe.rs
@@ -42,7 +42,7 @@ use crate::task::{Context, Poll};
 /// That was a bit of a whirlwind tour of unwind safety, but for more information
 /// about unwind safety and how it applies to Rust, see an [associated RFC][rfc].
 ///
-/// [rfc]: https://github.com/rust-lang/rfcs/blob/master/text/1236-stabilize-catch-panic.md
+/// [rfc]: https://rust-lang.github.io/rfcs/1236-stabilize-catch-panic.html
 ///
 /// ## What is `UnwindSafe`?
 ///

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -38,7 +38,7 @@ pub struct Unique<T: PointeeSized> {
     // for dropck to understand that we logically own a `T`.
     //
     // For details, see:
-    // https://github.com/rust-lang/rfcs/blob/master/text/0769-sound-generic-drop.md#phantom-data
+    // https://rust-lang.github.io/rfcs/0769-sound-generic-drop.html#phantom-data
     _marker: PhantomData<T>,
 }
 

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -313,7 +313,7 @@ pub use core::panic::abort_on_unwind;
 /// it becomes a problem the [`AssertUnwindSafe`] wrapper struct can be used to
 /// quickly assert that the usage here is indeed unwind safe.
 ///
-/// [rfc]: https://github.com/rust-lang/rfcs/blob/master/text/1236-stabilize-catch-panic.md
+/// [rfc]: https://rust-lang.github.io/rfcs/1236-stabilize-catch-panic.html
 ///
 /// # Notes
 ///

--- a/src/doc/rustc/src/lints/index.md
+++ b/src/doc/rustc/src/lints/index.md
@@ -57,4 +57,4 @@ warning: borrow of packed field is unsafe and requires unsafe function or block 
 For more information about the process and policy of future-incompatible
 changes, see [RFC 1589].
 
-[RFC 1589]: https://github.com/rust-lang/rfcs/blob/master/text/1589-rustc-bug-fix-procedure.md
+[RFC 1589]: https://rust-lang.github.io/rfcs/1589-rustc-bug-fix-procedure.html

--- a/src/doc/unstable-book/src/language-features/default-field-values.md
+++ b/src/doc/unstable-book/src/language-features/default-field-values.md
@@ -6,7 +6,7 @@ The tracking issue for this feature is: [#132162]
 
 The RFC for this feature is: [#3681]
 
-[#3681]: https://github.com/rust-lang/rfcs/blob/master/text/3681-default-field-values.md
+[#3681]: https://rust-lang.github.io/rfcs/3681-default-field-values.html
 
 ------------------------
 

--- a/src/doc/unstable-book/src/language-features/type-changing-struct-update.md
+++ b/src/doc/unstable-book/src/language-features/type-changing-struct-update.md
@@ -9,7 +9,7 @@ The tracking issue for this feature is: [#86555]
 This implements [RFC2528]. When turned on, you can create instances of the same struct
 that have different generic type or lifetime parameters.
 
-[RFC2528]: https://github.com/rust-lang/rfcs/blob/master/text/2528-type-changing-struct-update-syntax.md
+[RFC2528]: https://rust-lang.github.io/rfcs/2528-type-changing-struct-update-syntax.html
 
 ```rust
 #![allow(unused_variables, dead_code)]

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -278,7 +278,7 @@ pub struct Item {
     /// The full markdown docstring of this item. Absent if there is no documentation at all,
     /// Some("") if there is some documentation but it is empty (EG `#[doc = ""]`).
     pub docs: Option<String>,
-    /// This mapping resolves [intra-doc links](https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md) from the docstring to their IDs
+    /// This mapping resolves [intra-doc links](https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html) from the docstring to their IDs
     pub links: HashMap<String, Id>,
     /// Attributes on this item.
     ///

--- a/tests/run-make/raw-dylib-alt-calling-convention/rmake.rs
+++ b/tests/run-make/raw-dylib-alt-calling-convention/rmake.rs
@@ -1,7 +1,7 @@
 // `raw-dylib` is a Windows-specific attribute which emits idata sections for the items in the
 // attached extern block,
 // so they may be linked against without linking against an import library.
-// To learn more, read https://github.com/rust-lang/rfcs/blob/master/text/2627-raw-dylib-kind.md
+// To learn more, read https://rust-lang.github.io/rfcs/2627-raw-dylib-kind.html
 // This test uses this feature alongside alternative calling conventions, checking that both
 // features are compatible and result in the expected output upon execution of the binary.
 // See https://github.com/rust-lang/rust/pull/84171

--- a/tests/run-make/raw-dylib-c/rmake.rs
+++ b/tests/run-make/raw-dylib-c/rmake.rs
@@ -1,7 +1,7 @@
 // `raw-dylib` is a Windows-specific attribute which emits idata sections for the items in the
 // attached extern block,
 // so they may be linked against without linking against an import library.
-// To learn more, read https://github.com/rust-lang/rfcs/blob/master/text/2627-raw-dylib-kind.md
+// To learn more, read https://rust-lang.github.io/rfcs/2627-raw-dylib-kind.html
 // This test is the simplest of the raw-dylib tests, simply smoke-testing that the feature
 // can be used to build an executable binary with an expected output with native C files
 // compiling into dynamic libraries.

--- a/tests/run-make/raw-dylib-import-name-type/rmake.rs
+++ b/tests/run-make/raw-dylib-import-name-type/rmake.rs
@@ -1,7 +1,7 @@
 // `raw-dylib` is a Windows-specific attribute which emits idata sections for the items in the
 // attached extern block,
 // so they may be linked against without linking against an import library.
-// To learn more, read https://github.com/rust-lang/rfcs/blob/master/text/2627-raw-dylib-kind.md
+// To learn more, read https://rust-lang.github.io/rfcs/2627-raw-dylib-kind.html
 // This test uses this feature alongside `import_name_type`, which allows for customization
 // of how Windows symbols will be named. A sanity check of this feature is done by comparison
 // with expected output.

--- a/tests/run-make/raw-dylib-link-ordinal/rmake.rs
+++ b/tests/run-make/raw-dylib-link-ordinal/rmake.rs
@@ -1,7 +1,7 @@
 // `raw-dylib` is a Windows-specific attribute which emits idata sections for the items in the
 // attached extern block,
 // so they may be linked against without linking against an import library.
-// To learn more, read https://github.com/rust-lang/rfcs/blob/master/text/2627-raw-dylib-kind.md
+// To learn more, read https://rust-lang.github.io/rfcs/2627-raw-dylib-kind.html
 // `#[link_ordinal(n)]` allows Rust to link against DLLs that export symbols by ordinal rather
 // than by name. As long as the ordinal matches, the name of the function in Rust is not
 // required to match the name of the corresponding function in the exporting DLL.

--- a/tests/run-make/raw-dylib-stdcall-ordinal/rmake.rs
+++ b/tests/run-make/raw-dylib-stdcall-ordinal/rmake.rs
@@ -1,7 +1,7 @@
 // `raw-dylib` is a Windows-specific attribute which emits idata sections for the items in the
 // attached extern block,
 // so they may be linked against without linking against an import library.
-// To learn more, read https://github.com/rust-lang/rfcs/blob/master/text/2627-raw-dylib-kind.md
+// To learn more, read https://rust-lang.github.io/rfcs/2627-raw-dylib-kind.html
 // Almost identical to `raw-dylib-link-ordinal`, but with the addition of calling conventions,
 // such as stdcall.
 // See https://github.com/rust-lang/rust/pull/90782

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -88,7 +88,7 @@ These tests exercise associated constants in traits and impls, on aspects such a
 
 These tests cover associated types defined directly within inherent impls (not in traits).
 
-See [RFC 0195 Associated items - Inherent associated items](https://github.com/rust-lang/rfcs/blob/master/text/0195-associated-items.md#inherent-associated-items).
+See [RFC 0195 Associated items - Inherent associated items](https://rust-lang.github.io/rfcs/0195-associated-items.html#inherent-associated-items).
 
 ## `tests/ui/associated-item`: Associated Items
 
@@ -429,7 +429,7 @@ Tests for built-in derive macros (`Debug`, `Clone`, etc.) when used in conjuncti
 
 ## `tests/ui/destructuring-assignment/`
 
-Exercises destructuring assignments. See [RFC 2909 Destructuring assignment](https://github.com/rust-lang/rfcs/blob/master/text/2909-destructuring-assignment.md).
+Exercises destructuring assignments. See [RFC 2909 Destructuring assignment](https://rust-lang.github.io/rfcs/2909-destructuring-assignment.html).
 
 ## `tests/ui/diagnostic-flags/`
 
@@ -443,7 +443,7 @@ Everything to do with `--diagnostic-width`.
 
 ## `tests/ui/diagnostic_namespace/`
 
-Exercises `#[diagnostic::*]` namespaced attributes. See [RFC 3368 Diagnostic attribute namespace](https://github.com/rust-lang/rfcs/blob/master/text/3368-diagnostic-attribute-namespace.md).
+Exercises `#[diagnostic::*]` namespaced attributes. See [RFC 3368 Diagnostic attribute namespace](https://rust-lang.github.io/rfcs/3368-diagnostic-attribute-namespace.html).
 
 ## `tests/ui/did_you_mean/`
 
@@ -653,7 +653,7 @@ See:
 
 Functional Struct Update is the name for the idiom by which one can write `..<expr>` at the end of a struct literal expression to fill in all remaining fields of the struct literal by using `<expr>` as the source for them.
 
-See [RFC 0736 Privacy-respecting Functional Struct Update](https://github.com/rust-lang/rfcs/blob/master/text/0736-privacy-respecting-fru.md).
+See [RFC 0736 Privacy-respecting Functional Struct Update](https://rust-lang.github.io/rfcs/0736-privacy-respecting-fru.html).
 
 ## `tests/ui/functions-closures/`
 
@@ -959,7 +959,7 @@ See [Tracking issue for promoting `!` to a type (RFC 1216) #35121](https://githu
 
 ## `tests/ui/new-range/`
 
-See [RFC 3550 New Range](https://github.com/rust-lang/rfcs/blob/master/text/3550-new-range.md).
+See [RFC 3550 New Range](https://rust-lang.github.io/rfcs/3550-new-range.html).
 
 ## `tests/ui/nll/`: Non-lexical lifetimes
 
@@ -1038,7 +1038,7 @@ See [panic handler | Nomicon](https://doc.rust-lang.org/nomicon/panic-handler.ht
 
 Exercises `#![panic_runtime]`, `-C panic`, panic runtimes and panic unwind strategy.
 
-See [RFC 1513 Less unwinding](https://github.com/rust-lang/rfcs/blob/master/text/1513-less-unwinding.md).
+See [RFC 1513 Less unwinding](https://rust-lang.github.io/rfcs/1513-less-unwinding.html).
 
 ## `tests/ui/panics/`
 
@@ -1134,7 +1134,7 @@ Broad category of tests ranges, both in their `..` or `..=` form, as well as the
 
 ## `tests/ui/raw-ref-op/`: Using operators on `&raw` values
 
-Exercises `&raw mut <place>` and `&raw const <place>`. See [RFC 2582 Raw reference MIR operator](https://github.com/rust-lang/rfcs/blob/master/text/2582-raw-reference-mir-operator.md).
+Exercises `&raw mut <place>` and `&raw const <place>`. See [RFC 2582 Raw reference MIR operator](https://rust-lang.github.io/rfcs/2582-raw-reference-mir-operator.html).
 
 ## `tests/ui/reachable`
 
@@ -1444,7 +1444,7 @@ Tests for the `#[doc(hidden)]` items.
 
 ## `tests/ui/trivial-bounds/`
 
-`#![feature(trivial_bounds)]`. See [RFC 2056 Allow trivial where clause constraints](https://github.com/rust-lang/rfcs/blob/master/text/2056-allow-trivial-where-clause-constraints.md).
+`#![feature(trivial_bounds)]`. See [RFC 2056 Allow trivial where clause constraints](https://rust-lang.github.io/rfcs/2056-allow-trivial-where-clause-constraints.html).
 
 ## `tests/ui/try-block/`
 
@@ -1452,7 +1452,7 @@ Tests for the `#[doc(hidden)]` items.
 
 ## `tests/ui/try-trait/`
 
-`#![feature(try_trait_v2)]`. See [RFC 3058 Try Trait v2](https://github.com/rust-lang/rfcs/blob/master/text/3058-try-trait-v2.md).
+`#![feature(try_trait_v2)]`. See [RFC 3058 Try Trait v2](https://rust-lang.github.io/rfcs/3058-try-trait-v2.html).
 
 ## `tests/ui/tuple/`
 
@@ -1486,7 +1486,7 @@ General collection of type checking related tests.
 
 ## `tests/ui/ufcs/`
 
-See [RFC 0132 Unified Function Call Syntax](https://github.com/rust-lang/rfcs/blob/master/text/0132-ufcs.md).
+See [RFC 0132 Unified Function Call Syntax](https://rust-lang.github.io/rfcs/0132-ufcs.html).
 
 ## `tests/ui/unboxed-closures/`
 
@@ -1550,7 +1550,7 @@ See [Tracking issue for RFC 3458: Unsafe fields #132922](https://github.com/rust
 
 See:
 
-- [RFC 1909 Unsized rvalues](https://github.com/rust-lang/rfcs/blob/master/text/1909-unsized-rvalues.md)
+- [RFC 1909 Unsized rvalues](https://rust-lang.github.io/rfcs/1909-unsized-rvalues.html)
 - [de-RFC 3829: Remove unsized_locals](https://github.com/rust-lang/rfcs/pull/3829)
 - [Tracking issue for RFC #1909: Unsized Rvalues (`unsized_locals`, `unsized_fn_params`)](https://github.com/rust-lang/rust/issues/48055)
 

--- a/tests/ui/explain/basic.stdout
+++ b/tests/ui/explain/basic.stdout
@@ -68,4 +68,4 @@ alone suffices for that. `*mut fn()` is a pointer to a fn pointer.
 (Since these values are typically just passed to C code, however, this rarely
 makes a difference in practice.)
 
-[rfc401]: https://github.com/rust-lang/rfcs/blob/master/text/0401-coercions.md
+[rfc401]: https://rust-lang.github.io/rfcs/0401-coercions.html

--- a/tests/ui/explain/ensure-color-always-works.stdout
+++ b/tests/ui/explain/ensure-color-always-works.stdout
@@ -1,4 +1,4 @@
-Per ]8;;https://github.com/rust-lang/rfcs/blob/master/text/0401-coercions.md\RFC 401]8;;\, if you have a function declaration [2mfoo[0m:
+Per ]8;;https://rust-lang.github.io/rfcs/0401-coercions.html\RFC 401]8;;\, if you have a function declaration [2mfoo[0m:
 
 [95mstruct[0m[2m[97m [0m[33mS[0m[2m[97m;[0m[2m[97m
 

--- a/tests/ui/rfcs/rfc-1238-nonparametric-dropck/must-work-ex1.rs
+++ b/tests/ui/rfcs/rfc-1238-nonparametric-dropck/must-work-ex1.rs
@@ -1,6 +1,6 @@
 //! Test for <https://github.com/rust-lang/rust/issues/28498>.
 //! Example taken from RFC 1238 text
-//! <https://github.com/rust-lang/rfcs/blob/master/text/1238-nonparametric-dropck.md>.
+//! <https://rust-lang.github.io/rfcs/1238-nonparametric-dropck.html>.
 //@ run-pass
 
 use std::cell::Cell;

--- a/tests/ui/rfcs/rfc-1238-nonparametric-dropck/must-work-ex2.rs
+++ b/tests/ui/rfcs/rfc-1238-nonparametric-dropck/must-work-ex2.rs
@@ -1,6 +1,6 @@
 //! Test for <https://github.com/rust-lang/rust/issues/28498>.
 //! Example taken from RFC 1238 text
-//! <https://github.com/rust-lang/rfcs/blob/master/text/1238-nonparametric-dropck.md>.
+//! <https://rust-lang.github.io/rfcs/1238-nonparametric-dropck.html>.
 //@ run-pass
 
 use std::cell::Cell;

--- a/tests/ui/rfcs/rfc-1238-nonparametric-dropck/reject-ex1.rs
+++ b/tests/ui/rfcs/rfc-1238-nonparametric-dropck/reject-ex1.rs
@@ -1,6 +1,6 @@
 //! Test for <https://github.com/rust-lang/rust/issues/28498>.
 //! Example taken from RFC 1238 text
-//! <https://github.com/rust-lang/rfcs/blob/master/text/1238-nonparametric-dropck.md>.
+//! <https://rust-lang.github.io/rfcs/1238-nonparametric-dropck.html>.
 //! Compare against tests/ui/rfcs/rfc-1238-nonparametric-dropck/must-work-ex2.rs.
 
 use std::cell::Cell;

--- a/tests/ui/rfcs/rfc-1238-nonparametric-dropck/ugeh-ex1.rs
+++ b/tests/ui/rfcs/rfc-1238-nonparametric-dropck/ugeh-ex1.rs
@@ -1,6 +1,6 @@
 //! Test for <https://github.com/rust-lang/rust/issues/28498>.
 //! Example taken from RFC 1238 text
-//! <https://github.com/rust-lang/rfcs/blob/master/text/1238-nonparametric-dropck.md>.
+//! <https://rust-lang.github.io/rfcs/1238-nonparametric-dropck.html>.
 //@ run-pass
 
 #![feature(dropck_eyepatch)]

--- a/tests/ui/type-alias-impl-trait/issue-65679-inst-opaque-ty-from-val-twice.rs
+++ b/tests/ui/type-alias-impl-trait/issue-65679-inst-opaque-ty-from-val-twice.rs
@@ -7,7 +7,7 @@ pub type T = impl Sized;
 // to be the same as where it occurs, whereas `impl Trait`'s instance is location sensitive;
 // so difference assertion should not be declared on impl-trait-type-alias's instances.
 // for details, check RFC-2515:
-// https://github.com/rust-lang/rfcs/blob/master/text/2515-type_alias_impl_trait.md
+// https://rust-lang.github.io/rfcs/2515-type_alias_impl_trait.html
 
 #[define_opaque(T)]
 fn bop() {


### PR DESCRIPTION
I noticed many error codes link to Rust RFCs via the [source GitHub `.md` files](https://github.com/rust-lang/rfcs/tree/master/text) instead of linking to the [RFC Book](https://rust-lang.github.io/rfcs/). This PR updates those links to point to the RFC book - I also updated any other links to RFCs in the repo (not including subtrees) while I was at it.