### PR TITLE
yoink has_primitive_or_keyword_or_attribute_docs

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -246,23 +246,6 @@ impl AttributeExt for Attribute {
         self.has_name(sym::doc)
             && self.meta_item_list().is_some_and(|l| list_contains_name(&l, sym::hidden))
     }
-
-    fn is_doc_keyword_or_attribute(&self) -> bool {
-        if self.has_name(sym::doc)
-            && let Some(items) = self.meta_item_list()
-        {
-            for item in items {
-                if item.has_name(sym::keyword) || item.has_name(sym::attribute) {
-                    return true;
-                }
-            }
-        }
-        false
-    }
-
-    fn is_rustc_doc_primitive(&self) -> bool {
-        self.has_name(sym::rustc_doc_primitive)
-    }
 }
 
 impl Attribute {
@@ -998,12 +981,6 @@ pub trait AttributeExt: Debug {
 
     /// Returns `true` if this attribute contains `doc(hidden)`.
     fn is_doc_hidden(&self) -> bool;
-
-    /// Returns `true` is this attribute contains `doc(keyword)` or `doc(attribute)`.
-    fn is_doc_keyword_or_attribute(&self) -> bool;
-
-    /// Returns `true` if this is a `#[rustc_doc_primitive]` attribute.
-    fn is_rustc_doc_primitive(&self) -> bool;
 }
 
 // FIXME(fn_delegation): use function delegation instead of manually forwarding

--- a/compiler/rustc_attr_ir/src/attr.rs
+++ b/compiler/rustc_attr_ir/src/attr.rs
@@ -287,14 +287,6 @@ impl AttributeExt for Attribute {
     fn is_doc_hidden(&self) -> bool {
         matches!(self, Attribute::Parsed(AttributeKind::Doc(d)) if d.hidden.is_some())
     }
-
-    fn is_doc_keyword_or_attribute(&self) -> bool {
-        matches!(self, Attribute::Parsed(AttributeKind::Doc(d)) if d.attribute.is_some() || d.keyword.is_some())
-    }
-
-    fn is_rustc_doc_primitive(&self) -> bool {
-        matches!(self, Attribute::Parsed(AttributeKind::RustcDocPrimitive(..)))
-    }
 }
 
 // FIXME(fn_delegation): use function delegation instead of manually forwarding

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -5522,10 +5522,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             {
                 return;
             }
-            ResolveDocLinks::Exported
-                if !maybe_exported.eval(self.r)
-                    && !rustdoc::has_primitive_or_keyword_or_attribute_docs(attrs) =>
-            {
+            ResolveDocLinks::Exported if !maybe_exported.eval(self.r) => {
                 return;
             }
             ResolveDocLinks::ExportedMetadata

--- a/compiler/rustc_resolve/src/rustdoc.rs
+++ b/compiler/rustc_resolve/src/rustdoc.rs
@@ -364,16 +364,6 @@ pub fn inner_docs(attrs: &[impl AttributeExt]) -> bool {
     true
 }
 
-/// Has `#[rustc_doc_primitive]` or `#[doc(keyword)]` or `#[doc(attribute)]`.
-pub fn has_primitive_or_keyword_or_attribute_docs(attrs: &[impl AttributeExt]) -> bool {
-    for attr in attrs {
-        if attr.is_rustc_doc_primitive() || attr.is_doc_keyword_or_attribute() {
-            return true;
-        }
-    }
-    false
-}
-
 /// Simplified version of the corresponding function in rustdoc.
 fn preprocess_link(link: &str) -> Box<str> {
     // IMPORTANT: To be kept in sync with the corresponding function in rustdoc.

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -21,8 +21,8 @@ use rustc_middle::ty::{Ty, TyCtxt};
 use rustc_middle::{bug, span_bug, ty};
 use rustc_resolve::rustdoc::pulldown_cmark::LinkType;
 use rustc_resolve::rustdoc::{
-    MalformedGenerics, has_primitive_or_keyword_or_attribute_docs, prepare_to_doc_link_resolution,
-    source_span_for_markdown_range, strip_generics_from_path,
+    MalformedGenerics, prepare_to_doc_link_resolution, source_span_for_markdown_range,
+    strip_generics_from_path,
 };
 use rustc_span::BytePos;
 use rustc_span::def_id::ModId;
@@ -1085,7 +1085,6 @@ impl LinkCollector<'_, '_> {
                 && item_id
                     .as_local()
                     .is_some_and(|local_def_id| !effective_visibilities.is_exported(local_def_id))
-                && !has_primitive_or_keyword_or_attribute_docs(&item.attrs.other_attrs)
         };
 
         if let Some(def_id) = item.item_id.as_def_id()


### PR DESCRIPTION
It looks like this was added as an optimization in https://github.com/rust-lang/rust/pull/107932, but it should return `false` the vast majority of the time.