### PR TITLE
Fix the remaining `tests/debuginfo` failures on `msvc` 

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -406,12 +406,7 @@ impl<'ll, 'tcx> DebugInfoBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
         inlined_at: Option<&'ll DILocation>,
         span: Span,
     ) -> &'ll DILocation {
-        // When emitting debugging information, DWARF (i.e. everything but MSVC)
-        // treats line 0 as a magic value meaning that the code could not be
-        // attributed to any line in the source. That's also exactly what dummy
-        // spans are. Make that equivalence here, rather than passing dummy spans
-        // to lookup_debug_loc, which will return line 1 for them.
-        let (line, col) = if span.is_dummy() && !self.sess().target.is_like_msvc {
+        let (line, col) = if span.is_dummy() {
             (0, 0)
         } else {
             let DebugLoc { line, col, .. } = self.lookup_debug_loc(span.lo());

--- a/tests/debuginfo/basic-types-globals.rs
+++ b/tests/debuginfo/basic-types-globals.rs
@@ -13,7 +13,7 @@
 //@ lldb-command:v basic_types_globals::I
 //@ lldb-check:[...]basic_types_globals::I = -1
 //@ lldb-command:v basic_types_globals::C
-//@ lldb-check:[...]basic_types_globals::C = U+0x00000061 U'a'
+//@ lldb-check:[...]basic_types_globals::C = U+[...]61 U'a'
 //@ lldb-command:v basic_types_globals::I8
 //@ lldb-check:[...]basic_types_globals::I8 = 68
 //@ lldb-command:v basic_types_globals::I16

--- a/tests/debuginfo/borrowed-basic.rs
+++ b/tests/debuginfo/borrowed-basic.rs
@@ -61,7 +61,7 @@
 //@ lldb-check:[...] -1
 
 //@ lldb-command:v *char_ref
-//@ lldb-check: [...] U+0x00000061 U'a'
+//@ lldb-check: [...] U+[...]61 U'a'
 
 //@ lldb-command:v *i8_ref
 //@ lldb-check:[...] 68

--- a/tests/debuginfo/by-value-self-argument-in-trait-impl.rs
+++ b/tests/debuginfo/by-value-self-argument-in-trait-impl.rs
@@ -1,3 +1,9 @@
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/captured-fields-2.rs
+++ b/tests/debuginfo/captured-fields-2.rs
@@ -1,3 +1,10 @@
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ edition:2021
 //@ ignore-backends: gcc

--- a/tests/debuginfo/coroutine-locals.rs
+++ b/tests/debuginfo/coroutine-locals.rs
@@ -1,3 +1,14 @@
+//@ ignore-msvc: FIXME coroutine captured var `a` seems to not get proper debug info on MSVC
+
+// Once the above is fixed, the below revision is necessary
+
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/issue-22656.rs
+++ b/tests/debuginfo/issue-22656.rs
@@ -1,7 +1,11 @@
+//@ revisions: msvc non-msvc
+
 // This test makes sure that the LLDB pretty printer does not throw an exception
 // when trying to handle a Vec<> or anything else that contains zero-sized
 // fields.
 
+//@ [msvc] only-msvc
+//@ [non-msvc] ignore-msvc
 //@ ignore-gdb
 
 //@ compile-flags:-g
@@ -13,13 +17,16 @@
 //@ lldb-command:v v
 //@ lldb-check:[...] size=3 { [0] = 1 [1] = 2 [2] = 3 }
 //@ lldb-command:v zs
-//@ lldb-check:[...] {x:{}, y:123, z:{}, w:456}
+//@ [non-msvc] lldb-check:[...] {x:{}, y:123, z:{}, w:456}
+// LLDB's PDB handling implictly ignores ZSTs
+//@ [msvc] lldb-check:[...] {y:123, w:456}
 
 #![allow(unused_variables)]
 #![allow(dead_code)]
 
 struct ZeroSizedStruct;
 
+#[repr(C)]
 struct StructWithZeroSizedField {
     x: ZeroSizedStruct,
     y: u32,

--- a/tests/debuginfo/lexical-scope-in-for-loop.rs
+++ b/tests/debuginfo/lexical-scope-in-for-loop.rs
@@ -1,3 +1,13 @@
+//@ ignore-msvc: https://github.com/llvm/llvm-project/issues/221696
+// Once the above is resolved, this test will still require the below revision
+
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/lexical-scope-in-if-let.rs
+++ b/tests/debuginfo/lexical-scope-in-if-let.rs
@@ -1,3 +1,10 @@
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ ignore-backends: gcc
 
@@ -30,17 +37,21 @@
 
 // === LLDB TESTS =================================================================================
 
+// Note: when printing full frames on msvc, LLDB does not ommit variables that are out of scope, so
+// we add a wildcard at the end to make sure the e.g. "(int) x = <variable not available>" is
+// accounted for
+
 //@ lldb-command:run
 //@ lldb-command:frame variable
-//@ lldb-check:(int) a = 123
+//@ lldb-check:(int) a = 123[...]
 
 //@ lldb-command:continue
 //@ lldb-command:frame variable
-//@ lldb-check:(int) a = 123 (int) x = 42
+//@ lldb-check:(int) a = 123 (int) x = 42[...]
 
 //@ lldb-command:continue
 //@ lldb-command:frame variable
-//@ lldb-check:(int) a = 123 (int) x = 42 (int) b = 456 (bool) y = true
+//@ lldb-check:(int) a = 123 (int) x = 42 (int) b = 456 (bool) y = true[...]
 
 //@ lldb-command:continue
 //@ lldb-command:frame variable

--- a/tests/debuginfo/lexical-scope-in-if.rs
+++ b/tests/debuginfo/lexical-scope-in-if.rs
@@ -1,3 +1,13 @@
+//@ ignore-msvc: https://github.com/llvm/llvm-project/issues/221696
+// Once the above is resolved, this test will still require the below revision
+
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/lexical-scope-in-stack-closure.rs
+++ b/tests/debuginfo/lexical-scope-in-stack-closure.rs
@@ -1,3 +1,13 @@
+//@ ignore-msvc: https://github.com/llvm/llvm-project/issues/221696
+// Once the above is resolved, this test will still require the below revision
+
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/lexical-scope-in-unconditional-loop.rs
+++ b/tests/debuginfo/lexical-scope-in-unconditional-loop.rs
@@ -1,3 +1,13 @@
+//@ ignore-msvc: https://github.com/llvm/llvm-project/issues/221696
+// Once the above is resolved, this test will still require the below revision
+
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/lexical-scope-in-unique-closure.rs
+++ b/tests/debuginfo/lexical-scope-in-unique-closure.rs
@@ -1,3 +1,5 @@
+//@ ignore-msvc: https://github.com/llvm/llvm-project/issues/221696
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/lexical-scope-in-while.rs
+++ b/tests/debuginfo/lexical-scope-in-while.rs
@@ -1,3 +1,13 @@
+//@ ignore-msvc: https://github.com/llvm/llvm-project/issues/221696
+// Once the above is resolved, this test will still require the below revision
+
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/lexical-scope-with-macro.rs
+++ b/tests/debuginfo/lexical-scope-with-macro.rs
@@ -1,3 +1,13 @@
+//@ ignore-msvc: https://github.com/llvm/llvm-project/issues/221696
+// Once the above is resolved, this test will still require the below revision
+
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/lexical-scopes-in-block-expression.rs
+++ b/tests/debuginfo/lexical-scopes-in-block-expression.rs
@@ -1,3 +1,5 @@
+//@ ignore-msvc: https://github.com/llvm/llvm-project/issues/221696
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/name-shadowing-and-scope-nesting.rs
+++ b/tests/debuginfo/name-shadowing-and-scope-nesting.rs
@@ -1,3 +1,13 @@
+//@ ignore-msvc: https://github.com/llvm/llvm-project/issues/221696
+// Once the above is resolved, this test will still require the below revision
+
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/reference-debuginfo.rs
+++ b/tests/debuginfo/reference-debuginfo.rs
@@ -68,7 +68,7 @@
 //@ lldb-check:[...] -1
 
 //@ lldb-command:v *char_ref
-//@ lldb-check: [...] U+0x00000061 U'a'
+//@ lldb-check: [...] U+[...]61 U'a'
 
 //@ lldb-command:v *i8_ref
 //@ lldb-check:[...] 68

--- a/tests/debuginfo/shadowed-argument.rs
+++ b/tests/debuginfo/shadowed-argument.rs
@@ -1,3 +1,13 @@
+//@ ignore-msvc: https://github.com/llvm/llvm-project/issues/221696
+// Once the above is resolved, this test will still require the below revision
+
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/shadowed-variable.rs
+++ b/tests/debuginfo/shadowed-variable.rs
@@ -1,3 +1,13 @@
+//@ ignore-msvc: https://github.com/llvm/llvm-project/issues/221696
+// Once the above is resolved, this test will still require the below revision
+
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/simple-lexical-scope.rs
+++ b/tests/debuginfo/simple-lexical-scope.rs
@@ -1,3 +1,13 @@
+//@ ignore-msvc: https://github.com/llvm/llvm-project/issues/221696
+// Once the above is resolved, this test will still require the below revision
+
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/struct-with-destructor.rs
+++ b/tests/debuginfo/struct-with-destructor.rs
@@ -1,3 +1,10 @@
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/var-captured-in-nested-closure.rs
+++ b/tests/debuginfo/var-captured-in-nested-closure.rs
@@ -1,3 +1,10 @@
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/var-captured-in-sendable-closure.rs
+++ b/tests/debuginfo/var-captured-in-sendable-closure.rs
@@ -1,3 +1,10 @@
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc

--- a/tests/debuginfo/var-captured-in-stack-closure.rs
+++ b/tests/debuginfo/var-captured-in-stack-closure.rs
@@ -1,3 +1,10 @@
+//@ revisions: msvc
+
+// On MSVC, this test requires LLDB to be able to read `S_DEFRANGE_REGISTER_REL_INDIR` PDB nodes,
+// which is only possible on lldb 23.1+
+//@ [msvc] only-msvc
+//@ [msvc] min-llvm-lldb-version: 23.1.0
+
 //@ compile-flags:-g
 //@ disable-gdb-pretty-printers
 //@ ignore-backends: gcc


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Fixes the remainder of the failing tests from https://github.com/rust-lang/rust/issues/161657

I used lldb 22.1 to individually check each of the `S_DEFRANGE_REGISTER_REL_INDIR` node (using e.g. `llvm-pdbutil dump --symbols ".\build\x86_64-pc-windows-gnu\test\debuginfo\<test_name>.lldb\a.pdb" | rg "unknown \(4471\)"`)

Any tests with an `unknown (4471)` node (4471/0x1177 being the enum value for `S_DEFRANGE_REGISTER_REL_INDIR`) got an `[msvc]` revision to disable on LLDB older than 23.1.0.

I then updated to LLDB 23.1.0 and disabled any remaining test failures that ocurred due to the variable shadowing behavior (so that they do not instantly break when we eventually run 23 in CI). Technically we could have avoided disabling those tests by using the python API to inspect individual slots of the frame, or by printing the whole frame at each step and matching against that, but the amount of effort seems not worth it until [we determine whether or not LLDB can/will improve its behavior here.](https://github.com/llvm/llvm-project/issues/221696).

One note, LLDB 23 seems to like it even less when we use the parent debugger instance for the test harness. I'll fix that in a followup PR since it requires a little bit of fiddling to get it to work with LLDB <23 (the short version is it's much harder to exit with a non-0 status code when using a nested debugger instance. We should be able to run something like `os.kill(os.getpid(), signal.SIGTERM)` from the internal python to kill the parent LLDB process to work around that)

There were a few fixes that required special handling

### `borrowed-basic.rs`, `basic-types-globals.rs`, `reference-debuginfo.rs` 

LLDB appears to have changed their default formatting for chars again in v23.1.0 (`U+0x00000061 U'a'` -> `U+0061 U'a'`) luckily these are similar enough that we can use a wildcard to pass in both cases


### `dummy-span.rs`

There was a conditional to prevent using the (0,0) default dummy span on MSVC with a comment explaining why (it would default to the first line of the file instead). I removed the `is_msvc` check and this test worked and didn't break anything else so, best guess this got fixed at some point and the comment was outdated?

In any case, with this PR, the entirety of `tests/debuginfo` passes on `linux-gnu`, `windows-gnu`, and `windows-msvc` 🎉🎉

<img width="847" height="444" alt="image" src="https://github.com/user-attachments/assets/4c0f14d1-5ad4-4234-8380-59ad18ad6309" />


<img width="817" height="208" alt="image" src="https://github.com/user-attachments/assets/87819fcd-cdbb-4fd4-b2f8-c6cf2ecf5db3" />


r? @Kobzol, @jieyouxu 


