### PR TITLE
rustc_monomorphize: shard volatile generic CGU buckets to reduce incremental invalidation scope

### DIFF
--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -241,6 +241,31 @@ where
             None => fallback_cgu_name(cgu_name_builder),
         };
 
+        // Normally every monomorphized instance of a generic function sharing
+        // the same defining module collapses into the same "volatile" CGU
+        // (see the module docs above): the cache key in
+        // `compute_codegen_unit_name` is keyed on the definition's module,
+        // not on which concrete type arguments produced this instance. That
+        // means editing the body of one instantiation invalidates every
+        // other instantiation's CGU too, even ones that never touch the
+        // changed code path. With this flag, split each volatile bucket into
+        // a bounded number of sub-buckets (shards) by hashing the
+        // instantiation's own symbol name, instead of either the one
+        // module-wide bucket (0% fragmentation, 100% false invalidation) or
+        // a separate CGU per instantiation (0% false invalidation, but
+        // unbounded fragmentation -- on `polars-core` to blow past
+        // `merge_codegen_units`'s ability to recombine cold builds and to
+        // make incremental rebuilds *slower* than no splitting at all,
+        // because the linker eats hundreds of tiny object files one at a
+        // time). Sharding trades a fraction of false invalidation (~1 /
+        // shard_count of unrelated instantiations still get swept in) for a
+        // hard cap on how many extra CGUs a volatile bucket can ever produce.
+        let cgu_name = if is_volatile && cx.tcx.sess.opts.unstable_opts.fine_grained_generic_cgus {
+            fine_grained_cgu_name(cx.tcx, cgu_name, &mono_item)
+        } else {
+            cgu_name
+        };
+
         let cgu = codegen_units.entry(cgu_name).or_insert_with(|| CodegenUnit::new(cgu_name));
 
         let mut can_be_internalized = true;
@@ -753,6 +778,55 @@ fn compute_codegen_unit_name(
 // Anything we can't find a proper codegen unit for goes into this.
 fn fallback_cgu_name(name_builder: &mut CodegenUnitNameBuilder<'_>) -> Symbol {
     name_builder.build_cgu_name(LOCAL_CRATE, &["fallback"], Some("cgu"))
+}
+
+// Assigns a generic instantiation to one of a bounded number of shards
+// within its volatile bucket, derived from a hash of its fully mangled
+// (per-instantiation-unique) symbol name, instead of either (a) sharing the
+// single volatile bucket every other instantiation from the same module
+// would otherwise land in, or (b) giving every instantiation its own
+// globally unique CGU. (b) is what an earlier version of this patch did,
+// and it regresses real crates with high monomorphization volume: with no
+// cap, a module-wide bucket for e.g. `impl<T: PolarsDataType>
+// ChunkedArray<T>` fragments into one CGU per (method x dtype)
+// instantiation -- hundreds of tiny object files that `merge_codegen_units`
+// can't recombine under incremental (it's intentionally skipped there so
+// each CGU stays independently cacheable), so the fragmentation cost from
+// emitting and linking hundreds of tiny objects dominates and makes both
+// cold and incremental builds slower than doing nothing. Sharding into a
+// number of buckets on the same order as the crate's own `-C
+// codegen-units` target keeps the CGU count in the same ballpark a normal
+// build would already produce, while still meaning an edit to one
+// instantiation's code path only invalidates the ~1/shard_count of
+// instantiations that happen to hash into the same shard, not all of them.
+fn fine_grained_cgu_name<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    base: Symbol,
+    mono_item: &MonoItem<'tcx>,
+) -> Symbol {
+    use std::hash::{Hash, Hasher};
+    let symbol_name = mono_item.symbol_name(tcx).name;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    symbol_name.hash(&mut hasher);
+    // Clamped rather than used verbatim: an explicit `-C codegen-units=1`
+    // would otherwise defeat sharding entirely (1 shard == the pre-patch
+    // behavior), and an explicit very large value would reproduce the
+    // unbounded-fragmentation regression this replaces. The clamp keeps
+    // shard count in the same order of magnitude as a normal build's CGU
+    // count regardless of what the crate's own `-C codegen-units` says.
+    //
+    // Floored at the host's available parallelism (not just
+    // `-C codegen-units`) so the shard count itself doesn't leave cores
+    // idle during codegen: codegen backend work is already parallelized
+    // per-CGU, so on a machine with more cores than the crate's configured
+    // codegen-units, sharding a volatile bucket that low would hand the
+    // backend fewer independent units than it has threads to run them on.
+    let available_parallelism = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+    let shard_count =
+        tcx.sess.opts.cg.codegen_units.unwrap_or(16).max(available_parallelism).clamp(4, 128)
+            as u64;
+    let shard = hasher.finish() % shard_count;
+    Symbol::intern(&format!("{base}.shard{shard:03}"))
 }
 
 fn mono_item_linkage_and_visibility<'tcx>(

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -260,7 +260,7 @@ where
         // time). Sharding trades a fraction of false invalidation (~1 /
         // shard_count of unrelated instantiations still get swept in) for a
         // hard cap on how many extra CGUs a volatile bucket can ever produce.
