### PR TITLE
Add a `wasm32-none-component` target definition

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1504,6 +1504,7 @@ supported_targets! {
     ("thumbv7a-pc-windows-msvc", thumbv7a_pc_windows_msvc),
     ("thumbv7a-uwp-windows-msvc", thumbv7a_uwp_windows_msvc),
 
+    ("wasm32-none-component", wasm32_none_component),
     ("wasm32-unknown-emscripten", wasm32_unknown_emscripten),
     ("wasm32-unknown-unknown", wasm32_unknown_unknown),
     ("wasm32v1-none", wasm32v1_none),

--- a/compiler/rustc_target/src/spec/targets/wasm32_none_component.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_none_component.rs
@@ -1,0 +1,31 @@
+use crate::spec::{Arch, Cc, LinkerFlavor, Os, Target, TargetMetadata, base};
+
+pub(crate) fn target() -> Target {
+    let mut options = base::wasm::options();
+
+    options.os = Os::None;
+    options.linker = Some("wasm-component-ld".into());
+
+    options.add_pre_link_args(
+        LinkerFlavor::WasmLld(Cc::No),
+        &[
+            // For now this target just never has an entry symbol no matter the output
+            // type, so unconditionally pass this.
+            "--no-entry",
+        ],
+    );
+
+    Target {
+        llvm_target: "wasm32-none-component".into(),
+        metadata: TargetMetadata {
+            description: Some("WebAssembly".into()),
+            tier: Some(3),
+            host_tools: Some(false),
+            std: Some(false),
+        },
+        pointer_width: 32,
+        data_layout: "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20".into(),
+        arch: Arch::Wasm32,
+        options,
+    }
+}

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -143,6 +143,7 @@
     - [\*-pc-windows-msvc](platform-support/windows-msvc.md)
     - [\*-uwp-windows-msvc](platform-support/uwp-windows-msvc.md)
     - [\*-wrs-vxworks](platform-support/vxworks.md)
+    - [wasm32-none-component](platform-support/wasm32-none-component.md)
     - [wasm32-wasip1](platform-support/wasm32-wasip1.md)
     - [wasm32-wasip1-threads](platform-support/wasm32-wasip1-threads.md)
     - [wasm32-wasip2](platform-support/wasm32-wasip2.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -448,6 +448,7 @@ target | std | host | notes
 [`thumbv8m.base-nuttx-eabi`](platform-support/nuttx.md) | ✓ |  | ARMv8M Baseline with NuttX
 [`thumbv8m.main-nuttx-eabi`](platform-support/nuttx.md) | ✓ |  | ARMv8M Mainline with NuttX
 [`thumbv8m.main-nuttx-eabihf`](platform-support/nuttx.md) | ✓ |  | ARMv8M Mainline with NuttX, hardfloat
+[`wasm32-none-component`](platform-support/wasm32-none-component.md) | ✓ |  | WebAssembly bare components
 [`wasm64-unknown-unknown`](platform-support/wasm64-unknown-unknown.md) | ? |  | WebAssembly
 [`wasm32-wali-linux-musl`](platform-support/wasm32-wali-linux.md) | ? |  | WebAssembly with [WALI](https://github.com/arjunr2/WALI)
 [`x86_64-apple-tvos`](platform-support/apple-tvos.md) | ✓ |  | x86 64-bit tvOS

--- a/src/doc/rustc/src/platform-support/wasm32-none-component.md
+++ b/src/doc/rustc/src/platform-support/wasm32-none-component.md
@@ -1,0 +1,54 @@
+# `wasm32-none-component`
+
+**Tier: 3**
+
+The `wasm32-none-component` target is a `no_std` WebAssembly compilation target. This
+target produces a WebAssembly Component as the output and otherwise makes no
+assumptions about the environment that it is compiled within. As a `no_std`
+compilation target you're required to bring your own `#[global_allocator]` and
+`#[panic_handler`].
+
+The purpose of this target is to represent a compilation target the produces a
+WebAssembly component which otherwise does not bring in any APIs by default.
+This is suitable for testing out new component targets, for example, or for
+building possibly leaner components than one might acquire with the
+`wasm32-wasip{2,3}` targets, for example.
+
+Components produced for this target are not assumed to have any particular host
+that they're going to run within, so ecosystem crates are expected to fall back
+to `no_std` paths or wasm paths otherwise.
+
+One example usage of this target is to build a custom SDK based on the
+`wit-bindgen` crate on crates.io. This provides users the ability to import
+functions into a component, but this is an opt-in feature per build and
+otherwise won't happen by default. This can additionally be used to define
+exports as well.
+
+## Target maintainers
+
+[@alexcrichton](https://github.com/alexcrichton)
+
+## Requirements
+
+This target is cross-compiled and has no requirements beyond the base LLVM
+toolchain. The target uses `wasm-component-ld` to link which requires LLD to be
+built from the Rust source tree, and this ships by default with compiler builds.
+
+## Conditionally compiling code
+
+It's recommended to conditionally compile code for this target with:
+
+```text
+#[cfg(all(target_family = "wasm", target_os = "none"))]
+```
+
+It's worth noting though that this does not specifically select this target
+uniquely as this also matches the `wasm32v1-none` target, for example. Detecting
+this target and this target alone currently requires a `build.rs` to look at the
+`TARGET` being compiled for to look for the `wasm32-none-component` target name.
+
+## Enabled WebAssembly features
+
+The default set of WebAssembly features enabled for compilation is currently the
+same as [`wasm32-unknown-unknown`](./wasm32-unknown-unknown.md). See the
+documentation there for more information.

--- a/tests/assembly-llvm/targets/targets-elf.rs
+++ b/tests/assembly-llvm/targets/targets-elf.rs
@@ -655,6 +655,9 @@
 //@ revisions: wasm32_unknown_unknown
 //@ [wasm32_unknown_unknown] compile-flags: --target wasm32-unknown-unknown
 //@ [wasm32_unknown_unknown] needs-llvm-components: webassembly
+//@ revisions: wasm32_none_component
+//@ [wasm32_none_component] compile-flags: --target wasm32-none-component
+//@ [wasm32_none_component] needs-llvm-components: webassembly
 //@ revisions: wasm32v1_none
 //@ [wasm32v1_none] compile-flags: --target wasm32v1-none
 //@ [wasm32v1_none] needs-llvm-components: webassembly


### PR DESCRIPTION
This commit adds a new tier 3 target to the compiler named `wasm32-none-component`. This was previously approved some time ago in rust-lang/compiler-team#948. The main purpose of this target is to provide some means of producing a WebAssembly component which does not, by default, import any APIs at all. Users get to have fine-grained control over what exactly is imported and what exactly is exported.

There's no immediate plan at this time to seek out tier 2, so for now this is intended to just be a target that rustc knows about that's useful for experimenting with but otherwise shouldn't cause too much overhead otherwise.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
