### PR TITLE
Fix `i686-pc-windows-msvc` platform support docs and target spec metadata

### DIFF
--- a/compiler/rustc_target/src/spec/targets/i686_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_pc_windows_msvc.rs
@@ -25,7 +25,7 @@ pub(crate) fn target() -> Target {
         metadata: TargetMetadata {
             description: Some("32-bit MSVC (Windows 10+)".into()),
             tier: Some(1),
-            host_tools: Some(true),
+            host_tools: Some(false),
             std: Some(true),
         },
         pointer_width: 32,

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -25,7 +25,9 @@ are documented at our [Forge documentation site][forge].
 
 Tier 1 targets can be thought of as "guaranteed to work". The Rust project
 builds official binary releases for each tier 1 target, and automated testing
-ensures that each tier 1 target builds and passes tests after each change.
+ensures that each tier 1 target builds and passes tests after each change. For
+the full requirements, see [Tier 1 target
+policy](target-tier-policy.md#tier-1-target-policy) in the Target Tier Policy.
 
 Tier 1 targets with host tools additionally support running tools like `rustc`
 and `cargo` natively on the target, and automated testing ensures that tests
@@ -34,19 +36,17 @@ development platform, not just a compilation target. For the full requirements,
 see [Tier 1 with Host Tools](target-tier-policy.md#tier-1-with-host-tools) in
 the Target Tier Policy.
 
-All tier 1 targets with host tools support the full standard library.
+All tier 1 (with host tools) targets support the full standard library.
 
 target | notes
 -------|-------
 [`aarch64-apple-darwin`](platform-support/apple-darwin.md) | ARM64 macOS (11.0+, Big Sur+)
 [`aarch64-pc-windows-msvc`](platform-support/windows-msvc.md) | ARM64 Windows MSVC
 [`aarch64-unknown-linux-gnu`](platform-support/aarch64-unknown-linux-gnu.md) | ARM64 Linux (kernel 4.1+, glibc 2.17+)
-[`i686-pc-windows-msvc`](platform-support/windows-msvc.md) | 32-bit MSVC (Windows 10+, Windows Server 2016+, Pentium 4) [^x86_32-floats-return-ABI] [^win32-msvc-alignment]
 `i686-unknown-linux-gnu` | 32-bit Linux (kernel 3.2+, glibc 2.17+, Pentium 4) [^x86_32-floats-return-ABI]
 [`x86_64-pc-windows-gnu`](platform-support/windows-gnu.md) | 64-bit MinGW (Windows 10+, Windows Server 2016+)
 [`x86_64-pc-windows-msvc`](platform-support/windows-msvc.md) | 64-bit MSVC (Windows 10+, Windows Server 2016+)
 `x86_64-unknown-linux-gnu` | 64-bit Linux (kernel 3.2+, glibc 2.17+)
-
 [^x86_32-floats-return-ABI]: Due to limitations of the C ABI, floating-point support on `i686` targets is non-compliant: floating-point return values are passed via an x87 register, so NaN payload bits can be lost. Functions with the default Rust ABI are not affected. See [issue #115567][x86-32-float-return-issue].
 
 [^win32-msvc-alignment]: Due to non-standard behavior of MSVC, native C code on this target can cause types with an alignment of more than 4 bytes to be incorrectly aligned to only 4 bytes (this affects, e.g., `u64` and `i64`). Rust applies some mitigations to reduce the impact of this issue, but this can still cause unsoundness due to unsafe code that (correctly) assumes that references are always properly aligned. See [issue #112480](https://github.com/rust-lang/rust/issues/112480).
@@ -54,16 +54,13 @@ target | notes
 [77071]: https://github.com/rust-lang/rust/issues/77071
 [x86-32-float-return-issue]: https://github.com/rust-lang/rust/issues/115567
 
-## Tier 1
+## Tier 1 without Host Tools
 
-Tier 1 targets can be thought of as "guaranteed to work". The Rust project
-builds official binary releases for each tier 1 target, and automated testing
-ensures that each tier 1 target builds and passes tests after each change. For
-the full requirements, see [Tier 1 target
-policy](target-tier-policy.md#tier-1-target-policy) in the Target Tier Policy.
+target | notes
+-------|-------
+[`i686-pc-windows-msvc`](platform-support/windows-msvc.md) | 32-bit MSVC (Windows 10+, Windows Server 2016+, Pentium 4) [^x86_32-floats-return-ABI] [^win32-msvc-alignment]
 
-At this time, all Tier 1 targets are [Tier 1 with Host
-Tools](#tier-1-with-host-tools).
+All tier 1 (without host tools) targets support the full standard library.
 
 ## Tier 2 with Host Tools
 

--- a/src/doc/rustc/src/platform-support/windows-msvc.md
+++ b/src/doc/rustc/src/platform-support/windows-msvc.md
@@ -28,7 +28,7 @@ Windows 10 or higher is required for client installs, Windows Server 2016 or hig
 ### Host tooling
 
 The minimum supported Visual Studio version is 2017 but this support is not actively tested in CI.
-It is **highly** recommended to use the latest version of VS (currently VS 2022).
+It is **highly** recommended to use the latest version of VS (currently VS 2026).
 
 Only 64-bit `*-pc-windows-msvc` targets support host tools.
 

--- a/src/doc/rustc/src/platform-support/windows-msvc.md
+++ b/src/doc/rustc/src/platform-support/windows-msvc.md
@@ -5,8 +5,10 @@ Windows MSVC targets.
 **Tier 1 with host tools:**
 
 - `aarch64-pc-windows-msvc`: Windows on ARM64.
-- `i686-pc-windows-msvc`: Windows on 32-bit x86.
 - `x86_64-pc-windows-msvc`: Windows on 64-bit x86.
+
+**Tier 1 without host tools:**
+- `i686-pc-windows-msvc`: Windows on 32-bit x86.
 
 ## Target maintainers
 
@@ -27,6 +29,8 @@ Windows 10 or higher is required for client installs, Windows Server 2016 or hig
 
 The minimum supported Visual Studio version is 2017 but this support is not actively tested in CI.
 It is **highly** recommended to use the latest version of VS (currently VS 2022).
+
+Only 64-bit `*-pc-windows-msvc` targets support host tools.
 
 ### Platform details
 


### PR DESCRIPTION
## Summary

Follow-up fixes to https://github.com/rust-lang/rust/pull/162288.

- Fix an outdated claim that all T1 targets have host tools, since `i686-pc-windows-msvc` no longer does.
- Remove a duplicate Tier 1 section.
- Put `i686-pc-windows-msvc` under its own Tier 1 without host tools

## Context

* `i686-pc-windows-msvc` Tier 1 (with host tools) => Tier 1 (without host tools) RFC: https://github.com/rust-lang/rfcs/pull/3999
* cc https://github.com/rust-lang/rust/issues/158378