### PR TITLE
Implement parameter validation for functions using x86-interrupt abi.

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -597,7 +597,6 @@ impl<'a> AstValidator<'a> {
 
                         if let InterruptKind::X86 = interrupt_kind {
                             // "x86-interrupt" is special because it does have arguments.
-                            // FIXME(workingjubilee): properly lint on acceptable input types.
                             let inputs = &sig.decl.inputs;
                             let param_count = inputs.len();
                             if !matches!(param_count, 1 | 2) {

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -70,6 +70,7 @@ mod entry;
 pub mod intrinsic;
 mod region;
 pub mod wfcheck;
+mod x86_interrupt;
 
 use std::borrow::Cow;
 use std::num::NonZero;

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -47,6 +47,7 @@ use tracing::{debug, instrument};
 
 use super::compare_eii::{compare_eii_function_types, compare_eii_statics};
 use crate::autoderef::Autoderef;
+use crate::check::x86_interrupt;
 use crate::constrained_generic_params::{Parameter, identify_constrained_generic_params};
 use crate::diagnostics;
 use crate::diagnostics::InvalidReceiverTyHint;
@@ -1667,6 +1668,8 @@ fn check_fn_or_method<'tcx>(
             );
         }
     }
+
+    x86_interrupt::validate_x86_interrupt_abi(tcx, tcx.dcx(), sig, hir_decl, sig.abi());
 
     // If the function has a body, additionally require that the return type is sized.
     if let Some(body) = tcx.hir_maybe_body_owned_by(def_id) {

--- a/compiler/rustc_hir_analysis/src/check/x86_interrupt.rs
+++ b/compiler/rustc_hir_analysis/src/check/x86_interrupt.rs
@@ -1,0 +1,115 @@
+use rustc_abi::{BackendRepr, ExternAbi, Primitive};
+use rustc_errors::DiagCtxtHandle;
+use rustc_hir::{self as hir};
+use rustc_middle::ty::layout::TyAndLayout;
+use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt};
+
+use crate::diagnostics;
+
+pub(crate) fn validate_x86_interrupt_abi<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    dcx: DiagCtxtHandle<'_>,
+    fn_sig: ty::FnSig<'tcx>,
+    fn_decl: &hir::FnDecl<'_>,
+    abi: ExternAbi,
+) {
+    // Rules for input validation
+    // 1. 1-2 parameters (validated in AST layer)
+    // 2. Neither type may be unsized -> X86InterruptUnsized
+    // 3. Neither type may be zero-sized -> X86InterruptZeroSized
+    // 4. First parameter (frame) must be valid for any bit pattern -> X86InterruptInvalidFrame
+    // 5. First parameter (frame) must not be a pointer -> X86InterruptInvalidFrame
+    // 6. Second parameter (error code) must be single word-size integer,
+    //      and valid for any bit pattern -> X86InterruptInvalidErrorCode
+    if abi != ExternAbi::X86Interrupt {
+        return;
+    }
+
+    let get_param_layout = |(ty, _hir_ty): (Ty<'tcx>, &hir::Ty<'_>)| -> Option<TyAndLayout<'tcx>> {
+        if ty.has_infer_types() {
+            return None;
+        }
+
+        let layout = tcx.layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(ty)).ok()?;
+
+        Some(layout)
+    };
+
+    let validate_frame = |frame_tys: (Ty<'tcx>, &hir::Ty<'_>)| {
+        // Layout error handled elsewhere
+        let Some(layout) = get_param_layout(frame_tys) else {
+            return;
+        };
+        let (ty, hir_ty) = frame_tys;
+
+        if layout.is_unsized() {
+            dcx.emit_err(diagnostics::X86InterruptUnsized { span: hir_ty.span, ty });
+            return;
+        }
+
+        if layout.is_zst() {
+            dcx.emit_err(diagnostics::X86InterruptZeroSized { span: hir_ty.span, ty });
+            return;
+        }
+
+        let is_pointer = match layout.backend_repr {
+            BackendRepr::Scalar(s) => matches!(s.primitive(), Primitive::Pointer(_)),
+            BackendRepr::ScalarPair { a: s1, b: s2, b_offset: _ } => {
+                matches!(s1.primitive(), Primitive::Pointer(_))
+                    || matches!(s2.primitive(), Primitive::Pointer(_))
+            }
+            _ => false,
+        };
+
+        if is_pointer || layout.largest_niche.is_some() {
+            dcx.emit_err(diagnostics::X86InterruptInvalidFrame { span: hir_ty.span, ty });
+        }
+    };
+
+    let validate_error_code = |ec_tys: (Ty<'tcx>, &hir::Ty<'_>)| {
+        // Layout error handled elsewhere
+        let Some(layout) = get_param_layout(ec_tys) else {
+            return;
+        };
+        let (ty, hir_ty) = ec_tys;
+
+        if layout.is_unsized() {
+            dcx.emit_err(diagnostics::X86InterruptUnsized { span: hir_ty.span, ty });
+            return;
+        }
+
+        if layout.is_zst() {
+            dcx.emit_err(diagnostics::X86InterruptZeroSized { span: hir_ty.span, ty });
+            return;
+        }
+
+        let ec_ok = if let BackendRepr::Scalar(scalar) = layout.backend_repr
+            && let Primitive::Int(primitive, _) = scalar.primitive()
+            && primitive.size() == tcx.data_layout.pointer_size()
+            && scalar.is_always_valid(&tcx)
+        {
+            true
+        } else {
+            false
+        };
+
+        if !ec_ok {
+            dcx.emit_err(diagnostics::X86InterruptInvalidErrorCode { span: hir_ty.span, ty });
+        }
+    };
+
+    // this type is only used for layout computation, which does not rely on regions
+    let fn_sig = tcx.erase_and_anonymize_regions(fn_sig);
+    let param_tys: Vec<_> = fn_sig.inputs().iter().copied().zip(fn_decl.inputs).collect();
+
+    match param_tys.as_slice() {
+        [frame_tys] => {
+            validate_frame(*frame_tys);
+        }
+        [frame_tys, ec_tys] => {
+            validate_frame(*frame_tys);
+            validate_error_code(*ec_tys);
+        }
+        _ => { /* Ignore, arity handled at AST layer. */ }
+    }
+}

--- a/compiler/rustc_hir_analysis/src/diagnostics.rs
+++ b/compiler/rustc_hir_analysis/src/diagnostics.rs
@@ -1898,6 +1898,50 @@ pub(crate) struct CmseImplTrait {
 }
 
 #[derive(Diagnostic)]
+#[diag("invalid signature for `extern \"x86-interrupt\"` function")]
+#[note("invalid x86-interrupt parameter type: `{$ty}`")]
+#[note("functions with the \"x86-interrupt\" ABI must not use zero-sized types in their signature")]
+pub(crate) struct X86InterruptZeroSized<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub ty: Ty<'a>,
+}
+
+#[derive(Diagnostic)]
+#[diag("invalid signature for `extern \"x86-interrupt\"` function")]
+#[note("invalid x86-interrupt parameter type: `{$ty}`")]
+#[note("functions with the \"x86-interrupt\" ABI must not use unsized types in their signature")]
+pub(crate) struct X86InterruptUnsized<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub ty: Ty<'a>,
+}
+
+#[derive(Diagnostic)]
+#[diag("invalid signature for `extern \"x86-interrupt\"` function")]
+#[note("invalid x86-interrupt error code parameter type: `{$ty}`")]
+#[note(
+    "functions with the \"x86-interrupt\" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern"
+)]
+pub(crate) struct X86InterruptInvalidErrorCode<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub ty: Ty<'a>,
+}
+
+#[derive(Diagnostic)]
+#[diag("invalid signature for `extern \"x86-interrupt\"` function")]
+#[note("invalid x86-interrupt frame parameter type: `{$ty}`")]
+#[note(
+    "functions with the \"x86-interrupt\" ABI must have a non-pointer frame parameter that is valid for any bit pattern"
+)]
+pub(crate) struct X86InterruptInvalidFrame<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub ty: Ty<'a>,
+}
+
+#[derive(Diagnostic)]
 #[diag("return type notation not allowed in this position yet")]
 pub(crate) struct BadReturnTypeNotation {
     #[primary_span]

--- a/compiler/rustc_monomorphize/src/diagnostics.rs
+++ b/compiler/rustc_monomorphize/src/diagnostics.rs
@@ -217,3 +217,37 @@ pub(crate) struct StaticInitializerCyclic<'a> {
     pub head: &'a str,
     pub target: &'a str,
 }
