### PR TITLE
perf: Don't hash the full (byte) string for Symbol interner if it's long

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2816,7 +2816,7 @@ struct InternerInner {
     byte_strs: Vec<&'static [u8]>,
 }
 
-const HASH_UP_TO: usize = 128;
+const HASH_UP_TO: usize = 1024;
 
 impl Interner {
     // These arguments are `&str`, but because of the sharing, we are

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2816,7 +2816,7 @@ struct InternerInner {
     byte_strs: Vec<&'static [u8]>,
 }
 
-const HASH_UP_TO: usize = 16;
+const HASH_UP_TO: usize = 64;
 
 impl Interner {
     // These arguments are `&str`, but because of the sharing, we are

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2816,6 +2816,8 @@ struct InternerInner {
     byte_strs: Vec<&'static [u8]>,
 }
 
+const HASH_UP_TO: usize = 32;
+
 impl Interner {
     // These arguments are `&str`, but because of the sharing, we are
     // effectively pre-interning all these strings for both `Symbol` and
@@ -2831,8 +2833,11 @@ impl Interner {
         let mut byte_strs: Vec<&'static [u8]> = Vec::with_capacity(size_hint);
 
         for v in values {
-            match indices.entry(hasher.hash_one(&v), |&(s, _)| s == v, |&(s, _)| hasher.hash_one(s))
-            {
+            match indices.entry(
+                hasher.hash_one(&v[0..HASH_UP_TO]),
+                |&(s, _)| s == v,
+                |&(s, _)| hasher.hash_one(&s[0..HASH_UP_TO]),
+            ) {
                 Entry::Occupied(v) => conflicting_values.push(v.get().0),
                 Entry::Vacant(view) => {
                     view.insert((v, byte_strs.len() as u32));
@@ -2862,13 +2867,13 @@ impl Interner {
     #[inline]
     fn intern_inner(&self, byte_str: &[u8]) -> u32 {
         let hasher = FxBuildHasher::default();
-        let hash_of_byte_str = hasher.hash_one(byte_str);
+        let hash_of_byte_str = hasher.hash_one(&byte_str[0..HASH_UP_TO]);
 
         self.0.with_lock(|inner| {
             match inner.indices.entry(
                 hash_of_byte_str,
                 |&(s, _)| s == byte_str,
-                |&(s, _)| hasher.hash_one(s),
+                |&(s, _)| hasher.hash_one(&s[0..HASH_UP_TO]),
             ) {
                 Entry::Occupied(v) => v.get().1,
                 Entry::Vacant(view) => {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2816,7 +2816,7 @@ struct InternerInner {
     byte_strs: Vec<&'static [u8]>,
 }
 
-const HASH_UP_TO: usize = 64;
+const HASH_UP_TO: usize = 128;
 
 impl Interner {
     // These arguments are `&str`, but because of the sharing, we are

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2816,7 +2816,7 @@ struct InternerInner {
     byte_strs: Vec<&'static [u8]>,
 }
 
-const HASH_UP_TO: usize = 32;
+const HASH_UP_TO: usize = 16;
 
 impl Interner {
     // These arguments are `&str`, but because of the sharing, we are

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2834,9 +2834,9 @@ impl Interner {
 
         for v in values {
             match indices.entry(
-                hasher.hash_one(&v[0..HASH_UP_TO]),
+                hasher.hash_one(&v[0..HASH_UP_TO.min(v.len())]),
                 |&(s, _)| s == v,
-                |&(s, _)| hasher.hash_one(&s[0..HASH_UP_TO]),
+                |&(s, _)| hasher.hash_one(&s[0..HASH_UP_TO.min(s.len())]),
             ) {
                 Entry::Occupied(v) => conflicting_values.push(v.get().0),
                 Entry::Vacant(view) => {
@@ -2867,13 +2867,13 @@ impl Interner {
     #[inline]
     fn intern_inner(&self, byte_str: &[u8]) -> u32 {
         let hasher = FxBuildHasher::default();
-        let hash_of_byte_str = hasher.hash_one(&byte_str[0..HASH_UP_TO]);
+        let hash_of_byte_str = hasher.hash_one(&byte_str[0..HASH_UP_TO.min(byte_str.len())]);
 
         self.0.with_lock(|inner| {
             match inner.indices.entry(
                 hash_of_byte_str,
                 |&(s, _)| s == byte_str,
-                |&(s, _)| hasher.hash_one(&s[0..HASH_UP_TO]),
+                |&(s, _)| hasher.hash_one(&s[0..HASH_UP_TO.min(s.len())]),
             ) {
                 Entry::Occupied(v) => v.get().1,
                 Entry::Vacant(view) => {


### PR DESCRIPTION
When investigating `include-blob` bimodailty, I noticed that we hash the whole included blob (31MB) and every other string that we intern no matter the length. This intuitively seems a bit wasteful - simply speaking, I can't imagine that after 15MB of hashing, we get a meaningful hash quality improvement with 15MB more. This is in the spirit of the comment in `rustc-hash` readme:

> Spending more CPU cycles on a higher quality hash does not reduce hash collisions enough to make the compiler faster on real-world benchmarks.

This PR changes the code to only hash the first `N` bytes (more on `N` later). The assumption (and intuition) behind this is:

 - we assume most interned strings are short (idents, literals), so most strings are not affected
 - we assume that we get enough entropy in the first `N` bytes (+length)
     - In other words, most interned strings have distinct len and distinct first N bytes
 - If we get a collision, the algorithm needs to compare the full length string anyway
    - If the strings have distinct len, the `eq` check is very cheap, so it doesn't make that much sense to guard against that collision by computing very expensive hash of the whole string.
    - Even if the `len` is the same, we can probably assume that the unequal byte occurs pretty early anyway, so similar argument applies

About the specific `N`, I tried to measure a few options in this PR, mostly picked by intuition

 - 32 bytes - https://github.com/rust-lang/rust/pull/162529#issuecomment-5606527303
    - `include-blob` improvements, some regressions, not sure if relevant
 - 16 bytes -https://github.com/rust-lang/rust/pull/162529#issuecomment-5608208683
    - there's a distinct path for <=16 bytes in `hash_bytes` in FxHasher, so I wanted to try whether it makes a difference if we always use only that code path (and LLVM could optimize the other branch out)
    - This looks worse, 16 bytes is a pretty low threshold, this will hit a lot of strings
  - 64 bytes -  https://github.com/rust-lang/rust/pull/162529#issuecomment-5615728546
      - This is a cache line size, so a natural number to try. Looks best so far
      - Non-relevant results are tilted slightly red, but that might as well be just noise 

I'm still not 100% confident about picking the number, though, because I'm not sure we have crates in the benchmark suite that would stress the Symbol interner a lot, so I see a few paths to go from here:

 - just merge with 64 limit and hope for the best :crossed_fingers:
  
 - pick a fairly high "safe choice" (e.g. 1kb) for now
     - this will still improve `include-blob`, but it should rarely affect anything else

 - find some crates that stress this code a lot and measure on them
     - probably crates that are big or contain a lot of somewhat longer symbols (long identifiers, literals, etc.)
     - any ideas welcome :)


r? nnethercote

I want to know what you think, because you worked on this a lot, or if you have recommendations for crates to test this on. I'll squash and clean it up based on what we decide to do.

<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162529)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
