### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/rustdoc.md
+++ b/.github/ISSUE_TEMPLATE/rustdoc.md
@@ -36,7 +36,7 @@ For diagnostics, please provide a mockup of the desired output in a code block.
 <!--
 * rustdoc console output
 * browser screenshot of generated html
-* rustdoc json (prettify by running through `jq` or running thorugh an online formatter)
+* rustdoc json (prettify by running through `jq` or running through an online formatter)
 -->
 ```console
 <code>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3855,7 +3855,6 @@ dependencies = [
  "rustc_macros",
  "rustc_metadata",
  "rustc_middle",
- "rustc_mir_transform",
  "rustc_serialize",
  "rustc_session",
  "rustc_span",

--- a/compiler/rustc_ast_lowering/src/expr/closure.rs
+++ b/compiler/rustc_ast_lowering/src/expr/closure.rs
@@ -204,7 +204,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
         let bound_generic_params = self.lower_lifetime_binder(closure_id, generic_params);
         // Lower outside new scope to preserve `is_in_loop_condition`.
-        let fn_decl = self.lower_fn_decl(decl, closure_id, fn_decl_span, FnDeclKind::Closure, None);
+        let fn_decl = self.lower_fn_decl(decl, closure_id, FnDeclKind::Closure, None);
 
         let c = self.arena.alloc(hir::Closure {
             def_id: closure_def_id,
@@ -327,8 +327,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         // We need to lower the declaration outside the new scope, because we
         // have to conserve the state of being inside a loop condition for the
         // closure argument types.
-        let fn_decl =
-            self.lower_fn_decl(&decl, closure_id, fn_decl_span, FnDeclKind::Closure, None);
+        let fn_decl = self.lower_fn_decl(&decl, closure_id, FnDeclKind::Closure, None);
 
         if let Const::Yes(span) = constness {
             self.dcx().span_err(span, "const coroutines are not supported");

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -333,7 +333,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
                     let itctx = ImplTraitContext::Universal;
                     let (generics, decl) = this.lower_generics(generics, itctx, |this| {
-                        this.lower_fn_decl(decl, id, *fn_sig_span, FnDeclKind::Fn, coroutine_marker)
+                        this.lower_fn_decl(decl, id, FnDeclKind::Fn, coroutine_marker)
                     });
                     let sig = hir::FnSig {
                         decl,
@@ -742,7 +742,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let (generics, (decl, fn_args)) = self.lower_generics(generics, itctx, |this| {
                     (
                         // Disallow `impl Trait` in foreign items.
-                        this.lower_fn_decl(fdec, i.id, sig.span, FnDeclKind::ExternFn, None),
+                        this.lower_fn_decl(fdec, i.id, FnDeclKind::ExternFn, None),
                         this.lower_fn_params_to_idents(fdec),
                     )
                 });
@@ -1681,7 +1681,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let header = self.lower_fn_header(sig.header, hir::Safety::Safe, attrs);
         let itctx = ImplTraitContext::Universal;
         let (generics, decl) = self.lower_generics(generics, itctx, |this| {
-            this.lower_fn_decl(&sig.decl, id, sig.span, kind, coroutine_marker)
+            this.lower_fn_decl(&sig.decl, id, kind, coroutine_marker)
         });
         (generics, hir::FnSig { header, decl, span: self.lower_span(sig.span) })
     }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1602,7 +1602,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     generic_params,
                     safety: self.lower_safety(f.safety, hir::Safety::Safe),
                     abi: self.lower_extern(f.ext),
-                    decl: self.lower_fn_decl(&f.decl, t.id, t.span, FnDeclKind::Pointer, None),
+                    decl: self.lower_fn_decl(&f.decl, t.id, FnDeclKind::Pointer, None),
                     param_idents: self.lower_fn_params_to_idents(&f.decl),
                 }))
             }
@@ -1962,7 +1962,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
         &mut self,
         decl: &FnDecl,
         fn_node_id: NodeId,
-        fn_span: Span,
         kind: FnDeclKind,
         coro: Option<CoroutineMarker>,
     ) -> &'hir hir::FnDecl<'hir> {

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -29,7 +29,6 @@ rustc_lint_defs = { path = "../rustc_lint_defs" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_metadata = { path = "../rustc_metadata" }
 rustc_middle = { path = "../rustc_middle" }
-rustc_mir_transform = { path = "../rustc_mir_transform" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -217,14 +217,7 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     let fn_abi = cx.fn_abi_of_instance(instance, ty::List::empty());
     debug!("fn_abi: {:?}", fn_abi);
 
-    let nop_landing_pads = rustc_mir_transform::remove_noop_landing_pads::find_noop_landing_pads(
-        mir,
-        Some(rustc_mir_transform::remove_noop_landing_pads::ExtraInfo {
-            tcx,
-            instance,
-            typing_env: cx.typing_env(),
-        }),
-    );
+    let nop_landing_pads = tcx.find_noop_landing_pads_for_instance(mir, instance, cx.typing_env());
 
     if tcx.features().ergonomic_clones() {
         let monomorphized_mir = instance.instantiate_mir_and_normalize_erasing_regions(

--- a/compiler/rustc_error_codes/src/error_codes/E0747.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0747.md
@@ -1,5 +1,6 @@
 Generic arguments were not provided in the same order as the corresponding
-generic parameters are declared.
+generic parameters are declared, or a type was provided when a constant
+was expected.
 
 Erroneous code example:
 
@@ -17,4 +18,22 @@ order, as in the following:
 struct S<'a, T>(&'a T);
 
 type X = S<'static, ()>; // ok
+```
+
+Another erroneous code example:
+
+```compile_fail,E0747
+struct Foo<const N: usize>;
+
+fn foo() -> Foo<usize> {} // error: type provided when a constant was
+                          // expected
+```
+
+A constant expression must be provided when a constant generic parameter
+is declared, not a type, as in the following:
+
+```
+struct Foo<const N: usize>;
+
+fn foo() -> Foo<3> { Foo }
 ```

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -52,7 +52,7 @@ pub(super) fn failed_to_match_macro(
         FailedMacro::Attr(attr_args) => {
             try_match_macro_attr(psess, name, attr_args, body, rules, &mut tracker)
         }
-        FailedMacro::Derive => try_match_macro_derive(psess, name, body, rules, &mut tracker),
+        FailedMacro::Derive => try_match_macro_derive(psess, body, rules, &mut tracker),
     };
 
     if try_success_result.is_ok() {

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -50,7 +50,7 @@ pub(super) fn failed_to_match_macro(
     let try_success_result = match args {
         FailedMacro::Func => try_match_macro(psess, name, body, rules, &mut tracker),
         FailedMacro::Attr(attr_args) => {
-            try_match_macro_attr(psess, name, attr_args, body, rules, &mut tracker)
+            try_match_macro_attr(psess, attr_args, body, rules, &mut tracker)
         }
         FailedMacro::Derive => try_match_macro_derive(psess, body, rules, &mut tracker),
     };

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -48,7 +48,7 @@ pub(super) fn failed_to_match_macro(
     let mut tracker = CollectTrackerAndEmitter::new(name, psess.dcx(), sp);
 
     let try_success_result = match args {
-        FailedMacro::Func => try_match_macro(psess, name, body, rules, &mut tracker),
+        FailedMacro::Func => try_match_macro(psess, body, rules, &mut tracker),
         FailedMacro::Attr(attr_args) => {
             try_match_macro_attr(psess, attr_args, body, rules, &mut tracker)
         }

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -538,7 +538,7 @@ fn expand_macro_attr(
     }
 
     // Track nothing for the best performance.
-    match try_match_macro_attr(psess, name, &args, &body, rules, &mut NoopTracker) {
+    match try_match_macro_attr(psess, &args, &body, rules, &mut NoopTracker) {
         Ok((i, rule, named_matches)) => {
             let MacroRule::Attr { rhs, unsafe_rule, .. } = rule else {
                 panic!("try_macro_match_attr returned non-attr rule");
@@ -686,7 +686,6 @@ pub(super) fn try_match_macro<'matcher, T: Tracker<'matcher>>(
 #[instrument(level = "debug", skip(psess, attr_args, attr_body, rules, track), fields(tracking = %T::description()))]
 pub(super) fn try_match_macro_attr<'matcher, T: Tracker<'matcher>>(
     psess: &ParseSess,
-    name: Ident,
     attr_args: &TokenStream,
     attr_body: &TokenStream,
     rules: &'matcher [MacroRule],

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -447,7 +447,7 @@ fn expand_macro<'cx, 'a: 'cx>(
     }
 
     // Track nothing for the best performance.
-    let try_success_result = try_match_macro(psess, name, &arg, rules, &mut NoopTracker);
+    let try_success_result = try_match_macro(psess, &arg, rules, &mut NoopTracker);
 
     match try_success_result {
         Ok((rule_index, rule, named_matches)) => {
@@ -606,7 +606,6 @@ pub(super) enum CanRetry {
 #[instrument(level = "debug", skip(psess, arg, rules, track), fields(tracking = %T::description()))]
 pub(super) fn try_match_macro<'matcher, T: Tracker<'matcher>>(
     psess: &ParseSess,
-    name: Ident,
     arg: &TokenStream,
     rules: &'matcher [MacroRule],
     track: &mut T,

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -244,7 +244,7 @@ impl MacroRulesMacroExpander {
             trace_macros_note(&mut cx.expansions, sp, msg);
         }
 
-        match try_match_macro_derive(psess, name, body, rules, &mut NoopTracker) {
+        match try_match_macro_derive(psess, body, rules, &mut NoopTracker) {
             Ok((rule_index, rule, named_matches)) => {
                 let MacroRule::Derive { rhs, .. } = rule else {
                     panic!("try_match_macro_derive returned non-derive rule");
@@ -743,7 +743,6 @@ pub(super) fn try_match_macro_attr<'matcher, T: Tracker<'matcher>>(
 #[instrument(level = "debug", skip(psess, body, rules, track), fields(tracking = %T::description()))]
 pub(super) fn try_match_macro_derive<'matcher, T: Tracker<'matcher>>(
     psess: &ParseSess,
-    name: Ident,
     body: &TokenStream,
     rules: &'matcher [MacroRule],
     track: &mut T,

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -201,7 +201,7 @@ where
 
     lint_redundant_lifetimes(tcx, body_def_id, &outlives_env);
 
-    let errors = infcx.resolve_regions_with_outlives_env(&outlives_env, tcx.def_span(body_def_id));
+    let errors = infcx.resolve_regions_with_outlives_env(&outlives_env);
     if errors.is_empty() {
         return Ok(());
     }
@@ -215,8 +215,7 @@ where
         // the implied bounds hack if this contains `bevy_ecs`'s `ParamSet` type.
         false,
     );
-    let errors_compat =
-        infcx_compat.resolve_regions_with_outlives_env(&outlives_env, tcx.def_span(body_def_id));
+    let errors_compat = infcx_compat.resolve_regions_with_outlives_env(&outlives_env);
     if errors_compat.is_empty() {
         // FIXME: Once we fix bevy, this would be the place to insert a warning
         // to upgrade bevy.

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -235,7 +235,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn write_splatted_call(
         &self,
         hir_id: HirId,
-        span: Span,
         fn_id: SplatLoweringInfo<'tcx>,
         callee_generic_args: Option<GenericArgsRef<'tcx>>,
         first_tupled_arg_index: u16,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -827,7 +827,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // FIXME(const_trait_impl): does not enforce constness yet
                 self.write_splatted_call(
                     call_expr.hir_id,
-                    call_span,
                     fn_id,
                     callee_generic_args,
                     first_tupled_arg_index,

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -114,24 +114,6 @@ impl<T: Idx> DenseBitSet<T> {
         result
     }
 
-    /// Replaces this bitset with one having the same elements, but a larger domain size.
-    #[inline]
-    pub fn enlarge(self, new_domain_size: usize) -> DenseBitSet<T> {
-        // We could also support shrinking, but it's hard to imagine a real use-case for it.
-        assert!(self.domain_size <= new_domain_size);
-        let new_num_words = num_words(new_domain_size);
-
-        let DenseBitSet { domain_size: _, mut words, marker } = self;
-
-        if new_num_words != words.len() {
-            let mut words_vec = words.into_vec();
-            words_vec.resize(new_num_words, 0);
-            words = words_vec.into_boxed_slice()
-        }
-
-        DenseBitSet { domain_size: new_domain_size, words, marker }
-    }
-
     /// Clear all elements.
     #[inline]
     pub fn clear(&mut self) {
@@ -1259,6 +1241,11 @@ impl<T: Idx> GrowableBitSet<T> {
     /// Ensure that the set has allocated and initialized at least `min_num_bits` bits.
     fn ensure(&mut self, min_num_bits: usize) {
         let min_num_words = num_words(min_num_bits);
+        self.ensure_words(min_num_words);
+    }
+
+    /// Ensures that the set has allocated and initialized at least `min_num_words` words.
+    fn ensure_words(&mut self, min_num_words: usize) {
         if self.words.len() < min_num_words {
             self.words.resize(min_num_words, 0)
         }
@@ -1298,6 +1285,16 @@ impl<T: Idx> GrowableBitSet<T> {
     #[inline]
     pub fn iter(&self) -> BitIter<'_, T> {
         BitIter::new(&self.words)
+    }
+
+    /// Mutates `self = self | other`.
+    #[inline]
+    pub fn union(&mut self, other: &GrowableBitSet<T>) {
+        // Eagerly grow `self` to be at least as large as `other`.
+        // This is simpler than trying to check whether `other` has any nonzero
+        // bits beyond our current size.
+        self.ensure_words(other.words.len());
+        update_words(&mut self.words[..other.words.len()], &other.words, |a, b| a | b);
     }
 }
 

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -1231,7 +1231,6 @@ impl<'a, T: Idx> Iterator for MixedBitIter<'a, T> {
 /// just be `usize`.
 #[derive(Debug, PartialEq)]
 pub struct GrowableBitSet<T: Idx> {
-    domain_size: usize,
     words: Vec<Word>,
     marker: PhantomData<T>,
 }
@@ -1239,13 +1238,12 @@ pub struct GrowableBitSet<T: Idx> {
 // Manually implemented to provide `clone_from`.
 impl<T: Idx> Clone for GrowableBitSet<T> {
     fn clone(&self) -> Self {
-        let &GrowableBitSet { domain_size, ref words, marker } = self;
-        GrowableBitSet { domain_size, words: words.clone(), marker }
+        let &GrowableBitSet { ref words, marker } = self;
+        GrowableBitSet { words: words.clone(), marker }
     }
 
     fn clone_from(&mut self, source: &Self) {
-        let GrowableBitSet { domain_size, words, marker } = source;
-        self.domain_size.clone_from(domain_size);
+        let GrowableBitSet { words, marker } = source;
         self.words.clone_from(words);
         self.marker.clone_from(marker);
     }
@@ -1258,28 +1256,20 @@ impl<T: Idx> Default for GrowableBitSet<T> {
 }
 
 impl<T: Idx> GrowableBitSet<T> {
-    /// Ensure that the set can hold at least `min_domain_size` elements.
-    pub fn ensure(&mut self, min_domain_size: usize) {
-        if self.domain_size < min_domain_size {
-            self.domain_size = min_domain_size;
-        }
-
-        let min_num_words = num_words(min_domain_size);
+    /// Ensure that the set has allocated and initialized at least `min_num_bits` bits.
+    fn ensure(&mut self, min_num_bits: usize) {
+        let min_num_words = num_words(min_num_bits);
         if self.words.len() < min_num_words {
             self.words.resize(min_num_words, 0)
         }
     }
 
     pub fn new_empty() -> GrowableBitSet<T> {
-        GrowableBitSet { domain_size: 0, words: vec![], marker: PhantomData }
+        GrowableBitSet { words: vec![], marker: PhantomData }
     }
 
     pub fn with_capacity(capacity: usize) -> GrowableBitSet<T> {
-        GrowableBitSet {
-            domain_size: capacity,
-            words: vec![0; num_words(capacity)],
-            marker: PhantomData,
-        }
+        GrowableBitSet { words: Vec::with_capacity(num_words(capacity)), marker: PhantomData }
     }
 
     /// Returns `true` if the set has changed.

--- a/compiler/rustc_index/src/bit_set/tests.rs
+++ b/compiler/rustc_index/src/bit_set/tests.rs
@@ -555,6 +555,35 @@ fn grow() {
 }
 
 #[test]
+fn growable_union() {
+    // Create two input sets with partly-overlapping values, and different sizes.
+    let mut twos = GrowableBitSet::<usize>::new_empty();
+    for i in (0usize..100).map(|x| x * 2) {
+        twos.insert(i);
+    }
+
+    let mut threes = GrowableBitSet::<usize>::new_empty();
+    for i in (0usize..100).map(|x| x * 3) {
+        threes.insert(i);
+    }
+
+    // Double-check that we did end up with input sets of different sizes.
+    assert_ne!(twos.words.len(), threes.words.len());
+
+    // Perform a union in both directions, and check that the resulting contents are correct.
+    for (mut lhs, rhs) in [(twos.clone(), threes.clone()), (threes.clone(), twos.clone())] {
+        lhs.union(&rhs);
+
+        for i in 0..400 {
+            assert_eq!(
+                lhs.contains(i),
+                (i.is_multiple_of(2) && i < 200) || (i.is_multiple_of(3) && i < 300)
+            );
+        }
+    }
+}
+
+#[test]
 fn matrix_intersection() {
     let mut matrix: BitMatrix<usize, usize> = BitMatrix::new(200, 200);
 

--- a/compiler/rustc_infer/src/infer/outlives/mod.rs
+++ b/compiler/rustc_infer/src/infer/outlives/mod.rs
@@ -5,7 +5,6 @@ use std::iter;
 use rustc_data_structures::undo_log::UndoLogs;
 use rustc_middle::traits::query::OutlivesBound;
 use rustc_middle::ty;
-use rustc_span::Span;
 use tracing::instrument;
 
 use self::env::OutlivesEnvironment;
@@ -44,9 +43,8 @@ impl<'tcx> InferCtxt<'tcx> {
     pub fn resolve_regions_with_outlives_env(
         &self,
         outlives_env: &OutlivesEnvironment<'tcx>,
-        span: Span,
     ) -> Vec<RegionResolutionError<'tcx>> {
-        self.process_registered_region_obligations(outlives_env, span);
+        self.process_registered_region_obligations(outlives_env);
 
         let mut storage = {
             let mut inner = self.inner.borrow_mut();

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -68,7 +68,6 @@ use rustc_middle::ty::{
     self, GenericArgKind, GenericArgsRef, PolyTypeOutlivesClause, Region, RegionVid, Ty, TyCtxt,
     TypeVisitableExt, Upcast,
 };
-use rustc_span::Span;
 use rustc_type_ir::region_constraint::{self, LeafRegionConstraint};
 use smallvec::smallvec;
 use tracing::{debug, instrument};
@@ -335,13 +334,8 @@ impl<'tcx> InferCtxt<'tcx> {
     /// invoked after all type-inference variables have been bound --
     /// right before lexical region resolution.
     #[instrument(level = "debug", skip(self, outlives_env))]
-    pub fn process_registered_region_obligations(
-        &self,
-        outlives_env: &OutlivesEnvironment<'tcx>,
-        span: Span,
-    ) {
+    pub fn process_registered_region_obligations(&self, outlives_env: &OutlivesEnvironment<'tcx>) {
         use rustc_type_ir::InferCtxtLike;
-
         assert!(!self.in_snapshot(), "cannot process registered region obligations in a snapshot");
 
         if self.tcx.assumptions_on_binders() {

--- a/compiler/rustc_middle/src/hooks.rs
+++ b/compiler/rustc_middle/src/hooks.rs
@@ -4,16 +4,24 @@
 //! compilation, whereas hooks are just plain function pointers without any of the query magic.
 
 use rustc_hir::def_id::{DefId, DefPathHash};
+use rustc_index::bit_set::DenseBitSet;
 use rustc_session::StableCrateId;
 use rustc_span::def_id::{CrateNum, LocalDefId};
 use rustc_span::{ExpnHash, ExpnId};
 
 use crate::mir;
 use crate::query::on_disk_cache::CacheEncoder;
-use crate::ty::{Ty, TyCtxt};
+use crate::ty::{self, Ty, TyCtxt};
 
 macro_rules! declare_hooks {
-    ($($(#[$attr:meta])*hook $name:ident($($arg:ident: $K:ty),*) -> $V:ty;)*) => {
+    (
+        $(
+            $(#[$attr:meta])*
+            hook $name:ident(
+                $( $arg:ident: $K:ty ),* $(,)?
+            ) -> $V:ty;
+        )*
+    ) => {
 
         impl<'tcx> TyCtxt<'tcx> {
             $(
@@ -107,6 +115,14 @@ declare_hooks! {
 
     /// Serializes all eligible query return values into the on-disk cache.
     hook encode_query_values(encoder: &mut CacheEncoder<'tcx>) -> ();
+
+    /// Identifies landing pads that don't do anything, allowing some post-monomorphization
+    /// simplifications during codegen.
+    hook find_noop_landing_pads_for_instance(
+        body: &mir::Body<'tcx>,
+        instance: ty::Instance<'tcx>,
+        typing_env: ty::TypingEnv<'tcx>,
+    ) -> DenseBitSet<mir::BasicBlock>;
 }
 
 #[cold]

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -156,7 +156,7 @@ impl<'p, 'tcx> Visitor<'p, 'tcx> for MatchVisitor<'p, 'tcx> {
                 self.check_match(scrutinee, arms, MatchSource::Normal, span);
             }
             ExprKind::Let { ref pat, expr } => {
-                self.check_let(pat, Some(expr), ex.span, None);
+                self.check_let(pat, Some(expr), ex.span);
             }
             ExprKind::LogicalOp { op: LogicalOp::And, .. }
                 if !matches!(self.let_source, LetSource::None) =>
@@ -180,9 +180,8 @@ impl<'p, 'tcx> Visitor<'p, 'tcx> for MatchVisitor<'p, 'tcx> {
                 self.with_hir_source(hir_id, |this| {
                     let let_source =
                         if else_block.is_some() { LetSource::LetElse } else { LetSource::PlainLet };
-                    let else_span = else_block.map(|bid| this.thir.blocks[bid].span);
                     this.with_let_source(let_source, |this| {
-                        this.check_let(pattern, initializer, span, else_span)
+                        this.check_let(pattern, initializer, span)
                     });
                     visit::walk_stmt(this, stmt);
                 });
@@ -424,13 +423,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
     }
 
     #[instrument(level = "trace", skip(self))]
-    fn check_let(
-        &mut self,
-        pat: &'p Pat<'tcx>,
-        scrutinee: Option<ExprId>,
-        span: Span,
-        else_span: Option<Span>,
-    ) {
+    fn check_let(&mut self, pat: &'p Pat<'tcx>, scrutinee: Option<ExprId>, span: Span) {
         assert!(self.let_source != LetSource::None);
         let scrut = scrutinee.map(|id| &self.thir[id]);
         if let LetSource::PlainLet = self.let_source {

--- a/compiler/rustc_mir_dataflow/src/value_analysis.rs
+++ b/compiler/rustc_mir_dataflow/src/value_analysis.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use rustc_abi::{FieldIdx, VariantIdx};
 use rustc_data_structures::fx::{FxHashMap, FxIndexSet, StdEntry};
 use rustc_index::IndexVec;
-use rustc_index::bit_set::DenseBitSet;
+use rustc_index::bit_set::GrowableBitSet;
 use rustc_middle::mir::visit::{PlaceContext, Visitor};
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, Ty, TyCtxt, Unnormalized};
@@ -1039,9 +1039,9 @@ pub fn iter_fields<'tcx>(
 }
 
 /// Returns all locals with projections that have their reference or address taken.
-pub fn excluded_locals(body: &Body<'_>) -> DenseBitSet<Local> {
+pub fn excluded_locals(body: &Body<'_>) -> GrowableBitSet<Local> {
     struct Collector {
-        result: DenseBitSet<Local>,
+        result: GrowableBitSet<Local>,
     }
 
     impl<'tcx> Visitor<'tcx> for Collector {
@@ -1054,7 +1054,7 @@ pub fn excluded_locals(body: &Body<'_>) -> DenseBitSet<Local> {
         }
     }
 
-    let mut collector = Collector { result: DenseBitSet::new_empty(body.local_decls.len()) };
+    let mut collector = Collector { result: GrowableBitSet::new_empty() };
     collector.visit_body(body);
     collector.result
 }

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -1061,7 +1061,6 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
     #[instrument(level = "trace", skip(self), ret)]
     fn simplify_rvalue(
         &mut self,
-        lhs: &Place<'tcx>,
         rvalue: &mut Rvalue<'tcx>,
         location: Location,
     ) -> Option<VnIndex> {
@@ -2100,7 +2099,7 @@ impl<'tcx> MutVisitor<'tcx> for VnState<'_, '_, 'tcx> {
     ) {
         self.simplify_place_projection(lhs, location);
 
-        let value = self.simplify_rvalue(lhs, rvalue, location);
+        let value = self.simplify_rvalue(rvalue, location);
         if let Some(value) = value {
             // FIXME: Is it correct to make these retagging assignments?
             if let Some(const_) = self.try_as_constant(value) {

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -169,7 +169,7 @@ declare_passes! {
     mod prettify : ReorderBasicBlocks, ReorderLocals;
     mod promote_consts : PromoteTemps;
     mod ref_prop : ReferencePropagation;
-    pub mod remove_noop_landing_pads : RemoveNoopLandingPads;
+    mod remove_noop_landing_pads : RemoveNoopLandingPads;
     mod remove_place_mention : RemovePlaceMention;
     mod remove_storage_markers : RemoveStorageMarkers;
     mod remove_uninit_drops : RemoveUninitDrops;
@@ -215,6 +215,8 @@ pub fn provide(providers: &mut Providers) {
     ffi_unwind_calls::provide(&mut providers.queries);
     shim::provide(&mut providers.queries);
     cross_crate_inline::provide(&mut providers.queries);
+    providers.hooks.find_noop_landing_pads_for_instance =
+        remove_noop_landing_pads::find_noop_landing_pads_for_instance;
     providers.queries = query::Providers {
         mir_keys,
         mir_built,

--- a/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
+++ b/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
@@ -18,8 +18,8 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveNoopLandingPads {
         PassPolicy::optional(ctx.panic_strategy().unwinds())
     }
 
-    #[instrument(level = "debug", skip(self, _tcx, body))]
-    fn run_pass(&self, _tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+    #[instrument(level = "debug", skip(self, tcx, body))]
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         let def_id = body.source.def_id();
         debug!(?def_id);
 
@@ -33,7 +33,7 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveNoopLandingPads {
             return;
         }
 
-        let nop_landing_pads = find_noop_landing_pads(body, None);
+        let nop_landing_pads = find_noop_landing_pads(tcx, body, None);
 
         if nop_landing_pads.is_empty() {
             debug!("no nop landing pads in MIR");
@@ -74,10 +74,12 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveNoopLandingPads {
 impl RemoveNoopLandingPads {
     fn is_nop_landing_pad<'tcx>(
         &self,
+        tcx: TyCtxt<'tcx>,
         bbdata: &BasicBlockData<'tcx>,
         body: &Body<'tcx>,
         nop_landing_pads: &DenseBitSet<BasicBlock>,
-        extra: Option<&ExtraInfo<'tcx>>,
+        // Extra post-monomorphization info that allows more cases to be identified.
+        extra: Option<(Instance<'tcx>, ty::TypingEnv<'tcx>)>,
     ) -> bool {
         for stmt in &bbdata.statements {
             match &stmt.kind {
@@ -120,15 +122,15 @@ impl RemoveNoopLandingPads {
                 terminator.successors().all(|succ| nop_landing_pads.contains(succ))
             }
             TerminatorKind::Drop { place, .. } => {
-                if let Some(extra) = extra {
-                    let ty = place.ty(body, extra.tcx).ty;
-                    debug!("monomorphize: instance={:?}", extra.instance);
-                    let ty = extra.instance.instantiate_mir_and_normalize_erasing_regions(
-                        extra.tcx,
-                        extra.typing_env,
-                        ty::EarlyBinder::bind(extra.tcx, ty),
+                if let Some((instance, typing_env)) = extra {
+                    let ty = place.ty(body, tcx).ty;
+                    debug!("monomorphize: instance={instance:?}");
+                    let ty = instance.instantiate_mir_and_normalize_erasing_regions(
+                        tcx,
+                        typing_env,
+                        ty::EarlyBinder::bind(tcx, ty),
                     );
-                    let drop_fn = Instance::resolve_drop_glue(extra.tcx, ty);
+                    let drop_fn = Instance::resolve_drop_glue(tcx, ty);
                     if let ty::InstanceKind::Shim(ty::ShimKind::DropGlue(_, None)) = drop_fn.def {
                         // no need to drop anything, if all of our successors are also no-op then we
                         // can be skipped.
@@ -151,18 +153,20 @@ impl RemoveNoopLandingPads {
     }
 }
 
-/// This provides extra information that allows further analysis.
-///
-/// Used by rustc_codegen_ssa.
-pub struct ExtraInfo<'tcx> {
-    pub tcx: TyCtxt<'tcx>,
-    pub instance: Instance<'tcx>,
-    pub typing_env: ty::TypingEnv<'tcx>,
+/// Hook impl for [`TyCtxt::find_noop_landing_pads_for_instance`].
+pub(crate) fn find_noop_landing_pads_for_instance<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    instance: Instance<'tcx>,
+    typing_env: ty::TypingEnv<'tcx>,
+) -> DenseBitSet<BasicBlock> {
+    find_noop_landing_pads(tcx, body, Some((instance, typing_env)))
 }
 
-pub fn find_noop_landing_pads<'tcx>(
+fn find_noop_landing_pads<'tcx>(
+    tcx: TyCtxt<'tcx>,
     body: &Body<'tcx>,
-    extra: Option<ExtraInfo<'tcx>>,
+    extra: Option<(Instance<'tcx>, ty::TypingEnv<'tcx>)>,
 ) -> DenseBitSet<BasicBlock> {
     let mut nop_landing_pads = DenseBitSet::new_empty(body.basic_blocks.len());
 
@@ -171,10 +175,11 @@ pub fn find_noop_landing_pads<'tcx>(
     let postorder: Vec<_> = traversal::postorder(body).map(|(bb, _)| bb).collect();
     for bb in postorder {
         let is_nop_landing_pad = RemoveNoopLandingPads.is_nop_landing_pad(
+            tcx,
             &body.basic_blocks[bb],
             body,
             &nop_landing_pads,
-            extra.as_ref(),
+            extra,
         );
         if is_nop_landing_pad {
             nop_landing_pads.insert(bb);

--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -2,7 +2,7 @@ use rustc_abi::FieldIdx;
 use rustc_data_structures::flat_map_in_place::FlatMapInPlace;
 use rustc_hir::attrs::lang_items::LangItem;
 use rustc_index::IndexVec;
-use rustc_index::bit_set::DenseBitSet;
+use rustc_index::bit_set::{DenseBitSet, GrowableBitSet};
 use rustc_middle::bug;
 use rustc_middle::mir::visit::*;
 use rustc_middle::mir::*;
@@ -40,7 +40,6 @@ impl<'tcx> crate::MirPass<'tcx> for ScalarReplacementOfAggregates {
             let all_dead_locals = replace_flattened_locals(tcx, body, replacements);
             if !all_dead_locals.is_empty() {
                 excluded.union(&all_dead_locals);
-                excluded = excluded.enlarge(body.local_decls.len());
             } else {
                 break;
             }
@@ -57,7 +56,7 @@ impl<'tcx> crate::MirPass<'tcx> for ScalarReplacementOfAggregates {
 ///   client code.
 fn escaping_locals<'tcx>(
     tcx: TyCtxt<'tcx>,
-    excluded: &DenseBitSet<Local>,
+    excluded: &GrowableBitSet<Local>,
     body: &Body<'tcx>,
 ) -> DenseBitSet<Local> {
     let is_excluded_ty = |ty: Ty<'tcx>| {
@@ -208,9 +207,11 @@ fn replace_flattened_locals<'tcx>(
     tcx: TyCtxt<'tcx>,
     body: &mut Body<'tcx>,
     replacements: ReplacementMap<'tcx>,
-) -> DenseBitSet<Local> {
-    let mut all_dead_locals = DenseBitSet::new_empty(replacements.fragments.len());
-    for (local, replacements) in replacements.fragments.iter_enumerated() {
+) -> GrowableBitSet<Local> {
+    // Start with an empty GrowableBitSet, to avoid allocation if nothing is dead.
+    // Then fill the set in descending order so that it allocates at most once.
+    let mut all_dead_locals = GrowableBitSet::new_empty();
+    for (local, replacements) in replacements.fragments.iter_enumerated().rev() {
         if replacements.is_some() {
             all_dead_locals.insert(local);
         }
@@ -249,7 +250,7 @@ struct ReplacementVisitor<'tcx, 'll> {
     /// Work to do.
     replacements: &'ll ReplacementMap<'tcx>,
     /// This is used to check that we are not leaving references to replaced locals behind.
-    all_dead_locals: DenseBitSet<Local>,
+    all_dead_locals: GrowableBitSet<Local>,
     patch: MirPatch<'tcx>,
 }
 

--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -100,7 +100,6 @@ where
 ///   the `normalization_nested_goals`
 pub(super) fn instantiate_and_apply_query_response<D, I>(
     delegate: &D,
-    param_env: I::ParamEnv,
     original_values: &[I::GenericArg],
     response: CanonicalResponse<I>,
     span: I::Span,
@@ -115,7 +114,7 @@ where
     let Response { var_values, external_constraints, certainty } =
         delegate.instantiate_canonical(response, instantiation);
 
-    unify_query_var_values(delegate, param_env, &original_values, var_values, span);
+    unify_query_var_values(delegate, &original_values, var_values, span);
 
     let ExternalConstraintsData { region_constraints, opaque_types, normalization_nested_goals } =
         &*external_constraints;
@@ -490,7 +489,6 @@ where
 #[instrument(level = "trace", skip(delegate))]
 fn unify_query_var_values<D, I>(
     delegate: &D,
-    param_env: I::ParamEnv,
     original_values: &[I::GenericArg],
     var_values: CanonicalVarValues<I>,
     span: I::Span,
@@ -577,7 +575,6 @@ where
 pub fn instantiate_canonical_state<D, I, T>(
     delegate: &D,
     span: I::Span,
-    param_env: I::ParamEnv,
     prev_universe: ty::UniverseIndex,
     orig_values: &mut ThinVec<I::GenericArg>,
     state: inspect::CanonicalState<I, T>,
@@ -609,7 +606,7 @@ where
 
     let inspect::State { var_values, data } = delegate.instantiate_canonical(state, instantiation);
 
-    unify_query_var_values(delegate, param_env, orig_values, var_values, span);
+    unify_query_var_values(delegate, orig_values, var_values, span);
     data
 }
 

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -794,7 +794,6 @@ where
 
         let (normalization_nested_goals, certainty) = instantiate_and_apply_query_response(
             self.delegate,
-            goal.param_env,
             &orig_values,
             response,
             self.origin_span,
@@ -1955,7 +1954,6 @@ pub(super) fn evaluate_root_goal_for_proof_tree<D: SolverDelegate<Interner = I>,
 
     let (normalization_nested_goals, _certainty) = instantiate_and_apply_query_response(
         delegate,
-        goal.param_env,
         &proof_tree.orig_values,
         response,
         origin_span,

--- a/compiler/rustc_trait_selection/src/regions.rs
+++ b/compiler/rustc_trait_selection/src/regions.rs
@@ -74,10 +74,7 @@ impl<'tcx> InferCtxt<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
         assumed_wf_tys: impl IntoIterator<Item = Ty<'tcx>>,
     ) -> Vec<RegionResolutionError<'tcx>> {
-        self.resolve_regions_with_outlives_env(
-            &OutlivesEnvironment::new(self, body_def_id, param_env, assumed_wf_tys),
-            self.tcx.def_span(body_def_id),
-        )
+        self.resolve_regions_with_outlives_env(&OutlivesEnvironment::new(self, body_def_id, param_env, assumed_wf_tys))
     }
 }
 

--- a/compiler/rustc_trait_selection/src/regions.rs
+++ b/compiler/rustc_trait_selection/src/regions.rs
@@ -74,7 +74,12 @@ impl<'tcx> InferCtxt<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
         assumed_wf_tys: impl IntoIterator<Item = Ty<'tcx>>,
     ) -> Vec<RegionResolutionError<'tcx>> {
-        self.resolve_regions_with_outlives_env(&OutlivesEnvironment::new(self, body_def_id, param_env, assumed_wf_tys))
+        self.resolve_regions_with_outlives_env(&OutlivesEnvironment::new(
+            self,
+            body_def_id,
+            param_env,
+            assumed_wf_tys,
+        ))
     }
 }
 

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -98,7 +98,6 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
     )]
     pub fn instantiate_nested_goals(&self, span: Span) -> Vec<InspectGoal<'a, 'tcx>> {
         let infcx = self.goal.infcx;
-        let param_env = self.goal.goal.param_env;
         let mut orig_values = self.goal.orig_values.clone();
 
         let mut instantiated_goals = vec![];
@@ -109,7 +108,6 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
                     instantiate_canonical_state(
                         infcx,
                         span,
-                        param_env,
                         self.goal.prev_universe,
                         &mut orig_values,
                         goal,
@@ -124,7 +122,6 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
         let () = instantiate_canonical_state(
             infcx,
             span,
-            param_env,
             self.goal.prev_universe,
             &mut orig_values,
             self.final_state,
@@ -148,7 +145,6 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
         use rustc_middle::ty::InferCtxtLike;
 
         let infcx = self.goal.infcx;
-        let param_env = self.goal.goal.param_env;
         let mut orig_values = self.goal.orig_values.clone();
 
         for step in &self.steps {
@@ -157,7 +153,6 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
                     let impl_args = instantiate_canonical_state(
                         infcx,
                         span,
-                        param_env,
                         self.goal.prev_universe,
                         &mut orig_values,
                         impl_args,
@@ -166,7 +161,6 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
                     let () = instantiate_canonical_state(
                         infcx,
                         span,
-                        param_env,
                         self.goal.prev_universe,
                         &mut orig_values,
                         self.final_state,

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -173,7 +173,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
         }
 
         let outlives_env = OutlivesEnvironment::new(&infcx, CRATE_DEF_ID, full_env, []);
-        let _ = infcx.process_registered_region_obligations(&outlives_env, DUMMY_SP);
+        let _ = infcx.process_registered_region_obligations(&outlives_env);
 
         let region_data = infcx.inner.borrow_mut().unwrap_region_constraints().data().clone();
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -762,8 +762,6 @@ impl<T> Vec<T> {
     /// # Example
     ///
     /// ```rust
-    /// #![feature(vec_from_fn)]
-    ///
     /// let vec = Vec::from_fn(5, |i| i);
     ///
     /// // indexes are:  0  1  2  3  4
@@ -783,8 +781,6 @@ impl<T> Vec<T> {
     /// The `Vec<T>` is generated in ascending index order, starting from the front
     /// and going towards the back, so you can use closures with mutable state:
     /// ```
-    /// #![feature(vec_from_fn)]
-    ///
     /// let mut state = 1;
     /// let a = Vec::from_fn(6, |_| { let x = state; state *= 2; x });
     ///
@@ -792,7 +788,7 @@ impl<T> Vec<T> {
     /// ```
     #[cfg(not(no_global_oom_handling))]
     #[inline]
-    #[unstable(feature = "vec_from_fn", issue = "149698")]
+    #[stable(feature = "vec_from_fn", since = "CURRENT_RUSTC_VERSION")]
     pub fn from_fn<F>(length: usize, f: F) -> Self
     where
         F: FnMut(usize) -> T,


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#162623 (Use GrowableBitSet in the main loop of `rustc_mir_transform::sroa`)
 - rust-lang/rust#162678 (Disconnect `rustc_codegen_ssa` from `rustc_mir_transform`)
 - rust-lang/rust#162641 (Remove unused arguments of functions)
 - rust-lang/rust#162663 (Rustdoc issue template: fix typo in comment ("thorugh"))
 - rust-lang/rust#162684 (Add `E0747` explanation for `type/const` mismatch case)
 - rust-lang/rust#162685 (Stabilize `Vec::from_fn`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=162623,162678,162641,162663,162684,162685)
<!-- homu-ignore:end -->