+
+#[derive(Diagnostic)]
+#[diag("invalid signature for `extern \"x86-interrupt\"` function")]
+#[note("invalid x86-interrupt parameter type: `{$ty}`")]
+#[note("functions with the \"x86-interrupt\" ABI must not use zero-sized types in their signature")]
+pub(crate) struct X86InterruptZeroSized<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub ty: Ty<'a>,
+}
+
+#[derive(Diagnostic)]
+#[diag("invalid signature for `extern \"x86-interrupt\"` function")]
+#[note("invalid x86-interrupt error code parameter type: `{$ty}`")]
+#[note(
+    "functions with the \"x86-interrupt\" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern"
+)]
+pub(crate) struct X86InterruptInvalidErrorCode<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub ty: Ty<'a>,
+}
+
+#[derive(Diagnostic)]
+#[diag("invalid signature for `extern \"x86-interrupt\"` function")]
+#[note("invalid x86-interrupt frame parameter type: `{$ty}`")]
+#[note(
+    "functions with the \"x86-interrupt\" ABI must have a non-pointer frame parameter that is valid for any bit pattern"
+)]
+pub(crate) struct X86InterruptInvalidFrame<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub ty: Ty<'a>,
+}

--- a/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
@@ -1,12 +1,12 @@
 //! This module ensures that if a function's ABI requires a particular target feature,
 //! that target feature is enabled both on the callee and all callers.
-use rustc_abi::{BackendRepr, CanonAbi, ExternAbi, RegKind, X86Call};
+use rustc_abi::{BackendRepr, CanonAbi, ExternAbi, InterruptKind, Primitive, RegKind, X86Call};
 use rustc_hir::{CRATE_HIR_ID, HirId};
 use rustc_middle::mir::{self, Location, traversal};
 use rustc_middle::ty::{self, Instance, InstanceKind, Ty, TyCtxt};
 use rustc_span::def_id::DefId;
 use rustc_span::{DUMMY_SP, Span, Symbol, sym};
-use rustc_target::callconv::{FnAbi, PassMode};
+use rustc_target::callconv::{ArgAbi, FnAbi, PassMode};
 
 use crate::diagnostics;
 
@@ -41,6 +41,93 @@ fn passes_vectors_by_value(mode: &PassMode, repr: &BackendRepr) -> UsesVectorReg
             UsesVectorRegisters::ScalableVector
         }
         _ => UsesVectorRegisters::No,
+    }
+}
+
+/// Checks for whether a given function is a valid parameterization for the
+///   x86 interrupt ABI.
+fn do_check_x86_interrupt_abi<'tcx>(tcx: TyCtxt<'tcx>, abi: &FnAbi<'tcx, Ty<'tcx>>, def_id: DefId) {
+    // Rules laid out in check/x86_interrupt.rs, but relevant ones repeated here
+    // 1. No parameter may be ZST.
+    // 2. Parameters must be valid for any bit pattern
+    // 3. First parameter (frame) must not be a pointer.
+    // 4. Second parameter (error code) must be word-sized int, valid for any bit pattern
+    if !matches!(abi.conv, CanonAbi::Interrupt(InterruptKind::X86)) {
+        return;
+    }
+
+    let dcx = tcx.dcx();
+
+    let get_span = |idx: usize| -> Span {
+        def_id
+            .as_local()
+            .and_then(|local| tcx.hir_node_by_def_id(local).fn_decl())
+            .and_then(|decl| decl.inputs.get(idx))
+            .map_or_else(|| tcx.def_span(def_id), |ty| ty.span)
+    };
+
+    let validate_frame = |arg: &ArgAbi<'tcx, Ty<'tcx>>, idx: usize| {
+        if arg.layout.is_zst() {
+            dcx.emit_err(diagnostics::X86InterruptZeroSized {
+                span: get_span(idx),
+                ty: arg.layout.ty,
+            });
+            return;
+        }
+
+        let is_pointer = match arg.layout.backend_repr {
+            BackendRepr::Scalar(s) => matches!(s.primitive(), Primitive::Pointer(_)),
+            BackendRepr::ScalarPair { a: s1, b: s2, b_offset: _ } => {
+                matches!(s1.primitive(), Primitive::Pointer(_))
+                    || matches!(s2.primitive(), Primitive::Pointer(_))
+            }
+            _ => false,
+        };
+
+        if is_pointer || arg.layout.largest_niche.is_some() {
+            dcx.emit_err(diagnostics::X86InterruptInvalidFrame {
+                span: get_span(idx),
+                ty: arg.layout.ty,
+            });
+        }
+    };
+
+    let validate_error_code = |arg: &ArgAbi<'tcx, Ty<'tcx>>, idx: usize| {
+        if arg.layout.is_zst() {
+            dcx.emit_err(diagnostics::X86InterruptZeroSized {
+                span: get_span(idx),
+                ty: arg.layout.ty,
+            });
+            return;
+        }
+
+        let ec_ok = if let BackendRepr::Scalar(scalar) = arg.layout.backend_repr
+            && let Primitive::Int(primitive, _) = scalar.primitive()
+            && primitive.size() == tcx.data_layout.pointer_size()
+            && scalar.is_always_valid(&tcx)
+        {
+            true
+        } else {
+            false
+        };
+
+        if !ec_ok {
+            dcx.emit_err(diagnostics::X86InterruptInvalidErrorCode {
+                span: get_span(idx),
+                ty: arg.layout.ty,
+            });
+        }
+    };
+
+    match &*abi.args {
+        [frame] => {
+            validate_frame(frame, 0);
+        }
+        [frame, ec] => {
+            validate_frame(frame, 0);
+            validate_error_code(ec, 1);
+        }
+        _ => { /* Ignore, arity handled at AST layer. */ }
     }
 }
 
@@ -191,6 +278,7 @@ fn check_instance_abi<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) {
     };
     do_check_unsized_params(tcx, abi, /*is_call*/ false, loc);
     do_check_simd_vector_abi(tcx, abi, instance.def_id(), /*is_call*/ false, loc);
