### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr/closure.rs
+++ b/compiler/rustc_ast_lowering/src/expr/closure.rs
@@ -204,7 +204,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
         let bound_generic_params = self.lower_lifetime_binder(closure_id, generic_params);
         // Lower outside new scope to preserve `is_in_loop_condition`.
-        let fn_decl = self.lower_fn_decl(decl, closure_id, fn_decl_span, FnDeclKind::Closure, None);
+        let fn_decl = self.lower_fn_decl(decl, closure_id, FnDeclKind::Closure, None);
 
         let c = self.arena.alloc(hir::Closure {
             def_id: closure_def_id,
@@ -327,8 +327,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         // We need to lower the declaration outside the new scope, because we
         // have to conserve the state of being inside a loop condition for the
         // closure argument types.
-        let fn_decl =
-            self.lower_fn_decl(&decl, closure_id, fn_decl_span, FnDeclKind::Closure, None);
+        let fn_decl = self.lower_fn_decl(&decl, closure_id, FnDeclKind::Closure, None);
 
         if let Const::Yes(span) = constness {
             self.dcx().span_err(span, "const coroutines are not supported");

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -332,7 +332,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
                     let itctx = ImplTraitContext::Universal;
                     let (generics, decl) = this.lower_generics(generics, itctx, |this| {
-                        this.lower_fn_decl(decl, id, *fn_sig_span, FnDeclKind::Fn, coroutine_marker)
+                        this.lower_fn_decl(decl, id, FnDeclKind::Fn, coroutine_marker)
                     });
                     let sig = hir::FnSig {
                         decl,
@@ -741,7 +741,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let (generics, (decl, fn_args)) = self.lower_generics(generics, itctx, |this| {
                     (
                         // Disallow `impl Trait` in foreign items.
-                        this.lower_fn_decl(fdec, i.id, sig.span, FnDeclKind::ExternFn, None),
+                        this.lower_fn_decl(fdec, i.id, FnDeclKind::ExternFn, None),
                         this.lower_fn_params_to_idents(fdec),
                     )
                 });
@@ -1680,7 +1680,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let header = self.lower_fn_header(sig.header, hir::Safety::Safe, attrs);
         let itctx = ImplTraitContext::Universal;
         let (generics, decl) = self.lower_generics(generics, itctx, |this| {
-            this.lower_fn_decl(&sig.decl, id, sig.span, kind, coroutine_marker)
+            this.lower_fn_decl(&sig.decl, id, kind, coroutine_marker)
         });
         (generics, hir::FnSig { header, decl, span: self.lower_span(sig.span) })
     }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1599,7 +1599,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     generic_params,
                     safety: self.lower_safety(f.safety, hir::Safety::Safe),
                     abi: self.lower_extern(f.ext),
-                    decl: self.lower_fn_decl(&f.decl, t.id, t.span, FnDeclKind::Pointer, None),
+                    decl: self.lower_fn_decl(&f.decl, t.id, FnDeclKind::Pointer, None),
                     param_idents: self.lower_fn_params_to_idents(&f.decl),
                 }))
             }
@@ -1959,7 +1959,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
         &mut self,
         decl: &FnDecl,
         fn_node_id: NodeId,
