### PR TITLE
Suggest changing argument mutability from `&T` to `&mut T`

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -3012,6 +3012,28 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     false,
                 ));
             }
+            (
+                hir::ExprKind::AddrOf(hir::BorrowKind::Ref, hir::Mutability::Not, inner),
+                &ty::Ref(_, exp_inner, hir::Mutability::Mut),
+                &ty::Ref(_, check_inner, hir::Mutability::Not),
+            ) if {
+                let new_mut_ref =
+                    Ty::new_mut_ref(self.tcx, self.tcx.lifetimes.re_static, check_inner);
+                self.may_coerce(new_mut_ref, expected)
+                    || self.can_eq(self.param_env, check_inner, exp_inner)
+            } =>
+            {
+                let inner_span = inner.span.find_ancestor_inside(sp).unwrap_or(inner.span);
+                if sp.contains(inner_span) && sm.is_span_accessible(inner_span) {
+                    let borrow_span = sp.until(inner_span);
+                    return Some((
+                        vec![(borrow_span, "&mut ".to_string())],
+                        "change the borrow to be mutable".to_string(),
+                        Applicability::MachineApplicable,
+                        false,
+                    ));
+                }
+            }
             (_, &ty::Ref(_, exp, _), &ty::Ref(_, check, _)) => match (exp.kind(), check.kind()) {
                 (&ty::Str, &ty::Array(arr, _) | &ty::Slice(arr)) if arr == self.tcx.types.u8 => {
                     if let hir::ExprKind::Lit(_) = expr.kind

--- a/tests/ui/suggestions/suggest-changing-argument-mutability.rs
+++ b/tests/ui/suggestions/suggest-changing-argument-mutability.rs
@@ -1,0 +1,16 @@
+﻿fn takes_mut(_: &mut String) {}
+
+struct S;
+impl S {
+    fn mutate(&mut self, _: &mut i32) {}
+}
+
+fn main() {
+    let mut s = String::new();
+    takes_mut(&s);
+    //~^ ERROR mismatched types
+
+    let mut val = 42;
+    S.mutate(&val);
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/suggestions/suggest-changing-argument-mutability.stderr
+++ b/tests/ui/suggestions/suggest-changing-argument-mutability.stderr
@@ -1,0 +1,43 @@
+﻿error[E0308]: mismatched types
+  --> $DIR/suggest-changing-argument-mutability.rs:10:15
+   |
+LL |     takes_mut(&s);
+   |     --------- ^^ types differ in mutability
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut String`
+                      found reference `&String`
+note: function defined here
+  --> $DIR/suggest-changing-argument-mutability.rs:1:4
+   |
+LL | fn takes_mut(_: &mut String) {}
+   |    ^^^^^^^^^ ------------------
+help: change the borrow to be mutable
+   |
+LL |     takes_mut(&mut s);
+   |                +++
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-changing-argument-mutability.rs:14:14
+   |
+LL |     S.mutate(&val);
+   |       ------ ^^^^ types differ in mutability
+   |       |
+   |       arguments to this method are incorrect
+   |
+   = note: expected mutable reference `&mut i32`
+                      found reference `&i32`
+note: method defined here
+  --> $DIR/suggest-changing-argument-mutability.rs:5:8
+   |
+LL |     fn mutate(&mut self, _: &mut i32) {}
+   |        ^^^^^^ -----------------------
+help: change the borrow to be mutable
+   |
+LL |     S.mutate(&mut val);
+   |               +++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#159490.

When a function or method takes a mutable reference `&mut T` but an immutable reference `&T` is supplied (e.g. `read_line(&input)`), rustc reports `types differ in mutability` but did not provide a suggestion to change the borrow.

This commit adds a diagnostic suggestion in `rustc_hir_typeck` to change the borrow to mutable (`&mut ...`), along with a new UI regression test.