### PR TITLE
Stabilize `unsafe_cell_access`

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -2368,7 +2368,6 @@ impl<T> UnsafeCell<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(unsafe_cell_access)]
     /// use std::cell::UnsafeCell;
     ///
     /// let uc = UnsafeCell::new(5);
@@ -2377,7 +2376,8 @@ impl<T> UnsafeCell<T> {
     /// assert_eq!(old, 5);
     /// ```
     #[inline]
-    #[unstable(feature = "unsafe_cell_access", issue = "136327")]
+    #[stable(feature = "unsafe_cell_access", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "unsafe_cell_access", since = "CURRENT_RUSTC_VERSION")]
     #[rustc_should_not_be_called_on_const_items]
     pub const unsafe fn replace(&self, value: T) -> T {
         // SAFETY: pointer comes from `&self` so naturally satisfies invariants.
@@ -2510,7 +2510,6 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(unsafe_cell_access)]
     /// use std::cell::UnsafeCell;
     ///
     /// let uc = UnsafeCell::new(5);
@@ -2519,7 +2518,8 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// assert_eq!(val, &5);
     /// ```
     #[inline]
-    #[unstable(feature = "unsafe_cell_access", issue = "136327")]
+    #[stable(feature = "unsafe_cell_access", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "unsafe_cell_access", since = "CURRENT_RUSTC_VERSION")]
     #[rustc_should_not_be_called_on_const_items]
     pub const unsafe fn as_ref_unchecked(&self) -> &T {
         // SAFETY: pointer comes from `&self` so naturally satisfies ptr-to-ref invariants.
@@ -2538,7 +2538,6 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(unsafe_cell_access)]
     /// use std::cell::UnsafeCell;
     ///
     /// let uc = UnsafeCell::new(5);
@@ -2547,7 +2546,8 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// assert_eq!(uc.into_inner(), 6);
     /// ```
     #[inline]
-    #[unstable(feature = "unsafe_cell_access", issue = "136327")]
+    #[stable(feature = "unsafe_cell_access", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "unsafe_cell_access", since = "CURRENT_RUSTC_VERSION")]
     #[allow(clippy::mut_from_ref)]
     #[rustc_should_not_be_called_on_const_items]
     pub const unsafe fn as_mut_unchecked(&self) -> &mut T {

--- a/tests/ui/lint/const-item-interior-mutations-const-cell.rs
+++ b/tests/ui/lint/const-item-interior-mutations-const-cell.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![feature(unsafe_cell_access)]
+
 #![feature(sync_unsafe_cell)]
 #![feature(once_cell_try_insert)]
 #![feature(once_cell_try)]


### PR DESCRIPTION
Closes rust-lang/rust#136327
