### PR TITLE
Fix `path_trailing_sep` methods for Windows verbatim paths

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2983,7 +2983,8 @@ impl Path {
     #[must_use]
     #[inline]
     pub fn has_trailing_sep(&self) -> bool {
-        self.as_os_str().as_encoded_bytes().last().copied().is_some_and(is_sep_byte)
+        let comps = self.components();
+        self.as_os_str().as_encoded_bytes().last().copied().is_some_and(|b| comps.is_sep_byte(b))
     }
 
     /// Ensures that a path has a trailing [separator](MAIN_SEPARATOR),
@@ -3034,10 +3035,11 @@ impl Path {
     #[must_use]
     #[inline]
     pub fn trim_trailing_sep(&self) -> &Path {
+        let comps = self.components();
         if self.has_trailing_sep() && (!self.has_root() || self.parent().is_some()) {
             let mut bytes = self.inner.as_encoded_bytes();
             while let Some((last, init)) = bytes.split_last()
-                && is_sep_byte(*last)
+                && comps.is_sep_byte(*last)
             {
                 bytes = init;
             }

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -2597,3 +2597,20 @@ fn test_trim_trailing_sep() {
         assert_eq!(Path::new("c:..\\\\").trim_trailing_sep().as_os_str(), OsStr::new("c:.."));
     }
 }
+
+#[cfg(windows)]
+#[test]
+fn trailing_sep_verbatim() {
+    assert_eq!(Path::new(r"\\?\C:\path").has_trailing_sep(), false);
+    assert_eq!(Path::new(r"\\?\C:\path/").has_trailing_sep(), false);
+    assert_eq!(Path::new(r"\\?\C:\path\").has_trailing_sep(), true);
+    assert_eq!(Path::new(r"\\?\C:\").has_trailing_sep(), true);
+    assert_eq!(Path::new(r"\\?\C:/").has_trailing_sep(), false);
+
+    assert_eq!(Path::new(r"\\?\C:\path").trim_trailing_sep(), Path::new(r"\\?\C:\path"));
+    assert_eq!(Path::new(r"\\?\C:\path/").trim_trailing_sep(), Path::new(r"\\?\C:\path/"));
+    assert_eq!(Path::new(r"\\?\C:\path\").trim_trailing_sep(), Path::new(r"\\?\C:\path"));
+    assert_eq!(Path::new(r"\\?\C:\path/\\\").trim_trailing_sep(), Path::new(r"\\?\C:\path/"));
+    assert_eq!(Path::new(r"\\?\C:\").trim_trailing_sep(), Path::new(r"\\?\C:\"));
+    assert_eq!(Path::new(r"\\?\C:/").trim_trailing_sep(), Path::new(r"\\?\C:/"));
+}


### PR DESCRIPTION
Normally on Windows the path separator is either `\` or `/` but for verbatim paths it is only `\`. Currently the unstable `path_trailing_sep` methods (rust-lang/rust#142503) do not take that into account and just use the general `is_sep_byte` method.

This PR changes it to use the internal `Components::is_sep(self, b)` method that takes into account verbatim paths.