### PR TITLE
next_solver: Fix Field::OFFSET normalization

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to.rs
@@ -1068,13 +1068,25 @@ where
         else {
             return Err(NoSolution.into());
         };
-        let def_id = goal.predicate.alias.expect_projection_ty_def_id();
-        let ty = match ecx.cx().as_projection_lang_item(def_id) {
-            Some(SolverProjectionLangItem::FieldBase) => base,
-            Some(SolverProjectionLangItem::FieldType) => ty,
-            _ => panic!("unexpected associated type {:?} in `Field`", goal.predicate),
-        };
         ecx.probe_builtin_trait_candidate(BuiltinImplSource::Misc).enter(|ecx| {
+            let ty = match goal.predicate.alias.kind {
+                ty::AliasTermKind::ProjectionTy { def_id } => {
+                    match ecx.cx().as_projection_lang_item(def_id) {
+                        Some(SolverProjectionLangItem::FieldBase) => base,
+                        Some(SolverProjectionLangItem::FieldType) => ty,
+                        _ => panic!("unexpected associated type {:?} in `Field`", goal.predicate),
+                    }
+                }
+                ty::AliasTermKind::ProjectionConst { .. } => {
+                    return ecx.evaluate_const_and_instantiate_projection_term(
+                        goal.param_env,
+                        goal.predicate.alias,
+                        goal.predicate.term,
+                        goal.predicate.alias.expect_ct(),
+                    );
+                }
+                kind => panic!("expected projection, found {kind:?}"),
+            };
             ecx.instantiate_normalizes_to_term(goal, ty.into())?;
             ecx.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
         })

--- a/tests/ui/field_representing_types/offset-missing-features-issue-162338.rs
+++ b/tests/ui/field_representing_types/offset-missing-features-issue-162338.rs
@@ -1,0 +1,21 @@
+// Request MIR so normalization runs even though the crate has feature errors.
+//@ compile-flags: -Znext-solver --emit=mir
+
+#![feature(generic_const_args)]
+//~^ ERROR `generic_const_args` requires `min_generic_const_args` to be enabled
+#![allow(incomplete_features)]
+
+use std::field::{field_of, Field};
+//~^ ERROR use of unstable library feature `field_projections`
+//~| ERROR use of unstable library feature `field_projections`
+
+struct Struct {
+    b: i64,
+}
+
+fn project_ref() {
+    <field_of!(Struct, b)>::OFFSET;
+    //~^ ERROR use of unstable library feature `field_projections`
+    //~| ERROR use of unstable library feature `field_projections`
+}
+//~^ ERROR `main` function not found

--- a/tests/ui/field_representing_types/offset-missing-features-issue-162338.stderr
+++ b/tests/ui/field_representing_types/offset-missing-features-issue-162338.stderr
@@ -1,0 +1,58 @@
+error[E0658]: use of unstable library feature `field_projections`
+  --> $DIR/offset-missing-features-issue-162338.rs:17:6
+   |
+LL |     <field_of!(Struct, b)>::OFFSET;
+   |      ^^^^^^^^
+   |
+   = note: see issue #145383 <https://github.com/rust-lang/rust/issues/145383> for more information
+   = help: add `#![feature(field_projections)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: `generic_const_args` requires `min_generic_const_args` to be enabled
+  --> $DIR/offset-missing-features-issue-162338.rs:4:12
+   |
+LL | #![feature(generic_const_args)]
+   |            ^^^^^^^^^^^^^^^^^^
+   |
+   = help: enable all of these features
+
+error[E0601]: `main` function not found in crate `offset_missing_features_issue_162338`
+  --> $DIR/offset-missing-features-issue-162338.rs:20:2
+   |
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/offset-missing-features-issue-162338.rs`
+
+error[E0658]: use of unstable library feature `field_projections`
+  --> $DIR/offset-missing-features-issue-162338.rs:8:18
+   |
+LL | use std::field::{field_of, Field};
+   |                  ^^^^^^^^
+   |
+   = note: see issue #145383 <https://github.com/rust-lang/rust/issues/145383> for more information
+   = help: add `#![feature(field_projections)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `field_projections`
+  --> $DIR/offset-missing-features-issue-162338.rs:8:28
+   |
+LL | use std::field::{field_of, Field};
+   |                            ^^^^^
+   |
+   = note: see issue #145383 <https://github.com/rust-lang/rust/issues/145383> for more information
+   = help: add `#![feature(field_projections)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `field_projections`
+  --> $DIR/offset-missing-features-issue-162338.rs:17:5
+   |
+LL |     <field_of!(Struct, b)>::OFFSET;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #145383 <https://github.com/rust-lang/rust/issues/145383> for more information
+   = help: add `#![feature(field_projections)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0601, E0658.
+For more information about an error, try `rustc --explain E0601`.

--- a/tests/ui/field_representing_types/offset.rs
+++ b/tests/ui/field_representing_types/offset.rs
@@ -1,8 +1,10 @@
-//@ revisions: old next
+//@ revisions: old next generic_const_args
 //@ [next] compile-flags: -Znext-solver
+//@ [generic_const_args] compile-flags: -Znext-solver
 //@ run-pass
 #![expect(incomplete_features)]
 #![feature(field_projections)]
+#![cfg_attr(generic_const_args, feature(generic_const_args, min_generic_const_args))]
 
 use std::field::{Field, field_of};
 use std::mem::offset_of;
@@ -31,9 +33,21 @@ fn project_ref<'a, T, F: Field<Base = T>>(r: &'a T) -> &'a F::Type {
     unsafe { &*ptr::from_ref(r).byte_add(F::OFFSET).cast() }
 }
 
+#[repr(C)]
+struct Generic<T> {
+    a: u8,
+    b: T,
+}
+
+fn generic_offset<T>() -> usize {
+    <field_of!(Generic<T>, b)>::OFFSET
+}
+
 fn main() {
     assert_eq!(<field_of!(Struct, a)>::OFFSET, offset_of!(Struct, a));
     assert_eq!(<field_of!(Struct, b)>::OFFSET, offset_of!(Struct, b));
+    assert_eq!(generic_offset::<u8>(), offset_of!(Generic<u8>, b));
+    assert_eq!(generic_offset::<u64>(), offset_of!(Generic<u64>, b));
 
     let _: field_of!(Union, a);
     let _: field_of!(Union, b);


### PR DESCRIPTION
Fixes rust-lang/rust#162338

With `generic_const_args`, `Field::OFFSET` becomes a type-system constant. MIR normalization sends it to the builtin `Field` candidate, which assumes it's looking at an associated type and panics on `ProjectionConst`.

The candidate now handles type and const projections separately. I think this is the right place to fix it because the constant reaches the right candidate, but that candidate is missing the const case. I used `evaluate_const_and_instantiate_projection_term`, the same helper used for ordinary associated constants. Builtin instance resolution selects the default `Field::OFFSET` body, and the intrinsic gets the offset from the target layout. Constants that are still too generic become rigid aliases; unresolved inference stays ambiguous. The existing `Field` trait checks still apply.

Added a `generic_const_args` revision to the offset test, plus generic structs with `u8` and `u64` fields. The reduced case also has a regression test with MIR output enabled, since a metadata-only check doesn't reach the crash. The original example compiles now, and the reduced one reports the expected errors without an ICE.
