### PR TITLE
Pin intended next-solver E0283 on higher-ranked alias ambiguity

### DIFF
--- a/tests/ui/higher-ranked/trait-bounds/next-solver-alias-relate-ambiguity-162559.next.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/next-solver-alias-relate-ambiguity-162559.next.stderr
@@ -1,0 +1,30 @@
+error[E0283]: type annotations needed
+  --> $DIR/next-solver-alias-relate-ambiguity-162559.rs:45:5
+   |
+LL |     use_host(getter);
+   |     ^^^^^^^^ cannot infer type of the type parameter `D2` declared on the function `use_host`
+   |
+   = note: the type must implement `HasData`
+   = note: cannot satisfy `for<'a> <D as HasData>::Data<'a> == _`
+   = note: cannot satisfy `for<'a> <D as HasData>::Data<'a>: Tr`
+note: required by a bound in `use_host`
+  --> $DIR/next-solver-alias-relate-ambiguity-162559.rs:35:17
+   |
+LL | fn use_host<D2: HasData>(f: fn(&mut ()) -> D2::Data<'_>)
+   |                 ^^^^^^^ required by this bound in `use_host`
+note: required by a bound in `use_host`
+  --> $DIR/next-solver-alias-relate-ambiguity-162559.rs:37:27
+   |
+LL | fn use_host<D2: HasData>(f: fn(&mut ()) -> D2::Data<'_>)
+   |    -------- required by a bound in this function
+LL | where
+LL |     for<'a> D2::Data<'a>: Tr,
+   |                           ^^ required by this bound in `use_host`
+help: consider specifying a concrete type for the type parameter `D2`
+   |
+LL |     use_host::</* Type */>(getter);
+   |             ++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/higher-ranked/trait-bounds/next-solver-alias-relate-ambiguity-162559.rs
+++ b/tests/ui/higher-ranked/trait-bounds/next-solver-alias-relate-ambiguity-162559.rs
@@ -1,0 +1,48 @@
+//@ revisions: current next
+//@[current] check-pass
+//@[next] compile-flags: -Znext-solver
+//@[next] check-fail
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ edition: 2021
+
+/// Regression test for <https://github.com/rust-lang/rust/issues/162559>:
+/// compiling `wasmtime-wasi-http@48.0.1` fails with `E0283` under the next
+/// trait solver.
+///
+/// Minimized from the `wasmtime::component::bindgen!`-generated code for the
+/// `wasi:http/service` world: `HasData` stands in for
+/// `wasmtime::component::HasData`, the `fn(&mut _) -> D2::Data<'_>` argument
+/// is the host getter passed to `Accessor::with_getter`, and the
+/// `for<'a> D2::Data<'a>: Tr` obligation is one of the generated
+/// `HostRequestWithStore<T>`-shaped bounds.
+///
+/// The old solver eagerly equates `<D2 as HasData>::Data<'a>` with
+/// `<D as HasData>::Data<'a>` and infers `D2 = D`, while the next solver
+/// deliberately does not relate unresolved higher-ranked aliases (see
+/// <https://github.com/rust-lang/trait-system-refactor-initiative/issues/168>),
+/// so this is rejected with `E0283`. Wasmtime fixed the generated code to pass
+/// explicit generic arguments in
+/// <https://github.com/bytecodealliance/wasmtime/pull/14193>; for the next
+/// solver we simply make sure there is a compiler error with an actionable
+/// suggestion.
+
+trait HasData {
+    type Data<'a>;
+}
+
+trait Tr {}
+
+fn use_host<D2: HasData>(f: fn(&mut ()) -> D2::Data<'_>)
+where
+    for<'a> D2::Data<'a>: Tr,
+{
+}
+
+fn generated<D: HasData>(getter: fn(&mut ()) -> D::Data<'_>)
+where
+    for<'a> D::Data<'a>: Tr,
+{
+    use_host(getter); //[next]~ ERROR type annotations needed
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#162559.

## Summary

Compiling `wasmtime-wasi-http@48.0.1` fails on nightly with `E0283` (`cannot satisfy for<'a> <D as HasData>::Data<'a> == _`) while `-Znext-solver=coherence` (old-solver inference) accepts it. Per rust-lang/trait-system-refactor-initiative#168 this is intended breakage: the next solver deliberately does not relate unresolved higher-ranked aliases, whereas the old solver eagerly equated them and inferred the missing type parameter. Wasmtime already fixed the `bindgen!`-generated code to pass explicit generic arguments (bytecodealliance/wasmtime#14193, shipping in wasmtime 49).

This PR pins the intended rustc-side behavior with a regression test minimized from the issue (no wasmtime dependency), modeled on `rigid-equate-projections-in-higher-ranked-fn-signature.rs`:

- `current` revision (default test flags): passes, as before.
- `next` revision (`-Znext-solver`): fails with `E0283`, including the actionable turbofish suggestion.

No solver or diagnostic change: the emitted error already labels the un-inferrable type parameter and suggests the turbofish annotation, which is exactly the fix Wasmtime applied downstream.

## Repro (from the issue thread)

```rust
trait HasData { type Data<'a>; }
trait Tr {}
fn use_host<D2: HasData>(f: fn(&mut ()) -> D2::Data<'_>)
where for<'a> D2::Data<'a>: Tr {}
fn generated<D: HasData>(getter: fn(&mut ()) -> D::Data<'_>)
where for<'a> D::Data<'a>: Tr { use_host(getter); }
fn main() {}
```

- stable 1.98.1 / `-Znext-solver=no` / `-Znext-solver=coherence`: compiles.
- nightly 1.100.0 (default, next solver): `E0283` as in the issue.

## Test evidence

New test: `tests/ui/higher-ranked/trait-bounds/next-solver-alias-relate-ambiguity-162559.rs` (+ `.next.stderr`).

- `current` revision verified to pass under harness-default flags (checked with `--emit=metadata -Aunused -Znext-solver=coherence`).
- `next` revision output verified byte-identical under harness-equivalent flags (`--edition 2021 --emit=metadata -Aunused -Znext-solver -Zui-testing`).
- Oracle cross-check: the same procedure reproduces the sibling test's committed `.next.stderr` byte-for-byte, so the blessed snapshot method is sound. (A full local `x.py test` run was not possible on this small box; CI will confirm.)
- Pre-existing suite impact: none expected — no compiler sources touched, only two new test files added.
