### PR TITLE
raise ambiguity error on attribute macro that could be tool attribute

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics/mod.rs
+++ b/compiler/rustc_resolve/src/diagnostics/mod.rs
@@ -1740,3 +1740,14 @@ pub(crate) enum UnusedImportsSugg {
         num_to_remove: usize,
     },
 }
+
+#[derive(Diagnostic)]
+#[diag("attribute macro `{$attr_path}` is ambiguous")]
+#[note("ambiguous because of a name conflict with a tool namespace")]
+#[note("`{$tool}` could refer to a tool namespace")]
+pub(crate) struct ToolAttrAmbiguity {
+    #[primary_span]
+    pub path_span: Span,
+    pub attr_path: String,
+    pub tool: Symbol,
+}

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -1007,6 +1007,21 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 }
                 PathResult::Module(..) | PathResult::Indeterminate => unreachable!(),
             }
+
+            if kind == MacroKind::Attr
+                && let [tool, _second, ..] = path.as_slice()
+                && let Some(_decl) = self.registered_attr_tool_decls.get(&IdentKey::new(tool.ident))
+            {
+                if !matches!(initial_res, Some(Res::NonMacroAttr(NonMacroAttrKind::Tool))) {
+                    let attr_path =
+                        path.iter().map(|seg| seg.ident.to_string()).collect::<Vec<_>>().join("::");
+                    self.dcx().emit_err(diagnostics::ToolAttrAmbiguity {
+                        path_span,
+                        attr_path,
+                        tool: tool.ident.name,
+                    });
+                }
+            }
         }
 
         let macro_resolutions = self.single_segment_macro_resolutions.take(self);

--- a/tests/ui/diagnostic_namespace/existing_proc_macros.rs
+++ b/tests/ui/diagnostic_namespace/existing_proc_macros.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 //@ proc-macro: proc-macro-helper.rs
 
 extern crate proc_macro_helper;
@@ -17,6 +16,7 @@ mod test2 {
     }
 
     #[diagnostic::on_unimplemented]
+    //~^ ERROR attribute macro `diagnostic::on_unimplemented` is ambiguous
     trait Foo {}
 }
 

--- a/tests/ui/diagnostic_namespace/existing_proc_macros.stderr
+++ b/tests/ui/diagnostic_namespace/existing_proc_macros.stderr
@@ -1,0 +1,11 @@
+error: attribute macro `diagnostic::on_unimplemented` is ambiguous
+  --> $DIR/existing_proc_macros.rs:18:7
+   |
+LL |     #[diagnostic::on_unimplemented]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: ambiguous because of a name conflict with a tool namespace
+   = note: `diagnostic` could refer to a tool namespace
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/resolve/prelude-order.rs
+++ b/tests/ui/resolve/prelude-order.rs
@@ -59,7 +59,9 @@ extern crate macro_helpers as _;
 /* lang and libs implicitly in scope */
 
 // tool/extern -> extern
-#[type_ns::inner] //~ ERROR cannot find `inner` in `type_ns`
+#[type_ns::inner]
+//~^ ERROR attribute macro `type_ns::inner` is ambiguous
+//~| ERROR cannot find `inner` in `type_ns`
 fn t1() {}
 
 // tool/lang -> tool

--- a/tests/ui/resolve/prelude-order.stderr
+++ b/tests/ui/resolve/prelude-order.stderr
@@ -4,14 +4,23 @@ error[E0433]: cannot find `inner` in `type_ns`
 LL | #[type_ns::inner]
    |            ^^^^^ could not find `inner` in `type_ns`
 
+error: attribute macro `type_ns::inner` is ambiguous
+  --> $DIR/prelude-order.rs:62:3
+   |
+LL | #[type_ns::inner]
+   |   ^^^^^^^^^^^^^^
+   |
+   = note: ambiguous because of a name conflict with a tool namespace
+   = note: `type_ns` could refer to a tool namespace
+
 error[E0433]: cannot find `inner` in `usize`
-  --> $DIR/prelude-order.rs:74:10
+  --> $DIR/prelude-order.rs:76:10
    |
 LL | #[usize::inner]
    |          ^^^^^ could not find `inner` in `usize`
 
 error[E0573]: expected type, found crate `Option`
-  --> $DIR/prelude-order.rs:80:12
+  --> $DIR/prelude-order.rs:82:12
    |
 LL | fn e2() -> Option<i32> { None }
    |            ^^^^^^^^^^^ not a type
