### PR TITLE
Implement `ExactSizeIterator` for `Chain`

### DIFF
--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -304,6 +304,7 @@ where
 {
 }
 
+#[stable(feature = "chain_exact_size", since = "CURRENT_RUSTC_VERSION")]
 impl<A, B> ExactSizeIterator for Chain<A, B>
 where
     A: ExactSizeIterator,

--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -304,6 +304,13 @@ where
 {
 }
 
+impl<A, B> ExactSizeIterator for Chain<A, B>
+where
+    A: ExactSizeIterator,
+    B: ExactSizeIterator<Item = A::Item>,
+{
+}
+
 #[stable(feature = "default_iters", since = "1.70.0")]
 impl<A: Default, B: Default> Default for Chain<A, B> {
     /// Creates a `Chain` from the default values for `A` and `B`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162512)*
<!-- homu-ignore:end -->

While using the `par_map` function in `rustc`, I was trying to make it take `T: ExactSizeIterator`, and then got surprised that an iterator which was essentially `<slice>.iter().chain(std::iter::once(<item>))` did not implement the trait.

If both the input iterator are exact size, then it seems natural for the chain to also be exact size, I think.

I have no idea whether this requires an unstable feature, or if it can be added as-is (in any case it will definitely need a stability attribute, I think). Opening for vibes and perf.

r? joboet