### PR TITLE
iter::repeat_with, iter::successors, iter::from_fn added as diagnostic items

### DIFF
--- a/library/core/src/iter/sources/from_fn.rs
+++ b/library/core/src/iter/sources/from_fn.rs
@@ -42,6 +42,7 @@ use crate::fmt;
 /// ```
 #[inline]
 #[stable(feature = "iter_from_fn", since = "1.34.0")]
+#[rustc_diagnostic_item = "iter_from_fn"]
 pub fn from_fn<T, F>(f: F) -> FromFn<F>
 where
     F: FnMut() -> Option<T>,

--- a/library/core/src/iter/sources/repeat_with.rs
+++ b/library/core/src/iter/sources/repeat_with.rs
@@ -62,6 +62,7 @@ use crate::ops::Try;
 /// ```
 #[inline]
 #[stable(feature = "iterator_repeat_with", since = "1.28.0")]
+#[rustc_diagnostic_item = "iterator_repeat_with"]
 pub fn repeat_with<A, F: FnMut() -> A>(repeater: F) -> RepeatWith<F> {
     RepeatWith { repeater }
 }

--- a/library/core/src/iter/sources/repeat_with.rs
+++ b/library/core/src/iter/sources/repeat_with.rs
@@ -62,7 +62,7 @@ use crate::ops::Try;
 /// ```
 #[inline]
 #[stable(feature = "iterator_repeat_with", since = "1.28.0")]
-#[rustc_diagnostic_item = "iterator_repeat_with"]
+#[rustc_diagnostic_item = "iter_repeat_with"]
 pub fn repeat_with<A, F: FnMut() -> A>(repeater: F) -> RepeatWith<F> {
     RepeatWith { repeater }
 }

--- a/library/core/src/iter/sources/successors.rs
+++ b/library/core/src/iter/sources/successors.rs
@@ -19,6 +19,7 @@ use crate::iter::FusedIterator;
 /// assert_eq!(powers_of_10.collect::<Vec<_>>(), &[1, 10, 100, 1_000, 10_000]);
 /// ```
 #[stable(feature = "iter_successors", since = "1.34.0")]
+#[rustc_diagnostic_item = "iter_successors"]
 pub fn successors<T, F>(first: Option<T>, succ: F) -> Successors<T, F>
 where
     F: FnMut(&T) -> Option<T>,


### PR DESCRIPTION
added iter::repeat_with, iter::successors, iter::from_fn as diagnostic items, in order for clippy to be able to register them and work with them. Link to clippy issue: https://github.com/rust-lang/rust-clippy/issues/17719
