### PR TITLE
Use `SmallVec` in `TokenCursor`

### DIFF
--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -15,6 +15,7 @@ use rustc_data_structures::sync;
 use rustc_macros::{Decodable, Encodable, StableHash, Walkable};
 use rustc_serialize::{Decodable, Encodable};
 use rustc_span::{DUMMY_SP, Span, SpanDecoder, SpanEncoder, Symbol, sym};
+use smallvec::SmallVec;
 use thin_vec::ThinVec;
 
 use crate::ast::AttrStyle;
@@ -964,13 +965,13 @@ pub struct TokenCursor {
     // Token streams surrounding the current one. The `next_idx` within each cursor
     // is always greater than zero and always points one past the current
     // `TokenTree::Delimited`.
-    stack: Vec<TokenTreeCursor>,
+    stack: SmallVec<[TokenTreeCursor; 2]>,
 }
 
 impl TokenCursor {
     #[inline]
     pub fn new(stream: TokenStream) -> Self {
-        TokenCursor { curr: TokenTreeCursor::new(stream), stack: vec![] }
+        TokenCursor { curr: TokenTreeCursor::new(stream), stack: Default::default() }
     }
 
     /// Gets the next token and advances the cursor by one.
@@ -1115,7 +1116,7 @@ mod size_asserts {
     static_assert_size!(AttrTokenStream, 8);
     static_assert_size!(AttrTokenTree, 32);
     static_assert_size!(LazyAttrTokenStream, 8);
-    static_assert_size!(LazyAttrTokenStreamInner, 88);
+    static_assert_size!(LazyAttrTokenStreamInner, 104);
     static_assert_size!(Option<LazyAttrTokenStream>, 8); // must be small, used in many AST nodes
     static_assert_size!(TokenStream, 8);
     static_assert_size!(TokenTree, 32);

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -247,7 +247,7 @@ pub struct Parser<'a> {
 // nonterminals. Make sure it doesn't unintentionally get bigger. We only check a few arches
 // though, because `TokenTypeSet(u128)` alignment varies on others, changing the total size.
 #[cfg(all(target_pointer_width = "64", any(target_arch = "aarch64", target_arch = "x86_64")))]
-rustc_data_structures::static_assert_size!(Parser<'_>, 288);
+rustc_data_structures::static_assert_size!(Parser<'_>, 304);
 
 /// Stores span information about a closure.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This field gets cloned a lot during parsing, but most of the time the nesting is not very deep.
