### PR TITLE
Use `DenseBit` for `drop_live_at` in liveness tracing

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
@@ -110,7 +110,7 @@ struct LivenessResults<'a, 'typeck, 'tcx> {
     /// Points where the current variable is "drop live" -- meaning
     /// that there is no future "full use" that may use its value, but
     /// there is a future drop.
-    drop_live_at: IntervalSet<PointIndex>,
+    drop_live_at: DenseBitSet<PointIndex>,
 
     /// Locations where drops may occur.
     drop_locations: Vec<Location>,
@@ -126,7 +126,7 @@ impl<'a, 'typeck, 'tcx> LivenessResults<'a, 'typeck, 'tcx> {
             cx,
             defs: DenseBitSet::new_empty(num_points),
             use_live_at: IntervalSet::new(num_points),
-            drop_live_at: IntervalSet::new(num_points),
+            drop_live_at: DenseBitSet::new_empty(num_points),
             drop_locations: vec![],
             stack: vec![],
         }
@@ -146,12 +146,16 @@ impl<'a, 'typeck, 'tcx> LivenessResults<'a, 'typeck, 'tcx> {
             }
 
             if !self.drop_live_at.is_empty() {
-                self.cx.add_drop_live_facts_for(
-                    local,
-                    local_ty,
-                    &self.drop_locations,
-                    &self.drop_live_at,
-                );
+                // `drop_live_at` is using a DenseBitSet, but `add_drop_live_facts_for` expects
+                // an IntervalSet. We thus convert between those two here.
+                let mut set: IntervalSet<PointIndex> =
+                    IntervalSet::new(self.drop_live_at.domain_size());
+                for item in self.drop_live_at.iter() {
+                    // We iterate the `drop_live_at` set from smallest to largest values, so
+                    // we can use append to add things to the interval set at the end.
+                    set.append(item);
+                }
+                self.cx.add_drop_live_facts_for(local, local_ty, &self.drop_locations, &set);
             }
         }
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162488)*
<!-- homu-ignore:end -->

I noticed that `drop_live_at` only ever gets point, and never range, inserts, so I switched it over to `DenseBitSet`. This provides some nice [wins](https://perf.rust-lang.org/compare.html?start=745de6eca673de5329ec68f2689629a5ca45ab35&end=d1837740534cbf87b9fe919b7a89debf46362197&stat=instructions:u) on `serde`.

However, the `add_drop_live_facts_for` function expects to receive an `IntervalSet`. I first tried to switch the type of `LiveRegions::AtPoints` from `SparseIntervalMatrix` to `SparseBitMatrix`, but that had [regressions](https://perf.rust-lang.org/compare.html?start=745de6eca673de5329ec68f2689629a5ca45ab35&end=c87f1fbff20351758b66ae945c16e061ab4ae54c&stat=instructions:u). 

So in this PR, I simply reconstruct an `IntervalSet` from a `DenseBitSet`. Not super pretty, but perf. looks reasonable.

Let me know if this makes sense or not! :)

r? jackh726