### PR TITLE
Avoid suggesting gated generic arguments for Fn-family traits

### DIFF
--- a/compiler/rustc_hir_analysis/src/diagnostics/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/diagnostics/wrong_number_of_generic_args.rs
@@ -628,6 +628,14 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
             return;
         }
 
+        // Do not suggest angle-bracketed arguments that require the unstable feature.
+        if !self.tcx.features().unboxed_closures()
+            && self.tcx.is_trait(self.def_id)
+            && self.tcx.trait_def(self.def_id).paren_sugar
+        {
+            return;
+        }
+
         match self.gen_args_info {
             MissingLifetimes { .. } => {
                 self.suggest_adding_lifetime_args(err);

--- a/tests/ui/cast/dyn-any-to-fn-with-missing-generics.stderr
+++ b/tests/ui/cast/dyn-any-to-fn-with-missing-generics.stderr
@@ -13,11 +13,6 @@ error[E0107]: missing generics for trait `Fn`
    |
 LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
    |                                       ^^ expected 1 generic argument
-   |
-help: add missing generic argument
-   |
-LL |     println!("{:?}",(vfnfer[0] as dyn Fn<Args>)(3));
-   |                                         ++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/unboxed-closures/missing-fn-trait-args-issue-136407.feature_disabled.fixed
+++ b/tests/ui/unboxed-closures/missing-fn-trait-args-issue-136407.feature_disabled.fixed
@@ -6,31 +6,31 @@
 //@[feature_disabled] run-rustfix
 #![cfg_attr(feature_enabled, feature(unboxed_closures))]
 
-pub fn shared<T: Fn>() {}
+pub fn shared<T: Fn() -> ()>() {}
 //~^ ERROR missing generics
 //[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
 
-pub fn mutable<T: FnMut>() {}
+pub fn mutable<T: FnMut() -> ()>() {}
 //~^ ERROR missing generics
 //[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
 
-pub fn once<T: FnOnce>() {}
+pub fn once<T: FnOnce() -> ()>() {}
 //~^ ERROR missing generics
 //[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
 
-pub fn async_shared<T: AsyncFn>() {}
+pub fn async_shared<T: AsyncFn() -> ()>() {}
 //~^ ERROR missing generics
 //[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
 
-pub fn async_mutable<T: AsyncFnMut>() {}
+pub fn async_mutable<T: AsyncFnMut() -> ()>() {}
 //~^ ERROR missing generics
 //[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
 
-pub fn async_once<T: AsyncFnOnce>() {}
+pub fn async_once<T: AsyncFnOnce() -> ()>() {}
 //~^ ERROR missing generics
 //[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
 
-pub fn with_output<T: Fn<Output = ()>>() {}
+pub fn with_output<T: Fn() -> ()>() {}
 //~^ ERROR trait takes 1 generic argument but 0 generic arguments were supplied
 //[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
 

--- a/tests/ui/unboxed-closures/missing-fn-trait-args-issue-136407.feature_disabled.stderr
+++ b/tests/ui/unboxed-closures/missing-fn-trait-args-issue-136407.feature_disabled.stderr
@@ -1,0 +1,151 @@
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:9:18
+   |
+LL | pub fn shared<T: Fn>() {}
+   |                  ^^ help: use parenthetical notation instead: `Fn() -> ()`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0107]: missing generics for trait `Fn`
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:9:18
+   |
+LL | pub fn shared<T: Fn>() {}
+   |                  ^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn shared<T: Fn<Args>>() {}
+   |                    ++++++
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:13:19
+   |
+LL | pub fn mutable<T: FnMut>() {}
+   |                   ^^^^^ help: use parenthetical notation instead: `FnMut() -> ()`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0107]: missing generics for trait `FnMut`
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:13:19
+   |
+LL | pub fn mutable<T: FnMut>() {}
+   |                   ^^^^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn mutable<T: FnMut<Args>>() {}
+   |                        ++++++
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:17:16
+   |
+LL | pub fn once<T: FnOnce>() {}
+   |                ^^^^^^ help: use parenthetical notation instead: `FnOnce() -> ()`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0107]: missing generics for trait `FnOnce`
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:17:16
+   |
+LL | pub fn once<T: FnOnce>() {}
+   |                ^^^^^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn once<T: FnOnce<Args>>() {}
+   |                      ++++++
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:21:24
+   |
+LL | pub fn async_shared<T: AsyncFn>() {}
+   |                        ^^^^^^^ help: use parenthetical notation instead: `AsyncFn() -> ()`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0107]: missing generics for trait `AsyncFn`
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:21:24
+   |
+LL | pub fn async_shared<T: AsyncFn>() {}
+   |                        ^^^^^^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn async_shared<T: AsyncFn<Args>>() {}
+   |                               ++++++
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:25:25
+   |
+LL | pub fn async_mutable<T: AsyncFnMut>() {}
+   |                         ^^^^^^^^^^ help: use parenthetical notation instead: `AsyncFnMut() -> ()`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0107]: missing generics for trait `AsyncFnMut`
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:25:25
+   |
+LL | pub fn async_mutable<T: AsyncFnMut>() {}
+   |                         ^^^^^^^^^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn async_mutable<T: AsyncFnMut<Args>>() {}
+   |                                   ++++++
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:29:22
+   |
+LL | pub fn async_once<T: AsyncFnOnce>() {}
+   |                      ^^^^^^^^^^^ help: use parenthetical notation instead: `AsyncFnOnce() -> ()`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0107]: missing generics for trait `AsyncFnOnce`
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:29:22
+   |
+LL | pub fn async_once<T: AsyncFnOnce>() {}
+   |                      ^^^^^^^^^^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn async_once<T: AsyncFnOnce<Args>>() {}
+   |                                 ++++++
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:33:23
+   |
+LL | pub fn with_output<T: Fn<Output = ()>>() {}
+   |                       ^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `Fn() -> ()`
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:33:23
+   |
+LL | pub fn with_output<T: Fn<Output = ()>>() {}
+   |                       ^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn with_output<T: Fn<Args, Output = ()>>() {}
+   |                          +++++
+
+error: aborting due to 14 previous errors
+
+Some errors have detailed explanations: E0107, E0658.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/unboxed-closures/missing-fn-trait-args-issue-136407.feature_disabled.stderr
+++ b/tests/ui/unboxed-closures/missing-fn-trait-args-issue-136407.feature_disabled.stderr
@@ -13,11 +13,6 @@ error[E0107]: missing generics for trait `Fn`
    |
 LL | pub fn shared<T: Fn>() {}
    |                  ^^ expected 1 generic argument
