### PR TITLE
Remove needless test running instructions

### DIFF
--- a/tests/run-make-cargo/thumb-none-cortex-m/rmake.rs
+++ b/tests/run-make-cargo/thumb-none-cortex-m/rmake.rs
@@ -2,10 +2,6 @@
 //! for a collection of thumb targets. This is a smoke test that verifies that both cargo
 //! and rustc work in this case.
 //!
-//! How to run this
-//! $ ./x.py clean
-//! $ ./x.py test --target thumbv6m-none-eabi,thumbv7m-none-eabi tests/run-make-cargo
-//!
 //! Supported targets:
 //! - thumbv6m-none-eabi (Bare Cortex-M0, M0+, M1)
 //! - thumbv7em-none-eabi (Bare Cortex-M4, M7)

--- a/tests/run-make-cargo/thumb-none-qemu/rmake.rs
+++ b/tests/run-make-cargo/thumb-none-qemu/rmake.rs
@@ -6,10 +6,6 @@
 //!
 //! This test builds and runs the applications for various thumb targets using qemu.
 //!
-//! How to run this
-//! $ ./x.py clean
-//! $ ./x.py test --target thumbv6m-none-eabi,thumbv7m-none-eabi tests/run-make
-//!
 //! For supported targets, see `example/.cargo/config.toml`
 //!
 //! FIXME: https://github.com/rust-lang/rust/issues/128733 this test uses external

--- a/tests/run-make/static-pie/rmake.rs
+++ b/tests/run-make/static-pie/rmake.rs
@@ -1,6 +1,3 @@
-// How to manually run this
-// $ ./x.py test --target x86_64-unknown-linux-[musl,gnu] tests/run-make/static-pie
-
 //@ only-x86_64
 //@ only-linux
 //@ ignore-32bit

--- a/tests/run-make/wasm-override-linker/rmake.rs
+++ b/tests/run-make/wasm-override-linker/rmake.rs
@@ -1,6 +1,3 @@
-// How to run this
-// $ RUSTBUILD_FORCE_CLANG_BASED_TESTS=1 ./x.py test tests/run-make/wasm-override-linker/
-
 //@ needs-force-clang-based-tests
 // FIXME(#126180): This test can only run on `x86_64-gnu-debug`, because that CI job sets
 // RUSTBUILD_FORCE_CLANG_BASED_TESTS and only runs tests which contain "clang" in their


### PR DESCRIPTION
We have Rust Compiler Development Guide for that.

r? @jieyouxu 

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
