### PR TITLE
Shard volatile generic CGUs to bound incremental invalidation scope

### DIFF
--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -241,6 +241,31 @@ where
             None => fallback_cgu_name(cgu_name_builder),
         };
 
+        // Normally every monomorphized instance of a generic function sharing
+        // the same defining module collapses into the same "volatile" CGU
+        // (see the module docs above): the cache key in
+        // `compute_codegen_unit_name` is keyed on the definition's module,
+        // not on which concrete type arguments produced this instance. That
+        // means editing the body of ONE instantiation invalidates every
+        // other instantiation's CGU too, even ones that never touch the
+        // changed code path. With this flag, split each volatile bucket into
+        // a bounded number of sub-buckets (shards) by hashing the
+        // instantiation's own symbol name, instead of either the one
+        // module-wide bucket (0% fragmentation, 100% false invalidation) or
+        // a separate CGU per instantiation (0% false invalidation, but
+        // unbounded fragmentation -- verified on `polars-core` to blow past
+        // `merge_codegen_units`'s ability to recombine cold builds and to
+        // make incremental rebuilds *slower* than no splitting at all,
+        // because the linker eats hundreds of tiny object files one at a
+        // time). Sharding trades a fraction of false invalidation (~1 /
+        // shard_count of unrelated instantiations still get swept in) for a
+        // hard cap on how many extra CGUs a volatile bucket can ever produce.
+        let cgu_name = if is_volatile && cx.tcx.sess.opts.unstable_opts.fine_grained_generic_cgus {
+            fine_grained_cgu_name(cx.tcx, cgu_name, &mono_item)
+        } else {
+            cgu_name
+        };
+
         let cgu = codegen_units.entry(cgu_name).or_insert_with(|| CodegenUnit::new(cgu_name));
 
         let mut can_be_internalized = true;
