### PR TITLE
tidy: Sort multi-line types by treating `>` as a closing bracket

### DIFF
--- a/src/tools/tidy/src/alphabetical.rs
+++ b/src/tools/tidy/src/alphabetical.rs
@@ -51,7 +51,7 @@ fn indentation(line: &str) -> usize {
 }
 
 fn is_close_bracket(c: char) -> bool {
-    matches!(c, ')' | ']' | '}')
+    matches!(c, ')' | ']' | '}' | '>')
 }
 
 fn is_empty_or_comment(line: &&str) -> bool {

--- a/src/tools/tidy/src/alphabetical/tests.rs
+++ b/src/tools/tidy/src/alphabetical/tests.rs
@@ -409,10 +409,31 @@ fn multiline() {
     bad(lines, "bad:2: line not in alphabetical order (tip: use --bless to sort this list)");
 
     let lines = "\
+        // tidy-alphabetical-start
         force_unwind_tables: Option<bool> = (None, parse_opt_bool, [TRACKED],
              'force use of unwind tables'),
         incremental: Option<String> = (None, parse_opt_string, [UNTRACKED],
             'enable incremental compilation'),
+        // tidy-alphabetical-end
+    ";
+    good(lines);
+}
+
+#[test]
+fn multiline_types() {
+    let lines = "\
+        // tidy-alphabetical-start
+        rustc_data_structures::steal::Steal<
+            rustc_index::IndexVec<
+                rustc_middle::mir::Promoted,
+                rustc_middle::mir::Body<'tcx>
+            >
+        >,
+        rustc_index::IndexVec<
+            rustc_middle::mir::Promoted,
+            rustc_middle::mir::Body<'tcx>
+        >,
+        // tidy-alphabetical-end
     ";
     good(lines);
 }
@@ -476,6 +497,41 @@ fn bless_multiline() {
         )
     notaddition
         tidy-alphabetical-end
+    ";
+
+    bless_test(before, after);
+}
+
+#[test]
+fn bless_multiline_types() {
+    let before = "\
+        // tidy-alphabetical-start
+        rustc_index::IndexVec<
+            rustc_middle::mir::Promoted,
+            rustc_middle::mir::Body<'tcx>
+        >,
+        rustc_data_structures::steal::Steal<
+            rustc_index::IndexVec<
+                rustc_middle::mir::Promoted,
+                rustc_middle::mir::Body<'tcx>
+            >
+        >,
+        // tidy-alphabetical-end
+    ";
+
+    let after = "\
+        // tidy-alphabetical-start
+        rustc_data_structures::steal::Steal<
+            rustc_index::IndexVec<
+                rustc_middle::mir::Promoted,
+                rustc_middle::mir::Body<'tcx>
+            >
+        >,
+        rustc_index::IndexVec<
+            rustc_middle::mir::Promoted,
+            rustc_middle::mir::Body<'tcx>
+        >,
+        // tidy-alphabetical-end
     ";
 
     bless_test(before, after);


### PR DESCRIPTION
While tidying up some macros in the compiler, I noticed that `tidy-alphabetical-start` doesn't treat `>` as a closing bracket, so it gets confused when sorting lists where complex parameterized types have been broken across multiple lines.

This PR therefore changes tidy to treat `>` as a closing bracket, and adds some tests to verify the intended behaviour.

While we do have some places that sort lists of types, none of them happen to use multi-line types right now.