### PR TITLE
tests: accept more efficient simd output from LLVM 24

### DIFF
--- a/tests/assembly-llvm/simd-intrinsic-select.rs
+++ b/tests/assembly-llvm/simd-intrinsic-select.rs
@@ -1,11 +1,16 @@
 //@ add-minicore
-//@ revisions: x86-avx2 x86-avx512 aarch64
+//@ revisions: x86-avx2 x86-avx-512-llvm23 x86-avx-512 aarch64
 //@ [x86-avx2] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx2] compile-flags: -C target-feature=+avx2
 //@ [x86-avx2] needs-llvm-components: x86
-//@ [x86-avx512] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
-//@ [x86-avx512] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
-//@ [x86-avx512] needs-llvm-components: x86
+//@ [x86-avx-512-llvm23] max-llvm-major-version: 23
+//@ [x86-avx-512-llvm23] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
+//@ [x86-avx-512-llvm23] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
+//@ [x86-avx-512-llvm23] needs-llvm-components: x86
+//@ [x86-avx-512] min-llvm-version: 24
+//@ [x86-avx-512] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
+//@ [x86-avx-512] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
+//@ [x86-avx-512] needs-llvm-components: x86
 //@ [aarch64] compile-flags: --target=aarch64-unknown-linux-gnu
 //@ [aarch64] needs-llvm-components: aarch64
 //@ assembly-output: emit-asm
@@ -34,9 +39,13 @@ pub unsafe extern "C" fn select_i8x16(mask: m8x16, a: i8x16, b: i8x16) -> i8x16 
     // x86-avx2-NOT: vpsllw
     // x86-avx2: vpblendvb xmm0, xmm2, xmm1, xmm0
     //
-    // x86-avx512-NOT: vpsllw
-    // x86-avx512: vpmovb2m k1, xmm0
-    // x86-avx512-NEXT: vpblendmb xmm0 {k1}, xmm2, xmm1
+    // x86-avx-512-llvm23-NOT: vpsllw
+    // x86-avx-512-llvm23: vpmovb2m k1, xmm0
+    // x86-avx-512-llvm23-NEXT: vpblendmb xmm0 {k1}, xmm2, xmm1
+    //
+    // x86-avx-512-NOT: vpsllw
+    // x86-avx-512: vpmovb2m k1, xmm0
+    // x86-avx-512-NEXT: vpblendmb xmm0 {k1}, xmm2, xmm1
     //
     // aarch64-NOT: shl
     // aarch64: cmlt v0.16b, v0.16b, #0
@@ -50,9 +59,12 @@ pub unsafe extern "C" fn select_f32x4(mask: m32x4, a: f32x4, b: f32x4) -> f32x4 
     // x86-avx2-NOT: vpslld
     // x86-avx2: vblendvps xmm0, xmm2, xmm1, xmm0
     //
-    // x86-avx512-NOT: vpslld
-    // x86-avx512: vpmovd2m k1, xmm0
-    // x86-avx512-NEXT: vblendmps xmm0 {k1}, xmm2, xmm1
+    // x86-avx-512-llvm23-NOT: vpslld
+    // x86-avx-512-llvm23: vpmovd2m k1, xmm0
+    // x86-avx-512-llvm23-NEXT: vblendmps xmm0 {k1}, xmm2, xmm1
+    //
+    // x86-avx-512-NOT: vpslld
+    // x86-avx-512: vblendvps xmm0, xmm2, xmm1, xmm0
     //
     // aarch64-NOT: shl
     // aarch64: cmlt v0.4s, v0.4s, #0
@@ -66,9 +78,12 @@ pub unsafe extern "C" fn select_f64x2(mask: m64x2, a: f64x2, b: f64x2) -> f64x2 
     // x86-avx2-NOT: vpsllq
     // x86-avx2: vblendvpd xmm0, xmm2, xmm1, xmm0
     //
