### PR TITLE
fuchsia: dynamically enable fix-cortex-a53-835769 for generic CPUs

### DIFF
--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -10,7 +10,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_session::diagnostics::feature_err;
 use rustc_span::{Span, Symbol, edit_distance, sym};
-use rustc_target::spec::{Arch, SanitizerSet};
+use rustc_target::spec::{Arch, Os, SanitizerSet};
 use rustc_target::target_features::{RUSTC_SPECIFIC_FEATURES, Stability};
 use smallvec::SmallVec;
 
@@ -449,6 +449,18 @@ pub fn target_spec_to_backend_features<'a>(
         )
     {
         extend_backend_features("ptx70", true);
+    }
+
+    // When targetting aarch64 Fuchsia, the +fix-cortex-a53-835769 should be applied by default
+    // whenever using the generic (armv8-a) CPU. This matches Clang's behavior for aarch64 Fuchsia.
+    if sess.target.os == Os::Fuchsia
+        && sess.target.arch == Arch::AArch64
+        && matches!(
+            sess.opts.cg.target_cpu.as_deref().unwrap_or(&sess.target.cpu),
+            "generic" | "cortex-a53"
+        )
+    {
+        extend_backend_features("fix-cortex-a53-835769", true);
     }
 
     // Compute implied features

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_fuchsia.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_fuchsia.rs
@@ -5,7 +5,7 @@ use crate::spec::{
 pub(crate) fn target() -> Target {
     let mut base = base::fuchsia::opts();
     base.cpu = "generic".into();
-    base.features = "+v8a,+crc,+aes,+sha2,+neon,+fix-cortex-a53-835769".into();
+    base.features = "+v8a,+crc,+aes,+sha2,+neon".into();
     base.max_atomic_width = Some(128);
     base.stack_probes = StackProbeType::Inline;
     base.supported_sanitizers = SanitizerSet::ADDRESS

--- a/tests/codegen-llvm/aarch64-fuchsia-target-features.rs
+++ b/tests/codegen-llvm/aarch64-fuchsia-target-features.rs
@@ -1,8 +1,19 @@
 //@ add-minicore
+//@ revisions: DEFAULT GENERIC A53 A73 A73_ENABLE DEFAULT_DISABLE
 //@ compile-flags: --crate-type=rlib --target=aarch64-unknown-fuchsia
 //@ needs-llvm-components: aarch64
+//@ [GENERIC] compile-flags: -C target-cpu=generic
+//@ [A53] compile-flags: -C target-cpu=cortex-a53
+//@ [A73] compile-flags: -C target-cpu=cortex-a73
+//@ [A73_ENABLE] compile-flags: -C target-cpu=cortex-a73 -C target-feature=+fix-cortex-a53-835769
+//@ [DEFAULT_DISABLE] compile-flags: -C target-feature=-fix-cortex-a53-835769
 
-// CHECK: attributes #0 = { {{.*}}"target-features"="{{.*}}+fix-cortex-a53-835769{{.*}}" }
+// DEFAULT: attributes #0 = { {{.*}}"target-features"="{{.*}}+fix-cortex-a53-835769{{.*}}" }
+// GENERIC: attributes #0 = { {{.*}}"target-features"="{{.*}}+fix-cortex-a53-835769{{.*}}" }
+// A53: attributes #0 = { {{.*}}"target-features"="{{.*}}+fix-cortex-a53-835769{{.*}}" }
+// A73-NOT: fix-cortex-a53-835769
+// A73_ENABLE: attributes #0 = { {{.*}}"target-features"="{{.*}}+fix-cortex-a53-835769{{.*}}" }
+// DEFAULT_DISABLE: attributes #0 = { {{.*}}"target-features"="{{.*}}-fix-cortex-a53-835769" }
 
 #![feature(no_core, lang_items)]
 #![no_core]


### PR DESCRIPTION
Previously, `+fix-cortex-a53-835769` was statically included in `base.features` for `aarch64-unknown-fuchsia`. This caused the Cortex-A53 erratum workaround to be unconditionally enabled regardless of the selected target CPU (e.g., when passing `-C target-cpu=cortex-a73`).

The behavior we want is to have it enabled by default only for the generic CPU (armv8-a), and it should be togglable via the normal `-Ctarget-features=` flag. This matches the target-feature logic in clang.

AI: Note gemini was used to help verify this does match Clang's behavior and write out the matrix of different test invocations. I reviewed this code to the best of my ability before submitting.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
