### PR TITLE
dont suggest changing the mutability of a borrow that comes from a macro

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -2530,7 +2530,14 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         .sess
                         .source_map()
                         .span_take_while(span, |c| c.is_whitespace() || *c == '&');
-                    if points_at_arg && mutability.is_not() && refs_number > 0 {
+                    if points_at_arg
+                        && mutability.is_not()
+                        && refs_number > 0
+                        // The borrow can sit in a macro body, where rewriting it would edit the
+                        // macro definition and so every one of its call sites, or a crate the user
+                        // does not own. Fall through to the note in that case.
+                        && span.can_be_used_for_suggestions()
+                    {
                         // If we have a call like foo(&mut buf), then don't suggest foo(&mut mut buf)
                         if snippet
                             .trim_start_matches(|c: char| c.is_whitespace() || c == '&')

--- a/tests/ui/suggestions/auxiliary/mut_borrow_macro.rs
+++ b/tests/ui/suggestions/auxiliary/mut_borrow_macro.rs
@@ -1,0 +1,6 @@
+#[macro_export]
+macro_rules! call_it {
+    ($f:expr) => {
+        (0..100).for_each(&$f)
+    };
+}

--- a/tests/ui/suggestions/change-mut-borrow-in-macro.rs
+++ b/tests/ui/suggestions/change-mut-borrow-in-macro.rs
@@ -1,0 +1,26 @@
+//@ edition: 2021
+//@ aux-build: mut_borrow_macro.rs
+
+// The borrow that needs to become `&mut` lives in a macro body, so rewriting it would edit the
+// macro definition rather than the call site, and for an external macro a file the user does not
+// own.
+
+extern crate mut_borrow_macro;
+
+macro_rules! local_call_it {
+    ($f:expr) => {
+        (0..100).for_each(&$f)
+    };
+}
+
+fn main() {
+    let mut value = 0;
+    let mut func = |increment: usize| value += increment;
+    //~^ ERROR expected a closure that implements the `Fn` trait
+    local_call_it!(func);
+
+    let mut other = 0;
+    let mut other_func = |increment: usize| other += increment;
+    //~^ ERROR expected a closure that implements the `Fn` trait
+    mut_borrow_macro::call_it!(other_func);
+}

--- a/tests/ui/suggestions/change-mut-borrow-in-macro.stderr
+++ b/tests/ui/suggestions/change-mut-borrow-in-macro.stderr
@@ -1,0 +1,40 @@
+error[E0525]: expected a closure that implements the `Fn` trait, but this closure only implements `FnMut`
+  --> $DIR/change-mut-borrow-in-macro.rs:18:20
+   |
+LL |         (0..100).for_each(&$f)
+   |                  -------- --- the requirement to implement `Fn` derives from here
+   |                  |
+   |                  required by a bound introduced by this call
+...
+LL |     let mut func = |increment: usize| value += increment;
+   |                    ^^^^^^^^^^^^^^^^^^ ----- closure is `FnMut` because it mutates the variable `value` here
+   |                    |
+   |                    this closure implements `FnMut`, not `Fn`
+   |
+   = note: `FnMut(usize)` is implemented for `&mut {closure@$DIR/change-mut-borrow-in-macro.rs:18:20: 18:38}`, but not for `&{closure@$DIR/change-mut-borrow-in-macro.rs:18:20: 18:38}`
+   = note: required for `&{closure@$DIR/change-mut-borrow-in-macro.rs:18:20: 18:38}` to implement `FnMut(usize)`
+note: required by a bound in `for_each`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+
+error[E0525]: expected a closure that implements the `Fn` trait, but this closure only implements `FnMut`
+  --> $DIR/change-mut-borrow-in-macro.rs:23:26
+   |
+LL |     let mut other_func = |increment: usize| other += increment;
+   |                          ^^^^^^^^^^^^^^^^^^ ----- closure is `FnMut` because it mutates the variable `other` here
+   |                          |
+   |                          this closure implements `FnMut`, not `Fn`
+LL |
+LL |     mut_borrow_macro::call_it!(other_func);
+   |     --------------------------------------
+   |     |
+   |     the requirement to implement `Fn` derives from here
+   |     required by a bound introduced by this call
+   |
+   = note: `FnMut(usize)` is implemented for `&mut {closure@$DIR/change-mut-borrow-in-macro.rs:23:26: 23:44}`, but not for `&{closure@$DIR/change-mut-borrow-in-macro.rs:23:26: 23:44}`
+   = note: required for `&{closure@$DIR/change-mut-borrow-in-macro.rs:23:26: 23:44}` to implement `FnMut(usize)`
+note: required by a bound in `for_each`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0525`.


### PR DESCRIPTION
`suggest_change_mut` has no expansion guard so a borrow written in a macro body gets a `MachineApplicable` help pointing inside the macro or at a file in a dependency. with more than one local call site applying it forces the mutable borrow on every expansion and swaps `E0525` for `E0596`. adds `span.can_be_used_for_suggestions()` to the guard falling through to the existing note.

with a single local call site the suggestion is correct. the span is the defect.

the guard is in the shared helper so it covers all three call sites. full `tests/ui` 21979 passed 0 failed with zero existing baselines re blessed.

r? @chenyukang

cc @davidtwco

