### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_mir_transform/src/pass_manager.rs
+++ b/compiler/rustc_mir_transform/src/pass_manager.rs
@@ -333,8 +333,10 @@ fn run_passes_inner<'tcx>(
                 continue;
             };
 
-            if is_optimization_stage(body, phase_change)
+            if body.phase == MirPhase::Runtime(RuntimePhase::PostCleanup)
+                && phase_change == Some(MirPhase::Runtime(RuntimePhase::Optimized))
                 && let Some(limit) = &tcx.sess.opts.unstable_opts.mir_opt_bisect_limit
+                && matches!(pass.policy(&ctx), PassPolicy::Optional { .. })
                 && limited_by_opt_bisect(
                     tcx,
                     tcx.def_path_debug_str(body.source.def_id()),
@@ -415,11 +417,6 @@ pub(super) fn dump_mir_for_phase_change<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tc
     if let Some(dumper) = MirDumper::new(tcx, body.phase.name(), body) {
         dumper.set_show_pass_num().set_disambiguator(&"after").dump_mir(body)
     }
-}
-
-fn is_optimization_stage(body: &Body<'_>, phase_change: Option<MirPhase>) -> bool {
-    body.phase == MirPhase::Runtime(RuntimePhase::PostCleanup)
-        && phase_change == Some(MirPhase::Runtime(RuntimePhase::Optimized))
 }
 
 fn limited_by_opt_bisect<'tcx, P>(

--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -595,6 +595,8 @@
 pub use core::fmt::Alignment;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::Error;
+#[stable(feature = "fmt_numbuffer", since = "CURRENT_RUSTC_VERSION")]
+pub use core::fmt::NumBuffer;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{Arguments, write};
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/sync/sync_view.rs
+++ b/library/core/src/sync/sync_view.rs
@@ -46,7 +46,7 @@ use core::task::{Context, Poll};
 /// `SyncView` makes the value `Sync` without stripping the struct of its
 /// functionality:
 ///
-/// ```
+/// ```ignore-wasm
 /// #![feature(exclusive_wrapper)]
 ///
 /// use std::sync::SyncView;

--- a/library/core/src/sync/sync_view.rs
+++ b/library/core/src/sync/sync_view.rs
@@ -26,49 +26,62 @@ use core::task::{Context, Poll};
 ///
 /// ## Examples
 ///
-/// Using a non-`Sync` future prevents the wrapping struct from being `Sync`:
+/// A non-`Sync` field prevents the wrapping struct from being `Sync`:
 ///
-/// ```compile_fail
-/// use core::cell::Cell;
+/// ```compile_fail,E0277
+/// use std::sync::mpsc::{self, Receiver};
 ///
-/// async fn other() {}
-/// fn assert_sync<T: Sync>(t: T) {}
-/// struct State<F> {
-///     future: F
+/// struct Inbox {
+///     name: &'static str,
+///     receiver: Receiver<u32>,
 /// }
 ///
-/// assert_sync(State {
-///     future: async {
-///         let cell = Cell::new(1);
-///         let cell_ref = &cell;
-///         other().await;
-///         let value = cell_ref.get();
-///     }
-/// });
+/// fn require_send<T: Send>() {}
+/// fn require_send_sync<T: Send + Sync>() {}
+///
+/// require_send::<Inbox>();      // compiled
+/// require_send_sync::<Inbox>(); // compile-failed
 /// ```
 ///
-/// `SyncView` ensures the struct is `Sync` without stripping the future of its
+/// `SyncView` makes the value `Sync` without stripping the struct of its
 /// functionality:
 ///
 /// ```
 /// #![feature(exclusive_wrapper)]
-/// use core::cell::Cell;
-/// use core::sync::SyncView;
 ///
-/// async fn other() {}
-/// fn assert_sync<T: Sync>(t: T) {}
-/// struct State<F> {
-///     future: SyncView<F>
+/// use std::sync::SyncView;
+/// use std::sync::mpsc::{self, Receiver};
+/// use std::thread;
+///
+/// struct Inbox {
+///     name: &'static str,
+///     receiver: SyncView<Receiver<u32>>,
 /// }
 ///
-/// assert_sync(State {
-///     future: SyncView::new(async {
-///         let cell = Cell::new(1);
-///         let cell_ref = &cell;
-///         other().await;
-///         let value = cell_ref.get();
-///     })
+/// impl Inbox {
+///     fn name(&self) -> &'static str {
+///         self.name
+///     }
+///
+///     fn recv(&mut self) -> u32 {
+///         self.receiver.as_mut().recv().unwrap()
+///     }
+/// }
+///
+/// let (sender, receiver) = mpsc::channel();
+/// let mut inbox = Inbox { name: "jobs", receiver: SyncView::new(receiver) };
+/// sender.send(42).unwrap();
+/// drop(sender);
+///
+/// thread::scope(|scope| {
+///     let reader = scope.spawn(|| inbox.name());
+///     assert_eq!(inbox.name(), "jobs");
+///     assert_eq!(reader.join().unwrap(), "jobs");
 /// });
