### PR TITLE
split `macroless_generic_const_args` in two

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2685,7 +2685,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         match (body, kind) {
             (body, ConstItemKind::Body) => {
                 let is_direct = |body| {
-                    if self.tcx.features().macroless_generic_const_args() {
+                    if self.tcx.features().macroless_const_item_generic_const_args() {
                         self.can_lower_expr_to_const_arg_direct(
                             body,
                             DirectConstArgContext::MacrolessMinGenericConstArgs,

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -603,6 +603,9 @@ declare_features! (
     (unstable, macro_metavar_expr, "1.61.0", Some(83527)),
     /// Provides a way to concatenate identifiers using metavariable expressions.
     (unstable, macro_metavar_expr_concat, "1.81.0", Some(124225)),
+    /// Allows directly represented generic_const_args as the rhs of const items without the
+    /// `direct_const_arg!` macro.
+    (incomplete, macroless_const_item_generic_const_args, "CURRENT_RUSTC_VERSION", Some(162540)),
     /// Allows directly represented generic_const_args without the `direct_const_arg!` macro.
     (incomplete, macroless_generic_const_args, "1.99.0", Some(159006)),
     /// Allows `#[marker]` on certain traits allowing overlapping implementations.
@@ -854,5 +857,6 @@ pub const INCOMPATIBLE_FEATURES: &[(Symbol, Symbol)] = &[
 pub const DEPENDENT_FEATURES: &[(Symbol, &[Symbol])] = &[
     (sym::generic_const_args, &[sym::min_generic_const_args]),
     (sym::macroless_generic_const_args, &[sym::min_generic_const_args]),
+    (sym::macroless_const_item_generic_const_args, &[sym::min_generic_const_args]),
     (sym::unsized_const_params, &[sym::adt_const_params]),
 ];

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1252,6 +1252,7 @@ symbols! {
         macro_reexport,
         macro_use,
         macro_vis_matcher,
+        macroless_const_item_generic_const_args,
         macroless_generic_const_args,
         macros_in_extern,
         main,

--- a/src/doc/unstable-book/src/language-features/macroless-const-item-generic-const-args.md
+++ b/src/doc/unstable-book/src/language-features/macroless-const-item-generic-const-args.md
@@ -1,0 +1,74 @@
+# macroless_generic_const_args
+
+Enables implementing const items under `#![feature(min_generic_const_args)]` and `#![feature(generic_const_args)]` without the `direct_const_arg!` macro.
+
+The tracking issue for this feature is: [#162540]
+
+[#162540]: https://github.com/rust-lang/rust/issues/162540
+
+------------------------
+
+Warning: This feature is incomplete; its design and syntax may change.
+
+Related features:
+- [min_generic_const_args]. See that doc for what the `direct_const_arg!` is. This feature enables
+support for directly represented const arguments as the rhs of const items without the macro.
+- [macroless_generic_const_args]. For a version of this feature that works for const arguments in other
+positions
+
+[min_generic_const_args]: min-generic-const-args.md
+[macroless_generic_const_args]: macroless-generic-const-args.md
+
+## Examples
+
+Here is an example from [min_generic_const_args]:
+
+[min_generic_const_args]: min-generic-const-args.md
+
+```rust,ignore (needs new solver)
+#![allow(incomplete_features)]
+#![feature(
+    min_generic_const_args,
+    generic_const_args,
+    macroless_generic_const_args,
+    generic_const_items,
+)]
+
+trait Trait {
+    const ASSOC<const N: usize>: usize;
+}
+
+impl Trait for () {
+    const ASSOC<const N: usize>: usize = core::direct_const_arg!(N);
+}
+
+fn foo<const N: usize>() {
+    let a: [(); <() as Trait>::ASSOC::<N>]
+        = [(); N];
+}
+```
+
+Using `#![feature(macroless_const_item_generic_const_args)]` enables you to write the above without the macro:
+
+```rust,ignore (needs new solver)
+#![allow(incomplete_features)]
+#![feature(
+    min_generic_const_args,
+    generic_const_args,
+    macroless_generic_const_args,
+    generic_const_items,
+)]
+
+trait Trait {
+    const ASSOC<const N: usize>: usize;
+}
+
+impl Trait for () {
+    const ASSOC<const N: usize>: usize = N;
+}
+
+fn foo<const N: usize>() {
+    let a: [(); <() as Trait>::ASSOC::<N>]
+        = [(); N];
+}
+```

--- a/src/doc/unstable-book/src/language-features/macroless-generic-const-args.md
+++ b/src/doc/unstable-book/src/language-features/macroless-generic-const-args.md
@@ -10,10 +10,14 @@ The tracking issue for this feature is: [#159006]
 
 Warning: This feature is incomplete; its design and syntax may change.
 
-Related features: [min_generic_const_args]. See that doc for what the `direct_const_arg!` is. This feature enables
+Related features:
+- [min_generic_const_args]. See that doc for what the `direct_const_arg!` is. This feature enables
 support for directly represented const arguments without the macro.
+- [macroless_const_item_generic_const_args]. For a version of this feature that works for const arguments
+as the right hand side of a const item.
 
 [min_generic_const_args]: min-generic-const-args.md
+[macroless_const_item_generic_const_args]: macroless-const-item-generic-const-args.md
 
 ## Examples
 

--- a/tests/ui/const-generics/gca/const-pattern-field-type-mismatch-162394.rs
+++ b/tests/ui/const-generics/gca/const-pattern-field-type-mismatch-162394.rs
@@ -2,6 +2,7 @@
 
 #![allow(incomplete_features)]
 #![feature(macroless_generic_const_args)]
+#![feature(macroless_const_item_generic_const_args)]
 #![feature(generic_const_args, min_generic_const_args)]
 #![feature(min_adt_const_params)]
 

--- a/tests/ui/const-generics/gca/const-pattern-field-type-mismatch-162394.stderr
+++ b/tests/ui/const-generics/gca/const-pattern-field-type-mismatch-162394.stderr
@@ -1,5 +1,5 @@
 error: the constant `"foo"` is not of type `()`
-  --> $DIR/const-pattern-field-type-mismatch-162394.rs:16:5
+  --> $DIR/const-pattern-field-type-mismatch-162394.rs:17:5
    |
 LL |     const A2: Foo = Self::FooA("foo");
    |     ^^^^^^^^^^^^^ expected `()`, found `&'static str`

--- a/tests/ui/const-generics/gca/non-type-equality-ok.rs
+++ b/tests/ui/const-generics/gca/non-type-equality-ok.rs
@@ -4,6 +4,7 @@
 #![feature(
     min_generic_const_args,
     macroless_generic_const_args,
+    macroless_const_item_generic_const_args,
     generic_const_args,
     generic_const_items
 )]

--- a/tests/ui/feature-gates/feature-gate-macroless_const_item_generic_const_args.macroful.stderr
+++ b/tests/ui/feature-gates/feature-gate-macroless_const_item_generic_const_args.macroful.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/feature-gate-macroless_const_item_generic_const_args.rs:24:11
+   |
+LL |     let a: [(); <() as Trait>::ASSOC::<N>]
+   |            ------------------------------- expected due to this
+LL |         = [(); N];
+   |           ^^^^^^^ expected an array with a size of <() as Trait>::ASSOC::<N>, found one with a size of N
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/feature-gates/feature-gate-macroless_const_item_generic_const_args.rs
+++ b/tests/ui/feature-gates/feature-gate-macroless_const_item_generic_const_args.rs
@@ -1,0 +1,28 @@
+//@ revisions: macroless macroful
+//@[macroless] check-pass
+//@ compile-flags: -Znext-solver
+
+#![feature(
+    min_generic_const_args,
+    generic_const_args,
+    macroless_generic_const_args,
+    generic_const_items,
+)]
+
+#![cfg_attr(macroless, feature(macroless_const_item_generic_const_args))]
+
+trait Trait {
+    const ASSOC<const N: usize>: usize;
+}
+
+impl Trait for () {
+    const ASSOC<const N: usize>: usize = N;
+}
+
+fn foo<const N: usize>() {
+    let a: [(); <() as Trait>::ASSOC::<N>]
+        = [(); N];
+    //[macroful]~^ ERROR: mismatched types
+}
+
+fn main() {}


### PR DESCRIPTION
Two's a crowd! But One's a lonely.

Having `macroless_generic_const_args` apply to const items was quite annoying for users especially as we moved away from `type const` to just regular const items. We would quite commonly be "guessing wrong" with no easy way for users to opt out of `const ASSOC: usize = ...` being represented directly instead of an opaque body

I just swapped any failing tests over to using macroless_const_item_generic_const_args, didnt look through the whole set :>

We should probably bikeshed the feature name rn because it's currently inconsistent with what we wanted to rename all of the other gca features too :> Maybe this should be `gca_macroless_const_items`

cc rust-lang/rust#162540

r? khyperia