### PR TITLE
Retain `TypeRelating` errors in nested goals for `BestObligationVisitor:: non_trivial_candidates `

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -252,6 +252,7 @@ impl<'tcx> BestObligation<'tcx> {
                                         GoalSource::ImplWhereBound
                                             | GoalSource::AliasBoundConstCondition
                                             | GoalSource::AliasWellFormed
+                                            | GoalSource::TypeRelating
                                     ) && nested_goal.result().is_err()
                                 },
                             )

--- a/tests/ui/traits/next-solver/confusing-diagnostic-due-to-best-obligation-visitor.rs
+++ b/tests/ui/traits/next-solver/confusing-diagnostic-due-to-best-obligation-visitor.rs
@@ -1,0 +1,27 @@
+//@compile-flags: -Znext-solver=globally
+//@check-fail
+
+// See issue https://github.com/rust-lang/rust/issues/161882, test makes sure we don't report
+// irrelevant and not implemented bounds when we can't proof an obligation.
+
+struct MyError;
+
+trait MaybeFallible {
+    type Error: MaybeError; //~ ERROR: the trait bound `MyError: From<<Self as MaybeFallible>::Error>` is not satisfied
+}
+
+trait MaybeError: Sized
+where
+    MyError: From<Self>,
+{
+    type ComposeWithOther: MaybeError; //~ ERROR: the trait bound `MyError: From<<Self as MaybeError>::ComposeWithOther>` is not satisfied
+}
+
+fn compose<A: MaybeFallible, B>() -> Result<(), ()>
+where
+    <A::Error as MaybeError>::ComposeWithOther: From<B>, //~ ERROR: the trait bound `MyError: From<<A as MaybeFallible>::Error>` is not satisfied
+{
+    todo!()
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/confusing-diagnostic-due-to-best-obligation-visitor.stderr
+++ b/tests/ui/traits/next-solver/confusing-diagnostic-due-to-best-obligation-visitor.stderr
@@ -1,0 +1,67 @@
+error[E0277]: the trait bound `MyError: From<<A as MaybeFallible>::Error>` is not satisfied
+  --> $DIR/confusing-diagnostic-due-to-best-obligation-visitor.rs:22:49
+   |
+LL |     <A::Error as MaybeError>::ComposeWithOther: From<B>,
+   |                                                 ^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `From<<A as MaybeFallible>::Error>` is not implemented for `MyError`
+  --> $DIR/confusing-diagnostic-due-to-best-obligation-visitor.rs:7:1
+   |
+LL | struct MyError;
+   | ^^^^^^^^^^^^^^
+note: required by a bound in `MaybeError`
+  --> $DIR/confusing-diagnostic-due-to-best-obligation-visitor.rs:15:14
+   |
+LL | trait MaybeError: Sized
+   |       ---------- required by a bound in this trait
+LL | where
+LL |     MyError: From<Self>,
+   |              ^^^^^^^^^^ required by this bound in `MaybeError`
+help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL |     <A::Error as MaybeError>::ComposeWithOther: From<B>, MyError: From<<A as MaybeFallible>::Error>
+   |                                                          ++++++++++++++++++++++++++++++++++++++++++
+
+error[E0277]: the trait bound `MyError: From<<Self as MaybeFallible>::Error>` is not satisfied
+  --> $DIR/confusing-diagnostic-due-to-best-obligation-visitor.rs:10:17
+   |
+LL |     type Error: MaybeError;
+   |                 ^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `From<<Self as MaybeFallible>::Error>` is not implemented for `MyError`
+  --> $DIR/confusing-diagnostic-due-to-best-obligation-visitor.rs:7:1
+   |
+LL | struct MyError;
+   | ^^^^^^^^^^^^^^
+note: required by a bound in `MaybeError`
+  --> $DIR/confusing-diagnostic-due-to-best-obligation-visitor.rs:15:14
+   |
+LL | trait MaybeError: Sized
+   |       ---------- required by a bound in this trait
+LL | where
+LL |     MyError: From<Self>,
+   |              ^^^^^^^^^^ required by this bound in `MaybeError`
+
+error[E0277]: the trait bound `MyError: From<<Self as MaybeError>::ComposeWithOther>` is not satisfied
+  --> $DIR/confusing-diagnostic-due-to-best-obligation-visitor.rs:17:28
+   |
+LL |     type ComposeWithOther: MaybeError;
+   |                            ^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `From<<Self as MaybeError>::ComposeWithOther>` is not implemented for `MyError`
+  --> $DIR/confusing-diagnostic-due-to-best-obligation-visitor.rs:7:1
+   |
+LL | struct MyError;
+   | ^^^^^^^^^^^^^^
+note: required by a bound in `MaybeError`
+  --> $DIR/confusing-diagnostic-due-to-best-obligation-visitor.rs:15:14
+   |
+LL | trait MaybeError: Sized
+   |       ---------- required by a bound in this trait
+LL | where
+LL |     MyError: From<Self>,
+   |              ^^^^^^^^^^ required by this bound in `MaybeError`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
When getting the `non_trivial_candidates`, also consider candidates whose nested candidates have a `TypeRelating` failure as well, instead of only impl-where clauses.

Should fix rust-lang/rust#161882
related: [#t-types/call-for-participation > diagnostics proof tree visitor is too eager](https://rust-lang.zulipchat.com/#narrow/channel/618216-t-types.2Fcall-for-participation/topic/diagnostics.20proof.20tree.20visitor.20is.20too.20eager/with/622349291)

r? @lcnr

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
