### PR TITLE
Revert "Skip rustc book on i686"

### DIFF
--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -112,9 +112,9 @@ TEST_SET2 := --skip=tests --skip=library --skip=tidyselftest
 
 # this intentionally doesn't use `$(BOOTSTRAP)` so we can test the shebang on Windows
 ci-msvc-py:
-	$(Q)$(CFG_SRC_DIR)/x.py test --stage 2 $(TEST_SET1) --skip=src/tools/linkchecker
+	$(Q)$(CFG_SRC_DIR)/x.py test --stage 2 $(TEST_SET1)
 ci-msvc-ps1:
-	$(Q)$(CFG_SRC_DIR)/x.ps1 test --stage 2 $(TEST_SET2) --skip=src/tools/linkchecker
+	$(Q)$(CFG_SRC_DIR)/x.ps1 test --stage 2 $(TEST_SET2)
 ci-msvc: ci-msvc-py ci-msvc-ps1
 
 ## MingW native builders

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -1415,13 +1415,6 @@ impl CommandLineStep for RustcBook {
     /// in the "md-doc" directory in the build output directory. Then
     /// "rustbook" is used to convert it to HTML.
     fn run(self, builder: &Builder<'_>) {
-        // FIXME: Temporary workaround for https://github.com/rust-lang/rust/issues/158378
-        // Make sure this workaround doesn't break unit tests on the affected host.
-        if cfg!(not(test)) && self.target == "i686-pc-windows-msvc" {
-            eprintln!("WARNING: Skipping rustc book build to work around #158378");
-            return;
-        }
-
         let out_base = builder.out.join(self.target).join("md-doc").join("rustc");
         t!(fs::create_dir_all(&out_base));
         let out_listing = out_base.join("src/lints");

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -811,7 +811,6 @@ auto:
         --host=
         --target=i686-pc-windows-msvc
         --enable-profiler
-        --disable-docs
       SCRIPT: python x.py dist bootstrap --include-default-paths
       CODEGEN_BACKENDS: llvm
     <<: *job-windows

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -26,7 +26,6 @@ static DOCS_FALLBACK: &[(&str, &str)] = &[
     ("-apple-", "aarch64-apple-darwin"),
     ("aarch64", "aarch64-unknown-linux-gnu"),
     ("arm-", "aarch64-unknown-linux-gnu"),
-    ("i686-pc-windows", "x86_64-pc-windows-msvc"),
     ("", "x86_64-unknown-linux-gnu"),
 ];
 


### PR DESCRIPTION
Reverts https://github.com/rust-lang/rust/pull/158379
This should not be needed anymore since https://github.com/rust-lang/rust/pull/162288 merged