### PR TITLE
fix perf regression from abby canonical form

### DIFF
--- a/compiler/rustc_infer/src/infer/solver_region_constraints.rs
+++ b/compiler/rustc_infer/src/infer/solver_region_constraints.rs
@@ -6,20 +6,23 @@ pub type SolverRegionConstraint<'tcx> =
     rustc_type_ir::region_constraint::RegionConstraint<TyCtxt<'tcx>, Span>;
 
 #[derive(Clone, Debug)]
-pub(crate) struct SolverRegionConstraintStorage<'tcx>(SolverRegionConstraint<'tcx>);
+pub(crate) struct SolverRegionConstraintStorage<'tcx>(Option<SolverRegionConstraint<'tcx>>);
 
 impl<'tcx> SolverRegionConstraintStorage<'tcx> {
     pub(crate) fn new() -> Self {
-        Self(SolverRegionConstraint::new_true())
+        Self(None)
     }
 
     pub(crate) fn get_constraint(&self) -> SolverRegionConstraint<'tcx> {
-        self.0.clone()
+        match &self.0 {
+            Some(v) => v.clone(),
+            None => SolverRegionConstraint::new_true(),
+        }
     }
 
     #[instrument(level = "debug", skip(self))]
     pub(crate) fn overwrite(&mut self, constraint: SolverRegionConstraint<'tcx>) {
-        self.0 = constraint;
+        self.0 = Some(constraint);
     }
 }
 

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -481,12 +481,6 @@ impl<I: Interner, S: Clone + std::fmt::Debug + Eq + std::hash::Hash> RegionConst
     }
 }
 
-impl<I: Interner> Default for RegionConstraint<I> {
-    fn default() -> Self {
-        Self::new_true()
-    }
-}
-
 impl<I: Interner, S: Clone + std::fmt::Debug> LeafRegionConstraint<I, S> {
     pub fn is_ambig(&self) -> bool {
         matches!(self, Self::Ambiguity(_))

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -240,7 +240,7 @@ impl<I: Interner> Or<I> {
 }
 impl<I: Interner, S: Clone + std::hash::Hash + std::fmt::Debug + Eq> Or<I, S> {
     pub fn new_true() -> Self {
-        Self(Box::new([And::new([])]))
+        Self(Box::new([And::new_true()]))
     }
 
     pub fn is_true(&self) -> bool {
@@ -323,6 +323,10 @@ impl<I: Interner> And<I> {
     }
 }
 impl<I: Interner, S: Clone + std::hash::Hash + std::fmt::Debug + Eq> And<I, S> {
+    pub fn new_true() -> Self {
+        Self(Box::new([]))
+    }
+
     pub fn new(i: impl IntoIterator<Item = LeafRegionConstraint<I, S>>) -> Self {
         let mut seen = IndexSet::new();
         And(i
@@ -406,7 +410,7 @@ impl<I: Interner, S: Clone + std::fmt::Debug + Eq + std::hash::Hash> RegionConst
         }));
 
         Self {
-            and_constraint: if or_constraint.is_false() { And::new([]) } else { and_constraint },
+            and_constraint: if or_constraint.is_false() { And::new_true() } else { and_constraint },
             or_constraint,
         }
     }
@@ -422,7 +426,7 @@ impl<I: Interner, S: Clone + std::fmt::Debug + Eq + std::hash::Hash> RegionConst
         let or_constraint = Or::build_and(a.or_constraint, b.or_constraint);
 
         Self {
-            and_constraint: if or_constraint.is_false() { And::new([]) } else { and_constraint },
+            and_constraint: if or_constraint.is_false() { And::new_true() } else { and_constraint },
             or_constraint,
         }
     }
@@ -432,7 +436,7 @@ impl<I: Interner, S: Clone + std::fmt::Debug + Eq + std::hash::Hash> RegionConst
     }
 
     pub fn new_true() -> Self {
-        Self { and_constraint: And::new([]), or_constraint: Or::new_true() }
+        Self { and_constraint: And::new_true(), or_constraint: Or::new_true() }
     }
 
     pub fn is_true(&self) -> bool {
@@ -440,7 +444,7 @@ impl<I: Interner, S: Clone + std::fmt::Debug + Eq + std::hash::Hash> RegionConst
     }
 
     pub fn new_false() -> Self {
-        Self { and_constraint: And::new([]), or_constraint: Or::new_false() }
+        Self { and_constraint: And::new_true(), or_constraint: Or::new_false() }
     }
 
     pub fn is_false(&self) -> bool {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162531)*
<!-- homu-ignore:end -->

https://github.com/rust-lang/rust/pull/161306 regressed performance on stable

I believe all the perf impact is due to this

https://github.com/rust-lang/rust/blob/d8df82673d5911b6112a85bf91d9adefb2c66a1a/compiler/rustc_infer/src/infer/mod.rs#L186

before, `SolverRegionConstraintStorage` was a dummy simple thing, no allocations.

now, it's a `RegionConstraint { and: Box([]), or: Box([Box([])]) }`

the majority of the perf impact (70%ish I think) is because the compiler is not sufficiently smart to optimize `And::new([])` into `And(Box::new([]))` (the former does a bunch of `IndexSet` allocations and stuff, the latter is a no-op, just a nullptr plus zero length metadata)

the the rest of the perf impact (30%ish) is due to the `or` case allocating the `Box([Box([])])`, it's not just a nullptr+zero

options to fix:

- option A: just fix the `And::new([])` being terrible
- option B: option A, *and also*, `SolverRegionConstraintStorage` stores an `Option` that is lazily init on first access, to prevent the perf hit from the `or` case
- option C: option A, *and also*, use some kind of `SmallVec` something or other to make the `or` case be zero-alloc. I have not profiled this due to it being an invasive change and effort, this might not actually fix the perf.

This PR is out option A to see if it actually works with the full perf machinery with PGO and whatnot instead of just on my machine (I am very inexperienced with perf testing!). It might be the case that full PGO blah blah *is* actually sufficiently smart to optimize `And::new([])`, and the actual perf diff is due to the `or` case (which I'm calling the 30%ish impact, might be actually 100%), in which case this PR should produce a no-op perf diff.

r? @BoxyUwU 