### PR TITLE
Fix unsoundness bug on next trait solver for dyn const generics placeholder

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -1003,7 +1003,10 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
                         let kind = obligation.predicate.kind().skip_binder();
                         let keep = match kind {
                             ty::PredicateKind::Clause(ty::ClauseKind::ConstArgHasType(ct, _))
-                                if matches!(ct.kind(), ty::ConstKind::Param(..)) =>
+                                if matches!(
+                                    ct.kind(),
+                                    ty::ConstKind::Param(..) | ty::ConstKind::Placeholder(..)
+                                ) =>
                             {
                                 // ConstArgHasType clauses are not higher kinded. Assert as
                                 // such so we can fix this up if that ever changes.

--- a/tests/ui/const-generics/dyn-trait-ill-typed.rs
+++ b/tests/ui/const-generics/dyn-trait-ill-typed.rs
@@ -1,0 +1,14 @@
+//! Regression test for <https://github.com/rust-lang/trait-system-refactor-initiative/issues/296>.
+//@ compile-flags: -Znext-solver=globally
+//@ check-pass
+
+// CHECK PASS TO SHOW IT PASSES, BUT IT SHOULD NOT
+// THIS CODE SEGFAULTS, WITH REASON
+
+fn foo<const M: u32>() -> Box<dyn Tr<M>> {
+    loop {}
+}
+
+trait Tr<const N: usize> {}
+
+fn main() {}

--- a/tests/ui/const-generics/dyn-trait-ill-typed.rs
+++ b/tests/ui/const-generics/dyn-trait-ill-typed.rs
@@ -1,10 +1,11 @@
 //! Regression test for <https://github.com/rust-lang/trait-system-refactor-initiative/issues/296>.
 //@ compile-flags: -Znext-solver=globally
-//@ check-pass
+//@ check-fail
 
 // CHECK PASS TO SHOW IT PASSES, BUT IT SHOULD NOT
 // THIS CODE SEGFAULTS, WITH REASON
 
+//~v ERROR: the constant `M` is not of type `usize`
 fn foo<const M: u32>() -> Box<dyn Tr<M>> {
     loop {}
 }

--- a/tests/ui/const-generics/dyn-trait-ill-typed.stderr
+++ b/tests/ui/const-generics/dyn-trait-ill-typed.stderr
@@ -1,0 +1,14 @@
+error: the constant `M` is not of type `usize`
+  --> $DIR/dyn-trait-ill-typed.rs:9:27
+   |
+LL | fn foo<const M: u32>() -> Box<dyn Tr<M>> {
+   |                           ^^^^^^^^^^^^^^ expected `usize`, found `u32`
+   |
+note: required by a const generic parameter in `Tr`
+  --> $DIR/dyn-trait-ill-typed.rs:13:10
+   |
+LL | trait Tr<const N: usize> {}
+   |          ^^^^^^^^^^^^^^ required by this const generic parameter in `Tr`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

This seem to fix the related test, which would compile on next trait solver and should not.
It's related to the linked issue where it'd lead to a segmentation fault.

Closes https://github.com/rust-lang/trait-system-refactor-initiative/issues/296

r? @BoxyUwU 