### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -954,7 +954,7 @@ impl<'diag, 'tcx> MirBorrowckCtxt<'_, 'diag, 'tcx> {
             tcx,
             self.infcx.typing_env(self.infcx.param_env),
             fn_did,
-            self.infcx.resolve_vars_if_possible(args.no_bound_vars().unwrap()),
+            self.infcx.deeply_resolve_ignoring_regions(args.no_bound_vars().unwrap()),
         ) else {
             return;
         };

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
@@ -73,7 +73,7 @@ pub(crate) fn clone_and_resolve_opaque_types<'tcx>(
     let opaque_types = opaque_types
         .into_iter()
         .map(|entry| {
-            fold_regions(infcx.tcx, infcx.resolve_vars_if_possible(entry), |r, _| {
+            fold_regions(infcx.tcx, infcx.deeply_resolve_ignoring_regions(entry), |r, _| {
                 let vid = if let ty::RePlaceholder(placeholder) = r.kind() {
                     constraints.placeholder_region(infcx, placeholder).as_var()
                 } else {

--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -161,7 +161,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
 
             GenericArgKind::Type(mut t1) => {
                 // Scraped constraints may have had inference vars.
-                t1 = self.infcx.resolve_vars_if_possible(t1);
+                t1 = self.infcx.deeply_resolve_ignoring_regions(t1);
 
                 let implicit_region_bound =
                     ty::Region::new_var(tcx, universal_regions.implicit_region_bound());

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -145,7 +145,7 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
                 ty,
             )?;
             let new_var =
-                infcx.resolve_vars_if_possible(Ty::new_infer(infcx.tcx, ty::TyVar(ty_vid)));
+                infcx.deeply_resolve_ignoring_regions(Ty::new_infer(infcx.tcx, ty::TyVar(ty_vid)));
 
             // Any regions in this new type must be live everywhere, so we mark them as such.
             // (It may be that it only needs to be live where the opaque type itself is - which

--- a/compiler/rustc_hir_analysis/src/autoderef.rs
+++ b/compiler/rustc_hir_analysis/src/autoderef.rs
@@ -86,7 +86,7 @@ impl<'a, 'tcx> Iterator for Autoderef<'a, 'tcx> {
         // and Deref, and this has benefits for const and the emitted MIR.
         let (kind, new_ty) =
             if let Some(ty) = self.state.cur_ty.builtin_deref(self.include_raw_pointers) {
-                debug_assert_eq!(ty, self.infcx.resolve_vars_if_possible(ty));
+                debug_assert_eq!(ty, self.infcx.deeply_resolve_ignoring_regions(ty));
                 (AutoderefKind::Builtin, ty)
             } else if let Some(ty) = self.overloaded_deref_ty(self.state.cur_ty) {
                 // The overloaded deref check already normalizes the pointee type.
@@ -123,7 +123,7 @@ impl<'a, 'tcx> Autoderef<'a, 'tcx> {
             param_env,
             state: AutoderefSnapshot {
                 steps: vec![],
-                cur_ty: infcx.resolve_vars_if_possible(base_ty),
+                cur_ty: infcx.deeply_resolve_ignoring_regions(base_ty),
                 obligations: PredicateObligations::new(),
                 at_start: true,
                 reached_recursion_limit: false,
@@ -171,7 +171,7 @@ impl<'a, 'tcx> Autoderef<'a, 'tcx> {
         debug!("overloaded_deref_ty({:?}) = ({:?}, {:?})", ty, normalized_ty, obligations);
         self.state.obligations.extend(obligations);
 
-        Some(self.infcx.resolve_vars_if_possible(normalized_ty))
+        Some(self.infcx.deeply_resolve_ignoring_regions(normalized_ty))
     }
 
     #[instrument(level = "debug", skip(self), ret)]

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -427,8 +427,8 @@ fn check_opaque_meets_bounds<'tcx>(
     } else {
         // Check that any hidden types found during wf checking match the hidden types that `type_of` sees.
         for (mut key, mut ty) in infcx.take_opaque_types() {
-            ty.ty = infcx.resolve_vars_if_possible(ty.ty);
-            key = infcx.resolve_vars_if_possible(key);
+            ty.ty = infcx.deeply_resolve_ignoring_regions(ty.ty);
+            key = infcx.deeply_resolve_ignoring_regions(key);
             sanity_check_found_hidden_type(tcx, key, ty)?;
         }
         Ok(())
@@ -2314,8 +2314,8 @@ pub(super) fn check_coroutine_obligations(
         // Check that any hidden types found when checking these stalled coroutine obligations
         // are valid.
         for (key, ty) in infcx.take_opaque_types() {
-            let hidden_type = infcx.resolve_vars_if_possible(ty);
-            let key = infcx.resolve_vars_if_possible(key);
+            let hidden_type = infcx.deeply_resolve_ignoring_regions(ty);
+            let key = infcx.deeply_resolve_ignoring_regions(key);
             sanity_check_found_hidden_type(tcx, key, hidden_type)?;
         }
     } else {

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -584,9 +584,9 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
         .iter()
         .map(|(_, &(ty, _))| {
             assert!(
-                infcx.resolve_vars_if_possible(ty) == ty && ty.is_ty_var(),
+                infcx.deeply_resolve_ignoring_regions(ty) == ty && ty.is_ty_var(),
                 "{ty:?} should not have been constrained via normalization",
-                ty = infcx.resolve_vars_if_possible(ty)
+                ty = infcx.deeply_resolve_ignoring_regions(ty)
             );
             idx += 1;
             (

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1296,7 +1296,7 @@ fn check_region_late_boundedness<'tcx>(
                 .inner
                 .borrow_mut()
                 .unwrap_region_constraints()
-                .opportunistic_resolve_var(tcx, vid)
+                .shallow_resolve_region_var(tcx, vid)
             && let ty::ReLateParam(ty::LateParamRegion {
                 kind: ty::LateParamRegionKind::Named(trait_param_def_id),
                 ..
@@ -1321,7 +1321,7 @@ fn check_region_late_boundedness<'tcx>(
                 .inner
                 .borrow_mut()
                 .unwrap_region_constraints()
-                .opportunistic_resolve_var(tcx, vid)
+                .shallow_resolve_region_var(tcx, vid)
             && let ty::ReLateParam(ty::LateParamRegion {
                 kind: ty::LateParamRegionKind::Named(impl_param_def_id),
                 ..

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -708,7 +708,7 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
 
     let mut remapped_types = DefIdMap::default();
     for (def_id, (ty, args)) in collected_types {
-        match infcx.fully_resolve(ty) {
+        match infcx.deeply_resolve_via_region_graph(ty) {
             Ok(ty) => {
                 // `ty` contains free regions that we created earlier while liberating the
                 // trait fn signature. However, projection normalization expects `ty` to

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
@@ -189,7 +189,9 @@ pub(crate) fn check_refining_return_position_impl_trait_in_trait<'tcx>(
         return;
     }
     // Resolve any lifetime variables that may have been introduced during normalization.
-    let Ok((trait_bounds, impl_bounds)) = infcx.fully_resolve((trait_bounds, impl_bounds)) else {
+    let Ok((trait_bounds, impl_bounds)) =
+        infcx.deeply_resolve_via_region_graph((trait_bounds, impl_bounds))
+    else {
         // If resolution didn't fully complete, we cannot continue checking RPITIT refinement, and
         // delay a bug as the original code contains load-bearing errors.
         tcx.dcx().delayed_bug("encountered errors when checking RPITIT refinement (resolution)");

--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -333,7 +333,7 @@ fn orphan_check<'tcx>(
 
         let ocx = traits::ObligationCtxt::new(&infcx);
         let ty = ocx.normalize(&cause, ty::ParamEnv::empty(), Unnormalized::new_wip(user_ty));
-        let ty = infcx.resolve_vars_if_possible(ty);
+        let ty = infcx.deeply_resolve_ignoring_regions(ty);
         let errors = ocx.try_evaluate_obligations();
         if !errors.no_errors() {
             return Ok(user_ty);
@@ -377,7 +377,7 @@ fn orphan_check<'tcx>(
                         id_arg,
                     );
                 }
-                infcx.resolve_vars_if_possible(tys)
+                infcx.deeply_resolve_ignoring_regions(tys)
             });
             OrphanCheckErr::NonLocalInputType(tys)
         }

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1539,11 +1539,11 @@ pub fn suggest_impl_trait<'tcx>(
             );
             // FIXME(compiler-errors): We may benefit from resolving regions here.
             if ocx.try_evaluate_obligations().no_errors()
-                && let item_ty = infcx.resolve_vars_if_possible(item_ty)
+                && let item_ty = infcx.deeply_resolve_ignoring_regions(item_ty)
                 && let Some(item_ty) = item_ty.make_suggestable(infcx.tcx, false, None)
                 && let Some(sugg) = formatter(
                     infcx.tcx,
-                    infcx.resolve_vars_if_possible(args),
+                    infcx.deeply_resolve_ignoring_regions(args),
                     trait_def_id,
                     assoc_item_def_id,
                     item_ty,

--- a/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
@@ -191,7 +191,7 @@ fn get_impl_args(
 
     let assumed_wf_types = ocx.assumed_wf_types_and_report_errors(param_env, impl1_def_id)?;
     ocx.resolve_regions_and_report_errors(impl1_def_id, param_env, assumed_wf_types)?;
-    let Ok(impl2_args) = infcx.fully_resolve(impl2_args) else {
+    let Ok(impl2_args) = infcx.deeply_resolve_via_region_graph(impl2_args) else {
         let span = tcx.def_span(impl1_def_id);
         let guar = tcx.dcx().emit_err(GenericArgsOnOverriddenImpl { span });
         return Err(guar);

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -203,7 +203,10 @@ pub fn check_crate(tcx: TyCtxt<'_>) {
     // while the enclosing body is type-checked. Doing this in the pass above lets the parallel
     // front end reach the nested body owner first, computing (and caching) an error type for
     // the anon const that then conflicts with the type fed later on.
-    tcx.par_hir_body_owners(|item_def_id| {
+    //
+    // This must not be parallelized since `coroutine_by_move_body_def_id` creates new `DefId`-s
+    // inside, which must be done in deterministic order to have reproducible binaries.
+    tcx.hir_body_owners().for_each(|item_def_id| {
         // Ensure we generate the new `DefId` before finishing `check_crate`.
         // Afterwards we freeze the list of `DefId`s.
         if tcx.needs_coroutine_by_move_body_def_id(item_def_id.to_def_id()) {

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -103,7 +103,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             _ => self.check_expr(callee_expr),
         };
 
-        let expr_ty = self.resolve_vars_with_obligations(original_callee_ty);
+        let expr_ty = self.deeply_resolve_ignoring_regions_with_obligations(original_callee_ty);
 
         let mut autoderef = self.autoderef(callee_expr.span, expr_ty);
         let mut result = None;
@@ -237,7 +237,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         arg_exprs: &'tcx [hir::Expr<'tcx>],
         autoderef: &Autoderef<'a, 'tcx>,
     ) -> Option<CallStep<'tcx>> {
-        let adjusted_ty = self.resolve_vars_with_obligations(autoderef.final_ty());
+        let adjusted_ty =
+            self.deeply_resolve_ignoring_regions_with_obligations(autoderef.final_ty());
 
         // If the callee is a function pointer or a closure, then we're all set.
         match *adjusted_ty.kind() {
@@ -736,7 +737,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     return do_check();
                 }
 
-                resolved_inputs = self.resolve_vars_if_possible(formal_input_tys.to_vec());
+                resolved_inputs = self.deeply_resolve_ignoring_regions(formal_input_tys.to_vec());
             }
 
             // Fool typechecker by placing an adjusted type of the first arg to avoid errors.
@@ -873,7 +874,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         (rest_span, format!(").{}({rest_snippet}", segment.ident)),
                     ]
                 };
-                let self_ty = self.resolve_vars_if_possible(pick.callee.sig.inputs()[0]);
+                let self_ty = self.deeply_resolve_ignoring_regions(pick.callee.sig.inputs()[0]);
                 diag.multipart_suggestion(
                     format!(
                         "use the `.` operator to call the method `{}{}` on `{self_ty}`",
@@ -925,7 +926,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 Some((removal_span, descr, rustc_hir_pretty::qpath_to_string(self, qpath)));
         }
 
-        let callee_ty = self.resolve_vars_if_possible(callee_ty);
+        let callee_ty = self.deeply_resolve_ignoring_regions(callee_ty);
         let mut path = None;
         let mut err = self.dcx().create_err(diagnostics::InvalidCallee {
             span: callee_expr.span,

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -96,14 +96,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Result<Option<PointerKind<'tcx>>, ErrorGuaranteed> {
         debug!("pointer_kind({:?}, {:?})", t, span);
 
-        let t = self.resolve_vars_if_possible(t);
+        let t = self.deeply_resolve_ignoring_regions(t);
         t.error_reported()?;
 
         if self.type_is_sized_modulo_regions(self.param_env, t) {
             return Ok(Some(PointerKind::Thin));
         }
 
-        let t = self.resolve_vars_with_obligations(t);
+        let t = self.deeply_resolve_ignoring_regions_with_obligations(t);
 
         Ok(match *t.kind() {
             ty::Slice(_) | ty::Str => Some(PointerKind::Length),
@@ -396,7 +396,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                 err.emit();
             }
             CastError::CastToBool => {
-                let expr_ty = fcx.resolve_vars_if_possible(self.expr_ty);
+                let expr_ty = fcx.deeply_resolve_ignoring_regions(self.expr_ty);
                 let help = if self.expr_ty.is_numeric() {
                     diagnostics::CannotCastToBoolHelp::Numeric(
                         self.expr_span.shrink_to_hi().with_hi(self.span.hi()),
@@ -539,8 +539,8 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                 ) {
                     // Check `impl From<self.expr_ty> for self.cast_ty {}` for accurate suggestion:
                     if let Some(from_trait) = fcx.tcx.get_diagnostic_item(sym::From) {
-                        let ty = fcx.resolve_vars_if_possible(self.cast_ty);
-                        let expr_ty = fcx.resolve_vars_if_possible(self.expr_ty);
+                        let ty = fcx.deeply_resolve_ignoring_regions(self.cast_ty);
+                        let expr_ty = fcx.deeply_resolve_ignoring_regions(self.expr_ty);
                         if fcx
                             .infcx
                             .type_implements_trait(from_trait, [ty, expr_ty], fcx.param_env)
@@ -604,8 +604,8 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                 err.emit();
             }
             CastError::SizedUnsizedCast => {
-                let cast_ty = fcx.resolve_vars_if_possible(self.cast_ty);
-                let expr_ty = fcx.resolve_vars_if_possible(self.expr_ty);
+                let cast_ty = fcx.deeply_resolve_ignoring_regions(self.cast_ty);
+                let expr_ty = fcx.deeply_resolve_ignoring_regions(self.expr_ty);
                 fcx.dcx().emit_err(diagnostics::CastThinPointerToWidePointer {
                     span: self.span,
                     expr_ty,
@@ -615,8 +615,8 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             }
             CastError::IntToWideCast(known_metadata) => {
                 let expr_if_nightly = fcx.tcx.sess.is_nightly_build().then_some(self.expr_span);
-                let cast_ty = fcx.resolve_vars_if_possible(self.cast_ty);
-                let expr_ty = fcx.resolve_vars_if_possible(self.expr_ty);
+                let cast_ty = fcx.deeply_resolve_ignoring_regions(self.cast_ty);
+                let expr_ty = fcx.deeply_resolve_ignoring_regions(self.expr_ty);
                 let metadata = known_metadata.unwrap_or("type-specific metadata");
                 let known_wide = known_metadata.is_some();
                 let span = self.cast_span;
@@ -659,8 +659,8 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                 });
             }
             CastError::CastEnumDrop => {
-                let expr_ty = fcx.resolve_vars_if_possible(self.expr_ty);
-                let cast_ty = fcx.resolve_vars_if_possible(self.cast_ty);
+                let expr_ty = fcx.deeply_resolve_ignoring_regions(self.expr_ty);
+                let cast_ty = fcx.deeply_resolve_ignoring_regions(self.cast_ty);
 
                 fcx.dcx().emit_err(diagnostics::CastEnumDrop { span: self.span, expr_ty, cast_ty });
             }
@@ -707,7 +707,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             self.expr_ty,
             E0620,
             "cast to unsized type: `{}` as `{}`",
-            fcx.resolve_vars_if_possible(self.expr_ty),
+            fcx.deeply_resolve_ignoring_regions(self.expr_ty),
             tstr
         );
         match self.expr_ty.kind() {
@@ -747,8 +747,8 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         } else {
             (false, TRIVIAL_CASTS)
         };
-        let expr_ty = fcx.resolve_vars_if_possible(self.expr_ty);
-        let cast_ty = fcx.resolve_vars_if_possible(self.cast_ty);
+        let expr_ty = fcx.deeply_resolve_ignoring_regions(self.expr_ty);
+        let cast_ty = fcx.deeply_resolve_ignoring_regions(self.cast_ty);
         fcx.tcx.emit_node_span_lint(
             lint,
             self.expr.hir_id,
@@ -788,8 +788,8 @@ impl<'a, 'tcx> CastCheck<'tcx> {
 
     fn expr_span_for_type_resolution(&self, fcx: &FnCtxt<'a, 'tcx>) -> Span {
         if let hir::ExprKind::Index(_, idx, _) = self.expr.kind
-            && fcx.resolve_vars_if_possible(self.expr_ty).is_ty_var()
-            && fcx.resolve_vars_if_possible(fcx.node_ty(idx.hir_id)).is_ty_var()
+            && fcx.deeply_resolve_ignoring_regions(self.expr_ty).is_ty_var()
+            && fcx.deeply_resolve_ignoring_regions(fcx.node_ty(idx.hir_id)).is_ty_var()
         {
             index_operand_ambiguity_span(idx)
         } else {
@@ -801,7 +801,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
     pub(crate) fn check(mut self, fcx: &FnCtxt<'a, 'tcx>) {
         let expr_span = self.expr_span_for_type_resolution(fcx);
         self.expr_ty = fcx.structurally_resolve_type(expr_span, self.expr_ty);
-        self.cast_ty = fcx.resolve_vars_with_obligations(self.cast_ty);
+        self.cast_ty = fcx.deeply_resolve_ignoring_regions_with_obligations(self.cast_ty);
         if self.cast_ty.is_ty_var() {
             self.cast_ty = if let Some(guar) = self.try_report_ambiguous_binop_for_infer_cast(fcx) {
                 let err = Ty::new_error(fcx.tcx, guar);
@@ -863,7 +863,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             .pending_obligations()
             .into_iter()
             .filter_map(|mut obligation| {
-                let predicate = fcx.resolve_vars_if_possible(obligation.predicate);
+                let predicate = fcx.deeply_resolve_ignoring_regions(obligation.predicate);
                 if !matches!(
                     predicate.kind().skip_binder(),
                     ty::PredicateKind::Clause(ty::ClauseKind::Trait(_))
@@ -877,8 +877,8 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                 else {
                     return None;
                 };
-                let lhs_ty = fcx.resolve_vars_if_possible(fcx.node_ty(*lhs_hir_id));
-                let rhs_ty = fcx.resolve_vars_if_possible(fcx.node_ty(*rhs_hir_id));
+                let lhs_ty = fcx.deeply_resolve_ignoring_regions(fcx.node_ty(*lhs_hir_id));
+                let rhs_ty = fcx.deeply_resolve_ignoring_regions(fcx.node_ty(*rhs_hir_id));
 
                 if (fcx.tcx.hir_span(*lhs_hir_id).contains(cast_span)
                     && lhs_ty.contains(self.cast_ty))
@@ -1203,8 +1203,8 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         mut m_cast: ty::TypeAndMut<'tcx>,
     ) -> Result<CastKind, CastError<'tcx>> {
         // array-ptr-cast: allow mut-to-mut, mut-to-const, const-to-const
-        m_expr.ty = fcx.resolve_vars_with_obligations(m_expr.ty);
-        m_cast.ty = fcx.resolve_vars_with_obligations(m_cast.ty);
+        m_expr.ty = fcx.deeply_resolve_ignoring_regions_with_obligations(m_expr.ty);
+        m_cast.ty = fcx.deeply_resolve_ignoring_regions_with_obligations(m_cast.ty);
 
         if m_expr.mutbl >= m_cast.mutbl
             && let ty::Array(ety, _) = m_expr.ty.kind()

--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -60,9 +60,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // closure sooner rather than later, so first examine the expected
         // type, and see if can glean a closure kind from there.
         let (expected_sig, expected_kind) = match expected.to_option(self) {
-            Some(ty) => {
-                self.deduce_closure_signature(self.resolve_vars_with_obligations(ty), closure.kind)
-            }
+            Some(ty) => self.deduce_closure_signature(
+                self.deeply_resolve_ignoring_regions_with_obligations(ty),
+                closure.kind,
+            ),
             None => (None, None),
         };
 
@@ -411,7 +412,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let inferred_fnptr_sig = Ty::new_fn_ptr(self.tcx, inferred_sig.sig);
                     self.demand_eqtype(span, inferred_fnptr_sig, generalized_fnptr_sig);
 
-                    let resolved_sig = self.resolve_vars_if_possible(generalized_fnptr_sig);
+                    let resolved_sig = self.deeply_resolve_ignoring_regions(generalized_fnptr_sig);
 
                     if resolved_sig.visit_with(&mut MentionsTy { expected_ty }).is_continue() {
                         expected_sig = Some(ExpectedSig {
@@ -517,7 +518,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         cause_span: Option<Span>,
         projection: ty::PolyProjectionClause<'tcx>,
     ) -> Option<ExpectedSig<'tcx>> {
-        let projection = self.resolve_vars_if_possible(projection);
+        let projection = self.deeply_resolve_ignoring_regions(projection);
 
         let arg_param_ty = projection.skip_binder().projection_term.args.type_at(1);
         debug!(?arg_param_ty);
@@ -562,7 +563,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         cause_span: Option<Span>,
         projection: ty::PolyProjectionClause<'tcx>,
     ) -> Option<ExpectedSig<'tcx>> {
-        let projection = self.resolve_vars_if_possible(projection);
+        let projection = self.deeply_resolve_ignoring_regions(projection);
 
         let arg_param_ty = projection.skip_binder().projection_term.args.type_at(1);
         debug!(?arg_param_ty);
@@ -851,8 +852,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             )?;
             all_obligations.extend(obligations);
 
-            let inputs =
-                supplied_sig.inputs().into_iter().map(|&ty| self.resolve_vars_if_possible(ty));
+            let inputs = supplied_sig
+                .inputs()
+                .into_iter()
+                .map(|&ty| self.deeply_resolve_ignoring_regions(ty));
 
             let fn_sig_kind = FnSigKind::default()
                 .set_abi(ExternAbi::RustCall)
@@ -959,7 +962,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let closure_span = self.tcx.def_span(body_def_id);
         let ret_ty = ret_coercion.borrow().expected_ty();
-        let ret_ty = self.resolve_vars_with_obligations(ret_ty);
+        let ret_ty = self.deeply_resolve_ignoring_regions_with_obligations(ret_ty);
 
         let get_future_output = |clause: ty::Clause<'tcx>, span| {
             // Search for a pending obligation like
@@ -1064,7 +1067,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Extract the type from the projection. Note that there can
         // be no bound variables in this type because the "self type"
         // does not have any regions in it.
-        let output_ty = self.resolve_vars_if_possible(predicate.term);
+        let output_ty = self.deeply_resolve_ignoring_regions(predicate.term);
         debug!("deduce_future_output_from_projection: output_ty={:?}", output_ty);
         // This is a projection on a Fn trait so will always be a type.
         Some(output_ty.expect_type())

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -736,7 +736,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                 Some(ty::PredicateKind::Clause(ty::ClauseKind::Trait(trait_pred)))
                     if traits.contains(&trait_pred.def_id()) =>
                 {
-                    self.resolve_vars_if_possible(trait_pred)
+                    self.deeply_resolve_ignoring_regions(trait_pred)
                 }
                 _ => {
                     coercion.obligations.push(obligation);
@@ -1140,7 +1140,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         allow_two_phase: AllowTwoPhase,
         cause: Option<ObligationCause<'tcx>>,
     ) -> RelateResult<'tcx, Ty<'tcx>> {
-        let source = self.resolve_vars_with_obligations(expr_ty);
+        let source = self.deeply_resolve_ignoring_regions_with_obligations(expr_ty);
         debug!("coercion::try({:?}: {:?} -> {:?})", expr, source, target);
 
         let cause =
@@ -1335,8 +1335,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         new: &hir::Expr<'_>,
         new_ty: Ty<'tcx>,
     ) -> RelateResult<'tcx, Ty<'tcx>> {
-        let prev_ty = self.resolve_vars_with_obligations(prev_ty);
-        let new_ty = self.resolve_vars_with_obligations(new_ty);
+        let prev_ty = self.deeply_resolve_ignoring_regions_with_obligations(prev_ty);
+        let new_ty = self.deeply_resolve_ignoring_regions_with_obligations(new_ty);
         debug!(
             "coercion::try_find_coercion_lub({:?}, {:?}, exprs={:?} exprs)",
             prev_ty,
@@ -1755,7 +1755,7 @@ impl<'tcx> CoerceMany<'tcx> {
                 fcx.set_tainted_by_errors(
                     fcx.dcx().span_delayed_bug(cause.span, "coercion error but no error emitted"),
                 );
-                let (expected, found) = fcx.resolve_vars_if_possible((expected, found));
+                let (expected, found) = fcx.deeply_resolve_ignoring_regions((expected, found));
 
                 let mut err;
                 let mut unsized_return = false;

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -261,7 +261,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         mut expected_ty_expr: Option<&'tcx hir::Expr<'tcx>>,
         allow_two_phase: AllowTwoPhase,
     ) -> Result<Ty<'tcx>, Diag<'a>> {
-        let expected = self.resolve_vars_with_obligations(expected);
+        let expected = self.deeply_resolve_ignoring_regions_with_obligations(expected);
 
         let e = match self.coerce(expr, checked_ty, expected, allow_two_phase, None) {
             Ok(ty) => return Ok(ty),
@@ -276,7 +276,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         ));
         let expr = expr.peel_drop_temps();
         let cause = self.misc(expr.span);
-        let expr_ty = self.resolve_vars_if_possible(checked_ty);
+        let expr_ty = self.deeply_resolve_ignoring_regions(checked_ty);
         let mut err =
             self.err_ctxt().report_mismatched_types(&cause, self.param_env, expected, expr_ty, e);
 
@@ -423,7 +423,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         // Yeet the errors, we're already reporting errors.
                         errs.clear();
                     });
-                    Some(self.resolve_vars_if_possible(possible_rcvr_ty))
+                    Some(self.deeply_resolve_ignoring_regions(possible_rcvr_ty))
                 });
                 let Some(rcvr_ty) = possible_rcvr_ty else { return false };
                 rcvr_ty
@@ -546,7 +546,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 .borrow()
                                 .type_dependent_def_id(parent_expr.hir_id)
                         && let ideal_arg_ty =
-                            self.resolve_vars_if_possible(ideal_method.sig.inputs()[idx + 1])
+                            self.deeply_resolve_ignoring_regions(ideal_method.sig.inputs()[idx + 1])
                         && !ideal_arg_ty.has_non_region_infer()
                     {
                         self.emit_type_mismatch_suggestions(

--- a/compiler/rustc_hir_typeck/src/expectation.rs
+++ b/compiler/rustc_hir_typeck/src/expectation.rs
@@ -46,7 +46,7 @@ impl<'a, 'tcx> Expectation<'tcx> {
     ) -> Expectation<'tcx> {
         match *self {
             ExpectHasType(ety) => {
-                let ety = fcx.resolve_vars_with_obligations(ety);
+                let ety = fcx.deeply_resolve_ignoring_regions_with_obligations(ety);
                 if !ety.is_ty_var() { ExpectHasType(ety) } else { NoExpectation }
             }
             ExpectRvalueLikeUnsized(ety) => ExpectRvalueLikeUnsized(ety),
@@ -93,9 +93,11 @@ impl<'a, 'tcx> Expectation<'tcx> {
     fn resolve(self, fcx: &FnCtxt<'a, 'tcx>) -> Expectation<'tcx> {
         match self {
             NoExpectation => NoExpectation,
-            ExpectCastableToType(t) => ExpectCastableToType(fcx.resolve_vars_if_possible(t)),
-            ExpectHasType(t) => ExpectHasType(fcx.resolve_vars_if_possible(t)),
-            ExpectRvalueLikeUnsized(t) => ExpectRvalueLikeUnsized(fcx.resolve_vars_if_possible(t)),
+            ExpectCastableToType(t) => ExpectCastableToType(fcx.deeply_resolve_ignoring_regions(t)),
+            ExpectHasType(t) => ExpectHasType(fcx.deeply_resolve_ignoring_regions(t)),
+            ExpectRvalueLikeUnsized(t) => {
+                ExpectRvalueLikeUnsized(fcx.deeply_resolve_ignoring_regions(t))
+            }
         }
     }
 
@@ -112,7 +114,7 @@ impl<'a, 'tcx> Expectation<'tcx> {
     /// such a constraint, if it exists.
     pub(super) fn only_has_type(self, fcx: &FnCtxt<'a, 'tcx>) -> Option<Ty<'tcx>> {
         match self {
-            ExpectHasType(ty) => Some(fcx.resolve_vars_if_possible(ty)),
+            ExpectHasType(ty) => Some(fcx.deeply_resolve_ignoring_regions(ty)),
             NoExpectation | ExpectCastableToType(_) | ExpectRvalueLikeUnsized(_) => None,
         }
     }

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -82,7 +82,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // While we don't allow *arbitrary* coercions here, we *do* allow
         // coercions from ! to `expected`.
-        if self.resolve_vars_with_obligations(ty).is_never()
+        if self.deeply_resolve_ignoring_regions_with_obligations(ty).is_never()
             && self.tcx.expr_guaranteed_to_constitute_read_for_never(expr)
         {
             if let Some(adjustments) = self.typeck_results.borrow().adjustments().get(expr.hir_id) {
@@ -271,7 +271,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ) => self.check_expr_path(qpath, expr, call_expr_and_args),
             _ => self.check_expr_kind(expr, expected),
         };
-        let ty = self.resolve_vars_if_possible(ty);
+        let ty = self.deeply_resolve_ignoring_regions(ty);
 
         // Warn for non-block expressions with diverging children.
         match expr.kind {
@@ -300,7 +300,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // unless it's a place expression that isn't being read from, in which case
         // diverging would be unsound since we may never actually read the `!`.
         // e.g. `let _ = *never_ptr;` with `never_ptr: *const !`.
-        if self.resolve_vars_with_obligations(ty).is_never()
+        if self.deeply_resolve_ignoring_regions_with_obligations(ty).is_never()
             && self.tcx.expr_guaranteed_to_constitute_read_for_never(expr)
         {
             self.diverges.set(self.diverges.get() | Diverges::always(expr.span));
@@ -464,7 +464,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expr: &'tcx hir::Expr<'tcx>,
     ) -> Ty<'tcx> {
         let hint = expected.only_has_type(self).map_or(NoExpectation, |ty| {
-            match self.resolve_vars_with_obligations(ty).kind() {
+            match self.deeply_resolve_ignoring_regions_with_obligations(ty).kind() {
                 ty::Ref(_, ty, _) | ty::RawPtr(ty, _) => {
                     if oprnd.is_syntactic_place_expr() {
                         // Places may legitimately have unsized types.
@@ -1480,7 +1480,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Expectation<'tcx>,
     ) -> Ty<'tcx> {
         let rcvr_t = self.check_expr(rcvr);
-        let rcvr_t = self.resolve_vars_with_obligations(rcvr_t);
+        let rcvr_t = self.deeply_resolve_ignoring_regions_with_obligations(rcvr_t);
 
         match self.lookup_method(rcvr_t, segment, segment.ident.span, expr, rcvr, args) {
             Ok(method) => {
@@ -1551,9 +1551,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Find the type of `e`. Supply hints based on the type we are casting to,
         // if appropriate.
         let t_cast = self.lower_ty_saving_user_provided_ty(t);
-        let t_cast = self.resolve_vars_if_possible(t_cast);
+        let t_cast = self.deeply_resolve_ignoring_regions(t_cast);
         let t_expr = self.check_expr_with_expectation(e, ExpectCastableToType(t_cast));
-        let t_expr = self.resolve_vars_if_possible(t_expr);
+        let t_expr = self.deeply_resolve_ignoring_regions(t_expr);
 
         // Eagerly check for some obvious errors.
         if let Err(guar) = (t_expr, t_cast).error_reported() {
@@ -1675,11 +1675,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let coerce_to = expected
                 .to_option(self)
                 .and_then(|uty| {
-                    self.resolve_vars_with_obligations(uty)
+                    self.deeply_resolve_ignoring_regions_with_obligations(uty)
                         .builtin_index()
                         // Avoid using the original type variable as the coerce_to type, as it may resolve
                         // during the first coercion instead of being the LUB type.
-                        .filter(|t| !self.resolve_vars_with_obligations(*t).is_ty_var())
+                        .filter(|t| {
+                            !self.deeply_resolve_ignoring_regions_with_obligations(*t).is_ty_var()
+                        })
                 })
                 .unwrap_or_else(|| self.next_ty_var(expr.span));
             let mut coerce = CoerceMany::with_capacity(coerce_to, args.len());
@@ -1804,7 +1806,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Ty<'tcx> {
         let mut expectations = expected
             .only_has_type(self)
-            .and_then(|ty| self.resolve_vars_with_obligations(ty).opt_tuple_fields())
+            .and_then(|ty| {
+                self.deeply_resolve_ignoring_regions_with_obligations(ty).opt_tuple_fields()
+            })
             .unwrap_or_default()
             .iter();
 
@@ -1878,7 +1882,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) {
         let tcx = self.tcx;
 
-        let adt_ty = self.resolve_vars_with_obligations(adt_ty);
+        let adt_ty = self.deeply_resolve_ignoring_regions_with_obligations(adt_ty);
         let adt_ty_hint = expected.only_has_type(self).and_then(|expected| {
             self.fudge_inference_if_ok(|| {
                 let ocx = ObligationCtxt::new(self);
@@ -1886,7 +1890,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if !ocx.try_evaluate_obligations().no_errors() {
                     return Err(TypeError::Mismatch);
                 }
-                Ok(self.resolve_vars_if_possible(adt_ty))
+                Ok(self.deeply_resolve_ignoring_regions(adt_ty))
             })
             .ok()
         });
@@ -2144,7 +2148,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                         }
                                     }
                                 }
-                                self.resolve_vars_if_possible(fru_ty)
+                                self.deeply_resolve_ignoring_regions(fru_ty)
                             })
                             .collect();
                         // The use of fresh args that we have subtyped against
@@ -2168,7 +2172,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         let fresh_base_ty = Ty::new_adt(self.tcx, *adt, fresh_args);
                         self.check_expr_has_type_or_error(
                             base_expr,
-                            self.resolve_vars_if_possible(fresh_base_ty),
+                            self.deeply_resolve_ignoring_regions(fresh_base_ty),
                             |_| {},
                         );
                         fru_tys

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -157,7 +157,7 @@ pub trait TypeInformationCtxt<'tcx> {
 
     fn typeck_results(&self) -> Self::TypeckResults<'_>;
 
-    fn resolve_vars_if_possible<T: TypeFoldable<TyCtxt<'tcx>>>(&self, t: T) -> T;
+    fn deeply_resolve_ignoring_regions<T: TypeFoldable<TyCtxt<'tcx>>>(&self, t: T) -> T;
 
     fn structurally_resolve_type(&self, span: Span, ty: Ty<'tcx>) -> Ty<'tcx>;
 
@@ -188,8 +188,8 @@ impl<'tcx> TypeInformationCtxt<'tcx> for &FnCtxt<'_, 'tcx> {
         self.typeck_results.borrow()
     }
 
-    fn resolve_vars_if_possible<T: TypeFoldable<TyCtxt<'tcx>>>(&self, t: T) -> T {
-        self.infcx.resolve_vars_if_possible(t)
+    fn deeply_resolve_ignoring_regions<T: TypeFoldable<TyCtxt<'tcx>>>(&self, t: T) -> T {
+        self.infcx.deeply_resolve_ignoring_regions(t)
     }
 
     fn structurally_resolve_type(&self, sp: Span, ty: Ty<'tcx>) -> Ty<'tcx> {
@@ -242,7 +242,7 @@ impl<'tcx> TypeInformationCtxt<'tcx> for (&LateContext<'tcx>, LocalDefId) {
         ty
     }
 
-    fn resolve_vars_if_possible<T: TypeFoldable<TyCtxt<'tcx>>>(&self, t: T) -> T {
+    fn deeply_resolve_ignoring_regions<T: TypeFoldable<TyCtxt<'tcx>>>(&self, t: T) -> T {
         t
     }
 
@@ -1127,7 +1127,7 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
     ) -> Result<Ty<'tcx>, Cx::Error> {
         match ty {
             Some(ty) => {
-                let ty = self.cx.resolve_vars_if_possible(ty);
+                let ty = self.cx.deeply_resolve_ignoring_regions(ty);
                 self.cx.error_reported_in_ty(ty)?;
                 Ok(ty)
             }
@@ -1266,7 +1266,7 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
     where
         F: FnOnce() -> Result<PlaceWithHirId<'tcx>, Cx::Error>,
     {
-        let target = self.cx.resolve_vars_if_possible(adjustment.target);
+        let target = self.cx.deeply_resolve_ignoring_regions(adjustment.target);
         match adjustment.kind {
             adjustment::Adjust::Deref(deref_kind) => {
                 // Equivalent to *expr or something similar.

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -108,11 +108,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     /// Resolves type and const variables in `t` if possible. Unlike the infcx
-    /// version (resolve_vars_if_possible), this version will
+    /// version (deeply_resolve_ignoring_regions), this version will
     /// also select obligations if it seems useful, in an effort
     /// to get more type information.
     #[instrument(skip(self), level = "debug", ret)]
-    pub(crate) fn resolve_vars_with_obligations<T: TypeFoldable<TyCtxt<'tcx>>>(
+    pub(crate) fn deeply_resolve_ignoring_regions_with_obligations<
+        T: TypeFoldable<TyCtxt<'tcx>>,
+    >(
         &self,
         mut t: T,
     ) -> T {
@@ -123,7 +125,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         // If `t` is a type variable, see whether we already know what it is.
-        t = self.resolve_vars_if_possible(t);
+        t = self.deeply_resolve_ignoring_regions(t);
         if !t.has_non_region_infer() {
             debug!(?t);
             return t;
@@ -134,7 +136,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // indirect dependencies that don't seem worth tracking
         // precisely.
         self.select_obligations_where_possible(|_| {});
-        self.resolve_vars_if_possible(t)
+        self.deeply_resolve_ignoring_regions(t)
     }
 
     pub(crate) fn record_deferred_call_resolution(
@@ -166,7 +168,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     #[inline]
     pub(crate) fn write_ty(&self, id: HirId, ty: Ty<'tcx>) {
-        debug!("write_ty({:?}, {:?}) in fcx {}", id, self.resolve_vars_if_possible(ty), self.tag());
+        debug!(
+            "write_ty({:?}, {:?}) in fcx {}",
+            id,
+            self.deeply_resolve_ignoring_regions(ty),
+            self.tag()
+        );
         let mut typeck = self.typeck_results.borrow_mut();
         let mut node_ty = typeck.node_types_mut();
 
@@ -1473,7 +1480,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         sp: Span,
         ct: ty::Const<'tcx>,
     ) -> ty::Const<'tcx> {
-        let ct = self.resolve_vars_with_obligations(ct);
+        let ct = self.deeply_resolve_ignoring_regions_with_obligations(ct);
 
         if self.next_trait_solver()
             && let ty::ConstKind::Alias(..) = ct.kind()
@@ -1508,7 +1515,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// If no resolution is possible, then an error is reported.
     /// Numeric inference variables may be left unresolved.
     pub(crate) fn structurally_resolve_type(&self, sp: Span, ty: Ty<'tcx>) -> Ty<'tcx> {
-        let ty = self.resolve_vars_with_obligations(ty);
+        let ty = self.deeply_resolve_ignoring_regions_with_obligations(ty);
 
         if !ty.is_ty_var() { ty } else { self.type_must_be_known_at_this_point(sp, ty) }
     }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
@@ -196,18 +196,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let hir::ExprKind::Index(indexed_expr, idx, _) = rhs_expr.kind else {
             return false;
         };
-        if !self.resolve_vars_if_possible(self.node_ty(idx.hir_id)).is_ty_var() {
+        if !self.deeply_resolve_ignoring_regions(self.node_ty(idx.hir_id)).is_ty_var() {
             return false;
         }
-        let lhs_ty = self.resolve_vars_if_possible(self.node_ty(lhs_expr.hir_id));
-        let indexed_ty = self.resolve_vars_if_possible(self.node_ty(indexed_expr.hir_id));
+        let lhs_ty = self.deeply_resolve_ignoring_regions(self.node_ty(lhs_expr.hir_id));
+        let indexed_ty = self.deeply_resolve_ignoring_regions(self.node_ty(indexed_expr.hir_id));
         let rhs_ty = match *indexed_ty.kind() {
             ty::Array(element_ty, _) | ty::Slice(element_ty) => element_ty,
             ty::Ref(_, pointee_ty, _) => match *pointee_ty.kind() {
                 ty::Array(element_ty, _) | ty::Slice(element_ty) => element_ty,
-                _ => self.resolve_vars_if_possible(self.node_ty(rhs_expr.hir_id)),
+                _ => self.deeply_resolve_ignoring_regions(self.node_ty(rhs_expr.hir_id)),
             },
-            _ => self.resolve_vars_if_possible(self.node_ty(rhs_expr.hir_id)),
+            _ => self.deeply_resolve_ignoring_regions(self.node_ty(rhs_expr.hir_id)),
         };
         if !self.binop_accepts_types(binop.node, lhs_ty, rhs_ty) {
             return false;

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -246,7 +246,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut expected_input_tys: Option<Vec<_>> = expectation
             .only_has_type(self)
             .and_then(|expected_output| {
-                let formal_output = self.resolve_vars_with_obligations(formal_output);
+                let formal_output =
+                    self.deeply_resolve_ignoring_regions_with_obligations(formal_output);
                 // FIXME(#149379): This operation results in expected input
                 // types which are potentially not well-formed or for whom the
                 // function where-bounds don't actually hold. This results
@@ -283,7 +284,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         Ok(Some(
                             formal_input_tys
                                 .iter()
-                                .map(|&ty| self.resolve_vars_if_possible(ty))
+                                .map(|&ty| self.deeply_resolve_ignoring_regions(ty))
                                 .collect::<Vec<_>>(),
                         ))
                     })
@@ -387,7 +388,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Cause selection errors caused by resolving a single argument to point at the
             // argument and not the call. This lets us customize the span pointed to in the
             // fulfillment error to be more accurate.
-            let coerced_ty = self.resolve_vars_with_obligations(coerced_ty);
+            let coerced_ty = self.deeply_resolve_ignoring_regions_with_obligations(coerced_ty);
 
             let coerce_error =
                 self.coerce(provided_arg, checked_ty, coerced_ty, AllowTwoPhase::Yes, None).err();
@@ -541,7 +542,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                     ty::FnDef(..) => {
                         let fn_ptr = Ty::new_fn_ptr(self.tcx, arg_ty.fn_sig(self.tcx));
-                        let fn_ptr = self.resolve_vars_if_possible(fn_ptr).to_string();
+                        let fn_ptr = self.deeply_resolve_ignoring_regions(fn_ptr).to_string();
 
                         let fn_item_spa = arg.span;
                         tcx.sess.dcx().emit_err(diagnostics::PassFnItemToVariadicFunction {
@@ -572,7 +573,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .iter()
                     .copied()
                     .zip_eq(expected_input_tys.iter().copied())
-                    .map(|vars| self.resolve_vars_if_possible(vars)),
+                    .map(|vars| self.deeply_resolve_ignoring_regions(vars)),
             );
 
             self.report_arg_errors(
@@ -652,7 +653,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let formal_input_tupled_ty = formal_input_tys[first_tupled_arg_index_usz];
         // Keep the type variable if the argument is splatted, so we can force it to be a tuple later.
         let tuple_type = if tuple_arguments.is_splatted() {
-            let callee_tuple_type = self.resolve_vars_with_obligations(formal_input_tupled_ty);
+            let callee_tuple_type =
+                self.deeply_resolve_ignoring_regions_with_obligations(formal_input_tupled_ty);
             if callee_tuple_type.is_ty_var()
                 && let Some(tupled_args_count) = tupled_args_count
             {
@@ -1833,7 +1835,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 param.param.span(),
                                 format!(
                                     "this parameter needs to match the {} type of {deps_list}",
-                                    self.resolve_vars_if_possible(
+                                    self.deeply_resolve_ignoring_regions(
                                         formal_and_expected_inputs[param.deps[0]].1
                                     )
                                     .sort_string(self.tcx),
@@ -1857,7 +1859,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 format!(
                                     "{deps_list} need{} to match the {} type of this parameter",
                                     pluralize!((deps.len() != 1) as u32),
-                                    self.resolve_vars_if_possible(expected_ty)
+                                    self.deeply_resolve_ignoring_regions(expected_ty)
                                         .sort_string(self.tcx),
                                 ),
                             );
@@ -2036,7 +2038,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
 
                 let expected_display_type = self
-                    .resolve_vars_if_possible(formal_and_expected_inputs[idx].1)
+                    .deeply_resolve_ignoring_regions(formal_and_expected_inputs[idx].1)
                     .sort_string(self.tcx);
                 let label = if idxs_matched == params_with_generics.len() - 1 {
                     format!(
@@ -3331,7 +3333,7 @@ impl<'a, 'tcx> ArgsCtxt<'a, 'tcx> {
                     .expr_ty_adjusted_opt(expr)
                     .unwrap_or_else(|| Ty::new_misc_error(self.call_ctxt.fn_ctxt.tcx));
                 (
-                    self.call_ctxt.fn_ctxt.resolve_vars_if_possible(ty),
+                    self.call_ctxt.fn_ctxt.deeply_resolve_ignoring_regions(ty),
                     self.normalize_span(expr.span),
                 )
             })

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
@@ -139,7 +139,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         obligations_for_self_ty.retain_mut(|obligation| {
-            obligation.predicate = self.resolve_vars_if_possible(obligation.predicate);
+            obligation.predicate = self.deeply_resolve_ignoring_regions(obligation.predicate);
             !obligation.predicate.has_placeholders()
         });
         obligations_for_self_ty

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -262,8 +262,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         found_type: Ty<'tcx>,
     ) -> bool {
         let tcx = self.tcx;
-        let expected = self.resolve_vars_if_possible(expected_type);
-        let found = self.resolve_vars_if_possible(found_type);
+        let expected = self.deeply_resolve_ignoring_regions(expected_type);
+        let found = self.deeply_resolve_ignoring_regions(found_type);
 
         if expected.references_error() || found.references_error() || expected.is_unit() {
             return false;
@@ -992,7 +992,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         let found =
-            self.resolve_numeric_literals_with_default(self.resolve_vars_if_possible(found));
+            self.resolve_numeric_literals_with_default(self.deeply_resolve_ignoring_regions(found));
         // Only suggest changing the return type for methods that
         // haven't set a return type at all (and aren't `fn main()`, impl or closure).
         match &fn_decl.output {
@@ -1322,7 +1322,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if !expected.is_unit() {
             return;
         }
-        let found = self.resolve_vars_if_possible(found);
+        let found = self.deeply_resolve_ignoring_regions(found);
 
         let innermost_loop = if self.is_loop(id) {
             Some(self.tcx.hir_node(id))

--- a/compiler/rustc_hir_typeck/src/inline_asm.rs
+++ b/compiler/rustc_hir_typeck/src/inline_asm.rs
@@ -46,7 +46,7 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
 
     fn expr_ty(&self, expr: &hir::Expr<'tcx>) -> Ty<'tcx> {
         let ty = self.fcx.typeck_results.borrow().expr_ty_adjusted(expr);
-        let ty = self.fcx.resolve_vars_with_obligations(ty);
+        let ty = self.fcx.deeply_resolve_ignoring_regions_with_obligations(ty);
         if ty.has_non_region_infer() {
             Ty::new_misc_error(self.tcx())
         } else {
@@ -61,7 +61,9 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
         if self.fcx.type_is_sized_modulo_regions(self.fcx.param_env, ty) {
             return true;
         }
-        if let ty::Foreign(..) = self.fcx.resolve_vars_with_obligations(ty).kind() {
+        if let ty::Foreign(..) =
+            self.fcx.deeply_resolve_ignoring_regions_with_obligations(ty).kind()
+        {
             return true;
         }
         false

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -2147,8 +2147,14 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                             for nested_obligation in candidate.nested_obligations() {
                                 if !self.infcx.predicate_may_hold(&nested_obligation) {
                                     possibly_unsatisfied_predicates.push((
-                                        self.resolve_vars_if_possible(nested_obligation.predicate),
-                                        Some(self.resolve_vars_if_possible(obligation.predicate)),
+                                        self.deeply_resolve_ignoring_regions(
+                                            nested_obligation.predicate,
+                                        ),
+                                        Some(
+                                            self.deeply_resolve_ignoring_regions(
+                                                obligation.predicate,
+                                            ),
+                                        ),
                                         Some(nested_obligation.cause),
                                     ));
                                 }
@@ -2198,9 +2204,10 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             // Evaluate those obligations to see if they might possibly hold.
             for error in ocx.try_evaluate_obligations() {
                 result = ProbeResult::NoMatch;
-                let nested_predicate = self.resolve_vars_if_possible(error.obligation.predicate);
+                let nested_predicate =
+                    self.deeply_resolve_ignoring_regions(error.obligation.predicate);
                 if let Some(trait_predicate) = trait_predicate
-                    && nested_predicate == self.resolve_vars_if_possible(trait_predicate)
+                    && nested_predicate == self.deeply_resolve_ignoring_regions(trait_predicate)
                 {
                     // Don't report possibly unsatisfied predicates if the root
                     // trait obligation from a `TraitCandidate` is unsatisfied.
@@ -2208,7 +2215,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                 } else {
                     possibly_unsatisfied_predicates.push((
                         nested_predicate,
-                        Some(self.resolve_vars_if_possible(error.root_obligation.predicate))
+                        Some(self.deeply_resolve_ignoring_regions(error.root_obligation.predicate))
                             .filter(|root_predicate| *root_predicate != nested_predicate),
                         Some(error.obligation.cause),
                     ));
@@ -2329,7 +2336,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                         return false;
                     }
 
-                    !self.resolve_vars_if_possible(self_ty).is_ty_var()
+                    !self.deeply_resolve_ignoring_regions(self_ty).is_ty_var()
                 });
                 if constrained_opaque {
                     debug!("opaque type has been constrained");

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1252,7 +1252,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         within_macro_span: Option<Span>,
     ) -> ErrorGuaranteed {
         let tcx = self.tcx;
-        let rcvr_ty = self.resolve_vars_if_possible(rcvr_ty);
+        let rcvr_ty = self.deeply_resolve_ignoring_regions(rcvr_ty);
 
         if let Err(guar) = rcvr_ty.error_reported() {
             return guar;
@@ -2254,7 +2254,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         format!("{item_kind} `{item_name}` is available on `{prev_match}`"),
                     );
                 }
-                let rcvr_ty = self.resolve_vars_if_possible(
+                let rcvr_ty = self.deeply_resolve_ignoring_regions(
                     self.typeck_results
                         .borrow()
                         .expr_ty_adjusted_opt(rcvr_expr)
@@ -3305,7 +3305,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         let field_ty = field.ty(tcx, args).skip_norm_wip();
 
                         // Skip `_`, since that'll just lead to ambiguity.
-                        if self.resolve_vars_if_possible(field_ty).is_ty_var() {
+                        if self.deeply_resolve_ignoring_regions(field_ty).is_ty_var() {
                             return None;
                         }
 
@@ -3325,7 +3325,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     if let Some(ret_ty) = self
                         .ret_coercion
                         .as_ref()
-                        .map(|c| self.resolve_vars_if_possible(c.borrow().expected_ty()))
+                        .map(|c| self.deeply_resolve_ignoring_regions(c.borrow().expected_ty()))
                         && let ty::Adt(kind, _) = ret_ty.kind()
                         && tcx.get_diagnostic_item(diagnostic_item) == Some(kind.did())
                     {
@@ -3881,7 +3881,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         return_type: Option<Ty<'tcx>>,
     ) {
         let Some(output_ty) = self.tcx.get_impl_future_output_ty(ty) else { return };
-        let output_ty = self.resolve_vars_if_possible(output_ty);
+        let output_ty = self.deeply_resolve_ignoring_regions(output_ty);
         let method_exists =
             self.method_exists_for_diagnostic(item_name, output_ty, call.hir_id, return_type);
         debug!("suggest_await_before_method: is_method_exist={}", method_exists);

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -221,7 +221,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.check_expr(lhs_expr)
             }
         };
-        let lhs_ty = self.resolve_vars_with_obligations(lhs_ty);
+        let lhs_ty = self.deeply_resolve_ignoring_regions_with_obligations(lhs_ty);
 
         // N.B., as we have not yet type-checked the RHS, we don't have the
         // type at hand. Make a variable to represent it. The whole reason
@@ -256,7 +256,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             },
         );
-        let rhs_ty = self.resolve_vars_with_obligations(rhs_ty);
+        let rhs_ty = self.deeply_resolve_ignoring_regions_with_obligations(rhs_ty);
 
         let return_ty = self.overloaded_binop_ret_ty(
             expr, lhs_expr, rhs_expr, op, expected, lhs_ty, result, rhs_ty,
@@ -979,7 +979,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 method.sig.output()
             }
             Err(errors) => {
-                let actual = self.resolve_vars_if_possible(operand_ty);
+                let actual = self.deeply_resolve_ignoring_regions(operand_ty);
                 let guar = actual.error_reported().err().unwrap_or_else(|| {
                     let mut file = None;
                     let ty_str = self.tcx.short_string(actual, &mut file);

--- a/compiler/rustc_hir_typeck/src/opaque_types.rs
+++ b/compiler/rustc_hir_typeck/src/opaque_types.rs
@@ -93,7 +93,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
         error_on_missing_defining_use: bool,
     ) {
         for entry in opaque_types.iter_mut() {
-            *entry = self.resolve_vars_if_possible(*entry);
+            *entry = self.deeply_resolve_ignoring_regions(*entry);
         }
         debug!(?opaque_types);
 

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -497,7 +497,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let expected = if let AdjustMode::Peel { .. } = adjust_mode
             && pat.default_binding_modes
         {
-            self.resolve_vars_with_obligations(expected)
+            self.deeply_resolve_ignoring_regions_with_obligations(expected)
         } else {
             expected
         };
@@ -791,14 +791,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         lt.kind
                     );
                 }
-                // Call `resolve_vars_if_possible` here for inline const blocks.
-                let lit_ty = self.resolve_vars_if_possible(self.check_pat_expr_unadjusted(lt));
+                // Call `deeply_resolve_ignoring_regions` here for inline const blocks.
+                let lit_ty = self.deeply_resolve_ignoring_regions(self.check_pat_expr_unadjusted(lt));
                 // If `deref_patterns` is enabled, allow `if let "foo" = &&"foo" {}`.
                 if self.tcx.features().deref_patterns() {
                     let mut peeled_ty = lit_ty;
                     let mut pat_ref_layers = 0;
                     while let ty::Ref(_, inner_ty, mutbl) =
-                        *self.resolve_vars_with_obligations(peeled_ty).kind()
+                        *self.deeply_resolve_ignoring_regions_with_obligations(peeled_ty).kind()
                     {
                         // We rely on references at the head of constants being immutable.
                         debug_assert!(mutbl.is_not());
@@ -944,7 +944,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             match *expected.kind() {
                 // Allow `b"...": &[u8]`
                 ty::Ref(_, inner_ty, _)
-                    if self.resolve_vars_with_obligations(inner_ty).is_slice() =>
+                    if self
+                        .deeply_resolve_ignoring_regions_with_obligations(inner_ty)
+                        .is_slice() =>
                 {
                     trace!(?expr.hir_id.local_id, "polymorphic byte string lit");
                     pat_ty = Ty::new_imm_ref(
@@ -973,7 +975,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // string literal patterns to have type `str`. This is accounted for when lowering to MIR.
         if self.tcx.features().deref_patterns()
             && matches!(lit_kind, ast::LitKind::Str(..))
-            && self.resolve_vars_with_obligations(expected).is_str()
+            && self.deeply_resolve_ignoring_regions_with_obligations(expected).is_str()
         {
             pat_ty = self.tcx.types.str_;
         }
@@ -991,7 +993,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let cause = self.pattern_cause(ti, span);
         if let Err(mut err) = self.demand_suptype_with_origin(&cause, expected, pat_ty) {
             // If scrutinee is String and pattern is &str, suggest .as_str()
-            let expected = self.resolve_vars_with_obligations(expected);
+            let expected = self.deeply_resolve_ignoring_regions_with_obligations(expected);
             if let ty::Adt(adt, _) = expected.kind()
                 && self.tcx.is_lang_item(adt.did(), LangItem::String)
                 && pat_ty.is_ref()
@@ -1029,7 +1031,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // be peeled to `str` while ty here is still `&str`, if we don't
                 // err early here, a rather confusing unification error will be
                 // emitted instead).
-                let ty = self.resolve_vars_with_obligations(ty);
+                let ty = self.deeply_resolve_ignoring_regions_with_obligations(ty);
                 let fail =
                     !(ty.is_numeric() || ty.is_char() || ty.is_ty_var() || ty.references_error());
                 Some((fail, ty, expr.span))
@@ -1108,13 +1110,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             "only `char` and numeric types are allowed in range patterns"
         );
         let msg = |ty| {
-            let ty = self.resolve_vars_if_possible(ty);
+            let ty = self.deeply_resolve_ignoring_regions(ty);
             format!("this is of type `{ty}` but it should be `char` or numeric")
         };
         let mut one_side_err = |first_span, first_ty, second: Option<(bool, Ty<'tcx>, Span)>| {
             err.span_label(first_span, msg(first_ty));
             if let Some((_, ty, sp)) = second {
-                let ty = self.resolve_vars_if_possible(ty);
+                let ty = self.deeply_resolve_ignoring_regions(ty);
                 self.endpoint_has_type(&mut err, sp, ty);
             }
         };
@@ -1290,7 +1292,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) {
         let var_ty = self.local_ty(span, var_id);
         if let Err(mut err) = self.demand_eqtype_pat_diag(span, var_ty, ty, ti) {
-            let var_ty = self.resolve_vars_if_possible(var_ty);
+            let var_ty = self.deeply_resolve_ignoring_regions(var_ty);
             let msg = format!("first introduced with type `{var_ty}` here");
             err.span_label(self.tcx.hir_span(var_id), msg);
             let in_match = self.tcx.hir_parent_iter(var_id).any(|(_, n)| {
@@ -1308,7 +1310,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 &mut err,
                 span,
                 var_ty,
-                self.resolve_vars_if_possible(ty),
+                self.deeply_resolve_ignoring_regions(ty),
                 ba,
             );
             err.emit();
@@ -2734,7 +2736,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             [source_ty],
         );
         let target_ty = self.normalize(span, Unnormalized::new_wip(target_ty));
-        self.resolve_vars_with_obligations(target_ty)
+        self.deeply_resolve_ignoring_regions_with_obligations(target_ty)
     }
 
     /// Check if the interior of a deref pattern (either explicit or implicit) has any `ref mut`
@@ -2782,7 +2784,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             pat_info.max_ref_mutbl = pat_info.max_ref_mutbl.cap_to_weakly_not(pat_prefix_span);
         }
 
-        expected = self.resolve_vars_with_obligations(expected);
+        expected = self.deeply_resolve_ignoring_regions_with_obligations(expected);
         // Determine whether we're consuming an inherited reference and resetting the default
         // binding mode, based on edition and enabled experimental features.
         if let ByRef::Yes(inh_pin, inh_mut) = pat_info.binding_mode
@@ -3073,7 +3075,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         pat_info: PatInfo<'tcx>,
     ) -> Ty<'tcx> {
-        let expected = self.resolve_vars_with_obligations(expected);
+        let expected = self.deeply_resolve_ignoring_regions_with_obligations(expected);
 
         // If the pattern is irrefutable and `expected` is an infer ty, we try to equate it
         // to an array if the given pattern allows it. See issue #76342
@@ -3251,7 +3253,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             && let Some(span) = ti.span
             && let Some(_) = ti.origin_expr
         {
-            let resolved_ty = self.resolve_vars_if_possible(ti.expected);
+            let resolved_ty = self.deeply_resolve_ignoring_regions(ti.expected);
             let (is_slice_or_array_or_vector, resolved_ty) =
                 self.is_slice_or_array_or_vector(resolved_ty);
             match resolved_ty.kind() {

--- a/compiler/rustc_hir_typeck/src/place_op.rs
+++ b/compiler/rustc_hir_typeck/src/place_op.rs
@@ -74,7 +74,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         span: Span,
         base_expr: &hir::Expr<'_>,
     ) -> Option<(Ty<'tcx>, Ty<'tcx>)> {
-        let ty = self.resolve_vars_if_possible(ty);
+        let ty = self.deeply_resolve_ignoring_regions(ty);
         let mut err = self.dcx().struct_span_err(
             span,
             format!("negative integers cannot be used to index on a `{ty}`"),

--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -271,7 +271,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 );
             }
         };
-        let args = self.resolve_vars_if_possible(args);
+        let args = self.deeply_resolve_ignoring_regions(args);
         let closure_def_id = closure_def_id.expect_local();
 
         assert_eq!(self.tcx.hir_body_owner_def_id(body.id()), closure_def_id);
@@ -1329,7 +1329,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let root_var_min_capture_list = min_captures.and_then(|m| m.get(&var_hir_id))?;
 
-        let ty = self.resolve_vars_if_possible(self.node_ty(var_hir_id));
+        let ty = self.deeply_resolve_ignoring_regions(self.node_ty(var_hir_id));
 
         let ty = match closure_clause {
             hir::CaptureBy::Value { .. } => ty, // For move closure the capture kind should be by value
@@ -1427,7 +1427,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         closure_clause: hir::CaptureBy,
         var_hir_id: HirId,
     ) -> Option<FxIndexSet<UpvarMigrationInfo>> {
-        let ty = self.resolve_vars_if_possible(self.node_ty(var_hir_id));
+        let ty = self.deeply_resolve_ignoring_regions(self.node_ty(var_hir_id));
 
         // FIXME(#132279): Using `non_body_analysis` here feels wrong.
         if !ty.has_significant_drop(

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -807,8 +807,9 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
         let obligations = self.fcx.take_hir_typeck_potentially_region_dependent_goals();
         if self.fcx.tainted_by_errors().is_none() {
             for obligation in obligations {
-                let (predicate, mut cause) =
-                    self.fcx.resolve_vars_if_possible((obligation.predicate, obligation.cause));
+                let (predicate, mut cause) = self
+                    .fcx
+                    .deeply_resolve_ignoring_regions((obligation.predicate, obligation.cause));
                 if predicate.has_non_region_infer() {
                     self.fcx.dcx().span_delayed_bug(
                         cause.span,
@@ -833,7 +834,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
     where
         T: TypeFoldable<TyCtxt<'tcx>>,
     {
-        let value = self.fcx.resolve_vars_if_possible(value);
+        let value = self.fcx.deeply_resolve_ignoring_regions(value);
 
         let mut goals = vec![];
         let value =
@@ -847,7 +848,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
             goals
                 .into_iter()
                 .map(|pred| {
-                    self.fcx.resolve_vars_if_possible(pred).fold_with(&mut Resolver::new(
+                    self.fcx.deeply_resolve_ignoring_regions(pred).fold_with(&mut Resolver::new(
                         self.fcx,
                         span,
                         self.body,
@@ -876,7 +877,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
     where
         T: TypeFoldable<TyCtxt<'tcx>>,
     {
-        let value = self.fcx.resolve_vars_if_possible(value);
+        let value = self.fcx.deeply_resolve_ignoring_regions(value);
 
         let mut goals = vec![];
         let value =

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -165,7 +165,7 @@ impl CanonicalizeMode for CanonicalizeQueryResponse {
                 .inner
                 .borrow_mut()
                 .unwrap_region_constraints()
-                .opportunistic_resolve_var(canonicalizer.tcx, vid);
+                .shallow_resolve_region_var(canonicalizer.tcx, vid);
             debug!(
                 "canonical: region var found with vid {vid:?}, \
                      opportunistically resolved to {r:?}",
@@ -183,7 +183,7 @@ impl CanonicalizeMode for CanonicalizeQueryResponse {
                     .inner
                     .borrow_mut()
                     .unwrap_region_constraints()
-                    .probe_value(vid)
+                    .try_resolve_region_var(vid)
                     .unwrap_err();
                 canonicalizer.canonical_var_for_region(CanonicalVarKind::Region(universe), r)
             }
@@ -363,7 +363,7 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'cx, 'tcx> {
             }
 
             ty::Infer(ty::IntVar(vid)) => {
-                let nt = self.infcx.unwrap().opportunistic_resolve_int_var(vid);
+                let nt = self.infcx.unwrap().shallow_resolve_int_var(vid);
                 if nt != t {
                     return self.fold_ty(nt);
                 } else {
@@ -371,7 +371,7 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'cx, 'tcx> {
                 }
             }
             ty::Infer(ty::FloatVar(vid)) => {
-                let nt = self.infcx.unwrap().opportunistic_resolve_float_var(vid);
+                let nt = self.infcx.unwrap().shallow_resolve_float_var(vid);
                 if nt != t {
                     return self.fold_ty(nt);
                 } else {

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -82,14 +82,14 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         }
     }
 
-    fn universe_of_lt(&self, lt: ty::RegionVid) -> Option<ty::UniverseIndex> {
-        match self.inner.borrow_mut().unwrap_region_constraints().probe_value(lt) {
+    fn universe_of_region(&self, lt: ty::RegionVid) -> Option<ty::UniverseIndex> {
+        match self.inner.borrow_mut().unwrap_region_constraints().try_resolve_region_var(lt) {
             Err(universe) => Some(universe),
             Ok(_) => None,
         }
     }
 
-    fn universe_of_ct(&self, ct: ty::ConstVid) -> Option<ty::UniverseIndex> {
+    fn universe_of_const(&self, ct: ty::ConstVid) -> Option<ty::UniverseIndex> {
         match self.try_resolve_const_var(ct) {
             Err(universe) => Some(universe),
             Ok(_) => None,
@@ -118,30 +118,27 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         self.root_const_var(var)
     }
 
-    fn opportunistic_resolve_ty_var(&self, vid: ty::TyVid) -> Ty<'tcx> {
-        match self.try_resolve_ty_var(vid) {
-            Ok(ty) => ty,
-            Err(_) => Ty::new_var(self.tcx, self.root_var(vid)),
-        }
+    fn shallow_resolve_ty_var(&self, vid: ty::TyVid) -> Ty<'tcx> {
+        self.shallow_resolve_ty_var(vid)
     }
 
-    fn opportunistic_resolve_int_var(&self, vid: ty::IntVid) -> Ty<'tcx> {
-        self.opportunistic_resolve_int_var(vid)
+    fn shallow_resolve_int_var(&self, vid: ty::IntVid) -> Ty<'tcx> {
+        self.shallow_resolve_int_var(vid)
     }
 
-    fn opportunistic_resolve_float_var(&self, vid: ty::FloatVid) -> Ty<'tcx> {
-        self.opportunistic_resolve_float_var(vid)
+    fn shallow_resolve_float_var(&self, vid: ty::FloatVid) -> Ty<'tcx> {
+        self.shallow_resolve_float_var(vid)
     }
 
-    fn opportunistic_resolve_ct_var(&self, vid: ty::ConstVid) -> ty::Const<'tcx> {
-        match self.try_resolve_const_var(vid) {
-            Ok(ct) => ct,
-            Err(_) => ty::Const::new_var(self.tcx, self.root_const_var(vid)),
-        }
+    fn shallow_resolve_const_var(&self, vid: ty::ConstVid) -> ty::Const<'tcx> {
+        self.shallow_resolve_const_var(vid)
     }
 
-    fn opportunistic_resolve_lt_var(&self, vid: ty::RegionVid) -> ty::Region<'tcx> {
-        self.inner.borrow_mut().unwrap_region_constraints().opportunistic_resolve_var(self.tcx, vid)
+    fn shallow_resolve_region_var(&self, vid: ty::RegionVid) -> ty::Region<'tcx> {
+        self.inner
+            .borrow_mut()
+            .unwrap_region_constraints()
+            .shallow_resolve_region_var(self.tcx, vid)
     }
 
     fn ty_or_const_infer_var_changed(&self, var: TyOrConstInferVar) -> bool {

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -278,11 +278,11 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         self.shallow_resolve_const(ct)
     }
 
-    fn resolve_vars_if_possible<T>(&self, value: T) -> T
+    fn deeply_resolve_ignoring_regions<T>(&self, value: T) -> T
     where
         T: TypeFoldable<TyCtxt<'tcx>>,
     {
-        self.resolve_vars_if_possible(value)
+        self.deeply_resolve_ignoring_regions(value)
     }
 
     fn probe<T>(&self, probe: impl FnOnce() -> T) -> T {

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1372,9 +1372,27 @@ impl<'tcx> InferCtxt<'tcx> {
         self.inner.borrow_mut().const_unification_table().find(var).vid
     }
 
+    /// Resolves a const var to a rigid const, if it was constrained to one,
+    /// or else the root const var in the unification table.
+    pub fn shallow_resolve_const_var(&self, vid: ty::ConstVid) -> ty::Const<'tcx> {
+        match self.try_resolve_const_var(vid) {
+            Ok(ct) => ct,
+            Err(_) => ty::Const::new_var(self.tcx, self.root_const_var(vid)),
+        }
+    }
+
+    /// Resolves a type var to a rigid type, if it was constrained to one,
+    /// or else the root type var in the unification table.
+    pub fn shallow_resolve_ty_var(&self, vid: ty::TyVid) -> Ty<'tcx> {
+        match self.try_resolve_ty_var(vid) {
+            Ok(ty) => ty,
+            Err(_) => Ty::new_var(self.tcx, self.root_var(vid)),
+        }
+    }
+
     /// Resolves an int var to a rigid int type, if it was constrained to one,
     /// or else the root int var in the unification table.
-    pub fn opportunistic_resolve_int_var(&self, vid: ty::IntVid) -> Ty<'tcx> {
+    pub fn shallow_resolve_int_var(&self, vid: ty::IntVid) -> Ty<'tcx> {
         let mut inner = self.inner.borrow_mut();
         let value = inner.int_unification_table().probe_value(vid);
         match value {
@@ -1388,7 +1406,7 @@ impl<'tcx> InferCtxt<'tcx> {
 
     /// Resolves a float var to a rigid int type, if it was constrained to one,
     /// or else the root float var in the unification table.
-    pub fn opportunistic_resolve_float_var(&self, vid: ty::FloatVid) -> Ty<'tcx> {
+    pub fn shallow_resolve_float_var(&self, vid: ty::FloatVid) -> Ty<'tcx> {
         let mut inner = self.inner.borrow_mut();
         let value = inner.float_unification_table().probe_value(vid);
         match value {

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1265,7 +1265,7 @@ impl<'tcx> InferCtxt<'tcx> {
     /// The "shallow" part of the name refers to the fact that types may themselves contain more
     /// type variables. e.g. The field types of a struct. `shallow_resolve` does not recurse into
     /// these nested variables. If that's what you want, use [`deeply_resolve_ignoring_regions`](Self::deeply_resolve_ignoring_regions),
-    /// or better [`deeply_resolve`](rustc_type_ir::deeply_resolve), if you can, which *does* resolve regions.
+    /// or better [`deeply_resolve_via_unification_table`](rustc_type_ir::InferCtxtLike::deeply_resolve_via_unification_table), if you can, which *does* resolve regions.
     pub fn shallow_resolve(&self, ty: Ty<'tcx>) -> Ty<'tcx> {
         if let ty::Infer(v) = *ty.kind() {
             match v {

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1488,8 +1488,11 @@ impl<'tcx> InferCtxt<'tcx> {
     ///
     /// This method is idempotent, but it not typically not invoked
     /// except during the writeback phase.
-    pub fn fully_resolve<T: TypeFoldable<TyCtxt<'tcx>>>(&self, value: T) -> FixupResult<T> {
-        match resolve::fully_resolve(self, value) {
+    pub fn deeply_resolve_via_region_graph<T: TypeFoldable<TyCtxt<'tcx>>>(
+        &self,
+        value: T,
+    ) -> FixupResult<T> {
+        match resolve::deeply_resolve_via_region_graph(self, value) {
             Ok(value) => {
                 if value.has_non_region_infer() {
                     bug!("`{value:?}` is not fully resolved");

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1223,7 +1223,7 @@ impl<'tcx> InferCtxt<'tcx> {
     }
 
     pub fn ty_to_string(&self, t: Ty<'tcx>) -> String {
-        self.resolve_vars_if_possible(t).to_string()
+        self.deeply_resolve_ignoring_regions(t).to_string()
     }
 
     /// If `TyVar(vid)` resolves to a type, return that type. Else, return the
@@ -1399,13 +1399,13 @@ impl<'tcx> InferCtxt<'tcx> {
         }
     }
 
-    /// Where possible, replaces type/const variables in
-    /// `value` with their final value. Note that region variables
-    /// are unaffected. If a type/const variable has not been unified, it
-    /// is left as is. This is an idempotent operation that does
-    /// not affect inference state in any way and so you can do it
-    /// at will.
-    pub fn resolve_vars_if_possible<T>(&self, value: T) -> T
+    /// If a type/const variable has not (yet) been unified, it is left as is.
+    ///
+    /// This is an idempotent operation that does not affect inference state in any way,
+    /// which means it's safe to call this function at will.
+    ///
+    /// Region variables are unaffected.
+    pub fn deeply_resolve_ignoring_regions<T>(&self, value: T) -> T
     where
         T: TypeFoldable<TyCtxt<'tcx>>,
     {
@@ -1415,7 +1415,7 @@ impl<'tcx> InferCtxt<'tcx> {
         if !value.has_non_region_infer() {
             return value;
         }
-        let mut r = resolve::OpportunisticVarResolver::new(self);
+        let mut r = resolve::DeepResolverIgnoringRegions::new(self);
         value.fold_with(&mut r)
     }
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1247,6 +1247,25 @@ impl<'tcx> InferCtxt<'tcx> {
         }
     }
 
+    /// Resolve a type variable. Resolving means the following:
+    ///
+    /// - If a `Ty` is a rigid type (like, an integer, or some ADT), do nothing.
+    /// - If a `Ty` is a type infer variable, but has been equated with an actual type,
+    ///   return that type.
+    /// - If a `Ty` is an int or float infer variable, and has been equated with an integer
+    ///   or floating point type, return that type.
+    /// - If a `Ty` is any kind of infer variable that has been equated, but not yet with a rigid
+    ///   type, then this set of equated variables forms an equivalence class. One of the variables
+    ///   in that equivalent class is said to be the root variable, and resolving makes sure to
+    ///   consistently return this root variable. This is beneficial for caching.
+    ///   This behavior, of returning roots, changed in <https://github.com/rust-lang/rust/pull/158447>.
+    ///
+    /// Otherwise, resolving simply does nothing.
+    ///
+    /// The "shallow" part of the name refers to the fact that types may themselves contain more
+    /// type variables. e.g. The field types of a struct. `shallow_resolve` does not recurse into
+    /// these nested variables. If that's what you want, use [`deeply_resolve_ignoring_regions`](Self::deeply_resolve_ignoring_regions),
+    /// or better [`deeply_resolve`](rustc_type_ir::deeply_resolve), if you can, which *does* resolve regions.
     pub fn shallow_resolve(&self, ty: Ty<'tcx>) -> Ty<'tcx> {
         if let ty::Infer(v) = *ty.kind() {
             match v {
@@ -1312,6 +1331,8 @@ impl<'tcx> InferCtxt<'tcx> {
         }
     }
 
+    /// See docs on [`shallow_resolve`](Self::shallow_resolve) for more explanation.
+    /// It's the same, but for consts.
     pub fn shallow_resolve_const(&self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {
         match ct.kind() {
             ty::ConstKind::Infer(infer_ct) => match infer_ct {
@@ -1338,6 +1359,8 @@ impl<'tcx> InferCtxt<'tcx> {
         }
     }
 
+    /// See docs on [`shallow_resolve`](Self::shallow_resolve) for more explanation.
+    /// It's the same, but for terms (types or consts).
     pub fn shallow_resolve_term(&self, term: ty::Term<'tcx>) -> ty::Term<'tcx> {
         match term.kind() {
             ty::TermKind::Ty(ty) => self.shallow_resolve(ty).into(),
@@ -1404,7 +1427,7 @@ impl<'tcx> InferCtxt<'tcx> {
         }
     }
 
-    /// Resolves a float var to a rigid int type, if it was constrained to one,
+    /// Resolves a float var to a rigid type, if it was constrained to one,
     /// or else the root float var in the unification table.
     pub fn shallow_resolve_float_var(&self, vid: ty::FloatVid) -> Ty<'tcx> {
         let mut inner = self.inner.borrow_mut();

--- a/compiler/rustc_infer/src/infer/opaque_types/mod.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/mod.rs
@@ -166,7 +166,7 @@ impl<'tcx> InferCtxt<'tcx> {
         } else if let Some(res) = process(b, a) {
             res
         } else {
-            let (a, b) = self.resolve_vars_if_possible((a, b));
+            let (a, b) = self.deeply_resolve_ignoring_regions((a, b));
             Err(TypeError::Sorts(ExpectedFound::new(a, b)))
         }
     }

--- a/compiler/rustc_infer/src/infer/outlives/mod.rs
+++ b/compiler/rustc_infer/src/infer/outlives/mod.rs
@@ -36,7 +36,7 @@ impl<'tcx> InferCtxt<'tcx> {
     /// Process the region constraints and return any errors that
     /// result. After this, no more unification operations should be
     /// done -- or the compiler will panic -- but it is legal to use
-    /// `resolve_vars_if_possible` as well as `fully_resolve`.
+    /// `deeply_resolve_ignoring_regions` as well as `fully_resolve`.
     ///
     /// Don't call this directly unless you know what you're doing.
     /// You probably want to use `resolve_regions` instead.

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -66,7 +66,7 @@ use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::ty::outlives::{Component, push_outlives_components};
 use rustc_middle::ty::{
     self, GenericArgKind, GenericArgsRef, PolyTypeOutlivesClause, Region, RegionVid, Ty, TyCtxt,
-    TypeVisitableExt, Upcast, eager_resolve_vars,
+    TypeVisitableExt, Upcast, deeply_resolve_via_unification_table,
 };
 use rustc_span::Span;
 use rustc_type_ir::region_constraint::{self, LeafRegionConstraint};
@@ -371,7 +371,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 // `TypeOutlives` is structural, so we should try to opportunistically resolve all
                 // region vids before processing regions, so we have a better chance to match clauses
                 // in our param-env.
-                let (sup_type, sub_region) = eager_resolve_vars(self, (sup_type, sub_region));
+                let (sup_type, sub_region) = deeply_resolve_via_unification_table(self, (sup_type, sub_region));
 
                 if self.tcx.sess.opts.unstable_opts.higher_ranked_assumptions
                     && outlives_env

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -66,7 +66,7 @@ use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::ty::outlives::{Component, push_outlives_components};
 use rustc_middle::ty::{
     self, GenericArgKind, GenericArgsRef, PolyTypeOutlivesClause, Region, RegionVid, Ty, TyCtxt,
-    TypeVisitableExt, Upcast, deeply_resolve_via_unification_table,
+    TypeVisitableExt, Upcast,
 };
 use rustc_span::Span;
 use rustc_type_ir::region_constraint::{self, LeafRegionConstraint};
@@ -345,6 +345,8 @@ impl<'tcx> InferCtxt<'tcx> {
         outlives_env: &OutlivesEnvironment<'tcx>,
         span: Span,
     ) {
+        use rustc_type_ir::InferCtxtLike;
+
         assert!(!self.in_snapshot(), "cannot process registered region obligations in a snapshot");
 
         if self.tcx.assumptions_on_binders() {
@@ -371,7 +373,12 @@ impl<'tcx> InferCtxt<'tcx> {
                 // `TypeOutlives` is structural, so we should try to opportunistically resolve all
                 // region vids before processing regions, so we have a better chance to match clauses
                 // in our param-env.
-                let (sup_type, sub_region) = deeply_resolve_via_unification_table(self, (sup_type, sub_region));
+                //
+                // We *want* this folder to live in `rustc_type_ir`. Our best way to call into it is
+                // through `InferCtxtLike` and it is not defined as an inherent method on `InferCtxt`.
+                #[allow(rustc::usage_of_type_ir_traits)]
+                let (sup_type, sub_region) =
+                    self.deeply_resolve_via_unification_table((sup_type, sub_region));
 
                 if self.tcx.sess.opts.unstable_opts.higher_ranked_assumptions
                     && outlives_env

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -672,7 +672,7 @@ impl<'tcx> RegionConstraintCollector<'_, 'tcx> {
 
     /// Resolves a region var to its value in the unification table, if it exists.
     /// Otherwise, it is resolved to the root `ReVar` in the table.
-    pub fn opportunistic_resolve_var(
+    pub fn shallow_resolve_region_var(
         &mut self,
         tcx: TyCtxt<'tcx>,
         vid: ty::RegionVid,
@@ -685,7 +685,7 @@ impl<'tcx> RegionConstraintCollector<'_, 'tcx> {
         }
     }
 
-    pub fn probe_value(
+    pub fn try_resolve_region_var(
         &mut self,
         vid: ty::RegionVid,
     ) -> Result<ty::Region<'tcx>, ty::UniverseIndex> {
@@ -743,7 +743,7 @@ impl<'tcx> RegionConstraintCollector<'_, 'tcx> {
             | ty::ReEarlyParam(..)
             | ty::ReError(_) => ty::UniverseIndex::ROOT,
             ty::RePlaceholder(placeholder) => placeholder.universe,
-            ty::ReVar(vid) => match self.probe_value(vid) {
+            ty::ReVar(vid) => match self.try_resolve_region_var(vid) {
                 Ok(value) => self.universe(value),
                 Err(universe) => universe,
             },

--- a/compiler/rustc_infer/src/infer/resolve.rs
+++ b/compiler/rustc_infer/src/infer/resolve.rs
@@ -9,28 +9,28 @@ use super::{FixupError, FixupResult, InferCtxt};
 use crate::infer::TyOrConstInferVar;
 
 ///////////////////////////////////////////////////////////////////////////
-// OPPORTUNISTIC VAR RESOLVER
+// DEEP VAR RESOLVER
 
-/// The opportunistic resolver can be used at any time. It simply replaces
+/// The type and const resolver can be used at any time. It simply replaces
 /// type/const variables that have been unified with the things they have
 /// been unified with (similar to `shallow_resolve`, but deep). This is
 /// useful for printing messages etc but also required at various
 /// points for correctness.
-pub struct OpportunisticVarResolver<'a, 'tcx> {
+pub struct DeepResolverIgnoringRegions<'a, 'tcx> {
     infcx: &'a InferCtxt<'tcx>,
     /// We're able to use a cache here as the folder does
     /// not have any mutable state.
     cache: DelayedMap<Ty<'tcx>, Ty<'tcx>>,
 }
 
-impl<'a, 'tcx> OpportunisticVarResolver<'a, 'tcx> {
+impl<'a, 'tcx> DeepResolverIgnoringRegions<'a, 'tcx> {
     #[inline]
     pub fn new(infcx: &'a InferCtxt<'tcx>) -> Self {
-        OpportunisticVarResolver { infcx, cache: Default::default() }
+        DeepResolverIgnoringRegions { infcx, cache: Default::default() }
     }
 }
 
-impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for OpportunisticVarResolver<'a, 'tcx> {
+impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for DeepResolverIgnoringRegions<'a, 'tcx> {
     fn cx(&self) -> TyCtxt<'tcx> {
         self.infcx.tcx
     }
@@ -67,24 +67,24 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for OpportunisticVarResolver<'a, 'tcx> {
     }
 }
 
-/// The opportunistic region resolver opportunistically resolves regions
-/// variables to the variable with the least variable id. It is used when
-/// normalizing projections to avoid hitting the recursion limit by creating
-/// many versions of a predicate for types that in the end have to unify.
+/// The region resolver resolves region variables to the variable with the
+/// least variable id. It is used when normalizing projections to avoid
+/// hitting the recursion limit by creating many versions of a predicate
+/// for types that in the end have to unify.
 ///
 /// If you want to resolve type and const variables as well, call
-/// [InferCtxt::resolve_vars_if_possible] first.
-pub struct OpportunisticRegionResolver<'a, 'tcx> {
+/// [InferCtxt::deeply_resolve_ignoring_regions] first.
+pub struct DeepRegionResolver<'a, 'tcx> {
     infcx: &'a InferCtxt<'tcx>,
 }
 
-impl<'a, 'tcx> OpportunisticRegionResolver<'a, 'tcx> {
+impl<'a, 'tcx> DeepRegionResolver<'a, 'tcx> {
     pub fn new(infcx: &'a InferCtxt<'tcx>) -> Self {
-        OpportunisticRegionResolver { infcx }
+        DeepRegionResolver { infcx }
     }
 }
 
-impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for OpportunisticRegionResolver<'a, 'tcx> {
+impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for DeepRegionResolver<'a, 'tcx> {
     fn cx(&self) -> TyCtxt<'tcx> {
         self.infcx.tcx
     }

--- a/compiler/rustc_infer/src/infer/resolve.rs
+++ b/compiler/rustc_infer/src/infer/resolve.rs
@@ -104,7 +104,7 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for DeepRegionResolver<'a, 'tcx> {
                 .inner
                 .borrow_mut()
                 .unwrap_region_constraints()
-                .opportunistic_resolve_var(TypeFolder::cx(self), vid),
+                .shallow_resolve_region_var(TypeFolder::cx(self), vid),
             _ => r,
         }
     }

--- a/compiler/rustc_infer/src/infer/resolve.rs
+++ b/compiler/rustc_infer/src/infer/resolve.rs
@@ -124,7 +124,7 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for DeepRegionResolver<'a, 'tcx> {
 /// Full type resolution replaces all type and region variables with
 /// their concrete results. If any variable cannot be replaced (never unified, etc)
 /// then an `Err` result is returned.
-pub fn fully_resolve<'tcx, T>(infcx: &InferCtxt<'tcx>, value: T) -> FixupResult<T>
+pub fn deeply_resolve_via_region_graph<'tcx, T>(infcx: &InferCtxt<'tcx>, value: T) -> FixupResult<T>
 where
     T: TypeFoldable<TyCtxt<'tcx>>,
 {

--- a/compiler/rustc_infer/src/infer/snapshot/fudge.rs
+++ b/compiler/rustc_infer/src/infer/snapshot/fudge.rs
@@ -111,7 +111,7 @@ impl<'tcx> InferCtxt<'tcx> {
             // going to be popped, so we will have to
             // eliminate any references to them.
             let snapshot_vars = SnapshotVarData::new(self, variable_lengths);
-            Ok((snapshot_vars, self.resolve_vars_if_possible(value)))
+            Ok((snapshot_vars, self.deeply_resolve_ignoring_regions(value)))
         })?;
 
         // At this point, we need to replace any of the now-popped

--- a/compiler/rustc_next_trait_solver/src/canonical/canonicalizer.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/canonicalizer.rs
@@ -322,7 +322,7 @@ impl<'a, D: SolverDelegate<Interner = I>, I: Interner> Canonicalizer<'a, D, I> {
             ty::Infer(i) => match i {
                 ty::TyVar(vid) => {
                     debug_assert_eq!(
-                        self.delegate.opportunistic_resolve_ty_var(vid),
+                        self.delegate.shallow_resolve_ty_var(vid),
                         t,
                         "ty vid should have been resolved fully before canonicalization"
                     );
@@ -339,7 +339,7 @@ impl<'a, D: SolverDelegate<Interner = I>, I: Interner> Canonicalizer<'a, D, I> {
                 }
                 ty::IntVar(vid) => {
                     debug_assert_eq!(
-                        self.delegate.opportunistic_resolve_int_var(vid),
+                        self.delegate.shallow_resolve_int_var(vid),
                         t,
                         "ty vid should have been resolved fully before canonicalization"
                     );
@@ -347,7 +347,7 @@ impl<'a, D: SolverDelegate<Interner = I>, I: Interner> Canonicalizer<'a, D, I> {
                 }
                 ty::FloatVar(vid) => {
                     debug_assert_eq!(
-                        self.delegate.opportunistic_resolve_float_var(vid),
+                        self.delegate.shallow_resolve_float_var(vid),
                         t,
                         "ty vid should have been resolved fully before canonicalization"
                     );
@@ -489,7 +489,7 @@ impl<D: SolverDelegate<Interner = I>, I: Interner> TypeFolder<I> for Canonicaliz
 
             ty::ReVar(vid) => {
                 debug_assert_eq!(
-                    self.delegate.opportunistic_resolve_lt_var(vid),
+                    self.delegate.shallow_resolve_region_var(vid),
                     r,
                     "region vid should have been resolved fully before canonicalization"
                 );
@@ -501,7 +501,7 @@ impl<D: SolverDelegate<Interner = I>, I: Interner> TypeFolder<I> for Canonicaliz
                         ))
                     }
                     CanonicalizeMode::Response { .. } => {
-                        CanonicalVarKind::Region(self.delegate.universe_of_lt(vid).unwrap())
+                        CanonicalVarKind::Region(self.delegate.universe_of_region(vid).unwrap())
                     }
                 }
             }
@@ -534,7 +534,7 @@ impl<D: SolverDelegate<Interner = I>, I: Interner> TypeFolder<I> for Canonicaliz
             ty::ConstKind::Infer(i) => match i {
                 ty::InferConst::Var(vid) => {
                     debug_assert_eq!(
-                        self.delegate.opportunistic_resolve_ct_var(vid),
+                        self.delegate.shallow_resolve_const_var(vid),
                         c,
                         "const vid should have been resolved fully before canonicalization"
                     );
@@ -544,7 +544,7 @@ impl<D: SolverDelegate<Interner = I>, I: Interner> TypeFolder<I> for Canonicaliz
                             CanonicalVarKind::Const(ty::UniverseIndex::ROOT)
                         }
                         CanonicalizeMode::Response { .. } => {
-                            CanonicalVarKind::Const(self.delegate.universe_of_ct(vid).unwrap())
+                            CanonicalVarKind::Const(self.delegate.universe_of_const(vid).unwrap())
                         }
                     }
                 }

--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -19,7 +19,7 @@ use rustc_type_ir::relate::{
 };
 use rustc_type_ir::{
     self as ty, Canonical, CanonicalVarKind, CanonicalVarValues, InferCtxtLike, Interner, Region,
-    TypeFoldable, TypingMode, TypingModeEqWrapper, deeply_resolve_via_unification_table,
+    TypeFoldable, TypingMode, TypingModeEqWrapper,
 };
 use thin_vec::ThinVec;
 use tracing::instrument;
@@ -568,7 +568,7 @@ where
 {
     let var_values = CanonicalVarValues { var_values: delegate.cx().mk_args(var_values) };
     let state = inspect::State { var_values, data };
-    let state = deeply_resolve_via_unification_table(&**delegate, state);
+    let state = delegate.deeply_resolve_via_unification_table(state);
     Canonicalizer::canonicalize_response(delegate, max_input_universe, state)
 }
 

--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -19,7 +19,7 @@ use rustc_type_ir::relate::{
 };
 use rustc_type_ir::{
     self as ty, Canonical, CanonicalVarKind, CanonicalVarValues, InferCtxtLike, Interner, Region,
-    TypeFoldable, TypingMode, TypingModeEqWrapper, eager_resolve_vars,
+    TypeFoldable, TypingMode, TypingModeEqWrapper, deeply_resolve_via_unification_table,
 };
 use thin_vec::ThinVec;
 use tracing::instrument;
@@ -568,7 +568,7 @@ where
 {
     let var_values = CanonicalVarValues { var_values: delegate.cx().mk_args(var_values) };
     let state = inspect::State { var_values, data };
-    let state = eager_resolve_vars(&**delegate, state);
+    let state = deeply_resolve_via_unification_table(&**delegate, state);
     Canonicalizer::canonicalize_response(delegate, max_input_universe, state)
 }
 

--- a/compiler/rustc_next_trait_solver/src/normalize.rs
+++ b/compiler/rustc_next_trait_solver/src/normalize.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::{
     self as ty, AliasTerm, Binder, FallibleTypeFolder, InferCtxtLike, Interner, PredicateProxy,
-    TypeFoldable, TypeSuperFoldable, TypeVisitableExt, UniverseIndex, eager_resolve_vars,
+    TypeFoldable, TypeSuperFoldable, TypeVisitableExt, UniverseIndex, deeply_resolve_via_unification_table,
 };
 use tracing::instrument;
 
@@ -139,8 +139,8 @@ where
 
         if self.cx().renormalize_rigid_aliases() && orig_is_rigid == ty::IsRigid::Yes {
             // find out missing typing env change.
-            let original = eager_resolve_vars(infcx, original);
-            let normalized = eager_resolve_vars(infcx, normalized);
+            let original = deeply_resolve_via_unification_table(infcx, original);
+            let normalized = deeply_resolve_via_unification_table(infcx, normalized);
             assert_eq!(original, normalized, "rigid alias is further normalized");
         }
         Ok(normalized)
@@ -189,8 +189,8 @@ where
 
         if self.cx().renormalize_rigid_aliases() && orig_is_rigid == ty::IsRigid::Yes {
             // find out missing typing env change.
-            let original = eager_resolve_vars(infcx, original);
-            let normalized = eager_resolve_vars(infcx, normalized);
+            let original = deeply_resolve_via_unification_table(infcx, original);
+            let normalized = deeply_resolve_via_unification_table(infcx, normalized);
             assert_eq!(original, normalized, "rigid alias is further normalized");
         }
 

--- a/compiler/rustc_next_trait_solver/src/normalize.rs
+++ b/compiler/rustc_next_trait_solver/src/normalize.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::{
     self as ty, AliasTerm, Binder, FallibleTypeFolder, InferCtxtLike, Interner, PredicateProxy,
-    TypeFoldable, TypeSuperFoldable, TypeVisitableExt, UniverseIndex, deeply_resolve_via_unification_table,
+    TypeFoldable, TypeSuperFoldable, TypeVisitableExt, UniverseIndex,
 };
 use tracing::instrument;
 
@@ -139,8 +139,8 @@ where
 
         if self.cx().renormalize_rigid_aliases() && orig_is_rigid == ty::IsRigid::Yes {
             // find out missing typing env change.
-            let original = deeply_resolve_via_unification_table(infcx, original);
-            let normalized = deeply_resolve_via_unification_table(infcx, normalized);
+            let original = infcx.deeply_resolve_via_unification_table(original);
+            let normalized = infcx.deeply_resolve_via_unification_table(normalized);
             assert_eq!(original, normalized, "rigid alias is further normalized");
         }
         Ok(normalized)
@@ -189,8 +189,8 @@ where
 
         if self.cx().renormalize_rigid_aliases() && orig_is_rigid == ty::IsRigid::Yes {
             // find out missing typing env change.
-            let original = deeply_resolve_via_unification_table(infcx, original);
-            let normalized = deeply_resolve_via_unification_table(infcx, normalized);
+            let original = infcx.deeply_resolve_via_unification_table(original);
+            let normalized = infcx.deeply_resolve_via_unification_table(normalized);
             assert_eq!(original, normalized, "rigid alias is further normalized");
         }
 

--- a/compiler/rustc_next_trait_solver/src/placeholder.rs
+++ b/compiler/rustc_next_trait_solver/src/placeholder.rs
@@ -248,7 +248,7 @@ where
 
     fn fold_region(&mut self, r0: Region<I>) -> Region<I> {
         let r1 = match r0.kind() {
-            ty::ReVar(vid) => self.infcx.opportunistic_resolve_lt_var(vid),
+            ty::ReVar(vid) => self.infcx.shallow_resolve_region_var(vid),
             _ => r0,
         };
 

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -464,7 +464,7 @@ where
 
         // Vars that show up in the rest of the goal substs may have been constrained by
         // normalizing the self type as well, since type variables are not uniquified.
-        let goal = self.resolve_vars_if_possible(goal);
+        let goal = self.deeply_resolve_ignoring_regions(goal);
 
         if self.typing_mode().is_coherence()
             && let Ok(candidate) = self.consider_coherence_unknowable_candidate(goal)

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1098,7 +1098,7 @@ where
             }
             ty::TermKind::Const(ct) => {
                 if let ty::ConstKind::Infer(ty::InferConst::Var(vid)) = ct.kind() {
-                    self.delegate.universe_of_ct(vid).unwrap()
+                    self.delegate.universe_of_const(vid).unwrap()
                 } else {
                     return false;
                 }
@@ -1165,7 +1165,7 @@ where
                             return ControlFlow::Break(());
                         }
 
-                        self.check_nameable(self.delegate.universe_of_ct(vid).unwrap())
+                        self.check_nameable(self.delegate.universe_of_const(vid).unwrap())
                     }
                     ty::ConstKind::Placeholder(p) => self.check_nameable(p.universe()),
                     _ => {
@@ -1313,7 +1313,7 @@ where
 
     pub(super) fn eager_resolve_region(&self, r: Region<I>) -> Region<I> {
         if let ty::ReVar(vid) = r.kind() {
-            self.delegate.opportunistic_resolve_lt_var(vid)
+            self.delegate.shallow_resolve_region_var(vid)
         } else {
             r
         }
@@ -1672,7 +1672,7 @@ where
                     && let ty::RegionKind::ReVar(vid) = re.kind()
                     // This is only safe if we call `eager_resolve_vars` beforehand,
                     // which we do.
-                    && self.delegate.universe_of_lt(vid).unwrap()
+                    && self.delegate.universe_of_region(vid).unwrap()
                         .can_name(max_universe(&**self.delegate, sup_re))
                 {
                     vis.vars.contains(&vid)

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -659,7 +659,8 @@ where
         // duplicate entries.
         let opaque_types = self.delegate.clone_opaque_types_lookup_table();
 
-        let (goal, opaque_types) = self.delegate.deeply_resolve_via_unification_table((goal, opaque_types));
+        let (goal, opaque_types) =
+            self.delegate.deeply_resolve_via_unification_table((goal, opaque_types));
         let typing_mode = self.typing_mode();
         let step_kind = self.step_kind_for_source(source);
 
@@ -1604,8 +1605,9 @@ where
 
         let external_constraints =
             self.compute_external_query_constraints(certainty, normalization_nested_goals);
-        let (var_values, mut external_constraints) =
-            self.delegate.deeply_resolve_via_unification_table((self.var_values, external_constraints));
+        let (var_values, mut external_constraints) = self
+            .delegate
+            .deeply_resolve_via_unification_table((self.var_values, external_constraints));
 
         // Remove any trivial or duplicated region constraints once we've resolved regions
         let mut unique = HashSet::default();

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -19,8 +19,8 @@ use rustc_type_ir::solve::{
 use rustc_type_ir::{
     self as ty, CanonicalVarValues, ClauseKind, InferCtxtLike, Interner, MayBeErased,
     OpaqueTypeKey, PredicateKind, PredicateProxy, Region, RegionVid, TypeFoldable,
-    TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode,
-    eager_resolve_vars, max_universe,
+    TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode, deeply_resolve_via_unification_table,
+    max_universe,
 };
 use thin_vec::ThinVec;
 use tracing::{Level, debug, instrument, trace, warn};
@@ -659,7 +659,7 @@ where
         // so we only canonicalize the lookup table and ignore
         // duplicate entries.
         let opaque_types = self.delegate.clone_opaque_types_lookup_table();
-        let (goal, opaque_types) = eager_resolve_vars(&**self.delegate, (goal, opaque_types));
+        let (goal, opaque_types) = deeply_resolve_via_unification_table(&**self.delegate, (goal, opaque_types));
         let typing_mode = self.typing_mode();
         let step_kind = self.step_kind_for_source(source);
 
@@ -1300,11 +1300,11 @@ where
         })
     }
 
-    pub(super) fn resolve_vars_if_possible<T>(&self, value: T) -> T
+    pub(super) fn deeply_resolve_ignoring_regions<T>(&self, value: T) -> T
     where
         T: TypeFoldable<I>,
     {
-        self.delegate.resolve_vars_if_possible(value)
+        self.delegate.deeply_resolve_ignoring_regions(value)
     }
 
     pub(super) fn shallow_resolve(&self, ty: I::Ty) -> I::Ty {
@@ -1432,14 +1432,14 @@ where
                 self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
             }
             None if self.cx().features().generic_const_args() => {
-                // HACK(khyperia): calling `resolve_vars_if_possible` here shouldn't be necessary,
-                // `try_evaluate_const` calls `resolve_vars_if_possible` already. However, we want
+                // HACK(khyperia): calling `deeply_resolve_ignoring_regions` here shouldn't be necessary,
+                // `try_evaluate_const` calls `deeply_resolve_ignoring_regions` already. However, we want
                 // to check `has_non_region_infer` against the type with vars resolved (i.e. check
                 // if there are vars we failed to resolve), so we need to call it again here.
                 // Perhaps we could split EvaluateConstErr::HasGenericsOrInfers into HasGenerics and
                 // HasInfers or something, make evaluate_const return that, and make this branch be
                 // based on that, rather than checking `has_non_region_infer`.
-                if self.resolve_vars_if_possible(alias_const).has_non_region_infer() {
+                if self.deeply_resolve_ignoring_regions(alias_const).has_non_region_infer() {
                     self.evaluate_added_goals_and_make_canonical_response(Certainty::AMBIGUOUS)
                 } else {
                     // Evaluation failed because the const was too generic or was an invalid type
@@ -1605,7 +1605,7 @@ where
         let external_constraints =
             self.compute_external_query_constraints(certainty, normalization_nested_goals);
         let (var_values, mut external_constraints) =
-            eager_resolve_vars(&**self.delegate, (self.var_values, external_constraints));
+            deeply_resolve_via_unification_table(&**self.delegate, (self.var_values, external_constraints));
 
         // Remove any trivial or duplicated region constraints once we've resolved regions
         let mut unique = HashSet::default();
@@ -1772,7 +1772,7 @@ where
         param_env: I::ParamEnv,
         value: ty::Unnormalized<I, T>,
     ) -> Result<T, NoSolutionOrRerunNonErased> {
-        let value = self.delegate.resolve_vars_if_possible(value.skip_normalization());
+        let value = self.delegate.deeply_resolve_ignoring_regions(value.skip_normalization());
 
         if !self.cx().renormalize_rigid_aliases() && !value.has_non_rigid_aliases() {
             return Ok(value);
@@ -1795,7 +1795,7 @@ where
                 }
             };
 
-            Ok((self.resolve_vars_if_possible(infer_term), normalization_was_ambiguous))
+            Ok((self.deeply_resolve_ignoring_regions(infer_term), normalization_was_ambiguous))
         });
         value.try_fold_with(&mut folder)
     }
@@ -1929,7 +1929,7 @@ pub(super) fn evaluate_root_goal_for_proof_tree<D: SolverDelegate<Interner = I>,
     root_depth: usize,
 ) -> (Result<NestedNormalizationGoals<I>, NoSolution>, inspect::GoalEvaluation<I>) {
     let opaque_types = delegate.clone_opaque_types_lookup_table();
-    let (goal, opaque_types) = eager_resolve_vars(&**delegate, (goal, opaque_types));
+    let (goal, opaque_types) = deeply_resolve_via_unification_table(&**delegate, (goal, opaque_types));
     let typing_mode = delegate.typing_mode_raw().assert_not_erased();
 
     let (orig_values, canonical_goal) =

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -19,8 +19,7 @@ use rustc_type_ir::solve::{
 use rustc_type_ir::{
     self as ty, CanonicalVarValues, ClauseKind, InferCtxtLike, Interner, MayBeErased,
     OpaqueTypeKey, PredicateKind, PredicateProxy, Region, RegionVid, TypeFoldable,
-    TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode, deeply_resolve_via_unification_table,
-    max_universe,
+    TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode, max_universe,
 };
 use thin_vec::ThinVec;
 use tracing::{Level, debug, instrument, trace, warn};
@@ -659,7 +658,8 @@ where
         // so we only canonicalize the lookup table and ignore
         // duplicate entries.
         let opaque_types = self.delegate.clone_opaque_types_lookup_table();
-        let (goal, opaque_types) = deeply_resolve_via_unification_table(&**self.delegate, (goal, opaque_types));
+
+        let (goal, opaque_types) = self.delegate.deeply_resolve_via_unification_table((goal, opaque_types));
         let typing_mode = self.typing_mode();
         let step_kind = self.step_kind_for_source(source);
 
@@ -1605,7 +1605,7 @@ where
         let external_constraints =
             self.compute_external_query_constraints(certainty, normalization_nested_goals);
         let (var_values, mut external_constraints) =
-            deeply_resolve_via_unification_table(&**self.delegate, (self.var_values, external_constraints));
+            self.delegate.deeply_resolve_via_unification_table((self.var_values, external_constraints));
 
         // Remove any trivial or duplicated region constraints once we've resolved regions
         let mut unique = HashSet::default();
@@ -1929,7 +1929,7 @@ pub(super) fn evaluate_root_goal_for_proof_tree<D: SolverDelegate<Interner = I>,
     root_depth: usize,
 ) -> (Result<NestedNormalizationGoals<I>, NoSolution>, inspect::GoalEvaluation<I>) {
     let opaque_types = delegate.clone_opaque_types_lookup_table();
-    let (goal, opaque_types) = deeply_resolve_via_unification_table(&**delegate, (goal, opaque_types));
+    let (goal, opaque_types) = delegate.deeply_resolve_via_unification_table((goal, opaque_types));
     let typing_mode = delegate.typing_mode_raw().assert_not_erased();
 
     let (orig_values, canonical_goal) =

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -404,7 +404,7 @@ where
             // types from candidates.
             self.add_goal(GoalSource::TypeRelating, projection_goal)?;
             self.try_evaluate_added_goals()?;
-            Ok(self.resolve_vars_if_possible(normalized_term))
+            Ok(self.deeply_resolve_ignoring_regions(normalized_term))
         } else {
             Ok(term)
         }

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -1114,7 +1114,7 @@ where
                     return Ok(false);
                 }
                 match ecx.probe(|_| ProbeKind::ProjectionCompatibility).enter(|ecx| {
-                    let target_projection = ecx.resolve_vars_if_possible(target_projection);
+                    let target_projection = ecx.deeply_resolve_ignoring_regions(target_projection);
                     ecx.enter_forall_with_assumptions(
                         target_projection,
                         param_env,
@@ -1141,7 +1141,8 @@ where
                         let source_principal = upcast_principal.unwrap();
                         let target_principal = bound.rebind(target_principal);
                         // We might unify infer vars in previous iterations.
-                        let target_principal = ecx.resolve_vars_if_possible(target_principal);
+                        let target_principal =
+                            ecx.deeply_resolve_ignoring_regions(target_principal);
                         ecx.enter_forall_with_assumptions(
                             target_principal,
                             param_env,
@@ -1176,7 +1177,8 @@ where
                         };
 
                         // We might unify infer vars in previous iterations.
-                        let target_projection = ecx.resolve_vars_if_possible(target_projection);
+                        let target_projection =
+                            ecx.deeply_resolve_ignoring_regions(target_projection);
                         ecx.enter_forall_with_assumptions(
                             target_projection,
                             param_env,

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -130,7 +130,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             let ocx = ObligationCtxt::new(self);
             let normalized_fn_sig = ocx.normalize(&ObligationCause::dummy(), param_env, fn_sig);
             if ocx.evaluate_obligations_error_on_ambiguity().no_errors() {
-                let normalized_fn_sig = self.resolve_vars_if_possible(normalized_fn_sig);
+                let normalized_fn_sig = self.deeply_resolve_ignoring_regions(normalized_fn_sig);
                 if !normalized_fn_sig.has_infer() {
                     return normalized_fn_sig;
                 }
@@ -158,7 +158,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     where
         M: FnOnce(String) -> Diag<'a>,
     {
-        let actual_ty = self.resolve_vars_if_possible(actual_ty);
+        let actual_ty = self.deeply_resolve_ignoring_regions(actual_ty);
         debug!("type_error_struct_with_diag({:?}, {:?})", sp, actual_ty);
 
         let mut err = mk_diag(self.ty_to_string(actual_ty));
@@ -336,7 +336,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 span: Some(span),
                 root_ty,
             } => {
-                let expected_ty = self.resolve_vars_if_possible(root_ty);
+                let expected_ty = self.deeply_resolve_ignoring_regions(root_ty);
                 if !matches!(
                     expected_ty.kind(),
                     ty::Infer(ty::InferTy::TyVar(_) | ty::InferTy::FreshTy(_))
@@ -466,7 +466,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 }
                 _ => {
                     // `prior_arm_ty` can be `!`, `expected` will have better info when present.
-                    let t = self.resolve_vars_if_possible(match exp_found {
+                    let t = self.deeply_resolve_ignoring_regions(match exp_found {
                         Some(ty::error::ExpectedFound { expected, .. }) => expected,
                         _ => prior_arm_ty,
                     });
@@ -1576,7 +1576,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let (expected_found, exp_found, is_simple_error, values, param_env) = match values {
             None => (None, Mismatch::Fixed("type"), false, None, None),
             Some(ty::ParamEnvAnd { param_env, value: values }) => {
-                let values = self.resolve_vars_if_possible(values);
+                let values = self.deeply_resolve_ignoring_regions(values);
                 let (is_simple_error, exp_found) = match values {
                     ValuePairs::Terms(ExpectedFound { expected, found }) => {
                         match (expected.kind(), found.kind()) {
@@ -1988,7 +1988,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     ) -> Vec<TypeErrorAdditionalDiags> {
         let mut suggestions = Vec::new();
         let span = trace.cause.span;
-        let values = self.resolve_vars_if_possible(trace.values);
+        let values = self.deeply_resolve_ignoring_regions(trace.values);
         if let Some((expected, found)) = values.ty() {
             match (expected.kind(), found.kind()) {
                 (ty::Tuple(_), ty::Tuple(_)) => {}
@@ -2344,7 +2344,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 }
             }
             ValuePairs::PolySigs(exp_found) => {
-                let exp_found = self.resolve_vars_if_possible(exp_found);
+                let exp_found = self.deeply_resolve_ignoring_regions(exp_found);
                 if exp_found.references_error() {
                     return None;
                 }
@@ -2369,7 +2369,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         exp_found: ty::error::ExpectedFound<ty::Term<'tcx>>,
         long_ty_path: &mut Option<PathBuf>,
     ) -> Option<(DiagStyledString, DiagStyledString)> {
-        let exp_found = self.resolve_vars_if_possible(exp_found);
+        let exp_found = self.deeply_resolve_ignoring_regions(exp_found);
         if exp_found.references_error() {
             return None;
         }
@@ -2441,7 +2441,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         &self,
         exp_found: ty::error::ExpectedFound<T>,
     ) -> Option<(DiagStyledString, DiagStyledString)> {
-        let exp_found = self.resolve_vars_if_possible(exp_found);
+        let exp_found = self.deeply_resolve_ignoring_regions(exp_found);
         if exp_found.references_error() {
             return None;
         }
@@ -2467,7 +2467,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     /// FloatVar inference type are compatible with themselves or their concrete types (Int and
     /// Float types, respectively). When comparing two ADTs, these rules apply recursively.
     pub fn same_type_modulo_infer<T: relate::Relate<TyCtxt<'tcx>>>(&self, a: T, b: T) -> bool {
-        let (a, b) = self.resolve_vars_if_possible((a, b));
+        let (a, b) = self.deeply_resolve_ignoring_regions((a, b));
         SameTypeModuloInfer(self).relate(a, b).is_ok()
     }
 }

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -88,7 +88,7 @@ impl InferenceDiagnosticsData {
             ""
         } else if self.name == "_" {
             let displayed_ty = infcx
-                .resolve_vars_if_possible(in_type)
+                .deeply_resolve_ignoring_regions(in_type)
                 .fold_with(&mut ClosureEraser { infcx, depth: 0 });
             if displayed_ty.is_ty_or_numeric_infer() {
                 ""
@@ -308,7 +308,7 @@ fn ty_to_string<'tcx>(
     called_method_def_id: Option<DefId>,
 ) -> String {
     let mut p = fmt_printer(infcx, Namespace::TypeNS);
-    let ty = infcx.resolve_vars_if_possible(ty);
+    let ty = infcx.deeply_resolve_ignoring_regions(ty);
     // We use `fn` ptr syntax for closures, but this only works when the closure does not capture
     // anything. We also remove all type parameters that are fully known to the type system.
     let ty = ty.fold_with(&mut ClosureEraser { infcx, depth: 0 });
@@ -507,7 +507,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         should_label_span: bool,
         ty: Option<Ty<'tcx>>,
     ) -> Diag<'a> {
-        let term = self.resolve_vars_if_possible(term);
+        let term = self.deeply_resolve_ignoring_regions(term);
         let arg_data = self
             .extract_inference_diagnostics_data(term, ty::print::RegionHighlightMode::default());
 
@@ -1019,12 +1019,12 @@ impl<'a, 'tcx> FindInferSourceVisitor<'a, 'tcx> {
 
     fn node_args_opt(&self, hir_id: HirId) -> Option<GenericArgsRef<'tcx>> {
         let args = self.typeck_results.node_args_opt(hir_id);
-        self.tecx.resolve_vars_if_possible(args)
+        self.tecx.deeply_resolve_ignoring_regions(args)
     }
 
     fn opt_node_type(&self, hir_id: HirId) -> Option<Ty<'tcx>> {
         let ty = self.typeck_results.node_type_opt(hir_id);
-        self.tecx.resolve_vars_if_possible(ty)
+        self.tecx.deeply_resolve_ignoring_regions(ty)
     }
 
     // Check whether this generic argument is the inference variable we
@@ -1412,7 +1412,7 @@ impl<'a, 'tcx> Visitor<'tcx> for FindInferSourceVisitor<'a, 'tcx> {
                 .iter()
                 .position(|&arg| self.generic_arg_contains_target(arg))
             {
-                let args = self.tecx.resolve_vars_if_possible(args);
+                let args = self.tecx.deeply_resolve_ignoring_regions(args);
                 let generic_args =
                     &generics.own_args_no_defaults(tcx, args)[generics.own_counts().lifetimes..];
                 let span = match expr.kind {
@@ -1493,7 +1493,7 @@ impl<'a, 'tcx> Visitor<'tcx> for FindInferSourceVisitor<'a, 'tcx> {
         {
             let successor =
                 method_args.get(0).map_or_else(|| (")", span.hi()), |arg| (", ", arg.span.lo()));
-            let args = self.tecx.resolve_vars_if_possible(args);
+            let args = self.tecx.deeply_resolve_ignoring_regions(args);
             self.update_infer_source(InferSource {
                 span: path.ident.span,
                 kind: InferSourceKind::FullyQualifiedMethodCall {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
@@ -271,16 +271,12 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
                 (false, None, None, Some(span), String::new())
             };
 
-        let expected_trait_ref = self.cx.resolve_vars_if_possible(ty::TraitRef::new_from_args(
-            self.cx.tcx,
-            trait_def_id,
-            expected_args,
-        ));
-        let actual_trait_ref = self.cx.resolve_vars_if_possible(ty::TraitRef::new_from_args(
-            self.cx.tcx,
-            trait_def_id,
-            actual_args,
-        ));
+        let expected_trait_ref = self.cx.deeply_resolve_ignoring_regions(
+            ty::TraitRef::new_from_args(self.cx.tcx, trait_def_id, expected_args),
+        );
+        let actual_trait_ref = self.cx.deeply_resolve_ignoring_regions(
+            ty::TraitRef::new_from_args(self.cx.tcx, trait_def_id, actual_args),
+        );
 
         // Search the expected and actual trait references to see (a)
         // whether the sub/sup placeholders appear in them (sometimes
@@ -400,7 +396,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
         // the confusing lifetime-generality error into an actionable hint, e.g.:
         //   |buf|  →  |buf: &mut [u8]|
         if self.tcx().is_fn_trait(trait_def_id) {
-            let actual_self_ty = self.cx.resolve_vars_if_possible(
+            let actual_self_ty = self.cx.deeply_resolve_ignoring_regions(
                 ty::TraitRef::new_from_args(self.cx.tcx, trait_def_id, actual_args).self_ty(),
             );
             if let ty::Closure(closure_def_id, _) = *actual_self_ty.kind()

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
@@ -990,7 +990,7 @@ fn foo(&self) -> Self::T { String::new() }
         msg: impl Fn() -> String,
         is_bound_surely_present: bool,
     ) -> bool {
-        // FIXME: we would want to call `resolve_vars_if_possible` on `ty` before suggesting.
+        // FIXME: we would want to call `deeply_resolve_ignoring_regions` on `ty` before suggesting.
 
         let trait_bounds = bounds.iter().filter_map(|bound| match bound {
             hir::GenericBound::Trait(ptr) if ptr.modifiers == hir::TraitBoundModifiers::NONE => {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -430,7 +430,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 );
                 self.dcx().create_err(FulfillReqLifetime {
                     span,
-                    ty: self.resolve_vars_if_possible(ty),
+                    ty: self.deeply_resolve_ignoring_regions(ty),
                     note,
                 })
             }
@@ -495,7 +495,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 );
                 self.dcx().create_err(RefLongerThanData {
                     span,
-                    ty: self.resolve_vars_if_possible(ty),
+                    ty: self.deeply_resolve_ignoring_regions(ty),
                     notes: pointer_valid.into_iter().chain(data_valid).collect(),
                 })
             }

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
@@ -48,8 +48,8 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         second_span: Span,
     ) -> Option<SuggestRemoveSemiOrReturnBinding> {
         let remove_semicolon = [
-            (first_id, self.resolve_vars_if_possible(second_ty)),
-            (second_id, self.resolve_vars_if_possible(first_ty)),
+            (first_id, self.deeply_resolve_ignoring_regions(second_ty)),
+            (second_id, self.deeply_resolve_ignoring_regions(first_ty)),
         ]
         .into_iter()
         .find_map(|(id, ty)| {
@@ -926,7 +926,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     .as_ref()
                     .and_then(|typeck_results| typeck_results.node_type_opt(*hir_id))
             {
-                let pat_ty = self.resolve_vars_if_possible(pat_ty);
+                let pat_ty = self.deeply_resolve_ignoring_regions(pat_ty);
                 if self.same_type_modulo_infer(pat_ty, expected_ty)
                     && !(pat_ty, expected_ty).references_error()
                     && shadowed.insert(ident.name)

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
@@ -213,7 +213,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         // ambiguous impls. The latter *ought* to be a
         // coherence violation, so we don't report it here.
 
-        let predicate = self.resolve_vars_if_possible(obligation.predicate);
+        let predicate = self.deeply_resolve_ignoring_regions(obligation.predicate);
         let span = obligation.cause.span;
         let mut long_ty_path = None;
 
@@ -711,7 +711,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let mut mentioned = vec![predicate];
         let mut mentioned_strs: Vec<String> = vec![];
         for &error in related {
-            let related_pred = self.resolve_vars_if_possible(error.obligation.predicate);
+            let related_pred = self.deeply_resolve_ignoring_regions(error.obligation.predicate);
             if mentioned.contains(&related_pred) {
                 continue;
             }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -111,8 +111,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 let bound_predicate = obligation.predicate.kind();
                 match bound_predicate.skip_binder() {
                     ty::PredicateKind::Clause(ty::ClauseKind::Trait(trait_predicate)) => {
-                        let leaf_trait_predicate =
-                            self.resolve_vars_if_possible(bound_predicate.rebind(trait_predicate));
+                        let leaf_trait_predicate = self.deeply_resolve_ignoring_regions(
+                            bound_predicate.rebind(trait_predicate),
+                        );
 
                         // Let's use the root obligation as the main message, when we care about the
                         // most general case ("X doesn't implement Pattern<'_>") over the case that
@@ -153,7 +154,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             && !self.tcx.is_lang_item(root_pred.def_id(), LangItem::Unsize)
                             {
                                 (
-                                    self.resolve_vars_if_possible(
+                                    self.deeply_resolve_ignoring_regions(
                                         root_obligation.predicate.kind().rebind(root_pred),
                                     ),
                                     root_obligation,
@@ -710,7 +711,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     }
 
                     ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(ty)) => {
-                        let ty = self.resolve_vars_if_possible(ty);
+                        let ty = self.deeply_resolve_ignoring_regions(ty);
                         if self.next_trait_solver() {
                             if let Err(guar) = ty.error_reported() {
                                 return guar;
@@ -1202,7 +1203,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let noted_missing_impl =
             self.note_missing_impl_for_question_mark(err, self_ty, found_ty, trait_pred);
 
-        let mut prev_ty = self.resolve_vars_if_possible(
+        let mut prev_ty = self.deeply_resolve_ignoring_regions(
             typeck.expr_ty_adjusted_opt(expr).unwrap_or(Ty::new_misc_error(self.tcx)),
         );
 
@@ -1234,7 +1235,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             expr = rcvr_expr;
             chain.push((span, prev_ty));
 
-            let next_ty = self.resolve_vars_if_possible(
+            let next_ty = self.deeply_resolve_ignoring_regions(
                 typeck.expr_ty_adjusted_opt(expr).unwrap_or(Ty::new_misc_error(self.tcx)),
             );
 
@@ -1277,7 +1278,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // The last statement is of a type that can be converted to the return error type
                 && let [.., stmt] = block.stmts
                 && let hir::StmtKind::Semi(expr) = stmt.kind
-                && let expr_ty = self.resolve_vars_if_possible(
+                && let expr_ty = self.deeply_resolve_ignoring_regions(
                     typeck.expr_ty_adjusted_opt(expr)
                         .unwrap_or(Ty::new_misc_error(self.tcx)),
                 )
@@ -1322,7 +1323,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         // `expr` is now the "root" expression of the method call chain, which can be any
         // expression kind, like a method call or a path. If this expression is `Result<T, E>` as
         // well, then we also point at it.
-        prev_ty = self.resolve_vars_if_possible(
+        prev_ty = self.deeply_resolve_ignoring_regions(
             typeck.expr_ty_adjusted_opt(expr).unwrap_or(Ty::new_misc_error(self.tcx)),
         );
         chain.push((expr.span, prev_ty));
@@ -1669,7 +1670,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         obligation: &PredicateObligation<'tcx>,
         error: &MismatchedProjectionTypes<'tcx>,
     ) -> ErrorGuaranteed {
-        let predicate = self.resolve_vars_if_possible(obligation.predicate);
+        let predicate = self.deeply_resolve_ignoring_regions(obligation.predicate);
 
         if let Err(e) = predicate.error_reported() {
             return e;
@@ -1710,7 +1711,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         (
                             Some((
                                 data.projection_term,
-                                self.resolve_vars_if_possible(normalized_term),
+                                self.deeply_resolve_ignoring_regions(normalized_term),
                                 data.term,
                             )),
                             new_err,
@@ -1737,8 +1738,10 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     (
                         with_forced_trimmed_paths!(format!(
                             "type mismatch resolving `{}`",
-                            self.tcx
-                                .short_string(self.resolve_vars_if_possible(predicate), &mut file),
+                            self.tcx.short_string(
+                                self.deeply_resolve_ignoring_regions(predicate),
+                                &mut file
+                            ),
                         )),
                         obligation.cause.span,
                         None,
@@ -1872,7 +1875,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         with_forced_trimmed_paths!(Cow::from(format!(
                             "type mismatch resolving `{}`",
                             self.tcx.short_string(
-                                self.resolve_vars_if_possible(predicate),
+                                self.deeply_resolve_ignoring_regions(predicate),
                                 diag.long_ty_path()
                             ),
                         ))),
@@ -2280,7 +2283,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         return false;
                     }
 
-                    let impl_trait_ref = self.resolve_vars_if_possible(impl_trait_ref);
+                    let impl_trait_ref = self.deeply_resolve_ignoring_regions(impl_trait_ref);
                     if impl_trait_ref.references_error() {
                         return false;
                     }
@@ -2362,7 +2365,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     err.highlighted_span_help(self.tcx.def_span(single.impl_def_id), msg);
 
                     if let [TypeError::Sorts(exp_found)] = &terrs[..] {
-                        let exp_found = self.resolve_vars_if_possible(*exp_found);
+                        let exp_found = self.deeply_resolve_ignoring_regions(*exp_found);
                         let expected =
                             self.tcx.short_string(exp_found.expected, err.long_ty_path());
                         let found = self.tcx.short_string(exp_found.found, err.long_ty_path());
@@ -2783,7 +2786,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     ) -> Option<(Ty<'tcx>, Option<Span>)> {
         match code {
             ObligationCauseCode::BuiltinDerived(data) => {
-                let parent_trait_ref = self.resolve_vars_if_possible(data.parent_trait_pred);
+                let parent_trait_ref = self.deeply_resolve_ignoring_regions(data.parent_trait_pred);
                 match self.get_parent_trait_ref(&data.parent_code) {
                     Some(t) => Some(t),
                     None => {
@@ -3117,7 +3120,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         cause_code: &ObligationCauseCode<'tcx>,
     ) -> bool {
         if let ObligationCauseCode::BuiltinDerived(data) = cause_code {
-            let parent_trait_ref = self.resolve_vars_if_possible(data.parent_trait_pred);
+            let parent_trait_ref = self.deeply_resolve_ignoring_regions(data.parent_trait_pred);
             let self_ty = parent_trait_ref.skip_binder().self_ty();
             if obligated_types.iter().any(|ot| ot == &self_ty) {
                 return true;
@@ -3646,8 +3649,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         found_trait_ref: ty::TraitRef<'tcx>,
         expected_trait_ref: ty::TraitRef<'tcx>,
     ) -> Result<Diag<'a>, ErrorGuaranteed> {
-        let found_trait_ref = self.resolve_vars_if_possible(found_trait_ref);
-        let expected_trait_ref = self.resolve_vars_if_possible(expected_trait_ref);
+        let found_trait_ref = self.deeply_resolve_ignoring_regions(found_trait_ref);
+        let expected_trait_ref = self.deeply_resolve_ignoring_regions(expected_trait_ref);
 
         expected_trait_ref.self_ty().error_reported()?;
         let found_trait_ty = found_trait_ref.self_ty();
@@ -3962,7 +3965,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         self.tcx
                             .fn_trait_kind_from_def_id(trait_def_id)
                             .expect("expected to map DefId to ClosureKind"),
-                        ty.rebind(self.resolve_vars_if_possible(var)),
+                        ty.rebind(self.deeply_resolve_ignoring_regions(var)),
                     ));
                 }
             }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -280,7 +280,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         // roots, like `need_type_info` does when looking for the annotation source.
         let ambiguity_infer_var = |error: &FulfillmentError<'tcx>| match error.code {
             FulfillmentErrorCode::Ambiguity { overflow: None } => self
-                .ambiguity_term(self.resolve_vars_if_possible(error.obligation.predicate))
+                .ambiguity_term(self.deeply_resolve_ignoring_regions(error.obligation.predicate))
                 .and_then(|term| {
                     ty::GenericArg::from(term)
                         .walk()

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
@@ -77,7 +77,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
         let mut err = match cause {
             OverflowCause::DeeplyNormalize(alias_term) => {
-                let alias_term = self.resolve_vars_if_possible(alias_term);
+                let alias_term = self.deeply_resolve_ignoring_regions(alias_term);
                 let kind = alias_term.kind.descr();
                 let alias_str = with_short_path(self.tcx, alias_term);
                 struct_span_code_err!(
@@ -88,7 +88,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 )
             }
             OverflowCause::TraitSolver(predicate) => {
-                let predicate = self.resolve_vars_if_possible(predicate);
+                let predicate = self.deeply_resolve_ignoring_regions(predicate);
                 match predicate.kind().skip_binder() {
                     ty::PredicateKind::Subtype(ty::SubtypePredicate { a, b, a_is_expected: _ })
                     | ty::PredicateKind::Coerce(ty::CoercePredicate { a, b }) => {
@@ -143,7 +143,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         T: Upcast<TyCtxt<'tcx>, ty::Predicate<'tcx>> + Clone,
     {
         let predicate = obligation.predicate.clone().upcast(self.tcx);
-        let predicate = self.resolve_vars_if_possible(predicate);
+        let predicate = self.deeply_resolve_ignoring_regions(predicate);
         self.report_overflow_error(
             OverflowCause::TraitSolver(predicate),
             obligation.cause.span,
@@ -168,7 +168,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     /// we do not suggest increasing the overflow limit, which is not
     /// going to help).
     pub fn report_overflow_obligation_cycle(&self, cycle: &[PredicateObligation<'tcx>]) -> ! {
-        let cycle = self.resolve_vars_if_possible(cycle.to_owned());
+        let cycle = self.deeply_resolve_ignoring_regions(cycle.to_owned());
         assert!(!cycle.is_empty());
 
         debug!(?cycle, "report_overflow_error_cycle");
@@ -186,7 +186,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         obligation: PredicateObligation<'tcx>,
         suggest_increasing_limit: bool,
     ) -> ErrorGuaranteed {
-        let obligation = self.resolve_vars_if_possible(obligation);
+        let obligation = self.deeply_resolve_ignoring_regions(obligation);
         let mut err = self.build_overflow_error(
             OverflowCause::TraitSolver(obligation.predicate),
             obligation.cause.span,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -82,7 +82,7 @@ impl<'a, 'tcx> CoroutineData<'a, 'tcx> {
         infer_context.tcx.upvars_mentioned(coroutine_did).and_then(|upvars| {
             upvars.iter().find_map(|(upvar_id, upvar)| {
                 let upvar_ty = self.0.node_type(*upvar_id);
-                let upvar_ty = infer_context.resolve_vars_if_possible(upvar_ty);
+                let upvar_ty = infer_context.deeply_resolve_ignoring_regions(upvar_ty);
                 ty_matches(ty::Binder::dummy(upvar_ty))
                     .then(|| CoroutineInteriorOrUpvar::Upvar(upvar.span))
             })
@@ -328,7 +328,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let Some(base_ty) = typeck_results.expr_ty_opt(base_expr) else {
             return;
         };
-        let base_ty = self.resolve_vars_if_possible(base_ty);
+        let base_ty = self.deeply_resolve_ignoring_regions(base_ty);
         if base_ty.references_error() {
             return;
         }
@@ -1357,7 +1357,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             err.span_label(block.span, "this block is missing a tail expression");
             return;
         };
-        let ty = self.resolve_numeric_literals_with_default(self.resolve_vars_if_possible(ty));
+        let ty =
+            self.resolve_numeric_literals_with_default(self.deeply_resolve_ignoring_regions(ty));
         let trait_pred_and_self = trait_pred.map_bound(|trait_pred| (trait_pred, ty));
 
         let new_obligation =
@@ -1382,7 +1383,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         err: &mut Diag<'_>,
         trait_pred: ty::PolyTraitClause<'tcx>,
     ) -> bool {
-        let self_ty = self.resolve_vars_if_possible(trait_pred.self_ty());
+        let self_ty = self.deeply_resolve_ignoring_regions(trait_pred.self_ty());
         self.enter_forall(self_ty, |ty: Ty<'_>| {
             let Some(generics) = self.tcx.hir_get_generics(obligation.cause.body_def_id) else {
                 return false;
@@ -2498,7 +2499,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // Do not suggest removal of borrow from type arguments.
                 return;
             }
-            let trait_pred = self.resolve_vars_if_possible(trait_pred);
+            let trait_pred = self.deeply_resolve_ignoring_regions(trait_pred);
             if trait_pred.has_non_region_infer() {
                 // Do not ICE while trying to find if a reborrow would succeed on a trait with
                 // unresolved bindings.
@@ -2604,7 +2605,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             // Only suggest this if the expression behind the semicolon implements the predicate
             && let Some(typeck_results) = &self.typeck_results
             && let Some(ty) =
-                typeck_results.expr_ty_opt(expr).map(|ty| self.resolve_vars_if_possible(ty))
+                typeck_results.expr_ty_opt(expr).map(|ty| self.deeply_resolve_ignoring_regions(ty))
             && self.predicate_may_hold(&self.mk_trait_obligation_with_new_self_ty(
                 obligation.param_env, trait_pred.map_bound(|trait_pred| (trait_pred, ty))
             ))
@@ -2716,7 +2717,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 hir::ExprKind::Closure(closure) => closure.def_id,
                 _ => match typeck_results
                     .expr_ty_adjusted_opt(arg)
-                    .map(|ty| *self.resolve_vars_if_possible(ty).peel_refs().kind())
+                    .map(|ty| *self.deeply_resolve_ignoring_regions(ty).peel_refs().kind())
                 {
                     Some(ty::Closure(def_id, _)) => def_id.as_local()?,
                     _ => return None,
@@ -3795,10 +3796,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
 
         let capture_ty =
-            self.tcx.erase_and_anonymize_regions(self.resolve_vars_if_possible(capture_ty));
+            self.tcx.erase_and_anonymize_regions(self.deeply_resolve_ignoring_regions(capture_ty));
         let Some(capture) = captures.iter().zip(upvar_tys).find_map(|(&capture, upvar_ty)| {
-            let upvar_ty =
-                self.tcx.erase_and_anonymize_regions(self.resolve_vars_if_possible(upvar_ty));
+            let upvar_ty = self
+                .tcx
+                .erase_and_anonymize_regions(self.deeply_resolve_ignoring_regions(upvar_ty));
             (upvar_ty == capture_ty).then_some(capture)
         }) else {
             return false;
@@ -4133,10 +4135,10 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 }
             }
             ObligationCauseCode::Coercion { source, target } => {
-                let source =
-                    tcx.short_string(self.resolve_vars_if_possible(source), err.long_ty_path());
-                let target =
-                    tcx.short_string(self.resolve_vars_if_possible(target), err.long_ty_path());
+                let source = tcx
+                    .short_string(self.deeply_resolve_ignoring_regions(source), err.long_ty_path());
+                let target = tcx
+                    .short_string(self.deeply_resolve_ignoring_regions(target), err.long_ty_path());
                 err.note(with_forced_trimmed_paths!(format!(
                     "required for the cast from `{source}` to `{target}`",
                 )));
@@ -4408,7 +4410,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 err.note("shared static variables must have a type that implements `Sync`");
             }
             ObligationCauseCode::BuiltinDerived(ref data) => {
-                let parent_trait_ref = self.resolve_vars_if_possible(data.parent_trait_pred);
+                let parent_trait_ref = self.deeply_resolve_ignoring_regions(data.parent_trait_pred);
                 let ty = parent_trait_ref.skip_binder().self_ty();
                 if parent_trait_ref.references_error() {
                     // NOTE(eddyb) this was `.cancel()`, but `err`
@@ -4422,7 +4424,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 let is_upvar_tys_infer_tuple = if !matches!(ty.kind(), ty::Tuple(..)) {
                     false
                 } else if let ObligationCauseCode::BuiltinDerived(data) = &*data.parent_code {
-                    let parent_trait_ref = self.resolve_vars_if_possible(data.parent_trait_pred);
+                    let parent_trait_ref =
+                        self.deeply_resolve_ignoring_regions(data.parent_trait_pred);
                     let nested_ty = parent_trait_ref.skip_binder().self_ty();
                     matches!(nested_ty.kind(), ty::Coroutine(..))
                         || matches!(nested_ty.kind(), ty::Closure(..))
@@ -4559,7 +4562,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
             ObligationCauseCode::ImplDerived(ref data) => {
                 let mut parent_trait_pred =
-                    self.resolve_vars_if_possible(data.derived.parent_trait_pred);
+                    self.deeply_resolve_ignoring_regions(data.derived.parent_trait_pred);
                 let parent_def_id = parent_trait_pred.def_id();
                 if tcx.is_diagnostic_item(sym::FromResidual, parent_def_id)
                     && !tcx.features().enabled(sym::try_trait_v2)
@@ -4571,7 +4574,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 }
                 if tcx.is_diagnostic_item(sym::PinDerefMutHelper, parent_def_id) {
                     let parent_predicate =
-                        self.resolve_vars_if_possible(data.derived.parent_trait_pred);
+                        self.deeply_resolve_ignoring_regions(data.derived.parent_trait_pred);
 
                     // Skip PinDerefMutHelper in suggestions, but still show downstream suggestions.
 
@@ -4697,7 +4700,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     // the type `X`", like we would otherwise do in test `supertrait-auto-trait.rs`.
                     while let ObligationCauseCode::BuiltinDerived(derived) = &*data.parent_code {
                         let child_trait_ref =
-                            self.resolve_vars_if_possible(derived.parent_trait_pred);
+                            self.deeply_resolve_ignoring_regions(derived.parent_trait_pred);
                         let child_def_id = child_trait_ref.def_id();
                         if seen_requirements.insert(child_def_id) {
                             break;
@@ -4710,7 +4713,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 while let ObligationCauseCode::ImplDerived(child) = &*data.parent_code {
                     // Skip redundant recursive obligation notes. See `ui/issue-20413.rs`.
                     let child_trait_pred =
-                        self.resolve_vars_if_possible(child.derived.parent_trait_pred);
+                        self.deeply_resolve_ignoring_regions(child.derived.parent_trait_pred);
                     let child_def_id = child_trait_pred.def_id();
                     if seen_requirements.insert(child_def_id) {
                         break;
@@ -4750,7 +4753,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
             ObligationCauseCode::ImplDerivedHost(ref data) => {
                 let self_ty = tcx.short_string(
-                    self.resolve_vars_if_possible(data.derived.parent_host_clause.self_ty()),
+                    self.deeply_resolve_ignoring_regions(data.derived.parent_host_clause.self_ty()),
                     err.long_ty_path(),
                 );
                 let trait_path = tcx.short_string(
@@ -4804,7 +4807,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 );
             }
             ObligationCauseCode::WellFormedDerived(ref data) => {
-                let parent_trait_ref = self.resolve_vars_if_possible(data.parent_trait_pred);
+                let parent_trait_ref = self.deeply_resolve_ignoring_regions(data.parent_trait_pred);
                 let parent_predicate = parent_trait_ref;
 
                 *closure_capture_ty = Some(parent_trait_ref.skip_binder().self_ty());
@@ -4979,7 +4982,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     ) {
         let future_trait = self.tcx.require_lang_item(LangItem::Future, span);
 
-        let self_ty = self.resolve_vars_if_possible(trait_pred.self_ty());
+        let self_ty = self.deeply_resolve_ignoring_regions(trait_pred.self_ty());
         let impls_future = self.type_implements_trait(
             future_trait,
             [self.tcx.instantiate_bound_regions_with_erased(self_ty)],
@@ -5005,7 +5008,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             .normalize(Unnormalized::new_wip(projection_ty));
 
         debug!(
-            normalized_projection_type = ?self.resolve_vars_if_possible(projection_ty)
+            normalized_projection_type = ?self.deeply_resolve_ignoring_regions(projection_ty)
         );
         let try_obligation = self.mk_trait_obligation_with_new_self_ty(
             obligation.param_env,
@@ -5646,7 +5649,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let mut print_root_expr = true;
         let mut assocs = vec![];
         let mut expr = expr;
-        let mut prev_ty = self.resolve_vars_if_possible(
+        let mut prev_ty = self.deeply_resolve_ignoring_regions(
             typeck_results.expr_ty_adjusted_opt(expr).unwrap_or(Ty::new_misc_error(tcx)),
         );
         while let hir::ExprKind::MethodCall(path_segment, rcvr_expr, args, span) = expr.kind {
@@ -5656,7 +5659,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             expr = rcvr_expr;
             let assocs_in_this_method =
                 self.probe_assoc_types_at_expr(&type_diffs, span, prev_ty, expr.hir_id, param_env);
-            prev_ty = self.resolve_vars_if_possible(
+            prev_ty = self.deeply_resolve_ignoring_regions(
                 typeck_results.expr_ty_adjusted_opt(expr).unwrap_or(Ty::new_misc_error(tcx)),
             );
             self.look_for_iterator_item_mistakes(
@@ -5685,7 +5688,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 }
                 if let hir::Node::Param(param) = parent {
                     // ...and it is an fn argument.
-                    let prev_ty = self.resolve_vars_if_possible(
+                    let prev_ty = self.deeply_resolve_ignoring_regions(
                         typeck_results
                             .node_type_opt(param.hir_id)
                             .unwrap_or(Ty::new_misc_error(tcx)),
@@ -5850,7 +5853,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 projection,
             ));
             if ocx.try_evaluate_obligations().no_errors()
-                && let ty = self.resolve_vars_if_possible(ty)
+                && let ty = self.deeply_resolve_ignoring_regions(ty)
                 && !ty.is_ty_var()
             {
                 assocs_in_this_method.push(Some((span, (def_id, ty))));
@@ -5939,7 +5942,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
             // Resolve what each bound associated type actually is for the returned expression,
             // and keep only the ones that diverged from the signature.
-            let expr_ty = self.resolve_vars_if_possible(
+            let expr_ty = self.deeply_resolve_ignoring_regions(
                 typeck_results.expr_ty_adjusted_opt(expr).unwrap_or(Ty::new_misc_error(tcx)),
             );
             let assocs = self.probe_assoc_types_at_expr(
@@ -6098,7 +6101,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let hir::ExprKind::MethodCall(segment, rcvr, args, ..) = call.kind else { return };
         let Some(typeck) = &self.typeck_results else { return };
         let Some(rcvr_ty) = typeck.expr_ty_adjusted_opt(rcvr) else { return };
-        let rcvr_ty = self.resolve_vars_if_possible(rcvr_ty);
+        let rcvr_ty = self.deeply_resolve_ignoring_regions(rcvr_ty);
         let autoderef = (self.autoderef_steps)(rcvr_ty);
         for (ty, def_id) in autoderef.iter().filter_map(|(ty, obligations)| {
             if let ty::Adt(def, _) = ty.kind()

--- a/compiler/rustc_trait_selection/src/infer.rs
+++ b/compiler/rustc_trait_selection/src/infer.rs
@@ -31,13 +31,13 @@ impl<'tcx> InferCtxt<'tcx> {
     }
 
     fn type_is_copy_modulo_regions(&self, param_env: ty::ParamEnv<'tcx>, ty: Ty<'tcx>) -> bool {
-        let ty = self.resolve_vars_if_possible(ty);
+        let ty = self.deeply_resolve_ignoring_regions(ty);
         let copy_def_id = self.tcx.require_lang_item(LangItem::Copy, DUMMY_SP);
         traits::type_known_to_meet_bound_modulo_regions(self, param_env, ty, copy_def_id)
     }
 
     fn type_is_clone_modulo_regions(&self, param_env: ty::ParamEnv<'tcx>, ty: Ty<'tcx>) -> bool {
-        let ty = self.resolve_vars_if_possible(ty);
+        let ty = self.deeply_resolve_ignoring_regions(ty);
         let clone_def_id = self.tcx.require_lang_item(LangItem::Clone, DUMMY_SP);
         traits::type_known_to_meet_bound_modulo_regions(self, param_env, ty, clone_def_id)
     }
@@ -47,7 +47,7 @@ impl<'tcx> InferCtxt<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
         ty: Ty<'tcx>,
     ) -> bool {
-        let ty = self.resolve_vars_if_possible(ty);
+        let ty = self.deeply_resolve_ignoring_regions(ty);
         let use_cloned_def_id = self.tcx.require_lang_item(LangItem::UseCloned, DUMMY_SP);
         traits::type_known_to_meet_bound_modulo_regions(self, param_env, ty, use_cloned_def_id)
     }

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -176,7 +176,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                 } else if trait_pred.polarity() == ty::ClausePolarity::Positive {
                     match self.0.tcx.as_lang_item(trait_pred.def_id()) {
                         Some(LangItem::Sized) | Some(LangItem::MetaSized) => {
-                            let predicate = self.resolve_vars_if_possible(goal.predicate);
+                            let predicate = self.deeply_resolve_ignoring_regions(goal.predicate);
                             if sizedness_fast_path(self.tcx, predicate, goal.param_env) {
                                 Outcome::TriviallyHolds
                             } else {
@@ -184,8 +184,9 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                             }
                         }
                         Some(LangItem::Copy | LangItem::Clone) => {
-                            let self_ty =
-                                self.resolve_vars_if_possible(trait_pred.self_ty().skip_binder());
+                            let self_ty = self.deeply_resolve_ignoring_regions(
+                                trait_pred.self_ty().skip_binder(),
+                            );
                             // Unlike `Sized` traits, which always prefer the built-in impl,
                             // `Copy`/`Clone` may be shadowed by a param-env candidate which
                             // could force a lifetime error or guide inference. While that's
@@ -227,7 +228,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                     return Outcome::NoFastPath;
                 }
 
-                let ty = self.resolve_vars_if_possible(outlives.0);
+                let ty = self.deeply_resolve_ignoring_regions(outlives.0);
                 let mut infer_collector = CollectNonRegionInfer {
                     infers: Default::default(),
                     visited: Default::default(),
@@ -464,7 +465,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
                 | TypingMode::Reflection
                 | TypingMode::PostBorrowck { .. } => false,
                 TypingMode::PostAnalysis | TypingMode::Codegen => {
-                    let poly_trait_ref = self.resolve_vars_if_possible(goal_trait_ref);
+                    let poly_trait_ref = self.deeply_resolve_ignoring_regions(goal_trait_ref);
                     !poly_trait_ref.still_further_specializable()
                 }
                 TypingMode::ErasedNotCoherence(MayBeErased) => {
@@ -519,7 +520,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
 
     fn emit_next_solver_overflow_fcw(&self, goal: Goal<'tcx, ty::Predicate<'tcx>>, span: Span) {
         let tcx = self.tcx;
-        let goal = self.resolve_vars_if_possible(goal);
+        let goal = self.deeply_resolve_ignoring_regions(goal);
         let mut visitor = OverflowedGoalChain {
             span,
             predicates: vec![],

--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -141,7 +141,7 @@ pub(super) fn try_ambiguity_error_for_stalled<'tcx>(
                     root_obligation.cause.span,
                     format!(
                         "did not expect successful goal when collecting ambiguity errors for `{:?}`",
-                        infcx.resolve_vars_if_possible(root_obligation.predicate),
+                        infcx.deeply_resolve_ignoring_regions(root_obligation.predicate),
                     ),
                 );
                 None
@@ -150,7 +150,7 @@ pub(super) fn try_ambiguity_error_for_stalled<'tcx>(
                 span_bug!(
                     root_obligation.cause.span,
                     "did not expect selection error when collecting ambiguity errors for `{:?}`",
-                    infcx.resolve_vars_if_possible(root_obligation.predicate),
+                    infcx.deeply_resolve_ignoring_regions(root_obligation.predicate),
                 )
             }
         }
@@ -178,7 +178,7 @@ fn find_best_leaf_obligation<'tcx>(
     obligation: &PredicateObligation<'tcx>,
     consider_ambiguities: bool,
 ) -> PredicateObligation<'tcx> {
-    let obligation = infcx.resolve_vars_if_possible(obligation.clone());
+    let obligation = infcx.deeply_resolve_ignoring_regions(obligation.clone());
     // FIXME: we use a probe here as the `BestObligation` visitor does not
     // check whether it uses candidates which get shadowed by where-bounds.
     //

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -14,7 +14,7 @@ use std::assert_matches;
 use rustc_infer::infer::InferCtxt;
 use rustc_macros::extension;
 use rustc_middle::traits::solve::{Certainty, Goal, GoalSource, NoSolution, QueryResult};
-use rustc_middle::ty::{RequiredDepth, TyCtxt, VisitorResult, eager_resolve_vars, try_visit};
+use rustc_middle::ty::{RequiredDepth, TyCtxt, VisitorResult, deeply_resolve_via_unification_table, try_visit};
 use rustc_middle::{bug, ty};
 use rustc_next_trait_solver::canonical::instantiate_canonical_state;
 use rustc_next_trait_solver::solve::{MaybeCause, MaybeInfo, SolverDelegateEvalExt as _, inspect};
@@ -170,7 +170,7 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
                         self.final_state,
                     );
 
-                    return eager_resolve_vars(&**infcx, impl_args);
+                    return deeply_resolve_via_unification_table(&**infcx, impl_args);
                 }
                 inspect::ProbeStep::AddGoal(..) => {}
                 inspect::ProbeStep::MakeCanonicalResponse { .. }
@@ -361,7 +361,7 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
             depth,
             orig_values,
             prev_universe,
-            goal: eager_resolve_vars(&**infcx, uncanonicalized_goal),
+            goal: deeply_resolve_via_unification_table(&**infcx, uncanonicalized_goal),
             result,
             final_revision,
             source,

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -14,7 +14,7 @@ use std::assert_matches;
 use rustc_infer::infer::InferCtxt;
 use rustc_macros::extension;
 use rustc_middle::traits::solve::{Certainty, Goal, GoalSource, NoSolution, QueryResult};
-use rustc_middle::ty::{RequiredDepth, TyCtxt, VisitorResult, deeply_resolve_via_unification_table, try_visit};
+use rustc_middle::ty::{RequiredDepth, TyCtxt, VisitorResult, try_visit};
 use rustc_middle::{bug, ty};
 use rustc_next_trait_solver::canonical::instantiate_canonical_state;
 use rustc_next_trait_solver::solve::{MaybeCause, MaybeInfo, SolverDelegateEvalExt as _, inspect};
@@ -145,6 +145,8 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
         fields(goal = ?self.goal.goal, steps = ?self.steps)
     )]
     pub fn instantiate_impl_args(&self, span: Span) -> ty::GenericArgsRef<'tcx> {
+        use rustc_middle::ty::InferCtxtLike;
+
         let infcx = self.goal.infcx;
         let param_env = self.goal.goal.param_env;
         let mut orig_values = self.goal.orig_values.clone();
@@ -170,7 +172,10 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
                         self.final_state,
                     );
 
-                    return deeply_resolve_via_unification_table(&**infcx, impl_args);
+                    // We *want* this folder to live in `rustc_type_ir`. Our best way to call into it is
+                    // through `InferCtxtLike` and it is not defined as an inherent method on `InferCtxt`.
+                    #[allow(rustc::usage_of_type_ir_traits)]
+                    return infcx.deeply_resolve_via_unification_table(impl_args);
                 }
                 inspect::ProbeStep::AddGoal(..) => {}
                 inspect::ProbeStep::MakeCanonicalResponse { .. }
@@ -342,6 +347,8 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
         root: inspect::GoalEvaluation<TyCtxt<'tcx>>,
         source: GoalSource,
     ) -> Self {
+        use rustc_middle::ty::InferCtxtLike;
+
         let infcx = <&SolverDelegate<'tcx>>::from(infcx);
         let prev_universe = infcx.universe();
 
@@ -361,7 +368,10 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
             depth,
             orig_values,
             prev_universe,
-            goal: deeply_resolve_via_unification_table(&**infcx, uncanonicalized_goal),
+            // We *want* this folder to live in `rustc_type_ir`. Our best way to call into it is
+            // through `InferCtxtLike` and it is not defined as an inherent method on `InferCtxt`.
+            #[allow(rustc::usage_of_type_ir_traits)]
+            goal: infcx.deeply_resolve_via_unification_table(uncanonicalized_goal),
             result,
             final_revision,
             source,

--- a/compiler/rustc_trait_selection/src/solve/normalize.rs
+++ b/compiler/rustc_trait_selection/src/solve/normalize.rs
@@ -42,7 +42,7 @@ where
 {
     let infcx = at.infcx;
     let value = value.skip_normalization();
-    let value = infcx.resolve_vars_if_possible(value);
+    let value = infcx.deeply_resolve_ignoring_regions(value);
 
     if !infcx.tcx.renormalize_rigid_aliases() && !value.has_non_rigid_aliases() {
         return Normalized { value, obligations: Default::default() };
@@ -59,7 +59,7 @@ where
             Ok(result) => result,
             Err(err) => return Err(err),
         };
-        let normalized = infcx.resolve_vars_if_possible(infer_term);
+        let normalized = infcx.deeply_resolve_ignoring_regions(infer_term);
         let normalization_was_ambiguous = match result.certainty {
             Certainty::Yes => NormalizationWasAmbiguous::No,
             Certainty::Maybe { .. } => {

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -334,9 +334,9 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                 continue;
             }
 
-            // Call `infcx.resolve_vars_if_possible` to see if we can
+            // Call `infcx.deeply_resolve_ignoring_regions` to see if we can
             // get rid of any inference variables.
-            let obligation = infcx.resolve_vars_if_possible(Obligation::new(
+            let obligation = infcx.deeply_resolve_ignoring_regions(Obligation::new(
                 tcx,
                 dummy_cause.clone(),
                 new_env,
@@ -658,7 +658,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                 fresh_preds.insert(self.clean_pred(selcx.infcx, obligation.predicate));
 
             // Resolve any inference variables that we can, to help selection succeed
-            let predicate = selcx.infcx.resolve_vars_if_possible(obligation.predicate);
+            let predicate = selcx.infcx.deeply_resolve_ignoring_regions(obligation.predicate);
 
             // We only add a predicate as a user-displayable bound if
             // it involves a generic parameter, and doesn't contain

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -333,7 +333,7 @@ fn overlap<'tcx>(
         .iter()
         .any(|c| c.0.involves_placeholders());
 
-    let mut impl_header = infcx.resolve_vars_if_possible(impl1_header);
+    let mut impl_header = infcx.deeply_resolve_ignoring_regions(impl1_header);
 
     // Deeply normalize the impl header for diagnostics, ignoring any errors if this fails.
     if infcx.next_trait_solver() {
@@ -451,7 +451,7 @@ fn impl_intersection_has_impossible_obligation<'a, 'cx, 'tcx>(
                 .filter(|error| {
                     matches!(error.code, FulfillmentErrorCode::Ambiguity { overflow: Some(true) })
                 })
-                .map(|e| infcx.resolve_vars_if_possible(e.obligation.predicate))
+                .map(|e| infcx.deeply_resolve_ignoring_regions(e.obligation.predicate))
                 .collect(),
         }
     } else {
@@ -540,8 +540,9 @@ fn impl_intersection_has_negative_obligation(
     // Right above we plug inference variables with placeholders,
     // this gets us new impl1_header_args with the inference variables actually resolved
     // to those placeholders.
-    let impl1_header_args = infcx.resolve_vars_if_possible(impl1_header.impl_args);
-    // So there are no infer variables left now, except regions which aren't resolved by `resolve_vars_if_possible`.
+    let impl1_header_args = infcx.deeply_resolve_ignoring_regions(impl1_header.impl_args);
+    // So there are no infer variables left now, except regions which aren't resolved by
+    // `deeply_resolve_ignoring_regions`.
     assert!(!impl1_header_args.has_non_region_infer());
 
     let param_env = ty::EarlyBinder::bind(tcx, tcx.param_env(impl1_def_id))

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -638,7 +638,7 @@ fn plug_infer_with_placeholders<'tcx>(
                     .inner
                     .borrow_mut()
                     .unwrap_region_constraints()
-                    .opportunistic_resolve_var(self.infcx.tcx, vid);
+                    .shallow_resolve_region_var(self.infcx.tcx, vid);
                 if r.is_var() {
                     let Ok(InferOk { value: (), obligations }) =
                         self.infcx.at(&ObligationCause::dummy(), ty::ParamEnv::empty()).eq(

--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -33,7 +33,7 @@ pub fn evaluate_host_effect_obligation<'tcx>(
         );
     }
 
-    let ref obligation = selcx.infcx.resolve_vars_if_possible(obligation.clone());
+    let ref obligation = selcx.infcx.deeply_resolve_ignoring_regions(obligation.clone());
 
     // Force ambiguity for infer self ty.
     if obligation.predicate.self_ty().is_ty_var() {

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -145,7 +145,7 @@ where
         // this helps to reduce duplicate errors, as well as making
         // debug output much nicer to read and so on.
         debug_assert!(!obligation.param_env.has_non_region_infer());
-        obligation.predicate = infcx.resolve_vars_if_possible(obligation.predicate);
+        obligation.predicate = infcx.deeply_resolve_ignoring_regions(obligation.predicate);
 
         debug!(?obligation, "register_predicate_obligation");
 
@@ -236,7 +236,7 @@ where
                 }
 
                 self.infcx
-                    .resolve_vars_if_possible(pending_obligation.obligation.predicate)
+                    .deeply_resolve_ignoring_regions(pending_obligation.obligation.predicate)
                     .visit_with(&mut StalledOnCoroutines {
                         stalled_coroutines: self.stalled_coroutines,
                         cache: Default::default(),
@@ -387,7 +387,8 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
         debug!(?obligation, "pre-resolve");
 
         if obligation.predicate.has_non_region_infer() {
-            obligation.predicate = self.selcx.infcx.resolve_vars_if_possible(obligation.predicate);
+            obligation.predicate =
+                self.selcx.infcx.deeply_resolve_ignoring_regions(obligation.predicate);
         }
 
         let obligation = &pending_obligation.obligation;
@@ -903,7 +904,7 @@ impl<'a, 'tcx> FulfillProcessor<'a, 'tcx> {
 
                 debug!(
                     "process_predicate: pending obligation {:?} now stalled on {:?}",
-                    infcx.resolve_vars_if_possible(obligation.clone()),
+                    infcx.deeply_resolve_ignoring_regions(obligation.clone()),
                     stalled_on
                 );
 
@@ -954,13 +955,15 @@ impl<'a, 'tcx> FulfillProcessor<'a, 'tcx> {
             }
             ProjectAndUnifyResult::Holds(os) => {
                 let input_projection_term = infcx
-                    .resolve_vars_if_possible(project_obligation.predicate)
+                    .deeply_resolve_ignoring_regions(project_obligation.predicate)
                     .map_bound(|p| p.projection_term);
                 let all_same_projection_term = os.iter().all(|o| {
                     let Some(proj_clause) = o.predicate.as_projection_clause() else {
                         return false;
                     };
-                    infcx.resolve_vars_if_possible(proj_clause).map_bound(|p| p.projection_term)
+                    infcx
+                        .deeply_resolve_ignoring_regions(proj_clause)
+                        .map_bound(|p| p.projection_term)
                         == input_projection_term
                 });
                 if all_same_projection_term {
@@ -1029,7 +1032,7 @@ fn args_infer_vars<'tcx>(
 ) -> impl Iterator<Item = TyOrConstInferVar> {
     selcx
         .infcx
-        .resolve_vars_if_possible(args)
+        .deeply_resolve_ignoring_regions(args)
         .skip_binder() // ok because this check doesn't care about regions
         .iter()
         .filter(|arg| arg.has_non_region_infer())

--- a/compiler/rustc_trait_selection/src/traits/implied_outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/implied_outlives_bounds.rs
@@ -64,7 +64,7 @@ pub fn compute_implied_outlives_bounds_inner<'tcx>(
             continue;
         }
 
-        let arg = ocx.infcx.resolve_vars_if_possible(arg);
+        let arg = ocx.infcx.deeply_resolve_ignoring_regions(arg);
         // From the full set of obligations, just filter down to the region relationships.
         for obligation in
             wf::unnormalized_obligations(ocx.infcx, param_env, arg, DUMMY_SP, CRATE_DEF_ID)

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -232,7 +232,8 @@ fn pred_known_to_hold_modulo_regions<'tcx>(
         // is not smart enough, so we fall back to fulfillment when we're not certain
         // that an obligation holds or not. Even still, we must make sure that
         // the we do no inference in the process of checking this obligation.
-        let goal = infcx.resolve_vars_if_possible((obligation.predicate, obligation.param_env));
+        let goal =
+            infcx.deeply_resolve_ignoring_regions((obligation.predicate, obligation.param_env));
         infcx.probe(|_| {
             let ocx = ObligationCtxt::new(infcx);
             ocx.register_obligation(obligation);
@@ -240,7 +241,7 @@ fn pred_known_to_hold_modulo_regions<'tcx>(
             let errors = ocx.evaluate_obligations_error_on_ambiguity();
             match errors {
                 // Only known to hold if we did no inference.
-                TraitErrors::NoErrors => infcx.resolve_vars_if_possible(goal) == goal,
+                TraitErrors::NoErrors => infcx.deeply_resolve_ignoring_regions(goal) == goal,
 
                 TraitErrors::HasErrors(errors) => {
                     debug!(?errors);
@@ -631,7 +632,7 @@ pub fn try_evaluate_const<'tcx, E: Debug>(
     normalize_ty: impl FnOnce(Unnormalized<'tcx, Ty<'tcx>>) -> Result<Ty<'tcx>, E>,
 ) -> Result<ty::Const<'tcx>, EvaluateConstErr<E>> {
     let tcx = infcx.tcx;
-    let ct = infcx.resolve_vars_if_possible(ct);
+    let ct = infcx.deeply_resolve_ignoring_regions(ct);
     debug!(?ct);
 
     match ct.kind() {

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -406,7 +406,7 @@ fn do_normalize_clauses<'tcx>(
     // caller sites. We should also avoid cloning if possible.
     let normalized_env = ty::ParamEnv::new(tcx, clauses.iter().copied());
     let _errors = infcx.resolve_regions(cause.body_def_id, normalized_env, []);
-    match infcx.fully_resolve(clauses.clone()) {
+    match infcx.deeply_resolve_via_region_graph(clauses.clone()) {
         Ok(clauses) => clauses,
         Err(fixup_err) => {
             // The first folder only replaces infers from normalization failure. We might not have

--- a/compiler/rustc_trait_selection/src/traits/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/normalize.rs
@@ -78,7 +78,7 @@ impl<'tcx> At<'_, 'tcx> {
                 .normalize(value)
                 .into_value_registering_obligations(self.infcx, &mut *fulfill_cx);
             let errors = fulfill_cx.evaluate_obligations_error_on_ambiguity(self.infcx);
-            let value = self.infcx.resolve_vars_if_possible(value);
+            let value = self.infcx.deeply_resolve_ignoring_regions(value);
             match errors {
                 TraitErrors::NoErrors => Ok(value),
                 TraitErrors::HasErrors(errors) => {
@@ -171,7 +171,7 @@ impl<'a, 'b, 'tcx> AssocTypeNormalizer<'a, 'b, 'tcx> {
     }
 
     fn fold<T: TypeFoldable<TyCtxt<'tcx>>>(&mut self, value: T) -> T {
-        let value = self.selcx.infcx.resolve_vars_if_possible(value);
+        let value = self.selcx.infcx.deeply_resolve_ignoring_regions(value);
         debug!(?value);
 
         assert!(

--- a/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/outlives_bounds.rs
@@ -1,6 +1,6 @@
 use rustc_infer::infer::InferOk;
 use rustc_infer::infer::canonical::QueryRegionConstraint;
-use rustc_infer::infer::resolve::OpportunisticRegionResolver;
+use rustc_infer::infer::resolve::DeepRegionResolver;
 use rustc_infer::traits::query::type_op::ImpliedOutlivesBounds;
 use rustc_macros::extension;
 use rustc_middle::infer::canonical::{OriginalQueryValues, QueryRegionConstraints};
@@ -39,8 +39,8 @@ fn implied_outlives_bounds<'a, 'tcx>(
     ty: Ty<'tcx>,
     disable_implied_bounds_hack: bool,
 ) -> Vec<OutlivesBound<'tcx>> {
-    let ty = infcx.resolve_vars_if_possible(ty);
-    let ty = OpportunisticRegionResolver::new(infcx).fold_ty(ty);
+    let ty = infcx.deeply_resolve_ignoring_regions(ty);
+    let ty = DeepRegionResolver::new(infcx).fold_ty(ty);
 
     // We do not expect existential variables in implied bounds.
     // We may however encounter unconstrained lifetime variables

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -7,7 +7,7 @@ use rustc_errors::ErrorGuaranteed;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::DefineOpaqueTypes;
-use rustc_infer::infer::resolve::OpportunisticRegionResolver;
+use rustc_infer::infer::resolve::DeepRegionResolver;
 use rustc_infer::traits::{ObligationCauseCode, PredicateObligations};
 use rustc_middle::traits::select::OverflowError;
 use rustc_middle::traits::{BuiltinImplSource, ImplSource, ImplSourceUserDefinedData};
@@ -309,7 +309,7 @@ pub(super) fn opt_normalize_projection_term<'a, 'b, 'tcx>(
 ) -> Result<Option<Term<'tcx>>, InProgress> {
     let infcx = selcx.infcx;
     debug_assert!(!selcx.infcx.next_trait_solver());
-    let projection_term = infcx.resolve_vars_if_possible(projection_term);
+    let projection_term = infcx.deeply_resolve_ignoring_regions(projection_term);
     let cache_key = ProjectionCacheKey::new(projection_term, param_env);
 
     // FIXME(#20304) For now, I am caching here, which is good, but it
@@ -388,7 +388,7 @@ pub(super) fn opt_normalize_projection_term<'a, 'b, 'tcx>(
             // an impl, where-clause etc) and hence we must
             // re-normalize it
 
-            let projected_term = selcx.infcx.resolve_vars_if_possible(projected_term);
+            let projected_term = selcx.infcx.deeply_resolve_ignoring_regions(projected_term);
 
             let mut result = if projected_term.has_aliases() {
                 let normalized_ty = normalize_with_depth_to(
@@ -584,7 +584,7 @@ pub fn normalize_inherent_projection<'a, 'b, 'tcx>(
         const_of_item_or_delayed_bug(tcx, def_id).instantiate(tcx, args).map(Into::into)
     };
 
-    let term = selcx.infcx.resolve_vars_if_possible(term);
+    let term = selcx.infcx.deeply_resolve_ignoring_regions(term);
     let term =
         normalize_with_depth_to(selcx, param_env, cause.clone(), depth + 1, term, obligations);
 
@@ -1053,7 +1053,7 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                                     // NOTE(eddyb) inference variables can resolve to parameters, so
                                     // assume `poly_trait_ref` isn't monomorphic, if it contains any.
                                     let poly_trait_ref =
-                                        selcx.infcx.resolve_vars_if_possible(trait_ref);
+                                        selcx.infcx.deeply_resolve_ignoring_regions(trait_ref);
                                     !poly_trait_ref.still_further_specializable()
                                 }
                             }
@@ -1326,7 +1326,7 @@ fn confirm_candidate<'cx, 'tcx>(
     if let Ok(Projected::Progress(progress)) = &mut result
         && progress.term.has_infer_regions()
     {
-        progress.term = progress.term.fold_with(&mut OpportunisticRegionResolver::new(selcx.infcx));
+        progress.term = progress.term.fold_with(&mut DeepRegionResolver::new(selcx.infcx));
     }
 
     result
@@ -2221,7 +2221,7 @@ impl<'cx, 'tcx> ProjectionCacheKeyExt<'cx, 'tcx> for ProjectionCacheKey<'tcx> {
                 // from a specific call to `opt_normalize_projection_type` - if
                 // there's no precise match, the original cache entry is "stranded"
                 // anyway.
-                infcx.resolve_vars_if_possible(predicate.projection_term),
+                infcx.deeply_resolve_ignoring_regions(predicate.projection_term),
                 obligation.param_env,
             )
         })

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/custom.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/custom.rs
@@ -145,7 +145,7 @@ where
     })?;
 
     // Next trait solver performs operations locally, and normalize goals should resolve vars.
-    let value = infcx.resolve_vars_if_possible(value);
+    let value = infcx.deeply_resolve_ignoring_regions(value);
 
     let region_obligations = infcx.take_registered_region_obligations();
     let region_assumptions = infcx.take_registered_region_assumptions();

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -38,7 +38,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             param_env: obligation.param_env,
             cause: obligation.cause.clone(),
             recursion_depth: obligation.recursion_depth,
-            predicate: self.infcx.resolve_vars_if_possible(obligation.predicate),
+            predicate: self.infcx.deeply_resolve_ignoring_regions(obligation.predicate),
         };
 
         if obligation.predicate.skip_binder().self_ty().is_ty_var() {
@@ -209,7 +209,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
 
         self.infcx.probe(|_| {
-            let poly_trait_predicate = self.infcx.resolve_vars_if_possible(obligation.predicate);
+            let poly_trait_predicate =
+                self.infcx.deeply_resolve_ignoring_regions(obligation.predicate);
             let placeholder_trait_predicate =
                 self.infcx.enter_forall_and_leak_universe(poly_trait_predicate);
 
@@ -927,7 +928,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
 
         self.infcx.probe(|_snapshot| {
-            let poly_trait_predicate = self.infcx.resolve_vars_if_possible(obligation.predicate);
+            let poly_trait_predicate =
+                self.infcx.deeply_resolve_ignoring_regions(obligation.predicate);
             self.infcx.enter_forall(poly_trait_predicate, |placeholder_trait_predicate| {
                 let self_ty = placeholder_trait_predicate.self_ty();
                 let principal_trait_ref = match self_ty.kind() {
@@ -1373,7 +1375,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         obligation: &PolyTraitObligation<'tcx>,
         candidates: &mut SelectionCandidateSet<'tcx>,
     ) {
-        let self_ty = self.infcx.resolve_vars_if_possible(obligation.self_ty());
+        let self_ty = self.infcx.deeply_resolve_ignoring_regions(obligation.self_ty());
 
         match self_ty.skip_binder().kind() {
             ty::FnPtr(..) => candidates.vec.push(BuiltinCandidate),

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -379,7 +379,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     }
 
                     if !candidate_set.ambiguous && no_candidates_apply {
-                        let trait_ref = self.infcx.resolve_vars_if_possible(
+                        let trait_ref = self.infcx.deeply_resolve_ignoring_regions(
                             stack.obligation.predicate.skip_binder().trait_ref,
                         );
                         if !trait_ref.references_error() {
@@ -508,15 +508,16 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     ) -> Result<EvaluationResult, OverflowError> {
         debug_assert!(!self.infcx.next_trait_solver());
         self.evaluation_probe(|this| {
-            let goal =
-                this.infcx.resolve_vars_if_possible((obligation.predicate, obligation.param_env));
+            let goal = this
+                .infcx
+                .deeply_resolve_ignoring_regions((obligation.predicate, obligation.param_env));
             let mut result = this.evaluate_predicate_recursively(
                 TraitObligationStackList::empty(&ProvisionalEvaluationCache::default()),
                 obligation.clone(),
             )?;
             // If the predicate has done any inference, then downgrade the
             // result to ambiguous.
-            if this.infcx.resolve_vars_if_possible(goal) != goal {
+            if this.infcx.deeply_resolve_ignoring_regions(goal) != goal {
                 result = result.max(EvaluatedToAmbig);
             }
             Ok(result)
@@ -1445,7 +1446,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         debug!("is_knowable()");
 
-        let predicate = self.infcx.resolve_vars_if_possible(obligation.predicate);
+        let predicate = self.infcx.deeply_resolve_ignoring_regions(obligation.predicate);
 
         // Okay to skip binder because of the nature of the
         // trait-ref-is-knowable check, which does not care about
@@ -2470,7 +2471,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
         match self.match_impl(impl_def_id, impl_trait_header, obligation) {
             Ok(args) => args,
             Err(()) => {
-                let predicate = self.infcx.resolve_vars_if_possible(obligation.predicate);
+                let predicate = self.infcx.deeply_resolve_ignoring_regions(obligation.predicate);
                 bug!("impl {impl_def_id:?} was matchable against {predicate:?} but now is not")
             }
         }

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -215,7 +215,7 @@ fn fulfill_implication<'tcx>(
 
     // Now resolve the *generic parameters* we built for the target earlier, replacing
     // the inference variables inside with whatever we got from fulfillment.
-    Ok(infcx.resolve_vars_if_possible(target_args))
+    Ok(infcx.deeply_resolve_ignoring_regions(target_args))
 }
 
 pub(super) fn specialization_enabled_in(tcx: TyCtxt<'_>, _: LocalCrate) -> bool {

--- a/compiler/rustc_trait_selection/src/traits/structural_normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/structural_normalize.rs
@@ -69,7 +69,7 @@ impl<'tcx> At<'_, 'tcx> {
                 return Err(errors);
             }
 
-            Ok(self.infcx.resolve_vars_if_possible(new_infer))
+            Ok(self.infcx.deeply_resolve_ignoring_regions(new_infer))
         } else {
             Ok(self.normalize(term).into_value_registering_obligations(self.infcx, fulfill_cx))
         }

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -98,7 +98,7 @@ pub fn unnormalized_obligations<'tcx>(
     span: Span,
     body_def_id: LocalDefId,
 ) -> Option<PredicateObligations<'tcx>> {
-    debug_assert_eq!(term, infcx.resolve_vars_if_possible(term));
+    debug_assert_eq!(term, infcx.deeply_resolve_ignoring_regions(term));
 
     // However, if `term` IS an unresolved inference variable, returns `None`,
     // because we are not able to make any progress at all. This is to prevent

--- a/compiler/rustc_traits/src/codegen.rs
+++ b/compiler/rustc_traits/src/codegen.rs
@@ -72,7 +72,7 @@ pub(crate) fn codegen_select_candidate<'tcx>(
         return Err(CodegenObligationError::Unimplemented);
     }
 
-    let impl_source = infcx.resolve_vars_if_possible(impl_source);
+    let impl_source = infcx.deeply_resolve_ignoring_regions(impl_source);
     let impl_source = tcx.erase_and_anonymize_regions(impl_source);
     if impl_source.has_non_region_infer() {
         // Unused generic types or consts on an impl get replaced with inference vars,

--- a/compiler/rustc_traits/src/coroutine_witnesses.rs
+++ b/compiler/rustc_traits/src/coroutine_witnesses.rs
@@ -1,7 +1,7 @@
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::infer::canonical::QueryRegionConstraint;
 use rustc_infer::infer::canonical::query_response::make_query_region_constraints;
-use rustc_infer::infer::resolve::OpportunisticRegionResolver;
+use rustc_infer::infer::resolve::DeepRegionResolver;
 use rustc_infer::traits::{Obligation, ObligationCause};
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, fold_regions};
 use rustc_span::def_id::DefId;
@@ -90,7 +90,7 @@ fn compute_assumptions<'tcx>(
             Default::default(),
         )
         .constraints
-        .fold_with(&mut OpportunisticRegionResolver::new(&infcx));
+        .fold_with(&mut DeepRegionResolver::new(&infcx));
 
         tcx.mk_outlives_from_iter(
             constraints

--- a/compiler/rustc_traits/src/normalize_erasing_regions.rs
+++ b/compiler/rustc_traits/src/normalize_erasing_regions.rs
@@ -36,7 +36,7 @@ fn try_normalize_after_erasing_regions<'tcx, T: TypeFoldable<TyCtxt<'tcx>> + Par
                 None,
             );
 
-            let resolved_value = infcx.resolve_vars_if_possible(normalized_value);
+            let resolved_value = infcx.deeply_resolve_ignoring_regions(normalized_value);
             // It's unclear when `resolve_vars` would have an effect in a
             // fresh `InferCtxt`. If this assert does trigger, it will give
             // us a test case.

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -576,6 +576,20 @@ pub trait InferCtxtLike: Sized {
     );
 
     fn reset_opaque_types(&self);
+
+    /// Where possible, replaces type/const/region variables in `value` with their final value.
+    /// If a type/const/region variable has not (yet) been unified, it is left as is.
+    ///
+    /// This is an idempotent operation that does not affect inference state in any way,
+    /// which means it's safe to call this function at will.
+    fn deeply_resolve_via_unification_table<T: TypeFoldable<Self::Interner>>(&self, value: T) -> T {
+        if value.has_infer() {
+            let mut folder = DeepVariableResolver::new(self);
+            value.fold_with(&mut folder)
+        } else {
+            value
+        }
+    }
 }
 
 pub fn may_use_unstable_feature<'a, I: Interner, Infcx>(
@@ -619,26 +633,6 @@ where
         | TypingMode::PostBorrowck { .. }
         | TypingMode::PostAnalysis => infcx.cx().features().feature_bound_holds_in_crate(symbol),
         TypingMode::Codegen => true,
-    }
-}
-
-/// Where possible, replaces type/const/region variables in `value` with their final value.
-/// If a type/const/region variable has not (yet) been unified, it is left as is.
-///
-/// This is an idempotent operation that does not affect inference state in any way,
-/// which means it's safe to call this function at will.
-pub fn deeply_resolve_via_unification_table<
-    Infcx: InferCtxtLike,
-    T: TypeFoldable<Infcx::Interner>,
->(
-    infcx: &Infcx,
-    value: T,
-) -> T {
-    if value.has_infer() {
-        let mut folder = DeepVariableResolver::new(infcx);
-        value.fold_with(&mut folder)
-    } else {
-        value
     }
 }
 

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -423,25 +423,19 @@ pub trait InferCtxtLike: Sized {
     );
 
     fn universe_of_ty(&self, ty: ty::TyVid) -> Option<ty::UniverseIndex>;
-    fn universe_of_lt(&self, lt: ty::RegionVid) -> Option<ty::UniverseIndex>;
-    fn universe_of_ct(&self, ct: ty::ConstVid) -> Option<ty::UniverseIndex>;
+    fn universe_of_region(&self, lt: ty::RegionVid) -> Option<ty::UniverseIndex>;
+    fn universe_of_const(&self, ct: ty::ConstVid) -> Option<ty::UniverseIndex>;
 
     fn root_ty_var(&self, var: ty::TyVid) -> ty::TyVid;
     fn sub_unification_table_root_var(&self, var: ty::TyVid) -> ty::TyVid;
     fn is_sub_unification_table_root_var(&self, var: ty::TyVid) -> bool;
     fn root_const_var(&self, var: ty::ConstVid) -> ty::ConstVid;
 
-    fn opportunistic_resolve_ty_var(&self, vid: ty::TyVid) -> <Self::Interner as Interner>::Ty;
-    fn opportunistic_resolve_int_var(&self, vid: ty::IntVid) -> <Self::Interner as Interner>::Ty;
-    fn opportunistic_resolve_float_var(
-        &self,
-        vid: ty::FloatVid,
-    ) -> <Self::Interner as Interner>::Ty;
-    fn opportunistic_resolve_ct_var(
-        &self,
-        vid: ty::ConstVid,
-    ) -> <Self::Interner as Interner>::Const;
-    fn opportunistic_resolve_lt_var(&self, vid: ty::RegionVid) -> Region<Self::Interner>;
+    fn shallow_resolve_ty_var(&self, vid: ty::TyVid) -> <Self::Interner as Interner>::Ty;
+    fn shallow_resolve_int_var(&self, vid: ty::IntVid) -> <Self::Interner as Interner>::Ty;
+    fn shallow_resolve_float_var(&self, vid: ty::FloatVid) -> <Self::Interner as Interner>::Ty;
+    fn shallow_resolve_const_var(&self, vid: ty::ConstVid) -> <Self::Interner as Interner>::Const;
+    fn shallow_resolve_region_var(&self, vid: ty::RegionVid) -> Region<Self::Interner>;
 
     fn ty_or_const_infer_var_changed(&self, var: TyOrConstInferVar) -> bool;
 
@@ -675,15 +669,15 @@ impl<Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeFolder<I>
     fn fold_ty(&mut self, t: I::Ty) -> I::Ty {
         match t.kind() {
             ty::Infer(ty::TyVar(vid)) => {
-                let resolved = self.delegate.opportunistic_resolve_ty_var(vid);
+                let resolved = self.delegate.shallow_resolve_ty_var(vid);
                 if t != resolved && resolved.has_infer() {
                     resolved.fold_with(self)
                 } else {
                     resolved
                 }
             }
-            ty::Infer(ty::IntVar(vid)) => self.delegate.opportunistic_resolve_int_var(vid),
-            ty::Infer(ty::FloatVar(vid)) => self.delegate.opportunistic_resolve_float_var(vid),
+            ty::Infer(ty::IntVar(vid)) => self.delegate.shallow_resolve_int_var(vid),
+            ty::Infer(ty::FloatVar(vid)) => self.delegate.shallow_resolve_float_var(vid),
             _ => {
                 if t.has_infer() {
                     if let Some(&ty) = self.cache.get(&t) {
@@ -701,7 +695,7 @@ impl<Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeFolder<I>
 
     fn fold_region(&mut self, r: Region<I>) -> Region<I> {
         match r.kind() {
-            ty::ReVar(vid) => self.delegate.opportunistic_resolve_lt_var(vid),
+            ty::ReVar(vid) => self.delegate.shallow_resolve_region_var(vid),
             _ => r,
         }
     }
@@ -709,7 +703,7 @@ impl<Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeFolder<I>
     fn fold_const(&mut self, c: I::Const) -> I::Const {
         match c.kind() {
             ty::ConstKind::Infer(ty::InferConst::Var(vid)) => {
-                let resolved = self.delegate.opportunistic_resolve_ct_var(vid);
+                let resolved = self.delegate.shallow_resolve_const_var(vid);
                 if c != resolved && resolved.has_infer() {
                     resolved.fold_with(self)
                 } else {

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -514,7 +514,7 @@ pub trait InferCtxtLike: Sized {
         ty: <Self::Interner as Interner>::Const,
     ) -> <Self::Interner as Interner>::Const;
 
-    fn resolve_vars_if_possible<T>(&self, value: T) -> T
+    fn deeply_resolve_ignoring_regions<T>(&self, value: T) -> T
     where
         T: TypeFoldable<Self::Interner>;
 
@@ -628,20 +628,27 @@ where
     }
 }
 
-/// Resolves ty, region, and const vars to their inferred values or their root vars.
-pub fn eager_resolve_vars<Infcx: InferCtxtLike, T: TypeFoldable<Infcx::Interner>>(
+/// Where possible, replaces type/const/region variables in `value` with their final value.
+/// If a type/const/region variable has not (yet) been unified, it is left as is.
+///
+/// This is an idempotent operation that does not affect inference state in any way,
+/// which means it's safe to call this function at will.
+pub fn deeply_resolve_via_unification_table<
+    Infcx: InferCtxtLike,
+    T: TypeFoldable<Infcx::Interner>,
+>(
     infcx: &Infcx,
     value: T,
 ) -> T {
     if value.has_infer() {
-        let mut folder = EagerResolver::new(infcx);
+        let mut folder = DeepVariableResolver::new(infcx);
         value.fold_with(&mut folder)
     } else {
         value
     }
 }
 
-struct EagerResolver<'a, D, I = <D as InferCtxtLike>::Interner>
+struct DeepVariableResolver<'a, D, I = <D as InferCtxtLike>::Interner>
 where
     D: InferCtxtLike<Interner = I>,
     I: Interner,
@@ -652,13 +659,15 @@ where
     cache: DelayedMap<I::Ty, I::Ty>,
 }
 
-impl<'a, Infcx: InferCtxtLike> EagerResolver<'a, Infcx> {
+impl<'a, Infcx: InferCtxtLike> DeepVariableResolver<'a, Infcx> {
     fn new(delegate: &'a Infcx) -> Self {
-        EagerResolver { delegate, cache: Default::default() }
+        DeepVariableResolver { delegate, cache: Default::default() }
     }
 }
 
-impl<Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeFolder<I> for EagerResolver<'_, Infcx> {
+impl<Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeFolder<I>
+    for DeepVariableResolver<'_, Infcx>
+{
     fn cx(&self) -> I {
         self.delegate.cx()
     }

--- a/compiler/rustc_type_ir/src/relate/combine.rs
+++ b/compiler/rustc_type_ir/src/relate/combine.rs
@@ -243,7 +243,7 @@ where
             ty::Bivariant => {
                 let has_non_region_infer = |arg: I::GenericArg| {
                     arg.has_non_region_infer()
-                        && infcx.resolve_vars_if_possible(arg).has_non_region_infer()
+                        && infcx.deeply_resolve_ignoring_regions(arg).has_non_region_infer()
                 };
                 if has_non_region_infer(a) || has_non_region_infer(b) {
                     has_unconstrained_bivariant_arg = true;

--- a/compiler/rustc_type_ir/src/universe.rs
+++ b/compiler/rustc_type_ir/src/universe.rs
@@ -57,7 +57,7 @@ fn max_universe_inner<
     let mut visitor = MaxUniverse::<_, _, VISIT_PLACEHOLDER, VISIT_INFER>::new(infcx);
     // FIXME: make this a debug_assert and let callers resolve vars. Then the input only needs to
     // be `TypeVisitable`.
-    let t = infcx.resolve_vars_if_possible(t);
+    let t = infcx.deeply_resolve_ignoring_regions(t);
     t.visit_with(&mut visitor);
     visitor.max_universe()
 }

--- a/compiler/rustc_type_ir/src/universe.rs
+++ b/compiler/rustc_type_ir/src/universe.rs
@@ -140,7 +140,7 @@ impl<
                 self.max_universe = self.max_universe.max(p.universe)
             }
             ConstKind::Infer(rustc_type_ir::InferConst::Var(inf)) if VISIT_INFER => {
-                let u = self.infcx.universe_of_ct(inf).unwrap();
+                let u = self.infcx.universe_of_const(inf).unwrap();
                 debug!("var {inf:?} in universe {u:?}");
                 self.max_universe = self.max_universe.max(u);
             }
@@ -154,12 +154,12 @@ impl<
                 self.max_universe = self.max_universe.max(p.universe)
             }
             RegionKind::ReVar(var) if VISIT_INFER => {
-                match self.infcx.opportunistic_resolve_lt_var(var).kind() {
+                match self.infcx.shallow_resolve_region_var(var).kind() {
                     RegionKind::RePlaceholder(p) if VISIT_PLACEHOLDER => {
                         self.max_universe = self.max_universe.max(p.universe)
                     }
                     RegionKind::ReVar(var) if VISIT_INFER => {
-                        let u = self.infcx.universe_of_lt(var).unwrap();
+                        let u = self.infcx.universe_of_region(var).unwrap();
                         debug!("var {var:?} in universe {u:?}");
                         self.max_universe = self.max_universe.max(u);
                     }

--- a/library/core/src/sync/sync_view.rs
+++ b/library/core/src/sync/sync_view.rs
@@ -26,49 +26,62 @@ use core::task::{Context, Poll};
 ///
 /// ## Examples
 ///
-/// Using a non-`Sync` future prevents the wrapping struct from being `Sync`:
+/// A non-`Sync` field prevents the wrapping struct from being `Sync`:
 ///
-/// ```compile_fail
-/// use core::cell::Cell;
+/// ```compile_fail,E0277
+/// use std::sync::mpsc::{self, Receiver};
 ///
-/// async fn other() {}
-/// fn assert_sync<T: Sync>(t: T) {}
-/// struct State<F> {
-///     future: F
+/// struct Inbox {
+///     name: &'static str,
+///     receiver: Receiver<u32>,
 /// }
 ///
-/// assert_sync(State {
-///     future: async {
-///         let cell = Cell::new(1);
-///         let cell_ref = &cell;
-///         other().await;
-///         let value = cell_ref.get();
-///     }
-/// });
+/// fn require_send<T: Send>() {}
+/// fn require_send_sync<T: Send + Sync>() {}
+///
+/// require_send::<Inbox>();      // compiled
+/// require_send_sync::<Inbox>(); // compile-failed
 /// ```
 ///
-/// `SyncView` ensures the struct is `Sync` without stripping the future of its
+/// `SyncView` makes the value `Sync` without stripping the struct of its
 /// functionality:
 ///
 /// ```
 /// #![feature(exclusive_wrapper)]
-/// use core::cell::Cell;
-/// use core::sync::SyncView;
 ///
-/// async fn other() {}
-/// fn assert_sync<T: Sync>(t: T) {}
-/// struct State<F> {
-///     future: SyncView<F>
+/// use std::sync::SyncView;
+/// use std::sync::mpsc::{self, Receiver};
+/// use std::thread;
+///
+/// struct Inbox {
+///     name: &'static str,
+///     receiver: SyncView<Receiver<u32>>,
 /// }
 ///
-/// assert_sync(State {
-///     future: SyncView::new(async {
-///         let cell = Cell::new(1);
-///         let cell_ref = &cell;
-///         other().await;
-///         let value = cell_ref.get();
-///     })
+/// impl Inbox {
+///     fn name(&self) -> &'static str {
+///         self.name
+///     }
+///
+///     fn recv(&mut self) -> u32 {
+///         self.receiver.as_mut().recv().unwrap()
+///     }
+/// }
+///
+/// let (sender, receiver) = mpsc::channel();
+/// let mut inbox = Inbox { name: "jobs", receiver: SyncView::new(receiver) };
+/// sender.send(42).unwrap();
+/// drop(sender);
+///
+/// thread::scope(|scope| {
+///     let reader = scope.spawn(|| inbox.name());
+///     assert_eq!(inbox.name(), "jobs");
+///     assert_eq!(reader.join().unwrap(), "jobs");
 /// });
+///
+/// let message = thread::spawn(move || inbox.recv()).join().unwrap();
+/// assert_eq!(message, 42);
+/// println!("Shared Inbox across threads, then moved it to a worker and received 42");
 /// ```
 ///
 /// ## Parallels with a mutex

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -206,7 +206,6 @@ target | std | notes
 [`riscv32imc-unknown-none-elf`](platform-support/riscv32-unknown-none-elf.md) | * | Bare RISC-V (RV32IMC ISA)
 [`riscv64a23-unknown-linux-gnu`](platform-support/riscv64a23-unknown-linux-gnu.md) | ✓ | RISC-V Linux (kernel 6.8.0+, glibc 2.39)
 `riscv64gc-unknown-none-elf` | * | Bare RISC-V (RV64IMAFDC ISA)
-[`riscv64im-unknown-none-elf`](platform-support/riscv64im-unknown-none-elf.md) | * | Bare RISC-V (RV64IM ISA)
 `riscv64imac-unknown-none-elf` | * | Bare RISC-V (RV64IMAC ISA)
 `sparc64-unknown-linux-gnu` | ✓ | SPARC Linux (kernel 4.4+, glibc 2.23)
 [`s390x-unknown-none-softfloat`](platform-support/s390x-unknown-none-softfloat.md) | * | Bare S390x (softfloat ABI)
@@ -428,6 +427,7 @@ target | std | host | notes
 [`riscv64gc-unknown-nuttx-elf`](platform-support/nuttx.md) | ✓ |  | RISC-V 64bit with NuttX
 [`riscv64gc-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | OpenBSD/riscv64
 [`riscv64gc-unknown-redox`](platform-support/redox.md) | ✓ |  | RISC-V 64bit Redox OS
+[`riscv64im-unknown-none-elf`](platform-support/riscv64im-unknown-none-elf.md) | * |  | Bare RISC-V (RV64IM ISA)
 [`riscv64imac-unknown-nuttx-elf`](platform-support/nuttx.md) | ✓ |  | RISC-V 64bit with NuttX
 [`s390x-unknown-linux-musl`](platform-support/s390x-unknown-linux-musl.md) | ✓ |  | S390x Linux (kernel 3.2, musl 1.2.5)
 `sparc-unknown-linux-gnu` | ✓ |  | 32-bit SPARC Linux

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1990,7 +1990,7 @@ fn normalize<'tcx>(
     let normalized = infcx
         .at(&ObligationCause::dummy(), cx.param_env)
         .query_normalize(ty)
-        .map(|resolved| infcx.resolve_vars_if_possible(resolved.value));
+        .map(|resolved| infcx.deeply_resolve_ignoring_regions(resolved.value));
     match normalized {
         Ok(normalized_value) => {
             debug!("normalized {ty:?} to {normalized_value:?}");

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -432,7 +432,7 @@ fn generate_item_def_id_path(
         let ty = infcx
             .at(&ObligationCause::dummy(), tcx.param_env(def_id))
             .query_normalize(ty::Binder::dummy(ty.instantiate_identity().skip_norm_wip()))
-            .map(|resolved| infcx.resolve_vars_if_possible(resolved.value).skip_binder())
+            .map(|resolved| infcx.deeply_resolve_ignoring_regions(resolved.value).skip_binder())
             .unwrap_or(ty.skip_binder());
         if let Some(new_def_id) = ty.ty_adt_def().map(|adt| adt.did()) {
             def_id = new_def_id;

--- a/tests/run-make/parallel-reproducible-by-move-body/by-move-body.rs
+++ b/tests/run-make/parallel-reproducible-by-move-body/by-move-body.rs
@@ -1,0 +1,7 @@
+pub fn f1() {
+    let _ = async || {};
+}
+
+pub fn f2() {
+    let _ = async || {};
+}

--- a/tests/run-make/parallel-reproducible-by-move-body/rmake.rs
+++ b/tests/run-make/parallel-reproducible-by-move-body/rmake.rs
@@ -1,0 +1,65 @@
+//@ needs-target-std
+//@ ignore-cross-compile
+//@ ignore-windows-gnu
+// GNU Linker for Windows is non-deterministic. (from `reproducible-build-2` test in this suite)
+
+use std::rc::Rc;
+
+use run_make_support::{rfs, run_in_tmpdir, rustc};
+
+/// Test that parallel compiler produces identical metadata for the
+/// `DefId`s synthesized on demand by `coroutine_by_move_body_def_id`
+/// (`DefKind::SyntheticCoroutineBody`), across many async closures that
+/// each need one.
+fn main() {
+    const FILE_NAME: &str = "by-move-body";
+    let rmeta_name = format!("{FILE_NAME}.rmeta");
+
+    let mut reference = None;
+    let mut reference_stderr = None;
+
+    for _ in 0..10 {
+        // Tmp dir as previous runs affect output binary on windows.
+        run_in_tmpdir(|| {
+            let mut rustc = rustc();
+            rustc
+                .input(format!("{FILE_NAME}.rs"))
+                .arg("--edition=2021")
+                .arg("-Zremap-cwd-prefix=reproducible_dir")
+                .arg("-Ccodegen-units=1")
+                .arg("-Zthreads=2")
+                .arg("--crate-type=lib")
+                .emit("metadata")
+                .output(&rmeta_name);
+
+            let current_stderr = rustc.run().stderr_utf8();
+
+            let current = Rc::new(rfs::read(&rmeta_name));
+            reference.get_or_insert(Rc::clone(&current));
+            let reference_stderr = reference_stderr.get_or_insert_with(|| current_stderr.clone());
+
+            if Some(current.clone()) != reference {
+                let reference_bytes = reference.as_ref().unwrap();
+                let (pos, (left_byte, right_byte)) = current
+                    .iter()
+                    .zip(reference_bytes.iter())
+                    .enumerate()
+                    .find(|(_, (c, r))| c != r)
+                    .unwrap();
+                let range_start = pos.saturating_sub(1);
+                let range_end = (pos + 3).min(current.len()).min(reference_bytes.len());
+                panic!(
+                    "left: {current:x?}\nright: {reference:x?}\n \
+                     differs at byte {pos}: left = {left_byte:#x}, right = {right_byte:#x}\n\
+                     left range [{range_start}..{range_end}]: {:x?}\n\
+                     right range [{range_start}..{range_end}]: {:x?}\n\
+                     left stderr:\n{current_stderr}\n\
+                     right stderr:\n{reference_stderr}",
+                    &current[range_start..range_end],
+                    &reference_bytes[range_start..range_end],
+                )
+            }
+            assert_eq!(Some(current), reference);
+        });
+    }
+}

--- a/tests/ui/traits/next-solver/diagnostics/rpitit-fulfillment-error.rs
+++ b/tests/ui/traits/next-solver/diagnostics/rpitit-fulfillment-error.rs
@@ -1,0 +1,14 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/159680.
+//@ compile-flags: -Znext-solver=globally
+
+trait Crash {
+    fn build<'a>(&mut self, commands: impl Iterator + 'a) -> impl Iterator + 'a {
+        //~^ ERROR type mismatch resolving `impl Iterator == impl Iterator`
+
+        let further_commands = self;
+        self.build(further_commands)
+        //~^ ERROR `Self` is not an iterator
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/diagnostics/rpitit-fulfillment-error.stderr
+++ b/tests/ui/traits/next-solver/diagnostics/rpitit-fulfillment-error.stderr
@@ -1,0 +1,35 @@
+error[E0277]: `Self` is not an iterator
+  --> $DIR/rpitit-fulfillment-error.rs:9:20
+   |
+LL |         self.build(further_commands)
+   |              ----- ^^^^^^^^^^^^^^^^ `Self` is not an iterator
+   |              |
+   |              required by a bound introduced by this call
+   |
+   = note: required for `&mut Self` to implement `Iterator`
+note: required by a bound in `Crash::build`
+  --> $DIR/rpitit-fulfillment-error.rs:5:44
+   |
+LL |     fn build<'a>(&mut self, commands: impl Iterator + 'a) -> impl Iterator + 'a {
+   |                                            ^^^^^^^^ required by this bound in `Crash::build`
+help: consider further restricting `Self`
+   |
+LL |     fn build<'a>(&mut self, commands: impl Iterator + 'a) -> impl Iterator + 'a where Self: Iterator {
+   |                                                                                 ++++++++++++++++++++
+
+error[E0271]: type mismatch resolving `impl Iterator == impl Iterator`
+  --> $DIR/rpitit-fulfillment-error.rs:5:62
+   |
+LL |     fn build<'a>(&mut self, commands: impl Iterator + 'a) -> impl Iterator + 'a {
+   |                                       ------------------     ^^^^^^^^^^^^^^^^^^ expected `&mut Self`, found type parameter `impl Iterator + 'a`
+   |                                       |
+   |                                       found this type parameter
+   |
+   = note: expected associated type `impl Iterator + '_`
+              found associated type `impl Iterator + 'a`
+   = note: an associated type was expected, but a different one was found
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0271, E0277.
+For more information about an error, try `rustc --explain E0271`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#162126 (Rename various resolving functions for consistency, and document them)
 - rust-lang/rust#162580 (Parallel frontend: reproducible coroutine_by_move_body_def_id )
 - rust-lang/rust#162614 (add regression test for RPITIT fulfillment error)
 - rust-lang/rust#162621 (Clarify examples related to `Sync` and `SyncView`)
 - rust-lang/rust#162626 (Move `riscv64im-unknown-none-elf` to Tier 3 table)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=162126,162580,162614,162621,162626)
<!-- homu-ignore:end -->