-   |
-help: add missing generic argument
-   |
-LL | pub fn shared<T: Fn<Args>>() {}
-   |                    ++++++
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/missing-fn-trait-args-issue-136407.rs:13:19
@@ -34,11 +29,6 @@ error[E0107]: missing generics for trait `FnMut`
    |
 LL | pub fn mutable<T: FnMut>() {}
    |                   ^^^^^ expected 1 generic argument
-   |
-help: add missing generic argument
-   |
-LL | pub fn mutable<T: FnMut<Args>>() {}
-   |                        ++++++
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/missing-fn-trait-args-issue-136407.rs:17:16
@@ -55,11 +45,6 @@ error[E0107]: missing generics for trait `FnOnce`
    |
 LL | pub fn once<T: FnOnce>() {}
    |                ^^^^^^ expected 1 generic argument
-   |
-help: add missing generic argument
-   |
-LL | pub fn once<T: FnOnce<Args>>() {}
-   |                      ++++++
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/missing-fn-trait-args-issue-136407.rs:21:24
@@ -76,11 +61,6 @@ error[E0107]: missing generics for trait `AsyncFn`
    |
 LL | pub fn async_shared<T: AsyncFn>() {}
    |                        ^^^^^^^ expected 1 generic argument
-   |
-help: add missing generic argument
-   |
-LL | pub fn async_shared<T: AsyncFn<Args>>() {}
-   |                               ++++++
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/missing-fn-trait-args-issue-136407.rs:25:25
@@ -97,11 +77,6 @@ error[E0107]: missing generics for trait `AsyncFnMut`
    |
 LL | pub fn async_mutable<T: AsyncFnMut>() {}
    |                         ^^^^^^^^^^ expected 1 generic argument
-   |
-help: add missing generic argument
-   |
-LL | pub fn async_mutable<T: AsyncFnMut<Args>>() {}
-   |                                   ++++++
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/missing-fn-trait-args-issue-136407.rs:29:22
@@ -118,11 +93,6 @@ error[E0107]: missing generics for trait `AsyncFnOnce`
    |
 LL | pub fn async_once<T: AsyncFnOnce>() {}
    |                      ^^^^^^^^^^^ expected 1 generic argument
