### PR TITLE
Add a UI regression test.

### DIFF
--- a/tests/ui/attributes/positions/link-section.rs
+++ b/tests/ui/attributes/positions/link-section.rs
@@ -1,0 +1,11 @@
+//! Checks that `link_section` cannot be used on foreign statics.
+#![crate_type = "lib"]
+
+//@ edition:2024
+//@ check-pass
+// Regression test for <https://github.com/rust-lang/rust/issues/136220>.
+unsafe extern "C" {
+    #[unsafe(link_section = "__DATA,__buffer")] //~ WARN attribute cannot be used on foreign statics
+    //~| WARN previously accepted
+    pub static mut a: [u8; 1024];
+}

--- a/tests/ui/attributes/positions/link-section.stderr
+++ b/tests/ui/attributes/positions/link-section.stderr
@@ -1,0 +1,12 @@
+warning: the `link_section` attribute cannot be used on foreign statics
+  --> $DIR/link-section.rs:8:14
+   |
+LL |     #[unsafe(link_section = "__DATA,__buffer")]
+   |              ^^^^^^^^^^^^
+   |
+   = help: the `link_section` attribute can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Added a UI test for rust-lang/rust#136220. The `.stderr` file contains the expected output; the test verifies that a warning appears when `link_section` is applied to a foreign static variable. The diagnostic issue has already been fixed; my commit confirms it with a test. The tests `./x test tests/ui/attributes/positions` and `./x test tidy` passed. LLM was used to navigate the repository.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
