### PR TITLE
Prevent `should-fail` to be used in `rustdoc-ui` testsuite

### DIFF
--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -217,6 +217,8 @@ pub(crate) struct TestProps {
     pub(crate) compare_output_by_lines: bool,
     /// Use CCI (`--read-doc-meta` and `--write-doc-meta`) merge mode.
     pub(crate) use_rustdoc_cci_doc_meta_merge: bool,
+    /// Where the `//@ should-fail` instruction is present.
+    pub(crate) should_fail: bool,
 }
 
 mod directives {
@@ -323,6 +325,7 @@ impl TestProps {
             disable_gdb_pretty_printers: false,
             compare_output_by_lines: false,
             use_rustdoc_cci_doc_meta_merge: false,
+            should_fail: false,
         }
     }
 

--- a/src/tools/compiletest/src/directives/handlers.rs
+++ b/src/tools/compiletest/src/directives/handlers.rs
@@ -371,6 +371,9 @@ fn make_directive_handlers_map() -> HashMap<&'static str, Handler> {
                 &mut props.use_rustdoc_cci_doc_meta_merge,
             );
         }),
+        handler("should-fail", |config, ln, props| {
+            config.set_name_directive(ln, "should-fail", &mut props.should_fail);
+        }),
     ];
 
     handlers

--- a/src/tools/compiletest/src/runtest/rustdoc.rs
+++ b/src/tools/compiletest/src/runtest/rustdoc.rs
@@ -14,6 +14,9 @@ impl TestCx<'_> {
                 "If you want to check `--test`, put this test into `rustdoc-ui` testsuite instead",
             );
         }
+        if self.props.should_fail {
+            panic!("`should-fail` should not be used in `rustdoc-html` testsuite");
+        }
         let out_dir = self.output_base_dir();
         remove_and_create_dir_all(&out_dir).unwrap_or_else(|e| {
             panic!("failed to remove and recreate output directory `{out_dir}`: {e}")

--- a/src/tools/compiletest/src/runtest/ui.rs
+++ b/src/tools/compiletest/src/runtest/ui.rs
@@ -9,11 +9,20 @@ use crate::common::PassFailMode;
 use crate::json;
 use crate::runtest::{
     AllowUnused, Emit, LinkToAux, ProcRes, RunResult, TargetLocation, TestCx, TestOutput,
-    Truncated, UI_FIXED, WillExecute,
+    TestSuite, Truncated, UI_FIXED, WillExecute,
 };
 
 impl TestCx<'_> {
     pub(super) fn run_ui_test(&self) {
+        if self.config.suite == TestSuite::RustdocUi && self.props.should_fail {
+            writeln!(
+                self.stderr,
+                "`should-fail` should not be used in `rustdoc-ui` testsuite, use `failure-status` instead",
+            );
+            // Since it's expecting the test to fail/panic, we return without running anything,
+            // preventing the test to be marked as passed.
+            return;
+        }
         let pass_fail =
             self.effective_pass_fail_mode().expect("UI tests always have a pass/fail mode");
 

--- a/tests/rustdoc-ui/doctest/doctest-macro-38219.rs
+++ b/tests/rustdoc-ui/doctest/doctest-macro-38219.rs
@@ -2,7 +2,7 @@
 
 //@ compile-flags:--test
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
-//@ should-fail
+//@ failure-status: 101
 
 /// ```
 /// fail

--- a/tests/rustdoc-ui/doctest/doctest-macro-38219.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-macro-38219.stdout
@@ -1,0 +1,23 @@
+
+running 1 test
+test $DIR/doctest-macro-38219.rs - foo (line 7) ... FAILED
+
+failures:
+
+---- $DIR/doctest-macro-38219.rs - foo (line 7) stdout ----
+error[E0425]: cannot find value `fail` in this scope
+  --> $DIR/doctest-macro-38219.rs:8:1
+   |
+LL | fail
+   | ^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.
+Couldn't compile the test.
+
+failures:
+    $DIR/doctest-macro-38219.rs - foo (line 7)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/ice-unresolved-import-100241.rs
+++ b/tests/rustdoc-ui/ice-unresolved-import-100241.rs
@@ -1,13 +1,12 @@
 //! See [`S`].
 
 // Check that this isn't an ICE
-//@ should-fail
 
 // https://github.com/rust-lang/rust/issues/100241
 
 mod foo {
     pub use inner::S;
-    //~^ ERROR unresolved imports `inner`, `foo::S`
+    //~^ ERROR unresolved import `inner`
 }
 
 use foo::*;

--- a/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
+++ b/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
@@ -1,5 +1,5 @@
 error[E0432]: unresolved import `inner`
-  --> $DIR/ice-unresolved-import-100241.rs:9:13
+  --> $DIR/ice-unresolved-import-100241.rs:8:13
    |
 LL |     pub use inner::S;
    |             ^^^^^ use of unresolved module or unlinked crate `inner`


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/162030 and discussion with @fmease.

There is no reason to use `should-fail` for `rustdoc-ui` (or `rustdoc-html`) testsuite, so let's prevent it.

r? @fmease 