### PR TITLE
Remove `EarlyDiagCtxt::early_{note,help}`

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -1344,15 +1344,17 @@ fn warn_on_confusing_output_filename_flag(
             || config::CG_OPTIONS.iter().any(|option| eq_ignore_separators(option.name(), filename))
             || fake_args.iter().any(|arg| eq_ignore_separators(arg, filename))
         {
-            early_dcx.early_warn(
-                "option `-o` has no space between flag name and value, which can be confusing",
-            );
-            early_dcx.early_note(format!(
-                "output filename `-o {name}` is applied instead of a flag named `o{name}`"
-            ));
-            early_dcx.early_help(format!(
-                "insert a space between `-o` and `{name}` if this is intentional: `-o {name}`"
-            ));
+            early_dcx
+                .early_struct_warn(
+                    "option `-o` has no space between flag name and value, which can be confusing",
+                )
+                .with_note(format!(
+                    "output filename `-o {name}` is applied instead of a flag named `o{name}`"
+                ))
+                .with_help(format!(
+                    "insert a space between `-o` and `{name}` if this is intentional: `-o {name}`"
+                ))
+                .emit();
         }
     }
 }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -3194,29 +3194,28 @@ pub mod nightly_options {
             if really_allows_unstable_options {
                 continue;
             }
-            match opt.stability {
-                OptionStability::Unstable => {
-                    nightly_options_on_stable += 1;
-                    let msg = format!(
-                        "the option `{}` is only accepted on the nightly compiler",
-                        opt.name
-                    );
-                    // The non-zero nightly_options_on_stable will force an early_fatal eventually.
-                    let _ = early_dcx.early_err(msg);
-                }
-                OptionStability::Stable => {}
-            }
+
+            nightly_options_on_stable += 1;
+            let msg = format!("the option `{}` is only accepted on the nightly compiler", opt.name);
+            // The non-zero nightly_options_on_stable will force an early_fatal eventually.
+            let _ = early_dcx.early_err(msg);
         }
+
         if nightly_options_on_stable > 0 {
-            early_dcx
-                .early_help("consider switching to a nightly toolchain: `rustup default nightly`");
-            early_dcx.early_note("selecting a toolchain with `+toolchain` arguments require a rustup proxy; see <https://rust-lang.github.io/rustup/concepts/index.html>");
-            early_dcx.early_note("for more information about Rust's stability policy, see <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features>");
-            early_dcx.early_fatal(format!(
-                "{} nightly option{} were parsed",
-                nightly_options_on_stable,
-                if nightly_options_on_stable > 1 { "s" } else { "" }
+            let (s, were) = if nightly_options_on_stable > 1 { ("s", "were") } else { ("", "was") };
+            let mut err = early_dcx.early_struct_fatal(format!(
+                "{nightly_options_on_stable} nightly option{s} {were} parsed",
             ));
+            err.help("consider switching to a nightly toolchain: `rustup default nightly`");
+            err.note(
+                "selecting a toolchain with `+toolchain` arguments require a rustup proxy; \
+                see <https://rust-lang.github.io/rustup/concepts/index.html>",
+            );
+            err.note(
+                "for more information about Rust's stability policy, see \
+                <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features>",
+            );
+            err.emit();
         }
     }
 }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1767,14 +1767,6 @@ impl EarlyDiagCtxt {
         self.dcx = DiagCtxt::new(emitter);
     }
 
