### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/enzyme_ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/enzyme_ffi.rs
@@ -97,7 +97,7 @@ pub(crate) mod Enzyme_AD {
     use rustc_session::filesearch;
 
     use super::{CConcreteType, CTypeTreeRef, Context};
-    use crate::llvm::{EnzymeTypeTree, LLVMRustVersionMajor};
+    use crate::llvm::{self, EnzymeTypeTree};
 
     type EnzymeSetCLBoolFn = unsafe extern "C" fn(*mut c_void, u8);
     type EnzymeSetCLStringFn = unsafe extern "C" fn(*mut c_void, *const c_char);
@@ -434,7 +434,7 @@ pub(crate) mod Enzyme_AD {
         }
 
         fn get_enzyme_path(sysroot: &Sysroot) -> Result<String, EnzymeLibraryError> {
-            let llvm_version_major = unsafe { LLVMRustVersionMajor() };
+            let llvm_version_major = llvm::LLVMRustVersionMajor();
 
             let path_buf = sysroot
                 .all_paths()

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -894,7 +894,11 @@ unsafe extern "C" {
         SLen: c_uint,
     ) -> MetadataKindId;
 
-    pub(crate) fn LLVMGetVersion(major: &mut c_uint, minor: &mut c_uint, patch: &mut c_uint);
+    /// Gets the actual version of LLVM that we are linked to at runtime.
+    ///
+    /// # Safety
+    /// Can be called without initializing LLVM.
+    pub(crate) safe fn LLVMGetVersion(major: &mut c_uint, minor: &mut c_uint, patch: &mut c_uint);
 
     pub(crate) fn LLVMDisposeTargetMachine(T: ptr::NonNull<TargetMachine>);
 
@@ -2176,9 +2180,9 @@ unsafe extern "C" {
     /// Returns the LLVM major version that the compiler was built with.
     ///
     /// Note that this is hard-coded as `LLVM_VERSION_MAJOR` when `RustWrapper.cpp` is built. This
-    /// could be different than what the runtime LLVM library reports in `LLVMGetVersion`, so we
+    /// could be different than what the runtime LLVM library reports in [`LLVMGetVersion`], so we
     /// assert their equality in `configure_llvm`.
-    pub(crate) fn LLVMRustVersionMajor() -> u32;
+    pub(crate) safe fn LLVMRustVersionMajor() -> u32;
 
     /// Add LLVM module flags.
     ///

--- a/compiler/rustc_codegen_llvm/src/llvm/offload_ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/offload_ffi.rs
@@ -14,7 +14,7 @@ use rustc_fs_util::path_to_c_string;
 use rustc_session::config::host_tuple;
 use rustc_session::filesearch;
 
-use crate::llvm::LLVMRustVersionMajor;
+use crate::llvm;
 
 pub(crate) struct RustOffloadWrapper {
     LLVMRustBundleImages: LLVMRustBundleImagesFn,
@@ -119,7 +119,7 @@ impl RustOffloadWrapper {
     fn get_offload_and_lld_paths(
         sysroot: &rustc_session::config::Sysroot,
     ) -> Result<(PathBuf, Option<PathBuf>), RustOffloadLibraryError> {
-        let llvm_version_major = unsafe { LLVMRustVersionMajor() };
+        let llvm_version_major = llvm::LLVMRustVersionMajor();
         let mut searched = Vec::new();
 
         for root in sysroot.all_paths() {

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -459,15 +459,13 @@ pub(crate) fn print_version() {
     println!("LLVM version: {major}.{minor}.{patch}");
 }
 
+/// Returns the version of LLVM that we are actually linked to at runtime.
 pub(crate) fn get_version() -> (u32, u32, u32) {
-    // Can be called without initializing LLVM
-    unsafe {
-        let mut llvm_major = 0;
-        let mut llvm_minor = 0;
-        let mut llvm_patch = 0;
-        llvm::LLVMGetVersion(&mut llvm_major, &mut llvm_minor, &mut llvm_patch);
-        (llvm_major, llvm_minor, llvm_patch)
-    }
+    let mut llvm_major = 0;
+    let mut llvm_minor = 0;
+    let mut llvm_patch = 0;
+    llvm::LLVMGetVersion(&mut llvm_major, &mut llvm_minor, &mut llvm_patch);
+    (llvm_major, llvm_minor, llvm_patch)
 }
 
 pub(crate) fn print_passes() {

--- a/tests/ui/associated-types/associated-types-match-despite-generic.rs
+++ b/tests/ui/associated-types/associated-types-match-despite-generic.rs
@@ -1,0 +1,21 @@
+//! Regression test for <https://github.com/rust-lang/trait-system-refactor-initiative/issues/216>.
+//@compile-flags: -Znext-solver=globally
+//@ check-pass
+
+struct Outer;
+struct Inner;
+trait Id<T> {
+    type This;
+}
+impl<T, U> Id<U> for T {
+    type This = T;
+}
+
+fn free<T>(x: T) -> <T as Id<Inner>>::This
+where
+    <T as Id<Outer>>::This: Id<Inner, This = <T as Id<Inner>>::This>,
+{
+    x
+}
+
+fn main() {}

--- a/tests/ui/attributes/positions/link-section.rs
+++ b/tests/ui/attributes/positions/link-section.rs
@@ -1,0 +1,11 @@
+//! Checks that `link_section` cannot be used on foreign statics.
+#![crate_type = "lib"]
+
+//@ edition:2024
+//@ check-pass
+// Regression test for <https://github.com/rust-lang/rust/issues/136220>.
+unsafe extern "C" {
+    #[unsafe(link_section = "__DATA,__buffer")] //~ WARN attribute cannot be used on foreign statics
+    //~| WARN previously accepted
+    pub static mut a: [u8; 1024];
+}

--- a/tests/ui/attributes/positions/link-section.stderr
+++ b/tests/ui/attributes/positions/link-section.stderr
@@ -1,0 +1,12 @@
+warning: the `link_section` attribute cannot be used on foreign statics
+  --> $DIR/link-section.rs:8:14
+   |
+LL |     #[unsafe(link_section = "__DATA,__buffer")]
+   |              ^^^^^^^^^^^^
+   |
+   = help: the `link_section` attribute can be applied to functions and statics
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#162642 (Add regression test for matching associated types on new solver)
 - rust-lang/rust#162665 (Add a UI regression test.)
 - rust-lang/rust#162710 (cg_llvm: Make the LLVM version-check bindings safe)
 - rust-lang/rust#162722 (Fix typo in riscv64a23-unknown-linux-gnu platform docs)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=162642,162665,162710,162722)
<!-- homu-ignore:end -->

