### PR TITLE
Simplify the `G` in `Diag<'a, G>`

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -51,7 +51,7 @@ use rustc_data_structures::stable_hash::StableOrd;
 #[cfg(feature = "nightly")]
 use rustc_error_messages::{DiagArgValue, IntoDiagArg};
 #[cfg(feature = "nightly")]
-use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, msg};
+use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, Level, msg};
 use rustc_hashes::Hash64;
 use rustc_index::{Idx, IndexSlice, IndexVec};
 #[cfg(feature = "nightly")]
@@ -399,7 +399,7 @@ pub enum TargetDataLayoutError<'a> {
 }
 
 #[cfg(feature = "nightly")]
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for TargetDataLayoutError<'_> {
+impl<G> Diagnostic<'_, G> for TargetDataLayoutError<'_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         match self {
             TargetDataLayoutError::InvalidAddressSpace { addr_space, err, cause } => {

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -800,9 +800,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     fn lower_variant(&mut self, item_kind: &ItemKind, v: &Variant) -> hir::Variant<'hir> {
         if v.ident.name == kw::Underscore && self.tcx.features().unnamed_enum_variants() {
             // FIXME(#156628): lower unnamed enum variants to HIR.
-            self.dcx()
-                .struct_span_fatal(v.span, "unnamed enum variants are not yet implemented")
-                .emit()
+            self.dcx().span_fatal(v.span, "unnamed enum variants are not yet implemented");
         }
         let hir_id = self.lower_node_id(v.id);
         self.lower_attrs(hir_id, &v.attrs, v.span, Target::Variant);

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1795,9 +1795,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
         if expr::WillCreateDefIdsVisitor.visit_expr(expr).is_break() {
             // FIXME(mgca): make this non-fatal once we have a better way to handle
             // nested items in invalid `direct_const_arg!()` arguments.
-            self.dcx().struct_span_fatal(span, msg).emit()
+            self.dcx().span_fatal(span, msg)
         } else {
-            self.dcx().struct_span_err(span, msg).emit()
+            self.dcx().span_err(span, msg)
         }
     }
 
@@ -2983,9 +2983,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let literal = self.lower_lit(literal, span);
 
                 let kind = if !matches!(literal.node, LitKind::Int(..)) {
-                    let err =
-                        self.dcx().struct_span_err(expr.span, "negated literal must be an integer");
-                    hir::ConstArgKind::Error(err.emit())
+                    let err = self.dcx().span_err(expr.span, "negated literal must be an integer");
+                    hir::ConstArgKind::Error(err)
                 } else {
                     hir::ConstArgKind::Literal { lit: literal.node, negated: true }
                 };
@@ -3389,9 +3388,9 @@ impl UnrepresentableConstArgError {
             // FIXME(mgca): make this non-fatal once we have a better way to handle
             // nested items in const args
             // Issue: https://github.com/rust-lang/rust/issues/154539
-            lowering_context.dcx().struct_span_fatal(self.span, msg).emit()
+            lowering_context.dcx().span_fatal(self.span, msg)
         } else {
-            lowering_context.dcx().struct_span_err(self.span, msg).emit()
+            lowering_context.dcx().span_err(self.span, msg)
         };
 
         ConstArg {

--- a/compiler/rustc_ast_passes/src/diagnostics.rs
+++ b/compiler/rustc_ast_passes/src/diagnostics.rs
@@ -2,7 +2,7 @@
 
 use rustc_abi::ExternAbi;
 use rustc_errors::codes::*;
-use rustc_errors::{Applicability, Diag, EmissionGuarantee, Subdiagnostic};
+use rustc_errors::{Applicability, Diag, Subdiagnostic};
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Symbol};
 
@@ -663,7 +663,7 @@ pub(crate) struct EmptyLabelManySpans(pub Vec<Span>);
 
 // The derive for `Vec<Span>` does multiple calls to `span_label`, adding commas between each
 impl Subdiagnostic for EmptyLabelManySpans {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         diag.span_labels(self.0, "");
     }
 }

