### PR TITLE
docs(time): replace "method" with "function"

### DIFF
--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -345,7 +345,7 @@ impl Duration {
 
     /// Creates a new `Duration` from the specified number of weeks.
     ///
-    /// For this method, one week is defined as 7 days, or 604,800 seconds.
+    /// For this function, one week is defined as 7 days, or 604,800 seconds.
     ///
     /// # Panics
     ///
@@ -375,7 +375,7 @@ impl Duration {
 
     /// Creates a new `Duration` from the specified number of days.
     ///
-    /// For this method, one day is defined as 24 hours, or 86,400 seconds.
+    /// For this function, one day is defined as 24 hours, or 86,400 seconds.
     ///
     /// # Panics
     ///
@@ -405,7 +405,7 @@ impl Duration {
 
     /// Creates a new `Duration` from the specified number of hours.
     ///
-    /// For this method, one hour is defined as 60 minutes, or 3,600 seconds.
+    /// For this function, one hour is defined as 60 minutes, or 3,600 seconds.
     ///
     /// # Panics
     ///
@@ -435,7 +435,7 @@ impl Duration {
 
     /// Creates a new `Duration` from the specified number of minutes.
     ///
-    /// For this method, one minute is defined as 60 seconds.
+    /// For this function, one minute is defined as 60 seconds.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

I used the word "method" in rust-lang/rust#162195 and rust-lang/rust#162199, but these are associated functions, not methods, so I think it's correct to use the word "function".

@rustbot label +A-docs