+///
+/// let message = thread::spawn(move || inbox.recv()).join().unwrap();
+/// assert_eq!(message, 42);
+/// println!("Shared Inbox across threads, then moved it to a worker and received 42");
 /// ```
 ///
 /// ## Parallels with a mutex

--- a/src/ci/scripts/disable-git-crlf-conversion.sh
+++ b/src/ci/scripts/disable-git-crlf-conversion.sh
@@ -10,8 +10,4 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-# Workaround for issue where the home dir of `msys64` sometimes doesn't exist on github runners
-echo $HOME
-mkdir -p $HOME
-
 git config --replace-all --global core.autocrlf false

--- a/src/ci/scripts/install-mingw.sh
+++ b/src/ci/scripts/install-mingw.sh
@@ -84,12 +84,9 @@ if isWindows && isKnownToBeMingwBuild; then
 
     ciCommandAddPath "$(cygpath -m "$(pwd)/${mingw_dir}/bin")"
 
-    # MSYS2 is not installed on AArch64 runners
-    if [[ "${CI_JOB_NAME}" != *aarch64-llvm* ]]; then
-        # Initialize mingw for the user.
-        # This should be done by github but isn't for some reason.
-        # (see https://github.com/actions/runner-images/issues/12600)
-        /c/msys64/usr/bin/bash -lc ' '
-    fi
+    # Initialize mingw for the user.
+    # This should be done by github but isn't for some reason.
+    # (see https://github.com/actions/runner-images/issues/12600)
+    /c/msys64/usr/bin/bash -lc ' '
     done
 fi

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -217,6 +217,8 @@ pub(crate) struct TestProps {
     pub(crate) compare_output_by_lines: bool,
     /// Use CCI (`--read-doc-meta` and `--write-doc-meta`) merge mode.
     pub(crate) use_rustdoc_cci_doc_meta_merge: bool,
+    /// Where the `//@ should-fail` instruction is present.
+    pub(crate) should_fail: bool,
 }
 
 mod directives {
@@ -323,6 +325,7 @@ impl TestProps {
             disable_gdb_pretty_printers: false,
             compare_output_by_lines: false,
             use_rustdoc_cci_doc_meta_merge: false,
+            should_fail: false,
         }
     }
 

--- a/src/tools/compiletest/src/directives/handlers.rs
+++ b/src/tools/compiletest/src/directives/handlers.rs
@@ -371,6 +371,9 @@ fn make_directive_handlers_map() -> HashMap<&'static str, Handler> {
                 &mut props.use_rustdoc_cci_doc_meta_merge,
             );
         }),
+        handler("should-fail", |config, ln, props| {
+            config.set_name_directive(ln, "should-fail", &mut props.should_fail);
+        }),
     ];
 
     handlers

--- a/src/tools/compiletest/src/runtest/rustdoc.rs
+++ b/src/tools/compiletest/src/runtest/rustdoc.rs
@@ -14,6 +14,9 @@ impl TestCx<'_> {
                 "If you want to check `--test`, put this test into `rustdoc-ui` testsuite instead",
             );
         }