-   |
-help: add missing generic argument
-   |
-LL | pub fn async_once<T: AsyncFnOnce<Args>>() {}
-   |                                 ++++++
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/missing-fn-trait-args-issue-136407.rs:33:23
@@ -139,11 +109,6 @@ error[E0107]: trait takes 1 generic argument but 0 generic arguments were suppli
    |
 LL | pub fn with_output<T: Fn<Output = ()>>() {}
    |                       ^^ expected 1 generic argument
-   |
-help: add missing generic argument
-   |
-LL | pub fn with_output<T: Fn<Args, Output = ()>>() {}
-   |                          +++++
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/unboxed-closures/missing-fn-trait-args-issue-136407.feature_enabled.stderr
+++ b/tests/ui/unboxed-closures/missing-fn-trait-args-issue-136407.feature_enabled.stderr
@@ -1,0 +1,80 @@
+error[E0107]: missing generics for trait `Fn`
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:9:18
+   |
+LL | pub fn shared<T: Fn>() {}
+   |                  ^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn shared<T: Fn<Args>>() {}
+   |                    ++++++
+
+error[E0107]: missing generics for trait `FnMut`
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:13:19
+   |
+LL | pub fn mutable<T: FnMut>() {}
+   |                   ^^^^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn mutable<T: FnMut<Args>>() {}
+   |                        ++++++
+
+error[E0107]: missing generics for trait `FnOnce`
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:17:16
+   |
+LL | pub fn once<T: FnOnce>() {}
+   |                ^^^^^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn once<T: FnOnce<Args>>() {}
+   |                      ++++++
+
+error[E0107]: missing generics for trait `AsyncFn`
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:21:24
+   |
+LL | pub fn async_shared<T: AsyncFn>() {}
+   |                        ^^^^^^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn async_shared<T: AsyncFn<Args>>() {}
+   |                               ++++++
+
+error[E0107]: missing generics for trait `AsyncFnMut`
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:25:25
+   |
+LL | pub fn async_mutable<T: AsyncFnMut>() {}
+   |                         ^^^^^^^^^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn async_mutable<T: AsyncFnMut<Args>>() {}
+   |                                   ++++++
+
+error[E0107]: missing generics for trait `AsyncFnOnce`
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:29:22
+   |
+LL | pub fn async_once<T: AsyncFnOnce>() {}
+   |                      ^^^^^^^^^^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn async_once<T: AsyncFnOnce<Args>>() {}
+   |                                 ++++++
+
+error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/missing-fn-trait-args-issue-136407.rs:33:23
+   |
+LL | pub fn with_output<T: Fn<Output = ()>>() {}
+   |                       ^^ expected 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL | pub fn with_output<T: Fn<Args, Output = ()>>() {}
+   |                          +++++
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/unboxed-closures/missing-fn-trait-args-issue-136407.rs
+++ b/tests/ui/unboxed-closures/missing-fn-trait-args-issue-136407.rs
@@ -1,0 +1,37 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/136407>.
+// Missing arguments must not suggest gated Fn-family syntax without its feature.
+
+//@ revisions: feature_disabled feature_enabled
+//@ edition: 2024
+
+#![cfg_attr(feature_enabled, feature(unboxed_closures))]
+
+pub fn shared<T: Fn>() {}
+//~^ ERROR missing generics
+//[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
+
+pub fn mutable<T: FnMut>() {}
+//~^ ERROR missing generics
+//[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
+
+pub fn once<T: FnOnce>() {}
+//~^ ERROR missing generics
+//[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
+
+pub fn async_shared<T: AsyncFn>() {}
+//~^ ERROR missing generics
+//[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
+
+pub fn async_mutable<T: AsyncFnMut>() {}
+//~^ ERROR missing generics
+//[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
+
+pub fn async_once<T: AsyncFnOnce>() {}
+//~^ ERROR missing generics
+//[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
+
+pub fn with_output<T: Fn<Output = ()>>() {}
+//~^ ERROR trait takes 1 generic argument but 0 generic arguments were supplied
+//[feature_disabled]~| ERROR the precise format of `Fn`-family traits' type parameters
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#136407