-    pub fn early_note(&self, msg: impl Into<DiagMessage>) {
-        self.dcx.handle().note(msg)
-    }
-
-    pub fn early_help(&self, msg: impl Into<DiagMessage>) {
-        self.dcx.handle().struct_help(msg).emit()
-    }
-
     #[must_use = "raise_fatal must be called on the returned ErrorGuaranteed in order to exit with a non-zero status code"]
     pub fn early_err(&self, msg: impl Into<DiagMessage>) -> ErrorGuaranteed {
         self.dcx.handle().err(msg)

--- a/tests/run-make/option-output-no-space/rmake.rs
+++ b/tests/run-make/option-output-no-space/rmake.rs
@@ -14,7 +14,7 @@ fn main() {
             "warning: option `-o` has no space between flag name and value, which can be confusing",
         )
         .assert_stderr_contains(
-            "note: output filename `-o ptimize` is applied instead of a flag named `optimize`",
+            "= note: output filename `-o ptimize` is applied instead of a flag named `optimize`",
         );
     rustc()
         .input("main.rs")
@@ -24,7 +24,7 @@ fn main() {
             "warning: option `-o` has no space between flag name and value, which can be confusing",
         )
         .assert_stderr_contains(
-            "note: output filename `-o 0` is applied instead of a flag named `o0`",
+            "= note: output filename `-o 0` is applied instead of a flag named `o0`",
         );
     rustc().input("main.rs").arg("-o1").run();
     // test real args by iter optgroups
@@ -36,10 +36,10 @@ fn main() {
             "warning: option `-o` has no space between flag name and value, which can be confusing",
         )
         .assert_stderr_contains(
-            "note: output filename `-o ut-dir` is applied instead of a flag named `out-dir`",
+            "= note: output filename `-o ut-dir` is applied instead of a flag named `out-dir`",
         )
         .assert_stderr_contains(
-            "help: insert a space between `-o` and `ut-dir` if this is intentional: `-o ut-dir`",
+            "= help: insert a space between `-o` and `ut-dir` if this is intentional: `-o ut-dir`",
         );
     // test real args by iter CG_OPTIONS
     rustc()
@@ -50,10 +50,11 @@ fn main() {
             "warning: option `-o` has no space between flag name and value, which can be confusing",
         )
         .assert_stderr_contains(
-            "note: output filename `-o pt_level` is applied instead of a flag named `opt_level`",
+            "= note: output filename `-o pt_level` is applied instead of a flag named `opt_level`",
         )
         .assert_stderr_contains(
-            "help: insert a space between `-o` and `pt_level` if this is intentional: `-o pt_level`"
+            "= help: insert a space between `-o` and `pt_level` if this is intentional: \
+            `-o pt_level`",
         );
     // separater in-sensitive
     rustc()
@@ -64,10 +65,11 @@ fn main() {
             "warning: option `-o` has no space between flag name and value, which can be confusing",
         )
         .assert_stderr_contains(
-            "note: output filename `-o pt-level` is applied instead of a flag named `opt-level`",
+            "= note: output filename `-o pt-level` is applied instead of a flag named `opt-level`",
         )
         .assert_stderr_contains(
-            "help: insert a space between `-o` and `pt-level` if this is intentional: `-o pt-level`"
+            "= help: insert a space between `-o` and `pt-level` if this is intentional: \
+            `-o pt-level`",
         );
     rustc()
         .input("main.rs")
@@ -77,11 +79,11 @@ fn main() {
             "warning: option `-o` has no space between flag name and value, which can be confusing",
         )
         .assert_stderr_contains(
-            "note: output filename `-o verflow-checks` \
+            "= note: output filename `-o verflow-checks` \
             is applied instead of a flag named `overflow-checks`",
         )
         .assert_stderr_contains(
-            "help: insert a space between `-o` and `verflow-checks` \
+            "= help: insert a space between `-o` and `verflow-checks` \
             if this is intentional: `-o verflow-checks`",
         );
 

--- a/tests/ui/bootstrap/rustc_bootstrap.force_stable.stderr
+++ b/tests/ui/bootstrap/rustc_bootstrap.force_stable.stderr
@@ -1,10 +1,8 @@
 error: the option `Z` is only accepted on the nightly compiler
 
-help: consider switching to a nightly toolchain: `rustup default nightly`
-
-note: selecting a toolchain with `+toolchain` arguments require a rustup proxy; see <https://rust-lang.github.io/rustup/concepts/index.html>
-
-note: for more information about Rust's stability policy, see <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features>
-
-error: 1 nightly option were parsed
+error: 1 nightly option was parsed
+  |
+  = help: consider switching to a nightly toolchain: `rustup default nightly`
+  = note: selecting a toolchain with `+toolchain` arguments require a rustup proxy; see <https://rust-lang.github.io/rustup/concepts/index.html>
+  = note: for more information about Rust's stability policy, see <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features>
 


### PR DESCRIPTION
We have some top-level `help` and `note` diagnostics emittable at startup. These are weird. This PR eliminates them. Details in individual commits.

r? @estebank 