### PR TITLE
next solver: prefer to select impl candidates over global where-clause candidates

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/select.rs
+++ b/compiler/rustc_trait_selection/src/solve/select.rs
@@ -2,7 +2,7 @@ use std::ops::ControlFlow;
 
 use rustc_infer::infer::InferCtxt;
 use rustc_infer::traits::solve::inspect::ProbeKind;
-use rustc_infer::traits::solve::{CandidateSource, Certainty, Goal};
+use rustc_infer::traits::solve::{CandidateSource, Certainty, Goal, ParamEnvSource};
 use rustc_infer::traits::{
     BuiltinImplSource, ImplSource, ImplSourceUserDefinedData, Obligation, ObligationCause,
     PolyTraitObligation, Selection, SelectionError, SelectionResult,
@@ -93,8 +93,8 @@ fn candidate_should_be_dropped_in_favor_of<'tcx>(
     victim: &inspect::InspectCandidate<'_, 'tcx>,
     other: &inspect::InspectCandidate<'_, 'tcx>,
 ) -> bool {
-    // Don't winnow until `Certainty::Yes` -- we don't need to winnow until
-    // codegen, and only on the good path.
+    // Don't winnow until `Certainty::Yes` -- we don't need to winnow until constant evaluation or
+    // codegen.
     if matches!(other.result().unwrap(), Certainty::Maybe(_)) {
         return false;
     }
@@ -136,6 +136,15 @@ fn candidate_should_be_dropped_in_favor_of<'tcx>(
         (CandidateSource::Impl(victim_def_id), CandidateSource::Impl(other_def_id)) => {
             victim.goal().infcx().tcx.specializes((other_def_id, victim_def_id))
         }
+
+        // Prefer impl candidates over global where clause candidates. Unless `generic_const_args`
+        // is enabled, we currently don't use an empty environment when resolving and evaluating
+        // constants to lower them to patterns. If we don't drop where clause candidates here, we
+        // can fail to select impl candidates (#162331).
+        (
+            CandidateSource::ParamEnv(ParamEnvSource::Global),
+            CandidateSource::Impl(_) | CandidateSource::BuiltinImpl(_),
+        ) => true,
 
         _ => false,
     }

--- a/tests/ui/trait-bounds/ignore-where-clauses-in-const-pattern.rs
+++ b/tests/ui/trait-bounds/ignore-where-clauses-in-const-pattern.rs
@@ -1,0 +1,48 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/162331>
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+#![feature(const_trait_impl)]
+#![feature(const_clone)]
+
+// At the time of writing, when resolving an instance for `<u8 as Trait>::N`, the environment
+// contains `f`'s `u8: Trait` clause. The old solver dropped the where clause candidate in favor of
+// the `impl Trait for u8` candidate, but the new solver didn't, which resulted in ambiguity.
+
+pub trait Trait {
+    const N: usize;
+}
+
+impl Trait for u8 {
+    const N: usize = 0;
+}
+
+pub fn f()
+where
+    u8: Trait,
+{
+    match 0 {
+        <u8 as Trait>::N => {}
+        _ => {}
+    }
+}
+
+// At the time of writing, `ZERO` is evaluated in an environment containing `g`'s `(u8,): Clone`
+// clause. This wasn't dropped in favor of the built-in `(u8,): Clone` impl when resolving an
+// instance for `<(u8,) as Clone>::clone`, which resulted in ambiguity.
+
+const ZERO: (u8,) = (0,).clone();
+
+fn g()
+where
+    (u8,): Clone
+{
+    match (0,) {
+        ZERO => {}
+        _ => {}
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/162331

Ideally we'd use a more appropriate typing environment when doing const-eval for const-to-pat, which would also fix that (since the problem clauses wouldn't be present to begin with). Being able to do that seems kind of far off, though, so here's a quick fix that (mostly) matches what the old solver does.