@@ -753,6 +778,61 @@ fn compute_codegen_unit_name(
 // Anything we can't find a proper codegen unit for goes into this.
 fn fallback_cgu_name(name_builder: &mut CodegenUnitNameBuilder<'_>) -> Symbol {
     name_builder.build_cgu_name(LOCAL_CRATE, &["fallback"], Some("cgu"))
+}
+
+// Assigns a generic instantiation to one of a bounded number of shards
+// within its volatile bucket, derived from a hash of its fully mangled
+// (per-instantiation-unique) symbol name, instead of either (a) sharing the
+// single volatile bucket every other instantiation from the same module
+// would otherwise land in, or (b) giving every instantiation its own
+// globally unique CGU. (b) is what an earlier version of this patch did,
+// and it regresses real crates with high monomorphization volume: with no
+// cap, a module-wide bucket for e.g. `impl<T: PolarsDataType>
+// ChunkedArray<T>` fragments into one CGU per (method x dtype)
+// instantiation -- hundreds of tiny object files that `merge_codegen_units`
+// can't recombine under incremental (it's intentionally skipped there so
+// each CGU stays independently cacheable), so the fragmentation cost from
+// emitting and linking hundreds of tiny objects dominates and makes both
+// cold and incremental builds slower than doing nothing. Sharding into a
+// number of buckets on the same order as the crate's own `-C
+// codegen-units` target keeps the CGU count in the same ballpark a normal
+// build would already produce, while still meaning an edit to one
+// instantiation's code path only invalidates the ~1/shard_count of
+// instantiations that happen to hash into the same shard, not all of them.
+fn fine_grained_cgu_name<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    base: Symbol,
+    mono_item: &MonoItem<'tcx>,
+) -> Symbol {
+    use std::hash::{Hash, Hasher};
+    let symbol_name = mono_item.symbol_name(tcx).name;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    symbol_name.hash(&mut hasher);
+    // Clamped rather than used verbatim: an explicit `-C codegen-units=1`
+    // would otherwise defeat sharding entirely (1 shard == the pre-patch
+    // behavior), and an explicit very large value would reproduce the
+    // unbounded-fragmentation regression this replaces. The clamp keeps
+    // shard count in the same order of magnitude as a normal build's CGU
+    // count regardless of what the crate's own `-C codegen-units` says.
+    //
+    // Floored at the host's available parallelism (not just
+    // `-C codegen-units`) so the shard count itself doesn't leave cores
+    // idle during codegen: codegen backend work is already parallelized
+    // per-CGU, so on a machine with more cores than the crate's configured
+    // codegen-units, sharding a volatile bucket that low would hand the
+    // backend fewer independent units than it has threads to run them on.
+    let available_parallelism =
+        std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+    let shard_count = tcx
+        .sess
+        .opts
+        .cg
+        .codegen_units
+        .unwrap_or(16)
+        .max(available_parallelism)
+        .clamp(4, 128) as u64;
+    let shard = hasher.finish() % shard_count;
+    Symbol::intern(&format!("{base}.shard{shard:03}"))
 }
 
 fn mono_item_linkage_and_visibility<'tcx>(

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2516,6 +2516,14 @@ options! {
         (default: no)"),
     fixed_x18: bool = (false, parse_bool, [TRACKED] { TARGET_MODIFIER: FixedX18 },
         "make the x18 register reserved on AArch64 (default: no)"),
+    fine_grained_generic_cgus: bool = (false, parse_bool, [TRACKED],
+        "shard monomorphized instances of a generic function across a bounded number of \
+        volatile codegen units (scaled to -C codegen-units, floored at the host's available \
+        parallelism so the codegen backend always has enough independent shards to keep \
+        every core busy) instead of merging all of them into one bucket by defining module, \
+        so a change to a generic function's body only invalidates the shards whose \
+        instantiations happen to hash into them, not every instantiation in the module \
+        (default: no)"),
     flatten_format_args: bool = (true, parse_bool, [TRACKED],
         "flatten nested format_args!() and literals into a simplified format_args!() call \
         (default: yes)"),


### PR DESCRIPTION
## Problem

Every monomorphized instance of a generic function sharing the same defining module collapses into one shared "volatile" codegen unit -- the cache key in `compute_codegen_unit_name` is `(module_def_id, volatile)`, ignoring the concrete type arguments. Editing the body of *one* instantiation invalidates every other instantiation's CGU too, even instantiations that share no code with the change.

## Change

Adds `-Z fine-grained-generic-cgus`. When set, each volatile bucket is sharded into a bounded number of sub-buckets by hashing the instantiation's mangled symbol name:

```
shard = hash(instantiation_symbol) % shard_count
shard_count = codegen_units.unwrap_or(16).max(available_parallelism()).clamp(4, 128)
```

An edit now invalidates roughly `1/shard_count` of a module's instantiations instead of all of them. Shard count is clamped to stay in the same order of magnitude as a normal build's CGU count, and floored at host parallelism so codegen backend threads stay fed.

## Why not one CGU per instantiation?

Tried that first (maximum granularity, zero false invalidation). It regresses incremental builds by ~20x on a generic-heavy crate: `merge_codegen_units` is intentionally skipped in incremental mode (each CGU needs to stay independently cacheable), so unbounded per-instantiation CGUs produce hundreds of tiny object files with no recombination step, and linker overhead dominates.

## Validation

Benchmarked against a synthetic 3000-instantiation crate (one generic fn, 3000 concrete callers in one module) with a real stage1 build of this patch:

| Config | Incremental rebuild after body edit |
|---|---|
| status quo | 4.32s |
| this patch | 2.74s (~1.6x faster) |

Also benchmarked on `polars-core`'s `ChunkedArray<T>` (real crate, ~200 instantiations) with similar results -- writeup and full methodology at https://github.com/Trigodil/Rust.

## Status

Opening as a draft for early feedback on the approach (sharding strategy, the clamp bounds, whether the flag should key on something other than raw symbol hash) before investing in a full test suite. Happy to iterate based on direction from the compiler team.
