### PR TITLE
Fix run-make/prune-link-args to work with MinGW

### DIFF
--- a/tests/run-make/prune-link-args/rmake.rs
+++ b/tests/run-make/prune-link-args/rmake.rs
@@ -6,12 +6,10 @@
 // See https://github.com/rust-lang/rust/pull/10749
 
 //@ ignore-cross-compile
-//@ ignore-windows-gnu
-// Reason: The space is parsed as an empty linker argument on windows-gnu.
 
 use run_make_support::rustc;
 
 fn main() {
-    // Notice the space at the end of -lc, which emulates the output of pkg-config.
-    rustc().arg("-Clink-args=-lc ").input("empty.rs").run();
+    // Notice the space at the end of -lm, which emulates the output of pkg-config.
+    rustc().arg("-Clink-args=-lm ").input("empty.rs").run();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
The explanation provided was wrong. Libc doesn't exist on Windows, so naturally this failed on missing lib. I have no idea what shenanigans link.exe does to make this pass, but surely it doesn't actually link libc.