### PR TITLE
Make `std::fs::{File, ReadDir, DirEntry}` always `needs_drop` even when unsupported.

### DIFF
--- a/library/std/src/sys/fs/unsupported.rs
+++ b/library/std/src/sys/fs/unsupported.rs
@@ -29,6 +29,25 @@ pub struct FileType(!);
 #[derive(Debug)]
 pub struct DirBuilder {}
 
+// Dummy Drops so that `needs_drop::<std::fs::File>()` etc. is true independent of platform,
+// avoiding a portability hazard.
+// The types not listed here are pure data and don’t implement Drop even when real.
+impl Drop for File {
+    fn drop(&mut self) {
+        self.0
+    }
+}
+impl Drop for ReadDir {
+    fn drop(&mut self) {
+        self.0
+    }
+}
+impl Drop for DirEntry {
+    fn drop(&mut self) {
+        self.0
+    }
+}
+
 impl FileAttr {
     pub fn size(&self) -> u64 {
         self.0

--- a/library/std/src/sys/fs/vexos.rs
+++ b/library/std/src/sys/fs/vexos.rs
@@ -477,6 +477,13 @@ impl Drop for File {
     }
 }
 
+impl Drop for ReadDir {
+    fn drop(&mut self) {
+        // Dummy Drop so that `needs_drop::<ReadDir>()` is true independent of platform.
+        self.0
+    }
+}
+
 pub fn readdir(_p: &Path) -> io::Result<ReadDir> {
     // While there *is* a userspace function for reading file directories,
     // the necessary implementation cannot currently be done cleanly, as


### PR DESCRIPTION
This eliminates the portability hazard (and inconsistent linting of `clippy::drop_non_drop`) of types having destructors on some platforms and not others.

It is arguably a breaking change, but a breaking change that would also be required if any of these platforms later gains filesystem support.

An alternative to this change would be to implement `Drop` on the `std::fs` types instead of the `std::sys` types. That would be more reliable, but would be more of a public API change since `T: Drop` bounds are unfortunately possible.
