### PR TITLE
Ignore `self-in-const-generics` test for parallel frontend

### DIFF
--- a/tests/ui/traits/alias/self-in-const-generics.rs
+++ b/tests/ui/traits/alias/self-in-const-generics.rs
@@ -1,3 +1,5 @@
+//@ ignore-parallel-frontend triage https://github.com/rust-lang/rust/issues/162316
+
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 #![feature(trait_alias)]

--- a/tests/ui/traits/alias/self-in-const-generics.stderr
+++ b/tests/ui/traits/alias/self-in-const-generics.stderr
@@ -1,12 +1,12 @@
 error[E0038]: the trait alias `BB` is not dyn compatible
-  --> $DIR/self-in-const-generics.rs:9:16
+  --> $DIR/self-in-const-generics.rs:11:16
    |
 LL | fn foo(x: &dyn BB) {}
    |                ^^ `BB` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/self-in-const-generics.rs:7:12
+  --> $DIR/self-in-const-generics.rs:9:12
    |
 LL | trait BB = Bar<{ 2 + 1 }>;
    |       --   ^^^^^^^^^^^^^^ ...because it uses `Self` as a type parameter


### PR DESCRIPTION
This is the guidance for failing tests in the parallel frontend per [#t-infra/announcements > rustc parallel frontend CI job @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/533458-t-infra.2Fannouncements/topic/rustc.20parallel.20frontend.20CI.20job/near/612990835)
To work around https://github.com/rust-lang/rust/issues/162316