### PR TITLE
Add regression test for previous overflow evaluating the requirement

### DIFF
--- a/tests/ui/generic-associated-types/trait-method-requires-gat-impl-trait.rs
+++ b/tests/ui/generic-associated-types/trait-method-requires-gat-impl-trait.rs
@@ -1,0 +1,17 @@
+//! Regression test for <https://github.com/rust-lang/trait-system-refactor-initiative/issues/219>.
+//@compile-flags: -Znext-solver=globally
+//@ check-pass
+
+trait Trait {
+    type Assoc<V>;
+    fn foo<V>()
+    where
+        Self::Assoc<V>: Trait;
+}
+
+impl<T> Trait for T {
+    type Assoc<V> = T;
+    fn foo<V>() {}
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->

Closes https://github.com/rust-lang/trait-system-refactor-initiative/issues/219

Same deal, the test fails on https://github.com/rust-lang/rust/commit/5e91de65d75d3c849c643f5079509b9e5985a5c0 just like in rust-lang/rust#162642.

Again, placing the test is challenging but I did my best on folder and naming.