-        fn_span: Span,
         kind: FnDeclKind,
         coro: Option<CoroutineMarker>,
     ) -> &'hir hir::FnDecl<'hir> {

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -52,7 +52,7 @@ pub(super) fn failed_to_match_macro(
         FailedMacro::Attr(attr_args) => {
             try_match_macro_attr(psess, name, attr_args, body, rules, &mut tracker)
         }
-        FailedMacro::Derive => try_match_macro_derive(psess, name, body, rules, &mut tracker),
+        FailedMacro::Derive => try_match_macro_derive(psess, body, rules, &mut tracker),
     };
 
     if try_success_result.is_ok() {

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -50,7 +50,7 @@ pub(super) fn failed_to_match_macro(
     let try_success_result = match args {
         FailedMacro::Func => try_match_macro(psess, name, body, rules, &mut tracker),
         FailedMacro::Attr(attr_args) => {
-            try_match_macro_attr(psess, name, attr_args, body, rules, &mut tracker)
+            try_match_macro_attr(psess, attr_args, body, rules, &mut tracker)
         }
         FailedMacro::Derive => try_match_macro_derive(psess, body, rules, &mut tracker),
     };

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -48,7 +48,7 @@ pub(super) fn failed_to_match_macro(
     let mut tracker = CollectTrackerAndEmitter::new(name, psess.dcx(), sp);
 
     let try_success_result = match args {
-        FailedMacro::Func => try_match_macro(psess, name, body, rules, &mut tracker),
+        FailedMacro::Func => try_match_macro(psess, body, rules, &mut tracker),
         FailedMacro::Attr(attr_args) => {
             try_match_macro_attr(psess, attr_args, body, rules, &mut tracker)
         }

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -538,7 +538,7 @@ fn expand_macro_attr(
     }
 
     // Track nothing for the best performance.
-    match try_match_macro_attr(psess, name, &args, &body, rules, &mut NoopTracker) {
+    match try_match_macro_attr(psess, &args, &body, rules, &mut NoopTracker) {
         Ok((i, rule, named_matches)) => {
             let MacroRule::Attr { rhs, unsafe_rule, .. } = rule else {
                 panic!("try_macro_match_attr returned non-attr rule");
@@ -686,7 +686,6 @@ pub(super) fn try_match_macro<'matcher, T: Tracker<'matcher>>(
 #[instrument(level = "debug", skip(psess, attr_args, attr_body, rules, track), fields(tracking = %T::description()))]
 pub(super) fn try_match_macro_attr<'matcher, T: Tracker<'matcher>>(
     psess: &ParseSess,
-    name: Ident,
     attr_args: &TokenStream,
     attr_body: &TokenStream,
     rules: &'matcher [MacroRule],

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -447,7 +447,7 @@ fn expand_macro<'cx, 'a: 'cx>(
     }
 
     // Track nothing for the best performance.
-    let try_success_result = try_match_macro(psess, name, &arg, rules, &mut NoopTracker);
+    let try_success_result = try_match_macro(psess, &arg, rules, &mut NoopTracker);
 
     match try_success_result {
         Ok((rule_index, rule, named_matches)) => {
@@ -606,7 +606,6 @@ pub(super) enum CanRetry {
 #[instrument(level = "debug", skip(psess, arg, rules, track), fields(tracking = %T::description()))]
 pub(super) fn try_match_macro<'matcher, T: Tracker<'matcher>>(
     psess: &ParseSess,
-    name: Ident,
     arg: &TokenStream,
     rules: &'matcher [MacroRule],
     track: &mut T,

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -244,7 +244,7 @@ impl MacroRulesMacroExpander {
             trace_macros_note(&mut cx.expansions, sp, msg);
         }
 
-        match try_match_macro_derive(psess, name, body, rules, &mut NoopTracker) {
+        match try_match_macro_derive(psess, body, rules, &mut NoopTracker) {
             Ok((rule_index, rule, named_matches)) => {
                 let MacroRule::Derive { rhs, .. } = rule else {
                     panic!("try_match_macro_derive returned non-derive rule");
@@ -743,7 +743,6 @@ pub(super) fn try_match_macro_attr<'matcher, T: Tracker<'matcher>>(
 #[instrument(level = "debug", skip(psess, body, rules, track), fields(tracking = %T::description()))]
 pub(super) fn try_match_macro_derive<'matcher, T: Tracker<'matcher>>(
     psess: &ParseSess,
-    name: Ident,
     body: &TokenStream,
     rules: &'matcher [MacroRule],
     track: &mut T,

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -201,7 +201,7 @@ where
 
     lint_redundant_lifetimes(tcx, body_def_id, &outlives_env);
 
-    let errors = infcx.resolve_regions_with_outlives_env(&outlives_env, tcx.def_span(body_def_id));
+    let errors = infcx.resolve_regions_with_outlives_env(&outlives_env);
     if errors.is_empty() {
         return Ok(());
     }
@@ -215,8 +215,7 @@ where
         // the implied bounds hack if this contains `bevy_ecs`'s `ParamSet` type.
         false,
     );
-    let errors_compat =
-        infcx_compat.resolve_regions_with_outlives_env(&outlives_env, tcx.def_span(body_def_id));
+    let errors_compat = infcx_compat.resolve_regions_with_outlives_env(&outlives_env);
     if errors_compat.is_empty() {
         // FIXME: Once we fix bevy, this would be the place to insert a warning
         // to upgrade bevy.

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -228,7 +228,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn write_splatted_call(
         &self,
         hir_id: HirId,
-        span: Span,
         fn_id: SplatLoweringInfo<'tcx>,
         callee_generic_args: Option<GenericArgsRef<'tcx>>,
         first_tupled_arg_index: u16,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -825,7 +825,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // FIXME(const_trait_impl): does not enforce constness yet
                 self.write_splatted_call(
                     call_expr.hir_id,
-                    call_span,
                     fn_id,
                     callee_generic_args,
                     first_tupled_arg_index,

--- a/compiler/rustc_infer/src/infer/outlives/mod.rs
+++ b/compiler/rustc_infer/src/infer/outlives/mod.rs
@@ -5,7 +5,6 @@ use std::iter;
 use rustc_data_structures::undo_log::UndoLogs;
 use rustc_middle::traits::query::OutlivesBound;
 use rustc_middle::ty;
-use rustc_span::Span;
 use tracing::instrument;
 
 use self::env::OutlivesEnvironment;
@@ -44,9 +43,8 @@ impl<'tcx> InferCtxt<'tcx> {
     pub fn resolve_regions_with_outlives_env(
         &self,
         outlives_env: &OutlivesEnvironment<'tcx>,
-        span: Span,
     ) -> Vec<RegionResolutionError<'tcx>> {
-        self.process_registered_region_obligations(outlives_env, span);
+        self.process_registered_region_obligations(outlives_env);
 
         let mut storage = {
             let mut inner = self.inner.borrow_mut();

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -68,7 +68,6 @@ use rustc_middle::ty::{
     self, GenericArgKind, GenericArgsRef, PolyTypeOutlivesClause, Region, RegionVid, Ty, TyCtxt,
     TypeVisitableExt, Upcast, eager_resolve_vars,
 };
-use rustc_span::Span;
 use rustc_type_ir::region_constraint::{self, LeafRegionConstraint};
 use smallvec::smallvec;
 use tracing::{debug, instrument};
@@ -335,11 +334,7 @@ impl<'tcx> InferCtxt<'tcx> {
     /// invoked after all type-inference variables have been bound --
     /// right before lexical region resolution.
     #[instrument(level = "debug", skip(self, outlives_env))]
-    pub fn process_registered_region_obligations(
-        &self,
-        outlives_env: &OutlivesEnvironment<'tcx>,
-        span: Span,
-    ) {
+    pub fn process_registered_region_obligations(&self, outlives_env: &OutlivesEnvironment<'tcx>) {
         assert!(!self.in_snapshot(), "cannot process registered region obligations in a snapshot");
 
         if self.tcx.assumptions_on_binders() {

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -156,7 +156,7 @@ impl<'p, 'tcx> Visitor<'p, 'tcx> for MatchVisitor<'p, 'tcx> {
                 self.check_match(scrutinee, arms, MatchSource::Normal, span);
             }
             ExprKind::Let { ref pat, expr } => {
-                self.check_let(pat, Some(expr), ex.span, None);
+                self.check_let(pat, Some(expr), ex.span);
             }
             ExprKind::LogicalOp { op: LogicalOp::And, .. }
                 if !matches!(self.let_source, LetSource::None) =>
@@ -180,9 +180,8 @@ impl<'p, 'tcx> Visitor<'p, 'tcx> for MatchVisitor<'p, 'tcx> {
                 self.with_hir_source(hir_id, |this| {
                     let let_source =
                         if else_block.is_some() { LetSource::LetElse } else { LetSource::PlainLet };
-                    let else_span = else_block.map(|bid| this.thir.blocks[bid].span);
                     this.with_let_source(let_source, |this| {
-                        this.check_let(pattern, initializer, span, else_span)
+                        this.check_let(pattern, initializer, span)
                     });
                     visit::walk_stmt(this, stmt);
                 });
@@ -424,13 +423,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
     }
 
     #[instrument(level = "trace", skip(self))]
-    fn check_let(
-        &mut self,
-        pat: &'p Pat<'tcx>,
-        scrutinee: Option<ExprId>,
-        span: Span,
-        else_span: Option<Span>,
-    ) {
+    fn check_let(&mut self, pat: &'p Pat<'tcx>, scrutinee: Option<ExprId>, span: Span) {
         assert!(self.let_source != LetSource::None);
         let scrut = scrutinee.map(|id| &self.thir[id]);
         if let LetSource::PlainLet = self.let_source {

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1061,7 +1061,6 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
     #[instrument(level = "trace", skip(self), ret)]
     fn simplify_rvalue(
         &mut self,
-        lhs: &Place<'tcx>,
         rvalue: &mut Rvalue<'tcx>,
         location: Location,
     ) -> Option<VnIndex> {
@@ -2100,7 +2099,7 @@ impl<'tcx> MutVisitor<'tcx> for VnState<'_, '_, 'tcx> {
     ) {
         self.simplify_place_projection(lhs, location);
 
-        let value = self.simplify_rvalue(lhs, rvalue, location);
+        let value = self.simplify_rvalue(rvalue, location);
         if let Some(value) = value {
             // FIXME: Is it correct to make these retagging assignments?
             if let Some(const_) = self.try_as_constant(value) {

--- a/compiler/rustc_mir_transform/src/pass_manager.rs
+++ b/compiler/rustc_mir_transform/src/pass_manager.rs
@@ -333,8 +333,10 @@ fn run_passes_inner<'tcx>(
                 continue;
             };
 
-            if is_optimization_stage(body, phase_change)
+            if body.phase == MirPhase::Runtime(RuntimePhase::PostCleanup)
+                && phase_change == Some(MirPhase::Runtime(RuntimePhase::Optimized))
                 && let Some(limit) = &tcx.sess.opts.unstable_opts.mir_opt_bisect_limit
+                && matches!(pass.policy(&ctx), PassPolicy::Optional { .. })
                 && limited_by_opt_bisect(
                     tcx,
                     tcx.def_path_debug_str(body.source.def_id()),
@@ -415,11 +417,6 @@ pub(super) fn dump_mir_for_phase_change<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tc
     if let Some(dumper) = MirDumper::new(tcx, body.phase.name(), body) {
         dumper.set_show_pass_num().set_disambiguator(&"after").dump_mir(body)
     }
-}
-
-fn is_optimization_stage(body: &Body<'_>, phase_change: Option<MirPhase>) -> bool {
-    body.phase == MirPhase::Runtime(RuntimePhase::PostCleanup)
-        && phase_change == Some(MirPhase::Runtime(RuntimePhase::Optimized))
 }
 
 fn limited_by_opt_bisect<'tcx, P>(

--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -100,7 +100,6 @@ where
 ///   the `normalization_nested_goals`
 pub(super) fn instantiate_and_apply_query_response<D, I>(
     delegate: &D,
-    param_env: I::ParamEnv,
     original_values: &[I::GenericArg],
     response: CanonicalResponse<I>,
     span: I::Span,
@@ -115,7 +114,7 @@ where
     let Response { var_values, external_constraints, certainty } =
         delegate.instantiate_canonical(response, instantiation);
 
-    unify_query_var_values(delegate, param_env, &original_values, var_values, span);
+    unify_query_var_values(delegate, &original_values, var_values, span);
 
     let ExternalConstraintsData { region_constraints, opaque_types, normalization_nested_goals } =
         &*external_constraints;
@@ -490,7 +489,6 @@ where
 #[instrument(level = "trace", skip(delegate))]
 fn unify_query_var_values<D, I>(
     delegate: &D,
-    param_env: I::ParamEnv,
     original_values: &[I::GenericArg],
     var_values: CanonicalVarValues<I>,
     span: I::Span,
@@ -577,7 +575,6 @@ where
 pub fn instantiate_canonical_state<D, I, T>(
     delegate: &D,
     span: I::Span,
-    param_env: I::ParamEnv,
     prev_universe: ty::UniverseIndex,
     orig_values: &mut ThinVec<I::GenericArg>,
     state: inspect::CanonicalState<I, T>,
@@ -609,7 +606,7 @@ where
 
     let inspect::State { var_values, data } = delegate.instantiate_canonical(state, instantiation);
 
-    unify_query_var_values(delegate, param_env, orig_values, var_values, span);
+    unify_query_var_values(delegate, orig_values, var_values, span);
     data
 }
 

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -793,7 +793,6 @@ where
 
         let (normalization_nested_goals, certainty) = instantiate_and_apply_query_response(
             self.delegate,
-            goal.param_env,
             &orig_values,
             response,
             self.origin_span,
@@ -1953,7 +1952,6 @@ pub(super) fn evaluate_root_goal_for_proof_tree<D: SolverDelegate<Interner = I>,
 
     let (normalization_nested_goals, _certainty) = instantiate_and_apply_query_response(
         delegate,
-        goal.param_env,
         &proof_tree.orig_values,
         response,
         origin_span,

--- a/compiler/rustc_trait_selection/src/regions.rs
+++ b/compiler/rustc_trait_selection/src/regions.rs
@@ -74,10 +74,7 @@ impl<'tcx> InferCtxt<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
         assumed_wf_tys: impl IntoIterator<Item = Ty<'tcx>>,
     ) -> Vec<RegionResolutionError<'tcx>> {
-        self.resolve_regions_with_outlives_env(
-            &OutlivesEnvironment::new(self, body_def_id, param_env, assumed_wf_tys),
-            self.tcx.def_span(body_def_id),
-        )
+        self.resolve_regions_with_outlives_env(&OutlivesEnvironment::new(self, body_def_id, param_env, assumed_wf_tys))
     }
 }
 

--- a/compiler/rustc_trait_selection/src/regions.rs
+++ b/compiler/rustc_trait_selection/src/regions.rs
@@ -74,7 +74,12 @@ impl<'tcx> InferCtxt<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
         assumed_wf_tys: impl IntoIterator<Item = Ty<'tcx>>,
     ) -> Vec<RegionResolutionError<'tcx>> {
-        self.resolve_regions_with_outlives_env(&OutlivesEnvironment::new(self, body_def_id, param_env, assumed_wf_tys))
+        self.resolve_regions_with_outlives_env(&OutlivesEnvironment::new(
+            self,
+            body_def_id,
+            param_env,
+            assumed_wf_tys,
+        ))
     }
 }
 

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -98,7 +98,6 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
     )]
     pub fn instantiate_nested_goals(&self, span: Span) -> Vec<InspectGoal<'a, 'tcx>> {
         let infcx = self.goal.infcx;
-        let param_env = self.goal.goal.param_env;
         let mut orig_values = self.goal.orig_values.clone();
 
         let mut instantiated_goals = vec![];
@@ -109,7 +108,6 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
                     instantiate_canonical_state(
                         infcx,
                         span,
-                        param_env,
                         self.goal.prev_universe,
                         &mut orig_values,
                         goal,
@@ -124,7 +122,6 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
         let () = instantiate_canonical_state(
             infcx,
             span,
-            param_env,
             self.goal.prev_universe,
             &mut orig_values,
             self.final_state,
@@ -146,7 +143,6 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
     )]
     pub fn instantiate_impl_args(&self, span: Span) -> ty::GenericArgsRef<'tcx> {
         let infcx = self.goal.infcx;
-        let param_env = self.goal.goal.param_env;
         let mut orig_values = self.goal.orig_values.clone();
 
         for step in &self.steps {
@@ -155,7 +151,6 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
                     let impl_args = instantiate_canonical_state(
                         infcx,
                         span,
-                        param_env,
                         self.goal.prev_universe,
                         &mut orig_values,
                         impl_args,
@@ -164,7 +159,6 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
                     let () = instantiate_canonical_state(
                         infcx,
                         span,
-                        param_env,
                         self.goal.prev_universe,
                         &mut orig_values,
                         self.final_state,

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -173,7 +173,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
         }
 
         let outlives_env = OutlivesEnvironment::new(&infcx, CRATE_DEF_ID, full_env, []);
-        let _ = infcx.process_registered_region_obligations(&outlives_env, DUMMY_SP);
+        let _ = infcx.process_registered_region_obligations(&outlives_env);
 
         let region_data = infcx.inner.borrow_mut().unwrap_region_constraints().data().clone();
 

--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -595,6 +595,8 @@
 pub use core::fmt::Alignment;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::Error;
+#[stable(feature = "fmt_numbuffer", since = "CURRENT_RUSTC_VERSION")]
+pub use core::fmt::NumBuffer;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{Arguments, write};
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/sync/sync_view.rs
+++ b/library/core/src/sync/sync_view.rs
@@ -46,7 +46,7 @@ use core::task::{Context, Poll};
 /// `SyncView` makes the value `Sync` without stripping the struct of its
 /// functionality:
 ///
-/// ```
+/// ```ignore-wasm
 /// #![feature(exclusive_wrapper)]
 ///
 /// use std::sync::SyncView;

--- a/library/core/src/sync/sync_view.rs
+++ b/library/core/src/sync/sync_view.rs
@@ -26,49 +26,62 @@ use core::task::{Context, Poll};
 ///
 /// ## Examples
 ///
-/// Using a non-`Sync` future prevents the wrapping struct from being `Sync`:
+/// A non-`Sync` field prevents the wrapping struct from being `Sync`:
 ///
-/// ```compile_fail
-/// use core::cell::Cell;
+/// ```compile_fail,E0277
+/// use std::sync::mpsc::{self, Receiver};
 ///
-/// async fn other() {}
-/// fn assert_sync<T: Sync>(t: T) {}
-/// struct State<F> {
-///     future: F
+/// struct Inbox {
+///     name: &'static str,
+///     receiver: Receiver<u32>,
 /// }
 ///
-/// assert_sync(State {
-///     future: async {
-///         let cell = Cell::new(1);
-///         let cell_ref = &cell;
-///         other().await;
-///         let value = cell_ref.get();
-///     }
-/// });
+/// fn require_send<T: Send>() {}
+/// fn require_send_sync<T: Send + Sync>() {}
+///
+/// require_send::<Inbox>();      // compiled
+/// require_send_sync::<Inbox>(); // compile-failed
 /// ```
 ///
-/// `SyncView` ensures the struct is `Sync` without stripping the future of its
+/// `SyncView` makes the value `Sync` without stripping the struct of its
 /// functionality:
 ///
 /// ```
 /// #![feature(exclusive_wrapper)]
-/// use core::cell::Cell;
-/// use core::sync::SyncView;
 ///
-/// async fn other() {}
-/// fn assert_sync<T: Sync>(t: T) {}
-/// struct State<F> {
-///     future: SyncView<F>
+/// use std::sync::SyncView;
+/// use std::sync::mpsc::{self, Receiver};
+/// use std::thread;
+///
+/// struct Inbox {
+///     name: &'static str,
+///     receiver: SyncView<Receiver<u32>>,
 /// }
 ///
-/// assert_sync(State {
-///     future: SyncView::new(async {
-///         let cell = Cell::new(1);
-///         let cell_ref = &cell;
-///         other().await;
-///         let value = cell_ref.get();
-///     })
+/// impl Inbox {
+///     fn name(&self) -> &'static str {
+///         self.name
+///     }
+///
+///     fn recv(&mut self) -> u32 {
+///         self.receiver.as_mut().recv().unwrap()
+///     }
+/// }
+///
+/// let (sender, receiver) = mpsc::channel();
+/// let mut inbox = Inbox { name: "jobs", receiver: SyncView::new(receiver) };
+/// sender.send(42).unwrap();
+/// drop(sender);
+///
+/// thread::scope(|scope| {
+///     let reader = scope.spawn(|| inbox.name());
+///     assert_eq!(inbox.name(), "jobs");
+///     assert_eq!(reader.join().unwrap(), "jobs");
 /// });
+///
+/// let message = thread::spawn(move || inbox.recv()).join().unwrap();
+/// assert_eq!(message, 42);
+/// println!("Shared Inbox across threads, then moved it to a worker and received 42");
 /// ```
 ///
 /// ## Parallels with a mutex

--- a/src/ci/scripts/disable-git-crlf-conversion.sh
+++ b/src/ci/scripts/disable-git-crlf-conversion.sh
@@ -10,8 +10,4 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-# Workaround for issue where the home dir of `msys64` sometimes doesn't exist on github runners
-echo $HOME
-mkdir -p $HOME
-
 git config --replace-all --global core.autocrlf false

--- a/src/ci/scripts/install-mingw.sh
+++ b/src/ci/scripts/install-mingw.sh
@@ -84,12 +84,9 @@ if isWindows && isKnownToBeMingwBuild; then
 
     ciCommandAddPath "$(cygpath -m "$(pwd)/${mingw_dir}/bin")"
 
-    # MSYS2 is not installed on AArch64 runners
-    if [[ "${CI_JOB_NAME}" != *aarch64-llvm* ]]; then
-        # Initialize mingw for the user.
-        # This should be done by github but isn't for some reason.
-        # (see https://github.com/actions/runner-images/issues/12600)
-        /c/msys64/usr/bin/bash -lc ' '
-    fi
+    # Initialize mingw for the user.
+    # This should be done by github but isn't for some reason.
+    # (see https://github.com/actions/runner-images/issues/12600)
+    /c/msys64/usr/bin/bash -lc ' '
     done
 fi

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -217,6 +217,8 @@ pub(crate) struct TestProps {
     pub(crate) compare_output_by_lines: bool,
     /// Use CCI (`--read-doc-meta` and `--write-doc-meta`) merge mode.
     pub(crate) use_rustdoc_cci_doc_meta_merge: bool,
+    /// Where the `//@ should-fail` instruction is present.
+    pub(crate) should_fail: bool,
 }
 
 mod directives {
@@ -323,6 +325,7 @@ impl TestProps {
             disable_gdb_pretty_printers: false,
             compare_output_by_lines: false,
             use_rustdoc_cci_doc_meta_merge: false,
+            should_fail: false,
         }
     }
 

--- a/src/tools/compiletest/src/directives/handlers.rs
+++ b/src/tools/compiletest/src/directives/handlers.rs
@@ -371,6 +371,9 @@ fn make_directive_handlers_map() -> HashMap<&'static str, Handler> {
                 &mut props.use_rustdoc_cci_doc_meta_merge,
             );
         }),
+        handler("should-fail", |config, ln, props| {
+            config.set_name_directive(ln, "should-fail", &mut props.should_fail);
+        }),
     ];
 
     handlers

--- a/src/tools/compiletest/src/runtest/rustdoc.rs
+++ b/src/tools/compiletest/src/runtest/rustdoc.rs
@@ -14,6 +14,9 @@ impl TestCx<'_> {
                 "If you want to check `--test`, put this test into `rustdoc-ui` testsuite instead",
             );
         }
+        if self.props.should_fail {
+            panic!("`should-fail` should not be used in `rustdoc-html` testsuite");
+        }
         let out_dir = self.output_base_dir();
         remove_and_create_dir_all(&out_dir).unwrap_or_else(|e| {
             panic!("failed to remove and recreate output directory `{out_dir}`: {e}")

--- a/src/tools/compiletest/src/runtest/ui.rs
+++ b/src/tools/compiletest/src/runtest/ui.rs
@@ -9,11 +9,20 @@ use crate::common::PassFailMode;
 use crate::json;
 use crate::runtest::{
     AllowUnused, Emit, LinkToAux, ProcRes, RunResult, TargetLocation, TestCx, TestOutput,
-    Truncated, UI_FIXED, WillExecute,
+    TestSuite, Truncated, UI_FIXED, WillExecute,
 };
 
 impl TestCx<'_> {
     pub(super) fn run_ui_test(&self) {
+        if self.config.suite == TestSuite::RustdocUi && self.props.should_fail {
+            writeln!(
+                self.stderr,
+                "`should-fail` should not be used in `rustdoc-ui` testsuite, use `failure-status` instead",
+            );
+            // Since it's expecting the test to fail/panic, we return without running anything,
+            // preventing the test to be marked as passed.
+            return;
+        }
         let pass_fail =
             self.effective_pass_fail_mode().expect("UI tests always have a pass/fail mode");
 

--- a/tests/run-make-cargo/thumb-none-cortex-m/rmake.rs
+++ b/tests/run-make-cargo/thumb-none-cortex-m/rmake.rs
@@ -2,10 +2,6 @@
 //! for a collection of thumb targets. This is a smoke test that verifies that both cargo
 //! and rustc work in this case.
 //!
-//! How to run this
-//! $ ./x.py clean
-//! $ ./x.py test --target thumbv6m-none-eabi,thumbv7m-none-eabi tests/run-make-cargo
-//!
 //! Supported targets:
 //! - thumbv6m-none-eabi (Bare Cortex-M0, M0+, M1)
 //! - thumbv7em-none-eabi (Bare Cortex-M4, M7)

--- a/tests/run-make-cargo/thumb-none-qemu/rmake.rs
+++ b/tests/run-make-cargo/thumb-none-qemu/rmake.rs
@@ -6,10 +6,6 @@
 //!
 //! This test builds and runs the applications for various thumb targets using qemu.
 //!
-//! How to run this
-//! $ ./x.py clean
-//! $ ./x.py test --target thumbv6m-none-eabi,thumbv7m-none-eabi tests/run-make
-//!
 //! For supported targets, see `example/.cargo/config.toml`
 //!
 //! FIXME: https://github.com/rust-lang/rust/issues/128733 this test uses external

--- a/tests/run-make/static-pie/rmake.rs
+++ b/tests/run-make/static-pie/rmake.rs
@@ -1,6 +1,3 @@
-// How to manually run this
-// $ ./x.py test --target x86_64-unknown-linux-[musl,gnu] tests/run-make/static-pie
-
 //@ only-x86_64
 //@ only-linux
 //@ ignore-32bit

--- a/tests/run-make/wasm-override-linker/rmake.rs
+++ b/tests/run-make/wasm-override-linker/rmake.rs
@@ -1,6 +1,3 @@
-// How to run this
-// $ RUSTBUILD_FORCE_CLANG_BASED_TESTS=1 ./x.py test tests/run-make/wasm-override-linker/
-
 //@ needs-force-clang-based-tests
 // FIXME(#126180): This test can only run on `x86_64-gnu-debug`, because that CI job sets
 // RUSTBUILD_FORCE_CLANG_BASED_TESTS and only runs tests which contain "clang" in their

--- a/tests/rustdoc-ui/doctest/doctest-macro-38219.rs
+++ b/tests/rustdoc-ui/doctest/doctest-macro-38219.rs
@@ -2,7 +2,7 @@
 
 //@ compile-flags:--test
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
-//@ should-fail
+//@ failure-status: 101
 
 /// ```
 /// fail

--- a/tests/rustdoc-ui/doctest/doctest-macro-38219.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-macro-38219.stdout
@@ -1,0 +1,23 @@
+
+running 1 test
+test $DIR/doctest-macro-38219.rs - foo (line 7) ... FAILED
+
+failures:
+
+---- $DIR/doctest-macro-38219.rs - foo (line 7) stdout ----
+error[E0425]: cannot find value `fail` in this scope
+  --> $DIR/doctest-macro-38219.rs:8:1
+   |
+LL | fail
+   | ^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.
+Couldn't compile the test.
+
+failures:
+    $DIR/doctest-macro-38219.rs - foo (line 7)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/ice-unresolved-import-100241.rs
+++ b/tests/rustdoc-ui/ice-unresolved-import-100241.rs
@@ -1,13 +1,12 @@
 //! See [`S`].
 
 // Check that this isn't an ICE
-//@ should-fail
 
 // https://github.com/rust-lang/rust/issues/100241
 
 mod foo {
     pub use inner::S;
-    //~^ ERROR unresolved imports `inner`, `foo::S`
+    //~^ ERROR unresolved import `inner`
 }
 
 use foo::*;

--- a/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
+++ b/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
@@ -1,5 +1,5 @@
 error[E0432]: unresolved import `inner`
-  --> $DIR/ice-unresolved-import-100241.rs:9:13
+  --> $DIR/ice-unresolved-import-100241.rs:8:13
    |
 LL |     pub use inner::S;
    |             ^^^^^ use of unresolved module or unlinked crate `inner`

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1434,9 +1434,6 @@ cc = ["@Urgau"]
 [mentions."src/doc/rustc/src/check-cfg"]
 cc = ["@Urgau"]
 
-[mentions."src/doc/rustc/src/platform-support"]
-cc = ["@Noratrieb"]
-
 [mentions."tests/codegen-llvm/sanitizer"]
 cc = ["@rcvalle"]
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#161413 (mir-transform: Remove `is_optimization_stage`)
 - rust-lang/rust#161430 (Re-export `core::fmt::NumBuffer` in `alloc` (and `std`))
 - rust-lang/rust#162446 (Prevent `should-fail` to be used in `rustdoc-ui` testsuite)
 - rust-lang/rust#162621 (Clarify examples related to `Sync` and `SyncView`)
 - rust-lang/rust#162641 (Remove unused arguments of functions)
 - rust-lang/rust#162650 (Initialize mingw for all mingw targets)
 - rust-lang/rust#162651 (Remove needless test running instructions)
 - rust-lang/rust#162658 (Remove noras target docs mention)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=161413,161430,162446,162621,162641,162650,162651,162658)
<!-- homu-ignore:end -->