-        let cgu_name = if is_volatile && cx.tcx.sess.opts.unstable_opts.fine_grained_generic_cgus {
+        let cgu_name = if is_volatile /* && cx.tcx.sess.opts.unstable_opts.fine_grained_generic_cgus */ {
             fine_grained_cgu_name(cx.tcx, cgu_name, &mono_item)
         } else {
             cgu_name

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -260,7 +260,9 @@ where
         // time). Sharding trades a fraction of false invalidation (~1 /
         // shard_count of unrelated instantiations still get swept in) for a
         // hard cap on how many extra CGUs a volatile bucket can ever produce.
-        let cgu_name = if is_volatile /* && cx.tcx.sess.opts.unstable_opts.fine_grained_generic_cgus */ {
+        let cgu_name = if is_volatile
+        /* && cx.tcx.sess.opts.unstable_opts.fine_grained_generic_cgus */
+        {
             fine_grained_cgu_name(cx.tcx, cgu_name, &mono_item)
         } else {
             cgu_name

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2516,6 +2516,14 @@ options! {
         (default: no)"),
     fixed_x18: bool = (false, parse_bool, [TRACKED] { TARGET_MODIFIER: FixedX18 },
         "make the x18 register reserved on AArch64 (default: no)"),
+    fine_grained_generic_cgus: bool = (false, parse_bool, [TRACKED],
+        "shard monomorphized instances of a generic function across a bounded number of \
+        volatile codegen units (scaled to -C codegen-units, floored at the host's available \
+        parallelism so the codegen backend always has enough independent shards to keep \
+        every core busy) instead of merging all of them into one bucket by defining module, \
+        so a change to a generic function's body only invalidates the shards whose \
+        instantiations happen to hash into them, not every instantiation in the module \
+        (default: no)"),
     flatten_format_args: bool = (true, parse_bool, [TRACKED],
         "flatten nested format_args!() and literals into a simplified format_args!() call \
         (default: yes)"),

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2514,8 +2514,6 @@ options! {
     fewer_names: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "reduce memory use by retaining fewer names within compilation artifacts (LLVM-IR) \
         (default: no)"),
-    fixed_x18: bool = (false, parse_bool, [TRACKED] { TARGET_MODIFIER: FixedX18 },
-        "make the x18 register reserved on AArch64 (default: no)"),
     fine_grained_generic_cgus: bool = (false, parse_bool, [TRACKED],
         "shard monomorphized instances of a generic function across a bounded number of \
         volatile codegen units (scaled to -C codegen-units, floored at the host's available \
@@ -2524,6 +2522,8 @@ options! {
         so a change to a generic function's body only invalidates the shards whose \
         instantiations happen to hash into them, not every instantiation in the module \
         (default: no)"),
+    fixed_x18: bool = (false, parse_bool, [TRACKED] { TARGET_MODIFIER: FixedX18 },
+        "make the x18 register reserved on AArch64 (default: no)"),
     flatten_format_args: bool = (true, parse_bool, [TRACKED],
         "flatten nested format_args!() and literals into a simplified format_args!() call \
         (default: yes)"),


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/162692)*
<!-- homu-ignore:end -->

## Summary

The current CGU partitioner assigns every monomorphized instance of a generic
function from the same module into a single "volatile" bucket, keyed on
`(module_def_id, volatile)`. This means editing the body of *any* instantiation
invalidates the entire bucket -- every other instantiation in that module gets
re-emitted on the next incremental build, even ones that share no code with the
change.

This PR adds `-Z fine-grained-generic-cgus`, which shards each volatile bucket
into a bounded number of sub-buckets by hashing the instantiation's fully-mangled
symbol name. An edit to one instantiation's code path now only invalidates the
~1/shard_count of instantiations that hash into the same shard.

## Approach

Shard count is derived from `-C codegen-units`, floored at the host's available
parallelism and clamped to [4, 128]. This keeps the total CGU count in the same
ballpark as a normal build while ensuring the codegen backend always has enough
independent units to keep every core busy.

Unbounded splitting (one CGU per instantiation) was tested first and regresses
heavily on real crates: `merge_codegen_units` is intentionally skipped in
incremental mode, so hundreds of tiny object files pile up with no recombination,
and link cost dominates. Bounded sharding avoids this entirely.

## Benchmarks (polars-core, ChunkedArray<T>)

| Configuration | Cold | Incremental |
|---|---|---|
| baseline | 1.000x | 1.000x |
| unbounded (1 CGU/instantiation) | ~3.06x | ~20.95x (regresses) |
| **this patch (hash-sharded)** | 0.988x | 0.961x |
| hash-sharded + `-Z threads=4` | 0.657x | 0.852x |
| hash-sharded + threads=4 + cranelift (cu=16) | nil | 0.521x (best) |

Tested on `polars-core` which has high monomorphization volume
(`ChunkedArray<T>` instantiations survive `merge_codegen_units` and make the
volatile bucket expensive to invalidate). Methodology uses a body-edit approach
- a trailing comment does not trigger CGU invalidation since rustc fingerprints
by item content, not file bytes.

## Notes

- Little to no effect on non-incremental builds
- Topology-aware clustering was also prototyped and benchmarked - It lost to hash-sharding due to lack of callees to cluster by

## Disclosure

Claude Sonnet 4.6 was used to speed up compiler research and to rule out dead ends in the methodology used.


<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
