### PR TITLE
Parallelize gathering constraints in the borrow checker

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -1,6 +1,7 @@
 use std::fmt;
-use std::rc::Rc;
+use std::sync::Arc;
 
+use rustc_data_structures::marker::{DynSend, DynSync};
 use rustc_errors::Diag;
 use rustc_hir::def_id::LocalDefId;
 use rustc_infer::infer::region_constraints::{Constraint, ConstraintKind, RegionConstraintData};
@@ -35,7 +36,7 @@ pub(crate) enum UniverseInfo<'tcx> {
     /// Relating two types which have binders.
     RelateTys { expected: Ty<'tcx>, found: Ty<'tcx> },
     /// Created from performing a `TypeOp`.
-    TypeOp(Rc<dyn TypeOpInfo<'tcx> + 'tcx>),
+    TypeOp(Arc<dyn TypeOpInfo<'tcx> + DynSend + DynSync + 'tcx>),
     /// Any other reason.
     Other,
 }
@@ -89,7 +90,7 @@ pub(crate) trait ToUniverseInfo<'tcx> {
 
 impl<'tcx> ToUniverseInfo<'tcx> for crate::type_check::InstantiateOpaqueType<'tcx> {
     fn to_universe_info(self, base_universe: ty::UniverseIndex) -> UniverseInfo<'tcx> {
-        UniverseInfo::TypeOp(Rc::new(crate::type_check::InstantiateOpaqueType {
+        UniverseInfo::TypeOp(Arc::new(crate::type_check::InstantiateOpaqueType {
             base_universe: Some(base_universe),
             ..self
         }))
@@ -98,21 +99,24 @@ impl<'tcx> ToUniverseInfo<'tcx> for crate::type_check::InstantiateOpaqueType<'tc
 
 impl<'tcx> ToUniverseInfo<'tcx> for CanonicalTypeOpProvePredicateGoal<'tcx> {
     fn to_universe_info(self, base_universe: ty::UniverseIndex) -> UniverseInfo<'tcx> {
-        UniverseInfo::TypeOp(Rc::new(PredicateQuery { canonical_query: self, base_universe }))
+        UniverseInfo::TypeOp(Arc::new(PredicateQuery { canonical_query: self, base_universe }))
     }
 }
 
-impl<'tcx, T: Copy + fmt::Display + TypeFoldable<TyCtxt<'tcx>> + 'tcx> ToUniverseInfo<'tcx>
-    for CanonicalTypeOpNormalizeGoal<'tcx, T>
+impl<'tcx, T: Copy + fmt::Display + TypeFoldable<TyCtxt<'tcx>> + DynSend + DynSync + 'tcx>
+    ToUniverseInfo<'tcx> for CanonicalTypeOpNormalizeGoal<'tcx, T>
 {
     fn to_universe_info(self, base_universe: ty::UniverseIndex) -> UniverseInfo<'tcx> {
-        UniverseInfo::TypeOp(Rc::new(NormalizeQuery { canonical_query: self, base_universe }))
+        UniverseInfo::TypeOp(Arc::new(NormalizeQuery { canonical_query: self, base_universe }))
     }
 }
 
 impl<'tcx> ToUniverseInfo<'tcx> for CanonicalTypeOpAscribeUserTypeGoal<'tcx> {
     fn to_universe_info(self, base_universe: ty::UniverseIndex) -> UniverseInfo<'tcx> {
-        UniverseInfo::TypeOp(Rc::new(AscribeUserTypeQuery { canonical_query: self, base_universe }))
+        UniverseInfo::TypeOp(Arc::new(AscribeUserTypeQuery {
+            canonical_query: self,
+            base_universe,
+        }))
     }
 }
 

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -17,7 +17,7 @@ use std::borrow::Cow;
 use std::cell::{OnceCell, RefCell};
 use std::marker::PhantomData;
 use std::ops::{ControlFlow, Deref};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use borrow_set::LocalsStateAtExit;
 use polonius_engine::AllFacts;
@@ -303,7 +303,7 @@ struct CollectRegionConstraintsResult<'tcx> {
     move_data: MoveData<'tcx>,
     borrow_set: BorrowSet<'tcx>,
     location_table: PoloniusLocationTable,
-    location_map: Rc<DenseLocationMap>,
+    location_map: Arc<DenseLocationMap>,
     universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
     region_bound_pairs: Frozen<RegionBoundPairs<'tcx>>,
     known_type_outlives_obligations: Frozen<Vec<ty::PolyTypeOutlivesClause<'tcx>>>,
