### PR TITLE
keep the `use<..>` bound in the `refining_impl_trait` suggestion

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
@@ -96,6 +96,7 @@ pub(crate) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
             report_mismatched_rpitit_signature(
                 tcx,
                 trait_m_sig_with_self_for_diag,
+                trait_m_sig,
                 trait_m.def_id,
                 impl_m.def_id,
                 None,
@@ -116,6 +117,7 @@ pub(crate) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
             report_mismatched_rpitit_signature(
                 tcx,
                 trait_m_sig_with_self_for_diag,
+                trait_m_sig,
                 trait_m.def_id,
                 impl_m.def_id,
                 None,
@@ -218,6 +220,7 @@ pub(crate) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
             report_mismatched_rpitit_signature(
                 tcx,
                 trait_m_sig_with_self_for_diag,
+                trait_m_sig,
                 trait_m.def_id,
                 impl_m.def_id,
                 Some(span),
@@ -291,6 +294,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInTraitCollector<'tcx> {
 fn report_mismatched_rpitit_signature<'tcx>(
     tcx: TyCtxt<'tcx>,
     trait_m_sig: ty::FnSig<'tcx>,
+    trait_m_sig_with_impl_self: ty::FnSig<'tcx>,
     trait_m_def_id: DefId,
     impl_m_def_id: DefId,
     unmatched_bound: Option<Span>,
@@ -318,6 +322,10 @@ fn report_mismatched_rpitit_signature<'tcx>(
 
     let mut return_ty = trait_m_sig.output().fold_with(&mut super::RemapLateParam { tcx, mapping });
 
+    // An `async fn` suggestion replaces the desugared `Future` output rather than an opaque, so
+    // there is no `use<..>` bound to carry over.
+    let mut precise_capturing = None;
+
     if tcx.asyncness(impl_m_def_id).is_async() && tcx.asyncness(trait_m_def_id).is_async() {
         let &ty::Alias(
             _,
@@ -341,6 +349,9 @@ fn report_mismatched_rpitit_signature<'tcx>(
             span_bug!(tcx.def_span(trait_m_def_id), "expected `Future` projection bound in AFIT");
         };
         return_ty = future_output_ty;
+    } else {
+        precise_capturing =
+            trait_rpitit_use_bound(tcx, trait_m_def_id, trait_m_sig_with_impl_self.output());
     }
 
     let (span, impl_return_span, pre, post) =
@@ -363,7 +374,10 @@ fn report_mismatched_rpitit_signature<'tcx>(
     // standard approach used elsewhere in the compiler for formatting types in suggestions
     // (e.g., see `rustc_hir_typeck/src/demand.rs`).
     let return_ty_suggestion =
-        with_no_trimmed_paths!(with_types_for_signature!(format!("{return_ty}")));
+        with_no_trimmed_paths!(with_types_for_signature!(match &precise_capturing {
+            Some(use_bound) => format!("{return_ty} + {use_bound}"),
+            None => format!("{return_ty}"),
+        }));
 
     let span = unmatched_bound.unwrap_or(span);
     tcx.emit_node_span_lint(
@@ -438,6 +452,52 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for CollectParams<'_, 'tcx> {
             ct.super_visit_with(self);
         }
     }
+}
+
+/// The `use<..>` bound the impl has to repeat so that its opaque captures no more than the
+/// trait's RPITIT does, phrased in terms of the impl's own generics.
+///
+/// A capture list is not part of how an opaque prints, and everything but the method's late-bound
+/// lifetimes has to appear in one, so a suggestion built from the trait's bounds alone would
+/// capture those lifetimes and be rejected by the check `use<..>` exists to satisfy.
+fn trait_rpitit_use_bound<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    trait_m_def_id: DefId,
+    trait_return_ty: Ty<'tcx>,
+) -> Option<String> {
+    let ty::Alias(_, alias) = *trait_return_ty.kind() else {
+        return None;
+    };
+    let projection = alias.try_to_projection()?;
+    if !tcx.is_impl_trait_in_trait(projection.kind) {
+        return None;
+    }
+
+    // An opaque only declares the late-bound lifetimes it captured, so declaring all of them
+    // means the impl captures the same set on its own.
+    let captured_lifetimes = tcx
+        .generics_of(projection.kind)
+        .own_params
+        .iter()
+        .filter(|param| matches!(param.kind, ty::GenericParamDefKind::Lifetime))
+        .count();
+    let late_bound_lifetimes = tcx
+        .fn_sig(trait_m_def_id)
+        .skip_binder()
+        .bound_vars()
+        .iter()
+        .filter(|var| matches!(var, ty::BoundVariableKind::Region(_)))
+        .count();
+    if captured_lifetimes == late_bound_lifetimes {
+        return None;
+    }
+
+    let mut captures = FxIndexSet::default();
+    for arg in projection.args {
+        arg.visit_with(&mut CollectParams { params: &mut captures });
+    }
+    captures.sort_by_cached_key(|arg| !matches!(arg.kind(), ty::GenericArgKind::Lifetime(_)));
+    Some(format!("use<{}>", captures.iter().join(", ")))
 }
 
 fn report_mismatched_rpitit_captures<'tcx>(

--- a/tests/ui/impl-trait/in-trait/refine-precise-capturing-issue-141047.rs
+++ b/tests/ui/impl-trait/in-trait/refine-precise-capturing-issue-141047.rs
@@ -1,0 +1,51 @@
+// The suggestion has to carry the trait's `use<..>` list over, expressed in terms of the impl's own
+// generics, or applying it turns this warning into a hard error.
+
+#![deny(refining_impl_trait)]
+
+trait Captures {
+    fn f(&self) -> impl use<Self> + Send;
+}
+
+impl Captures for () {
+    fn f(&self) -> () {}
+    //~^ ERROR impl trait in impl method signature does not match trait method signature
+}
+
+struct W<T>(T);
+
+impl<T: Send> Captures for W<T> {
+    fn f(&self) -> () {}
+    //~^ ERROR impl trait in impl method signature does not match trait method signature
+}
+
+trait CapturesParam<T> {
+    fn f(&self) -> impl use<Self, T> + Send;
+}
+
+impl CapturesParam<u8> for () {
+    fn f(&self) -> () {}
+    //~^ ERROR impl trait in impl method signature does not match trait method signature
+}
+
+// The trait captures everything in scope, so the suggestion is already correct.
+trait NoCaptures {
+    fn f(&self) -> impl Send;
+}
+
+impl NoCaptures for () {
+    fn f(&self) -> () {}
+    //~^ ERROR impl trait in impl method signature does not match trait method signature
+}
+
+// The impl would capture the same lifetime by default, so the suggestion is already correct.
+trait CapturesLifetime {
+    fn f<'a>(&'a self) -> impl use<'a, Self> + Send;
+}
+
+impl CapturesLifetime for () {
+    fn f<'a>(&'a self) -> () {}
+    //~^ ERROR impl trait in impl method signature does not match trait method signature
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/refine-precise-capturing-issue-141047.stderr
+++ b/tests/ui/impl-trait/in-trait/refine-precise-capturing-issue-141047.stderr
@@ -1,0 +1,93 @@
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-precise-capturing-issue-141047.rs:11:20
+   |
+LL |     fn f(&self) -> impl use<Self> + Send;
+   |                    --------------------- return type from trait method defined here
+...
+LL |     fn f(&self) -> () {}
+   |                    ^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+note: the lint level is defined here
+  --> $DIR/refine-precise-capturing-issue-141047.rs:4:9
+   |
+LL | #![deny(refining_impl_trait)]
+   |         ^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(refining_impl_trait_internal)]` implied by `#[deny(refining_impl_trait)]`
+help: replace the return type so that it matches the trait
+   |
+LL -     fn f(&self) -> () {}
+LL +     fn f(&self) -> impl std::marker::Send + use<> {}
+   |
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-precise-capturing-issue-141047.rs:18:20
+   |
+LL |     fn f(&self) -> impl use<Self> + Send;
+   |                    --------------------- return type from trait method defined here
+...
+LL |     fn f(&self) -> () {}
+   |                    ^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: replace the return type so that it matches the trait
+   |
+LL -     fn f(&self) -> () {}
+LL +     fn f(&self) -> impl std::marker::Send + use<T> {}
+   |
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-precise-capturing-issue-141047.rs:27:20
+   |
+LL |     fn f(&self) -> impl use<Self, T> + Send;
+   |                    ------------------------ return type from trait method defined here
+...
+LL |     fn f(&self) -> () {}
+   |                    ^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: replace the return type so that it matches the trait
+   |
+LL -     fn f(&self) -> () {}
+LL +     fn f(&self) -> impl std::marker::Send + use<> {}
+   |
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-precise-capturing-issue-141047.rs:37:20
+   |
+LL |     fn f(&self) -> impl Send;
+   |                    --------- return type from trait method defined here
+...
+LL |     fn f(&self) -> () {}
+   |                    ^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: replace the return type so that it matches the trait
+   |
+LL -     fn f(&self) -> () {}
+LL +     fn f(&self) -> impl std::marker::Send {}
+   |
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-precise-capturing-issue-141047.rs:47:27
+   |
+LL |     fn f<'a>(&'a self) -> impl use<'a, Self> + Send;
+   |                           ------------------------- return type from trait method defined here
+...
+LL |     fn f<'a>(&'a self) -> () {}
+   |                           ^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: replace the return type so that it matches the trait
+   |
+LL -     fn f<'a>(&'a self) -> () {}
+LL +     fn f<'a>(&'a self) -> impl std::marker::Send {}
+   |
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
the suggestion formats the traits RPITIT and `Display` doesnt print `use<..>` so `impl use<Self> + Send` renders as `impl std::marker::Send`. applying it makes the impl capture the elided `&self` lifetime which doesnt compile. new helper re emits the capture list when the trait dropped a lifetime.

one note. no existing baselines were re blessed so the new test is the only in tree coverage of an undercapturing RPITIT.

fixes https://github.com/rust-lang/rust/issues/141047

r? @davidtwco 