### PR TITLE
Gate ELF code in metadata.rs for ELF only

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -129,13 +129,10 @@ pub(super) fn search_for_section<'a>(
 fn add_gnu_property_note(
     file: &mut write::Object<'static>,
     architecture: Architecture,
-    binary_format: BinaryFormat,
     endianness: Endianness,
 ) {
-    // check bti protection
-    if binary_format != BinaryFormat::Elf
-        || !matches!(architecture, Architecture::X86_64 | Architecture::Aarch64)
-    {
+    // Only X86_64 and Aarch64 require a GNU property note.
+    if !matches!(architecture, Architecture::X86_64 | Architecture::Aarch64) {
         return;
     }
 
@@ -253,12 +250,14 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
 
         file.set_mangling(original_mangling);
     }
-    let e_flags = elf_e_flags(architecture, sess);
-    // adapted from LLVM's `MCELFObjectTargetWriter::getOSABI`
-    let os_abi = elf_os_abi(sess);
-    let abi_version = 0;
-    add_gnu_property_note(&mut file, architecture, binary_format, endianness);
-    file.flags = FileFlags::Elf { os_abi, abi_version, e_flags };
+    if binary_format == BinaryFormat::Elf {
+        let e_flags = elf_e_flags(architecture, sess);
+        // adapted from LLVM's `MCELFObjectTargetWriter::getOSABI`
+        let os_abi = elf_os_abi(sess);
+        let abi_version = 0;
+        add_gnu_property_note(&mut file, architecture, endianness);
+        file.flags = FileFlags::Elf { os_abi, abi_version, e_flags };
+    }
     Some(file)
 }
 
@@ -382,7 +381,6 @@ pub(super) fn elf_e_flags(architecture: Architecture, sess: &Session) -> u32 {
             }
         }
         Architecture::PowerPc64 => {
-            const EF_PPC64_ABI_UNKNOWN: u32 = 0;
             const EF_PPC64_ABI_ELF_V1: u32 = 1;
             const EF_PPC64_ABI_ELF_V2: u32 = 2;
 
@@ -392,11 +390,7 @@ pub(super) fn elf_e_flags(architecture: Architecture, sess: &Session) -> u32 {
                 // which leads to broken binaries if ELFv1 is used for the object files.
                 LlvmAbi::ElfV1 => EF_PPC64_ABI_ELF_V1,
                 LlvmAbi::ElfV2 => EF_PPC64_ABI_ELF_V2,
-                _ if sess.target.options.binary_format.to_object() == BinaryFormat::Elf => {
-                    bug!("invalid ABI specified for this PPC64 ELF target");
-                }
-                // Fall back
-                _ => EF_PPC64_ABI_UNKNOWN,
+                _ => bug!("invalid ABI specified for this PPC64 ELF target"),
             }
         }
         Architecture::Sparc32Plus => elf::EF_SPARC_32PLUS,


### PR DESCRIPTION
This PR gates ELF specific code for `BinaryFormat::Elf`. With this change, fallback for PowerPC64 on AIX is no longer needed. 

---------

Assisted-by: IBM Bob
The issue was discovered by IBM Bob while checking changes for other things, and I personally verified the bug. Although the fix is trivial, I ran it through IBM Bob to make sure I wasn’t missing anything.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
