### PR TITLE
Revert "fuchsia: Add safestack as a supported sanitizer for x86_64 fuchsia"

### DIFF
--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_fuchsia.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_fuchsia.rs
@@ -9,9 +9,7 @@ pub(crate) fn target() -> Target {
     base.features = "+cmpxchg16b,+lahfsahf,+popcnt,+sse3,+sse4.1,+sse4.2,+ssse3".into();
     base.max_atomic_width = Some(128);
     base.stack_probes = StackProbeType::Inline;
-    base.supported_sanitizers =
-        SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::LEAK | SanitizerSet::SAFESTACK;
-    base.default_sanitizers = SanitizerSet::SAFESTACK;
+    base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::LEAK;
     base.supports_xray = true;
 
     Target {

--- a/tests/assembly-llvm/stack-protector/stack-protector-target-support.rs
+++ b/tests/assembly-llvm/stack-protector/stack-protector-target-support.rs
@@ -177,15 +177,13 @@
 //@ compile-flags: -C opt-level=2
 
 #![crate_type = "lib"]
-#![feature(no_core, lang_items, sanitize)]
+#![feature(no_core, lang_items)]
 #![crate_type = "lib"]
 #![no_core]
 
 extern crate minicore;
 use minicore::*;
 
-// We only do this because we can't disable default sanitizers via compile-flags.
-#[sanitize(safestack = "off")]
 #[no_mangle]
 pub fn foo() {
     // CHECK: foo{{:|()}}


### PR DESCRIPTION

This reverts commit 7a44484407077776e30120f5e72cdef2820e8856.

This is leading to the issue seen in
https://github.com/rust-lang/rust/issues/162272. We're also seeing the same build issues when using a rust toolchain that contains this commit for building fuchsia targets.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
