### PR TITLE
Add `E0747` explanation for `type/const` mismatch case

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0747.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0747.md
@@ -1,5 +1,6 @@
 Generic arguments were not provided in the same order as the corresponding
-generic parameters are declared.
+generic parameters are declared, or a type was provided when a constant
+was expected.
 
 Erroneous code example:
 
@@ -17,4 +18,22 @@ order, as in the following:
 struct S<'a, T>(&'a T);
 
 type X = S<'static, ()>; // ok
+```
+
+Another erroneous code example:
+
+```compile_fail,E0747
+struct Foo<const N: usize>;
+
+fn foo() -> Foo<usize> {} // error: type provided when a constant was
+                          // expected
+```
+
+A constant expression must be provided when a constant generic parameter
+is declared, not a type, as in the following:
+
+```
+struct Foo<const N: usize>;
+
+fn foo() -> Foo<3> { Foo }
 ```


### PR DESCRIPTION
Fixes rust-lang/rust#162320

r? @GuillaumeGomez 