### PR TITLE
Add Armv8.1-M targets for Cortex-M55 and Cortex-M85 based microcontrollers

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1521,6 +1521,8 @@ supported_targets! {
     ("thumbv8m.base-none-eabi", thumbv8m_base_none_eabi),
     ("thumbv8m.main-none-eabi", thumbv8m_main_none_eabi),
     ("thumbv8m.main-none-eabihf", thumbv8m_main_none_eabihf),
+    ("thumbv8.1m.main-none-eabi", thumbv81m_main_none_eabi),
+    ("thumbv8.1m.main-none-eabihf", thumbv81m_main_none_eabihf),
 
     ("armv7a-none-eabi", armv7a_none_eabi),
     ("thumbv7a-none-eabi", thumbv7a_none_eabi),

--- a/compiler/rustc_target/src/spec/targets/thumbv81m_main_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv81m_main_none_eabi.rs
@@ -1,0 +1,28 @@
+// Targets the Cortex-M55/-M85 processors (Armv8.1-M Mainline architecture profile),
+// without the Floating Point extension.
+
+use crate::spec::{Arch, CfgAbi, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+
+pub(crate) fn target() -> Target {
+    Target {
+        llvm_target: "thumbv8.1m.main-none-eabi".into(),
+        metadata: TargetMetadata {
+            description: Some("Bare ARMv8.1-M Mainline with DSP and LOB".into()),
+            tier: Some(2),
+            host_tools: Some(false),
+            std: Some(false),
+        },
+        pointer_width: 32,
+        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
+        arch: Arch::Arm,
+
+        options: TargetOptions {
+            cfg_abi: CfgAbi::Eabi,
+            llvm_floatabi: Some(FloatAbi::Soft),
+            // We assume you have the DSP and LOB extensions (which are technically optional).
+            features: "+dsp,+lob".into(),
+            max_atomic_width: Some(32),
+            ..base::arm_none::opts()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/targets/thumbv81m_main_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv81m_main_none_eabihf.rs
@@ -1,0 +1,31 @@
+// Targets the Cortex-M55/-M85 processors (Armv8.1-M Mainline architecture profile),
+// with the Floating Point extension.
+//
+// It does not assume you have M-Profile Vector Extensions (aka Helium)
+
+use crate::spec::{Arch, CfgAbi, FloatAbi, Target, TargetMetadata, TargetOptions, base};
+
+pub(crate) fn target() -> Target {
+    Target {
+        llvm_target: "thumbv8.1m.main-none-eabihf".into(),
+        metadata: TargetMetadata {
+            description: Some("Bare ARMv8.1-M Mainline, hardfloat, with DSP and LOB".into()),
+            tier: Some(2),
+            host_tools: Some(false),
+            std: Some(false),
+        },
+        pointer_width: 32,
+        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
+        arch: Arch::Arm,
+
+        options: TargetOptions {
+            cfg_abi: CfgAbi::EabiHf,
+            llvm_floatabi: Some(FloatAbi::Hard),
+            // The Cortex-M55 and Cortex-M85 both have FPv5-D16 double-precision FPUs
+            // We also assume you have the DSP and LOB extensions (which are technically optional).
+            features: "+dsp,+fp-armv8d16,+lob".into(),
+            max_atomic_width: Some(32),
+            ..base::arm_none::opts()
+        },
+    }
+}

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -36,6 +36,8 @@ pub struct Finder {
 /// when the newly-bumped stage 0 compiler now knows about the formerly-missing targets.
 const STAGE0_MISSING_TARGETS: &[&str] = &[
     // just a dummy comment so the list doesn't get onelined
+    "thumbv8.1m.main-none-eabihf",
+    "thumbv8.1m.main-none-eabi",
 ];
 
 /// Minimum version threshold for libstdc++ required when using prebuilt LLVM

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -67,6 +67,7 @@
       - [thumbv7m-none-eabi](./platform-support/thumbv7m-none-eabi.md)
       - [thumbv8m.base-none-eabi](./platform-support/thumbv8m.base-none-eabi.md)
       - [thumbv8m.main-none-eabi\*](./platform-support/thumbv8m.main-none-eabi.md)
+      - [thumbv8.1m.main-none-eabi\*](./platform-support/thumbv8.1m.main-none-eabi.md)
       - [armebv7r-none-eabi{,hf}](platform-support/armebv7r-none-eabi.md)
     - [arm\*-unknown-linux-\*](./platform-support/arm-linux.md)
         - [armeb-unknown-linux-gnueabi](platform-support/armeb-unknown-linux-gnueabi.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -445,6 +445,8 @@ target | std | host | notes
 [`thumbv8m.base-nuttx-eabi`](platform-support/nuttx.md) | ✓ |  | ARMv8M Baseline with NuttX
 [`thumbv8m.main-nuttx-eabi`](platform-support/nuttx.md) | ✓ |  | ARMv8M Mainline with NuttX
 [`thumbv8m.main-nuttx-eabihf`](platform-support/nuttx.md) | ✓ |  | ARMv8M Mainline with NuttX, hardfloat
+[`thumbv8.1m.main-none-eabi`](platform-support/thumbv8.1m.main-none-eabi.md) | * |  | Bare Armv8.1-M Mainline, with DSP and LOB
+[`thumbv8.1m.main-none-eabihf`](platform-support/thumbv8.1m.main-none-eabi.md) | * |  | Bare Armv8.1-M Mainline, hardfloat, with DSP and LOB
 [`wasm64-unknown-unknown`](platform-support/wasm64-unknown-unknown.md) | ? |  | WebAssembly
 [`wasm32-wali-linux-musl`](platform-support/wasm32-wali-linux.md) | ? |  | WebAssembly with [WALI](https://github.com/arjunr2/WALI)
 [`x86_64-apple-tvos`](platform-support/apple-tvos.md) | ✓ |  | x86 64-bit tvOS

--- a/src/doc/rustc/src/platform-support/arm-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/arm-none-eabi.md
@@ -26,6 +26,7 @@ their own document.
   - [`thumbv7em-none-eabi` and `thumbv7em-none-eabihf`](thumbv7em-none-eabi.md)
   - [`thumbv8m.base-none-eabi`](thumbv8m.base-none-eabi.md)
   - [`thumbv8m.main-none-eabi` and `thumbv8m.main-none-eabihf`](thumbv8m.main-none-eabi.md)
+  - [`thumbv8.1m.main-none-eabi` and `thumbv8.1m.main-none-eabihf`](thumbv8.1m.main-none-eabi.md)
 - *Legacy* Arm Architectures
   - None
 

--- a/src/doc/rustc/src/platform-support/thumbv8.1m.main-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/thumbv8.1m.main-none-eabi.md
@@ -39,31 +39,31 @@ to use these flags.
 
 ### Table of supported CPUs for `thumbv8.1m.main-none-eabi`
 
-| CPU         | FPU | DSP | MVE       | Target CPU    | Target Features       |
-| ----------- | --- | --- | --------- | ------------- | --------------------- |
-| Unspecified | No  | No  | No        | None          | None                  |
-| Cortex-M55  | No  | Yes | No        | `cortex-m55`  | `-fpregs,-mve`        |
-| Cortex-M55  | DP  | Yes | No        | `cortex-m55`  | `-mve`                |
-| Cortex-M55  | No  | Yes | Int       | `cortex-m55`  | `-fpregs,-mve.fp,+mve`|
-| Cortex-M55  | DP  | Yes | Int       | `cortex-m55`  | `-mve.fp`             |
-| Cortex-M55  | DP  | Yes | Int+Float | `cortex-m55`  | None                  |
-| Cortex-M85  | No  | Yes | No        | `cortex-m85`  | `-fpregs,-mve`        |
-| Cortex-M85  | DP  | Yes | No        | `cortex-m85`  | `-mve`                |
-| Cortex-M85  | No  | Yes | Int       | `cortex-m85`  | `-fpregs,-mve.fp,+mve`|
-| Cortex-M85  | DP  | Yes | Int       | `cortex-m85`  | `-mve.fp`             |
-| Cortex-M85  | DP  | Yes | Int+Float | `cortex-m85`  | None                  |
+| CPU         | FPU | MVE       | Target CPU    | Target Features       |
+| ----------- | --- | --------- | ------------- | --------------------- |
+| Unspecified | No  | No        | None          | None                  |
+| Cortex-M55  | No  | No        | `cortex-m55`  | `-fpregs,-mve`        |
+| Cortex-M55  | DP  | No        | `cortex-m55`  | `-mve`                |
+| Cortex-M55  | No  | Int       | `cortex-m55`  | `-fpregs,-mve.fp,+mve`|
+| Cortex-M55  | DP  | Int       | `cortex-m55`  | `-mve.fp`             |
+| Cortex-M55  | DP  | Int+Float | `cortex-m55`  | None                  |
+| Cortex-M85  | No  | No        | `cortex-m85`  | `-fpregs,-mve`        |
+| Cortex-M85  | DP  | No        | `cortex-m85`  | `-mve`                |
+| Cortex-M85  | No  | Int       | `cortex-m85`  | `-fpregs,-mve.fp,+mve`|
+| Cortex-M85  | DP  | Int       | `cortex-m85`  | `-mve.fp`             |
+| Cortex-M85  | DP  | Int+Float | `cortex-m85`  | None                  |
 
 ### Table of supported CPUs for `thumbv8.1m.main-none-eabihf`
 
-| CPU         | FPU | DSP | MVE       | Target CPU    | Target Features       |
-| ----------- | --- | --- | --------- | ------------- | --------------------- |
-| Unspecified | DP  | No  | No        | None          | None                  |
-| Cortex-M55  | DP  | Yes | No        | `cortex-m55`  | `-mve`                |
-| Cortex-M55  | DP  | Yes | Int       | `cortex-m55`  | `-mve.fp`             |
-| Cortex-M55  | DP  | Yes | Int+Float | `cortex-m55`  | None                  |
-| Cortex-M85  | DP  | Yes | No        | `cortex-m85`  | `-mve`                |
-| Cortex-M85  | DP  | Yes | Int       | `cortex-m85`  | `-mve.fp`             |
-| Cortex-M85  | DP  | Yes | Int+Float | `cortex-m85`  | None                  |
+| CPU         | FPU | MVE       | Target CPU    | Target Features       |
+| ----------- | --- | --------- | ------------- | --------------------- |
+| Unspecified | DP  | No        | None          | None                  |
+| Cortex-M55  | DP  | No        | `cortex-m55`  | `-mve`                |
+| Cortex-M55  | DP  | Int       | `cortex-m55`  | `-mve.fp`             |
+| Cortex-M55  | DP  | Int+Float | `cortex-m55`  | None                  |
+| Cortex-M85  | DP  | No        | `cortex-m85`  | `-mve`                |
+| Cortex-M85  | DP  | Int       | `cortex-m85`  | `-mve.fp`             |
+| Cortex-M85  | DP  | Int+Float | `cortex-m85`  | None                  |
 
 *Technically* you can use this hard-float ABI on a CPU which has no FPU but does
 have Integer MVE, because MVE provides the same set of registers as the FPU

--- a/src/doc/rustc/src/platform-support/thumbv8.1m.main-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/thumbv8.1m.main-none-eabi.md
@@ -1,0 +1,111 @@
+# `thumbv8.1m.main-none-eabi` and `thumbv8.1m.main-none-eabihf`
+
+* **Tier: 3**
+* **Library Support:** core and alloc (bare-metal, `#![no_std]`)
+
+Bare-metal target for CPUs in the Mainline [Armv8.1-M] architecture family,
+supporting a subset of the [T32 ISA][t32-isa].
+
+Processors in this family include the:
+
+* [Arm Cortex-M55][cortex-m55]
+* [Arm Cortex-M85][cortex-m85]
+
+This target assumes your processor supports the *DSP* and *Low-Overhead Branch* extensions.
+
+See [`arm-none-eabi`](arm-none-eabi.md) for information applicable to all
+`arm-none-eabi` targets, in particular the difference between the `eabi` and
+`eabihf` ABI.
+
+[t32-isa]: https://developer.arm.com/Architectures/T32%20Instruction%20Set%20Architecture
+[Armv8.1-M]: https://developer.arm.com/documentation/ddi0553/latest/
+[cortex-m55]: https://developer.arm.com/Processors/Cortex-M55
+[cortex-m85]: https://developer.arm.com/Processors/Cortex-M85
+
+## Target maintainers
+
+- [Rust Embedded Devices Working Group Arm Team](https://github.com/rust-embedded/wg?tab=readme-ov-file#the-arm-team)
+- [arm-maintainers][arm_maintainers] ([rust@arm.com][arm_email])
+    - Use `@rustbot ping arm-maintainers` to ping us
+
+[arm_maintainers]: https://github.com/rust-lang/team/blob/master/teams/arm-maintainers.toml
+[arm_email]: mailto:rust@arm.com
+
+## Target CPU and Target Feature options
+
+See [the bare-metal Arm
+docs](arm-none-eabi.md#target-cpu-and-target-feature-options) for details on how
+to use these flags.
+
+### Table of supported CPUs for `thumbv8.1m.main-none-eabi`
+
+| CPU         | FPU | DSP | MVE       | Target CPU    | Target Features       |
+| ----------- | --- | --- | --------- | ------------- | --------------------- |
+| Unspecified | No  | No  | No        | None          | None                  |
+| Cortex-M55  | No  | Yes | No        | `cortex-m55`  | `-fpregs,-mve`        |
+| Cortex-M55  | DP  | Yes | No        | `cortex-m55`  | `-mve`                |
+| Cortex-M55  | No  | Yes | Int       | `cortex-m55`  | `-fpregs,-mve.fp,+mve`|
+| Cortex-M55  | DP  | Yes | Int       | `cortex-m55`  | `-mve.fp`             |
+| Cortex-M55  | DP  | Yes | Int+Float | `cortex-m55`  | None                  |
+| Cortex-M85  | No  | Yes | No        | `cortex-m85`  | `-fpregs,-mve`        |
+| Cortex-M85  | DP  | Yes | No        | `cortex-m85`  | `-mve`                |
+| Cortex-M85  | No  | Yes | Int       | `cortex-m85`  | `-fpregs,-mve.fp,+mve`|
+| Cortex-M85  | DP  | Yes | Int       | `cortex-m85`  | `-mve.fp`             |
+| Cortex-M85  | DP  | Yes | Int+Float | `cortex-m85`  | None                  |
+
+### Table of supported CPUs for `thumbv8.1m.main-none-eabihf`
+
+| CPU         | FPU | DSP | MVE       | Target CPU    | Target Features       |
+| ----------- | --- | --- | --------- | ------------- | --------------------- |
+| Unspecified | DP  | No  | No        | None          | None                  |
+| Cortex-M55  | DP  | Yes | No        | `cortex-m55`  | `-mve`                |
+| Cortex-M55  | DP  | Yes | Int       | `cortex-m55`  | `-mve.fp`             |
+| Cortex-M55  | DP  | Yes | Int+Float | `cortex-m55`  | None                  |
+| Cortex-M85  | DP  | Yes | No        | `cortex-m85`  | `-mve`                |
+| Cortex-M85  | DP  | Yes | Int       | `cortex-m85`  | `-mve.fp`             |
+| Cortex-M85  | DP  | Yes | Int+Float | `cortex-m85`  | None                  |
+
+*Technically* you can use this hard-float ABI on a CPU which has no FPU but does
+have Integer MVE, because MVE provides the same set of registers as the FPU
+(including `s0` and `d0`). The particular set of flags that might enable this
+unusual scenario are currently not recorded here.
+
+<div class="warning">
+
+Never use the `-fpregs` *target-feature* with the `thumbv8.1m.main-none-eabihf`
+target as it will cause compilation units to have different ABIs, which is
+unsound.
+
+</div>
+
+### M-Profile Vector Extensions
+
+The M-Profile Vector Extensions (also known as MVE, and marketed as "Helium") allow the processor to perform SIMD operations. MVE is available in either *integer-only* or *integer-and-float* variants. This target does not assume MVE support by default, but it can be added by specifying a *target-cpu*, or using certain *target-features* (noted below).
+
+### Arm Cortex-M55
+
+The target CPU is `cortex-m55`.
+
+* Has an optional double-precision FPU that also supports half-precision FP16
+  values
+  * support is enabled by default with this *target-cpu* the 'eabihf' target
+  * disable support using the `-fpregs` *target-feature* (`eabi` only)
+* Has optional support for M-Profile Vector Extensions
+  * The appropriate feature for the MVE is either `mve` (integer) or `mve.fp`
+    (float)
+  * `mve.fp` is enabled by default on this *target-cpu*
+  * disable using `-mve.fp` (disable float MVE) or `-mve` (disable all MVE)
+
+### Arm Cortex-M85
+
+The target CPU is `cortex-m85`.
+
+* Has an optional double-precision FPU that also supports half-precision FP16
+  values
+  * support is enabled by default with this *target-cpu* or the 'eabihf' target
+  * disable support using the `-fpregs` *target-feature* (`eabi` only)
+* Has optional support for M-Profile Vector Extensions
+  * The appropriate feature for the MVE is either `mve` (integer) or `mve.fp`
+    (float)
+  * `mve.fp` is enabled by default on this *target-cpu*
+  * disable using `-mve.fp` (disable float MVE) or `-mve` (disable all MVE)

--- a/src/doc/rustc/src/platform-support/thumbv8m.main-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/thumbv8m.main-none-eabi.md
@@ -10,8 +10,6 @@ Processors in this family include the:
 
 * [Arm Cortex-M33][cortex-m33]
 * [Arm Cortex-M35P][cortex-m35p]
-* [Arm Cortex-M55][cortex-m55]
-* [Arm Cortex-M85][cortex-m85]
 
 See [`arm-none-eabi`](arm-none-eabi.md) for information applicable to all
 `arm-none-eabi` targets, in particular the difference between the `eabi` and
@@ -21,8 +19,6 @@ See [`arm-none-eabi`](arm-none-eabi.md) for information applicable to all
 [Armv8-M]: https://developer.arm.com/documentation/ddi0553/latest/
 [cortex-m33]: https://developer.arm.com/Processors/Cortex-M33
 [cortex-m35p]: https://developer.arm.com/Processors/Cortex-M35P
-[cortex-m55]: https://developer.arm.com/Processors/Cortex-M55
-[cortex-m85]: https://developer.arm.com/Processors/Cortex-M85
 
 ## Target maintainers
 
@@ -52,16 +48,6 @@ to use these flags.
 | Cortex-M35P | No  | Yes | No        | `cortex-m35p` | `-fpregs`             |
 | Cortex-M35P | SP  | No  | No        | `cortex-m35p` | `-dsp`                |
 | Cortex-M35P | SP  | Yes | No        | `cortex-m35p` | None                  |
-| Cortex-M55  | No  | Yes | No        | `cortex-m55`  | `-fpregs,-mve`        |
-| Cortex-M55  | DP  | Yes | No        | `cortex-m55`  | `-mve`                |
-| Cortex-M55  | No  | Yes | Int       | `cortex-m55`  | `-fpregs,-mve.fp,+mve`|
-| Cortex-M55  | DP  | Yes | Int       | `cortex-m55`  | `-mve.fp`             |
-| Cortex-M55  | DP  | Yes | Int+Float | `cortex-m55`  | None                  |
-| Cortex-M85  | No  | Yes | No        | `cortex-m85`  | `-fpregs,-mve`        |
-| Cortex-M85  | DP  | Yes | No        | `cortex-m85`  | `-mve`                |
-| Cortex-M85  | No  | Yes | Int       | `cortex-m85`  | `-fpregs,-mve.fp,+mve`|
-| Cortex-M85  | DP  | Yes | Int       | `cortex-m85`  | `-mve.fp`             |
-| Cortex-M85  | DP  | Yes | Int+Float | `cortex-m85`  | None                  |
 
 ### Table of supported CPUs for `thumbv8m.main-none-eabihf`
 
@@ -72,17 +58,6 @@ to use these flags.
 | Cortex-M33  | SP  | Yes | No        | `cortex-m33`  | None                  |
 | Cortex-M33P | SP  | No  | No        | `cortex-m35p` | `-dsp`                |
 | Cortex-M33P | SP  | Yes | No        | `cortex-m35p` | None                  |
-| Cortex-M55  | DP  | Yes | No        | `cortex-m55`  | `-mve`                |
-| Cortex-M55  | DP  | Yes | Int       | `cortex-m55`  | `-mve.fp`             |
-| Cortex-M55  | DP  | Yes | Int+Float | `cortex-m55`  | None                  |
-| Cortex-M85  | DP  | Yes | No        | `cortex-m85`  | `-mve`                |
-| Cortex-M85  | DP  | Yes | Int       | `cortex-m85`  | `-mve.fp`             |
-| Cortex-M85  | DP  | Yes | Int+Float | `cortex-m85`  | None                  |
-
-*Technically* you can use this hard-float ABI on a CPU which has no FPU but does
-have Integer MVE, because MVE provides the same set of registers as the FPU
-(including `s0` and `d0`). The particular set of flags that might enable this
-unusual scenario are currently not recorded here.
 
 <div class="warning">
 
@@ -113,41 +88,3 @@ The target CPU is `cortex-m35p`.
 * Has an optional single precision FPU
   * support is enabled by default with this *target-cpu*
   * disable support using the `-fpregs` *target-feature* (`eabi` only)
-
-### Arm Cortex-M55
-
-The target CPU is `cortex-m55`.
-
-* Has DSP extensions
-  * support is controlled by the `dsp` *target-feature*
-  * enabled by default with this *target-cpu*
-* Has an optional double-precision FPU that also supports half-precision FP16
-  values
-  * support is enabled by default with this *target-cpu*
-  * disable support using the `-fpregs` *target-feature* (`eabi` only)
-* Has optional support for M-Profile Vector Extensions
-  * Also known as *Helium Technology*
-  * Available with only integer support, or both integer/float support
-  * The appropriate feature for the MVE is either `mve` (integer) or `mve.fp`
-    (float)
-  * `mve.fp` is enabled by default on this target CPU
-  * disable using `-mve.fp` (disable float MVE) or `-mve` (disable all MVE)
-
-### Arm Cortex-M85
-
-The target CPU is `cortex-m85`.
-
-* Has DSP extensions
-  * support is controlled by the `dsp` *target-feature*
-  * enabled by default with this *target-cpu*
-* Has an optional double-precision FPU that also supports half-precision FP16
-  values
-  * support is enabled by default with this *target-cpu*
-  * disable support using the `-fpregs` *target-feature* (`eabi` only)
-* Has optional support for M-Profile Vector Extensions
-  * Also known as *Helium Technology*
-  * Available with only integer support, or both integer/float support
-  * The appropriate feature for the MVE is either `mve` (integer) or `mve.fp`
-    (float)
-  * `mve.fp` is enabled by default on this target CPU
-  * disable using `-mve.fp` (disable float MVE) or `-mve` (disable all MVE)

--- a/src/tools/tier-check/src/main.rs
+++ b/src/tools/tier-check/src/main.rs
@@ -49,6 +49,8 @@ fn main() {
         "thumbv8m.base-none-eabi",
         "thumbv8m.main-none-eabi",
         "thumbv8m.main-none-eabihf",
+        "thumbv8.1m.main-none-eabi",
+        "thumbv8.1m.main-none-eabihf",
         "thumbv8m.base-nuttx-eabi",
         "thumbv8m.main-nuttx-eabi",
         "thumbv8m.main-nuttx-eabihf",

--- a/tests/assembly-llvm/targets/targets-elf.rs
+++ b/tests/assembly-llvm/targets/targets-elf.rs
@@ -646,9 +646,15 @@
 //@ revisions: thumbv8m_main_none_eabi
 //@ [thumbv8m_main_none_eabi] compile-flags: --target thumbv8m.main-none-eabi
 //@ [thumbv8m_main_none_eabi] needs-llvm-components: arm
+//@ revisions: thumbv81m_main_none_eabi
+//@ [thumbv81m_main_none_eabi] compile-flags: --target thumbv8.1m.main-none-eabi
+//@ [thumbv81m_main_none_eabi] needs-llvm-components: arm
 //@ revisions: thumbv8m_main_none_eabihf
 //@ [thumbv8m_main_none_eabihf] compile-flags: --target thumbv8m.main-none-eabihf
 //@ [thumbv8m_main_none_eabihf] needs-llvm-components: arm
+//@ revisions: thumbv81m_main_none_eabihf
+//@ [thumbv81m_main_none_eabihf] compile-flags: --target thumbv8.1m.main-none-eabihf
+//@ [thumbv81m_main_none_eabihf] needs-llvm-components: arm
 //@ revisions: wasm32_unknown_emscripten
 //@ [wasm32_unknown_emscripten] compile-flags: --target wasm32-unknown-emscripten
 //@ [wasm32_unknown_emscripten] needs-llvm-components: webassembly


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162519)*
<!-- homu-ignore:end -->

Here is a new target for Armv8.1-M processors, including the Cortex-M55 and Cortex-M85. There's a soft-float version (EABI) and a hard-float version (EABIHF), as is usual for Arm bare-metal targets.

These targets assume you have the DSP and [Low-Overhead Branch (LOB)](https://support.arm.com/documentation/107564/0100/Introduction/Low-Overhead-Branch--LOB--extension) architecture extensions enabled, as the Cortex-M55 and Cortex-M85 do. The LOB extension allows for much tighter loops, and hence higher performance with less code space.

LOB isn't available in Armv8.0-M, and DSP is off by default because not all Cortex-M33 processors have it enabled. You also need to *know* you are on Armv8.1-M so you can enable the LOB bit in the Configuration Control Register to turn it on. The `cortex-m-rt` crate can look at the target name to do that automatically.

All that means I think that means it's worth having this target as distinct from the existing Armv8.0-M Mainline target (`thumbv8m.main-none-eabi*`).

Here's a sample function:

```rust
#![no_std]

#[unsafe(no_mangle)]
pub fn process(data: &[u8]) -> u32 {
    let mut result = 0;
    for item in data.iter() {
        if *item > 10 {
            result += 1;
        }
    }
    result
}
```

Here's the `thumbv8m.main-none-eabi` assembly, at `opt-level=s`:

```text
process:
	cbz     r1, .LBB0_4
	push    {r7, lr}
	mov     r7, sp
	mov     r2, r0
	movs    r0, #0
.LBB0_2:
	ldrb    r3, [r2], #1
	cmp     r3, #10
	it      hi
	addhi   r0, #1
	subs    r1, #1
	bne     .LBB0_2
	pop     {r7, pc}
.LBB0_4:
	movs    r0, #0
	bx      lr
```

Here's the `thumbv8.1m.main-none-eabi` assembly at `opt-level=s`:

```text
process:
	push    {r7, lr}
	mov     r7, sp
	movs    r2, #0
	wls     lr, r1, .LBB0_2    ; While Loop Start using `LR` to count up to `R1`
.LBB0_1:
	ldrb    r1, [r0], #1
	cmp     r1, #10
	cinc    r2, r2, hi         ; Conditional Increment (replaces 'it hi; addhi r2, #1')
	le      lr, .LBB0_1        ; Loop End, which takes zero cycles after the first loop
.LBB0_2:
	mov     r0, r2
	pop     {r7, pc}
```

At `opt-level=3`, LLVM seems to prefer to unroll the loop, which is possibly sub-optimal. But that's an LLVM issue, and you do still get the use of `CINC`, which reduces code size and increases performance over Armv8.0-M.

I'm proposing these targets at Tier 3 initially, with the hope we can get it up to Tier 2 with the rest of the Arm M-profile targets.

- [x] No LLMs were used in the creation of this PR.

## Tier 3 Target Policy

> - A tier 3 target must have a designated developer or developers (the "target
>   maintainers") on record to be CCed when issues arise regarding the target.
>  (The mechanism to track and CC such developers may evolve over time.)

I'm offering the Rust Embedded Devices Working Group (who agreed in their last weekly meeting), and I'm proposing Arm also maintain this target as they do `thumbv8m.main-none-eabi*`. If they decline, or it takes time to get that agreement, I'm happy to take them out for now.

The target will get added to the `rust-embedded/cortex-m` repository for testing with the `cortex-m` and `cortex-m-rt` crates.

> - Targets must use naming consistent with any existing targets; for instance, a
>   target for the same CPU or OS as an existing Rust target should use the same
>   name for that CPU or OS. Targets should normally use the same names and
>   naming conventions as used elsewhere in the broader ecosystem beyond Rust
>   (such as in other toolchains), unless they have a very good reason to
>   diverge. Changing the name of a target can be highly disruptive, especially
>   once the target reaches a higher tier, so getting the name right is important
>   even for a tier 3 target.
>   - Target names should not introduce undue confusion or ambiguity unless
>     absolutely necessary to maintain ecosystem compatibility. For example, if
>     the name of the target makes people extremely likely to form incorrect
>     beliefs about what it targets, the name should be changed or augmented to
>     disambiguate it.
>   - If possible, use only letters, numbers, dashes and underscores for the name.
>     Periods (`.`) are known to cause issues in Cargo.

I believe this is our *first* target to use a point-release of an Arm Architecture. I picked [the same target string that LLVM uses](https://github.com/llvm/llvm-project/blob/cdab5d7b28a38112cf91784ea7d404d2d4c6a68e/llvm/unittests/Target/ARM/InstSizes.cpp#L76), even though I don't like it.

> - Tier 3 targets may have unusual requirements to build or use, but must not
>   create legal issues or impose onerous legal terms for the Rust project or for
>   Rust developers or users.

It's no different to the existing Arm M-profile targets.

> - Neither this policy nor any decisions made regarding targets shall create any
>   binding agreement or estoppel by any party. If any member of an approving
>   Rust team serves as one of the maintainers of a target, or has any legal or
>   employment requirement (explicit or implicit) that might affect their
>   decisions regarding a target, they must recuse themselves from any approval
>   decisions regarding the target's tier status, though they may otherwise
>   participate in discussions.
>   - This requirement does not prevent part or all of this policy from being
>     cited in an explicit contract or work agreement (e.g. to implement or
>     maintain support for a target). This requirement exists to ensure that a
>     developer or team responsible for reviewing and approving a target does not
>     face any legal threats or obligations that would prevent them from freely
>     exercising their judgment in such approval, even if such judgment involves
>     subjective matters or goes beyond the letter of these requirements.

Noted

> - Tier 3 targets should attempt to implement as much of the standard libraries
>   as possible and appropriate (`core` for most targets, `alloc` for targets
>   that can support dynamic memory allocation, `std` for targets with an
>   operating system or equivalent layer of system-provided functionality), but
>   may leave some code unimplemented (either unavailable or stubbed out as
>   appropriate), whether because the target makes it impossible to implement or
>   challenging to implement. The authors of pull requests are not obligated to
>   avoid calling any portions of the standard library on the basis of a tier 3
>   target not implementing those portions.

The Arm bare-metal targets are naturally `no_std`.

> - The target must provide documentation for the Rust community explaining how
>   to build for the target, using cross-compilation if possible. If the target
>   supports running binaries, or running tests (even if they do not pass), the
>   documentation must explain how to run such binaries or tests for the target,
>   using emulation if possible or dedicated hardware if necessary.

Target docs updated, with the new page based on the existing Armv8-M target docs.

> - Tier 3 targets must not impose burden on the authors of pull requests, or
>   other developers in the community, to maintain the target. In particular,
>   do not post comments (automated or manual) on a PR that derail or suggest a
>   block on the PR based on a tier 3 target. Do not send automated messages or
>   notifications (via any medium, including via `@`) to a PR author or others
>   involved with a PR regarding a tier 3 target, unless they have opted into
>   such messages.
>   - Backlinks such as those generated by the issue/PR tracker when linking to
>     an issue or PR are not considered a violation of this policy, within
>     reason. However, such messages (even on a separate repository) must not
>     generate notifications to anyone involved with a PR who has not requested
>     such notifications.

Noted

> - Patches adding or updating tier 3 targets must not break any existing tier 2
>   or tier 1 target, and must not knowingly break another tier 3 target without
>   approval of either the compiler team or the maintainers of the other tier 3
>   target.
>   - In particular, this may come up when working on closely related targets,
>     such as variations of the same architecture with different features. Avoid
>     introducing unconditional uses of features that another variation of the
>     target may not have; use conditional compilation or runtime detection, as
>     appropriate, to let each target run code supported by that target.

Noted. There is a `"v8.1m.main"` target feature in `rustc` already so code can do the right thing where that's required.

> - Tier 3 targets must be able to produce assembly using at least one of
>   rustc's supported backends from any host target. (Having support in a fork
>   of the backend is not sufficient, it must be upstream.)

Built locally to test it works - see examples above.

r? compiler
