### PR TITLE
Use lld by default on `loongarch64-unknown-linux-gnu` nightly

### DIFF
--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs
@@ -1,5 +1,6 @@
 use crate::spec::{
-    Arch, CodeModel, LlvmAbi, SanitizerSet, Target, TargetMetadata, TargetOptions, base,
+    Arch, Cc, CodeModel, LinkerFlavor, Lld, LlvmAbi, SanitizerSet, Target, TargetMetadata,
+    TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -21,6 +22,10 @@ pub(crate) fn target() -> Target {
             llvm_abiname: LlvmAbi::Lp64d,
             max_atomic_width: Some(64),
             mcount: "_mcount".into(),
+            pre_link_args: TargetOptions::link_args(
+                LinkerFlavor::Gnu(Cc::Yes, Lld::No),
+                &["-Wl,--no-rosegment"],
+            ),
             supported_sanitizers: SanitizerSet::ADDRESS
                 | SanitizerSet::CFI
                 | SanitizerSet::LEAK

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_musl.rs
@@ -1,5 +1,6 @@
 use crate::spec::{
-    Arch, CodeModel, LlvmAbi, SanitizerSet, Target, TargetMetadata, TargetOptions, base,
+    Arch, Cc, CodeModel, LinkerFlavor, Lld, LlvmAbi, SanitizerSet, Target, TargetMetadata,
+    TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -22,6 +23,10 @@ pub(crate) fn target() -> Target {
             max_atomic_width: Some(64),
             mcount: "_mcount".into(),
             crt_static_default: false,
+            pre_link_args: TargetOptions::link_args(
+                LinkerFlavor::Gnu(Cc::Yes, Lld::No),
+                &["-Wl,--no-rosegment"],
+            ),
             supported_sanitizers: SanitizerSet::ADDRESS
                 | SanitizerSet::CFI
                 | SanitizerSet::LEAK

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
@@ -1,5 +1,6 @@
 use crate::spec::{
-    Arch, CodeModel, LlvmAbi, SanitizerSet, Target, TargetMetadata, TargetOptions, base,
+    Arch, Cc, CodeModel, LinkerFlavor, Lld, LlvmAbi, SanitizerSet, Target, TargetMetadata,
+    TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -21,6 +22,10 @@ pub(crate) fn target() -> Target {
             llvm_abiname: LlvmAbi::Lp64d,
             max_atomic_width: Some(64),
             mcount: "_mcount".into(),
+            pre_link_args: TargetOptions::link_args(
+                LinkerFlavor::Gnu(Cc::Yes, Lld::No),
+                &["-Wl,--no-rosegment"],
+            ),
             supported_sanitizers: SanitizerSet::ADDRESS
                 | SanitizerSet::CFI
                 | SanitizerSet::LEAK

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1125,7 +1125,7 @@ impl Config {
         let is_host_system_llvm =
             target_config.get(&host_target).and_then(|c| c.llvm_config.as_ref()).is_some();
 
-        for (target, linker_override) in default_linux_linker_overrides() {
+        for (target, linker_override) in default_linux_linker_overrides(&channel) {
             // If the user overrode the default Linux linker, do not apply bootstrap defaults
             if targets_with_user_linker_override.contains(&target) {
                 continue;

--- a/src/bootstrap/src/core/config/toml/target.rs
+++ b/src/bootstrap/src/core/config/toml/target.rs
@@ -130,9 +130,20 @@ impl<'de> Deserialize<'de> for DefaultLinuxLinkerOverride {
 
 /// Set of linker overrides for selected Linux targets.
 #[cfg(not(test))]
-pub fn default_linux_linker_overrides() -> HashMap<String, DefaultLinuxLinkerOverride> {
-    [("x86_64-unknown-linux-gnu".to_string(), DefaultLinuxLinkerOverride::SelfContainedLldCc)]
-        .into()
+pub fn default_linux_linker_overrides(
+    channel: &str,
+) -> HashMap<String, DefaultLinuxLinkerOverride> {
+    let mut overrides = HashMap::from([(
+        "x86_64-unknown-linux-gnu".to_string(),
+        DefaultLinuxLinkerOverride::SelfContainedLldCc,
+    )]);
+    if channel == "nightly" || channel == "dev" {
+        overrides.insert(
+            "loongarch64-unknown-linux-gnu".to_string(),
+            DefaultLinuxLinkerOverride::SelfContainedLldCc,
+        );
+    }
+    overrides
 }
 
 #[cfg(test)]
@@ -141,7 +152,9 @@ thread_local! {
 }
 
 #[cfg(test)]
-pub fn default_linux_linker_overrides() -> HashMap<String, DefaultLinuxLinkerOverride> {
+pub fn default_linux_linker_overrides(
+    _channel: &str,
+) -> HashMap<String, DefaultLinuxLinkerOverride> {
     TEST_LINUX_LINKER_OVERRIDES.with(|cell| cell.borrow().clone()).unwrap_or_default()
 }
 


### PR DESCRIPTION
This PR makes LLD the default linker for `loongarch64-unknown-linux-gnu` on nightly.

As a prerequisite, it aligns the LoongArch64 Linux `LOAD` segment layout of LLD and other GNU-compatible linkers with GNU ld. This keeps the layout consistent and allows Linux to make better use of file-backed PMD mappings.

The LLD default is initially limited to nightly to allow some soak time before rolling it out to beta and stable.

To opt out of using LLD, `RUSTFLAGS="-Clinker-features=-lld"` would be used. To opt out of using rust-lld, falling back to the LLD installed on the system, `RUSTFLAGS="-Clink-self-contained=-linker"` would be used.