### PR TITLE
Remove confusing reference to “Immediate Undefined Behavior” from docs

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -96,7 +96,7 @@
 //! it is, the only safe approach is to ensure that they are indeed initialized.)
 //!
 //! An example of the implications of the above rules is that an expression such
-//! as `unsafe { &*(0 as *const u8) }` is Immediate Undefined Behavior.
+//! as `unsafe { &*(0 as *const u8) }` is Undefined Behavior.
 //!
 //! [valid value]: ../../reference/behavior-considered-undefined.html#invalid-values
 //!


### PR DESCRIPTION
The docs in core::ptr capitalize "Immediate Undefined Behavior" as if that were a technical term of art; it’s not. The code described just causes undefined behavior, not some special kind that is any more "Immediate" than usual.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
