### PR TITLE
coverage: Remove an untested case for non-coroutine synthetic MIR

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/hir_info.rs
+++ b/compiler/rustc_mir_transform/src/coverage/hir_info.rs
@@ -35,11 +35,11 @@ pub(crate) fn extract_hir_info<'tcx>(
         // Synthetic by-move coroutine bodies don't have useful HIR of their own.
         // Use the original coroutine body instead. These synthetic bodies are
         // created with a coroutine type, so we can inspect that type as-is.
-        if tcx.is_synthetic_mir(def_id) {
-            match *tcx.type_of(def_id).instantiate_identity().skip_normalization().kind() {
-                ty::Coroutine(coroutine_def_id, _) => def_id = coroutine_def_id.expect_local(),
-                _ => def_id = tcx.local_parent(def_id),
-            }
+        if tcx.is_synthetic_mir(def_id)
+            && let def_ty = tcx.type_of(def_id).instantiate_identity().skip_normalization()
+            && let &ty::Coroutine(coroutine_def_id, _) = def_ty.kind()
+        {
+            def_id = coroutine_def_id.expect_local()
         }
         def_id
     };


### PR DESCRIPTION
- https://github.com/rust-lang/rust/pull/131802
- https://github.com/rust-lang/rust/pull/156970
---

This special case was originally added in https://github.com/rust-lang/rust/pull/131802 to avoid an ICE. It was later refined in https://github.com/rust-lang/rust/pull/156970 to use `ty::Coroutine(coroutine_def_id, _)` instead if possible.

From what I can tell, that refinement made the original special case unreachable. Certainly it cannot be hit by any existing coverage tests, including the regression test added by https://github.com/rust-lang/rust/pull/131802. And given the need for the refinement in https://github.com/rust-lang/rust/pull/156970, it's unclear whether the fallback case would even be correct if it were reachable.

There's a small chance that we end up having to revert this PR, if it does lead to a reported ICE in currently-unknown circumstances. But if that happens, then hopefully we'll at least have a repro to add to the test suite.