### PR TITLE
Improve Windows debugger launcher

### DIFF
--- a/src/etc/rust-windbg.cmd
+++ b/src/etc/rust-windbg.cmd
@@ -1,8 +1,26 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 
 for /f "delims=" %%i in ('rustc --print=sysroot') do set rustc_sysroot=%%i
 
-set rust_etc=%rustc_sysroot%\lib\rustlib\etc
+set rust_etc=!rustc_sysroot!\lib\rustlib\etc
 
-windbg -c ".nvload %rust_etc%\intrinsic.natvis; .nvload %rust_etc%\liballoc.natvis; .nvload %rust_etc%\libcore.natvis;" %*
+set natvis_cmd=.nvload !rust_etc!\intrinsic.natvis; .nvload !rust_etc!\liballoc.natvis; .nvload !rust_etc!\libcore.natvis;
+
+where windbgx >nul 2>&1
+if !errorlevel! equ 0 (
+    if defined VERBOSE echo Launching windbgx...
+    windbgx -c "!natvis_cmd!" %*
+    exit /b !errorlevel!
+)
+
+where windbg >nul 2>&1
+if !errorlevel! equ 0 (
+    if defined VERBOSE echo Launching windbg...
+    windbg -c "!natvis_cmd!" %*
+    exit /b !errorlevel!
+)
+
+echo Error: Neither windbgx nor windbg found in PATH
+echo Please install Windows Debugger or add it to your PATH
+exit /b 1


### PR DESCRIPTION
While testing a trivial Rust application on my Windows machine, I discovered that `rust-windbg.cmd` could only launch `windbg` (legacy Windows debugger), could not detect `windbgx`, the more modern Windows debugger that fully supports Rust.
Prefer `windbgx` when available, fall back to `windbg` if the former is not available, propagate the debugger exit status, and report a clear error when neither debugger is found.

Executed tests:
[x] `windbgx` available -> launched correctly
[x] `windbgx` not available, `windbg` available -> legacy `windbg` called
[x] neither available -> error message printed

When a debugger is found and launched successfully, the script returns its exit code (0 normally). When neither debugger is found, PowerShell reports `$LASTEXITCODE` as 1.

LLM disclosure: I wrote the commit by hand after finding the issue myself. I used an LLM to review the commit before submitting.