### PR TITLE
Remove outdated windows-gnu test ignores

### DIFF
--- a/tests/debuginfo/empty-string.rs
+++ b/tests/debuginfo/empty-string.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows-gnu: #128981
 //@ ignore-android: FIXME(#10381)
 //@ compile-flags:-g
 //@ ignore-backends: gcc

--- a/tests/debuginfo/method-on-enum.rs
+++ b/tests/debuginfo/method-on-enum.rs
@@ -5,8 +5,6 @@
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 
-//@ ignore-windows-gnu: #128973
-
 // === GDB TESTS ===================================================================================
 
 //@ gdb-command:run

--- a/tests/debuginfo/numeric-types.rs
+++ b/tests/debuginfo/numeric-types.rs
@@ -1,7 +1,5 @@
 //@ compile-flags:-g
 
-//@ ignore-windows-gnu: #128981
-
 // Note: u128 visualization was not supported in 10.0.22621.3233 but was fixed in 10.0.26100.2161.
 
 // FIXME(#133107): this is temporarily marked as `only-64bit` because of course 32-bit msvc has

--- a/tests/debuginfo/pretty-huge-vec.rs
+++ b/tests/debuginfo/pretty-huge-vec.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows-gnu: #128981
 //@ ignore-android: FIXME(#10381)
 //@ ignore-ohos: similiar to android
 //@ ignore-aix: FIXME(#137965)

--- a/tests/debuginfo/pretty-slices.rs
+++ b/tests/debuginfo/pretty-slices.rs
@@ -1,5 +1,4 @@
 //@ ignore-android: FIXME(#10381)
-//@ ignore-windows-gnu: #128981
 //@ compile-flags:-g
 //@ ignore-backends: gcc
 

--- a/tests/debuginfo/pretty-std-collections.rs
+++ b/tests/debuginfo/pretty-std-collections.rs
@@ -1,5 +1,4 @@
 //@ ignore-android: FIXME(#10381)
-//@ ignore-windows-gnu: #128981
 //@ compile-flags:-g
 //@ ignore-backends: gcc
 

--- a/tests/debuginfo/pretty-uninitialized-vec.rs
+++ b/tests/debuginfo/pretty-uninitialized-vec.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows-gnu: #128981
 //@ ignore-android: FIXME(#10381)
 //@ compile-flags:-g
 //@ ignore-backends: gcc

--- a/tests/debuginfo/rc_arc.rs
+++ b/tests/debuginfo/rc_arc.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows-gnu: #128981
 //@ compile-flags:-g
 
 //@ min-cdb-version: 10.0.18317.1001

--- a/tests/run-make/avr-rjmp-offset/rmake.rs
+++ b/tests/run-make/avr-rjmp-offset/rmake.rs
@@ -11,10 +11,6 @@
 //! "emit-asm" is used, as described in the issue description of #129301:
 //! https://github.com/rust-lang/rust/issues/129301#issue-2475070770
 
-// FIXME(#133480): this has been randomly failing on `x86_64-mingw` due to linker hangs or
-// crashes... so I'm going to disable this test for windows for now.
-//@ ignore-windows-gnu
-
 use run_make_support::{llvm_objdump, path, rustc, rustc_minicore};
 
 fn main() {

--- a/tests/ui/alloc-error/alloc-error-backtrace.rs
+++ b/tests/ui/alloc-error/alloc-error-backtrace.rs
@@ -17,9 +17,6 @@
 //@ ignore-watchos needs the `.dSYM` files to be moved to the device
 //@ ignore-visionos needs the `.dSYM` files to be moved to the device
 
-// FIXME(#117097): backtrace (possibly unwinding mechanism) seems to be different on at least
-// `i686-mingw` (32-bit windows-gnu)? cc #128911.
-//@ ignore-windows-gnu
 //@ ignore-backends: gcc
 //@ ignore-msvc see #62897 and `backtrace-debuginfo.rs` test
 

--- a/tests/ui/runtime/backtrace-debuginfo.rs
+++ b/tests/ui/runtime/backtrace-debuginfo.rs
@@ -16,9 +16,6 @@
 //@ ignore-watchos needs the `.dSYM` files to be moved to the device
 //@ ignore-visionos needs the `.dSYM` files to be moved to the device
 
-// FIXME(#117097): backtrace (possibly unwinding mechanism) seems to be different on at least
-// `i686-mingw` (32-bit windows-gnu)? cc #128911.
-//@ ignore-windows-gnu
 //@ ignore-backends: gcc
 
 use std::env;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->