### PR TITLE
RISC-V: Add Zmmul target feature

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -692,7 +692,7 @@ static RISCV_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
         },
         &[],
     ),
-    ("m", Stable, &[]),
+    ("m", Stable, &["zmmul"]),
     ("relax", Unstable(sym::riscv_target_feature), &[]),
     (
         "rva23u64",
@@ -793,6 +793,7 @@ static RISCV_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("zksed", Stable, &[]),
     ("zksh", Stable, &[]),
     ("zkt", Stable, &[]),
+    ("zmmul", Unstable(sym::riscv_target_feature), &[]),
     ("ztso", Stable, &[]),
     ("zvbb", Unstable(sym::riscv_target_feature), &["zvkb"]), // Zvbb ⊃ Zvkb
     ("zvbc", Unstable(sym::riscv_target_feature), &["zve64x"]),

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -693,11 +693,10 @@ static RISCV_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
         &[],
     ),
     // According to the RISC-V spec, the M ISA extension (integer multiplication/division) is supported only when the M bit
-    // of the misa register is 1, while Zmmul means integer multiplication is always supported, even on systems with a writable misa.
+    // of the misa register is 1, while Zmmul means integer multiplication is always supported.
     //
-    // The Rust/LLVM "m" target feature means something slightly different: with "m" enabled, it is expected that multiplication
-    // and division will be unconditionally available (M bit will always be 1 in misa); therefore, "m" implies "zmmul" in the context
-    // of target features.
+    // The Rust/LLVM "m" target feature means something slightly different: with "m" enabled, it is assumed that integer
+    // multiplication and division will always be available (M bit will be 1 in misa), so "m" implies "zmmul".
     //
     // See discussion in the PR adding Zmmul: https://github.com/rust-lang/rust/pull/162552
     ("m", Stable, &["zmmul"]),

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -692,6 +692,14 @@ static RISCV_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
         },
         &[],
     ),