+        if self.props.should_fail {
+            panic!("`should-fail` should not be used in `rustdoc-html` testsuite");
+        }
         let out_dir = self.output_base_dir();
         remove_and_create_dir_all(&out_dir).unwrap_or_else(|e| {
             panic!("failed to remove and recreate output directory `{out_dir}`: {e}")

--- a/src/tools/compiletest/src/runtest/ui.rs
+++ b/src/tools/compiletest/src/runtest/ui.rs
@@ -9,11 +9,20 @@ use crate::common::PassFailMode;
 use crate::json;
 use crate::runtest::{
     AllowUnused, Emit, LinkToAux, ProcRes, RunResult, TargetLocation, TestCx, TestOutput,
-    Truncated, UI_FIXED, WillExecute,
+    TestSuite, Truncated, UI_FIXED, WillExecute,
 };
 
 impl TestCx<'_> {
     pub(super) fn run_ui_test(&self) {
+        if self.config.suite == TestSuite::RustdocUi && self.props.should_fail {
+            writeln!(
+                self.stderr,
+                "`should-fail` should not be used in `rustdoc-ui` testsuite, use `failure-status` instead",
+            );
+            // Since it's expecting the test to fail/panic, we return without running anything,
+            // preventing the test to be marked as passed.
+            return;
+        }
         let pass_fail =
             self.effective_pass_fail_mode().expect("UI tests always have a pass/fail mode");
 

--- a/tests/run-make-cargo/thumb-none-cortex-m/rmake.rs
+++ b/tests/run-make-cargo/thumb-none-cortex-m/rmake.rs
@@ -2,10 +2,6 @@
 //! for a collection of thumb targets. This is a smoke test that verifies that both cargo
 //! and rustc work in this case.
 //!
-//! How to run this
-//! $ ./x.py clean
-//! $ ./x.py test --target thumbv6m-none-eabi,thumbv7m-none-eabi tests/run-make-cargo
-//!
 //! Supported targets:
 //! - thumbv6m-none-eabi (Bare Cortex-M0, M0+, M1)
 //! - thumbv7em-none-eabi (Bare Cortex-M4, M7)

--- a/tests/run-make-cargo/thumb-none-qemu/rmake.rs
+++ b/tests/run-make-cargo/thumb-none-qemu/rmake.rs
@@ -6,10 +6,6 @@
 //!
 //! This test builds and runs the applications for various thumb targets using qemu.
 //!
-//! How to run this
-//! $ ./x.py clean
-//! $ ./x.py test --target thumbv6m-none-eabi,thumbv7m-none-eabi tests/run-make
-//!
 //! For supported targets, see `example/.cargo/config.toml`
 //!
 //! FIXME: https://github.com/rust-lang/rust/issues/128733 this test uses external

--- a/tests/run-make/static-pie/rmake.rs
+++ b/tests/run-make/static-pie/rmake.rs
@@ -1,6 +1,3 @@
-// How to manually run this
-// $ ./x.py test --target x86_64-unknown-linux-[musl,gnu] tests/run-make/static-pie
-
 //@ only-x86_64
 //@ only-linux
 //@ ignore-32bit

--- a/tests/run-make/wasm-override-linker/rmake.rs
+++ b/tests/run-make/wasm-override-linker/rmake.rs
@@ -1,6 +1,3 @@
-// How to run this
-// $ RUSTBUILD_FORCE_CLANG_BASED_TESTS=1 ./x.py test tests/run-make/wasm-override-linker/
-
 //@ needs-force-clang-based-tests
 // FIXME(#126180): This test can only run on `x86_64-gnu-debug`, because that CI job sets
 // RUSTBUILD_FORCE_CLANG_BASED_TESTS and only runs tests which contain "clang" in their

--- a/tests/rustdoc-ui/doctest/doctest-macro-38219.rs
+++ b/tests/rustdoc-ui/doctest/doctest-macro-38219.rs
@@ -2,7 +2,7 @@
 
 //@ compile-flags:--test
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
-//@ should-fail
+//@ failure-status: 101
 
 /// ```
 /// fail

--- a/tests/rustdoc-ui/doctest/doctest-macro-38219.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-macro-38219.stdout
@@ -1,0 +1,23 @@
+
+running 1 test
+test $DIR/doctest-macro-38219.rs - foo (line 7) ... FAILED
+
+failures:
+
+---- $DIR/doctest-macro-38219.rs - foo (line 7) stdout ----
+error[E0425]: cannot find value `fail` in this scope
+  --> $DIR/doctest-macro-38219.rs:8:1
+   |
+LL | fail
+   | ^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.
+Couldn't compile the test.
+
+failures:
+    $DIR/doctest-macro-38219.rs - foo (line 7)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/ice-unresolved-import-100241.rs
+++ b/tests/rustdoc-ui/ice-unresolved-import-100241.rs
@@ -1,13 +1,12 @@
 //! See [`S`].
 
 // Check that this isn't an ICE
-//@ should-fail
 
 // https://github.com/rust-lang/rust/issues/100241
 
 mod foo {
     pub use inner::S;
-    //~^ ERROR unresolved imports `inner`, `foo::S`
+    //~^ ERROR unresolved import `inner`
 }
 
 use foo::*;

--- a/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
+++ b/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
@@ -1,5 +1,5 @@
 error[E0432]: unresolved import `inner`
-  --> $DIR/ice-unresolved-import-100241.rs:9:13
+  --> $DIR/ice-unresolved-import-100241.rs:8:13
    |
 LL |     pub use inner::S;
    |             ^^^^^ use of unresolved module or unlinked crate `inner`

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1434,9 +1434,6 @@ cc = ["@Urgau"]
 [mentions."src/doc/rustc/src/check-cfg"]
 cc = ["@Urgau"]
 
-[mentions."src/doc/rustc/src/platform-support"]
-cc = ["@Noratrieb"]
-
 [mentions."tests/codegen-llvm/sanitizer"]
 cc = ["@rcvalle"]
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#161413 (mir-transform: Remove `is_optimization_stage`)
 - rust-lang/rust#161430 (Re-export `core::fmt::NumBuffer` in `alloc` (and `std`))
 - rust-lang/rust#162446 (Prevent `should-fail` to be used in `rustdoc-ui` testsuite)
 - rust-lang/rust#162621 (Clarify examples related to `Sync` and `SyncView`)
 - rust-lang/rust#162650 (Initialize mingw for all mingw targets)
 - rust-lang/rust#162651 (Remove needless test running instructions)
 - rust-lang/rust#162658 (Remove noras target docs mention)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=161413,161430,162446,162621,162650,162651,162658)
<!-- homu-ignore:end -->

