### PR TITLE
Add regression test for matching associated types on new solver

### DIFF
--- a/tests/ui/associated-types/associated-types-match-despite-generic.rs
+++ b/tests/ui/associated-types/associated-types-match-despite-generic.rs
@@ -1,0 +1,21 @@
+//! Regression test for <https://github.com/rust-lang/trait-system-refactor-initiative/issues/216>.
+//@compile-flags: -Znext-solver=globally
+//@ check-pass
+
+struct Outer;
+struct Inner;
+trait Id<T> {
+    type This;
+}
+impl<T, U> Id<U> for T {
+    type This = T;
+}
+
+fn free<T>(x: T) -> <T as Id<Inner>>::This
+where
+    <T as Id<Outer>>::This: Id<Inner, This = <T as Id<Inner>>::This>,
+{
+    x
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Closes https://github.com/rust-lang/trait-system-refactor-initiative/issues/216
The regression test fails on 5e91de65, which I think is just before it was fixed.
The test placement is always tricky for me but it seemed to have to do with associated types so here we are.

Any feedback is appreciated!