+    // According to the RISC-V spec, the M ISA extension (integer multiplication/division) is supported only when the M bit
+    // of the misa register is 1, while Zmmul means integer multiplication is always supported, even on systems with a writable misa.
+    //
+    // The Rust/LLVM "m" target feature means something slightly different: with "m" enabled, it is expected that multiplication
+    // and division will be unconditionally available (M bit will always be 1 in misa); therefore, "m" implies "zmmul" in the context
+    // of target features.
+    //
+    // See discussion in the PR adding Zmmul: https://github.com/rust-lang/rust/pull/162552
     ("m", Stable, &["zmmul"]),
     ("relax", Unstable(sym::riscv_target_feature), &[]),
     (

--- a/library/std_detect/src/detect/arch/riscv.rs
+++ b/library/std_detect/src/detect/arch/riscv.rs
@@ -104,6 +104,7 @@ features! {
     /// | `"zksed"`       | Zksed       | 6.8                 |
     /// | `"zksh"`        | Zksh        | 6.8                 |
     /// | `"zkt"`         | Zkt         | 6.8                 |
+    /// | `"zmmul"`       | Zmmul       | Yes [^ima] [^dep]   |
     /// | `"ztso"`        | Ztso        | 6.8                 |
     /// | `"zvbb"`        | Zvbb        | 6.8                 |
     /// | `"zvbc"`        | Zvbc        | 6.8                 |
@@ -220,6 +221,8 @@ features! {
 
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] m: "m";
     /// "M" Extension for Integer Multiplication and Division
+    @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zmmul: "zmmul";
+    //// "Zmmul" Extension for Integer Multiplication
 
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] a: "a";
     /// "A" Extension for Atomic Instructions

--- a/library/std_detect/src/detect/arch/riscv.rs
+++ b/library/std_detect/src/detect/arch/riscv.rs
@@ -104,7 +104,7 @@ features! {
     /// | `"zksed"`       | Zksed       | 6.8                 |
     /// | `"zksh"`        | Zksh        | 6.8                 |
     /// | `"zkt"`         | Zkt         | 6.8                 |
-    /// | `"zmmul"`       | Zmmul       | Yes [^ima] [^dep]   |
+    /// | `"zmmul"`       | Zmmul       | No [^ima] [^dep]    |
     /// | `"ztso"`        | Ztso        | 6.8                 |
     /// | `"zvbb"`        | Zvbb        | 6.8                 |
     /// | `"zvbc"`        | Zvbc        | 6.8                 |
@@ -222,7 +222,7 @@ features! {
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] m: "m";
     /// "M" Extension for Integer Multiplication and Division
     @FEATURE: #[unstable(feature = "stdarch_riscv_feature_detection", issue = "111192")] zmmul: "zmmul";
-    //// "Zmmul" Extension for Integer Multiplication
+    /// "Zmmul" Extension for Integer Multiplication
 
     @FEATURE: #[stable(feature = "riscv_ratified", since = "1.78.0")] a: "a";
     /// "A" Extension for Atomic Instructions

--- a/library/std_detect/src/detect/os/riscv.rs
+++ b/library/std_detect/src/detect/os/riscv.rs
@@ -147,6 +147,8 @@ pub(crate) fn imply_features(mut value: cache::Initializer) -> cache::Initialize
 
         imply!(zicntr | zihpm | f | zfinx | zve32x => zicsr);
 
+        imply!(m => zmmul);
+
         // Loop until the feature flags converge.
         if prev == value {
             return value;

--- a/library/std_detect/tests/cpu-detection.rs
+++ b/library/std_detect/tests/cpu-detection.rs
@@ -243,6 +243,7 @@ fn riscv_linux() {
     println!("zicboz: {}", is_riscv_feature_detected!("zicboz"));
     println!("zicond: {}", is_riscv_feature_detected!("zicond"));
     println!("m: {}", is_riscv_feature_detected!("m"));
+    println!("zmmul: {}", is_riscv_feature_detected!("zmmul"));
     println!("a: {}", is_riscv_feature_detected!("a"));
     println!("zalrsc: {}", is_riscv_feature_detected!("zalrsc"));
     println!("zaamo: {}", is_riscv_feature_detected!("zaamo"));

--- a/src/tools/rust-analyzer/crates/hir-ty/src/target_feature.rs
+++ b/src/tools/rust-analyzer/crates/hir-ty/src/target_feature.rs
@@ -204,6 +204,7 @@ const TARGET_FEATURE_IMPLICATIONS_RAW: &[(&str, &[&str])] = &[
     // RISC-V
     ("a", &["zaamo", "zalrsc"]),
     ("d", &["f"]),
+    ("m", &["zmmul"]),
     ("zabha", &["zaamo"]),
     ("zdinx", &["zfinx"]),
     ("zfh", &["zfhmin"]),

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -479,6 +479,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `zksed`
 `zksh`
 `zkt`
+`zmmul`
 `zreg`
 `ztso`
 `zvbb`


### PR DESCRIPTION
Zmmul is a ratified subset of the M extension that only supports multiplication, but not division ([spec](https://docs.riscv.org/reference/isa/v20260120/unpriv/m-st-ext.html#11-1-3-zmmul-extension-version-1-0)). LLVM already supports the extension under the same name, so until rust-lang/rust#162235 I'd just been using it directly.

There are two things I would particularly appreciate input on:

- Should M imply Zmmul?
  - From the [Machine-Level ISA spec](https://docs.riscv.org/reference/isa/v20260120/priv/machine.html) and [this discussion](https://github.com/riscv/riscv-isa-manual/issues/869) in the RISC-V ISA Manual repo, it seems that Zmmul means all multiplication instructions are always supported, whereas M means they're only supported if the M bit is set in the `misa` register. 
  - On the other hand, LLVM has M imply Zmmul ([RISCVFeatures.td](https://github.com/llvm/llvm-project/blob/f6f71edb4346d586bb97485116175efd9a696ee8/llvm/lib/Target/RISCV/RISCVFeatures.td#L214-L229)), so it feels nice to match that.
- How might I go about stabilizing this?
  - Can it be done right away?
  - Should it wait a few releases?
  - Is it better to batch it with the stabilization of other RISC-V target features, similarly to how it was done in rust-lang/rust#145948?

No LLMs were used in the making of this PR, and all mistakes are those of a first-time rustc contributor.
