### PR TITLE
Fix ICE emitted when unsized parameters are passed to functions with x86-interrupt ABI.

### DIFF
--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -90,7 +90,10 @@ pub(super) fn check_fn<'a, 'tcx>(
         }
 
         // Check that argument is Sized.
-        if !params_can_be_unsized || fn_sig.abi() == rustc_abi::ExternAbi::RustTail {
+        if !params_can_be_unsized
+            || fn_sig.abi() == rustc_abi::ExternAbi::RustTail
+            || fn_sig.abi() == rustc_abi::ExternAbi::X86Interrupt
+        {
             fcx.require_type_is_sized(
                 param_ty,
                 param.ty_span,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -4300,6 +4300,20 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 {
                     err.help("unsized fn params are gated as an unstable feature");
                 }
+                // The `unsized_fn_params` feature allows unsized parameters to be passed to functions,
+                // except for ABIs that pass their parameters explicitly by value and therefore need
+                // a known size. The ABI is referenced in order to make it clear that this is intentional
+                // behavior.
+                if tcx.features().unsized_fn_params()
+                    && let Some(hir_id) = hir_id
+                    && let Some(sig) = tcx.parent_hir_node(hir_id).fn_sig()
+                    && matches!(sig.header.abi, ExternAbi::X86Interrupt | ExternAbi::RustTail)
+                {
+                    err.note(format!(
+                        "argument required to be sized due to `extern {}` ABI",
+                        sig.header.abi
+                    ));
+                }
             }
             ObligationCauseCode::SizedReturnType | ObligationCauseCode::SizedCallReturnType => {
                 err.note("the return type of a function must have a statically known size");

--- a/tests/ui/abi/x86-interrupt-unsized-param-ice-124806.i686.stderr
+++ b/tests/ui/abi/x86-interrupt-unsized-param-ice-124806.i686.stderr
@@ -1,0 +1,16 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/x86-interrupt-unsized-param-ice-124806.rs:20:49
+   |
+LL | extern "x86-interrupt" fn interrupt_unsized(_a: str) {}
+   |                                                 ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: argument required to be sized due to `extern "x86-interrupt"` ABI
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | extern "x86-interrupt" fn interrupt_unsized(_a: &str) {}
+   |                                                 +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/abi/x86-interrupt-unsized-param-ice-124806.rs
+++ b/tests/ui/abi/x86-interrupt-unsized-param-ice-124806.rs
@@ -1,0 +1,23 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/124806>
+//!
+//! `extern "x86-interrupt"` passes its parameters `byval`, so they must be
+//!   `Sized` even with `unsized_fn_params` enabled. An unsized parameter once
+//!   reached code generation and caused an ICE.
+//@ add-minicore
+//@ revisions: x64 i686
+//
+//@ [x64] needs-llvm-components: x86
+//@ [x64] compile-flags: --target=x86_64-unknown-linux-gnu --crate-type=rlib
+//@ [i686] needs-llvm-components: x86
+//@ [i686] compile-flags: --target=i686-unknown-linux-gnu --crate-type=rlib
+//@ ignore-backends: gcc
+#![no_core]
+#![feature(no_core, abi_x86_interrupt, unsized_fn_params)]
+
+extern crate minicore;
+use minicore::*;
+
+extern "x86-interrupt" fn interrupt_unsized(_a: str) {}
+//~^ ERROR the size for values of type `str` cannot be known at compilation time
+//~| NOTE argument required to be sized due to `extern "x86-interrupt"` ABI
+//~| NOTE doesn't have a size known at compile-time

--- a/tests/ui/abi/x86-interrupt-unsized-param-ice-124806.x64.stderr
+++ b/tests/ui/abi/x86-interrupt-unsized-param-ice-124806.x64.stderr
@@ -1,0 +1,16 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/x86-interrupt-unsized-param-ice-124806.rs:20:49
+   |
+LL | extern "x86-interrupt" fn interrupt_unsized(_a: str) {}
+   |                                                 ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: argument required to be sized due to `extern "x86-interrupt"` ABI
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | extern "x86-interrupt" fn interrupt_unsized(_a: &str) {}
+   |                                                 +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/explicit-tail-calls/no-unsized-arguments.aarch64.stderr
+++ b/tests/ui/explicit-tail-calls/no-unsized-arguments.aarch64.stderr
@@ -5,6 +5,7 @@ LL |     extern "tail" fn unsized_argument(x: [u8]) -> u8 {
    |                                          ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
+   = note: argument required to be sized due to `extern "tail"` ABI
 help: function arguments must have a statically known size, borrowed slices always have a known size
    |
 LL |     extern "tail" fn unsized_argument(x: &[u8]) -> u8 {

--- a/tests/ui/explicit-tail-calls/no-unsized-arguments.x86.stderr
+++ b/tests/ui/explicit-tail-calls/no-unsized-arguments.x86.stderr
@@ -5,6 +5,7 @@ LL |     extern "tail" fn unsized_argument(x: [u8]) -> u8 {
    |                                          ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
+   = note: argument required to be sized due to `extern "tail"` ABI
 help: function arguments must have a statically known size, borrowed slices always have a known size
    |
 LL |     extern "tail" fn unsized_argument(x: &[u8]) -> u8 {

--- a/tests/ui/explicit-tail-calls/no-unsized-arguments.x86_64.stderr
+++ b/tests/ui/explicit-tail-calls/no-unsized-arguments.x86_64.stderr
@@ -5,6 +5,7 @@ LL |     extern "tail" fn unsized_argument(x: [u8]) -> u8 {
    |                                          ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
+   = note: argument required to be sized due to `extern "tail"` ABI
 help: function arguments must have a statically known size, borrowed slices always have a known size
    |
 LL |     extern "tail" fn unsized_argument(x: &[u8]) -> u8 {


### PR DESCRIPTION
This PR aims to solve an issue where unsized types could be passed to the x86-interrupt ABI and cause an ICE to be emitted. 

**Note:** There was an update to the note message used when the `extern "tail"` abi encounters an error with the same root cause.  These behaviors felt correlated enough that adding a note here would be useful to the end users of both. If this is undesirable, reverting this behavior is trivial.

Relevant unstable feature: https://github.com/rust-lang/rust/issues/40180
Fixes rust-lang/rust#124806

<!-- homu-ignore:start -->
---

_LLM Policy disclaimer: An LLM agent was used in the analysis of the codebase and the self-review of this PR_. Specifically, with prompts in the form of:
- What region of code is relevant to these behaviors? What types, functions, etc, are relevant here?
- Which files do I need to review before proceeding?

The addition to suggestions.rs _(in the oh-so-helpful way they like to when not asked to)_ was LLM proposed and human verified. The code was trivial enough that alternatives didn't seem reasonable.
<!-- homu-ignore:end -->
