### PR TITLE
Use correct source parameter spans in async closure inference diagnostics

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -1361,7 +1361,9 @@ impl<'a, 'tcx> Visitor<'tcx> for FindInferSourceVisitor<'a, 'tcx> {
                 "param: span {:?}, ty_span {:?}, pat.span {:?}",
                 param.span, param.ty_span, param.pat.span
             );
-            if param.ty_span != param.pat.span {
+            // Async lowering such as closure parameters changes the pattern's expansion context,
+            // but preserves the original source span for its implicit type, issue #139150
+            if !param.ty_span.source_equal(param.pat.span) {
                 debug!("skipping param: has explicit type");
                 continue;
             }
@@ -1370,9 +1372,9 @@ impl<'a, 'tcx> Visitor<'tcx> for FindInferSourceVisitor<'a, 'tcx> {
 
             if self.generic_arg_contains_target(param_ty.into()) {
                 self.update_infer_source(InferSource {
-                    span: param.pat.span,
+                    span: param.ty_span,
                     kind: InferSourceKind::ClosureArg {
-                        insert_span: param.pat.span.shrink_to_hi(),
+                        insert_span: param.ty_span.shrink_to_hi(),
                         ty: param_ty,
                         kind: param.pat.kind,
                     },

--- a/tests/ui/async-await/async-closures/ambiguous-arg.stderr
+++ b/tests/ui/async-await/async-closures/ambiguous-arg.stderr
@@ -1,12 +1,17 @@
 error[E0282]: type annotations needed
-  --> $DIR/ambiguous-arg.rs:7:25
+  --> $DIR/ambiguous-arg.rs:7:12
    |
 LL |       async |check, a, b| {
-   |  _________________________^
+   |  ____________^^^^^________-
 LL | |
 LL | |         temp.abs_diff(12);
 LL | |     };
-   | |_____^ cannot infer type
+   | |_____- type must be known at this point
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     async |check: /* Type */, a, b| {
+   |                 ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/async-closures/parameter-inference-span-issue-139150.rs
+++ b/tests/ui/async-await/async-closures/parameter-inference-span-issue-139150.rs
@@ -1,0 +1,45 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/139150>.
+// Prefer the source parameter over the lowered async closure body for type annotations.
+
+//@ edition: 2024
+
+fn wildcard() {
+    async |_| {};
+    //~^ ERROR type annotations needed
+}
+
+fn named() {
+    let _ = async |value| { let _ = value; };
+    //~^ ERROR type annotations needed
+}
+
+fn tuple() {
+    let _ = async |(first, second)| { let _ = (first, second); };
+    //~^ ERROR type annotations needed
+}
+
+fn by_ref() {
+    let _ = async |ref value| { let _ = value; };
+    //~^ ERROR type annotations needed
+}
+
+fn explicit() {
+    let _ = async |_: Option<_>| {};
+    //~^ ERROR type annotations needed
+}
+
+fn synchronous() {
+    let _ = |_| {};
+    //~^ ERROR type annotations needed
+}
+
+macro_rules! generated {
+    () => { async |_| {} };
+    //~^ ERROR type annotations needed
+}
+
+fn from_macro() {
+    let _ = generated!();
+}
+
+fn main() {}

--- a/tests/ui/async-await/async-closures/parameter-inference-span-issue-139150.stderr
+++ b/tests/ui/async-await/async-closures/parameter-inference-span-issue-139150.stderr
@@ -1,41 +1,46 @@
 error[E0282]: type annotations needed
-  --> $DIR/parameter-inference-span-issue-139150.rs:7:15
+  --> $DIR/parameter-inference-span-issue-139150.rs:7:12
    |
 LL |     async |_| {};
-   |               ^^ cannot infer type
+   |            ^  -- type must be known at this point
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     async |_: /* Type */| {};
+   |             ++++++++++++
 
 error[E0282]: type annotations needed
-  --> $DIR/parameter-inference-span-issue-139150.rs:12:33
+  --> $DIR/parameter-inference-span-issue-139150.rs:12:20
    |
 LL |     let _ = async |value| { let _ = value; };
-   |                                 ^
+   |                    ^^^^^  ------------------ type must be known at this point
    |
-help: consider giving this pattern a type
+help: consider giving this closure parameter an explicit type
    |
-LL |     let _ = async |value| { let _: /* Type */ = value; };
-   |                                  ++++++++++++
+LL |     let _ = async |value: /* Type */| { let _ = value; };
+   |                         ++++++++++++
 
 error[E0282]: type annotations needed for `(_, _)`
-  --> $DIR/parameter-inference-span-issue-139150.rs:17:43
+  --> $DIR/parameter-inference-span-issue-139150.rs:17:20
    |
 LL |     let _ = async |(first, second)| { let _ = (first, second); };
-   |                                           ^   --------------- type must be known at this point
+   |                    ^^^^^^^^^^^^^^^            --------------- type must be known at this point
    |
-help: consider giving this pattern a type, where the placeholders `_` are specified
+help: consider giving this closure parameter an explicit type, where the placeholders `_` are specified
    |
-LL |     let _ = async |(first, second)| { let _: (_, _) = (first, second); };
-   |                                            ++++++++
+LL |     let _ = async |(first, second): (_, _)| { let _ = (first, second); };
+   |                                   ++++++++
 
-error[E0282]: type annotations needed for `&_`
-  --> $DIR/parameter-inference-span-issue-139150.rs:22:37
+error[E0282]: type annotations needed
+  --> $DIR/parameter-inference-span-issue-139150.rs:22:20
    |
 LL |     let _ = async |ref value| { let _ = value; };
-   |                                     ^   ----- type must be known at this point
+   |                    ^^^^^^^^^            ----- type must be known at this point
    |
-help: consider giving this pattern a type, where the placeholder `_` is specified
+help: consider giving this closure parameter an explicit type
    |
-LL |     let _ = async |ref value| { let _: &_ = value; };
-   |                                      ++++
+LL |     let _ = async |ref value: /* Type */| { let _ = value; };
+   |                             ++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/parameter-inference-span-issue-139150.rs:27:34

--- a/tests/ui/async-await/async-closures/parameter-inference-span-issue-139150.stderr
+++ b/tests/ui/async-await/async-closures/parameter-inference-span-issue-139150.stderr
@@ -1,0 +1,70 @@
+error[E0282]: type annotations needed
+  --> $DIR/parameter-inference-span-issue-139150.rs:7:15
+   |
+LL |     async |_| {};
+   |               ^^ cannot infer type
+
+error[E0282]: type annotations needed
+  --> $DIR/parameter-inference-span-issue-139150.rs:12:33
+   |
+LL |     let _ = async |value| { let _ = value; };
+   |                                 ^
+   |
+help: consider giving this pattern a type
+   |
+LL |     let _ = async |value| { let _: /* Type */ = value; };
+   |                                  ++++++++++++
+
+error[E0282]: type annotations needed for `(_, _)`
+  --> $DIR/parameter-inference-span-issue-139150.rs:17:43
+   |
+LL |     let _ = async |(first, second)| { let _ = (first, second); };
+   |                                           ^   --------------- type must be known at this point
+   |
+help: consider giving this pattern a type, where the placeholders `_` are specified
+   |
+LL |     let _ = async |(first, second)| { let _: (_, _) = (first, second); };
+   |                                            ++++++++
+
+error[E0282]: type annotations needed for `&_`
+  --> $DIR/parameter-inference-span-issue-139150.rs:22:37
+   |
+LL |     let _ = async |ref value| { let _ = value; };
+   |                                     ^   ----- type must be known at this point
+   |
+help: consider giving this pattern a type, where the placeholder `_` is specified
+   |
+LL |     let _ = async |ref value| { let _: &_ = value; };
+   |                                      ++++
+
+error[E0282]: type annotations needed
+  --> $DIR/parameter-inference-span-issue-139150.rs:27:34
+   |
+LL |     let _ = async |_: Option<_>| {};
+   |                                  ^^ cannot infer type
+
+error[E0282]: type annotations needed
+  --> $DIR/parameter-inference-span-issue-139150.rs:32:14
+   |
+LL |     let _ = |_| {};
+   |              ^
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     let _ = |_: /* Type */| {};
+   |               ++++++++++++
+
+error[E0282]: type annotations needed
+  --> $DIR/parameter-inference-span-issue-139150.rs:37:23
+   |
+LL |     () => { async |_| {} };
+   |                       ^^ cannot infer type
+...
+LL |     let _ = generated!();
+   |             ------------ in this macro invocation
+   |
+   = note: this error originates in the macro `generated` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
Fixes rust-lang/rust#139150