--- a/compiler/rustc_attr_parsing/src/diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/diagnostics.rs
@@ -3,8 +3,7 @@ use std::num::IntErrorKind;
 use rustc_attr_ir::{AttrPath, MirDialect, MirPhase};
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, E0264, EmissionGuarantee, Level,
-    MultiSpan,
+    Applicability, Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, E0264, Level, MultiSpan,
 };
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Symbol};
@@ -1473,9 +1472,7 @@ impl<'a> AttributeParseError<'a> {
         diag: &mut Diag<'_, G>,
         possibilities: &[Symbol],
         strings: bool,
-    ) where
-        G: EmissionGuarantee,
-    {
+    ) {
         let quote = if strings { '"' } else { '`' };
         match possibilities {
             &[] => {}
@@ -1508,9 +1505,7 @@ impl<'a> AttributeParseError<'a> {
         diag: &mut Diag<'_, G>,
         possibilities: &[Symbol],
         strings: bool,
-    ) where
-        G: EmissionGuarantee,
-    {
+    ) {
         let description = self.description();
 
         let quote = if strings { '"' } else { '`' };
@@ -1539,10 +1534,7 @@ impl<'a> AttributeParseError<'a> {
         }
     }
 
-    fn render_suggestions<G>(&self, diag: &mut Diag<'_, G>)
-    where
-        G: EmissionGuarantee,
-    {
+    fn render_suggestions<G>(&self, diag: &mut Diag<'_, G>) {
         let description = self.description();
 
         match &self.suggestions {
@@ -1591,7 +1583,7 @@ impl AttributeParseErrorSuggestions {
     }
 }
 
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AttributeParseError<'_> {
+impl<'a, G> Diagnostic<'a, G> for AttributeParseError<'_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         let name = self.path.to_string();
 

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -2,7 +2,7 @@
 
 use std::assert_matches;
 
-use rustc_errors::{Applicability, Diag, EmissionGuarantee};
+use rustc_errors::{Applicability, Diag};
 use rustc_hir as hir;
 use rustc_hir::intravisit::Visitor;
 use rustc_infer::infer::NllRegionVariableOrigin;
@@ -55,7 +55,7 @@ impl<'tcx> BorrowExplanation<'tcx> {
     pub(crate) fn is_explained(&self) -> bool {
         !matches!(self, BorrowExplanation::Unexplained)
     }
-    pub(crate) fn add_explanation_to_diagnostic<G: EmissionGuarantee>(
+    pub(crate) fn add_explanation_to_diagnostic<G>(
         &self,
         cx: &MirBorrowckCtxt<'_, '_, 'tcx>,
         err: &mut Diag<'_, G>,
@@ -437,7 +437,7 @@ impl<'tcx> BorrowExplanation<'tcx> {
         }
     }
 
-    fn add_object_lifetime_default_note<G: EmissionGuarantee>(
+    fn add_object_lifetime_default_note<G>(
         &self,
         tcx: TyCtxt<'tcx>,
         err: &mut Diag<'_, G>,
@@ -494,7 +494,7 @@ impl<'tcx> BorrowExplanation<'tcx> {
         }
     }
 
-    fn add_lifetime_bound_suggestion_to_diagnostic<G: EmissionGuarantee>(
+    fn add_lifetime_bound_suggestion_to_diagnostic<G>(
         &self,
         err: &mut Diag<'_, G>,
         category: &ConstraintCategory<'tcx>,
@@ -523,7 +523,7 @@ impl<'tcx> BorrowExplanation<'tcx> {
     }
 }
 
-fn suggest_rewrite_if_let<G: EmissionGuarantee>(
+fn suggest_rewrite_if_let<G>(
     tcx: TyCtxt<'_>,
     expr: &hir::Expr<'_>,
     pat: &str,

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use rustc_abi::{FieldIdx, VariantIdx};
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_errors::formatting::DiagMessageAddArg;
-use rustc_errors::{Applicability, Diag, DiagMessage, EmissionGuarantee, MultiSpan, listify, msg};
+use rustc_errors::{Applicability, Diag, DiagMessage, MultiSpan, listify, msg};
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::def::{CtorKind, Namespace};
 use rustc_hir::{
@@ -669,7 +669,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
     ///
     /// This is very similar to `fn suggest_static_lifetime_for_gat_from_hrtb` which handles this
     /// note for failed type tests instead of outlives errors.
-    fn add_placeholder_from_predicate_note<G: EmissionGuarantee>(
+    fn add_placeholder_from_predicate_note<G>(
         &self,
         diag: &mut Diag<'_, G>,
         path: &[OutlivesConstraint<'tcx>],
@@ -731,7 +731,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
 
     /// Add a label to region errors and borrow explanations when outlives constraints arise from
     /// proving a type implements `Sized` or `Copy`.
-    fn add_sized_or_copy_bound_info<G: EmissionGuarantee>(
+    fn add_sized_or_copy_bound_info<G>(
         &self,
         err: &mut Diag<'_, G>,
         blamed_category: ConstraintCategory<'tcx>,

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Display};
 use std::iter;
 
 use rustc_data_structures::fx::IndexEntry;
-use rustc_errors::{Diag, EmissionGuarantee};
+use rustc_errors::Diag;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_middle::ty::print::RegionHighlightMode;
@@ -105,7 +105,7 @@ impl RegionName {
         }
     }
 
-    pub(crate) fn highlight_region_name<G: EmissionGuarantee>(&self, diag: &mut Diag<'_, G>) {
+    pub(crate) fn highlight_region_name<G>(&self, diag: &mut Diag<'_, G>) {
         match &self.source {
             RegionNameSource::NamedLateParamRegion(span)
             | RegionNameSource::NamedEarlyParamRegion(span) => {

--- a/compiler/rustc_builtin_macros/src/diagnostics.rs
+++ b/compiler/rustc_builtin_macros/src/diagnostics.rs
@@ -1,8 +1,7 @@
 use rustc_errors::codes::*;
 use rustc_errors::formatting::DiagMessageAddArg;
 use rustc_errors::{
-    Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, MultiSpan, SingleLabelManySpans,
-    Subdiagnostic, msg,
+    Diag, DiagCtxtHandle, Diagnostic, Level, MultiSpan, SingleLabelManySpans, Subdiagnostic, msg,
 };
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Symbol};
@@ -543,7 +542,7 @@ pub(crate) struct EnvNotDefinedWithUserMessage {
 }
 
 // Hand-written implementation to support custom user messages.
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for EnvNotDefinedWithUserMessage {
+impl<'a, G> Diagnostic<'a, G> for EnvNotDefinedWithUserMessage {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         let mut diag = Diag::new(dcx, level, self.msg_from_user.to_string());
@@ -774,7 +773,7 @@ pub(crate) struct FormatUnusedArg {
 // Allow the singular form to be a subdiagnostic of the multiple-unused
 // form of diagnostic.
 impl Subdiagnostic for FormatUnusedArg {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         diag.span_label(
             self.span,
             msg!(
@@ -958,7 +957,7 @@ pub(crate) struct AsmClobberNoReg {
     pub(crate) clobbers: Vec<Span>,
 }
 
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AsmClobberNoReg {
+impl<'a, G> Diagnostic<'a, G> for AsmClobberNoReg {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         Diag::new(
             dcx,

--- a/compiler/rustc_codegen_llvm/src/diagnostics.rs
+++ b/compiler/rustc_codegen_llvm/src/diagnostics.rs
@@ -2,9 +2,7 @@ use std::ffi::{CString, c_uint};
 use std::path::Path;
 
 use rustc_data_structures::small_c_str::SmallCStr;
-use rustc_errors::{
-    Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, format_diag_message, msg,
-};
+use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, Level, format_diag_message, msg};
 use rustc_macros::Diagnostic;
 use rustc_span::Span;
 
@@ -22,7 +20,7 @@ pub(crate) struct SanitizerMemtagRequiresMte;
 
 pub(crate) struct ParseTargetMachineConfig<'a>(pub LlvmError<'a>);
 
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for ParseTargetMachineConfig<'_> {
+impl<G> Diagnostic<'_, G> for ParseTargetMachineConfig<'_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         // Reuse the formatted primary message from `LlvmError` without emitting it.
         let diag: Diag<'_, ()> = self.0.into_diag(dcx, level);
@@ -141,7 +139,7 @@ pub(crate) enum LlvmError<'a> {
 
 pub(crate) struct WithLlvmError<'a>(pub LlvmError<'a>, pub String);
 
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for WithLlvmError<'_> {
+impl<G> Diagnostic<'_, G> for WithLlvmError<'_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         use LlvmError::*;
         let msg_with_llvm_err = match &self.0 {

--- a/compiler/rustc_codegen_ssa/src/diagnostics.rs
+++ b/compiler/rustc_codegen_ssa/src/diagnostics.rs
@@ -9,8 +9,7 @@ use std::process::ExitStatus;
 use rustc_abi::NumScalableVectors;
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Diag, DiagArgValue, DiagCtxtHandle, DiagSymbolList, Diagnostic, EmissionGuarantee, IntoDiagArg,
-    Level, msg,
+    Diag, DiagArgValue, DiagCtxtHandle, DiagSymbolList, Diagnostic, IntoDiagArg, Level, msg,
 };
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_middle::ty::Ty;
@@ -203,7 +202,7 @@ pub enum LinkRlibError {
 
 pub(crate) struct ThorinErrorWrapper(pub thorin::Error);
 
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for ThorinErrorWrapper {
+impl<G> Diagnostic<'_, G> for ThorinErrorWrapper {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let build = |msg| Diag::new(dcx, level, msg);
         match self.0 {
@@ -335,7 +334,7 @@ pub(crate) struct LinkingFailed<'a> {
     pub sysroot_dir: PathBuf,
 }
 
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for LinkingFailed<'_> {
+impl<G> Diagnostic<'_, G> for LinkingFailed<'_> {
     fn into_diag(mut self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let mut diag =
             Diag::new(dcx, level, msg!("linking with `{$linker_path}` failed: {$exit_status}"));
@@ -464,7 +463,7 @@ pub(crate) struct LinkExeUnexpectedError;
 
 pub(crate) struct LinkExeStatusStackBufferOverrun;
 
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for LinkExeStatusStackBufferOverrun {
+impl<'a, G> Diagnostic<'a, G> for LinkExeStatusStackBufferOverrun {
     fn into_diag(self, dcx: rustc_errors::DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         let mut diag = Diag::new(dcx, level, msg!("0xc0000409 is `STATUS_STACK_BUFFER_OVERRUN`"));
         diag.note(msg!(
@@ -1266,7 +1265,7 @@ pub(crate) struct TargetFeatureDisableOrEnable<'a> {
 #[help("add the missing features in a `target_feature` attribute")]
 pub(crate) struct MissingFeatures;
 
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for TargetFeatureDisableOrEnable<'_> {
+impl<G> Diagnostic<'_, G> for TargetFeatureDisableOrEnable<'_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let mut diag = Diag::new(
             dcx,

--- a/compiler/rustc_const_eval/src/diagnostics.rs
+++ b/compiler/rustc_const_eval/src/diagnostics.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use rustc_errors::codes::*;
 use rustc_errors::formatting::DiagMessageAddArg;
-use rustc_errors::{Diag, DiagArgValue, EmissionGuarantee, MultiSpan, Subdiagnostic, msg};
+use rustc_errors::{Diag, DiagArgValue, MultiSpan, Subdiagnostic, msg};
 use rustc_hir::ConstContext;
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_middle::ty::{Mutability, Ty};
@@ -317,7 +317,7 @@ pub(crate) struct FrameNote {
 }
 
 impl Subdiagnostic for FrameNote {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         let mut span: MultiSpan = self.span.into();
         if self.has_label && !self.span.is_dummy() {
             span.push_span_label(self.span, msg!("the failure occurred here"));

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -20,59 +20,15 @@ use crate::{
     Suggestions,
 };
 
-/// Trait for types that `Diag::emit` can return as a "guarantee" (or "proof")
-/// token that the emission happened.
-pub trait EmissionGuarantee: Sized {
-    /// This exists so that bugs and fatal errors can both result in `!` (an
-    /// abort) when emitted, but have different aborting behaviour.
-    type EmitResult = Self;
-
-    /// Implementation of `Diag::emit`, fully controlled by each `impl` of
-    /// `EmissionGuarantee`, to make it impossible to create a value of
-    /// `Self::EmitResult` without actually performing the emission.
-    #[track_caller]
-    fn emit_producing_guarantee(diag: Diag<'_, Self>) -> Self::EmitResult;
-}
-
-impl EmissionGuarantee for ErrorGuaranteed {
-    fn emit_producing_guarantee(diag: Diag<'_, Self>) -> Self::EmitResult {
-        diag.emit_producing_error_guaranteed()
-    }
-}
-
-impl EmissionGuarantee for () {
-    fn emit_producing_guarantee(diag: Diag<'_, Self>) -> Self::EmitResult {
-        diag.emit_producing_nothing();
-    }
-}
-
 /// Marker type which enables implementation of `create_bug` and `emit_bug` functions for
 /// bug diagnostics.
 #[derive(Copy, Clone)]
 pub struct BugAbort;
 
-impl EmissionGuarantee for BugAbort {
-    type EmitResult = !;
-
-    fn emit_producing_guarantee(diag: Diag<'_, Self>) -> Self::EmitResult {
-        diag.emit_producing_nothing();
-        panic::panic_any(ExplicitBug);
-    }
-}
-
 /// Marker type which enables implementation of `create_fatal` and `emit_fatal` functions for
 /// fatal diagnostics.
 #[derive(Copy, Clone)]
 pub struct FatalAbort;
-
-impl EmissionGuarantee for FatalAbort {
-    type EmitResult = !;
-
-    fn emit_producing_guarantee(diag: Diag<'_, Self>) -> Self::EmitResult {
-        diag.emit_producing_nothing();
-        crate::FatalError.raise()
-    }
-}
 
 /// Trait implemented by error types. This is rarely implemented manually. Instead, use
 /// `#[derive(Diagnostic)]` -- see [rustc_macros::Diagnostic].
@@ -80,7 +36,7 @@ impl EmissionGuarantee for FatalAbort {
 /// When implemented manually, it should be generic over the emission
 /// guarantee, i.e.:
 /// ```ignore (fragment)
-/// impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for Foo { ... }
+/// impl<'a, G> Diagnostic<'a, G> for Foo { ... }
 /// ```
 /// rather than being specific:
 /// ```ignore (fragment)
@@ -95,7 +51,7 @@ impl EmissionGuarantee for FatalAbort {
 ///   rather than the `Diagnostic` impl.
 /// - Derived impls are always generic, and it's good for the hand-written
 ///   impls to be consistent with them.
-pub trait Diagnostic<'a, G: EmissionGuarantee = ErrorGuaranteed> {
+pub trait Diagnostic<'a, G = ErrorGuaranteed> {
     /// Write out as a diagnostic out of `DiagCtxt`.
     #[must_use]
     #[track_caller]
@@ -105,7 +61,6 @@ pub trait Diagnostic<'a, G: EmissionGuarantee = ErrorGuaranteed> {
 impl<'a, T, G> Diagnostic<'a, G> for Spanned<T>
 where
     T: Diagnostic<'a, G>,
-    G: EmissionGuarantee,
 {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         self.node.into_diag(dcx, level).with_span(self.span)
@@ -127,7 +82,7 @@ impl<'a, F: FnOnce(&mut Diag<'_, ()>)> Diagnostic<'a, ()> for DiagDecorator<F> {
 /// `#[derive(Subdiagnostic)]` -- see [rustc_macros::Subdiagnostic].
 pub trait Subdiagnostic {
     /// Add a subdiagnostic to an existing diagnostic.
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>);
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>);
 }
 
 #[derive(Clone, Debug, Encodable, Decodable)]
@@ -433,16 +388,16 @@ pub struct Subdiag {
 /// Wraps a `DiagInner`, adding some useful things.
 /// - The `dcx` field, allowing it to (a) emit itself, and (b) do a drop check
 ///   that it has been emitted or cancelled.
-/// - The `EmissionGuarantee`, which determines the type returned from `emit`.
+/// - `G`, which determines the type returned from `emit`.
 ///
 /// Each constructed `Diag` must be consumed by a function such as `emit`,
-/// `cancel`, `delay_as_bug`, or `into_diag`. A panic occurs if a `Diag`
-/// is dropped without being consumed by one of these functions.
+/// `cancel`, or `delay_as_bug`. A panic occurs if a `Diag` is dropped without
+/// being consumed by one of these functions.
 ///
 /// If there is some state in a downstream crate you would like to access in
 /// the methods of `Diag` here, consider extending `DiagCtxtFlags`.
 #[must_use]
-pub struct Diag<'a, G: EmissionGuarantee = ErrorGuaranteed> {
+pub struct Diag<'a, G = ErrorGuaranteed> {
     pub dcx: DiagCtxtHandle<'a>,
 
     /// Why the `Option`? It is always `Some` until the `Diag` is consumed via
@@ -465,7 +420,7 @@ impl<G> !Clone for Diag<'_, G> {}
 
 rustc_data_structures::static_assert_size!(Diag<'_, ()>, 3 * size_of::<usize>());
 
-impl<G: EmissionGuarantee> Deref for Diag<'_, G> {
+impl<G> Deref for Diag<'_, G> {
     type Target = DiagInner;
 
     fn deref(&self) -> &DiagInner {
@@ -473,15 +428,77 @@ impl<G: EmissionGuarantee> Deref for Diag<'_, G> {
     }
 }
 
-impl<G: EmissionGuarantee> DerefMut for Diag<'_, G> {
+impl<G> DerefMut for Diag<'_, G> {
     fn deref_mut(&mut self) -> &mut DiagInner {
         self.diag.as_mut().unwrap()
     }
 }
 
-impl<G: EmissionGuarantee> Debug for Diag<'_, G> {
+impl<G> Debug for Diag<'_, G> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.diag.fmt(f)
+    }
+}
+
+impl Diag<'_, BugAbort> {
+    #[track_caller]
+    pub fn emit(self) -> ! {
+        assert_eq!(self.level, Level::Bug);
+        self.emit_producing_nothing();
+        panic::panic_any(ExplicitBug);
+    }
+}
+
+impl Diag<'_, FatalAbort> {
+    #[track_caller]
+    pub fn emit(self) -> ! {
+        assert_eq!(self.level, Level::Fatal);
+        self.emit_producing_nothing();
+        crate::FatalError.raise()
+    }
+}
+
+impl Diag<'_, ErrorGuaranteed> {
+    #[track_caller]
+    pub fn emit(self) -> ErrorGuaranteed {
+        self.emit_producing_error_guaranteed()
+    }
+
+    /// Emit the diagnostic unless `delay` is true,
+    /// in which case the emission will be delayed as a bug.
+    ///
+    /// See `emit` and `delay_as_bug` for details.
+    #[track_caller]
+    pub fn emit_unless_delay(mut self, delay: bool) -> ErrorGuaranteed {
+        if delay {
+            self.downgrade_to_delayed_bug();
+        }
+        self.emit()
+    }
+
+    /// Delay emission of this diagnostic as a bug.
+    ///
+    /// This can be useful in contexts where an error indicates a bug but
+    /// typically this only happens when other compilation errors have already
+    /// happened. In those cases this can be used to defer emission of this
+    /// diagnostic as a bug in the compiler only if no other errors have been
+    /// emitted.
+    ///
+    /// In the meantime, though, callsites are required to deal with the "bug"
+    /// locally in whichever way makes the most sense.
+    #[track_caller]
+    pub fn delay_as_bug(mut self) -> ErrorGuaranteed {
+        self.downgrade_to_delayed_bug();
+        self.emit()
+    }
+}
+
+impl Diag<'_, ()> {
+    #[track_caller]
+    pub fn emit(self) {
+        assert_ne!(self.level, Level::Bug);
+        assert_ne!(self.level, Level::Fatal);
+        self.emit_producing_nothing();
     }
 }
 
@@ -528,7 +545,7 @@ macro_rules! with_fn {
     };
 }
 
-impl<'a, G: EmissionGuarantee> Diag<'a, G> {
+impl<'a, G> Diag<'a, G> {
     #[track_caller]
     pub fn new(dcx: DiagCtxtHandle<'a>, level: Level, message: impl Into<DiagMessage>) -> Self {
         Self::new_diagnostic(dcx, DiagInner::new(level, message))
@@ -566,13 +583,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         self.level = Level::DelayedBug;
     }
 
-    /// Make emitting this diagnostic fatal
-    ///
-    /// Changes the level of this diagnostic to Fatal, and importantly also changes the emission guarantee.
-    /// This is sound for errors that would otherwise be printed, but now simply exit the process instead.
-    /// This function still gives an emission guarantee, the guarantee is now just that it exits fatally.
-    /// For delayed bugs this is different, since those are buffered. If we upgrade one to fatal, another
-    /// might now be ignored.
+    /// Make emitting this diagnostic fatal.
     #[track_caller]
     pub fn upgrade_to_fatal(mut self) -> Diag<'a, FatalAbort> {
         assert!(
@@ -1282,13 +1293,13 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         self
     }
 
-    /// Most `emit_producing_guarantee` functions use this as a starting point.
+    /// Most `emit` methods use this as a starting point.
     fn emit_producing_nothing(mut self) {
         let diag = self.take_diag();
         self.dcx.emit_diagnostic(diag);
     }
 
-    /// `ErrorGuaranteed::emit_producing_guarantee` uses this.
+    /// `Diag<'_, ErrorGuaranteed>::emit` uses this.
     fn emit_producing_error_guaranteed(mut self) -> ErrorGuaranteed {
         let diag = self.take_diag();
 
@@ -1310,24 +1321,6 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         guar.unwrap()
     }
 
-    /// Emit and consume the diagnostic.
-    #[track_caller]
-    pub fn emit(self) -> G::EmitResult {
-        G::emit_producing_guarantee(self)
-    }
-
-    /// Emit the diagnostic unless `delay` is true,
-    /// in which case the emission will be delayed as a bug.
-    ///
-    /// See `emit` and `delay_as_bug` for details.
-    #[track_caller]
-    pub fn emit_unless_delay(mut self, delay: bool) -> G::EmitResult {
-        if delay {
-            self.downgrade_to_delayed_bug();
-        }
-        self.emit()
-    }
-
     /// Cancel and consume the diagnostic. (A diagnostic must either be emitted or
     /// cancelled or it will panic when dropped).
     pub fn cancel(mut self) {
@@ -1347,27 +1340,11 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         let diag = self.take_diag();
         self.dcx.stash_diagnostic(span, key, diag)
     }
-
-    /// Delay emission of this diagnostic as a bug.
-    ///
-    /// This can be useful in contexts where an error indicates a bug but
-    /// typically this only happens when other compilation errors have already
-    /// happened. In those cases this can be used to defer emission of this
-    /// diagnostic as a bug in the compiler only if no other errors have been
-    /// emitted.
-    ///
-    /// In the meantime, though, callsites are required to deal with the "bug"
-    /// locally in whichever way makes the most sense.
-    #[track_caller]
-    pub fn delay_as_bug(mut self) -> G::EmitResult {
-        self.downgrade_to_delayed_bug();
-        self.emit()
-    }
 }
 
 /// Destructor bomb: every `Diag` must be consumed (emitted, cancelled, etc.)
 /// or we emit a bug.
-impl<G: EmissionGuarantee> Drop for Diag<'_, G> {
+impl<G> Drop for Diag<'_, G> {
     fn drop(&mut self) {
         match self.diag.take() {
             Some(diag) if !panicking() => {

--- a/compiler/rustc_errors/src/diagnostic_impls.rs
+++ b/compiler/rustc_errors/src/diagnostic_impls.rs
@@ -5,7 +5,7 @@ use rustc_macros::Subdiagnostic;
 use rustc_span::{Span, Symbol};
 
 use crate::diagnostic::DiagLocation;
-use crate::{Diag, EmissionGuarantee, Subdiagnostic};
+use crate::{Diag, Subdiagnostic};
 
 impl IntoDiagArg for DiagLocation {
     fn into_diag_arg(self, _: &mut Option<std::path::PathBuf>) -> DiagArgValue {
@@ -42,7 +42,7 @@ pub struct SingleLabelManySpans {
     pub label: &'static str,
 }
 impl Subdiagnostic for SingleLabelManySpans {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         diag.span_labels(self.spans, self.label);
     }
 }

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -3,8 +3,6 @@
 //! This module contains the code for creating and emitting diagnostics.
 
 // tidy-alphabetical-start
-#![cfg_attr(bootstrap, feature(never_type))]
-#![feature(associated_type_defaults)]
 #![feature(default_field_values)]
 #![feature(macro_metavar_expr_concat)]
 #![feature(negative_impls)]
@@ -35,7 +33,7 @@ pub use codes::*;
 pub use decorate_diag::{BufferedEarlyLint, DecorateDiagCompat, LintBuffer};
 pub use diagnostic::{
     BugAbort, Diag, DiagDecorator, DiagInner, DiagLocation, DiagStyledString, Diagnostic,
-    EmissionGuarantee, FatalAbort, StringPart, Subdiag, Subdiagnostic,
+    FatalAbort, StringPart, Subdiag, Subdiagnostic,
 };
 pub use diagnostic_impls::{
     DiagSymbolList, ElidedLifetimeInPathSubdiag, ExpectedLifetimeParameter,
@@ -1565,19 +1563,19 @@ impl DelayedDiagInner {
     }
 }
 
-/// | Level        | is_error | EmissionGuarantee | Top-level | Used in lints?
-/// | -----        | -------- | ----------------- | --------- | --------------
-/// | Bug          | yes      | BugAbort          | yes       | -
-/// | Fatal        | yes      | FatalAbort        | yes       | -
-/// | Error        | yes      | ErrorGuaranteed   | yes       | yes
-/// | DelayedBug   | yes      | ErrorGuaranteed   | yes       | -
-/// | ForceWarning | -        | ()                | yes       | lint-only
-/// | Warning      | -        | ()                | yes       | yes
-/// | Note         | -        | ()                | rare      | -
-/// | Help         | -        | ()                | rare      | -
-/// | FailureNote  | -        | ()                | rare      | -
-/// | Allow        | -        | ()                | yes       | lint-only
-/// | Expect       | -        | ()                | yes       | lint-only
+/// | Level        | is_error | emit return type | Top-level | Used in lints?
+/// | -----        | -------- | ---------------- | --------- | --------------
+/// | Bug          | yes      | BugAbort         | yes       | -
+/// | Fatal        | yes      | FatalAbort       | yes       | -
+/// | Error        | yes      | ErrorGuaranteed  | yes       | yes
+/// | DelayedBug   | yes      | ErrorGuaranteed  | yes       | -
+/// | ForceWarning | -        | ()               | yes       | lint-only
+/// | Warning      | -        | ()               | yes       | yes
+/// | Note         | -        | ()               | rare      | -
+/// | Help         | -        | ()               | rare      | -
+/// | FailureNote  | -        | ()               | rare      | -
+/// | Allow        | -        | ()               | yes       | lint-only
+/// | Expect       | -        | ()               | yes       | lint-only
 ///
 #[derive(Copy, PartialEq, Eq, Clone, Hash, Debug, Encodable, Decodable)]
 pub enum Level {

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1554,7 +1554,7 @@ fn check_scalable_vector(tcx: TyCtxt<'_>, span: Span, def_id: LocalDefId, scalab
             return;
         }
         ScalableElt::ElementCount(..) if fields.len() >= 2 => {
-            tcx.dcx().struct_span_err(span, "scalable vectors cannot have multiple fields").emit();
+            tcx.dcx().span_err(span, "scalable vectors cannot have multiple fields");
             return;
         }
         ScalableElt::Container if fields.is_empty() => {

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -4,7 +4,7 @@ use std::ops::ControlFlow;
 use rustc_abi::{ExternAbi, FieldIdx, MAX_SIMD_LANES, ScalableElt};
 use rustc_data_structures::unord::{UnordMap, UnordSet};
 use rustc_errors::codes::*;
-use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, MultiSpan};
+use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, Level, MultiSpan};
 use rustc_hir as hir;
 use rustc_hir::attrs::ReprAttr::ReprPacked;
 use rustc_hir::attrs::lang_items::LangItem;
@@ -41,7 +41,7 @@ use crate::check::wfcheck::{
 use crate::collect::ItemCtxt;
 use crate::diagnostics;
 
-fn add_abi_diag_help<T: EmissionGuarantee>(abi: ExternAbi, diag: &mut Diag<'_, T>) {
+fn add_abi_diag_help<G>(abi: ExternAbi, diag: &mut Diag<'_, G>) {
     if let ExternAbi::Cdecl { unwind } = abi {
         let c_abi = ExternAbi::C { unwind };
         diag.help(format!("use `extern {c_abi}` instead",));

--- a/compiler/rustc_hir_analysis/src/diagnostics.rs
+++ b/compiler/rustc_hir_analysis/src/diagnostics.rs
@@ -3,8 +3,7 @@
 use rustc_abi::ExternAbi;
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, DiagCtxtHandle, DiagSymbolList, Diagnostic, EmissionGuarantee, Level,
-    MultiSpan, listify, msg,
+    Applicability, Diag, DiagCtxtHandle, DiagSymbolList, Diagnostic, Level, MultiSpan, listify, msg,
 };
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_middle::ty::{self, Ty};
@@ -468,7 +467,7 @@ pub(crate) struct MissingGenericParams {
 }
 
 // FIXME: This doesn't need to be a manual impl!
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for MissingGenericParams {
+impl<'a, G> Diagnostic<'a, G> for MissingGenericParams {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         let mut err = Diag::new(
@@ -2070,7 +2069,7 @@ pub(crate) struct UncoveredTyParam<'tcx> {
     pub(crate) local_ty: Option<Ty<'tcx>>,
 }
 
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for UncoveredTyParam<'_> {
+impl<G> Diagnostic<'_, G> for UncoveredTyParam<'_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let Self { param, local_ty } = self;
 

--- a/compiler/rustc_hir_analysis/src/diagnostics/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/diagnostics/wrong_number_of_generic_args.rs
@@ -1,6 +1,6 @@
 use GenericArgsInfo::*;
 use rustc_errors::codes::*;
-use rustc_errors::{Applicability, Diag, Diagnostic, EmissionGuarantee, MultiSpan, pluralize};
+use rustc_errors::{Applicability, Diag, Diagnostic, MultiSpan, pluralize};
 use rustc_hir as hir;
 use rustc_middle::ty::{self as ty, AssocItem, AssocItems, TyCtxt};
 use rustc_span::def_id::DefId;
@@ -543,7 +543,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
     }
 
     /// Builds the `expected 1 type argument / supplied 2 type arguments` message.
-    fn notify(&self, err: &mut Diag<'_, impl EmissionGuarantee>) {
+    fn notify<G>(&self, err: &mut Diag<'_, G>) {
         let (quantifier, bound) = self.get_quantifier_and_bound();
         let provided_args = self.num_provided_args();
 
@@ -595,7 +595,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         }
     }
 
-    fn suggest(&self, err: &mut Diag<'_, impl EmissionGuarantee>) {
+    fn suggest<G>(&self, err: &mut Diag<'_, G>) {
         debug!(
             "suggest(self.provided {:?}, self.gen_args.span(): {:?})",
             self.num_provided_args(),
@@ -623,7 +623,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
     /// ```text
     /// type Map = HashMap<String>;
     /// ```
-    fn suggest_adding_args(&self, err: &mut Diag<'_, impl EmissionGuarantee>) {
+    fn suggest_adding_args<G>(&self, err: &mut Diag<'_, G>) {
         if self.gen_args.parenthesized != hir::GenericArgsParentheses::No {
             return;
         }
@@ -650,7 +650,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         }
     }
 
-    fn suggest_adding_lifetime_args(&self, err: &mut Diag<'_, impl EmissionGuarantee>) {
+    fn suggest_adding_lifetime_args<G>(&self, err: &mut Diag<'_, G>) {
         debug!("suggest_adding_lifetime_args(path_segment: {:?})", self.path_segment);
         let num_missing_args = self.num_missing_lifetime_args();
         let num_params_to_take = num_missing_args;
@@ -704,7 +704,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         }
     }
 
-    fn suggest_adding_type_and_const_args(&self, err: &mut Diag<'_, impl EmissionGuarantee>) {
+    fn suggest_adding_type_and_const_args<G>(&self, err: &mut Diag<'_, G>) {
         let num_missing_args = self.num_missing_type_or_const_args();
         let msg = format!("add missing {} argument{}", self.kind(), pluralize!(num_missing_args));
 
@@ -764,10 +764,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
     /// ```compile_fail
     /// Into::into::<Option<_>>(42) // suggests considering `Into::<Option<_>>::into(42)`
     /// ```
-    fn suggest_moving_args_from_assoc_fn_to_trait(
-        &self,
-        err: &mut Diag<'_, impl EmissionGuarantee>,
-    ) {
+    fn suggest_moving_args_from_assoc_fn_to_trait<G>(&self, err: &mut Diag<'_, G>) {
         let Some(trait_) = self.tcx.trait_of_assoc(self.def_id) else {
             return;
         };
@@ -820,9 +817,9 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         }
     }
 
-    fn suggest_moving_args_from_assoc_fn_to_trait_for_qualified_path(
+    fn suggest_moving_args_from_assoc_fn_to_trait_for_qualified_path<G>(
         &self,
-        err: &mut Diag<'_, impl EmissionGuarantee>,
+        err: &mut Diag<'_, G>,
         qpath: &'tcx hir::QPath<'tcx>,
         msg: String,
         num_assoc_fn_excess_args: usize,
@@ -851,9 +848,9 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         }
     }
 
-    fn suggest_moving_args_from_assoc_fn_to_trait_for_method_call(
+    fn suggest_moving_args_from_assoc_fn_to_trait_for_method_call<G>(
         &self,
-        err: &mut Diag<'_, impl EmissionGuarantee>,
+        err: &mut Diag<'_, G>,
         trait_def_id: DefId,
         expr: &'tcx hir::Expr<'tcx>,
         msg: String,
@@ -907,7 +904,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
     /// ```text
     /// type Map = HashMap<String, String, String, String>;
     /// ```
-    fn suggest_removing_args_or_generics(&self, err: &mut Diag<'_, impl EmissionGuarantee>) {
+    fn suggest_removing_args_or_generics<G>(&self, err: &mut Diag<'_, G>) {
         let num_provided_lt_args = self.num_provided_lifetime_args();
         let num_provided_type_const_args = self.num_provided_type_or_const_args();
         let unbound_assoc_items = self.get_unbound_associated_item();
@@ -1099,7 +1096,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
     }
 
     /// Builds the `type defined here` message.
-    fn show_definition(&self, err: &mut Diag<'_, impl EmissionGuarantee>) {
+    fn show_definition<G>(&self, err: &mut Diag<'_, G>) {
         let Some(def_span) = self.tcx.def_ident_span(self.def_id) else { return };
         if !self.tcx.sess.source_map().is_span_accessible(def_span) {
             return;
@@ -1146,7 +1143,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
     }
 
     /// Add note if `impl Trait` is explicitly specified.
-    fn note_synth_provided(&self, err: &mut Diag<'_, impl EmissionGuarantee>) {
+    fn note_synth_provided<G>(&self, err: &mut Diag<'_, G>) {
         if !self.is_synth_provided() {
             return;
         }
@@ -1155,7 +1152,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
     }
 }
 
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for WrongNumberOfGenericArgs<'_, '_> {
+impl<'a, G> Diagnostic<'a, G> for WrongNumberOfGenericArgs<'_, '_> {
     fn into_diag(
         self,
         dcx: rustc_errors::DiagCtxtHandle<'a>,

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
@@ -2,8 +2,8 @@ use rustc_ast::TraitObjectSyntax;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, StashKey,
-    Suggestions, struct_span_code_err,
+    Applicability, Diag, DiagCtxtHandle, Diagnostic, Level, StashKey, Suggestions,
+    struct_span_code_err,
 };
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::def::{DefKind, Res};
@@ -739,7 +739,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     }
 
     /// Make sure that we are in the condition to suggest the blanket implementation.
-    fn maybe_suggest_blanket_trait_impl<G: EmissionGuarantee>(
+    fn maybe_suggest_blanket_trait_impl<G>(
         &self,
         span: Span,
         hir_id: hir::HirId,

--- a/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
@@ -97,12 +97,10 @@ pub(super) fn infer_clauses(
             } else {
                 "overflow computing implied lifetime bounds".to_string()
             };
-            tcx.dcx()
-                .struct_span_fatal(
-                    clauses_added.iter().map(|id| tcx.def_span(*id)).collect::<Vec<_>>(),
-                    msg,
-                )
-                .emit();
+            tcx.dcx().span_fatal(
+                clauses_added.iter().map(|id| tcx.def_span(*id)).collect::<Vec<_>>(),
+                msg,
+            );
         }
     }
 

--- a/compiler/rustc_hir_typeck/src/diagnostics.rs
+++ b/compiler/rustc_hir_typeck/src/diagnostics.rs
@@ -6,8 +6,8 @@ use rustc_abi::ExternAbi;
 use rustc_ast::{AssignOpKind, Label};
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, DiagArgValue, DiagCtxtHandle, DiagSymbolList, Diagnostic,
-    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic, msg,
+    Applicability, Diag, DiagArgValue, DiagCtxtHandle, DiagSymbolList, Diagnostic, IntoDiagArg,
+    Level, MultiSpan, Subdiagnostic, msg,
 };
 use rustc_hir as hir;
 use rustc_hir::ExprKind;
@@ -275,7 +275,7 @@ pub(crate) struct SuggestAnnotations {
     pub suggestions: Vec<SuggestAnnotation>,
 }
 impl Subdiagnostic for SuggestAnnotations {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         if self.suggestions.is_empty() {
             return;
         }
@@ -338,7 +338,7 @@ pub(crate) struct TypeMismatchFruTypo {
 }
 
 impl Subdiagnostic for TypeMismatchFruTypo {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         diag.arg("expr", self.expr.as_deref().unwrap_or("NONE"));
 
         // Only explain that `a ..b` is a range if it's split up
@@ -561,7 +561,7 @@ pub(crate) struct RemoveSemiForCoerce {
 }
 
 impl Subdiagnostic for RemoveSemiForCoerce {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         let mut multispan: MultiSpan = self.semi.into();
         multispan.push_span_label(
             self.expr,
@@ -704,7 +704,7 @@ pub(crate) struct BreakNonLoop<'a> {
     pub break_expr_span: Span,
 }
 
-impl<'a, G: EmissionGuarantee> Diagnostic<'_, G> for BreakNonLoop<'a> {
+impl<'a, G> Diagnostic<'_, G> for BreakNonLoop<'a> {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let mut diag = Diag::new(dcx, level, msg!("`break` with value from a `{$kind}` loop"));
@@ -906,7 +906,7 @@ pub(crate) enum CastUnknownPointerSub {
 }
 
 impl rustc_errors::Subdiagnostic for CastUnknownPointerSub {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         match self {
             CastUnknownPointerSub::To(span) => {
                 let msg = msg!("needs more type information");
@@ -1202,7 +1202,7 @@ pub(crate) struct NakedFunctionsAsmBlock {
     pub non_asms: Vec<Span>,
 }
 
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for NakedFunctionsAsmBlock {
+impl<G> Diagnostic<'_, G> for NakedFunctionsAsmBlock {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let mut diag = Diag::new(

--- a/compiler/rustc_hir_typeck/src/intrinsicck.rs
+++ b/compiler/rustc_hir_typeck/src/intrinsicck.rs
@@ -78,7 +78,7 @@ fn check_transmute<'tcx>(
     let normalize = |ty: Unnormalized<'tcx, Ty<'tcx>>| -> Result<Ty<'tcx>, ErrorGuaranteed> {
         tcx.try_normalize_erasing_regions(typing_env, ty).map_err(|err| {
             let err = LayoutError::NormalizationFailure(ty.skip_normalization(), err);
-            tcx.dcx().struct_span_err(span, err.to_string()).emit()
+            tcx.dcx().span_err(span, err.to_string())
         })
     };
 

--- a/compiler/rustc_lint/src/diagnostics.rs
+++ b/compiler/rustc_lint/src/diagnostics.rs
@@ -5,8 +5,8 @@ use rustc_data_structures::fx::FxIndexMap;
 use rustc_errors::codes::*;
 use rustc_errors::formatting::DiagMessageAddArg;
 use rustc_errors::{
-    Applicability, Diag, DiagCtxtHandle, DiagMessage, DiagStyledString, Diagnostic,
-    EmissionGuarantee, Level, Subdiagnostic, SuggestionStyle, msg,
+    Applicability, Diag, DiagCtxtHandle, DiagMessage, DiagStyledString, Diagnostic, Level,
+    Subdiagnostic, SuggestionStyle, msg,
 };
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
@@ -42,7 +42,7 @@ pub(crate) enum OverruledAttributeSub {
 }
 
 impl Subdiagnostic for OverruledAttributeSub {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         match self {
             OverruledAttributeSub::DefaultSource { id } => {
                 diag.note(msg!("`forbid` lint level is the default for {$id}"));
@@ -638,7 +638,7 @@ pub(crate) struct BuiltinUnpermittedTypeInitSub {
 }
 
 impl Subdiagnostic for BuiltinUnpermittedTypeInitSub {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         let mut err = self.err;
         loop {
             if let Some(span) = err.span {
@@ -689,7 +689,7 @@ pub(crate) struct BuiltinClashingExternSub<'a> {
 }
 
 impl Subdiagnostic for BuiltinClashingExternSub<'_> {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         let mut expected_str = DiagStyledString::new();
         expected_str.push(self.expected.fn_sig(self.tcx).to_string(), false);
         let mut found_str = DiagStyledString::new();
@@ -1363,7 +1363,7 @@ pub(crate) struct NonBindingLetSub {
 }
 
 impl Subdiagnostic for NonBindingLetSub {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         let can_suggest_binding = self.drop_fn_start_end.is_some() || !self.is_assign_desugar;
 
         if can_suggest_binding {
@@ -1740,7 +1740,7 @@ pub(crate) enum NonSnakeCaseDiagSub {
 }
 
 impl Subdiagnostic for NonSnakeCaseDiagSub {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         match self {
             NonSnakeCaseDiagSub::Label { span } => {
                 diag.span_label(span, msg!("should have a snake_case name"));
@@ -2924,7 +2924,7 @@ pub(crate) struct MismatchedLifetimeSyntaxes {
     pub suggestions: Vec<MismatchedLifetimeSyntaxesSuggestion>,
 }
 
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for MismatchedLifetimeSyntaxes {
+impl<'a, G> Diagnostic<'a, G> for MismatchedLifetimeSyntaxes {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         let counts = self.inputs.len() + self.outputs.len();
         let message = match counts {
@@ -3037,7 +3037,7 @@ impl MismatchedLifetimeSyntaxesSuggestion {
 }
 
 impl Subdiagnostic for MismatchedLifetimeSyntaxesSuggestion {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         use MismatchedLifetimeSyntaxesSuggestion::*;
 
         let style = |optional_alternative| {

--- a/compiler/rustc_lint/src/if_let_rescope.rs
+++ b/compiler/rustc_lint/src/if_let_rescope.rs
@@ -3,7 +3,7 @@ use std::ops::ControlFlow;
 
 use hir::intravisit::{self, Visitor};
 use rustc_ast::Recovered;
-use rustc_errors::{Applicability, Diag, EmissionGuarantee, Subdiagnostic, SuggestionStyle, msg};
+use rustc_errors::{Applicability, Diag, Subdiagnostic, SuggestionStyle, msg};
 use rustc_hir::{self as hir, HirIdSet};
 use rustc_lint_defs::{LintId, declare_lint, fcw, impl_lint_pass};
 use rustc_macros::{Diagnostic, Subdiagnostic};
@@ -324,7 +324,7 @@ struct IfLetRescopeRewrite {
 }
 
 impl Subdiagnostic for IfLetRescopeRewrite {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         let mut suggestions = vec![];
         for match_head in self.match_heads {
             match match_head {

--- a/compiler/rustc_macros/src/diagnostics/diagnostic.rs
+++ b/compiler/rustc_macros/src/diagnostics/diagnostic.rs
@@ -48,9 +48,7 @@ impl<'a> DiagnosticDerive<'a> {
 
         // A lifetime of `'a` causes conflicts, but `_sess` is fine.
         structure.gen_impl(quote! {
-            gen impl<'_sess, G> rustc_errors::Diagnostic<'_sess, G> for @Self
-                where G: rustc_errors::EmissionGuarantee
-            {
+            gen impl<'_sess, G> rustc_errors::Diagnostic<'_sess, G> for @Self {
                 #[track_caller]
                 fn into_diag(
                     self,

--- a/compiler/rustc_macros/src/diagnostics/subdiagnostic.rs
+++ b/compiler/rustc_macros/src/diagnostics/subdiagnostic.rs
@@ -97,9 +97,7 @@ impl SubdiagnosticDerive {
                 fn add_to_diag<__G>(
                     self,
                     #diag: &mut rustc_errors::Diag<'_, __G>,
-                ) where
-                    __G: rustc_errors::EmissionGuarantee,
-                {
+                ) {
                     #implementation
                 }
             }

--- a/compiler/rustc_metadata/src/diagnostics.rs
+++ b/compiler/rustc_metadata/src/diagnostics.rs
@@ -2,7 +2,7 @@ use std::io::Error;
 use std::path::{Path, PathBuf};
 
 use rustc_errors::codes::*;
-use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, msg};
+use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, Level, msg};
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Span, Symbol, sym};
 use rustc_target::spec::{PanicStrategy, TargetTuple};
@@ -305,7 +305,7 @@ pub(crate) struct MultipleCandidates {
     pub candidates: Vec<PathBuf>,
 }
 
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for MultipleCandidates {
+impl<G> Diagnostic<'_, G> for MultipleCandidates {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let mut diag = Diag::new(
             dcx,
@@ -418,7 +418,7 @@ pub(crate) struct InvalidMetadataFiles {
     pub crate_rejections: Vec<String>,
 }
 
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for InvalidMetadataFiles {
+impl<G> Diagnostic<'_, G> for InvalidMetadataFiles {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let mut diag = Diag::new(
@@ -450,7 +450,7 @@ pub(crate) struct CannotFindCrate {
     pub is_tier_3: bool,
 }
 
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for CannotFindCrate {
+impl<G> Diagnostic<'_, G> for CannotFindCrate {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let mut diag =

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -7,7 +7,7 @@ use rustc_ast::NodeId;
 use rustc_attr_ir::{
     ConstStability, DefaultBodyStability, DeprecatedSince, Deprecation, Stability, StabilityLevel,
 };
-use rustc_errors::{Applicability, Diag, Diagnostic, EmissionGuarantee, LintBuffer, msg};
+use rustc_errors::{Applicability, Diag, Diagnostic, LintBuffer, msg};
 use rustc_feature::GateIssue;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, HirId};
@@ -114,7 +114,7 @@ pub(crate) struct Deprecated {
     pub since_kind: DeprecatedSinceKind,
 }
 
-impl<'a, G: EmissionGuarantee> rustc_errors::Diagnostic<'a, G> for Deprecated {
+impl<'a, G> rustc_errors::Diagnostic<'a, G> for Deprecated {
     fn into_diag(
         self,
         dcx: rustc_errors::DiagCtxtHandle<'a>,

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -13,7 +13,7 @@ use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-use rustc_errors::{Applicability, Diag, EmissionGuarantee, ErrorGuaranteed};
+use rustc_errors::{Applicability, Diag, ErrorGuaranteed};
 use rustc_hir as hir;
 use rustc_hir::HirId;
 use rustc_hir::def_id::DefId;
@@ -914,7 +914,7 @@ pub enum DynCompatibilityViolationSolution {
 }
 
 impl DynCompatibilityViolationSolution {
-    pub fn add_to<G: EmissionGuarantee>(self, err: &mut Diag<'_, G>) {
+    pub fn add_to<G>(self, err: &mut Diag<'_, G>) {
         match self {
             DynCompatibilityViolationSolution::None => {}
             DynCompatibilityViolationSolution::AddSelfOrMakeSized {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2637,9 +2637,9 @@ impl<'tcx> TyCtxt<'tcx> {
         m.spans.inject_use_span.shrink_to_lo()
     }
 
-    pub fn disabled_nightly_features<E: rustc_errors::EmissionGuarantee>(
+    pub fn disabled_nightly_features<G>(
         self,
-        diag: &mut Diag<'_, E>,
+        diag: &mut Diag<'_, G>,
         features: impl IntoIterator<Item = (String, Symbol)>,
     ) {
         if !self.sess.is_nightly_build() {

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -6,9 +6,7 @@ use rustc_abi::{
     PointerKind, Primitive, ReprFlags, ReprOptions, Scalar, Size, TagEncoding, TargetDataLayout,
     TyAbiInterface, VariantIdx, Variants,
 };
-use rustc_errors::{
-    Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, IntoDiagArg, Level,
-};
+use rustc_errors::{Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, IntoDiagArg, Level};
 use rustc_hir as hir;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::def_id::DefId;
@@ -1344,7 +1342,7 @@ pub enum FnAbiError<'tcx> {
     Layout(LayoutError<'tcx>),
 }
 
-impl<'a, 'b, G: EmissionGuarantee> Diagnostic<'a, G> for FnAbiError<'b> {
+impl<'a, 'b, G> Diagnostic<'a, G> for FnAbiError<'b> {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         match self {
             Self::Layout(e) => Diag::new(dcx, level, e.to_string()),

--- a/compiler/rustc_mir_build/src/diagnostics.rs
+++ b/compiler/rustc_mir_build/src/diagnostics.rs
@@ -1,7 +1,7 @@
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level,
-    MultiSpan, Subdiagnostic, msg,
+    Applicability, Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, Level, MultiSpan, Subdiagnostic,
+    msg,
 };
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_middle::ty::{self, Ty};
@@ -585,7 +585,7 @@ pub(crate) struct UnsafeNotInheritedLintNote {
 }
 
 impl Subdiagnostic for UnsafeNotInheritedLintNote {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         diag.span_note(
             self.signature_span,
             msg!("an unsafe function restricts its caller, but its body is safe by default"),
@@ -625,7 +625,7 @@ pub(crate) struct NonExhaustivePatternsTypeNotEmpty<'a, 'tcx> {
     pub(crate) ty: Ty<'tcx>,
 }
 
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for NonExhaustivePatternsTypeNotEmpty<'_, '_> {
+impl<'a, G> Diagnostic<'a, G> for NonExhaustivePatternsTypeNotEmpty<'_, '_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         let mut diag =
             Diag::new(dcx, level, msg!("non-exhaustive patterns: type `{$ty}` is non-empty"));
@@ -730,7 +730,7 @@ pub(crate) struct UnreachablePattern<'tcx> {
     pub(crate) inner: UnreachablePatternInner<'tcx>,
 }
 
-impl<'a, 'tcx, G: EmissionGuarantee> Diagnostic<'a, G> for UnreachablePattern<'tcx> {
+impl<'a, 'tcx, G> Diagnostic<'a, G> for UnreachablePattern<'tcx> {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         let mut diag = self.inner.into_diag(dcx, level);
@@ -1260,7 +1260,7 @@ pub(crate) struct Variant {
 }
 
 impl<'tcx> Subdiagnostic for AdtDefinedHere<'tcx> {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         diag.arg("ty", self.ty);
         let mut spans = MultiSpan::from(self.adt_def_span);
 

--- a/compiler/rustc_mir_build/src/thir/pattern/migration.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/migration.rs
@@ -1,7 +1,7 @@
 //! Automatic migration of Rust 2021 patterns to a form valid in both Editions 2021 and 2024.
 
 use rustc_data_structures::fx::FxIndexMap;
-use rustc_errors::{Applicability, Diag, EmissionGuarantee, MultiSpan, pluralize};
+use rustc_errors::{Applicability, Diag, MultiSpan, pluralize};
 use rustc_hir::{BindingMode, ByRef, HirId, Mutability};
 use rustc_lint_defs::builtin::RUST_2024_INCOMPATIBLE_PAT;
 use rustc_middle::ty::{self, Rust2024IncompatiblePatInfo, TyCtxt};
@@ -90,7 +90,7 @@ impl<'a> PatMigration<'a> {
         format!("cannot {verb1}{or_verb2} within an implicitly-borrowing pattern{in_rust_2024}")
     }
 
-    fn format_subdiagnostics(self, diag: &mut Diag<'_, impl EmissionGuarantee>) {
+    fn format_subdiagnostics<G>(self, diag: &mut Diag<'_, G>) {
         // Format and emit explanatory notes about default binding modes. Reversing the spans' order
         // means if we have nested spans, the innermost ones will be visited first.
         for (span, def_br_mutbl) in self.default_mode_labels.into_iter().rev() {

--- a/compiler/rustc_mir_transform/src/diagnostics.rs
+++ b/compiler/rustc_mir_transform/src/diagnostics.rs
@@ -1,7 +1,6 @@
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, DiagCtxtHandle, DiagSymbolList, Diagnostic, EmissionGuarantee, Level,
-    Subdiagnostic, msg,
+    Applicability, Diag, DiagCtxtHandle, DiagSymbolList, Diagnostic, Level, Subdiagnostic, msg,
 };
 use rustc_lint_defs::Lint;
 use rustc_lint_defs::builtin::{ARITHMETIC_OVERFLOW, UNCONDITIONAL_PANIC};
@@ -219,7 +218,7 @@ pub(crate) struct UnusedAssignOverwrite {
 }
 
 impl Subdiagnostic for UnusedAssignOverwrite {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         diag.span_label(self.assigned_span, "this value is reassigned later and never used");
         diag.span_label(
             self.overwrite_span,
@@ -298,7 +297,7 @@ pub(crate) struct UnusedVariableStringInterp {
 }
 
 impl Subdiagnostic for UnusedVariableStringInterp {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         diag.span_label(
             self.lit,
             msg!("you might have meant to use string interpolation in this string literal"),

--- a/compiler/rustc_mir_transform/src/lint_tail_expr_drop_order.rs
+++ b/compiler/rustc_mir_transform/src/lint_tail_expr_drop_order.rs
@@ -524,7 +524,7 @@ struct LocalLabel<'a> {
 
 /// A custom `Subdiagnostic` implementation so that the notes are delivered in a specific order
 impl Subdiagnostic for LocalLabel<'_> {
-    fn add_to_diag<G: rustc_errors::EmissionGuarantee>(self, diag: &mut rustc_errors::Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut rustc_errors::Diag<'_, G>) {
         diag.span_label(
             self.span,
             msg!(

--- a/compiler/rustc_parse/src/diagnostics.rs
+++ b/compiler/rustc_parse/src/diagnostics.rs
@@ -7,8 +7,8 @@ use rustc_ast::token::{self, InvisibleOrigin, MetaVarKind, Token};
 use rustc_ast_pretty::pprust;
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, IntoDiagArg,
-    Level, Subdiagnostic, SuggestionStyle, msg,
+    Applicability, Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, IntoDiagArg, Level,
+    Subdiagnostic, SuggestionStyle, msg,
 };
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::edition::{Edition, LATEST_STABLE_EDITION};
@@ -1537,7 +1537,7 @@ pub(crate) struct ExpectedIdentifier {
     pub help_cannot_start_number: Option<HelpIdentifierStartsWithNumber>,
 }
 
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for ExpectedIdentifier {
+impl<'a, G> Diagnostic<'a, G> for ExpectedIdentifier {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         let token_descr = TokenDescription::from_token(&self.token);
@@ -1603,7 +1603,7 @@ pub(crate) struct ExpectedSemi {
     pub sugg: ExpectedSemiSugg,
 }
 
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for ExpectedSemi {
+impl<'a, G> Diagnostic<'a, G> for ExpectedSemi {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         let token_descr = TokenDescription::from_token(&self.token);
@@ -2010,7 +2010,7 @@ pub(crate) struct FnTraitMissingParen {
 }
 
 impl Subdiagnostic for FnTraitMissingParen {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         diag.span_label(self.span, msg!("`Fn` bounds require arguments in parentheses"));
         diag.span_suggestion_short(
             self.span.shrink_to_hi(),
@@ -3697,7 +3697,7 @@ pub(crate) struct UseDerefMacro {
 }
 
 impl Subdiagnostic for UseDerefMacro {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         let Self { field, before, after } = self;
 
         let mut parts = Vec::new();
@@ -4355,7 +4355,7 @@ pub(crate) struct HiddenUnicodeCodepointsDiagLabels {
 }
 
 impl Subdiagnostic for HiddenUnicodeCodepointsDiagLabels {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         for (c, span) in self.spans {
             diag.span_label(span, format!("{c:?}"));
         }
@@ -4369,7 +4369,7 @@ pub(crate) enum HiddenUnicodeCodepointsDiagSub {
 
 // Used because of multiple multipart_suggestion and note
 impl Subdiagnostic for HiddenUnicodeCodepointsDiagSub {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         match self {
             HiddenUnicodeCodepointsDiagSub::Escape { spans } => {
                 diag.multipart_suggestion_with_style(

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -1007,7 +1007,7 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
         err.emit()
     }
 
-    fn report_unterminated_block_comment(&self, start: BytePos, doc_style: Option<DocStyle>) {
+    fn report_unterminated_block_comment(&self, start: BytePos, doc_style: Option<DocStyle>) -> ! {
         let msg = match doc_style {
             Some(_) => "unterminated block doc-comment",
             None => "unterminated block comment",

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -17,7 +17,7 @@ use rustc_ast as ast;
 use rustc_ast::token;
 use rustc_ast::tokenstream::{DelimSpacing, DelimSpan, Spacing, TokenStream, TokenTree};
 use rustc_ast_pretty::pprust;
-use rustc_errors::{Diag, EmissionGuarantee, FatalError, PResult, pluralize};
+use rustc_errors::{Diag, FatalError, PResult, pluralize};
 pub use rustc_lexer::UNICODE_VERSION;
 use rustc_session::parse::ParseSess;
 use rustc_span::edit_distance::find_best_match_for_name;
@@ -165,11 +165,11 @@ pub fn new_parser_from_file<'a>(
     new_parser_from_source_file(psess, source_file, strip_tokens)
 }
 
-pub fn utf8_error<E: EmissionGuarantee>(
+pub fn utf8_error<G>(
     sm: &SourceMap,
     path: &str,
     sp: Option<Span>,
-    err: &mut Diag<'_, E>,
+    err: &mut Diag<'_, G>,
     utf8err: Utf8Error,
     contents: &[u8],
 ) {

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1720,7 +1720,7 @@ impl<'a> Parser<'a> {
         );
         err.span_label(op_span, format!("not a valid {} operator", kind.fixity));
 
-        let help_base_case = |mut err: Diag<'_, _>, base| {
+        let help_base_case = |mut err: Diag<'_, ErrorGuaranteed>, base| {
             err.help(format!("use `{}= 1` instead", kind.op.chr()));
             err.emit();
             Ok(base)

--- a/compiler/rustc_passes/src/diagnostics.rs
+++ b/compiler/rustc_passes/src/diagnostics.rs
@@ -2,9 +2,7 @@ use std::io::Error;
 use std::path::{Path, PathBuf};
 
 use rustc_errors::codes::*;
-use rustc_errors::{
-    Diag, DiagCtxtHandle, DiagSymbolList, Diagnostic, EmissionGuarantee, Level, MultiSpan, msg,
-};
+use rustc_errors::{Diag, DiagCtxtHandle, DiagSymbolList, Diagnostic, Level, MultiSpan, msg};
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_middle::middle::resolve::MainDefinition;
 use rustc_middle::ty::Ty;
@@ -423,7 +421,7 @@ pub(crate) struct NoMainErr {
     pub add_teach_note: bool,
 }
 
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for NoMainErr {
+impl<'a, G> Diagnostic<'a, G> for NoMainErr {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         let mut diag =
@@ -489,7 +487,7 @@ pub(crate) struct DuplicateLangItem {
     pub(crate) duplicate: Duplicate,
 }
 
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for DuplicateLangItem {
+impl<G> Diagnostic<'_, G> for DuplicateLangItem {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let mut diag = Diag::new(

--- a/compiler/rustc_resolve/src/diagnostics/mod.rs
+++ b/compiler/rustc_resolve/src/diagnostics/mod.rs
@@ -2,7 +2,7 @@ use rustc_errors::codes::*;
 use rustc_errors::formatting::DiagMessageAddArg;
 use rustc_errors::{
     Applicability, Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, ElidedLifetimeInPathSubdiag,
-    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic, msg,
+    IntoDiagArg, Level, MultiSpan, Subdiagnostic, msg,
 };
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{Ident, Span, Spanned, Symbol};
@@ -1380,7 +1380,7 @@ pub(crate) enum ItemWas {
 }
 
 impl Subdiagnostic for FoundItemConfigureOut {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         let mut multispan: MultiSpan = self.span.into();
         match self.item_was {
             ItemWas::BehindFeature { feature, span } => {
@@ -1522,7 +1522,7 @@ pub(crate) struct Ambiguity {
     pub is_error: bool,
 }
 
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for Ambiguity {
+impl<'a, G> Diagnostic<'a, G> for Ambiguity {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         let Self {
             ident,

--- a/compiler/rustc_session/src/diagnostics.rs
+++ b/compiler/rustc_session/src/diagnostics.rs
@@ -4,8 +4,7 @@ use rustc_ast::token;
 use rustc_ast::util::literal::LitError;
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Diag, DiagCtxtHandle, DiagMessage, Diagnostic, EmissionGuarantee, ErrorGuaranteed, Level,
-    MultiSpan, StashKey,
+    Diag, DiagCtxtHandle, DiagMessage, Diagnostic, ErrorGuaranteed, Level, MultiSpan, StashKey,
 };
 use rustc_feature::{GateIssue, find_feature_issue};
 use rustc_macros::{Diagnostic, Subdiagnostic};
@@ -96,11 +95,7 @@ pub fn feature_warn_issue(
 
 /// Adds the diagnostics for a feature to an existing error.
 /// Must be a language feature!
-pub fn add_feature_diagnostics<G: EmissionGuarantee>(
-    err: &mut Diag<'_, G>,
-    sess: &Session,
-    feature: Symbol,
-) {
+pub fn add_feature_diagnostics<G>(err: &mut Diag<'_, G>, sess: &Session, feature: Symbol) {
     add_feature_diagnostics_for_issue(err, sess, feature, GateIssue::Language, false, None);
 }
 
@@ -109,7 +104,7 @@ pub fn add_feature_diagnostics<G: EmissionGuarantee>(
 /// This variant allows you to control whether it is a library or language feature.
 /// Almost always, you want to use this for a language feature. If so, prefer
 /// `add_feature_diagnostics`.
-pub fn add_feature_diagnostics_for_issue<G: EmissionGuarantee>(
+pub fn add_feature_diagnostics_for_issue<G>(
     err: &mut Diag<'_, G>,
     sess: &Session,
     feature: Symbol,
@@ -197,7 +192,7 @@ pub(crate) struct FeatureGateError {
     pub(crate) explain: DiagMessage,
 }
 
-impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for FeatureGateError {
+impl<'a, G> Diagnostic<'a, G> for FeatureGateError {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, G> {
         Diag::new(dcx, level, self.explain).with_span(self.span).with_code(E0658)

--- a/compiler/rustc_trait_selection/src/diagnostics.rs
+++ b/compiler/rustc_trait_selection/src/diagnostics.rs
@@ -2,8 +2,8 @@ use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_errors::codes::*;
 use rustc_errors::formatting::DiagMessageAddArg;
 use rustc_errors::{
-    Applicability, Diag, DiagCtxtHandle, DiagMessage, DiagStyledString, Diagnostic,
-    EmissionGuarantee, IntoDiagArg, Level, MultiSpan, Subdiagnostic, msg,
+    Applicability, Diag, DiagCtxtHandle, DiagMessage, DiagStyledString, Diagnostic, IntoDiagArg,
+    Level, MultiSpan, Subdiagnostic, msg,
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
@@ -36,7 +36,7 @@ pub(crate) struct NegativePositiveConflict<'tcx> {
     pub positive_impl_span: Result<Span, Symbol>,
 }
 
-impl<G: EmissionGuarantee> Diagnostic<'_, G> for NegativePositiveConflict<'_> {
+impl<G> Diagnostic<'_, G> for NegativePositiveConflict<'_> {
     #[track_caller]
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
         let mut diag = Diag::new(
@@ -89,7 +89,7 @@ pub(crate) enum AdjustSignatureBorrow {
 }
 
 impl Subdiagnostic for AdjustSignatureBorrow {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         match self {
             AdjustSignatureBorrow::Borrow { to_borrow } => {
                 diag.arg("borrow_len", to_borrow.len());
@@ -437,7 +437,7 @@ pub(crate) enum RegionOriginNote<'a> {
 }
 
 impl Subdiagnostic for RegionOriginNote<'_> {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         let label_or_note = |diag: &mut Diag<'_, G>, span, msg: DiagMessage| {
             let sub_count = diag.children.iter().filter(|d| d.span.is_dummy()).count();
             let expanded_sub_count = diag.children.iter().filter(|d| !d.span.is_dummy()).count();
@@ -532,7 +532,7 @@ pub(crate) enum LifetimeMismatchLabels {
 }
 
 impl Subdiagnostic for LifetimeMismatchLabels {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         match self {
             LifetimeMismatchLabels::InRet { param_span, ret_span, span, label_var1 } => {
                 diag.span_label(param_span, msg!("this parameter and the return type are declared with different lifetimes..."));
@@ -605,7 +605,7 @@ pub(crate) struct AddLifetimeParamsSuggestion<'a> {
 }
 
 impl Subdiagnostic for AddLifetimeParamsSuggestion<'_> {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         let mut mk_suggestion = || {
             let Some(anon_reg) = self.tcx.is_suitable_region(self.generic_param_scope, self.sub)
             else {
@@ -789,7 +789,7 @@ pub(crate) struct IntroducesStaticBecauseUnmetLifetimeReq {
 }
 
 impl Subdiagnostic for IntroducesStaticBecauseUnmetLifetimeReq {
-    fn add_to_diag<G: EmissionGuarantee>(mut self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(mut self, diag: &mut Diag<'_, G>) {
         self.unmet_requirements.push_span_label(
             self.binding_span,
             msg!("introduces a `'static` lifetime requirement"),
@@ -1184,7 +1184,7 @@ pub(crate) struct ConsiderBorrowingParamHelp {
 }
 
 impl Subdiagnostic for ConsiderBorrowingParamHelp {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         let mut type_param_span: MultiSpan = self.spans.clone().into();
         for &span in &self.spans {
             // Seems like we can't call f() here as Into<DiagMessage> is required
@@ -1661,7 +1661,7 @@ pub(crate) struct SuggestTuplePatternMany {
 }
 
 impl Subdiagnostic for SuggestTuplePatternMany {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         diag.arg("path", self.path);
         let message = msg!("try wrapping the pattern in a variant of `{$path}`");
         diag.multipart_suggestions(
@@ -1907,7 +1907,7 @@ pub(crate) struct AddPreciseCapturingAndParams {
 }
 
 impl Subdiagnostic for AddPreciseCapturingAndParams {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         diag.arg("new_lifetime", self.new_lifetime);
         diag.multipart_suggestion(
             msg!("add a `use<...>` bound to explicitly capture `{$new_lifetime}` after turning all argument-position `impl Trait` into type parameters, noting that this possibly affects the API of this crate"),
@@ -2047,7 +2047,7 @@ pub struct AddPreciseCapturingForOvercapture {
 }
 
 impl Subdiagnostic for AddPreciseCapturingForOvercapture {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         let applicability = if self.apit_spans.is_empty() {
             Applicability::MachineApplicable
         } else {

--- a/compiler/rustc_trait_selection/src/diagnostics/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/diagnostics/note_and_explain.rs
@@ -1,5 +1,5 @@
 use rustc_errors::formatting::DiagMessageAddArg;
-use rustc_errors::{Diag, EmissionGuarantee, IntoDiagArg, Subdiagnostic, msg};
+use rustc_errors::{Diag, IntoDiagArg, Subdiagnostic, msg};
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::bug;
 use rustc_middle::ty::{self, TyCtxt};
@@ -163,7 +163,7 @@ impl RegionExplanation<'_> {
 }
 
 impl Subdiagnostic for RegionExplanation<'_> {
-    fn add_to_diag<G: EmissionGuarantee>(self, diag: &mut Diag<'_, G>) {
+    fn add_to_diag<G>(self, diag: &mut Diag<'_, G>) {
         let msg = msg!(
             "{$pref_kind ->
                 *[should_not_happen] [{$pref_kind}]

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use rustc_errors::{Diag, E0275, EmissionGuarantee, ErrorGuaranteed, struct_span_code_err};
+use rustc_errors::{Diag, E0275, ErrorGuaranteed, struct_span_code_err};
 use rustc_hir::def::Namespace;
 use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_infer::traits::{Obligation, PredicateObligation};
@@ -17,10 +17,7 @@ pub enum OverflowCause<'tcx> {
     TraitSolver(ty::Predicate<'tcx>),
 }
 
-pub fn suggest_new_overflow_limit<'tcx, G: EmissionGuarantee>(
-    tcx: TyCtxt<'tcx>,
-    err: &mut Diag<'_, G>,
-) {
+pub fn suggest_new_overflow_limit<'tcx, G>(tcx: TyCtxt<'tcx>, err: &mut Diag<'_, G>) {
     let suggested_limit = match tcx.recursion_limit() {
         Limit(0) => Limit(2),
         limit => limit * 2,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -9,8 +9,7 @@ use rustc_abi::ExternAbi;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, EmissionGuarantee, MultiSpan, Style, SuggestionStyle, pluralize,
-    struct_span_code_err,
+    Applicability, Diag, MultiSpan, Style, SuggestionStyle, pluralize, struct_span_code_err,
 };
 use rustc_hir::attrs::lang_items::{self, LangItem};
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
@@ -120,7 +119,7 @@ fn predicate_constraint(generics: &hir::Generics<'_>, pred: ty::Predicate<'_>) -
 /// Type parameter needs more bounds. The trivial case is `T` `where T: Bound`, but
 /// it can also be an `impl Trait` param that needs to be decomposed to a type
 /// param for cleaner code.
-pub fn suggest_restriction<'tcx, G: EmissionGuarantee>(
+pub fn suggest_restriction<'tcx, G>(
     tcx: TyCtxt<'tcx>,
     item_id: LocalDefId,
     hir_generics: &hir::Generics<'tcx>,
@@ -2751,7 +2750,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         false
     }
 
-    pub(super) fn suggest_borrow_for_unsized_closure_return<G: EmissionGuarantee>(
+    pub(super) fn suggest_borrow_for_unsized_closure_return<G>(
         &self,
         body_def_id: LocalDefId,
         err: &mut Diag<'_, G>,
@@ -3296,7 +3295,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     ///
     /// Returns `true` if an async-await specific note was added to the diagnostic.
     #[instrument(level = "debug", skip_all, fields(?obligation.predicate, ?obligation.cause.span))]
-    pub fn maybe_note_obligation_cause_for_async_await<G: EmissionGuarantee>(
+    pub fn maybe_note_obligation_cause_for_async_await<G>(
         &self,
         err: &mut Diag<'_, G>,
         obligation: &PredicateObligation<'tcx>,
@@ -3528,7 +3527,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     /// Unconditionally adds the diagnostic note described in
     /// `maybe_note_obligation_cause_for_async_await`'s documentation comment.
     #[instrument(level = "debug", skip_all)]
-    fn note_obligation_cause_for_async_await<G: EmissionGuarantee>(
+    fn note_obligation_cause_for_async_await<G>(
         &self,
         err: &mut Diag<'_, G>,
         interior_or_upvar_span: CoroutineInteriorOrUpvar,
@@ -3762,7 +3761,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         );
     }
 
-    fn note_closure_capture<G: EmissionGuarantee>(
+    fn note_closure_capture<G>(
         &self,
         err: &mut Diag<'_, G>,
         closure_def_id: DefId,
@@ -3814,7 +3813,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         true
     }
 
-    pub(super) fn note_obligation_cause_code<G: EmissionGuarantee, T>(
+    pub(super) fn note_obligation_cause_code<G, T>(
         &self,
         body_def_id: LocalDefId,
         err: &mut Diag<'_, G>,
@@ -3843,7 +3842,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         );
     }
 
-    fn note_obligation_cause_code_inner<G: EmissionGuarantee, T>(
+    fn note_obligation_cause_code_inner<G, T>(
         &self,
         body_def_id: LocalDefId,
         err: &mut Diag<'_, G>,
@@ -5199,7 +5198,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
     }
 
-    fn note_function_argument_obligation<G: EmissionGuarantee>(
+    fn note_function_argument_obligation<G>(
         &self,
         body_def_id: LocalDefId,
         err: &mut Diag<'_, G>,
@@ -5438,7 +5437,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
     }
 
-    fn suggest_option_method_if_applicable<G: EmissionGuarantee>(
+    fn suggest_option_method_if_applicable<G>(
         &self,
         failed_pred: ty::Predicate<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
@@ -5513,7 +5512,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
     }
 
-    fn look_for_iterator_item_mistakes<G: EmissionGuarantee>(
+    fn look_for_iterator_item_mistakes<G>(
         &self,
         assocs_in_this_method: &[Option<(Span, (DefId, Ty<'tcx>))>],
         typeck_results: &TypeckResults<'tcx>,
@@ -5662,7 +5661,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
     }
 
-    fn point_at_chain<G: EmissionGuarantee>(
+    fn point_at_chain<G>(
         &self,
         expr: &hir::Expr<'_>,
         typeck_results: &TypeckResults<'tcx>,
@@ -5911,7 +5910,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     ///    |     | `Iterator::Item` is `&mut Vec<u8>` here
     ///    |     this expression has type `Vec<Vec<u8>>`
     /// ```
-    fn point_at_chain_in_return_position<G: EmissionGuarantee>(
+    fn point_at_chain_in_return_position<G>(
         &self,
         body_def_id: LocalDefId,
         expr: &hir::Expr<'_>,
@@ -7099,7 +7098,7 @@ pub fn suggest_desugaring_async_fn_to_impl_future_in_trait<'tcx>(
 
 /// On `impl` evaluation cycles, look for `Self::AssocTy` restrictions in `where` clauses, explain
 /// they are not allowed and if possible suggest alternatives.
-fn point_at_assoc_type_restriction<G: EmissionGuarantee>(
+fn point_at_assoc_type_restriction<G>(
     tcx: TyCtxt<'_>,
     err: &mut Diag<'_, G>,
     self_ty_str: &str,

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -7,7 +7,7 @@
 use std::fmt::Debug;
 
 use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
-use rustc_errors::{Diag, EmissionGuarantee};
+use rustc_errors::Diag;
 use rustc_hir::def_id::{CRATE_DEF_ID, DefId};
 use rustc_infer::infer::{DefineOpaqueTypes, InferCtxt, TyCtxtInferExt};
 use rustc_infer::traits::{PredicateObligations, TraitErrors};
@@ -61,14 +61,14 @@ pub struct OverlapResult<'tcx> {
     pub overflowing_predicates: Vec<ty::Predicate<'tcx>>,
 }
 
-pub fn add_placeholder_note<G: EmissionGuarantee>(err: &mut Diag<'_, G>) {
+pub fn add_placeholder_note<G>(err: &mut Diag<'_, G>) {
     err.note(
         "this behavior recently changed as a result of a bug fix; \
          see rust-lang/rust#56105 for details",
     );
 }
 
-pub(crate) fn suggest_increasing_recursion_limit<'tcx, G: EmissionGuarantee>(
+pub(crate) fn suggest_increasing_recursion_limit<'tcx, G>(
     tcx: TyCtxt<'tcx>,
     err: &mut Diag<'_, G>,
     overflowing_predicates: &[ty::Predicate<'tcx>],

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -9,7 +9,7 @@ use std::ops::ControlFlow;
 
 use hir::def::DefKind;
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
-use rustc_errors::{Diag, EmissionGuarantee};
+use rustc_errors::Diag;
 use rustc_hir as hir;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::def_id::DefId;
@@ -63,7 +63,7 @@ pub enum IntercrateAmbiguityCause<'tcx> {
 impl<'tcx> IntercrateAmbiguityCause<'tcx> {
     /// Emits notes when the overlap is caused by complex intercrate ambiguities.
     /// See #23980 for details.
-    pub fn add_intercrate_ambiguity_hint<G: EmissionGuarantee>(&self, err: &mut Diag<'_, G>) {
+    pub fn add_intercrate_ambiguity_hint<G>(&self, err: &mut Diag<'_, G>) {
         err.note(self.intercrate_ambiguity_hint());
     }
 

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -12,8 +12,8 @@
 pub mod specialization_graph;
 
 use rustc_data_structures::fx::FxIndexSet;
+use rustc_errors::Diag;
 use rustc_errors::codes::*;
-use rustc_errors::{Diag, EmissionGuarantee};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_infer::traits::Obligation;
 use rustc_lint_defs::builtin::COHERENCE_LEAK_CHECK;
@@ -528,7 +528,7 @@ fn report_conflicting_impls<'tcx>(
     // Work to be done after we've built the Diag. We have to define it now
     // because the lint emit methods don't return back the Diag that's passed
     // in.
-    fn decorate<'tcx, G: EmissionGuarantee>(
+    fn decorate<'tcx, G>(
         tcx: TyCtxt<'tcx>,
         overlap: &OverlapError<'tcx>,
         impl_span: Span,

--- a/src/doc/rustc-dev-guide/src/diagnostics/diagnostic-structs.md
+++ b/src/doc/rustc-dev-guide/src/diagnostics/diagnostic-structs.md
@@ -93,7 +93,7 @@ In the end, the `Diagnostic` derive will generate an implementation of
 `Diagnostic` that looks like the following:
 
 ```rust,ignore
-impl<'a, G: EmissionGuarantee> Diagnostic<'a> for FieldAlreadyDeclared {
+impl<'a, G> Diagnostic<'a> for FieldAlreadyDeclared {
     fn into_diag(self, dcx: &'a DiagCtxt, level: Level) -> Diag<'a, G> {
         let mut diag = Diag::new(dcx, level, "field `{$field_name}` is already declared");
         diag.set_span(self.span);

--- a/src/tools/clippy/clippy_utils/src/diagnostics.rs
+++ b/src/tools/clippy/clippy_utils/src/diagnostics.rs
@@ -10,7 +10,7 @@
 
 use rustc_errors::{Applicability, Diag, DiagCtxtHandle, DiagMessage, Diagnostic, Level, MultiSpan};
 #[cfg(debug_assertions)]
-use rustc_errors::{EmissionGuarantee, SubstitutionPart, Suggestions};
+use rustc_errors::{SubstitutionPart, Suggestions};
 use rustc_hir::HirId;
 use rustc_lint::{LateContext, Lint, LintContext};
 use rustc_span::Span;
@@ -43,7 +43,7 @@ fn docs_link(diag: &mut Diag<'_, ()>, lint: &'static Lint) {
 ///
 /// This function makes sure we also validate them in debug clippy builds.
 #[cfg(debug_assertions)]
-fn validate_diag(diag: &Diag<'_, impl EmissionGuarantee>) {
+fn validate_diag<G>(diag: &Diag<'_, G>) {
     let suggestions = match &diag.suggestions {
         Suggestions::Enabled(suggs) => &**suggs,
         Suggestions::Sealed(suggs) => &**suggs,


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162630)*
<!-- homu-ignore:end -->

The `EmissionGuarantee` trait isn't necessary, and just complicates things. Details in individual commits.

r? @oli-obk