### PR TITLE
Make `run-make` testsuite work with other codegen backend than LLVM

### DIFF
--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -203,6 +203,11 @@ impl TestCx<'_> {
             // through a specific CI runner).
             .env("LLVM_COMPONENTS", &self.config.llvm_components);
 
+        if let Some(codegen_backend) = &self.config.override_codegen_backend {
+            // In case it's a different codegen backend than LLVM.
+            cmd.env("RUSTC_CODEGEN_BACKEND", codegen_backend.as_str());
+        }
+
         // The `run-make-cargo` and `build-std` suites need an in-tree `cargo`, `run-make` does not.
         if matches!(self.config.suite, TestSuite::RunMakeCargo | TestSuite::BuildStd) {
             cmd.env(

--- a/src/tools/run-make-support/src/external_deps/rustc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustc.rs
@@ -76,6 +76,9 @@ pub fn rustc_path() -> String {
 fn setup_common() -> Command {
     let mut cmd = Command::new(rustc_path());
     set_host_compiler_dylib_path(&mut cmd);
+    if let Ok(codegen_backend) = std::env::var("RUSTC_CODEGEN_BACKEND") {
+        cmd.arg(format!("-Zcodegen-backend={codegen_backend}"));
+    }
     cmd
 }
 

--- a/tests/run-make/amdgpu-kd/rmake.rs
+++ b/tests/run-make/amdgpu-kd/rmake.rs
@@ -5,6 +5,7 @@
 
 //@ needs-llvm-components: amdgpu
 //@ needs-rust-lld
+//@ ignore-backends: gcc
 
 use run_make_support::targets::is_windows_gnu;
 use run_make_support::{llvm_readobj, rustc};

--- a/tests/run-make/atomic-lock-free/rmake.rs
+++ b/tests/run-make/atomic-lock-free/rmake.rs
@@ -2,6 +2,8 @@
 // guaranteed to be lock-free.
 
 //@ only-linux
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{llvm_components_contain, llvm_readobj, rustc};
 

--- a/tests/run-make/avr-custom-target-missing-cpu/rmake.rs
+++ b/tests/run-make/avr-custom-target-missing-cpu/rmake.rs
@@ -2,6 +2,7 @@
 // Make sure that reports the normal missing-CPU diagnostic instead of ICEing
 //
 //@ needs-llvm-components: avr
+//@ ignore-backends: gcc
 
 use run_make_support::rustc;
 

--- a/tests/run-make/avr-rjmp-offset/rmake.rs
+++ b/tests/run-make/avr-rjmp-offset/rmake.rs
@@ -1,5 +1,7 @@
 //@ needs-llvm-components: avr
 //@ needs-rust-lld
+//@ ignore-backends: gcc
+
 //! Regression test for #129301/llvm-project#106722 within `rustc`.
 //!
 //! Some LLVM-versions had wrong offsets in the local labels, causing the first

--- a/tests/run-make/branch-protection-check-IBT/rmake.rs
+++ b/tests/run-make/branch-protection-check-IBT/rmake.rs
@@ -37,6 +37,7 @@
 // FIXME(#93754): increase the test coverage of this test.
 //@ only-x86_64-unknown-linux-gnu
 //@ ignore-cross-compile
+//@ ignore-backends: gcc
 
 use run_make_support::{bare_rustc, llvm_readobj};
 

--- a/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
+++ b/tests/run-make/c-link-to-rust-va-list-fn/rmake.rs
@@ -8,6 +8,8 @@
 //@ ignore-sgx: (x86 machine code cannot be directly executed)
 //@ ignore-pauthtest: (it requires non-trivial compilation of c sources, and only supports dynamic
 //  linking, ignore the test).
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{cc, extra_c_flags, run, rustc, static_lib_name};
 

--- a/tests/run-make/cdylib/rmake.rs
+++ b/tests/run-make/cdylib/rmake.rs
@@ -9,6 +9,8 @@
 //     - `bar()` which implements basic addition.
 
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{cc, cwd, dynamic_lib_name, is_windows_msvc, rfs, run, rustc};
 

--- a/tests/run-make/codegen-options-parsing/rmake.rs
+++ b/tests/run-make/codegen-options-parsing/rmake.rs
@@ -2,6 +2,8 @@
 // contain specific helpful indications.
 
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::regex::Regex;
 use run_make_support::rustc;

--- a/tests/run-make/compressed-debuginfo/rmake.rs
+++ b/tests/run-make/compressed-debuginfo/rmake.rs
@@ -2,6 +2,8 @@
 
 //@ only-linux
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 // FIXME: This test isn't comprehensive and isn't covering all possible combinations.
 

--- a/tests/run-make/const-destruct-stable-toolchain/rmake.rs
+++ b/tests/run-make/const-destruct-stable-toolchain/rmake.rs
@@ -1,5 +1,7 @@
 //@ needs-target-std
-//
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 // Test that the suggestion to constrain a type parameter that is dropped in a const
 // function with a `[const] Destruct` bound is only offered on nightly, since the bound
 // requires an unstable feature.

--- a/tests/run-make/const-trait-stable-toolchain/rmake.rs
+++ b/tests/run-make/const-trait-stable-toolchain/rmake.rs
@@ -1,5 +1,7 @@
 //@ needs-target-std
-//
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 // Test output of const super trait errors in both stable and nightly.
 // We don't want to provide suggestions on stable that only make sense in nightly.
 

--- a/tests/run-make/cross-lang-lto-upstream-rlibs/rmake.rs
+++ b/tests/run-make/cross-lang-lto-upstream-rlibs/rmake.rs
@@ -1,5 +1,7 @@
 //@ needs-target-std
-//
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 // When using the flag -C linker-plugin-lto, static libraries could lose their upstream object
 // files during compilation. This bug was fixed in #53031, and this test compiles a staticlib
 // dependent on upstream, checking that the upstream object file still exists after no LTO and

--- a/tests/run-make/cross-lang-lto/rmake.rs
+++ b/tests/run-make/cross-lang-lto/rmake.rs
@@ -1,5 +1,7 @@
 //@ needs-target-std
-//
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 // This test checks that the object files we generate are actually
 // LLVM bitcode files (as used by linker LTO plugins) when compiling with
 // -Clinker-plugin-lto.

--- a/tests/run-make/embed-source-dwarf/rmake.rs
+++ b/tests/run-make/embed-source-dwarf/rmake.rs
@@ -3,6 +3,8 @@
 //@ ignore-apple
 //@ ignore-wasm (`object` doesn't handle wasm object files)
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 // This test should be replaced with one in tests/debuginfo once we can easily
 // tell via GDB or LLDB if debuginfo contains source code. Cheap tricks in LLDB

--- a/tests/run-make/emit-stack-sizes/rmake.rs
+++ b/tests/run-make/emit-stack-sizes/rmake.rs
@@ -10,6 +10,8 @@
 //@ only-elf
 // Reason: this feature only works when the output object format is ELF.
 // This won't be the case on Windows/OSX - for example, OSX produces a Mach-O binary.
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{llvm_readobj, rustc};
 

--- a/tests/run-make/extern-fn-explicit-align/rmake.rs
+++ b/tests/run-make/extern-fn-explicit-align/rmake.rs
@@ -7,6 +7,8 @@
 
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{build_native_static_lib, run, rustc};
 

--- a/tests/run-make/fat-lto-module-summary/rmake.rs
+++ b/tests/run-make/fat-lto-module-summary/rmake.rs
@@ -1,3 +1,6 @@
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 use run_make_support::{llvm_bcanalyzer, rustc};
 
 fn main() {

--- a/tests/run-make/fat-then-thin-lto/rmake.rs
+++ b/tests/run-make/fat-then-thin-lto/rmake.rs
@@ -4,6 +4,8 @@
 // and allowing users to build with lto=thin.
 
 //@ only-x86_64-unknown-linux-gnu
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{dynamic_lib_name, llvm_objdump, rustc};
 

--- a/tests/run-make/forced-unwind-terminate-pof/rmake.rs
+++ b/tests/run-make/forced-unwind-terminate-pof/rmake.rs
@@ -7,6 +7,8 @@
 //@ ignore-cross-compile
 //@ ignore-windows
 //Reason: pthread (POSIX threads) is not available on Windows
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{run, rustc};
 

--- a/tests/run-make/issue-149402-suggest-unresolve/rmake.rs
+++ b/tests/run-make/issue-149402-suggest-unresolve/rmake.rs
@@ -4,6 +4,8 @@
 //!
 //@ only-nightly
 //@ needs-target-std
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{diff, rustc, similar};
 

--- a/tests/run-make/link-cfg/rmake.rs
+++ b/tests/run-make/link-cfg/rmake.rs
@@ -13,6 +13,7 @@
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
 //@ needs-llvm-components: x86
+//@ ignore-backends: gcc
 
 use run_make_support::{bare_rustc, build_native_dynamic_lib, build_native_static_lib, run, rustc};
 

--- a/tests/run-make/link-eh-frame-terminator/rmake.rs
+++ b/tests/run-make/link-eh-frame-terminator/rmake.rs
@@ -10,6 +10,8 @@
 // Reason: the usage of a large array in the test causes an out-of-memory
 // error on 32 bit systems.
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{bin_name, llvm_objdump, run, rustc};
 

--- a/tests/run-make/linker-plugin-lto-fat/rmake.rs
+++ b/tests/run-make/linker-plugin-lto-fat/rmake.rs
@@ -5,6 +5,8 @@
 
 //@ only-x86_64-unknown-linux-gnu
 //@ needs-rust-lld
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{dynamic_lib_name, llvm_as, llvm_objdump, rustc};
 

--- a/tests/run-make/llvm-ident/rmake.rs
+++ b/tests/run-make/llvm-ident/rmake.rs
@@ -1,5 +1,7 @@
 //@ only-linux
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::llvm::llvm_bin_dir;
 use run_make_support::{

--- a/tests/run-make/llvm-location-discriminator-limit-dummy-span/rmake.rs
+++ b/tests/run-make/llvm-location-discriminator-limit-dummy-span/rmake.rs
@@ -10,6 +10,8 @@
 //@ ignore-cross-compile
 //@ needs-dynamic-linking
 //@ only-nightly (requires unstable rustc flag)
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 // This test trips a check in the MSVC linker for an outdated processor:
 // "LNK1322: cannot avoid potential ARM hazard (Cortex-A53 MPCore processor bug #843419)"

--- a/tests/run-make/lto-avoid-object-duplication/rmake.rs
+++ b/tests/run-make/lto-avoid-object-duplication/rmake.rs
@@ -15,6 +15,8 @@
 // Only checking on Unix platforms should suffice.
 //FIXME(Oneirical): This could be adapted to work on Windows by checking how
 // that output differs.
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{llvm_objdump, regex, rust_lib_name, rustc, static_lib_name};
 

--- a/tests/run-make/lto-empty/rmake.rs
+++ b/tests/run-make/lto-empty/rmake.rs
@@ -6,6 +6,8 @@
 // See https://github.com/rust-lang/rust/issues/63349
 
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::rustc;
 

--- a/tests/run-make/lto-linkage-used-attr/rmake.rs
+++ b/tests/run-make/lto-linkage-used-attr/rmake.rs
@@ -6,6 +6,8 @@
 
 //@ only-x86_64-unknown-linux-gnu
 // Reason: some of the inline assembly directives are architecture-specific.
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::rustc;
 

--- a/tests/run-make/lto-long-filenames/rmake.rs
+++ b/tests/run-make/lto-long-filenames/rmake.rs
@@ -8,6 +8,8 @@
 // See https://github.com/rust-lang/rust/issues/49914
 
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{rfs, rustc};
 

--- a/tests/run-make/lto-long-filenames_cn/rmake.rs
+++ b/tests/run-make/lto-long-filenames_cn/rmake.rs
@@ -5,6 +5,8 @@
 // as this is not something rustc can fix by itself,
 // we just skip the test on windows-gnu for now. Hence:
 //@ ignore-windows-gnu
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{rfs, rustc};
 

--- a/tests/run-make/lto-no-link-whole-rlib/rmake.rs
+++ b/tests/run-make/lto-no-link-whole-rlib/rmake.rs
@@ -5,6 +5,8 @@
 
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{build_native_static_lib, run, rustc};
 

--- a/tests/run-make/lto-readonly-lib/rmake.rs
+++ b/tests/run-make/lto-readonly-lib/rmake.rs
@@ -6,6 +6,8 @@
 // See https://github.com/rust-lang/rust/pull/17619
 
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{run, rust_lib_name, rustc, test_while_readonly};
 

--- a/tests/run-make/lto-smoke-c/rmake.rs
+++ b/tests/run-make/lto-smoke-c/rmake.rs
@@ -5,6 +5,8 @@
 
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{cc, extra_c_flags, extra_cxx_flags, run, rustc, static_lib_name};
 

--- a/tests/run-make/lto-smoke/rmake.rs
+++ b/tests/run-make/lto-smoke/rmake.rs
@@ -4,6 +4,8 @@
 // See https://github.com/rust-lang/rust/issues/10741
 
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::rustc;
 

--- a/tests/run-make/min-global-align/rmake.rs
+++ b/tests/run-make/min-global-align/rmake.rs
@@ -6,6 +6,8 @@
 //@ only-linux
 // Reason: this test is specific to linux, considering compilation is targeted
 // towards linux architectures only.
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{assert_count_is, llvm_components_contain, rfs, rustc};
 

--- a/tests/run-make/mismatching-target-triples/rmake.rs
+++ b/tests/run-make/mismatching-target-triples/rmake.rs
@@ -5,6 +5,7 @@
 // error message is used.
 // See https://github.com/rust-lang/rust/issues/10814
 //@ needs-llvm-components: x86
+//@ ignore-backends: gcc
 
 use run_make_support::rustc;
 

--- a/tests/run-make/missing-unstable-trait-bound/rmake.rs
+++ b/tests/run-make/missing-unstable-trait-bound/rmake.rs
@@ -2,6 +2,8 @@
 //@ ignore-wasm32
 //@ ignore-wasm64
 // ignore-tidy-linelength
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 // Ensure that on stable we don't suggest restricting with an unsafe trait and we continue
 // mentioning the rest of the obligation chain.

--- a/tests/run-make/musl-default-linking/rmake.rs
+++ b/tests/run-make/musl-default-linking/rmake.rs
@@ -5,6 +5,7 @@ use run_make_support::{rustc, serde_json};
 // we should be trying to move these targets to dynamically link
 // musl libc by default.
 //@ needs-llvm-components: aarch64 arm powerpc x86
+//@ ignore-backends: gcc
 static LEGACY_STATIC_LINKING_TARGETS: &[&'static str] = &[
     "aarch64-unknown-linux-musl",
     "arm-unknown-linux-musleabi",

--- a/tests/run-make/naked-symbol-visibility/rmake.rs
+++ b/tests/run-make/naked-symbol-visibility/rmake.rs
@@ -2,6 +2,8 @@
 //@ only-x86_64
 //@ needs-target-std
 //@ needs-crate-type: dylib
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::object::ObjectSymbol;
 use run_make_support::object::read::{File, Object, Symbol};

--- a/tests/run-make/no-builtins-attribute/rmake.rs
+++ b/tests/run-make/no-builtins-attribute/rmake.rs
@@ -1,4 +1,7 @@
 //@ needs-target-std
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 // `no_builtins` is an attribute related to LLVM's optimizations. In order to ensure that it has an
 // effect on link-time optimizations (LTO), it should be added to function declarations in a crate.
 // This test uses the `llvm-filecheck` tool to determine that this attribute is successfully

--- a/tests/run-make/no-builtins-linker-plugin-lto/rmake.rs
+++ b/tests/run-make/no-builtins-linker-plugin-lto/rmake.rs
@@ -1,4 +1,6 @@
 //@ only-x86_64-unknown-linux-gnu
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use std::fs;
 use std::path::Path;

--- a/tests/run-make/no-builtins-lto/rmake.rs
+++ b/tests/run-make/no-builtins-lto/rmake.rs
@@ -1,4 +1,6 @@
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 // The rlib produced by a no_builtins crate should be explicitly linked
 // during compilation, and as a result be present in the linker arguments.

--- a/tests/run-make/optimization-remarks-dir-pgo/rmake.rs
+++ b/tests/run-make/optimization-remarks-dir-pgo/rmake.rs
@@ -6,6 +6,8 @@
 
 //@ needs-profiler-runtime
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{
     has_extension, has_prefix, invalid_utf8_contains, llvm_profdata, run, rustc, shallow_find_files,

--- a/tests/run-make/output-type-permutations/rmake.rs
+++ b/tests/run-make/output-type-permutations/rmake.rs
@@ -6,6 +6,8 @@
 
 //@ ignore-cross-compile
 // Reason: some cross-compiled targets don't support various crate types and fail to link.
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use std::path::PathBuf;
 

--- a/tests/run-make/pgo-branch-weights/rmake.rs
+++ b/tests/run-make/pgo-branch-weights/rmake.rs
@@ -9,6 +9,8 @@
 
 //@ needs-profiler-runtime
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use std::path::Path;
 

--- a/tests/run-make/pgo-embed-bc-lto/rmake.rs
+++ b/tests/run-make/pgo-embed-bc-lto/rmake.rs
@@ -4,6 +4,8 @@
 
 //@ needs-profiler-runtime
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use std::path::Path;
 

--- a/tests/run-make/pgo-gen-lto/rmake.rs
+++ b/tests/run-make/pgo-gen-lto/rmake.rs
@@ -6,6 +6,8 @@
 // Reason: this exercises LTO profiling
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{cwd, has_extension, has_prefix, run, rustc, shallow_find_files};
 

--- a/tests/run-make/pgo-gen-no-imp-symbols/rmake.rs
+++ b/tests/run-make/pgo-gen-no-imp-symbols/rmake.rs
@@ -1,5 +1,7 @@
 //@ needs-target-std
-//
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 // LLVM's profiling instrumentation adds a few symbols that are used by the profiler runtime.
 // Since these show up as globals in the LLVM IR, the compiler generates dllimport-related
 // __imp_ stubs for them. This can lead to linker errors because the instrumentation

--- a/tests/run-make/pgo-indirect-call-promotion/rmake.rs
+++ b/tests/run-make/pgo-indirect-call-promotion/rmake.rs
@@ -9,6 +9,8 @@
 // Reason: llvm_profdata is used
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{llvm_filecheck, llvm_profdata, rfs, run, rustc};
 

--- a/tests/run-make/pgo-use/rmake.rs
+++ b/tests/run-make/pgo-use/rmake.rs
@@ -7,6 +7,8 @@
 
 //@ needs-profiler-runtime
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{
     cwd, has_extension, has_prefix, llvm_filecheck, llvm_profdata, rfs, run_with_args, rustc,

--- a/tests/run-make/print-cfg/rmake.rs
+++ b/tests/run-make/print-cfg/rmake.rs
@@ -9,6 +9,7 @@
 //@ needs-llvm-components: arm x86 webassembly
 // Note: without the needs-llvm-components it will fail on LLVM built without the required
 // components listed above.
+//@ ignore-backends: gcc
 
 use std::collections::HashSet;
 use std::iter::FromIterator;

--- a/tests/run-make/print-request-help-stable-unstable/rmake.rs
+++ b/tests/run-make/print-request-help-stable-unstable/rmake.rs
@@ -1,6 +1,10 @@
 //! Check that unstable print requests are omitted from help if compiler is in stable channel.
 //!
 //! Issue: <https://github.com/rust-lang/rust/issues/138698>
+
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 use run_make_support::{diff, rustc, similar};
 
 fn main() {

--- a/tests/run-make/print-target-cpus-native/rmake.rs
+++ b/tests/run-make/print-target-cpus-native/rmake.rs
@@ -1,6 +1,7 @@
 //@ ignore-cross-compile
 //@ needs-llvm-components: aarch64 x86
 // FIXME(#132514): Is needs-llvm-components actually necessary for this test?
+//@ ignore-backends: gcc
 
 use run_make_support::{assert_contains_regex, rfs, rustc, target};
 

--- a/tests/run-make/print-target-list/rmake.rs
+++ b/tests/run-make/print-target-list/rmake.rs
@@ -5,6 +5,7 @@
 //@ needs-llvm-components: aarch64 arm avr bpf csky hexagon loongarch m68k mips msp430 nvptx powerpc riscv sparc systemz webassembly x86
 // FIXME(jieyouxu): there has to be a better way to do this, without the needs-llvm-components it
 // will fail on LLVM built without all of the components listed above.
+//@ ignore-backends: gcc
 
 use run_make_support::bare_rustc;
 

--- a/tests/run-make/print-to-output/rmake.rs
+++ b/tests/run-make/print-to-output/rmake.rs
@@ -6,6 +6,7 @@
 // will fail on LLVM built without all of the components listed above. If adding a new target that
 // relies on a llvm component not listed above, it will need to be added to the required llvm
 // components above.
+//@ ignore-backends: gcc
 
 use std::path::PathBuf;
 

--- a/tests/run-make/reachable-extern-fn-available-lto/rmake.rs
+++ b/tests/run-make/reachable-extern-fn-available-lto/rmake.rs
@@ -8,6 +8,8 @@
 // See https://github.com/rust-lang/rust/issues/14500
 
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{cc, extra_c_flags, run, rustc, static_lib_name};
 

--- a/tests/run-make/remap-path-prefix-dwarf/rmake.rs
+++ b/tests/run-make/remap-path-prefix-dwarf/rmake.rs
@@ -7,6 +7,8 @@
 //@ needs-target-std
 //@ ignore-windows
 // Reason: the remap path prefix is not printed in the dwarf dump.
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{cwd, is_darwin, llvm_dwarfdump, rust_lib_name, rustc};
 

--- a/tests/run-make/repr128-dwarf/rmake.rs
+++ b/tests/run-make/repr128-dwarf/rmake.rs
@@ -1,6 +1,9 @@
 //@ ignore-cross-compile
 //@ ignore-wasm (`object` can't handle wasm object files)
 //@ ignore-windows
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 // This test should be replaced with one in tests/debuginfo once GDB or LLDB support 128-bit enums.
 
 use std::collections::HashMap;

--- a/tests/run-make/reproducible-build-2/rmake.rs
+++ b/tests/run-make/reproducible-build-2/rmake.rs
@@ -11,6 +11,9 @@
 //@ ignore-windows-gnu
 // GNU Linker for Windows is non-deterministic.
 
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 use run_make_support::{bin_name, is_windows_msvc, rfs, rust_lib_name, rustc};
 
 fn main() {

--- a/tests/run-make/reproducible-build/rmake.rs
+++ b/tests/run-make/reproducible-build/rmake.rs
@@ -21,6 +21,8 @@
 // Tracking Issue: https://github.com/rust-lang/rust/issues/129080
 
 //@ ignore-cross-compile (linker binary needs to run)
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{
     bin_name, cwd, diff, is_darwin, is_windows, regex, rfs, run_in_tmpdir, rust_lib_name, rustc,

--- a/tests/run-make/requires-consistent-cpu-no-native/rmake.rs
+++ b/tests/run-make/requires-consistent-cpu-no-native/rmake.rs
@@ -10,6 +10,9 @@
 // Finally, the test verifies that `-Ctarget-cpu=native` is rejected when using
 // the second custom target.
 
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 use std::fs;
 
 use run_make_support::*;

--- a/tests/run-make/rustc-help/rmake.rs
+++ b/tests/run-make/rustc-help/rmake.rs
@@ -1,5 +1,8 @@
 // Tests `rustc --help` and similar invocations against snapshots and each other.
 
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 use run_make_support::{bare_rustc, diff, similar};
 
 fn main() {

--- a/tests/run-make/rustdoc/flag-namespaces-from-rustc/rmake.rs
+++ b/tests/run-make/rustdoc/flag-namespaces-from-rustc/rmake.rs
@@ -1,3 +1,6 @@
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 use run_make_support::{Diff, rustc, rustdoc};
 
 fn compare_outputs(args: &[&str]) {

--- a/tests/run-make/rustdoc/target-modifiers/rmake.rs
+++ b/tests/run-make/rustdoc/target-modifiers/rmake.rs
@@ -5,6 +5,9 @@
 //!
 //! Please see https://github.com/rust-lang/rust/issues/144521.
 
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 use run_make_support::{rustc, rustdoc};
 
 fn main() {

--- a/tests/run-make/sanitizer-cdylib-link/rmake.rs
+++ b/tests/run-make/sanitizer-cdylib-link/rmake.rs
@@ -7,6 +7,8 @@
 
 //@ needs-sanitizer-support
 //@ needs-sanitizer-address
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 //@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
 

--- a/tests/run-make/sanitizer-dylib-link/rmake.rs
+++ b/tests/run-make/sanitizer-dylib-link/rmake.rs
@@ -6,6 +6,8 @@
 
 //@ needs-sanitizer-support
 //@ needs-sanitizer-address
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 //@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
 

--- a/tests/run-make/sanitizer-staticlib-link/rmake.rs
+++ b/tests/run-make/sanitizer-staticlib-link/rmake.rs
@@ -10,6 +10,8 @@
 
 //@ needs-sanitizer-support
 //@ needs-sanitizer-address
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 //@ compile-flags: -C unsafe-allow-abi-mismatch=sanitizer
 

--- a/tests/run-make/simd-ffi/rmake.rs
+++ b/tests/run-make/simd-ffi/rmake.rs
@@ -5,6 +5,9 @@
 // Note that this test does not check linking or binary execution.
 // See https://github.com/rust-lang/rust/pull/21233
 
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 use run_make_support::{llvm_components_contain, rustc};
 
 fn main() {

--- a/tests/run-make/split-debuginfo/rmake.rs
+++ b/tests/run-make/split-debuginfo/rmake.rs
@@ -55,6 +55,9 @@
 // at all, and lumped windows-msvc and windows-gnu together at that.
 //@ ignore-windows-gnu
 
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 #![deny(warnings)]
 
 use std::collections::BTreeSet;

--- a/tests/run-make/static-pie/rmake.rs
+++ b/tests/run-make/static-pie/rmake.rs
@@ -4,6 +4,8 @@
 //@ only-x86_64
 //@ only-linux
 //@ ignore-32bit
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use std::process::Command;
 

--- a/tests/run-make/target-cpu-precedence/rmake.rs
+++ b/tests/run-make/target-cpu-precedence/rmake.rs
@@ -2,6 +2,7 @@
 // the last value is used both for the corresponding target modifier in the
 // crate metadata and for the target CPU recorded in the LLVM IR.
 //@ needs-llvm-components: nvptx
+//@ ignore-backends: gcc
 
 use run_make_support::*;
 

--- a/tests/run-make/target-specs/rmake.rs
+++ b/tests/run-make/target-specs/rmake.rs
@@ -5,6 +5,7 @@
 // using them correctly, or fails with the right error message when using them improperly.
 // See https://github.com/rust-lang/rust/pull/16156
 //@ needs-llvm-components: x86
+//@ ignore-backends: gcc
 
 use run_make_support::{diff, rfs, rustc};
 

--- a/tests/run-make/target-without-atomic-cas/rmake.rs
+++ b/tests/run-make/target-without-atomic-cas/rmake.rs
@@ -5,6 +5,8 @@
 
 // ignore-tidy-linelength
 //@ needs-llvm-components: arm
+//@ ignore-backends: gcc
+
 // Note: without the needs-llvm-components it will fail on LLVM built without all of the components
 // listed above. If any new targets are added, please double-check their respective llvm components
 // are specified above.

--- a/tests/run-make/thumb-interworking/rmake.rs
+++ b/tests/run-make/thumb-interworking/rmake.rs
@@ -1,5 +1,7 @@
 //@ needs-llvm-components: arm
 //@ needs-rust-lld
+//@ ignore-backends: gcc
+
 use run_make_support::{
     llvm_filecheck, llvm_objdump, path, rfs, run, rustc, rustc_minicore, source_root,
 };

--- a/tests/run-make/track-pgo-dep-info/rmake.rs
+++ b/tests/run-make/track-pgo-dep-info/rmake.rs
@@ -7,6 +7,8 @@
 //@ ignore-cross-compile
 // Reason: the binary is executed
 //@ needs-profiler-runtime
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{llvm_profdata, rfs, run, rustc};
 

--- a/tests/run-make/used-proc-macro/rmake.rs
+++ b/tests/run-make/used-proc-macro/rmake.rs
@@ -4,6 +4,8 @@
 //@ ignore-windows llvm-readobj --all doesn't show local symbols on Windows
 //@ needs-crate-type: proc-macro
 //@ ignore-musl (FIXME: can't find `-lunwind`)
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{dynamic_lib_name, llvm_readobj, rustc};
 

--- a/tests/run-make/volatile-intrinsics/rmake.rs
+++ b/tests/run-make/volatile-intrinsics/rmake.rs
@@ -1,4 +1,6 @@
 //@ ignore-cross-compile
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
 
 use run_make_support::{assert_contains, rfs, run, rustc};
 

--- a/tests/run-make/wasm-unexpected-features/rmake.rs
+++ b/tests/run-make/wasm-unexpected-features/rmake.rs
@@ -1,4 +1,7 @@
 //@ needs-rust-lld
+// FIXME: Once GCC backend is fixed, remove this `ignore-backends`.
+//@ ignore-backends: gcc
+
 use std::path::Path;
 
 use run_make_support::{path, rfs, rustc, rustc_minicore, wasmparser};


### PR DESCRIPTION
Needed for rust-lang/rust#159924.

Currently, we always run `run-make` testsuite with the codegen backend rustc was compiled with. However, in CI it's compiled with LLVM, so when we want to test with GCC (with `--test-codegen-backend`), it compiles `rmake.rs` with the GCC backend, but when running the test, it doesn't use the GCC backend since it just calls `rustc`. So to get around that, I now pass the codegen backend through the environment and set it in the `rustc` function of `run_make_support`.

To be noted that for now it's only for the `rustc` function, no other command uses it. Should I extend it right away for all commands (well, likely only `cargo`) or just `rustc` for now is enough?

r? @jieyouxu 