### PR TITLE
Check `compare_impl_item` before resolving free-item consts

### DIFF
--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -31,6 +31,11 @@ fn resolve_instance_raw<'tcx>(
             tcx.normalize_erasing_regions(typing_env, Unnormalized::new_wip(args)),
         )
     } else {
+        if tcx.opt_associated_item(def_id).is_some_and(|assoc| assoc.trait_item_def_id().is_some())
+            && let Some(local_def_id) = def_id.as_local()
+        {
+            tcx.ensure_result().compare_impl_item(local_def_id)?;
+        }
         let def = if tcx.intrinsic(def_id).is_some() {
             debug!(" => intrinsic");
             ty::InstanceKind::Intrinsic(def_id)

--- a/tests/ui/const-generics/mismatched-assoc-const-generic-ice.rs
+++ b/tests/ui/const-generics/mismatched-assoc-const-generic-ice.rs
@@ -1,0 +1,20 @@
+//@ compile-flags: -Znext-solver=globally
+
+// mismatched trait/impl const-generic param types
+// (E0053) used to ICE in CTFE instead of stopping at the error (#161532)
+
+#![feature(generic_const_args)]
+#![feature(min_generic_const_args)]
+#![feature(generic_const_items)]
+#![allow(incomplete_features)]
+
+trait Owner {
+    const K<const N: u16>: u32;
+}
+
+impl Owner for () {
+    const K<const N: u32>: u32 = N + 1;
+    //~^ ERROR associated constant `K` has an incompatible generic parameter for trait `Owner`
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mismatched-assoc-const-generic-ice.stderr
+++ b/tests/ui/const-generics/mismatched-assoc-const-generic-ice.stderr
@@ -1,0 +1,16 @@
+error[E0053]: associated constant `K` has an incompatible generic parameter for trait `Owner`
+  --> $DIR/mismatched-assoc-const-generic-ice.rs:16:13
+   |
+LL | trait Owner {
+   |       -----
+LL |     const K<const N: u16>: u32;
+   |             ------------ expected const parameter of type `u16`
+...
+LL | impl Owner for () {
+   | -----------------
+LL |     const K<const N: u32>: u32 = N + 1;
+   |             ^^^^^^^^^^^^ found const parameter of type `u32`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0053`.


### PR DESCRIPTION
Fixes rust-lang/rust#161532.

## Problem

An associated const whose generic parameter type mismatches between trait declaration and its impl is correctly rejected with code E0053 with the following reproducing code, but doesn't stop compilation and evaluates the impl's `K` anyway and hits an internal `scalar_immediate size does not match layout` assertion, since the impl body expected a `u32`, but the args were evaluated against the trait's expected `u16`

```rust
#![feature(generic_const_args)]
#![feature(min_generic_const_args)]
#![feature(generic_const_items)]

trait Owner {
    const K<const N: u16>: u32;
}

impl Owner for () {
    const K<const N: u32>: u32 = N + 1;

fn main() {}
```

## Root cause
`resolve_instance_raw` can go on two paths:

- When `def_id` is a trait item, `resolve_associated_item` runs and already guards against this exact case by calling
  `compare_impl_item` before resolving to the impl's definition.

- When `def_id` is already a concrete item, as happens here when the next-generation trait solver's `evaluate_const_and_instantiate_projection_term` resolves the projection directly to the impl's `K`, `trait_of_assoc` returns `None` which leads to the free-item branch running instead, which has never checked `compare_impl_item` at all.

## Fix

Added the same `compare_impl_item` guard to the free-item branch, gated on the item actually overriding a trait item
(`trait_item_def_id().is_some()`). This rejects an E0053-tainted impl item before evaluation.

## Testing

Added `tests/ui/const-generics/mismatched-assoc-const-generic-ice.rs` reproducing the original ICE. With the fix, only the E0053 is reported and compilation aborts cleanly.

Note: an earlier attempt guarded `confirm_impl_candidate` (the old-solver projection-confirmation path) instead that never fired for this since resolution goes through the next-gen solver, and produces a different ICE. Mentioning it here in case it's useful context for reviewers, though it's not a part of this diff.