@@ -347,7 +347,7 @@ fn borrowck_collect_region_constraints(
     let locals_are_invalidated_at_exit = tcx.hir_body_owner_kind(def).is_fn_or_closure();
     let borrow_set = BorrowSet::build(tcx, body, locals_are_invalidated_at_exit, &move_data);
 
-    let location_map = Rc::new(DenseLocationMap::new(body));
+    let location_map = Arc::new(DenseLocationMap::new(body));
 
     let mut polonius_facts =
         (polonius_input || PoloniusFacts::enabled(infcx.tcx)).then_some(PoloniusFacts::default());
@@ -370,7 +370,7 @@ fn borrowck_collect_region_constraints(
         &borrow_set,
         &mut polonius_facts,
         &move_data,
-        Rc::clone(&location_map),
+        Arc::clone(&location_map),
     );
 
     CollectRegionConstraintsResult {

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -318,11 +318,11 @@ struct CollectRegionConstraintsResult<'tcx> {
 /// the current body. This initializes the relevant data structures
 /// and then type checks the MIR body.
 fn borrowck_collect_region_constraints(
-    tcx: TyCtxt,
+    tcx: TyCtxt<'_>,
     root_def_id: LocalDefId,
     def: LocalDefId,
     polonius_input: bool,
-) -> CollectRegionConstraintsResult {
+) -> CollectRegionConstraintsResult<'_> {
     let infcx = BorrowckInferCtxt::new(tcx, def, root_def_id);
     let (input_body, promoted) = tcx.mir_promoted(def);
     let input_body: &Body<'_> = &input_body.borrow();

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -317,12 +317,13 @@ struct CollectRegionConstraintsResult<'tcx> {
 /// Start borrow checking by collecting the region constraints for
 /// the current body. This initializes the relevant data structures
 /// and then type checks the MIR body.
-fn borrowck_collect_region_constraints<'tcx>(
-    root_cx: &BorrowCheckRootCtxt<'_, 'tcx>,
+fn borrowck_collect_region_constraints(
+    tcx: TyCtxt,
+    root_def_id: LocalDefId,
     def: LocalDefId,
-) -> CollectRegionConstraintsResult<'tcx> {
-    let tcx = root_cx.tcx;
-    let infcx = BorrowckInferCtxt::new(tcx, def, root_cx.root_def_id());
+    polonius_input: bool,
+) -> CollectRegionConstraintsResult {
+    let infcx = BorrowckInferCtxt::new(tcx, def, root_def_id);
     let (input_body, promoted) = tcx.mir_promoted(def);
     let input_body: &Body<'_> = &input_body.borrow();
     let input_promoted: &IndexSlice<_, _> = &promoted.borrow();
@@ -348,8 +349,6 @@ fn borrowck_collect_region_constraints<'tcx>(
 
     let location_map = Rc::new(DenseLocationMap::new(body));
 
-    let polonius_input = root_cx.consumer.as_ref().map_or(false, |c| c.polonius_input())
-        || infcx.tcx.sess.opts.unstable_opts.polonius.is_legacy_enabled();
     let mut polonius_facts =
         (polonius_input || PoloniusFacts::enabled(infcx.tcx)).then_some(PoloniusFacts::default());
 
@@ -362,7 +361,7 @@ fn borrowck_collect_region_constraints<'tcx>(
         deferred_closure_requirements,
         polonius_context,
     } = type_check::type_check(
-        root_cx,
+        root_def_id,
         &infcx,
         body,
         &promoted,

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -318,7 +318,7 @@ struct CollectRegionConstraintsResult<'tcx> {
 /// the current body. This initializes the relevant data structures
 /// and then type checks the MIR body.
 fn borrowck_collect_region_constraints<'tcx>(
-    root_cx: &mut BorrowCheckRootCtxt<'_, 'tcx>,
+    root_cx: &BorrowCheckRootCtxt<'_, 'tcx>,
     def: LocalDefId,
 ) -> CollectRegionConstraintsResult<'tcx> {
     let tcx = root_cx.tcx;

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -2,8 +2,8 @@
 
 use std::io;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use polonius_engine::{Algorithm, AllFacts, Output};
 use rustc_data_structures::frozen::Frozen;
@@ -85,7 +85,7 @@ pub(crate) fn replace_regions_in_mir<'tcx>(
 pub(crate) fn compute_closure_requirements_modulo_opaques<'tcx>(
     infcx: &BorrowckInferCtxt<'tcx>,
     body: &Body<'tcx>,
-    location_map: Rc<DenseLocationMap>,
+    location_map: Arc<DenseLocationMap>,
     universal_region_relations: &Frozen<UniversalRegionRelations<'tcx>>,
     constraints: &MirTypeckRegionConstraints<'tcx>,
 ) -> Option<ClosureRegionRequirements<'tcx>> {
@@ -117,7 +117,7 @@ pub(crate) fn compute_regions<'tcx>(
     location_table: &PoloniusLocationTable,
     move_data: &MoveData<'tcx>,
     borrow_set: &BorrowSet<'tcx>,
-    location_map: Rc<DenseLocationMap>,
+    location_map: Arc<DenseLocationMap>,
     universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
     constraints: MirTypeckRegionConstraints<'tcx>,
     mut polonius_facts: Option<AllFacts<RustcFacts>>,

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use std::fmt;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use rustc_data_structures::frozen::Frozen;
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
@@ -334,7 +334,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         infcx: &BorrowckInferCtxt<'tcx>,
         lowered_constraints: LoweredConstraints<'tcx>,
         universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
