### PR TITLE
Add regression test for item-local diagnostic attribute lint levels

### DIFF
--- a/tests/ui/diagnostic_namespace/local-lint-level-issue-135772.rs
+++ b/tests/ui/diagnostic_namespace/local-lint-level-issue-135772.rs
@@ -1,0 +1,34 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/135772>.
+// Unknown diagnostic attributes must respect item-local lint levels.
+
+//@ check-pass
+
+trait _Trait {}
+
+#[allow(unknown_or_malformed_diagnostic_attributes)]
+#[diagnostic::abcdef]
+impl _Trait for () {}
+
+#[diagnostic::abcdef]
+#[allow(unknown_or_malformed_diagnostic_attributes)]
+impl _Trait for bool {}
+
+#[expect(unknown_or_malformed_diagnostic_attributes)]
+#[diagnostic::abcdef]
+impl _Trait for u8 {}
+
+macro_rules! impl_trait {
+    ($ty:ty) => {
+        #[allow(unknown_or_malformed_diagnostic_attributes)]
+        #[diagnostic::abcdef]
+        impl _Trait for $ty {}
+    };
+}
+
+impl_trait!(u16);
+
+#[diagnostic::abcdef]
+//~^ WARN unknown diagnostic attribute
+impl _Trait for u32 {}
+
+fn main() {}

--- a/tests/ui/diagnostic_namespace/local-lint-level-issue-135772.stderr
+++ b/tests/ui/diagnostic_namespace/local-lint-level-issue-135772.stderr
@@ -1,0 +1,10 @@
+warning: unknown diagnostic attribute
+  --> $DIR/local-lint-level-issue-135772.rs:30:15
+   |
+LL | #[diagnostic::abcdef]
+   |               ^^^^^^
+   |
+   = note: `#[warn(unknown_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Closes rust-lang/rust#135772

This issue was fixed by https://github.com/rust-lang/rust/pull/160499 indirectly.

r? @mejrs