@@ -22,7 +31,7 @@ LL + use std::option::Option;
    |
 
 error[E0308]: mismatched types
-  --> $DIR/prelude-order.rs:83:1
+  --> $DIR/prelude-order.rs:85:1
    |
 LL | #[test]
    | ^^^^^^^- help: try adding a return type: `-> &'static str`
@@ -32,7 +41,7 @@ LL | #[test]
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> $DIR/prelude-order.rs:87:1
+  --> $DIR/prelude-order.rs:89:1
    |
 LL | #[global_allocator]
    | ^^^^^^^^^^^^^^^^^^^- help: try adding a return type: `-> &'static str`
@@ -41,7 +50,7 @@ LL | #[global_allocator]
    |
    = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0308, E0433, E0573.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/tool-attributes/tool-attributes-shadowing.rs
+++ b/tests/ui/tool-attributes/tool-attributes-shadowing.rs
@@ -1,4 +1,6 @@
 mod rustfmt {}
 
-#[rustfmt::skip] //~ ERROR: cannot find `skip` in `rustfmt`
+#[rustfmt::skip]
+//~^ ERROR attribute macro `rustfmt::skip` is ambiguous
+//~| ERROR: cannot find `skip` in `rustfmt`
 fn main() {}

--- a/tests/ui/tool-attributes/tool-attributes-shadowing.stderr
+++ b/tests/ui/tool-attributes/tool-attributes-shadowing.stderr
@@ -4,6 +4,15 @@ error[E0433]: cannot find `skip` in `rustfmt`
 LL | #[rustfmt::skip]
    |            ^^^^ could not find `skip` in `rustfmt`
 
-error: aborting due to 1 previous error
+error: attribute macro `rustfmt::skip` is ambiguous
+  --> $DIR/tool-attributes-shadowing.rs:3:3
+   |
+LL | #[rustfmt::skip]
+   |   ^^^^^^^^^^^^^
+   |
+   = note: ambiguous because of a name conflict with a tool namespace
+   = note: `rustfmt` could refer to a tool namespace
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/162597#issuecomment-5735554754 for clean crater run; the errors are unrelated/spurious.

We need some sort of ambiguity error in other to implement the [register tool rfc](https://rust-lang.github.io/rfcs/3808-register-tool.html#fixing-name-resolution-errors):

> #### Fixing name resolution errors
>
>Note that `register_tool` changes name resolution, and may give errors if you have a crate named `some_tool`.
The compiler will suggest ways to fix the new errors.
>
>If a tool name conflicts with a crate name, you can disambiguate the crate with `::some_tool`:
>```rust
>#![register_tool(some_tool)]
>extern crate some_tool;
>
>#[some_tool::attribute] //~ ERROR: is this the tool or a proc-macro?
>fn bar() {
>    // ...
>}
>
>#[::some_tool::attribute] // OK: This is the proc-macro defined in the crate.
>fn foo() {
>   // ...
>}
>```
>However, if you want to go on to use a tool attribute,
>you must rename the crate so it doesn't conflict:
>```rust
>#![register_tool(some_tool)]
>extern crate some_tool as my_library;
>
>#[some_tool::attribute] // OK: This is the attribute specified by the tool.
>fn bar() {
>    // ...
>}
>```
>Alternatively, if you only want to use lints, you can use `register_lint_tool` instead of `register_tool`, which will avoid resolution errors.
>
>Overlaps like this are expected to be rare in practice.

This PR implements the ambiguity error (**not** the "leading `::` to disambiguate" part). 

This is a breaking change if:
- someone has a crate or module named diagnostic|miri|rust_analyzer|clippy|rustfmt and exports an attribute macro from it
- it is then used it as `#[(diagnostic|miri|rust_analyzer|clippy|rustfmt)::attr_macro]` (rather than `use module_or_crate::attr_macro; #[attr_macro]`)
- the same applies for tools registered with `register_tool`, but that's unstable.


See https://github.com/rust-lang/rust/pull/158146 for context. This is a simpler version of that PR.


This does not implement unconditionally resolving these as tool attributes but does reserve the ability to do so. This would allow things like this to compile:
```rust
mod rustfmt {}

#[rustfmt::skip]
fn main() {}
```

and see also https://github.com/rust-lang/rust/issues/98291 for a case where it would be nice to assume e.g. `#[rustfmt::skip]` is actually a tool attribute and thus inert.