-        location_map: Rc<DenseLocationMap>,
+        location_map: Arc<DenseLocationMap>,
     ) -> Self {
         let universal_regions = &universal_region_relations.universal_regions;
 

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
@@ -1,5 +1,5 @@
 use std::iter;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use rustc_data_structures::frozen::Frozen;
 use rustc_data_structures::fx::FxIndexMap;
@@ -205,7 +205,7 @@ pub(crate) fn compute_definition_site_hidden_types<'tcx>(
     infcx: &BorrowckInferCtxt<'tcx>,
     universal_region_relations: &Frozen<UniversalRegionRelations<'tcx>>,
     constraints: &MirTypeckRegionConstraints<'tcx>,
-    location_map: Rc<DenseLocationMap>,
+    location_map: Arc<DenseLocationMap>,
     hidden_types: &mut FxIndexMap<LocalDefId, ty::DefinitionSiteHiddenType<'tcx>>,
     unconstrained_hidden_type_errors: &mut Vec<UnexpectedHiddenRegion<'tcx>>,
     opaque_types: &[(OpaqueTypeKey<'tcx>, ProvisionalHiddenType<'tcx>)],

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/region_ctxt.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/region_ctxt.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use rustc_data_structures::frozen::Frozen;
 use rustc_index::IndexVec;
@@ -38,7 +38,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
     pub(super) fn new(
         infcx: &'a BorrowckInferCtxt<'tcx>,
         universal_region_relations: &'a Frozen<UniversalRegionRelations<'tcx>>,
-        location_map: Rc<DenseLocationMap>,
+        location_map: Arc<DenseLocationMap>,
         constraints: &MirTypeckRegionConstraints<'tcx>,
     ) -> RegionCtxt<'a, 'tcx> {
         let mut outlives_constraints = constraints.outlives_constraints.clone();

--- a/compiler/rustc_borrowck/src/region_infer/values.rs
+++ b/compiler/rustc_borrowck/src/region_infer/values.rs
@@ -1,5 +1,5 @@
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_index::Idx;
@@ -52,7 +52,7 @@ enum LiveRegions {
 #[derive(Clone)] // FIXME(#146079)
 pub(crate) struct LivenessValues {
     /// The map from locations to points.
-    location_map: Rc<DenseLocationMap>,
+    location_map: Arc<DenseLocationMap>,
 
     /// Where a region is live.
     live_regions: LiveRegions,
@@ -63,7 +63,7 @@ pub(crate) struct LivenessValues {
 
 impl LivenessValues {
     /// Create an empty map of regions to locations where they're live.
-    pub(crate) fn with_specific_points(location_map: Rc<DenseLocationMap>) -> Self {
+    pub(crate) fn with_specific_points(location_map: Arc<DenseLocationMap>) -> Self {
         LivenessValues {
             live_regions: LiveRegions::AtPoints(SparseIntervalMatrix::new(
                 location_map.num_points(),
@@ -77,7 +77,7 @@ impl LivenessValues {
     ///
     /// Unlike `with_specific_points`, does not track exact locations where something is live, only
     /// which regions are live.
-    pub(crate) fn without_specific_points(location_map: Rc<DenseLocationMap>) -> Self {
+    pub(crate) fn without_specific_points(location_map: Arc<DenseLocationMap>) -> Self {
         LivenessValues {
             live_regions: LiveRegions::InBody(Default::default()),
             location_map,
@@ -269,7 +269,7 @@ impl<'tcx> PlaceholderIndices<'tcx> {
 /// because (since it is returned) it must live for at least `'a`. But
 /// it would also contain various points from within the function.
 pub(crate) struct RegionValues<'tcx, N: Idx> {
-    location_map: Rc<DenseLocationMap>,
+    location_map: Arc<DenseLocationMap>,
     placeholder_indices: PlaceholderIndices<'tcx>,
     points: SparseIntervalMatrix<N, PointIndex>,
     free_regions: SparseBitMatrix<N, RegionVid>,
@@ -284,7 +284,7 @@ impl<'tcx, N: Idx> RegionValues<'tcx, N> {
     /// Each of the regions in num_region_variables will be initialized with an
     /// empty set of points and no causal information.
     pub(crate) fn new(
-        location_map: Rc<DenseLocationMap>,
+        location_map: Arc<DenseLocationMap>,
         num_universal_regions: usize,
         placeholder_indices: PlaceholderIndices<'tcx>,
     ) -> Self {

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -36,11 +36,6 @@ pub(super) struct BorrowCheckRootCtxt<'diag, 'tcx: 'diag> {
     /// Only used for deferred error reporting. See
     /// [`crate::region_infer::opaque_types::handle_unconstrained_hidden_type_errors`]
     unconstrained_hidden_type_errors: Vec<UnexpectedHiddenRegion<'tcx>>,
-    /// The region constraints computed by [borrowck_collect_region_constraints]. This uses
-    /// an [FxIndexMap] to guarantee that iterating over it visits nested bodies before
-    /// their parents.
-    collect_region_constraints_results:
-        FxIndexMap<LocalDefId, CollectRegionConstraintsResult<'tcx>>,
     propagated_borrowck_results: FxHashMap<LocalDefId, PropagatedBorrowCheckResults<'tcx>>,
     tainted_by_errors: &'diag Cell<Option<ErrorGuaranteed>>,
     /// This should be `None` during normal compilation. See [`crate::consumers`] for more
@@ -60,7 +55,6 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
             root_def_id,
             hidden_types: Default::default(),
             unconstrained_hidden_type_errors: Default::default(),
-            collect_region_constraints_results: Default::default(),
             propagated_borrowck_results: Default::default(),
             tainted_by_errors,
             consumer,
@@ -97,9 +91,15 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
         }
     }
 
-    fn handle_opaque_type_uses(&mut self) {
+    fn handle_opaque_type_uses(
+        &mut self,
+        collect_region_constraints_results: &mut FxIndexMap<
+            LocalDefId,
+            CollectRegionConstraintsResult<'tcx>,
+        >,
+    ) {
         let mut per_body_info = Vec::new();
-        for (def_id, input) in &mut self.collect_region_constraints_results {
+        for (def_id, input) in collect_region_constraints_results.iter_mut() {
             let (num_entries, opaque_types) = clone_and_resolve_opaque_types(
                 &input.infcx,
                 &input.universal_region_relations,
@@ -122,11 +122,11 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
             self.tcx,
             &mut self.hidden_types,
             &mut self.unconstrained_hidden_type_errors,
-            &mut self.collect_region_constraints_results,
+            collect_region_constraints_results,
         );
 
         for (input, (opaque_types_storage_num_entries, opaque_types)) in
-            self.collect_region_constraints_results.values_mut().zip(per_body_info)
+            collect_region_constraints_results.values_mut().zip(per_body_info)
         {
             if input.deferred_opaque_type_errors.is_empty() {
                 input.deferred_opaque_type_errors = apply_definition_site_hidden_types(
@@ -168,13 +168,13 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
     fn apply_closure_requirements_modulo_opaques(
         &mut self,
         diags_buffer: &mut BorrowckDiagnosticsBuffer<'diag, 'tcx>,
+        results: &mut FxIndexMap<LocalDefId, CollectRegionConstraintsResult<'tcx>>,
     ) {
         let mut closure_requirements_modulo_opaques = FxHashMap::default();
         // We need to `mem::take` both `self.collect_region_constraints_results` and
         // `input.deferred_closure_requirements` as we otherwise can't iterate over
         // them while mutably using the containing struct.
-        let collect_region_constraints_results =
-            mem::take(&mut self.collect_region_constraints_results);
+        let collect_region_constraints_results = mem::take(results);
         // We iterate over all bodies here, visiting nested bodies before their parent.
         for (def_id, mut input) in collect_region_constraints_results {
             // A body depends on opaque types if it either has any opaque type uses itself,
@@ -223,7 +223,7 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
                     let req = Self::compute_closure_requirements_modulo_opaques(&input);
                     closure_requirements_modulo_opaques.insert(def_id, req);
                 }
-                self.collect_region_constraints_results.insert(def_id, input);
+                results.insert(def_id, input);
             } else {
                 assert!(input.deferred_closure_requirements.is_empty());
                 let result = borrowck_check_region_constraints(self, diags_buffer, input);
@@ -276,9 +276,17 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
             .nested_bodies_within(self.root_def_id)
             .iter()
             .chain(std::iter::once(self.root_def_id));
+
+        // The region constraints computed by [borrowck_collect_region_constraints]. This uses
+        // an [FxIndexMap] to guarantee that iterating over it visits nested bodies before
+        // their parents.
+        let mut collect_region_constraints_results: FxIndexMap<
+            LocalDefId,
+            CollectRegionConstraintsResult<'tcx>,
+        > = FxIndexMap::default();
         for def_id in all_bodies {
             let result = borrowck_collect_region_constraints(self, def_id);
-            self.collect_region_constraints_results.insert(def_id, result);
+            collect_region_constraints_results.insert(def_id, result);
         }
 
         let diags_buffer = &mut BorrowckDiagnosticsBuffer::default();
@@ -290,10 +298,13 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
         //
         // We eagerly finish borrowck for bodies which don't depend on
         // opaques.
-        self.apply_closure_requirements_modulo_opaques(diags_buffer);
+        self.apply_closure_requirements_modulo_opaques(
+            diags_buffer,
+            &mut collect_region_constraints_results,
+        );
 
         // We handle opaque type uses for all bodies together.
-        self.handle_opaque_type_uses();
+        self.handle_opaque_type_uses(&mut collect_region_constraints_results);
 
         // Now walk over all bodies which depend on opaque types and finish borrowck.
         //
@@ -301,7 +312,7 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
         // depend on opaque types and then finish borrow checking the parent. Bodies
         // which don't depend on opaques have already been fully borrowchecked in
         // `apply_closure_requirements_modulo_opaques` as an optimization.
-        for (def_id, mut input) in mem::take(&mut self.collect_region_constraints_results) {
+        for (def_id, mut input) in mem::take(&mut collect_region_constraints_results) {
             for (def_id, args, locations) in mem::take(&mut input.deferred_closure_requirements) {
                 // We visit nested bodies before their parent, so we're already
                 // done with nested bodies at this point.

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -3,7 +3,7 @@ use std::mem;
 use std::rc::Rc;
 
 use rustc_abi::FieldIdx;
-use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
+use rustc_data_structures::fx::{FxBuildHasher, FxHashMap, FxIndexMap};
 use rustc_errors::DiagCtxtHandle;
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::mir::ConstraintCategory;
@@ -267,15 +267,7 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
     }
 
     pub(super) fn do_mir_borrowck(&mut self) {
-        // The list of all bodies we need to borrowck. This first looks at
-        // nested bodies, and then their parents. This means accessing e.g.
-        // `used_mut_upvars` for a closure can assume that we've already
-        // checked that closure.
-        let all_bodies = self
-            .tcx
-            .nested_bodies_within(self.root_def_id)
-            .iter()
-            .chain(std::iter::once(self.root_def_id));
+        let nested_bodies = self.tcx.nested_bodies_within(self.root_def_id);
 
         // The region constraints computed by [borrowck_collect_region_constraints]. This uses
         // an [FxIndexMap] to guarantee that iterating over it visits nested bodies before
@@ -283,7 +275,14 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
         let mut collect_region_constraints_results: FxIndexMap<
             LocalDefId,
             CollectRegionConstraintsResult<'tcx>,
-        > = FxIndexMap::default();
+        > = FxIndexMap::with_capacity_and_hasher(nested_bodies.len(), FxBuildHasher::default());
+
+        // The list of all bodies we need to borrowck. This first looks at
+        // nested bodies, and then their parents. This means accessing e.g.
+        // `used_mut_upvars` for a closure can assume that we've already
+        // checked that closure.
+        let all_bodies = nested_bodies.iter().chain(std::iter::once(self.root_def_id));
+
         for def_id in all_bodies {
             let result = borrowck_collect_region_constraints(self, def_id);
             collect_region_constraints_results.insert(def_id, result);

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -283,8 +283,15 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
         // checked that closure.
         let all_bodies = nested_bodies.iter().chain(std::iter::once(self.root_def_id));
 
+        let polonius_input = self.consumer.as_ref().map_or(false, |c| c.polonius_input())
+            || self.tcx.sess.opts.unstable_opts.polonius.is_legacy_enabled();
         for def_id in all_bodies {
-            let result = borrowck_collect_region_constraints(self, def_id);
+            let result = borrowck_collect_region_constraints(
+                self.tcx,
+                self.root_def_id(),
+                def_id,
+                polonius_input,
+            );
             collect_region_constraints_results.insert(def_id, result);
         }
 

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -3,8 +3,9 @@ use std::mem;
 use std::sync::Arc;
 
 use rustc_abi::FieldIdx;
-use rustc_data_structures::fx::{FxBuildHasher, FxHashMap, FxIndexMap};
-use rustc_data_structures::sync::{Lock, par_for_each_in};
+use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
+use rustc_data_structures::sharded::ShardedHashMap;
+use rustc_data_structures::sync::par_for_each_in;
 use rustc_errors::DiagCtxtHandle;
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::mir::ConstraintCategory;
@@ -266,14 +267,14 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
     pub(super) fn do_mir_borrowck(&mut self) {
         let nested_bodies = self.tcx.nested_bodies_within(self.root_def_id);
 
+        let capacity = nested_bodies.len() + 1;
         // The region constraints computed by [borrowck_collect_region_constraints]. This uses
         // an [FxIndexMap] to guarantee that iterating over it visits nested bodies before
         // their parents.
-        let collect_region_constraints_results: FxIndexMap<
+        let collect_region_constraints_results: ShardedHashMap<
             LocalDefId,
             CollectRegionConstraintsResult<'tcx>,
-        > = FxIndexMap::with_capacity_and_hasher(nested_bodies.len() + 1, FxBuildHasher::default());
-        let collect_region_constraints_results = Lock::new(collect_region_constraints_results);
+        > = ShardedHashMap::with_capacity(capacity);
 
         // The list of all bodies we need to borrowck. This first looks at
         // nested bodies, and then their parents. This means accessing e.g.
@@ -286,13 +287,17 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
 
         let tcx = self.tcx;
         let root_def_id = self.root_def_id;
-        par_for_each_in(all_bodies, |def_id| {
+        par_for_each_in(all_bodies.clone(), |def_id| {
             let result =
                 borrowck_collect_region_constraints(tcx, root_def_id, *def_id, polonius_input);
-            collect_region_constraints_results.lock().insert(*def_id, result);
+            collect_region_constraints_results.insert_unique(*def_id, result);
         });
-        let mut collect_region_constraints_results =
-            collect_region_constraints_results.into_inner();
+
+        // We need to resort the results by the def id order here.
+        let mut collect_region_constraints_results = all_bodies
+            .into_iter()
+            .map(|def_id| (def_id, collect_region_constraints_results.remove(&def_id).unwrap()))
+            .collect();
 
         let diags_buffer = &mut BorrowckDiagnosticsBuffer::default();
 

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -3,9 +3,9 @@ use std::mem;
 use std::sync::Arc;
 
 use rustc_abi::FieldIdx;
-use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
+use rustc_data_structures::fx::{FxBuildHasher, FxHashMap, FxIndexMap};
 use rustc_data_structures::sharded::ShardedHashMap;
-use rustc_data_structures::sync::par_for_each_in;
+use rustc_data_structures::sync::{is_dyn_thread_safe, par_for_each_in};
 use rustc_errors::DiagCtxtHandle;
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::mir::ConstraintCategory;
@@ -268,13 +268,6 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
         let nested_bodies = self.tcx.nested_bodies_within(self.root_def_id);
 
         let capacity = nested_bodies.len() + 1;
-        // The region constraints computed by [borrowck_collect_region_constraints]. This uses
-        // an [FxIndexMap] to guarantee that iterating over it visits nested bodies before
-        // their parents.
-        let collect_region_constraints_results: ShardedHashMap<
-            LocalDefId,
-            CollectRegionConstraintsResult<'tcx>,
-        > = ShardedHashMap::with_capacity(capacity);
 
         // The list of all bodies we need to borrowck. This first looks at
         // nested bodies, and then their parents. This means accessing e.g.
@@ -287,17 +280,38 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
 
         let tcx = self.tcx;
         let root_def_id = self.root_def_id;
-        par_for_each_in(all_bodies.clone(), |def_id| {
-            let result =
-                borrowck_collect_region_constraints(tcx, root_def_id, *def_id, polonius_input);
-            collect_region_constraints_results.insert_unique(*def_id, result);
-        });
 
-        // We need to resort the results by the def id order here.
-        let mut collect_region_constraints_results = all_bodies
-            .into_iter()
-            .map(|def_id| (def_id, collect_region_constraints_results.remove(&def_id).unwrap()))
-            .collect();
+        // Use a different strategy when running under multiple threads, so that we don't have to
+        // re-sort the results when we have a single thread
+        let mut collect_region_constraints_results = if is_dyn_thread_safe() {
+            // The region constraints computed by [borrowck_collect_region_constraints]. This has
+            // to guarantee that iterating over it visits nested bodies before
+            // their parents, so it has to keep the order from `all_bodies`.
+            let results: ShardedHashMap<LocalDefId, CollectRegionConstraintsResult<'tcx>> =
+                ShardedHashMap::with_capacity(capacity);
+
+            par_for_each_in(all_bodies.clone(), |def_id| {
+                let result =
+                    borrowck_collect_region_constraints(tcx, root_def_id, *def_id, polonius_input);
+                results.insert_unique(*def_id, result);
+            });
+
+            // We need to resort the results by the def id order here.
+            all_bodies
+                .into_iter()
+                .map(|def_id| (def_id, results.remove(&def_id).unwrap()))
+                .collect()
+        } else {
+            let mut results: FxIndexMap<LocalDefId, CollectRegionConstraintsResult<'tcx>> =
+                FxIndexMap::with_capacity_and_hasher(capacity, FxBuildHasher::default());
+
+            for def_id in all_bodies {
+                let result =
+                    borrowck_collect_region_constraints(tcx, root_def_id, def_id, polonius_input);
+                results.insert(def_id, result);
+            }
+            results
+        };
 
         let diags_buffer = &mut BorrowckDiagnosticsBuffer::default();
 

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -3,9 +3,8 @@ use std::mem;
 use std::sync::Arc;
 
 use rustc_abi::FieldIdx;
-use rustc_data_structures::fx::{FxBuildHasher, FxHashMap, FxIndexMap};
-use rustc_data_structures::sharded::ShardedHashMap;
-use rustc_data_structures::sync::{is_dyn_thread_safe, par_for_each_in};
+use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
+use rustc_data_structures::sync::par_map;
 use rustc_errors::DiagCtxtHandle;
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::mir::ConstraintCategory;
@@ -267,8 +266,6 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
     pub(super) fn do_mir_borrowck(&mut self) {
         let nested_bodies = self.tcx.nested_bodies_within(self.root_def_id);
 
-        let capacity = nested_bodies.len() + 1;
-
         // The list of all bodies we need to borrowck. This first looks at
         // nested bodies, and then their parents. This means accessing e.g.
         // `used_mut_upvars` for a closure can assume that we've already
@@ -283,35 +280,12 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
 
         // Use a different strategy when running under multiple threads, so that we don't have to
         // re-sort the results when we have a single thread
-        let mut collect_region_constraints_results = if is_dyn_thread_safe() {
-            // The region constraints computed by [borrowck_collect_region_constraints]. This has
-            // to guarantee that iterating over it visits nested bodies before
-            // their parents, so it has to keep the order from `all_bodies`.
-            let results: ShardedHashMap<LocalDefId, CollectRegionConstraintsResult<'tcx>> =
-                ShardedHashMap::with_capacity(capacity);
-
-            par_for_each_in(all_bodies.clone(), |def_id| {
-                let result =
-                    borrowck_collect_region_constraints(tcx, root_def_id, *def_id, polonius_input);
-                results.insert_unique(*def_id, result);
-            });
-
-            // We need to resort the results by the def id order here.
-            all_bodies
-                .into_iter()
-                .map(|def_id| (def_id, results.remove(&def_id).unwrap()))
-                .collect()
-        } else {
-            let mut results: FxIndexMap<LocalDefId, CollectRegionConstraintsResult<'tcx>> =
-                FxIndexMap::with_capacity_and_hasher(capacity, FxBuildHasher::default());
-
-            for def_id in all_bodies {
-                let result =
-                    borrowck_collect_region_constraints(tcx, root_def_id, def_id, polonius_input);
-                results.insert(def_id, result);
-            }
-            results
-        };
+        let mut collect_region_constraints_results: FxIndexMap<
+            LocalDefId,
+            CollectRegionConstraintsResult<'tcx>,
+        > = par_map(all_bodies, |def_id| {
+            (def_id, borrowck_collect_region_constraints(tcx, root_def_id, def_id, polonius_input))
+        });
 
         let diags_buffer = &mut BorrowckDiagnosticsBuffer::default();
 

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -1,6 +1,6 @@
 use std::cell::Cell;
 use std::mem;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use rustc_abi::FieldIdx;
 use rustc_data_structures::fx::{FxBuildHasher, FxHashMap, FxIndexMap};
@@ -110,7 +110,7 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
                 &input.infcx,
                 &input.universal_region_relations,
                 &input.constraints,
-                Rc::clone(&input.location_map),
+                Arc::clone(&input.location_map),
                 &mut self.hidden_types,
                 &mut self.unconstrained_hidden_type_errors,
                 &opaque_types,
@@ -238,7 +238,7 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
         compute_closure_requirements_modulo_opaques(
             &input.infcx,
             &input.body_owned,
-            Rc::clone(&input.location_map),
+            Arc::clone(&input.location_map),
             &input.universal_region_relations,
             &input.constraints,
         )

--- a/compiler/rustc_borrowck/src/root_cx.rs
+++ b/compiler/rustc_borrowck/src/root_cx.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use rustc_abi::FieldIdx;
 use rustc_data_structures::fx::{FxBuildHasher, FxHashMap, FxIndexMap};
+use rustc_data_structures::sync::{Lock, par_for_each_in};
 use rustc_errors::DiagCtxtHandle;
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::mir::ConstraintCategory;
@@ -59,10 +60,6 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
             tainted_by_errors,
             consumer,
         }
-    }
-
-    pub(super) fn root_def_id(&self) -> LocalDefId {
-        self.root_def_id
     }
 
     pub(super) fn set_tainted_by_errors(&self, guar: ErrorGuaranteed) {
@@ -272,10 +269,11 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
         // The region constraints computed by [borrowck_collect_region_constraints]. This uses
         // an [FxIndexMap] to guarantee that iterating over it visits nested bodies before
         // their parents.
-        let mut collect_region_constraints_results: FxIndexMap<
+        let collect_region_constraints_results: FxIndexMap<
             LocalDefId,
             CollectRegionConstraintsResult<'tcx>,
-        > = FxIndexMap::with_capacity_and_hasher(nested_bodies.len(), FxBuildHasher::default());
+        > = FxIndexMap::with_capacity_and_hasher(nested_bodies.len() + 1, FxBuildHasher::default());
+        let collect_region_constraints_results = Lock::new(collect_region_constraints_results);
 
         // The list of all bodies we need to borrowck. This first looks at
         // nested bodies, and then their parents. This means accessing e.g.
@@ -285,15 +283,16 @@ impl<'diag, 'tcx> BorrowCheckRootCtxt<'diag, 'tcx> {
 
         let polonius_input = self.consumer.as_ref().map_or(false, |c| c.polonius_input())
             || self.tcx.sess.opts.unstable_opts.polonius.is_legacy_enabled();
-        for def_id in all_bodies {
-            let result = borrowck_collect_region_constraints(
-                self.tcx,
-                self.root_def_id(),
-                def_id,
-                polonius_input,
-            );
-            collect_region_constraints_results.insert(def_id, result);
-        }
+
+        let tcx = self.tcx;
+        let root_def_id = self.root_def_id;
+        par_for_each_in(all_bodies, |def_id| {
+            let result =
+                borrowck_collect_region_constraints(tcx, root_def_id, *def_id, polonius_input);
+            collect_region_constraints_results.lock().insert(*def_id, result);
+        });
+        let mut collect_region_constraints_results =
+            collect_region_constraints_results.into_inner();
 
         let diags_buffer = &mut BorrowckDiagnosticsBuffer::default();
 

--- a/compiler/rustc_borrowck/src/type_check/canonical.rs
+++ b/compiler/rustc_borrowck/src/type_check/canonical.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use rustc_data_structures::marker::{DynSend, DynSync};
 use rustc_errors::ErrorGuaranteed;
 use rustc_infer::infer::canonical::Canonical;
 use rustc_infer::infer::outlives::env::RegionBoundPairs;
@@ -191,7 +192,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         location: impl NormalizeLocation,
     ) -> T
     where
-        T: type_op::normalize::Normalizable<'tcx> + fmt::Display + Copy + 'tcx,
+        T: type_op::normalize::Normalizable<'tcx> + fmt::Display + Copy + DynSend + DynSync + 'tcx,
     {
         self.normalize_with_category(value, location, ConstraintCategory::Boring)
     }
@@ -202,7 +203,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         location: impl NormalizeLocation,
     ) -> Result<T, ErrorGuaranteed>
     where
-        T: type_op::normalize::Normalizable<'tcx> + fmt::Display + Copy + 'tcx,
+        T: type_op::normalize::Normalizable<'tcx> + fmt::Display + Copy + DynSend + DynSync + 'tcx,
     {
         self.fully_perform_op(
             location.to_locations(),
@@ -219,7 +220,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         category: ConstraintCategory<'tcx>,
     ) -> T
     where
-        T: type_op::normalize::Normalizable<'tcx> + fmt::Display + Copy + 'tcx,
+        T: type_op::normalize::Normalizable<'tcx> + fmt::Display + Copy + DynSend + DynSync + 'tcx,
     {
         let param_env = self.infcx.param_env;
         let result: Result<_, ErrorGuaranteed> = self.fully_perform_op(

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -49,7 +49,7 @@ use crate::region_infer::values::{LivenessValues, PlaceholderIndex, PlaceholderI
 use crate::session_diagnostics::{MoveUnsized, SimdIntrinsicArgConst};
 use crate::type_check::free_region_relations::{CreateResult, UniversalRegionRelations};
 use crate::universal_regions::{DefiningTy, UniversalRegions};
-use crate::{BorrowCheckRootCtxt, BorrowckInferCtxt, DeferredClosureRequirements, path_utils};
+use crate::{BorrowckInferCtxt, DeferredClosureRequirements, path_utils};
 
 macro_rules! span_mirbug {
     ($context:expr, $elem:expr, $($message:tt)*) => ({
@@ -96,7 +96,7 @@ mod relate_tys;
 /// - `move_data` -- move-data constructed when performing the maybe-init dataflow analysis
 /// - `location_map` -- map between MIR `Location` and `PointIndex`
 pub(crate) fn type_check<'tcx>(
-    root_cx: &BorrowCheckRootCtxt<'_, 'tcx>,
+    root_def_id: LocalDefId,
     infcx: &BorrowckInferCtxt<'tcx>,
     body: &Body<'tcx>,
     promoted: &IndexSlice<Promoted, Body<'tcx>>,
@@ -155,7 +155,7 @@ pub(crate) fn type_check<'tcx>(
 
     let mut deferred_closure_requirements = Default::default();
     let mut typeck = TypeChecker {
-        root_cx,
+        root_def_id,
         infcx,
         last_span: body.span,
         body,
@@ -242,7 +242,7 @@ enum FieldAccessError {
 /// way, it accrues region constraints -- these can later be used by
 /// NLL region checking.
 struct TypeChecker<'a, 'tcx> {
-    root_cx: &'a BorrowCheckRootCtxt<'a, 'tcx>,
+    root_def_id: LocalDefId,
     infcx: &'a BorrowckInferCtxt<'tcx>,
     last_span: Span,
     body: &'a Body<'tcx>,
@@ -2743,7 +2743,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         args: GenericArgsRef<'tcx>,
         location: Location,
     ) -> ty::InstantiatedClauses<'tcx> {
-        let root_def_id = self.root_cx.root_def_id();
+        let root_def_id = self.root_def_id;
         // We will have to handle propagated closure requirements for this closure,
         // but need to defer this until the nested body has been fully borrow checked.
         self.deferred_closure_requirements.push((def_id, args, location.to_locations()));

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1,6 +1,6 @@
 //! This pass type-checks the MIR to ensure it is not broken.
 
-use std::rc::Rc;
+use std::sync::Arc;
 use std::{fmt, iter, mem};
 
 use rustc_abi::FieldIdx;
@@ -105,12 +105,12 @@ pub(crate) fn type_check<'tcx>(
     borrow_set: &BorrowSet<'tcx>,
     polonius_facts: &mut Option<PoloniusFacts>,
     move_data: &MoveData<'tcx>,
-    location_map: Rc<DenseLocationMap>,
+    location_map: Arc<DenseLocationMap>,
 ) -> MirTypeckResults<'tcx> {
     let mut constraints = MirTypeckRegionConstraints {
         placeholder_indices: PlaceholderIndices::default(),
         placeholder_index_to_region: IndexVec::default(),
-        liveness_constraints: LivenessValues::with_specific_points(Rc::clone(&location_map)),
+        liveness_constraints: LivenessValues::with_specific_points(Arc::clone(&location_map)),
         outlives_constraints: OutlivesConstraintSet::default(),
         type_tests: Vec::default(),
         universe_causes: FxIndexMap::default(),
@@ -550,7 +550,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         let polonius_facts = &mut None;
         let mut constraints = Default::default();
         let mut liveness_constraints =
-            LivenessValues::without_specific_points(Rc::new(DenseLocationMap::new(promoted_body)));
+            LivenessValues::without_specific_points(Arc::new(DenseLocationMap::new(promoted_body)));
         let mut deferred_closure_requirements = Default::default();
 
         // Don't try to add borrow_region facts for the promoted MIR as they refer

--- a/compiler/rustc_data_structures/src/sharded.rs
+++ b/compiler/rustc_data_structures/src/sharded.rs
@@ -129,6 +129,16 @@ impl<T> Sharded<T> {
             Self::Shards(shards) => Either::Right(shards.iter().map(|shard| shard.0.try_lock())),
         }
     }
+
+    #[inline]
+    pub fn into_shards(self) -> impl Iterator<Item = T> {
+        match self {
+            Self::Single(single) => Either::Left(iter::once(single.into_inner())),
+            Self::Shards(shards) => {
+                Either::Right(shards.into_iter().map(|shard| shard.0.into_inner()))
+            }
+        }
+    }
 }
 
 #[inline]
@@ -164,6 +174,21 @@ impl<K: Eq + Hash, V> ShardedHashMap<K, V> {
         let shard = self.lock_shard_by_hash(hash);
         let (_, value) = shard.find(hash, |(k, _)| k.borrow() == key)?;
         Some(value.clone())
+    }
+
+    #[inline]
+    pub fn remove<Q>(&self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let hash = make_hash(&key);
+        let mut shard = self.lock_shard_by_hash(hash);
+
+        match table_entry(&mut shard, hash, &key) {
+            Entry::Occupied(e) => Some(e.remove().0.1),
+            Entry::Vacant(_) => None,
+        }
     }
 
     #[inline]
@@ -207,6 +232,10 @@ impl<K: Eq + Hash, V> ShardedHashMap<K, V> {
                 shard.insert_unique(hash, (key, value), |(k, _)| make_hash(k));
             }
         }
+    }
+
+    pub fn into_iter(self) -> impl Iterator<Item = (K, V)> {
+        self.into_shards().map(|table| table.into_iter()).flatten()
     }
 }
 

--- a/compiler/rustc_data_structures/src/sync/parallel.rs
+++ b/compiler/rustc_data_structures/src/sync/parallel.rs
@@ -7,7 +7,7 @@ use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use parking_lot::Mutex;
 
 use crate::FatalErrorMarker;
-use crate::sync::{DynSend, DynSync, FromDyn, IntoDynSyncSend, mode};
+use crate::sync::{CacheAligned, DynSend, DynSync, FromDyn, IntoDynSyncSend, mode};
 
 /// A guard used to hold panics that occur during a parallel section to later by unwound.
 /// This is used for the parallel compiler to prevent fatal errors from non-deterministically
@@ -237,19 +237,19 @@ pub fn par_map<I: DynSend, T: IntoIterator<Item = I>, R: DynSend, C: FromIterato
         if let Some(proof) = mode::check_dyn_thread_safe() {
             let map = proof.derive(map);
 
-            let mut items: Vec<(Option<I>, Option<R>)> =
-                t.into_iter().map(|i| (Some(i), None)).collect();
+            let mut items: Vec<CacheAligned<(Option<I>, Option<R>)>> =
+                t.into_iter().map(|i| CacheAligned((Some(i), None))).collect();
 
             par_slice(
                 &mut items,
                 guard,
                 |i| {
-                    i.1 = Some(map(i.0.take().unwrap()));
+                    i.0.1 = Some(map(i.0.0.take().unwrap()));
                 },
                 proof,
             );
 
-            items.into_iter().filter_map(|i| i.1).collect()
+            items.into_iter().filter_map(|i| i.0.1).collect()
         } else {
             t.into_iter().filter_map(|i| guard.run(|| map(i))).collect()
         }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162485)*
<!-- homu-ignore:end -->

I was staring into this code the whole day today, and while my experiments to introduce arenas or reduce allocations kinda failed miserably (rust(c) is really resilient against any usage of arenas, sigh), it looks like parallelizing this loop wasn't that complicated, so I tried to do it.

The `Lock<FxIndexMap<...>>` thing isn't ideal, some sharding would be better, but we can see what happens.