-    // x86-avx512-NOT: vpsllq
-    // x86-avx512: vpmovq2m k1, xmm0
-    // x86-avx512-NEXT: vblendmpd xmm0 {k1}, xmm2, xmm1
+    // x86-avx-512-llvm23-NOT: vpsllq
+    // x86-avx-512-llvm23: vpmovq2m k1, xmm0
+    // x86-avx-512-llvm23-NEXT: vblendmpd xmm0 {k1}, xmm2, xmm1
+    //
+    // x86-avx-512-NOT: vpsllq
+    // x86-avx-512: vblendvpd xmm0, xmm2, xmm1, xmm0
     //
     // aarch64-NOT: shl
     // aarch64: cmlt v0.2d, v0.2d, #0
@@ -77,29 +92,38 @@ pub unsafe extern "C" fn select_f64x2(mask: m64x2, a: f64x2, b: f64x2) -> f64x2 
 }
 
 // x86-avx2-LABEL: select_f64x4
-// x86-avx512-LABEL: select_f64x4
+// x86-avx-512-llvm23-LABEL: select_f64x4
+// x86-avx-512-LABEL: select_f64x4
 #[no_mangle]
-#[cfg(any(x86_avx2, x86_avx512))]
+#[cfg(any(x86_avx2, x86_avx_512, x86_avx_512_llvm23))]
 pub unsafe extern "C" fn select_f64x4(mask: m64x4, a: f64x4, b: f64x4) -> f64x4 {
     // The parameter is a 256 bit vector which in the C abi is only valid for avx targets.
     //
     // x86-avx2-NOT: vpsllq
     // x86-avx2: vblendvpd ymm0, ymm2, ymm1, ymm0
     //
-    // x86-avx512-NOT: vpsllq
-    // x86-avx512: vpmovq2m k1, ymm0
-    // x86-avx512-NEXT: vblendmpd ymm0 {k1}, ymm2, ymm1
+    // x86-avx-512-llvm23-NOT: vpsllq
+    // x86-avx-512-llvm23: vpmovq2m k1, ymm0
+    // x86-avx-512-llvm23-NEXT: vblendmpd ymm0 {k1}, ymm2, ymm1
+    //
+    // x86-avx-512-NOT: vpsllq
+    // x86-avx-512: vblendvpd ymm0, ymm2, ymm1, ymm0
     simd_select(mask, a, b)
 }
 
-// x86-avx512-LABEL: select_f64x8
+// x86-avx-512-llvm23-LABEL: select_f64x8
+// x86-avx-512-LABEL: select_f64x8
 #[no_mangle]
-#[cfg(x86_avx512)]
+#[cfg(any(x86_avx_512, x86_avx_512_llvm23))]
 pub unsafe extern "C" fn select_f64x8(mask: m64x8, a: f64x8, b: f64x8) -> f64x8 {
     // The parameter is a 256 bit vector which in the C abi is only valid for avx512 targets.
     //
-    // x86-avx512-NOT: vpsllq
-    // x86-avx512: vpmovq2m k1, zmm0
-    // x86-avx512-NEXT: vblendmpd zmm0 {k1}, zmm2, zmm1
+    // x86-avx-512-llvm23-NOT: vpsllq
+    // x86-avx-512-llvm23: vpmovq2m k1, zmm0
+    // x86-avx-512-llvm23-NEXT: vblendmpd zmm0 {k1}, zmm2, zmm1
+    //
+    // x86-avx-512-NOT: vpsllq
+    // x86-avx-512: vpmovq2m k1, zmm0
+    // x86-avx-512-NEXT: vblendmpd zmm0 {k1}, zmm2, zmm1
     simd_select(mask, a, b)
 }

--- a/tests/assembly-llvm/simd-intrinsic-select.rs
+++ b/tests/assembly-llvm/simd-intrinsic-select.rs
@@ -1,3 +1,4 @@
+// ignore-tidy-linelength
 //@ add-minicore
 //@ revisions: x86-avx2 x86-avx-512-llvm23 x86-avx-512 aarch64
 //@ [x86-avx2] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel


### PR DESCRIPTION
A [recent change](https://github.com/llvm/llvm-project/commit/4200a8e34e488aaf9c1b5b1966aa4c1bbec8b4d5) caused LLVM to identify `vpmov*, vpblend*` type instructions and merges them into single `vblendv*` instructions.

An LLM was used to identify the breaking change in the relevant range automatically (and it gave some explanation as to why, which matches the LLVM commit message), but the changes are all mine.

@rustbot label: +llvm-main