### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -207,14 +207,28 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     fn visit_foreign_item(&mut self, i: &'a ast::ForeignItem) {
         match i.kind {
             ast::ForeignItemKind::Fn(..) | ast::ForeignItemKind::Static(..) => {
-                let link_name = attr::first_attr_value_str_by_name(&i.attrs, sym::link_name);
-                let links_to_llvm = link_name.is_some_and(|val| val.as_str().starts_with("llvm."));
-                if links_to_llvm {
+                let symbol_name = if let Some(link_name) =
+                    attr::first_attr_value_str_by_name(&i.attrs, sym::link_name)
+                {
+                    link_name
+                } else {
+                    i.kind.ident().unwrap().name
+                };
+
+                let name = symbol_name.as_str();
+                if name.starts_with("llvm.") {
                     gate!(
                         self,
                         link_llvm_intrinsics,
                         i.span,
                         "linking to LLVM intrinsics is experimental"
+                    );
+                } else if name.starts_with("__enzyme_") {
+                    gate!(
+                        self,
+                        link_enzyme_intrinsics,
+                        i.span,
+                        "linking to Enzyme intrinsics is experimental"
                     );
                 }
             }

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -272,6 +272,8 @@ declare_features! (
     (internal, lang_items, "1.0.0", None),
     /// Allows `#[link(..., cfg(..))]`; perma-unstable per #37406
     (internal, link_cfg, "1.14.0", None),
+    /// Allows using `#[link_name="__enzyme_*"]`.
+    (internal, link_enzyme_intrinsics, "CURRENT_RUSTC_VERSION", None),
     /// Allows using `?Trait` trait bounds in more contexts.
     (internal, more_maybe_bounds, "1.82.0", None),
     /// Allow negative trait bounds. This is an internal-only feature for testing the trait solver!

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1212,6 +1212,7 @@ symbols! {
         link_args,
         link_cfg,
         link_dash_arg: "link-arg",
+        link_enzyme_intrinsics,
         link_llvm_intrinsics,
         link_name,
         link_ordinal,

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -112,9 +112,9 @@ TEST_SET2 := --skip=tests --skip=library --skip=tidyselftest
 
 # this intentionally doesn't use `$(BOOTSTRAP)` so we can test the shebang on Windows
 ci-msvc-py:
-	$(Q)$(CFG_SRC_DIR)/x.py test --stage 2 $(TEST_SET1) --skip=src/tools/linkchecker
+	$(Q)$(CFG_SRC_DIR)/x.py test --stage 2 $(TEST_SET1)
 ci-msvc-ps1:
-	$(Q)$(CFG_SRC_DIR)/x.ps1 test --stage 2 $(TEST_SET2) --skip=src/tools/linkchecker
+	$(Q)$(CFG_SRC_DIR)/x.ps1 test --stage 2 $(TEST_SET2)
 ci-msvc: ci-msvc-py ci-msvc-ps1
 
 ## MingW native builders

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -1415,13 +1415,6 @@ impl CommandLineStep for RustcBook {
     /// in the "md-doc" directory in the build output directory. Then
     /// "rustbook" is used to convert it to HTML.
     fn run(self, builder: &Builder<'_>) {
-        // FIXME: Temporary workaround for https://github.com/rust-lang/rust/issues/158378
-        // Make sure this workaround doesn't break unit tests on the affected host.
-        if cfg!(not(test)) && self.target == "i686-pc-windows-msvc" {
-            eprintln!("WARNING: Skipping rustc book build to work around #158378");
-            return;
-        }
-
         let out_base = builder.out.join(self.target).join("md-doc").join("rustc");
         t!(fs::create_dir_all(&out_base));
         let out_listing = out_base.join("src/lints");

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -811,7 +811,6 @@ auto:
         --host=
         --target=i686-pc-windows-msvc
         --enable-profiler
-        --disable-docs
       SCRIPT: python x.py dist bootstrap --include-default-paths
       CODEGEN_BACKENDS: llvm
     <<: *job-windows

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -26,7 +26,6 @@ static DOCS_FALLBACK: &[(&str, &str)] = &[
     ("-apple-", "aarch64-apple-darwin"),
     ("aarch64", "aarch64-unknown-linux-gnu"),
     ("arm-", "aarch64-unknown-linux-gnu"),
-    ("i686-pc-windows", "x86_64-pc-windows-msvc"),
     ("", "x86_64-unknown-linux-gnu"),
 ];
 

--- a/tests/ui/feature-gates/feature-gate-link-enzyme-intrinsics-enabled.rs
+++ b/tests/ui/feature-gates/feature-gate-link-enzyme-intrinsics-enabled.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+// gate-test-link_enzyme_intrinsics
+#![feature(link_enzyme_intrinsics)]
+
+unsafe extern "C" {
+    fn __enzyme_autodiff();
+    fn __enzyme_fwddiff();
+    fn __enzyme_augmentfwd();
+    fn __enzyme_reverse();
+    #[link_name = "__enzyme_autodiff"]
+    fn autodiff();
+
+    static __enzyme_dup: i32;
+    #[link_name = "__enzyme_dup"]
+    static ENZYME_DUP: i32;
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-link-enzyme-intrinsics-no-gate.rs
+++ b/tests/ui/feature-gates/feature-gate-link-enzyme-intrinsics-no-gate.rs
@@ -1,0 +1,30 @@
+// gate-test-link_enzyme_intrinsics
+
+unsafe extern "C" {
+    fn __enzyme_autodiff();
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    fn __enzyme_fwddiff();
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    fn __enzyme_augmentfwd();
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    fn __enzyme_reverse();
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    #[link_name = "__enzyme_autodiff"]
+    fn autodiff();
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    static __enzyme_dup: i32;
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    #[link_name = "__enzyme_dup"]
+    static ENZYME_DUP: i32;
+    //~^ ERROR linking to Enzyme intrinsics is experimental
+
+    static enzyme_dup: i32;
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-link-enzyme-intrinsics-no-gate.stderr
+++ b/tests/ui/feature-gates/feature-gate-link-enzyme-intrinsics-no-gate.stderr
@@ -1,0 +1,66 @@
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:4:5
+   |
+LL |     fn __enzyme_autodiff();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:7:5
+   |
+LL |     fn __enzyme_fwddiff();
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:10:5
+   |
+LL |     fn __enzyme_augmentfwd();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:13:5
+   |
+LL |     fn __enzyme_reverse();
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:17:5
+   |
+LL |     fn autodiff();
+   |     ^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:20:5
+   |
+LL |     static __enzyme_dup: i32;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: linking to Enzyme intrinsics is experimental
+  --> $DIR/feature-gate-link-enzyme-intrinsics-no-gate.rs:24:5
+   |
+LL |     static ENZYME_DUP: i32;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(link_enzyme_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/higher-ranked/hr-fn-ptr-trait-impl-mismatch-29061.rs
+++ b/tests/ui/higher-ranked/hr-fn-ptr-trait-impl-mismatch-29061.rs
@@ -1,0 +1,33 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/29061>.
+//!
+//! A trait implemented for a higher-ranked fn pointer is not implemented for a fn pointer
+//! with a specific lifetime, and vice versa. The errors now spell out which form the impl
+//! applies to instead of just saying the bound is unsatisfied.
+
+//@ edition: 2024
+
+#![allow(dead_code)]
+
+fn x(_: &()) {}
+
+trait HR {}
+impl HR for fn(&()) {}
+fn hr<T: HR>(_: T) {}
+
+trait NotHR {}
+impl<'a> NotHR for fn(&'a ()) {}
+fn not_hr<T: NotHR>(_: T) {}
+
+fn a<'a>() {
+    let not_hr_func: fn(&'a ()) = x;
+    let hr_func: fn(&()) = x;
+    let hr_func2: for<'b> fn(&'b ()) = x;
+    hr(not_hr_func);
+    //~^ ERROR implementation of `HR` is not general enough
+    not_hr(hr_func);
+    //~^ ERROR implementation of `NotHR` is not general enough
+    not_hr(hr_func2);
+    //~^ ERROR implementation of `NotHR` is not general enough
+}
+
+fn main() {}

--- a/tests/ui/higher-ranked/hr-fn-ptr-trait-impl-mismatch-29061.stderr
+++ b/tests/ui/higher-ranked/hr-fn-ptr-trait-impl-mismatch-29061.stderr
@@ -1,0 +1,29 @@
+error: implementation of `HR` is not general enough
+  --> $DIR/hr-fn-ptr-trait-impl-mismatch-29061.rs:25:5
+   |
+LL |     hr(not_hr_func);
+   |     ^^^^^^^^^^^^^^^ implementation of `HR` is not general enough
+   |
+   = note: `HR` would have to be implemented for the type `fn(&'0 ())`, for some specific lifetime `'0`...
+   = note: ...but `HR` is actually implemented for the type `for<'a> fn(&'a ())`
+
+error: implementation of `NotHR` is not general enough
+  --> $DIR/hr-fn-ptr-trait-impl-mismatch-29061.rs:27:5
+   |
+LL |     not_hr(hr_func);
+   |     ^^^^^^^^^^^^^^^ implementation of `NotHR` is not general enough
+   |
+   = note: `NotHR` would have to be implemented for the type `for<'a> fn(&'a ())`
+   = note: ...but `NotHR` is actually implemented for the type `fn(&'0 ())`, for some specific lifetime `'0`
+
+error: implementation of `NotHR` is not general enough
+  --> $DIR/hr-fn-ptr-trait-impl-mismatch-29061.rs:29:5
+   |
+LL |     not_hr(hr_func2);
+   |     ^^^^^^^^^^^^^^^^ implementation of `NotHR` is not general enough
+   |
+   = note: `NotHR` would have to be implemented for the type `for<'b> fn(&'b ())`
+   = note: ...but `NotHR` is actually implemented for the type `fn(&'0 ())`, for some specific lifetime `'0`
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/try-block/try-block-unused-delims.current.fixed
+++ b/tests/ui/try-block/try-block-unused-delims.current.fixed
@@ -1,3 +1,6 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
 //@ check-pass
 //@ edition: 2018
 //@ run-rustfix

--- a/tests/ui/try-block/try-block-unused-delims.current.stderr
+++ b/tests/ui/try-block/try-block-unused-delims.current.stderr
@@ -1,11 +1,11 @@
 warning: unnecessary parentheses around function argument
-  --> $DIR/try-block-unused-delims.rs:11:13
+  --> $DIR/try-block-unused-delims.rs:14:13
    |
 LL |     consume((try {}));
    |             ^      ^
    |
 note: the lint level is defined here
-  --> $DIR/try-block-unused-delims.rs:6:9
+  --> $DIR/try-block-unused-delims.rs:9:9
    |
 LL | #![warn(unused_parens, unused_braces)]
    |         ^^^^^^^^^^^^^
@@ -16,13 +16,13 @@ LL +     consume(try {});
    |
 
 warning: unnecessary braces around function argument
-  --> $DIR/try-block-unused-delims.rs:14:13
+  --> $DIR/try-block-unused-delims.rs:17:13
    |
 LL |     consume({ try {} });
    |             ^^      ^^
    |
 note: the lint level is defined here
-  --> $DIR/try-block-unused-delims.rs:6:24
+  --> $DIR/try-block-unused-delims.rs:9:24
    |
 LL | #![warn(unused_parens, unused_braces)]
    |                        ^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL +     consume(try {});
    |
 
 warning: unnecessary parentheses around `match` scrutinee expression
-  --> $DIR/try-block-unused-delims.rs:17:11
+  --> $DIR/try-block-unused-delims.rs:20:11
    |
 LL |     match (try {}) {
    |           ^      ^
@@ -45,7 +45,7 @@ LL +     match try {} {
    |
 
 warning: unnecessary parentheses around `let` scrutinee expression
-  --> $DIR/try-block-unused-delims.rs:22:22
+  --> $DIR/try-block-unused-delims.rs:25:22
    |
 LL |     if let Err(()) = (try {}) {}
    |                      ^      ^
@@ -57,7 +57,7 @@ LL +     if let Err(()) = try {} {}
    |
 
 warning: unnecessary parentheses around `match` scrutinee expression
-  --> $DIR/try-block-unused-delims.rs:25:11
+  --> $DIR/try-block-unused-delims.rs:28:11
    |
 LL |     match (try {}) {
    |           ^      ^

--- a/tests/ui/try-block/try-block-unused-delims.next.fixed
+++ b/tests/ui/try-block/try-block-unused-delims.next.fixed
@@ -11,21 +11,21 @@
 fn consume<T>(_: Result<T, T>) -> T { todo!() }
 
 fn main() {
-    consume((try {}));
+    consume(try {});
     //~^ WARN unnecessary parentheses
 
-    consume({ try {} });
+    consume(try {});
     //~^ WARN unnecessary braces
 
-    match (try {}) {
+    match try {} {
         //~^ WARN unnecessary parentheses
         Ok(()) | Err(()) => (),
     }
 
-    if let Err(()) = (try {}) {}
+    if let Err(()) = try {} {}
     //~^ WARN unnecessary parentheses
 
-    match (try {}) {
+    match try {} {
         //~^ WARN unnecessary parentheses
         Ok(()) | Err(()) => (),
     }

--- a/tests/ui/try-block/try-block-unused-delims.next.stderr
+++ b/tests/ui/try-block/try-block-unused-delims.next.stderr
@@ -1,0 +1,72 @@
+warning: unnecessary parentheses around function argument
+  --> $DIR/try-block-unused-delims.rs:14:13
+   |
+LL |     consume((try {}));
+   |             ^      ^
+   |
+note: the lint level is defined here
+  --> $DIR/try-block-unused-delims.rs:9:9
+   |
+LL | #![warn(unused_parens, unused_braces)]
+   |         ^^^^^^^^^^^^^
+help: remove these parentheses
+   |
+LL -     consume((try {}));
+LL +     consume(try {});
+   |
+
+warning: unnecessary braces around function argument
+  --> $DIR/try-block-unused-delims.rs:17:13
+   |
+LL |     consume({ try {} });
+   |             ^^      ^^
+   |
+note: the lint level is defined here
+  --> $DIR/try-block-unused-delims.rs:9:24
+   |
+LL | #![warn(unused_parens, unused_braces)]
+   |                        ^^^^^^^^^^^^^
+help: remove these braces
+   |
+LL -     consume({ try {} });
+LL +     consume(try {});
+   |
+
+warning: unnecessary parentheses around `match` scrutinee expression
+  --> $DIR/try-block-unused-delims.rs:20:11
+   |
+LL |     match (try {}) {
+   |           ^      ^
+   |
+help: remove these parentheses
+   |
+LL -     match (try {}) {
+LL +     match try {} {
+   |
+
+warning: unnecessary parentheses around `let` scrutinee expression
+  --> $DIR/try-block-unused-delims.rs:25:22
+   |
+LL |     if let Err(()) = (try {}) {}
+   |                      ^      ^
+   |
+help: remove these parentheses
+   |
+LL -     if let Err(()) = (try {}) {}
+LL +     if let Err(()) = try {} {}
+   |
+
+warning: unnecessary parentheses around `match` scrutinee expression
+  --> $DIR/try-block-unused-delims.rs:28:11
+   |
+LL |     match (try {}) {
+   |           ^      ^
+   |
+help: remove these parentheses
+   |
+LL -     match (try {}) {
+LL +     match try {} {
+   |
+
+warning: 5 warnings emitted
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#162122 (Put manual calls of Enzyme intrinsics behind a feature gate)
 - rust-lang/rust#162553 (Revert "Skip rustc book on i686")
 - rust-lang/rust#162562 (Add regression test for higher-ranked fn pointer trait impl mismatch errors)
 - rust-lang/rust#162518 (Add a revision for previously fixed solver issue)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=162122,162553,162562,162518)
<!-- homu-ignore:end -->

