### PR TITLE
Add regression test for higher-ranked fn pointer trait impl mismatch errors

### DIFF
--- a/tests/ui/higher-ranked/hr-fn-ptr-trait-impl-mismatch-29061.rs
+++ b/tests/ui/higher-ranked/hr-fn-ptr-trait-impl-mismatch-29061.rs
@@ -1,0 +1,33 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/29061>.
+//!
+//! A trait implemented for a higher-ranked fn pointer is not implemented for a fn pointer
+//! with a specific lifetime, and vice versa. The errors now spell out which form the impl
+//! applies to instead of just saying the bound is unsatisfied.
+
+//@ edition: 2024
+
+#![allow(dead_code)]
+
+fn x(_: &()) {}
+
+trait HR {}
+impl HR for fn(&()) {}
+fn hr<T: HR>(_: T) {}
+
+trait NotHR {}
+impl<'a> NotHR for fn(&'a ()) {}
+fn not_hr<T: NotHR>(_: T) {}
+
+fn a<'a>() {
+    let not_hr_func: fn(&'a ()) = x;
+    let hr_func: fn(&()) = x;
+    let hr_func2: for<'b> fn(&'b ()) = x;
+    hr(not_hr_func);
+    //~^ ERROR implementation of `HR` is not general enough
+    not_hr(hr_func);
+    //~^ ERROR implementation of `NotHR` is not general enough
+    not_hr(hr_func2);
+    //~^ ERROR implementation of `NotHR` is not general enough
+}
+
+fn main() {}

--- a/tests/ui/higher-ranked/hr-fn-ptr-trait-impl-mismatch-29061.stderr
+++ b/tests/ui/higher-ranked/hr-fn-ptr-trait-impl-mismatch-29061.stderr
@@ -1,0 +1,29 @@
+error: implementation of `HR` is not general enough
+  --> $DIR/hr-fn-ptr-trait-impl-mismatch-29061.rs:25:5
+   |
+LL |     hr(not_hr_func);
+   |     ^^^^^^^^^^^^^^^ implementation of `HR` is not general enough
+   |
+   = note: `HR` would have to be implemented for the type `fn(&'0 ())`, for some specific lifetime `'0`...
+   = note: ...but `HR` is actually implemented for the type `for<'a> fn(&'a ())`
+
+error: implementation of `NotHR` is not general enough
+  --> $DIR/hr-fn-ptr-trait-impl-mismatch-29061.rs:27:5
+   |
+LL |     not_hr(hr_func);
+   |     ^^^^^^^^^^^^^^^ implementation of `NotHR` is not general enough
+   |
+   = note: `NotHR` would have to be implemented for the type `for<'a> fn(&'a ())`
+   = note: ...but `NotHR` is actually implemented for the type `fn(&'0 ())`, for some specific lifetime `'0`
+
+error: implementation of `NotHR` is not general enough
+  --> $DIR/hr-fn-ptr-trait-impl-mismatch-29061.rs:29:5
+   |
+LL |     not_hr(hr_func2);
+   |     ^^^^^^^^^^^^^^^^ implementation of `NotHR` is not general enough
+   |
+   = note: `NotHR` would have to be implemented for the type `for<'b> fn(&'b ())`
+   = note: ...but `NotHR` is actually implemented for the type `fn(&'0 ())`, for some specific lifetime `'0`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Closes rust-lang/rust#29061

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
