### PR TITLE
Improve Armv7-R documentation

### DIFF
--- a/src/doc/rustc/src/platform-support/armv7r-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv7r-none-eabi.md
@@ -3,18 +3,30 @@
 * **Tier: 2**
 * **Library Support:** core and alloc (bare-metal, `#![no_std]`)
 
-Bare-metal target for CPUs in the Armv7-R architecture family, supporting dual
-ARM/Thumb mode. The `armv7r-none-eabi*` targets use Arm mode by default and the
-`thumbv7r-none-eabi*` targets use Thumb mode by default. The `-eabi` targets use
-a soft-float ABI and do not require an FPU, while the `-eabihf` targets use a
-hard-float ABI and do require an FPU.
+Bare-metal target for CPUs in the [Armv7-R] architecture family, supporting both
+the [A32 (Arm) ISA][a32-isa] and [T32 (Thumb) ISA][t32-isa].
 
-Processors in this family include the [Arm Cortex-R4, 5, 7, and 8][cortex-r].
+The `armv7r-none-eabi*` targets use A32 (Arm) mode by default and the
+`thumbv7r-none-eabi*` targets use T32 (Thumb) mode by default.
+
+Processors in this family include the:
+
+* [Arm Cortex-R4][cortex-r4]
+* [Arm Cortex-R5][cortex-r5]
+* [Arm Cortex-R7][cortex-r7]
+* [Arm Cortex-R8][cortex-r8]
 
 See [`arm-none-eabi`](arm-none-eabi.md) for information applicable to all
-`arm-none-eabi` targets.
+`arm-none-eabi` targets, in particular the difference between the `eabi` and
+`eabihf` ABI.
 
-[cortex-r]: https://en.wikipedia.org/wiki/ARM_Cortex-R
+[t32-isa]: https://developer.arm.com/Architectures/T32%20Instruction%20Set%20Architecture
+[a32-isa]: https://developer.arm.com/Architectures/A32%20Instruction%20Set%20Architecture
+[Armv7-R]: https://support.arm.com/documentation/ddi0406
+[cortex-r4]: https://developer.arm.com/Processors/Cortex-R4
+[cortex-r5]: https://developer.arm.com/Processors/Cortex-R5
+[cortex-r7]: https://developer.arm.com/Processors/Cortex-R7
+[cortex-r8]: https://developer.arm.com/Processors/Cortex-R8
 
 ## Target maintainers
 
@@ -31,17 +43,62 @@ See [`arm-none-eabi`](arm-none-eabi.md) for information applicable to all
 
 When using the hardfloat (`-eabibf`) targets, the minimum floating-point
 features assumed are those of the `vfpv3-d16`, which includes single- and
-double-precision, with 16 double-precision registers. This floating-point unit
-appears in Cortex-R4F and Cortex-R5F processors. See [VFP in the Cortex-R
+double-precision, with 16 double-precision registers. See [VFP in the Cortex-R
 processors][vfp] for more details on the possible FPU variants.
 
 If your processor supports a different set of floating-point features than the
-default expectations of `vfpv3-d16`, then these should also be enabled or
-disabled as needed with `-C target-feature=(+/-)`.
+default expectations of `vfpv3-d16` (for example, if it only supports
+single-precision and not double-precision), then those features should also be
+enabled or disabled as needed with `-C target-feature=(+/-)` (or using a custom
+JSON target). If you are removing features then you will also need to recompile
+the Rust Standard Library from source (e.g. using `-Zbuild-std=core`).
 
-[endianness]: https://developer.arm.com/documentation/den0042/a/Coding-for-Cortex-R-Processors/Endianness
+See [the bare-metal Arm
+docs](arm-none-eabi.md#target-cpu-and-target-feature-options) for details on how
+to use these flags.
 
 [vfp]: https://developer.arm.com/documentation/den0042/a/Floating-Point/Floating-point-basics-and-the-IEEE-754-standard/VFP-in-the-Cortex-R-processors
+
+
+### Table of supported CPUs for `(arm|thumb)v7r-none-eabi`
+
+| CPU       | FPU | Target CPU  | Target Features |
+|-----------|-----|-------------|-----------------|
+| Any       | No  | None        | None            |
+| Cortex-R4 | No  | `cortex-r4` | None            |
+| Cortex-R4 | DP  | `cortex-r4` | `+vfp3`         |
+| Cortex-R4 | SP  | `cortex-r4` | `+vfp3,-fp64`   |
+| Cortex-R5 | No  | `cortex-r5` | `-fpregs`       |
+| Cortex-R5 | DP  | `cortex-r5` | None            |
+| Cortex-R5 | SP  | `cortex-r5` | `-fp64`         |
+| Cortex-R7 | No  | `cortex-r7` | `-fpregs`       |
+| Cortex-R7 | DP  | `cortex-r7` | None            |
+| Cortex-R7 | SP  | `cortex-r7` | `-fp64`         |
+| Cortex-R8 | No  | `cortex-r8` | `-fpregs`       |
+| Cortex-R8 | DP  | `cortex-r8` | None            |
+| Cortex-R8 | SP  | `cortex-r8` | `-fp64`         |
+
+### Table of supported CPUs for `(arm|thumb)v7r-none-eabihf`
+
+| CPU       | FPU | Target CPU  | Target Features |
+|-----------|-----|-------------|-----------------|
+| Any       | DP  | None        | None            |
+| Any       | SP  | None        | `-fp64`         |
+| Cortex-R4 | DP  | `cortex-r4` | None            |
+| Cortex-R4 | SP  | `cortex-r4` | `-fp64`         |
+| Cortex-R5 | DP  | `cortex-r5` | None            |
+| Cortex-R5 | SP  | `cortex-r5` | `-fp64`         |
+| Cortex-R7 | DP  | `cortex-r7` | None            |
+| Cortex-R7 | SP  | `cortex-r7` | `-fp64`         |
+| Cortex-R8 | DP  | `cortex-r8` | None            |
+| Cortex-R8 | SP  | `cortex-r8` | `-fp64`         |
+
+<div class="warning">
+
+Never use the `-fpregs` *target-feature* with the `(arm|thumb)v7r-none-eabi` targets
+as it will cause compilation units to have different ABIs, which is unsound.
+
+</div>
 
 ## Start-up and Low-Level Code
 


### PR DESCRIPTION
People have [fallen over the issue](https://github.com/rust-lang/rust/issues/128448) where `target-cpu=cortex-r5` unexpectedly turns on FPU support, even on an EABI soft-float target. So this update attempts to document the full set of Armv7-R processors, their FPU options, and how to set things up for the precise combination you have.

It is modelled after the Armv7E-M documentation.

I know the features it recommends are "unstable" but I really do not know any other way of controlling what kind of FPU `rustc` is generating code for. I'd love a simple `-Ctarget-cpu=cortex-r5 -Ctarget-fpu=vfp3-d16-sp` option but we don't have one at this time.

This actually matters more on Armv7-R than on Armv7E-M, because `rustc` currently assumes a double-precision FPU and some hardware only has a single-precision FPU. So you *need* target features to make the target work on that hardware.

* [x] No LLMs were used in the creation of this PR

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
