### PR TITLE
Make `u64::midpoint` auto-vectorize

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1346,7 +1346,7 @@ impl u64 {
         from_xe_bytes_doc = "",
         bound_condition = "",
     }
-    midpoint_impl! { u64, u128, unsigned }
+    midpoint_impl! { u64, unsigned }
     widening_mul_impl! { u64, u128 }
     widening_carryless_mul_impl! { u64, u128 }
     carrying_carryless_mul_impl! { u64, u128 }

--- a/tests/codegen-llvm/autovec/midpoint-should-vectorize.rs
+++ b/tests/codegen-llvm/autovec/midpoint-should-vectorize.rs
@@ -1,0 +1,25 @@
+//@ revisions: X86_64
+//@ compile-flags: -Copt-level=3
+//@[X86_64] only-x86_64
+//@[X86_64] compile-flags: -Ctarget-feature=+avx2
+
+#![crate_type = "lib"]
+#![no_std]
+
+// Ensure u64::midpoint can auto-vectorize
+
+// CHECK-LABEL: define{{.*}}void @midpoint_vec(
+// CHECK: load <4 x i64>
+// CHECK-NEXT: load <4 x i64>
+// CHECK-NEXT: xor <4 x i64>
+// CHECK-NEXT: lshr <4 x i64>
+// CHECK-NEXT: and <4 x i64>
+// CHECK-NEXT: add <4 x i64>
+// CHECK-NEXT: store <4 x i64>
+// CHECK-NEXT: ret void
+#[unsafe(no_mangle)]
+pub fn midpoint_vec(r: &mut [u64; 4], a: &[u64; 4], b: &[u64; 4]) {
+    for i in 0..4 {
+        r[i] = a[i].midpoint(b[i]);
+    }
+}


### PR DESCRIPTION
As reported [on Zulip](https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/u64.3A.3Amidpoint.20doesn't.20autovectorize/with/622981234), change `u64::midpoint` so it doesn't use `u128` internally so it auto-vectorizes. I also added a codegen test.

<!-- homu-ignore:start -->
I did not use a LLM to make this.
<!-- homu-ignore:end -->
