### PR TITLE
Attemped fix for home dir problem on `dist-aarch64-llvm-mingw`

### DIFF
--- a/src/ci/scripts/disable-git-crlf-conversion.sh
+++ b/src/ci/scripts/disable-git-crlf-conversion.sh
@@ -10,4 +10,8 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# Workaround for issue where the home dir of `msys64` sometimes doesn't exist on github runners
+echo $HOME
+mkdir -p $HOME
+
 git config --replace-all --global core.autocrlf false


### PR DESCRIPTION
This is a fix for this spurious failure, which seems to regularly happen lately
https://github.com/rust-lang/rust/pull/162550#issuecomment-5608460056

disclaimer: I have no clue what is causing this and that I'm just attacking the symptoms. Seems like some kind of github runner misconfiguration?

The PR is being discussed here: [#t-infra > Tree ops @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Tree.20ops/near/622969695)