### PR TITLE
Add a revision for previously fixed solver issue

### DIFF
--- a/tests/ui/try-block/try-block-unused-delims.current.fixed
+++ b/tests/ui/try-block/try-block-unused-delims.current.fixed
@@ -1,3 +1,6 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
 //@ check-pass
 //@ edition: 2018
 //@ run-rustfix

--- a/tests/ui/try-block/try-block-unused-delims.current.stderr
+++ b/tests/ui/try-block/try-block-unused-delims.current.stderr
@@ -1,11 +1,11 @@
 warning: unnecessary parentheses around function argument
-  --> $DIR/try-block-unused-delims.rs:11:13
+  --> $DIR/try-block-unused-delims.rs:14:13
    |
 LL |     consume((try {}));
    |             ^      ^
    |
 note: the lint level is defined here
-  --> $DIR/try-block-unused-delims.rs:6:9
+  --> $DIR/try-block-unused-delims.rs:9:9
    |
 LL | #![warn(unused_parens, unused_braces)]
    |         ^^^^^^^^^^^^^
@@ -16,13 +16,13 @@ LL +     consume(try {});
    |
 
 warning: unnecessary braces around function argument
-  --> $DIR/try-block-unused-delims.rs:14:13
+  --> $DIR/try-block-unused-delims.rs:17:13
    |
 LL |     consume({ try {} });
    |             ^^      ^^
    |
 note: the lint level is defined here
-  --> $DIR/try-block-unused-delims.rs:6:24
+  --> $DIR/try-block-unused-delims.rs:9:24
    |
 LL | #![warn(unused_parens, unused_braces)]
    |                        ^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL +     consume(try {});
    |
 
 warning: unnecessary parentheses around `match` scrutinee expression
-  --> $DIR/try-block-unused-delims.rs:17:11
+  --> $DIR/try-block-unused-delims.rs:20:11
    |
 LL |     match (try {}) {
    |           ^      ^
@@ -45,7 +45,7 @@ LL +     match try {} {
    |
 
 warning: unnecessary parentheses around `let` scrutinee expression
-  --> $DIR/try-block-unused-delims.rs:22:22
+  --> $DIR/try-block-unused-delims.rs:25:22
    |
 LL |     if let Err(()) = (try {}) {}
    |                      ^      ^
@@ -57,7 +57,7 @@ LL +     if let Err(()) = try {} {}
    |
 
 warning: unnecessary parentheses around `match` scrutinee expression
-  --> $DIR/try-block-unused-delims.rs:25:11
+  --> $DIR/try-block-unused-delims.rs:28:11
    |
 LL |     match (try {}) {
    |           ^      ^

--- a/tests/ui/try-block/try-block-unused-delims.next.fixed
+++ b/tests/ui/try-block/try-block-unused-delims.next.fixed
@@ -11,21 +11,21 @@
 fn consume<T>(_: Result<T, T>) -> T { todo!() }
 
 fn main() {
-    consume((try {}));
+    consume(try {});
     //~^ WARN unnecessary parentheses
 
-    consume({ try {} });
+    consume(try {});
     //~^ WARN unnecessary braces
 
-    match (try {}) {
+    match try {} {
         //~^ WARN unnecessary parentheses
         Ok(()) | Err(()) => (),
     }
 
-    if let Err(()) = (try {}) {}
+    if let Err(()) = try {} {}
     //~^ WARN unnecessary parentheses
 
-    match (try {}) {
+    match try {} {
         //~^ WARN unnecessary parentheses
         Ok(()) | Err(()) => (),
     }

--- a/tests/ui/try-block/try-block-unused-delims.next.stderr
+++ b/tests/ui/try-block/try-block-unused-delims.next.stderr
@@ -1,0 +1,72 @@
+warning: unnecessary parentheses around function argument
+  --> $DIR/try-block-unused-delims.rs:14:13
+   |
+LL |     consume((try {}));
+   |             ^      ^
+   |
+note: the lint level is defined here
+  --> $DIR/try-block-unused-delims.rs:9:9
+   |
+LL | #![warn(unused_parens, unused_braces)]
+   |         ^^^^^^^^^^^^^
+help: remove these parentheses
+   |
+LL -     consume((try {}));
+LL +     consume(try {});
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/try-block-unused-delims.rs:17:13
+   |
+LL |     consume({ try {} });
+   |             ^^      ^^
+   |
+note: the lint level is defined here
+  --> $DIR/try-block-unused-delims.rs:9:24
+   |
+LL | #![warn(unused_parens, unused_braces)]
+   |                        ^^^^^^^^^^^^^
+help: remove these braces
+   |
+LL -     consume({ try {} });
+LL +     consume(try {});
+   |
+
+warning: unnecessary parentheses around `match` scrutinee expression
+  --> $DIR/try-block-unused-delims.rs:20:11
+   |
+LL |     match (try {}) {
+   |           ^      ^
+   |
+help: remove these parentheses
+   |
+LL -     match (try {}) {
+LL +     match try {} {
+   |
+
+warning: unnecessary parentheses around `let` scrutinee expression
+  --> $DIR/try-block-unused-delims.rs:25:22
+   |
+LL |     if let Err(()) = (try {}) {}
+   |                      ^      ^
+   |
+help: remove these parentheses
+   |
+LL -     if let Err(()) = (try {}) {}
+LL +     if let Err(()) = try {} {}
+   |
+
+warning: unnecessary parentheses around `match` scrutinee expression
+  --> $DIR/try-block-unused-delims.rs:28:11
+   |
+LL |     match (try {}) {
+   |           ^      ^
+   |
+help: remove these parentheses
+   |
+LL -     match (try {}) {
+LL +     match try {} {
+   |
+
+warning: 5 warnings emitted
+


### PR DESCRIPTION
Closes https://github.com/rust-lang/trait-system-refactor-initiative/issues/87 , which has been previously fixed by rust-lang/rust#149320 (cc https://rust-lang.zulipchat.com/#narrow/channel/618216-t-types.2Fcall-for-participation/topic/enable.20-Znext-solver.20for.20try-block.20test/with/622722733)

r? adwinwhite