### PR TITLE
document that `!` does bitwise and logical negation

### DIFF
--- a/library/core/src/ops/bit.rs
+++ b/library/core/src/ops/bit.rs
@@ -1,4 +1,5 @@
-/// The unary logical negation operator `!`.
+/// The unary negation operator `!`. It performs either logical or bitwise negation,
+/// depending on the type.
 ///
 /// # Examples
 ///
@@ -37,15 +38,23 @@ pub const trait Not {
     #[stable(feature = "rust1", since = "1.0.0")]
     type Output;
 
-    /// Performs the unary `!` operation.
+    /// Performs the unary `!` operation using logical or bitwise negation.
     ///
     /// # Examples
     ///
     /// ```
+    /// // Logical negation changes between true and false:
     /// assert_eq!(!true, false);
     /// assert_eq!(!false, true);
+    ///
+    /// // Bitwise negation changes between 0 and 1 in the binary
+    /// // representation of integers:
     /// assert_eq!(!1u8, 254);
     /// assert_eq!(!0u8, 255);
+    ///
+    /// // The same examples, represented in binary:
+    /// assert_eq!(!0b0000_0001u8, 0b1111_1110);
+    /// assert_eq!(!0b0000_0000u8, 0b1111_1111);
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
The documentation summary for `core::ops::Not` says that it performs
logical negation. That's misleading because it also performs bitwise
negation on integers. Since C has separate operators for logical and
bitwise negation, this could lead a C programmer to look
elsewhere for Rust's equivalent of `~`.

I also updated the documentation for `Not::not()` to clarify the meaning of logical not vs bitwise not.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
