### PR TITLE
Simplify diagnostic levels

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::profiling::{SelfProfilerRef, VerboseTimingGuard};
 use rustc_errors::emitter::Emitter;
 use rustc_errors::{
     Diag, DiagArgMap, DiagCtxt, DiagCtxtHandle, DiagMessage, ErrCode, FatalError, FatalErrorMarker,
-    Level, MultiSpan, Style, Suggestions, catch_fatal_errors,
+    Level, MultiSpan, Style, Sublevel, Suggestions, catch_fatal_errors,
 };
 use rustc_fs_util::link_or_copy;
 use rustc_incremental::{copy_cgu_workproduct_to_incr_comp_cache_dir, in_incr_comp_dir_sess};
@@ -1217,7 +1217,7 @@ struct Diagnostic {
 // missing the following fields from `rustc_errors::Subdiag`.
 // - `span`: it doesn't impl `Send`.
 struct Subdiagnostic {
-    level: Level,
+    level: Sublevel,
     messages: Vec<(DiagMessage, Style)>,
 }
 

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -166,9 +166,7 @@ impl AnnotateSnippetEmitter {
         // If at least one portion of the message is styled, we need to
         // "pre-style" the message
         let mut title = if msgs.iter().any(|(_, style)| style != &crate::Style::NoStyle) {
-            annotation_level
-                .clone()
-                .secondary_title(Cow::Owned(self.pre_style_msgs(msgs, *level, args)))
+            annotation_level.clone().secondary_title(Cow::Owned(self.pre_style_msgs(msgs, args)))
         } else {
             annotation_level.clone().primary_title(format_diag_messages(msgs, args))
         };
@@ -255,7 +253,7 @@ impl AnnotateSnippetEmitter {
             // If at least one portion of the message is styled, we need to
             // "pre-style" the message
             let msg = if c.messages.iter().any(|(_, style)| style != &crate::Style::NoStyle) {
-                Cow::Owned(self.pre_style_msgs(&c.messages, c.level, args))
+                Cow::Owned(self.pre_style_msgs(&c.messages, args))
             } else {
                 format_diag_messages(&c.messages, args)
             };
@@ -544,16 +542,11 @@ impl AnnotateSnippetEmitter {
         .short_message(self.short_message)
     }
 
-    fn pre_style_msgs(
-        &self,
-        msgs: &[(DiagMessage, Style)],
-        level: Level,
-        args: &DiagArgMap,
-    ) -> String {
+    fn pre_style_msgs(&self, msgs: &[(DiagMessage, Style)], args: &DiagArgMap) -> String {
         msgs.iter()
             .filter_map(|(m, style)| {
                 let text = format_diag_message(m, args);
-                let style = style.anstyle(level);
+                let style = style.anstyle();
                 if text.is_empty() { None } else { Some(format!("{style}{text}{style:#}")) }
             })
             .collect()

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -306,8 +306,7 @@ impl AnnotateSnippetEmitter {
                     // do not display this suggestion, it is meant only for tools
                 }
                 SuggestionStyle::HideCodeAlways => {
-                    let msg =
-                        format_diag_messages(&[(suggestion.msg.to_owned(), Style::NoStyle)], args);
+                    let msg = format_diag_message(&suggestion.msg, args).into_owned();
                     group = group.element(annotate_snippets::Level::HELP.message(msg));
                 }
                 SuggestionStyle::HideCodeInline

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -28,7 +28,7 @@ use crate::emitter::{
 use crate::formatting::{format_diag_message, format_diag_messages};
 use crate::{
     CodeSuggestion, DiagInner, DiagMessage, Emitter, ErrCode, Level, MultiSpan, Style, Subdiag,
-    SuggestionStyle, TerminalUrl,
+    Sublevel, SuggestionStyle, TerminalUrl,
 };
 
 /// Generates diagnostics using annotate-snippet
@@ -125,11 +125,20 @@ fn annotation_level_for_level(level: Level) -> annotate_snippets::level::Level<'
         }
         Level::Fatal | Level::Error => annotate_snippets::level::ERROR,
         Level::ForceWarning | Level::Warning => annotate_snippets::Level::WARNING,
-        Level::Note | Level::OnceNote => annotate_snippets::Level::NOTE,
-        Level::Help | Level::OnceHelp => annotate_snippets::Level::HELP,
+        Level::Note => annotate_snippets::Level::NOTE,
+        Level::Help => annotate_snippets::Level::HELP,
         Level::FailureNote => annotate_snippets::Level::NOTE.no_name(),
         Level::Allow => panic!("Should not call with Allow"),
         Level::Expect => panic!("Should not call with Expect"),
+    }
+}
+
+fn annotation_level_for_sublevel(level: Sublevel) -> annotate_snippets::level::Level<'static> {
+    match level {
+        Sublevel::Error => annotate_snippets::Level::ERROR,
+        Sublevel::Warning => annotate_snippets::Level::WARNING,
+        Sublevel::Note | Sublevel::OnceNote => annotate_snippets::Level::NOTE,
+        Sublevel::Help | Sublevel::OnceHelp => annotate_snippets::Level::HELP,
     }
 }
 
@@ -184,7 +193,7 @@ impl AnnotateSnippetEmitter {
         let Some(sm) = self.sm.as_ref() else {
             group = group.elements(children.iter().map(|c| {
                 let msg = format_diag_messages(&c.messages, args);
-                let level = annotation_level_for_level(c.level);
+                let level = annotation_level_for_sublevel(c.level);
                 level.message(msg)
             }));
 
@@ -247,7 +256,7 @@ impl AnnotateSnippetEmitter {
         }
 
         for c in children {
-            let level = annotation_level_for_level(c.level);
+            let level = annotation_level_for_sublevel(c.level);
 
             // If at least one portion of the message is styled, we need to
             // "pre-style" the message

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -307,10 +307,8 @@ impl AnnotateSnippetEmitter {
                     // do not display this suggestion, it is meant only for tools
                 }
                 SuggestionStyle::HideCodeAlways => {
-                    let msg = format_diag_messages(
-                        &[(suggestion.msg.to_owned(), Style::HeaderMsg)],
-                        args,
-                    );
+                    let msg =
+                        format_diag_messages(&[(suggestion.msg.to_owned(), Style::NoStyle)], args);
                     group = group.element(annotate_snippets::Level::HELP.message(msg));
                 }
                 SuggestionStyle::HideCodeInline

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -5,7 +5,6 @@
 //!
 //! [annotate_snippets]: https://docs.rs/crate/annotate-snippets/
 
-use std::borrow::Cow;
 use std::fmt::Debug;
 use std::io;
 use std::io::Write;
@@ -166,7 +165,7 @@ impl AnnotateSnippetEmitter {
         // If at least one portion of the message is styled, we need to
         // "pre-style" the message
         let mut title = if msgs.iter().any(|(_, style)| style != &crate::Style::NoStyle) {
-            annotation_level.clone().secondary_title(Cow::Owned(self.pre_style_msgs(msgs, args)))
+            annotation_level.clone().secondary_title(self.pre_style_msgs(msgs, args))
         } else {
             annotation_level.clone().primary_title(format_diag_messages(msgs, args))
         };
@@ -184,7 +183,7 @@ impl AnnotateSnippetEmitter {
         // If we don't have span information, emit and exit
         let Some(sm) = self.sm.as_ref() else {
             group = group.elements(children.iter().map(|c| {
-                let msg = format_diag_messages(&c.messages, args).to_string();
+                let msg = format_diag_messages(&c.messages, args);
                 let level = annotation_level_for_level(c.level);
                 level.message(msg)
             }));
@@ -253,7 +252,7 @@ impl AnnotateSnippetEmitter {
             // If at least one portion of the message is styled, we need to
             // "pre-style" the message
             let msg = if c.messages.iter().any(|(_, style)| style != &crate::Style::NoStyle) {
-                Cow::Owned(self.pre_style_msgs(&c.messages, args))
+                self.pre_style_msgs(&c.messages, args)
             } else {
                 format_diag_messages(&c.messages, args)
             };

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -16,7 +16,8 @@ use tracing::debug;
 
 use crate::{
     CodeSuggestion, DiagCtxtHandle, DiagMessage, ErrCode, ErrorGuaranteed, ExplicitBug, Level,
-    MultiSpan, StashKey, Style, Substitution, SubstitutionPart, SuggestionStyle, Suggestions,
+    MultiSpan, StashKey, Style, Sublevel, Substitution, SubstitutionPart, SuggestionStyle,
+    Suggestions,
 };
 
 /// Trait for types that `Diag::emit` can return as a "guarantee" (or "proof")
@@ -314,9 +315,7 @@ impl DiagInner {
             Level::ForceWarning
             | Level::Warning
             | Level::Note
-            | Level::OnceNote
             | Level::Help
-            | Level::OnceHelp
             | Level::FailureNote
             | Level::Allow
             | Level::Expect => false,
@@ -343,7 +342,12 @@ impl DiagInner {
         }
     }
 
-    pub(crate) fn sub(&mut self, level: Level, message: impl Into<DiagMessage>, span: MultiSpan) {
+    pub(crate) fn sub(
+        &mut self,
+        level: Sublevel,
+        message: impl Into<DiagMessage>,
+        span: MultiSpan,
+    ) {
         let sub = Subdiag { level, messages: vec![(message.into(), Style::NoStyle)], span };
         self.children.push(sub);
     }
@@ -367,7 +371,7 @@ impl DiagInner {
     pub fn emitted_at_sub_diag(&self) -> Subdiag {
         let track = format!("-Ztrack-diagnostics: created at {}", self.emitted_at);
         Subdiag {
-            level: crate::Level::Note,
+            level: crate::Sublevel::Note,
             messages: vec![(DiagMessage::Str(Cow::Owned(track)), Style::NoStyle)],
             span: MultiSpan::new(),
         }
@@ -420,7 +424,7 @@ impl PartialEq for DiagInner {
 /// For example, a note attached to an error.
 #[derive(Clone, Debug, PartialEq, Hash, Encodable, Decodable)]
 pub struct Subdiag {
-    pub level: Level,
+    pub level: Sublevel,
     pub messages: Vec<(DiagMessage, Style)>,
     pub span: MultiSpan,
 }
@@ -701,12 +705,12 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
     with_fn! { with_note,
     /// Add a note attached to this diagnostic.
     pub fn note(&mut self, msg: impl Into<DiagMessage>) -> &mut Self {
-        self.sub(Level::Note, msg, MultiSpan::new());
+        self.sub(Sublevel::Note, msg, MultiSpan::new());
         self
     } }
 
     pub fn highlighted_note(&mut self, msg: Vec<StringPart>) -> &mut Self {
-        self.sub_with_highlights(Level::Note, msg, MultiSpan::new());
+        self.sub_with_highlights(Sublevel::Note, msg, MultiSpan::new());
         self
     }
 
@@ -715,13 +719,13 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         span: impl Into<MultiSpan>,
         msg: Vec<StringPart>,
     ) -> &mut Self {
-        self.sub_with_highlights(Level::Note, msg, span.into());
+        self.sub_with_highlights(Sublevel::Note, msg, span.into());
         self
     }
 
     /// This is like [`Diag::note()`], but it's only printed once.
     pub fn note_once(&mut self, msg: impl Into<DiagMessage>) -> &mut Self {
-        self.sub(Level::OnceNote, msg, MultiSpan::new());
+        self.sub(Sublevel::OnceNote, msg, MultiSpan::new());
         self
     }
 
@@ -733,7 +737,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         sp: impl Into<MultiSpan>,
         msg: impl Into<DiagMessage>,
     ) -> &mut Self {
-        self.sub(Level::Note, msg, sp.into());
+        self.sub(Sublevel::Note, msg, sp.into());
         self
     } }
 
@@ -744,14 +748,14 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         sp: S,
         msg: impl Into<DiagMessage>,
     ) -> &mut Self {
-        self.sub(Level::OnceNote, msg, sp.into());
+        self.sub(Sublevel::OnceNote, msg, sp.into());
         self
     }
 
     with_fn! { with_warn,
     /// Add a warning attached to this diagnostic.
     pub fn warn(&mut self, msg: impl Into<DiagMessage>) -> &mut Self {
-        self.sub(Level::Warning, msg, MultiSpan::new());
+        self.sub(Sublevel::Warning, msg, MultiSpan::new());
         self
     } }
 
@@ -762,26 +766,26 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         sp: S,
         msg: impl Into<DiagMessage>,
     ) -> &mut Self {
-        self.sub(Level::Warning, msg, sp.into());
+        self.sub(Sublevel::Warning, msg, sp.into());
         self
     }
 
     with_fn! { with_help,
     /// Add a help message attached to this diagnostic.
     pub fn help(&mut self, msg: impl Into<DiagMessage>) -> &mut Self {
-        self.sub(Level::Help, msg, MultiSpan::new());
+        self.sub(Sublevel::Help, msg, MultiSpan::new());
         self
     } }
 
     /// This is like [`Diag::help()`], but it's only printed once.
     pub fn help_once(&mut self, msg: impl Into<DiagMessage>) -> &mut Self {
-        self.sub(Level::OnceHelp, msg, MultiSpan::new());
+        self.sub(Sublevel::OnceHelp, msg, MultiSpan::new());
         self
     }
 
     /// Add a help message attached to this diagnostic with a customizable highlighted message.
     pub fn highlighted_help(&mut self, msg: Vec<StringPart>) -> &mut Self {
-        self.sub_with_highlights(Level::Help, msg, MultiSpan::new());
+        self.sub_with_highlights(Sublevel::Help, msg, MultiSpan::new());
         self
     }
 
@@ -791,7 +795,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         span: impl Into<MultiSpan>,
         msg: Vec<StringPart>,
     ) -> &mut Self {
-        self.sub_with_highlights(Level::Help, msg, span.into());
+        self.sub_with_highlights(Sublevel::Help, msg, span.into());
         self
     }
 
@@ -803,7 +807,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         sp: impl Into<MultiSpan>,
         msg: impl Into<DiagMessage>,
     ) -> &mut Self {
-        self.sub(Level::Help, msg, sp.into());
+        self.sub(Sublevel::Help, msg, sp.into());
         self
     } }
 
@@ -1226,13 +1230,13 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
     /// public methods above.
     ///
     /// Used by `proc_macro_server` for implementing `server::Diagnostic`.
-    pub fn sub(&mut self, level: Level, message: impl Into<DiagMessage>, span: MultiSpan) {
+    pub fn sub(&mut self, level: Sublevel, message: impl Into<DiagMessage>, span: MultiSpan) {
         self.deref_mut().sub(level, message, span);
     }
 
     /// Convenience function for internal use, clients should use one of the
     /// public methods above.
-    fn sub_with_highlights(&mut self, level: Level, messages: Vec<StringPart>, span: MultiSpan) {
+    fn sub_with_highlights(&mut self, level: Sublevel, messages: Vec<StringPart>, span: MultiSpan) {
         let messages = messages.into_iter().map(|m| (m.content.into(), m.style)).collect();
         let sub = Subdiag { level, messages, span };
         self.children.push(sub);

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -26,7 +26,8 @@ use tracing::{debug, warn};
 use crate::formatting::format_diag_message;
 use crate::timings::TimingRecord;
 use crate::{
-    CodeSuggestion, DiagInner, DiagMessage, Level, MultiSpan, Style, Subdiag, SuggestionStyle,
+    CodeSuggestion, DiagInner, DiagMessage, Level, MultiSpan, Style, Subdiag, Sublevel,
+    SuggestionStyle,
 };
 
 /// Describes the way the content of the `rendered` field of the json output is generated
@@ -209,7 +210,7 @@ pub trait Emitter {
                 );
 
                 children.push(Subdiag {
-                    level: Level::Note,
+                    level: Sublevel::Note,
                     messages: vec![(DiagMessage::from(msg), Style::NoStyle)],
                     span: MultiSpan::new(),
                 });
@@ -379,7 +380,7 @@ impl Emitter for EmitterWithNote {
     }
 
     fn emit_diagnostic(&mut self, mut diag: DiagInner) {
-        diag.sub(Level::Note, self.note.clone(), MultiSpan::new());
+        diag.sub(Sublevel::Note, self.note.clone(), MultiSpan::new());
         self.emitter.emit_diagnostic(diag);
     }
 }

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -555,33 +555,10 @@ pub fn get_stderr_color_choice(color: ColorConfig, stderr: &std::io::Stderr) -> 
     if matches!(choice, ColorChoice::Auto) { AutoStream::choice(stderr) } else { choice }
 }
 
-/// On Windows, BRIGHT_BLUE is hard to read on black. Use cyan instead.
-///
-/// See #36178.
-const BRIGHT_BLUE: anstyle::Style = if cfg!(windows) {
-    AnsiColor::BrightCyan.on_default()
-} else {
-    AnsiColor::BrightBlue.on_default()
-};
-
 impl Style {
-    pub(crate) fn anstyle(&self, lvl: Level) -> anstyle::Style {
+    pub(crate) fn anstyle(&self) -> anstyle::Style {
         match self {
-            Style::Addition => AnsiColor::BrightGreen.on_default(),
-            Style::Removal => AnsiColor::BrightRed.on_default(),
-            Style::LineAndColumn => anstyle::Style::new(),
-            Style::LineNumber => BRIGHT_BLUE.effects(Effects::BOLD),
-            Style::Quotation => anstyle::Style::new(),
-            Style::MainHeaderMsg => if cfg!(windows) {
-                AnsiColor::BrightWhite.on_default()
-            } else {
-                anstyle::Style::new()
-            }
-            .effects(Effects::BOLD),
-            Style::UnderlinePrimary | Style::LabelPrimary => lvl.color().effects(Effects::BOLD),
-            Style::UnderlineSecondary | Style::LabelSecondary => BRIGHT_BLUE.effects(Effects::BOLD),
             Style::HeaderMsg | Style::NoStyle => anstyle::Style::new(),
-            Style::Level(lvl) => lvl.color().effects(Effects::BOLD),
             Style::Highlight => AnsiColor::Magenta.on_default().effects(Effects::BOLD),
         }
     }

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -558,7 +558,7 @@ pub fn get_stderr_color_choice(color: ColorConfig, stderr: &std::io::Stderr) -> 
 impl Style {
     pub(crate) fn anstyle(&self) -> anstyle::Style {
         match self {
-            Style::HeaderMsg | Style::NoStyle => anstyle::Style::new(),
+            Style::NoStyle => anstyle::Style::new(),
             Style::Highlight => AnsiColor::Magenta.on_default().effects(Effects::BOLD),
         }
     }

--- a/compiler/rustc_errors/src/formatting.rs
+++ b/compiler/rustc_errors/src/formatting.rs
@@ -24,11 +24,8 @@ fn to_fluent_args<'iter>(iter: impl Iterator<Item = DiagArg<'iter>>) -> FluentAr
 }
 
 /// Convert `DiagMessage`s to a string
-pub fn format_diag_messages(
-    messages: &[(DiagMessage, Style)],
-    args: &DiagArgMap,
-) -> Cow<'static, str> {
-    Cow::Owned(messages.iter().map(|(m, _)| format_diag_message(m, args)).collect::<String>())
+pub fn format_diag_messages(messages: &[(DiagMessage, Style)], args: &DiagArgMap) -> String {
+    messages.iter().map(|(m, _)| format_diag_message(m, args)).collect::<String>()
 }
 
 /// Convert a `DiagMessage` to a string

--- a/compiler/rustc_errors/src/json.rs
+++ b/compiler/rustc_errors/src/json.rs
@@ -379,20 +379,13 @@ impl Diagnostic {
         let buf = Arc::try_unwrap(buf.0).unwrap().into_inner().unwrap();
         let buf = String::from_utf8(buf).unwrap();
 
-        Diagnostic {
-            message: formatted_message.to_string(),
-            code,
-            level,
-            spans,
-            children,
-            rendered: Some(buf),
-        }
+        Diagnostic { message: formatted_message, code, level, spans, children, rendered: Some(buf) }
     }
 
     fn from_sub_diagnostic(subdiag: &Subdiag, args: &DiagArgMap, je: &JsonEmitter) -> Diagnostic {
         let formatted_message = format_diag_messages(&subdiag.messages, args);
         Diagnostic {
-            message: formatted_message.to_string(),
+            message: formatted_message,
             code: None,
             level: subdiag.level.to_str(),
             spans: DiagnosticSpan::from_multispan(&subdiag.span, args, je),

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1665,7 +1665,6 @@ impl IntoDiagArg for Level {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub enum Style {
-    HeaderMsg,
     NoStyle,
     Highlight,
 }

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1640,23 +1640,6 @@ impl fmt::Display for Level {
 }
 
 impl Level {
-    fn color(self) -> anstyle::Style {
-        match self {
-            Bug | Fatal | Error | DelayedBug => AnsiColor::BrightRed.on_default(),
-            ForceWarning | Warning => {
-                if cfg!(windows) {
-                    AnsiColor::BrightYellow.on_default()
-                } else {
-                    AnsiColor::Yellow.on_default()
-                }
-            }
-            Note | OnceNote => AnsiColor::BrightGreen.on_default(),
-            Help | OnceHelp => AnsiColor::BrightCyan.on_default(),
-            FailureNote => anstyle::Style::new(),
-            Allow | Expect => unreachable!(),
-        }
-    }
-
     pub fn to_str(self) -> &'static str {
         match self {
             Bug | DelayedBug => "error: internal compiler error",
@@ -1682,20 +1665,9 @@ impl IntoDiagArg for Level {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Encodable, Decodable)]
 pub enum Style {
-    MainHeaderMsg,
     HeaderMsg,
-    LineAndColumn,
-    LineNumber,
-    Quotation,
-    UnderlinePrimary,
-    UnderlineSecondary,
-    LabelPrimary,
-    LabelSecondary,
     NoStyle,
-    Level(Level),
     Highlight,
-    Addition,
-    Removal,
 }
 
 // FIXME(eddyb) this doesn't belong here AFAICT, should be moved to callsite.

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -617,8 +617,7 @@ impl<'a> DiagCtxtHandle<'a> {
             DelayedBug => {
                 return self.dcx.inner.borrow_mut().emit_diagnostic(diag, self.tainted_with_errors);
             }
-            ForceWarning | Warning | Note | OnceNote | Help | OnceHelp | FailureNote | Allow
-            | Expect => None,
+            ForceWarning | Warning | Note | Help | FailureNote | Allow | Expect => None,
         };
 
         // FIXME(Centril, #69537): Consider reintroducing panic on overwriting a stashed diagnostic
@@ -1287,7 +1286,6 @@ impl DiagCtxtInner {
                 }
             }
             Note | Help | FailureNote => {}
-            OnceNote | OnceHelp => panic!("bad level: {:?}", diagnostic.level),
             Allow => {
                 // Nothing emitted for allowed lints.
                 if diagnostic.has_future_breakage() {
@@ -1346,8 +1344,11 @@ impl DiagCtxtInner {
 
                 let not_yet_emitted = |sub: &mut Subdiag| {
                     debug!(?sub);
-                    if sub.level != OnceNote && sub.level != OnceHelp {
-                        return true;
+                    match sub.level {
+                        Sublevel::Error | Sublevel::Warning | Sublevel::Note | Sublevel::Help => {
+                            return true;
+                        }
+                        Sublevel::OnceNote | Sublevel::OnceHelp => {}
                     }
                     let mut hasher = StableHasher::new();
                     sub.hash(&mut hasher);
@@ -1358,7 +1359,7 @@ impl DiagCtxtInner {
                 diagnostic.children.retain_mut(not_yet_emitted);
                 if already_emitted {
                     let msg = "duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`";
-                    diagnostic.sub(Note, msg, MultiSpan::new());
+                    diagnostic.sub(Sublevel::Note, msg, MultiSpan::new());
                 }
 
                 if is_error {
@@ -1508,7 +1509,7 @@ impl DiagCtxtInner {
                 let msg = msg!(
                     "`flushed_delayed` got diagnostic with level {$level}, instead of the expected `DelayedBug`"
                 ).arg("level", bug.level).format();
-                bug.sub(Note, msg, bug.span.primary_span().unwrap().into());
+                bug.sub(Sublevel::Note, msg, bug.span.primary_span().unwrap().into());
             }
             bug.level = Bug;
 
@@ -1559,26 +1560,24 @@ impl DelayedDiagInner {
         .arg("emitted_at", diag.emitted_at.clone())
         .arg("note", self.note)
         .format();
-        diag.sub(Note, msg, diag.span.primary_span().unwrap_or(DUMMY_SP).into());
+        diag.sub(Sublevel::Note, msg, diag.span.primary_span().unwrap_or(DUMMY_SP).into());
         diag
     }
 }
 
-/// | Level        | is_error | EmissionGuarantee | Top-level | Sub | Used in lints?
-/// | -----        | -------- | ----------------- | --------- | --- | --------------
-/// | Bug          | yes      | BugAbort          | yes       | -   | -
-/// | Fatal        | yes      | FatalAbort        | yes       | -   | -
-/// | Error        | yes      | ErrorGuaranteed   | yes       | -   | yes
-/// | DelayedBug   | yes      | ErrorGuaranteed   | yes       | -   | -
-/// | ForceWarning | -        | ()                | yes       | -   | lint-only
-/// | Warning      | -        | ()                | yes       | yes | yes
-/// | Note         | -        | ()                | rare      | yes | -
-/// | OnceNote     | -        | ()                | -         | yes | lint-only
-/// | Help         | -        | ()                | rare      | yes | -
-/// | OnceHelp     | -        | ()                | -         | yes | lint-only
-/// | FailureNote  | -        | ()                | rare      | -   | -
-/// | Allow        | -        | ()                | yes       | -   | lint-only
-/// | Expect       | -        | ()                | yes       | -   | lint-only
+/// | Level        | is_error | EmissionGuarantee | Top-level | Used in lints?
+/// | -----        | -------- | ----------------- | --------- | --------------
+/// | Bug          | yes      | BugAbort          | yes       | -
+/// | Fatal        | yes      | FatalAbort        | yes       | -
+/// | Error        | yes      | ErrorGuaranteed   | yes       | yes
+/// | DelayedBug   | yes      | ErrorGuaranteed   | yes       | -
+/// | ForceWarning | -        | ()                | yes       | lint-only
+/// | Warning      | -        | ()                | yes       | yes
+/// | Note         | -        | ()                | rare      | -
+/// | Help         | -        | ()                | rare      | -
+/// | FailureNote  | -        | ()                | rare      | -
+/// | Allow        | -        | ()                | yes       | lint-only
+/// | Expect       | -        | ()                | yes       | lint-only
 ///
 #[derive(Copy, PartialEq, Eq, Clone, Hash, Debug, Encodable, Decodable)]
 pub enum Level {
@@ -1613,14 +1612,8 @@ pub enum Level {
     /// A message giving additional context.
     Note,
 
-    /// A note that is only emitted once.
-    OnceNote,
-
     /// A message suggesting how to fix something.
     Help,
-
-    /// A help that is only emitted once.
-    OnceHelp,
 
     /// Similar to `Note`, but used in cases where compilation has failed. When printed for human
     /// consumption, it doesn't have any kind of `note:` label.
@@ -1645,8 +1638,8 @@ impl Level {
             Bug | DelayedBug => "error: internal compiler error",
             Fatal | Error => "error",
             ForceWarning | Warning => "warning",
-            Note | OnceNote => "note",
-            Help | OnceHelp => "help",
+            Note => "note",
+            Help => "help",
             FailureNote => "failure-note",
             Allow | Expect => unreachable!(),
         }
@@ -1660,6 +1653,42 @@ impl Level {
 impl IntoDiagArg for Level {
     fn into_diag_arg(self, _: &mut Option<std::path::PathBuf>) -> DiagArgValue {
         DiagArgValue::Str(Cow::from(self.to_string()))
+    }
+}
+
+/// The level for a subdiagnostic.
+#[derive(Copy, PartialEq, Eq, Clone, Hash, Debug, Encodable, Decodable)]
+pub enum Sublevel {
+    /// See `Level::Error`.
+    ///
+    /// The compiler never uses this level in a subdiagnostic, but it can be produced by proc
+    /// macros. See tests/ui/proc-macro/sub-error-diag.rs for details.
+    Error,
+
+    /// See `Level::Warning`.
+    Warning,
+
+    /// See `Level::Note`.
+    Note,
+
+    /// A note that is only emitted once.
+    OnceNote,
+
+    /// See `Level::Help`.
+    Help,
+
+    /// A help that is only emitted once.
+    OnceHelp,
+}
+
+impl Sublevel {
+    pub fn to_str(self) -> &'static str {
+        match self {
+            Sublevel::Error => "error",
+            Sublevel::Warning => "warning",
+            Sublevel::Note | Sublevel::OnceNote => "note",
+            Sublevel::Help | Sublevel::OnceHelp => "help",
+        }
     }
 }
 

--- a/compiler/rustc_expand/src/module.rs
+++ b/compiler/rustc_expand/src/module.rs
@@ -4,12 +4,11 @@ use std::path::{self, Path, PathBuf};
 use rustc_ast::{AttrVec, Attribute, Inline, Item, ModSpans};
 use rustc_attr_parsing::template;
 use rustc_attr_parsing::validate_attr::emit_malformed_attribute;
-use rustc_errors::{Diag, ErrorGuaranteed};
+use rustc_errors::{Diag, ErrorGuaranteed, FatalError};
 use rustc_parse::lexer::StripTokens;
 use rustc_parse::{exp, new_parser_from_file, unwrap_or_emit_fatal};
 use rustc_session::Session;
 use rustc_session::parse::ParseSess;
-use rustc_span::fatal_error::FatalError;
 use rustc_span::{Ident, Span, sym};
 use thin_vec::ThinVec;
 

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -414,6 +414,18 @@ impl ToInternal<rustc_errors::Level> for Level {
     }
 }
 
+impl ToInternal<rustc_errors::Sublevel> for Level {
+    fn to_internal(self) -> rustc_errors::Sublevel {
+        match self {
+            Level::Error => rustc_errors::Sublevel::Error,
+            Level::Warning => rustc_errors::Sublevel::Warning,
+            Level::Note => rustc_errors::Sublevel::Note,
+            Level::Help => rustc_errors::Sublevel::Help,
+            _ => unreachable!("unknown proc_macro::Level variant: {:?}", self),
+        }
+    }
+}
+
 fn cancel_diags_into_string(diags: Vec<Diag<'_>>) -> String {
     let mut messages = diags.into_iter().flat_map(Diag::cancel_into_message);
     let msg = messages.next().expect("no diagnostic has a message");

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -10,8 +10,8 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::unord::UnordSet;
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, ErrorGuaranteed, Level, MultiSpan, StashKey, StringPart, Suggestions, msg,
-    pluralize, struct_span_code_err,
+    Applicability, Diag, ErrorGuaranteed, MultiSpan, StashKey, StringPart, Sublevel, Suggestions,
+    msg, pluralize, struct_span_code_err,
 };
 use rustc_hir::attrs::diagnostic::CustomDiagnostic;
 use rustc_hir::attrs::lang_items::LangItem;
@@ -2286,7 +2286,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     }
 
                     if let [child, ..] = &err.children[..]
-                        && child.level == Level::Help
+                        && child.level == Sublevel::Help
                         && let Some(line) = child.messages.get(0)
                         && let Some(line) = line.0.as_str()
                         && line.starts_with("the trait")


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162514)*
<!-- homu-ignore:end -->

This PR separates diagnostic levels from subdiagnostic levels and does a few preliminary cleanups. Details in individual commits.

r? @oli-obk