+    do_check_x86_interrupt_abi(tcx, abi, instance.def_id());
 }
 
 /// Check the ABI at a call site, emitting an error when:

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -649,7 +649,10 @@ impl<'a, Ty> FnAbi<'a, Ty> {
         C: HasDataLayout + HasTargetSpec + HasX86AbiOpt,
     {
         if abi == ExternAbi::X86Interrupt {
-            if let Some(arg) = self.args.first_mut() {
+            if let Some(arg) = self.args.first_mut()
+                && !arg.is_ignore()
+                && arg.layout.is_sized()
+            {
                 arg.pass_by_stack_offset(None);
             }
             return;

--- a/tests/codegen-llvm/abi-x86-interrupt.rs
+++ b/tests/codegen-llvm/abi-x86-interrupt.rs
@@ -15,4 +15,4 @@ use minicore::*;
 
 // CHECK: define x86_intrcc void @has_x86_interrupt_abi
 #[no_mangle]
-pub extern "x86-interrupt" fn has_x86_interrupt_abi(_p: *const u8) {}
+pub extern "x86-interrupt" fn has_x86_interrupt_abi(_p: [usize; 5]) {}

--- a/tests/ui/abi/cannot-be-called.amdgpu.stderr
+++ b/tests/ui/abi/cannot-be-called.amdgpu.stderr
@@ -25,7 +25,7 @@ LL | extern "riscv-interrupt-s" fn riscv_s() {}
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:51:8
    |
-LL | extern "x86-interrupt" fn x86(_x: *const u8) {}
+LL | extern "x86-interrupt" fn x86(_x: [usize; 5]) {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
@@ -55,7 +55,7 @@ LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:100:22
    |
-LL | fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
+LL | fn x86_ptr(f: extern "x86-interrupt" fn([usize; 5]), frame: [usize; 5]) {
    |                      ^^^^^^^^^^^^^^^
 
 error: functions with the "gpu-kernel" ABI cannot be called

--- a/tests/ui/abi/cannot-be-called.avr.stderr
+++ b/tests/ui/abi/cannot-be-called.avr.stderr
@@ -19,7 +19,7 @@ LL | extern "riscv-interrupt-s" fn riscv_s() {}
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:51:8
    |
-LL | extern "x86-interrupt" fn x86(_x: *const u8) {}
+LL | extern "x86-interrupt" fn x86(_x: [usize; 5]) {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
@@ -49,7 +49,7 @@ LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:100:22
    |
-LL | fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
+LL | fn x86_ptr(f: extern "x86-interrupt" fn([usize; 5]), frame: [usize; 5]) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target

--- a/tests/ui/abi/cannot-be-called.i686.stderr
+++ b/tests/ui/abi/cannot-be-called.i686.stderr
@@ -61,14 +61,14 @@ LL | fn gpu_kernel_ptr(f: extern "gpu-kernel" fn()) {
 error: functions with the "x86-interrupt" ABI cannot be called
   --> $DIR/cannot-be-called.rs:68:5
    |
-LL |     x86(&raw const BYTE);
-   |     ^^^^^^^^^^^^^^^^^^^^
+LL |     x86([0; 5]);
+   |     ^^^^^^^^^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
   --> $DIR/cannot-be-called.rs:68:5
    |
-LL |     x86(&raw const BYTE);
-   |     ^^^^^^^^^^^^^^^^^^^^
+LL |     x86([0; 5]);
+   |     ^^^^^^^^^^^
 
 error: functions with the "x86-interrupt" ABI cannot be called
   --> $DIR/cannot-be-called.rs:102:5

--- a/tests/ui/abi/cannot-be-called.msp430.stderr
+++ b/tests/ui/abi/cannot-be-called.msp430.stderr
@@ -19,7 +19,7 @@ LL | extern "riscv-interrupt-s" fn riscv_s() {}
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:51:8
    |
-LL | extern "x86-interrupt" fn x86(_x: *const u8) {}
+LL | extern "x86-interrupt" fn x86(_x: [usize; 5]) {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
@@ -49,7 +49,7 @@ LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:100:22
    |
-LL | fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
+LL | fn x86_ptr(f: extern "x86-interrupt" fn([usize; 5]), frame: [usize; 5]) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target

--- a/tests/ui/abi/cannot-be-called.nvptx.stderr
+++ b/tests/ui/abi/cannot-be-called.nvptx.stderr
@@ -25,7 +25,7 @@ LL | extern "riscv-interrupt-s" fn riscv_s() {}
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:51:8
    |
-LL | extern "x86-interrupt" fn x86(_x: *const u8) {}
+LL | extern "x86-interrupt" fn x86(_x: [usize; 5]) {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "avr-interrupt" is not a supported ABI for the current target
@@ -55,7 +55,7 @@ LL | fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:100:22
    |
-LL | fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
+LL | fn x86_ptr(f: extern "x86-interrupt" fn([usize; 5]), frame: [usize; 5]) {
    |                      ^^^^^^^^^^^^^^^
 
 error: functions with the "gpu-kernel" ABI cannot be called

--- a/tests/ui/abi/cannot-be-called.riscv32.stderr
+++ b/tests/ui/abi/cannot-be-called.riscv32.stderr
@@ -13,7 +13,7 @@ LL | extern "avr-interrupt" fn avr() {}
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:51:8
    |
-LL | extern "x86-interrupt" fn x86(_x: *const u8) {}
+LL | extern "x86-interrupt" fn x86(_x: [usize; 5]) {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
@@ -37,7 +37,7 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:100:22
    |
-LL | fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
+LL | fn x86_ptr(f: extern "x86-interrupt" fn([usize; 5]), frame: [usize; 5]) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target

--- a/tests/ui/abi/cannot-be-called.riscv64.stderr
+++ b/tests/ui/abi/cannot-be-called.riscv64.stderr
@@ -13,7 +13,7 @@ LL | extern "avr-interrupt" fn avr() {}
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:51:8
    |
-LL | extern "x86-interrupt" fn x86(_x: *const u8) {}
+LL | extern "x86-interrupt" fn x86(_x: [usize; 5]) {}
    |        ^^^^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target
@@ -37,7 +37,7 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
 error[E0570]: "x86-interrupt" is not a supported ABI for the current target
   --> $DIR/cannot-be-called.rs:100:22
    |
-LL | fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
+LL | fn x86_ptr(f: extern "x86-interrupt" fn([usize; 5]), frame: [usize; 5]) {
    |                      ^^^^^^^^^^^^^^^
 
 error[E0570]: "gpu-kernel" is not a supported ABI for the current target

--- a/tests/ui/abi/cannot-be-called.rs
+++ b/tests/ui/abi/cannot-be-called.rs
@@ -48,7 +48,7 @@ extern "riscv-interrupt-m" fn riscv_m() {}
 //[x64,x64_win,i686,avr,msp430,amdgpu,nvptx]~^ ERROR is not a supported ABI
 extern "riscv-interrupt-s" fn riscv_s() {}
 //[x64,x64_win,i686,avr,msp430,amdgpu,nvptx]~^ ERROR is not a supported ABI
-extern "x86-interrupt" fn x86(_x: *const u8) {}
+extern "x86-interrupt" fn x86(_x: [usize; 5]) {}
 //[riscv32,riscv64,avr,msp430,amdgpu,nvptx]~^ ERROR is not a supported ABI
 extern "gpu-kernel" fn gpu_kernel() {}
 //[x64,x64_win,i686,riscv32,riscv64,avr,msp430]~^ ERROR is not a supported ABI
@@ -65,7 +65,7 @@ fn call_the_interrupts() {
     //[riscv32,riscv64]~^ ERROR functions with the "riscv-interrupt-m" ABI cannot be called
     riscv_s();
     //[riscv32,riscv64]~^ ERROR functions with the "riscv-interrupt-s" ABI cannot be called
-    x86(&raw const BYTE);
+    x86([0; 5]);
     //[x64,x64_win,i686]~^ ERROR functions with the "x86-interrupt" ABI cannot be called
     gpu_kernel();
     //[amdgpu,nvptx]~^ ERROR functions with the "gpu-kernel" ABI cannot be called
@@ -97,7 +97,7 @@ fn riscv_s_ptr(f: extern "riscv-interrupt-s" fn()) {
     //[riscv32,riscv64]~^ ERROR functions with the "riscv-interrupt-s" ABI cannot be called
 }
 
-fn x86_ptr(f: extern "x86-interrupt" fn(*const u8), frame: *const u8) {
+fn x86_ptr(f: extern "x86-interrupt" fn([usize; 5]), frame: [usize; 5]) {
     //[riscv32,riscv64,avr,msp430,amdgpu,nvptx]~^ ERROR is not a supported ABI
     f(frame)
     //[x64,x64_win,i686]~^ ERROR functions with the "x86-interrupt" ABI cannot be called

--- a/tests/ui/abi/cannot-be-called.x64.stderr
+++ b/tests/ui/abi/cannot-be-called.x64.stderr
@@ -61,14 +61,14 @@ LL | fn gpu_kernel_ptr(f: extern "gpu-kernel" fn()) {
 error: functions with the "x86-interrupt" ABI cannot be called
   --> $DIR/cannot-be-called.rs:68:5
    |
-LL |     x86(&raw const BYTE);
-   |     ^^^^^^^^^^^^^^^^^^^^
+LL |     x86([0; 5]);
+   |     ^^^^^^^^^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
   --> $DIR/cannot-be-called.rs:68:5
    |
-LL |     x86(&raw const BYTE);
-   |     ^^^^^^^^^^^^^^^^^^^^
+LL |     x86([0; 5]);
+   |     ^^^^^^^^^^^
 
 error: functions with the "x86-interrupt" ABI cannot be called
   --> $DIR/cannot-be-called.rs:102:5

--- a/tests/ui/abi/cannot-be-called.x64_win.stderr
+++ b/tests/ui/abi/cannot-be-called.x64_win.stderr
@@ -61,14 +61,14 @@ LL | fn gpu_kernel_ptr(f: extern "gpu-kernel" fn()) {
 error: functions with the "x86-interrupt" ABI cannot be called
   --> $DIR/cannot-be-called.rs:68:5
    |
-LL |     x86(&raw const BYTE);
-   |     ^^^^^^^^^^^^^^^^^^^^
+LL |     x86([0; 5]);
+   |     ^^^^^^^^^^^
    |
 note: an `extern "x86-interrupt"` function can only be called using inline assembly
   --> $DIR/cannot-be-called.rs:68:5
    |
-LL |     x86(&raw const BYTE);
-   |     ^^^^^^^^^^^^^^^^^^^^
+LL |     x86([0; 5]);
+   |     ^^^^^^^^^^^
 
 error: functions with the "x86-interrupt" ABI cannot be called
   --> $DIR/cannot-be-called.rs:102:5

--- a/tests/ui/abi/interrupt-invalid-signature.i686.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.i686.stderr
@@ -1,15 +1,15 @@
 error: invalid signature for `extern "x86-interrupt"` function
-  --> $DIR/interrupt-invalid-signature.rs:83:53
+  --> $DIR/interrupt-invalid-signature.rs:83:54
    |
-LL | extern "x86-interrupt" fn x86_ret(_p: *const u8) -> u8 {
-   |                                                     ^^
+LL | extern "x86-interrupt" fn x86_ret(_p: [usize; 5]) -> u8 {
+   |                                                      ^^
    |
    = note: functions with the "x86-interrupt" ABI cannot have a return type
 help: remove the return type
-  --> $DIR/interrupt-invalid-signature.rs:83:53
+  --> $DIR/interrupt-invalid-signature.rs:83:54
    |
-LL | extern "x86-interrupt" fn x86_ret(_p: *const u8) -> u8 {
-   |                                                     ^^
+LL | extern "x86-interrupt" fn x86_ret(_p: [usize; 5]) -> u8 {
+   |                                                      ^^
 
 error: invalid signature for `extern "x86-interrupt"` function
   --> $DIR/interrupt-invalid-signature.rs:89:1
@@ -22,8 +22,8 @@ LL | extern "x86-interrupt" fn x86_0() {
 error: invalid signature for `extern "x86-interrupt"` function
   --> $DIR/interrupt-invalid-signature.rs:100:33
    |
-LL | extern "x86-interrupt" fn x86_3(_p1: *const u8, _p2: *const u8, _p3: *const u8) {
-   |                                 ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^
+LL | extern "x86-interrupt" fn x86_3(_p1: [usize; 5], _p2: usize, _p3: *const u8) {
+   |                                 ^^^^^^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^^^^
    |
    = note: functions with the "x86-interrupt" ABI must be have either 1 or 2 parameters (but found 3)
 

--- a/tests/ui/abi/interrupt-invalid-signature.rs
+++ b/tests/ui/abi/interrupt-invalid-signature.rs
@@ -80,7 +80,7 @@ extern "riscv-interrupt-s" fn riscv_s_ret() -> u8 {
 }
 
 #[cfg(any(x64, i686))]
-extern "x86-interrupt" fn x86_ret(_p: *const u8) -> u8 {
+extern "x86-interrupt" fn x86_ret(_p: [usize; 5]) -> u8 {
     //[x64,i686]~^ ERROR invalid signature
     1
 }
@@ -91,13 +91,13 @@ extern "x86-interrupt" fn x86_0() {
 }
 
 #[cfg(any(x64, i686))]
-extern "x86-interrupt" fn x86_1(_p1: *const u8) {}
+extern "x86-interrupt" fn x86_1(_p1: [usize; 5]) {}
 
 #[cfg(any(x64, i686))]
-extern "x86-interrupt" fn x86_2(_p1: *const u8, _p2: *const u8) {}
+extern "x86-interrupt" fn x86_2(_p1: [usize; 5], _p2: usize) {}
 
 #[cfg(any(x64, i686))]
-extern "x86-interrupt" fn x86_3(_p1: *const u8, _p2: *const u8, _p3: *const u8) {
+extern "x86-interrupt" fn x86_3(_p1: [usize; 5], _p2: usize, _p3: *const u8) {
     //[x64,i686]~^ ERROR invalid signature
 }
 

--- a/tests/ui/abi/interrupt-invalid-signature.x64.stderr
+++ b/tests/ui/abi/interrupt-invalid-signature.x64.stderr
@@ -1,15 +1,15 @@
 error: invalid signature for `extern "x86-interrupt"` function
-  --> $DIR/interrupt-invalid-signature.rs:83:53
+  --> $DIR/interrupt-invalid-signature.rs:83:54
    |
-LL | extern "x86-interrupt" fn x86_ret(_p: *const u8) -> u8 {
-   |                                                     ^^
+LL | extern "x86-interrupt" fn x86_ret(_p: [usize; 5]) -> u8 {
+   |                                                      ^^
    |
    = note: functions with the "x86-interrupt" ABI cannot have a return type
 help: remove the return type
-  --> $DIR/interrupt-invalid-signature.rs:83:53
+  --> $DIR/interrupt-invalid-signature.rs:83:54
    |
-LL | extern "x86-interrupt" fn x86_ret(_p: *const u8) -> u8 {
-   |                                                     ^^
+LL | extern "x86-interrupt" fn x86_ret(_p: [usize; 5]) -> u8 {
+   |                                                      ^^
 
 error: invalid signature for `extern "x86-interrupt"` function
   --> $DIR/interrupt-invalid-signature.rs:89:1
@@ -22,8 +22,8 @@ LL | extern "x86-interrupt" fn x86_0() {
 error: invalid signature for `extern "x86-interrupt"` function
   --> $DIR/interrupt-invalid-signature.rs:100:33
    |
-LL | extern "x86-interrupt" fn x86_3(_p1: *const u8, _p2: *const u8, _p3: *const u8) {
-   |                                 ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^
+LL | extern "x86-interrupt" fn x86_3(_p1: [usize; 5], _p2: usize, _p3: *const u8) {
+   |                                 ^^^^^^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^^^^
    |
    = note: functions with the "x86-interrupt" ABI must be have either 1 or 2 parameters (but found 3)
 

--- a/tests/ui/abi/interrupt-returns-never-or-unit.rs
+++ b/tests/ui/abi/interrupt-returns-never-or-unit.rs
@@ -31,6 +31,8 @@ This test uses `cfg` because it is not testing whether these ABIs work on the pl
     abi_riscv_interrupt
 )]
 
+#![allow(improper_ctypes_definitions)]
+
 extern crate minicore;
 use minicore::*;
 
@@ -57,7 +59,7 @@ extern "riscv-interrupt-s" fn riscv_s_ret_never() -> ! {
 }
 
 #[cfg(any(x64, i686))]
-extern "x86-interrupt" fn x86_ret_never(_p: *const u8) -> ! {
+extern "x86-interrupt" fn x86_ret_never(_p: [usize; 5]) -> ! {
     loop {}
 }
 
@@ -84,7 +86,7 @@ extern "riscv-interrupt-s" fn riscv_s_ret_unit() -> () {
 }
 
 #[cfg(any(x64, i686))]
-extern "x86-interrupt" fn x86_ret_unit(_x: *const u8) -> () {
+extern "x86-interrupt" fn x86_ret_unit(_x: [usize; 5]) -> () {
     ()
 }
 
@@ -103,4 +105,4 @@ fn riscv_m_ptr(_f: extern "riscv-interrupt-m" fn() -> !) {}
 fn riscv_s_ptr(_f: extern "riscv-interrupt-s" fn() -> !) {}
 
 #[cfg(any(x64, i686))]
-fn x86_ptr(_f: extern "x86-interrupt" fn(*const u8) -> !) {}
+fn x86_ptr(_f: extern "x86-interrupt" fn([usize; 5]) -> !) {}

--- a/tests/ui/abi/x86-interrupt-generic-param-instantiation.i686.stderr
+++ b/tests/ui/abi/x86-interrupt-generic-param-instantiation.i686.stderr
@@ -1,0 +1,77 @@
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:29:41
+   |
+LL | extern "x86-interrupt" fn handler<F>(_: F) {}
+   |                                         ^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+note: the above error was encountered while instantiating `fn handler::<()>`
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:50:63
+   |
+LL |     let test_zst_frame_fails: extern "x86-interrupt" fn(()) = handler::<()>;
+   |                                                               ^^^^^^^^^^^^^
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:36:53
+   |
+LL | extern "x86-interrupt" fn handler_ec<F, E>(_: F, _: E) {}
+   |                                                     ^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+note: the above error was encountered while instantiating `fn handler_ec::<Frame, ()>`
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:52:69
+   |
+LL |     let test_zst_code_fails: extern "x86-interrupt" fn(Frame, ()) = handler_ec::<Frame, ()>;
+   |                                                                     ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:29:41
+   |
+LL | extern "x86-interrupt" fn handler<F>(_: F) {}
+   |                                         ^
+   |
+   = note: invalid x86-interrupt frame parameter type: `bool`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+note: the above error was encountered while instantiating `fn handler::<bool>`
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:54:67
+   |
+LL |     let test_niche_frame_fails: extern "x86-interrupt" fn(bool) = handler::<bool>;
+   |                                                                   ^^^^^^^^^^^^^^^
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:36:53
+   |
+LL | extern "x86-interrupt" fn handler_ec<F, E>(_: F, _: E) {}
+   |                                                     ^
+   |
+   = note: invalid x86-interrupt error code parameter type: `bool`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+note: the above error was encountered while instantiating `fn handler_ec::<Frame, bool>`
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:56:73
+   |
+LL |     let test_niche_code_fails: extern "x86-interrupt" fn(Frame, bool) = handler_ec::<Frame, bool>;
+   |                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:36:53
+   |
+LL | extern "x86-interrupt" fn handler_ec<F, E>(_: F, _: E) {}
+   |                                                     ^
+   |
+   = note: invalid x86-interrupt error code parameter type: `u8`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+note: the above error was encountered while instantiating `fn handler_ec::<Frame, u8>`
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:58:73
+   |
+LL |     let test_invalid_code_fails: extern "x86-interrupt" fn(Frame, u8) = handler_ec::<Frame, u8>;
+   |                                                                         ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/abi/x86-interrupt-generic-param-instantiation.rs
+++ b/tests/ui/abi/x86-interrupt-generic-param-instantiation.rs
@@ -1,0 +1,60 @@
+//! Tests x86 interrupt ABI parameter validation for generic instantiations.
+//@ add-minicore
+//@ revisions: x64 i686
+//
+//@ [x64] needs-llvm-components: x86
+//@ [x64] compile-flags: --target=x86_64-unknown-linux-gnu --crate-type=rlib
+//@ [i686] needs-llvm-components: x86
+//@ [i686] compile-flags: --target=i686-unknown-linux-gnu --crate-type=rlib
+//@ build-fail
+//@ ignore-backends: gcc
+
+#![no_core]
+#![feature(no_core, abi_x86_interrupt)]
+
+#![allow(improper_ctypes_definitions)]
+
+extern crate minicore;
+use minicore::*;
+
+#[repr(C)]
+struct Frame {
+    ip: u64,
+    cs: u64,
+    flags: u64,
+    sp: u64,
+    ss: u64
+}
+
+extern "x86-interrupt" fn handler<F>(_: F) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+//~| NOTE invalid x86-interrupt parameter type: `()`
+//~| NOTE functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+//~| ERROR invalid signature for `extern "x86-interrupt"` function
+//~| NOTE invalid x86-interrupt frame parameter type: `bool`
+//~| NOTE functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+extern "x86-interrupt" fn handler_ec<F, E>(_: F, _: E) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+//~| NOTE invalid x86-interrupt parameter type: `()`
+//~| NOTE functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+//~| ERROR invalid signature for `extern "x86-interrupt"` function
+//~| NOTE invalid x86-interrupt error code parameter type: `bool`
+//~| NOTE functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter
+//~| ERROR invalid signature for `extern "x86-interrupt"` function
+//~| NOTE invalid x86-interrupt error code parameter type: `u8`
+//~| NOTE functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter
+
+pub fn tests() {
+    let test_generic_frame_works:  extern "x86-interrupt" fn(Frame) = handler::<Frame>;
+    let test_code_works: extern "x86-interrupt" fn(Frame, usize) = handler_ec::<Frame, usize>;
+    let test_zst_frame_fails: extern "x86-interrupt" fn(()) = handler::<()>;
+    //~^ NOTE the above error was encountered while instantiating `fn handler::<()>`
+    let test_zst_code_fails: extern "x86-interrupt" fn(Frame, ()) = handler_ec::<Frame, ()>;
+    //~^ NOTE the above error was encountered while instantiating `fn handler_ec::<Frame, ()>`
+    let test_niche_frame_fails: extern "x86-interrupt" fn(bool) = handler::<bool>;
+    //~^ NOTE the above error was encountered while instantiating `fn handler::<bool>`
+    let test_niche_code_fails: extern "x86-interrupt" fn(Frame, bool) = handler_ec::<Frame, bool>;
+    //~^ NOTE the above error was encountered while instantiating `fn handler_ec::<Frame, bool>`
+    let test_invalid_code_fails: extern "x86-interrupt" fn(Frame, u8) = handler_ec::<Frame, u8>;
+    //~^ NOTE the above error was encountered while instantiating `fn handler_ec::<Frame, u8>`
+}

--- a/tests/ui/abi/x86-interrupt-generic-param-instantiation.x64.stderr
+++ b/tests/ui/abi/x86-interrupt-generic-param-instantiation.x64.stderr
@@ -1,0 +1,77 @@
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:29:41
+   |
+LL | extern "x86-interrupt" fn handler<F>(_: F) {}
+   |                                         ^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+note: the above error was encountered while instantiating `fn handler::<()>`
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:50:63
+   |
+LL |     let test_zst_frame_fails: extern "x86-interrupt" fn(()) = handler::<()>;
+   |                                                               ^^^^^^^^^^^^^
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:36:53
+   |
+LL | extern "x86-interrupt" fn handler_ec<F, E>(_: F, _: E) {}
+   |                                                     ^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+note: the above error was encountered while instantiating `fn handler_ec::<Frame, ()>`
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:52:69
+   |
+LL |     let test_zst_code_fails: extern "x86-interrupt" fn(Frame, ()) = handler_ec::<Frame, ()>;
+   |                                                                     ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:29:41
+   |
+LL | extern "x86-interrupt" fn handler<F>(_: F) {}
+   |                                         ^
+   |
+   = note: invalid x86-interrupt frame parameter type: `bool`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+note: the above error was encountered while instantiating `fn handler::<bool>`
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:54:67
+   |
+LL |     let test_niche_frame_fails: extern "x86-interrupt" fn(bool) = handler::<bool>;
+   |                                                                   ^^^^^^^^^^^^^^^
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:36:53
+   |
+LL | extern "x86-interrupt" fn handler_ec<F, E>(_: F, _: E) {}
+   |                                                     ^
+   |
+   = note: invalid x86-interrupt error code parameter type: `bool`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+note: the above error was encountered while instantiating `fn handler_ec::<Frame, bool>`
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:56:73
+   |
+LL |     let test_niche_code_fails: extern "x86-interrupt" fn(Frame, bool) = handler_ec::<Frame, bool>;
+   |                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:36:53
+   |
+LL | extern "x86-interrupt" fn handler_ec<F, E>(_: F, _: E) {}
+   |                                                     ^
+   |
+   = note: invalid x86-interrupt error code parameter type: `u8`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+note: the above error was encountered while instantiating `fn handler_ec::<Frame, u8>`
+  --> $DIR/x86-interrupt-generic-param-instantiation.rs:58:73
+   |
+LL |     let test_invalid_code_fails: extern "x86-interrupt" fn(Frame, u8) = handler_ec::<Frame, u8>;
+   |                                                                         ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/abi/x86-interrupt-param-types.i686.stderr
+++ b/tests/ui/abi/x86-interrupt-param-types.i686.stderr
@@ -1,0 +1,308 @@
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:68:55
+   |
+LL | extern "x86-interrupt" fn test_frame_unsized_fails(_: str) {}
+   |                                                       ^^^
+   |
+   = note: invalid x86-interrupt parameter type: `str`
+   = note: functions with the "x86-interrupt" ABI must not use unsized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:70:51
+   |
+LL | extern "x86-interrupt" fn test_frame_zst_fails(_: ()) {}
+   |                                                   ^^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:72:52
+   |
+LL | extern "x86-interrupt" fn test_frame_bool_fails(_: bool) {}
+   |                                                    ^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `bool`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:74:52
+   |
+LL | extern "x86-interrupt" fn test_frame_char_fails(_: char) {}
+   |                                                    ^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `char`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:76:61
+   |
+LL | extern "x86-interrupt" fn test_frame_indirect_bool_fails(_: NewBool) {}
+   |                                                             ^^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `NewBool`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:78:55
+   |
+LL | extern "x86-interrupt" fn test_frame_pointer_fails(_: *const u8) {}
+   |                                                       ^^^^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `*const u8`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:80:59
+   |
+LL | extern "x86-interrupt" fn test_frame_mut_pointer_fails(_: *mut u8) {}
+   |                                                           ^^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `*mut u8`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:82:57
+   |
+LL | extern "x86-interrupt" fn test_frame_reference_fails(_: &Frame) {}
+   |                                                         ^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `&Frame`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:84:61
+   |
+LL | extern "x86-interrupt" fn test_frame_mut_reference_fails(_: &mut Frame) {}
+   |                                                             ^^^^^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `&mut Frame`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:86:66
+   |
+LL | extern "x86-interrupt" fn test_frame_optional_reference_fails(_: Opt<&Frame>) {}
+   |                                                                  ^^^^^^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `Opt<&Frame>`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:88:70
+   |
+LL | extern "x86-interrupt" fn test_frame_optional_mut_reference_fails(_: Opt<&mut Frame>) {}
+   |                                                                      ^^^^^^^^^^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `Opt<&mut Frame>`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:94:64
+   |
+LL | extern "x86-interrupt" fn test_code_unsized_fails(_: Frame, _: str) {}
+   |                                                                ^^^
+   |
+   = note: invalid x86-interrupt parameter type: `str`
+   = note: functions with the "x86-interrupt" ABI must not use unsized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:96:60
+   |
+LL | extern "x86-interrupt" fn test_code_zst_fails(_: Frame, _: ()) {}
+   |                                                            ^^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:98:59
+   |
+LL | extern "x86-interrupt" fn test_code_u8_fails(_: Frame, _: u8) {}
+   |                                                           ^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `u8`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:100:60
+   |
+LL | extern "x86-interrupt" fn test_code_u16_fails(_: Frame, _: u16) {}
+   |                                                            ^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `u16`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:103:66
+   |
+LL | extern "x86-interrupt" fn test_code_32bit_u64_fails(_: Frame, _: u64) {}
+   |                                                                  ^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `u64`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:109:70
+   |
+LL | extern "x86-interrupt" fn test_code_non_scalar_32_fails(_: Frame, _: NonScalar32) {}
+   |                                                                      ^^^^^^^^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `NonScalar32`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:114:64
+   |
+LL | extern "x86-interrupt" fn test_code_pointer_fails(_: Frame, _: *const u8) {}
+   |                                                                ^^^^^^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `*const u8`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:116:68
+   |
+LL | extern "x86-interrupt" fn test_code_mut_pointer_fails(_: Frame, _: *mut u8) {}
+   |                                                                    ^^^^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `*mut u8`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:118:61
+   |
+LL | extern "x86-interrupt" fn test_code_u128_fails(_: Frame, _: u128) {}
+   |                                                             ^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `u128`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:120:61
+   |
+LL | extern "x86-interrupt" fn test_code_bool_fails(_: Frame, _: bool) {}
+   |                                                             ^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `bool`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:122:62
+   |
+LL | extern "x86-interrupt" fn test_code_array_fails(_: Frame, _: [u8; 3]) {}
+   |                                                              ^^^^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `[u8; 3]`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:124:61
+   |
+LL | extern "x86-interrupt" fn test_code_enum_fails(_: Frame, _: Enumtype) {}
+   |                                                             ^^^^^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `Enumtype`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:130:68
+   |
+LL | extern "x86-interrupt" fn test_code_32bit_float_fails(_: Frame, _: f32) {}
+   |                                                                    ^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `f32`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:132:61
+   |
+LL | extern "x86-interrupt" fn test_code_char_fails(_: Frame, _: char) {}
+   |                                                             ^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `char`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:155:60
+   |
+LL |     extern "x86-interrupt" fn test_impl_frame_zst_fails(_: ()) {}
+   |                                                            ^^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:157:64
+   |
+LL |     extern "x86-interrupt" fn test_impl_frame_unsized_fails(_: str) {}
+   |                                                                ^^^
+   |
+   = note: invalid x86-interrupt parameter type: `str`
+   = note: functions with the "x86-interrupt" ABI must not use unsized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:159:69
+   |
+LL |     extern "x86-interrupt" fn test_impl_code_zst_fails(_: Frame, _: ()) {}
+   |                                                                     ^^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:161:73
+   |
+LL |     extern "x86-interrupt" fn test_impl_code_unsized_fails(_: Frame, _: str) {}
+   |                                                                         ^^^
+   |
+   = note: invalid x86-interrupt parameter type: `str`
+   = note: functions with the "x86-interrupt" ABI must not use unsized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:176:39
+   |
+LL |     fn test_extern_frame_zst_fails(_: ());
+   |                                       ^^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:178:43
+   |
+LL |     fn test_extern_frame_unsized_fails(_: str);
+   |                                           ^^^
+   |
+   = note: invalid x86-interrupt parameter type: `str`
+   = note: functions with the "x86-interrupt" ABI must not use unsized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:180:48
+   |
+LL |     fn test_extern_code_zst_fails(_: Frame, _: ());
+   |                                                ^^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:182:52
+   |
+LL |     fn test_extern_code_unsized_fails(_: Frame, _: str);
+   |                                                    ^^^
+   |
+   = note: invalid x86-interrupt parameter type: `str`
+   = note: functions with the "x86-interrupt" ABI must not use unsized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:184:49
+   |
+LL |     fn test_extern_code_enum_fails(_: Frame, _: Enumtype);
+   |                                                 ^^^^^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `Enumtype`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: aborting due to 34 previous errors
+

--- a/tests/ui/abi/x86-interrupt-param-types.rs
+++ b/tests/ui/abi/x86-interrupt-param-types.rs
@@ -1,0 +1,229 @@
+//! Tests x86 interrupt ABI parameter validation
+//! Specifically, we don't test the arity of the parameters (that is handled
+//!   by `interrupt-invalid-signature.rs`), but the shape of the parameters.
+//!  In short:
+//!    Frames:
+//!    1. Reference or value
+//!    2. Complete over all possible bit patterns
+//!    3. Neither ZST or unsized
+//!    Codes:
+//!    1. Presence optional
+//!    2. Machine sized scalar, complete over all possible bit patterns.
+//@ add-minicore
+//@ revisions: x64 i686
+//
+//@ [x64] needs-llvm-components: x86
+//@ [x64] compile-flags: --target=x86_64-unknown-linux-gnu --crate-type=rlib
+//@ [i686] needs-llvm-components: x86
+//@ [i686] compile-flags: --target=i686-unknown-linux-gnu --crate-type=rlib
+//@ ignore-backends: gcc
+#![no_core]
+#![feature(
+    no_core,
+    abi_x86_interrupt,
+    unsized_fn_params
+)]
+
+extern crate minicore;
+use minicore::*;
+
+#[repr(C)]
+struct Frame {
+    ip: u64,
+    cs: u64,
+    flags: u64,
+    sp: u64,
+    ss: u64
+}
+
+#[repr(C)]
+struct NonScalar32 {
+    a: u8,
+    b: u16
+}
+
+#[repr(C)]
+struct NonScalar64 {
+    a: u8,
+    b: u32
+}
+
+#[repr(transparent)]
+struct Newtype(usize);
+
+#[repr(u64)]
+enum Enumtype {
+    A
+}
+
+enum Opt<T> {
+    Some(T),
+    None
+}
+
+#[repr(C)]
+struct NewBool{ a: bool }
+
+/* Frame parameter tests */
+extern "x86-interrupt" fn test_frame_unsized_fails(_: str) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_frame_zst_fails(_: ()) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_frame_bool_fails(_: bool) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_frame_char_fails(_: char) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_frame_indirect_bool_fails(_: NewBool) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_frame_pointer_fails(_: *const u8) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_frame_mut_pointer_fails(_: *mut u8) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_frame_reference_fails(_: &Frame) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_frame_mut_reference_fails(_: &mut Frame) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_frame_optional_reference_fails(_: Opt<&Frame>) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_frame_optional_mut_reference_fails(_: Opt<&mut Frame>) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+
+extern "x86-interrupt" fn test_frame_actual_frame_works(_: Frame) {}
+
+/* Error code parameter tests */
+extern "x86-interrupt" fn test_code_unsized_fails(_: Frame, _: str) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_code_zst_fails(_: Frame, _: ()) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_code_u8_fails(_: Frame, _: u8) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_code_u16_fails(_: Frame, _: u16) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+#[cfg(i686)]
+extern "x86-interrupt" fn test_code_32bit_u64_fails(_: Frame, _: u64) {}
+//[i686]~^ ERROR invalid signature for `extern "x86-interrupt"` function
+#[cfg(x64)]
+extern "x86-interrupt" fn test_code_64bit_u32_fails(_: Frame, _: u32) {}
+//[x64]~^ ERROR invalid signature for `extern "x86-interrupt"` function
+#[cfg(i686)]
+extern "x86-interrupt" fn test_code_non_scalar_32_fails(_: Frame, _: NonScalar32) {}
+//[i686]~^ ERROR invalid signature for `extern "x86-interrupt"` function
+#[cfg(x64)]
+extern "x86-interrupt" fn test_code_non_scalar_64_fails(_: Frame, _: NonScalar64) {}
+//[x64]~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_code_pointer_fails(_: Frame, _: *const u8) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_code_mut_pointer_fails(_: Frame, _: *mut u8) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_code_u128_fails(_: Frame, _: u128) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_code_bool_fails(_: Frame, _: bool) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_code_array_fails(_: Frame, _: [u8; 3]) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_code_enum_fails(_: Frame, _: Enumtype) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+#[cfg(x64)]
+extern "x86-interrupt" fn test_code_64bit_float_fails(_: Frame, _: f64) {}
+//[x64]~^ ERROR invalid signature for `extern "x86-interrupt"` function
+#[cfg(i686)]
+extern "x86-interrupt" fn test_code_32bit_float_fails(_: Frame, _: f32) {}
+//[i686]~^ ERROR invalid signature for `extern "x86-interrupt"` function
+extern "x86-interrupt" fn test_code_char_fails(_: Frame, _: char) {}
+//~^ ERROR invalid signature for `extern "x86-interrupt"` function
+
+#[cfg(i686)]
+extern "x86-interrupt" fn test_code_32bit_u32_works(_: Frame, _: u32) {}
+#[cfg(x64)]
+extern "x86-interrupt" fn test_code_64bit_u64_works(_: Frame, _: u64) {}
+extern "x86-interrupt" fn test_code_usize_works(_: Frame, _: usize) {}
+extern "x86-interrupt" fn test_code_newtype_works(_: Frame, _: Newtype) {}
+extern "x86-interrupt" fn test_code_signedness_works(_: Frame, _: isize) {}
+
+/* Impl shape tests */
+#[repr(C)]
+struct FancyFrame {
+    ip: u64,
+    cs: u64,
+    flags: u64,
+    sp: u64,
+    ss: u64
+}
+
+impl FancyFrame {
+
+    extern "x86-interrupt" fn test_impl_frame_zst_fails(_: ()) {}
+    //~^ ERROR invalid signature for `extern "x86-interrupt"` function
+    extern "x86-interrupt" fn test_impl_frame_unsized_fails(_: str) {}
+    //~^ ERROR invalid signature for `extern "x86-interrupt"` function
+    extern "x86-interrupt" fn test_impl_code_zst_fails(_: Frame, _: ()) {}
+    //~^ ERROR invalid signature for `extern "x86-interrupt"` function
+    extern "x86-interrupt" fn test_impl_code_unsized_fails(_: Frame, _: str) {}
+    //~^ ERROR invalid signature for `extern "x86-interrupt"` function
+
+    extern "x86-interrupt" fn test_impl_self_works(_: Self) {}
+    extern "x86-interrupt" fn test_impl_frame_works(_: Frame) {}
+    extern "x86-interrupt" fn test_impl_code_works(_: Frame, _: usize) {}
+}
+
+/* Trait shape tests */
+trait Handler {
+    extern "x86-interrupt" fn test_trait_impl_passes(_: Self);
+}
+
+/* Foreign decl test */
+unsafe extern "x86-interrupt" {
+    fn test_extern_frame_zst_fails(_: ());
+    //~^ ERROR invalid signature for `extern "x86-interrupt"` function
+    fn test_extern_frame_unsized_fails(_: str);
+    //~^ ERROR invalid signature for `extern "x86-interrupt"` function
+    fn test_extern_code_zst_fails(_: Frame, _: ());
+    //~^ ERROR invalid signature for `extern "x86-interrupt"` function
+    fn test_extern_code_unsized_fails(_: Frame, _: str);
+    //~^ ERROR invalid signature for `extern "x86-interrupt"` function
+    fn test_extern_code_enum_fails(_: Frame, _: Enumtype);
+    //~^ ERROR invalid signature for `extern "x86-interrupt"` function
+
+    fn test_extern_frame_works(_: Frame);
+    fn test_extern_code_works(_: Frame, _: usize);
+    fn test_extern_code_newtype_works(_: Frame, _: Newtype);
+}
+
+/* Complex frame tests */
+struct Addr(u64);
+
+#[repr(C)]
+struct ComplexFrame { ip: Addr, cs: u64, flags: u64, sp: Addr, ss: u64 }
+
+struct Idt { function_pointer_member_should_work: extern "x86-interrupt" fn(ComplexFrame) }
+
+/* Generic tests */
+trait WithType {
+    type Associated;
+
+    extern "x86-interrupt" fn test_trait_default_works(_: Self) {}
+}
+
+struct GenericFrame<T: Copy> {
+    ip: T,
+    cs: T,
+    flags: T,
+    sp: T,
+    ss: T
+}
+
+impl<T: Copy> GenericFrame<T> {
+    extern "x86-interrupt" fn test_generic_impl_works(_: Self) {}
+}
+
+#[repr(transparent)]
+struct GenericNewType<T: Copy>(T);
+
+extern "x86-interrupt" fn test_const_param_generic_works<const N: usize>(_: [u64; N]) {}
+extern "x86-interrupt" fn test_body_generics_works<const N: usize>(_: Frame) {}
+extern "x86-interrupt" fn test_param_generics_frame_works<F>(_: F) {}
+extern "x86-interrupt" fn test_param_generics_code_works<F, E>(_: F, _: E) {}
+extern "x86-interrupt" fn test_param_generics_wrapper_works<F>(_: Opt<F>) {}
+extern "x86-interrupt" fn test_param_generics_assoc_type_works<F: WithType>(_: F::Associated) {}
+extern "x86-interrupt" fn test_param_impl_generics_works(_: impl Copy) {}
+extern "x86-interrupt" fn test_param_impl_newtype_works(_: Frame, _: GenericNewType<usize>) {}

--- a/tests/ui/abi/x86-interrupt-param-types.x64.stderr
+++ b/tests/ui/abi/x86-interrupt-param-types.x64.stderr
@@ -1,0 +1,308 @@
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:68:55
+   |
+LL | extern "x86-interrupt" fn test_frame_unsized_fails(_: str) {}
+   |                                                       ^^^
+   |
+   = note: invalid x86-interrupt parameter type: `str`
+   = note: functions with the "x86-interrupt" ABI must not use unsized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:70:51
+   |
+LL | extern "x86-interrupt" fn test_frame_zst_fails(_: ()) {}
+   |                                                   ^^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:72:52
+   |
+LL | extern "x86-interrupt" fn test_frame_bool_fails(_: bool) {}
+   |                                                    ^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `bool`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:74:52
+   |
+LL | extern "x86-interrupt" fn test_frame_char_fails(_: char) {}
+   |                                                    ^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `char`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:76:61
+   |
+LL | extern "x86-interrupt" fn test_frame_indirect_bool_fails(_: NewBool) {}
+   |                                                             ^^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `NewBool`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:78:55
+   |
+LL | extern "x86-interrupt" fn test_frame_pointer_fails(_: *const u8) {}
+   |                                                       ^^^^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `*const u8`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:80:59
+   |
+LL | extern "x86-interrupt" fn test_frame_mut_pointer_fails(_: *mut u8) {}
+   |                                                           ^^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `*mut u8`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:82:57
+   |
+LL | extern "x86-interrupt" fn test_frame_reference_fails(_: &Frame) {}
+   |                                                         ^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `&Frame`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:84:61
+   |
+LL | extern "x86-interrupt" fn test_frame_mut_reference_fails(_: &mut Frame) {}
+   |                                                             ^^^^^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `&mut Frame`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:86:66
+   |
+LL | extern "x86-interrupt" fn test_frame_optional_reference_fails(_: Opt<&Frame>) {}
+   |                                                                  ^^^^^^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `Opt<&Frame>`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:88:70
+   |
+LL | extern "x86-interrupt" fn test_frame_optional_mut_reference_fails(_: Opt<&mut Frame>) {}
+   |                                                                      ^^^^^^^^^^^^^^^
+   |
+   = note: invalid x86-interrupt frame parameter type: `Opt<&mut Frame>`
+   = note: functions with the "x86-interrupt" ABI must have a non-pointer frame parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:94:64
+   |
+LL | extern "x86-interrupt" fn test_code_unsized_fails(_: Frame, _: str) {}
+   |                                                                ^^^
+   |
+   = note: invalid x86-interrupt parameter type: `str`
+   = note: functions with the "x86-interrupt" ABI must not use unsized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:96:60
+   |
+LL | extern "x86-interrupt" fn test_code_zst_fails(_: Frame, _: ()) {}
+   |                                                            ^^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:98:59
+   |
+LL | extern "x86-interrupt" fn test_code_u8_fails(_: Frame, _: u8) {}
+   |                                                           ^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `u8`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:100:60
+   |
+LL | extern "x86-interrupt" fn test_code_u16_fails(_: Frame, _: u16) {}
+   |                                                            ^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `u16`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:106:66
+   |
+LL | extern "x86-interrupt" fn test_code_64bit_u32_fails(_: Frame, _: u32) {}
+   |                                                                  ^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `u32`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:112:70
+   |
+LL | extern "x86-interrupt" fn test_code_non_scalar_64_fails(_: Frame, _: NonScalar64) {}
+   |                                                                      ^^^^^^^^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `NonScalar64`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:114:64
+   |
+LL | extern "x86-interrupt" fn test_code_pointer_fails(_: Frame, _: *const u8) {}
+   |                                                                ^^^^^^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `*const u8`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:116:68
+   |
+LL | extern "x86-interrupt" fn test_code_mut_pointer_fails(_: Frame, _: *mut u8) {}
+   |                                                                    ^^^^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `*mut u8`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:118:61
+   |
+LL | extern "x86-interrupt" fn test_code_u128_fails(_: Frame, _: u128) {}
+   |                                                             ^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `u128`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:120:61
+   |
+LL | extern "x86-interrupt" fn test_code_bool_fails(_: Frame, _: bool) {}
+   |                                                             ^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `bool`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:122:62
+   |
+LL | extern "x86-interrupt" fn test_code_array_fails(_: Frame, _: [u8; 3]) {}
+   |                                                              ^^^^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `[u8; 3]`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:124:61
+   |
+LL | extern "x86-interrupt" fn test_code_enum_fails(_: Frame, _: Enumtype) {}
+   |                                                             ^^^^^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `Enumtype`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:127:68
+   |
+LL | extern "x86-interrupt" fn test_code_64bit_float_fails(_: Frame, _: f64) {}
+   |                                                                    ^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `f64`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:132:61
+   |
+LL | extern "x86-interrupt" fn test_code_char_fails(_: Frame, _: char) {}
+   |                                                             ^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `char`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:155:60
+   |
+LL |     extern "x86-interrupt" fn test_impl_frame_zst_fails(_: ()) {}
+   |                                                            ^^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:157:64
+   |
+LL |     extern "x86-interrupt" fn test_impl_frame_unsized_fails(_: str) {}
+   |                                                                ^^^
+   |
+   = note: invalid x86-interrupt parameter type: `str`
+   = note: functions with the "x86-interrupt" ABI must not use unsized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:159:69
+   |
+LL |     extern "x86-interrupt" fn test_impl_code_zst_fails(_: Frame, _: ()) {}
+   |                                                                     ^^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:161:73
+   |
+LL |     extern "x86-interrupt" fn test_impl_code_unsized_fails(_: Frame, _: str) {}
+   |                                                                         ^^^
+   |
+   = note: invalid x86-interrupt parameter type: `str`
+   = note: functions with the "x86-interrupt" ABI must not use unsized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:176:39
+   |
+LL |     fn test_extern_frame_zst_fails(_: ());
+   |                                       ^^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:178:43
+   |
+LL |     fn test_extern_frame_unsized_fails(_: str);
+   |                                           ^^^
+   |
+   = note: invalid x86-interrupt parameter type: `str`
+   = note: functions with the "x86-interrupt" ABI must not use unsized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:180:48
+   |
+LL |     fn test_extern_code_zst_fails(_: Frame, _: ());
+   |                                                ^^
+   |
+   = note: invalid x86-interrupt parameter type: `()`
+   = note: functions with the "x86-interrupt" ABI must not use zero-sized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:182:52
+   |
+LL |     fn test_extern_code_unsized_fails(_: Frame, _: str);
+   |                                                    ^^^
+   |
+   = note: invalid x86-interrupt parameter type: `str`
+   = note: functions with the "x86-interrupt" ABI must not use unsized types in their signature
+
+error: invalid signature for `extern "x86-interrupt"` function
+  --> $DIR/x86-interrupt-param-types.rs:184:49
+   |
+LL |     fn test_extern_code_enum_fails(_: Frame, _: Enumtype);
+   |                                                 ^^^^^^^^
+   |
+   = note: invalid x86-interrupt error code parameter type: `Enumtype`
+   = note: functions with the "x86-interrupt" ABI must have a machine-word sized integer error code parameter that is valid for any bit pattern
+
+error: aborting due to 34 previous errors
+

--- a/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.rs
+++ b/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.rs
@@ -7,24 +7,24 @@
 extern crate minicore;
 use minicore::*;
 
-extern "x86-interrupt" fn f7(_p: *const u8) {} //~ ERROR "x86-interrupt" ABI is experimental
+extern "x86-interrupt" fn f7(_p: [usize; 5]) {} //~ ERROR "x86-interrupt" ABI is experimental
 trait Tr {
-    extern "x86-interrupt" fn m7(_p: *const u8); //~ ERROR "x86-interrupt" ABI is experimental
-    extern "x86-interrupt" fn dm7(_p: *const u8) {} //~ ERROR "x86-interrupt" ABI is experimental
+    extern "x86-interrupt" fn m7(_p: [usize; 5]); //~ ERROR "x86-interrupt" ABI is experimental
+    extern "x86-interrupt" fn dm7(_p: [usize; 5]) {} //~ ERROR "x86-interrupt" ABI is experimental
 }
 
 struct S;
 
 // Methods in trait impl
 impl Tr for S {
-    extern "x86-interrupt" fn m7(_p: *const u8) {} //~ ERROR "x86-interrupt" ABI is experimental
+    extern "x86-interrupt" fn m7(_p: [usize; 5]) {} //~ ERROR "x86-interrupt" ABI is experimental
 }
 
 // Methods in inherent impl
 impl S {
-    extern "x86-interrupt" fn im7(_p: *const u8) {} //~ ERROR "x86-interrupt" ABI is experimental
+    extern "x86-interrupt" fn im7(_p: [usize; 5]) {} //~ ERROR "x86-interrupt" ABI is experimental
 }
 
-type A7 = extern "x86-interrupt" fn(*const u8); //~ ERROR "x86-interrupt" ABI is experimental
+type A7 = extern "x86-interrupt" fn([usize; 5]); //~ ERROR "x86-interrupt" ABI is experimental
 
 extern "x86-interrupt" {} //~ ERROR "x86-interrupt" ABI is experimental

--- a/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.stderr
@@ -1,7 +1,7 @@
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-x86-interrupt.rs:10:8
    |
-LL | extern "x86-interrupt" fn f7(_p: *const u8) {}
+LL | extern "x86-interrupt" fn f7(_p: [usize; 5]) {}
    |        ^^^^^^^^^^^^^^^
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
@@ -11,7 +11,7 @@ LL | extern "x86-interrupt" fn f7(_p: *const u8) {}
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-x86-interrupt.rs:12:12
    |
-LL |     extern "x86-interrupt" fn m7(_p: *const u8);
+LL |     extern "x86-interrupt" fn m7(_p: [usize; 5]);
    |            ^^^^^^^^^^^^^^^
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
@@ -21,7 +21,7 @@ LL |     extern "x86-interrupt" fn m7(_p: *const u8);
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-x86-interrupt.rs:13:12
    |
-LL |     extern "x86-interrupt" fn dm7(_p: *const u8) {}
+LL |     extern "x86-interrupt" fn dm7(_p: [usize; 5]) {}
    |            ^^^^^^^^^^^^^^^
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
@@ -31,7 +31,7 @@ LL |     extern "x86-interrupt" fn dm7(_p: *const u8) {}
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-x86-interrupt.rs:20:12
    |
-LL |     extern "x86-interrupt" fn m7(_p: *const u8) {}
+LL |     extern "x86-interrupt" fn m7(_p: [usize; 5]) {}
    |            ^^^^^^^^^^^^^^^
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
@@ -41,7 +41,7 @@ LL |     extern "x86-interrupt" fn m7(_p: *const u8) {}
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-x86-interrupt.rs:25:12
    |
-LL |     extern "x86-interrupt" fn im7(_p: *const u8) {}
+LL |     extern "x86-interrupt" fn im7(_p: [usize; 5]) {}
    |            ^^^^^^^^^^^^^^^
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
@@ -51,7 +51,7 @@ LL |     extern "x86-interrupt" fn im7(_p: *const u8) {}
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-x86-interrupt.rs:28:18
    |
-LL | type A7 = extern "x86-interrupt" fn(*const u8);
+LL | type A7 = extern "x86-interrupt" fn([usize; 5]);
    |                  ^^^^^^^^^^^^^^^
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information


### PR DESCRIPTION
Unsized parameters or zero sized parameters provided to an function with the x86-interrupt abi could emit ICE. Such parameters are conceptually invalid. This commit implements parameter validation logic for the x86-iterrupt ABI to prevent these error classes and to improve user diagnostics.

Relevant unstable feature: https://github.com/rust-lang/rust/issues/40180
Fixes rust-lang/rust#124806
Fixes rust-lang/rust#126418
(May also close this, a reviewer's input would be optimal: https://github.com/rust-lang/rust/issues/63018. It depends on what the desired resolution is, because current rules don't bound the size requirements of frame though they could be trivially added. The bug itself seems to be resolved at this point.)
<!-- homu-ignore:start -->
---
**LLM assistance disclosure:** An LLM was used in the development of this PR, specifically for the following tasks:
- Querying about the repository's structure, common types, and existing patterns
- Preliminary code-review and style checks

There exists no LLM generated code, comments, documentation, or tests in this PR.
<!-- homu-ignore:end -->
